### PR TITLE
Crash when given a non-existent content file

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2071,6 +2071,12 @@ namespace MWWorld
             {
                 contentLoader.load(col.getPath(*it), idx);
             }
+            else
+            {
+                std::stringstream msg;
+                msg << "Failed loading " << *it << ": the content file does not exist";
+                throw std::runtime_error(msg.str());
+            }
         }
     }
 


### PR DESCRIPTION
Prevent crash ([bug #1071](https://bugs.openmw.org/issues/1071))

It feels a bit hackish, but I don't see a better way.
