### PR TITLE
Use duration rather than frame counts.  Stops false detection of being "...

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -58,7 +58,8 @@ namespace MWMechanics
             WalkState mWalkState;
 
             int mStuckCount;
-            int mEvadeCount;
+            float mStuckDuration;
+            float mEvadeDuration;
 
             bool mStoredAvailableNodes;
             bool mChooseAction;


### PR DESCRIPTION
...stuck" with high frame rates (e.g. indoors).  Resolves bug #1235.
