### PR TITLE
Patial fix for Bug #1156.  Basic z-steering works for cliff racers, 

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -259,7 +259,25 @@ namespace MWMechanics
                 mRotate = true;
             }
 
-            mMovement.mPosition[1] = 1;
+            // FIXME: temporary solution for flying creatures
+            //        this method (i.e. execute) needs a general cleanup,
+            //        or even a rewrite, including changes to variable names
+            //        to those more commonly used (e.g. melee should refer to
+            //        fighting in very close distances) to make it easier
+            //        for maintainers to follow
+            if(actor.getClass().canFly(actor))
+            {
+                Ogre::Vector3 posHoriz(pos.pos[0], pos.pos[1], 0.f);
+                Ogre::Vector3 targetPosHoriz(targetPos.pos[0], targetPos.pos[1], 0.f);
+                // mimic vanilla behaviour - move horizontally until close, then move
+                // vertically
+                if(posHoriz.squaredDistance(targetPosHoriz) > 3600) // arbitrary number^2
+                    mMovement.mPosition[1] = 1;
+                else // if target is higher move up
+                    mMovement.mPosition[2] = ((targetPos.pos[2] - pos.pos[2]) > 0) ? 1 : -1;
+            }
+            else
+                mMovement.mPosition[1] = 1;
             mReadyToAttack = false;
         }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1018,6 +1018,11 @@ void CharacterController::update(float duration)
 
         vec.x *= mMovementSpeed;
         vec.y *= mMovementSpeed;
+        // FIXME: temporary fix for flying creatures, a proper fix needs a separate
+        //        implementation using something like the strategy pattern to handle
+        //        flying & swimming movements differently
+        if(flying)
+            vec.z *= mMovementSpeed;
 
         CharacterState movestate = CharState_None;
         CharacterState idlestate = CharState_SpecialIdle;
@@ -1084,7 +1089,8 @@ void CharacterController::update(float duration)
         fatigue.setCurrent(fatigue.getCurrent() - fatigueLoss, fatigue.getCurrent() < 0);
         cls.getCreatureStats(mPtr).setFatigue(fatigue);
 
-        if(sneak || inwater || flying)
+        // FIXME: temporary fix for flying creatures
+        if(sneak || inwater)// || flying)
             vec.z = 0.0f;
 
         if (inwater || flying)
@@ -1119,7 +1125,8 @@ void CharacterController::update(float duration)
             vec.y *= mult;
             vec.z  = 0.0f;
         }
-        else if(vec.z > 0.0f && mJumpState == JumpState_None)
+        // FIXME: temporary fix for flying creatures
+        else if(!flying && (vec.z > 0.0f && mJumpState == JumpState_None))
         {
             // Started a jump.
             float z = cls.getJump(mPtr);
@@ -1181,7 +1188,8 @@ void CharacterController::update(float duration)
         {
            if(!(vec.z > 0.0f))
                 mJumpState = JumpState_None;
-            vec.z = 0.0f;
+           if(!flying) // FIXME: temporary fix for flying creatures
+               vec.z = 0.0f;
 
             if(std::abs(vec.x/2.0f) > std::abs(vec.y))
             {


### PR DESCRIPTION
but the movements in AiCombat need refining.  The cliff racers also can't find paths around obstacles very well.  This patch is really just a workaround, it will likely require a rewrite at some point.  Finally the cliff racers do not detect the player until very close, unlike vanilla.
