### PR TITLE
Changed IRC notifications for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ notifications:
       - "chat.freenode.net#openmw"
     on_success: change
     on_failure: always
-
+    use_notice: true


### PR DESCRIPTION
 Changed IRC notifications for Travis CI from normal messages to IRC notices, so they will be visible on IRC channel.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
