### PR TITLE
fix to broken aiwander logic

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -539,14 +539,14 @@ namespace MWMechanics
     }
 
     void AiWander::trimAllowedNodes(std::vector<ESM::Pathgrid::Point>& nodes,
-                                    PathFinder& pathfinder)
+                                    const PathFinder& pathfinder)
     {
         // TODO: how to add these back in once the door opens?
         // Idea: keep a list of detected closed doors (see aicombat.cpp)
         // Every now and then check whether one of the doors is opened. (maybe
         // at the end of playing idle?) If the door is opened then re-calculate
         // allowed nodes starting from the spawn point.
-        std::list<ESM::Pathgrid::Point>& paths = pathfinder.getPath();
+        std::list<ESM::Pathgrid::Point> paths = pathfinder.getPath();
         while(paths.size() >= 2)
         {
             ESM::Pathgrid::Point pt = paths.back();

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -77,7 +77,7 @@ namespace MWMechanics
             ESM::Pathgrid::Point mCurrentNode;
             bool mTrimCurrentNode;
             void trimAllowedNodes(std::vector<ESM::Pathgrid::Point>& nodes,
-                                  PathFinder& pathfinder);
+                                  const PathFinder& pathfinder);
 
             PathFinder mPathFinder;
 

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -57,7 +57,7 @@ namespace MWMechanics
                 return mPath.size();
             }
 
-            std::list<ESM::Pathgrid::Point>& getPath()
+            const std::list<ESM::Pathgrid::Point>& getPath() const
             {
                 return mPath;
             }


### PR DESCRIPTION
My apologize, guys. From the first look I didn't get what that `paths.pop_back();` in `trimAllowedNodes` for. Now original behaviour is returned.
