### PR TITLE
Fixes for warnings when building with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,7 @@ if (WIN32)
         4706 # Assignment in conditional expression
         4738 # Storing 32-bit float result in memory, possible loss of performance
         4986 # Undocumented warning that occurs in the crtdbg.h file
+        4987 # nonstandard extension used (triggered by setjmp.h)
         4996 # Function was declared deprecated
 
         # cause by ogre extensivly
@@ -610,7 +611,9 @@ if (WIN32)
         4305 # Truncating value (double to float, for example)
         4309 # Variable overflow, trying to store 128 in a signed char for example
         4355 # Using 'this' in member initialization list
+        4505 # Unreferenced local function has been removed
         4701 # Potentially uninitialized local variable used
+        4702 # Unreachable code
         4800 # Boolean optimization warning, e.g. myBool = (myInt != 0) instead of myBool = myInt
         )
 
@@ -618,19 +621,31 @@ if (WIN32)
         set(WARNINGS "${WARNINGS} /wd${d}")
     endforeach(d)
 
-    set_target_properties(shiny PROPERTIES COMPILE_FLAGS ${WARNINGS})
-    set_target_properties(shiny.OgrePlatform PROPERTIES COMPILE_FLAGS ${WARNINGS})
+    # boost::wave has a few issues with signed / unsigned conversions, so we suppress those here
+    set(SHINY_WARNINGS "${WARNINGS} /wd4245")
+    set_target_properties(shiny PROPERTIES COMPILE_FLAGS ${SHINY_WARNINGS})
+    # there's an unreferenced local variable in the ogre platform, suppress it
+    set(SHINY_OGRE_WARNINGS "${WARNINGS} /wd4101")
+    set_target_properties(shiny.OgrePlatform PROPERTIES COMPILE_FLAGS ${SHINY_OGRE_WARNINGS})
+    set_target_properties(sdl4ogre PROPERTIES COMPILE_FLAGS ${WARNINGS})
+    set_target_properties(oics PROPERTIES COMPILE_FLAGS ${WARNINGS})
     set_target_properties(components PROPERTIES COMPILE_FLAGS ${WARNINGS})
     if (BUILD_LAUNCHER)
         set_target_properties(omwlauncher PROPERTIES COMPILE_FLAGS ${WARNINGS})
     endif (BUILD_LAUNCHER)
     set_target_properties(openmw PROPERTIES COMPILE_FLAGS ${WARNINGS})
-        if (BUILD_BSATOOL)
+    if (BUILD_BSATOOL)
         set_target_properties(bsatool PROPERTIES COMPILE_FLAGS ${WARNINGS})
-            endif (BUILD_BSATOOL)
+    endif (BUILD_BSATOOL)
     if (BUILD_ESMTOOL)
         set_target_properties(esmtool PROPERTIES COMPILE_FLAGS ${WARNINGS})
     endif (BUILD_ESMTOOL)
+    if (BUILD_OPENCS)
+        set_target_properties(opencs PROPERTIES COMPILE_FLAGS ${WARNINGS})
+    endif (BUILD_OPENCS)
+    if (BUILD_MWINIIMPORTER)
+        set_target_properties(mwiniimport PROPERTIES COMPILE_FLAGS ${WARNINGS})
+    endif (BUILD_MWINIIMPORTER)
   endif(MSVC)
 
   # Same for MinGW

--- a/apps/opencs/view/world/vartypedelegate.cpp
+++ b/apps/opencs/view/world/vartypedelegate.cpp
@@ -79,7 +79,7 @@ void CSVWorld::VarTypeDelegateFactory::add (ESM::VarType type)
     std::vector<std::string> enums =
         CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_ValueType);
 
-    if (type<0 && type>=enums.size())
+    if (static_cast<size_t>(type) >= enums.size())
         throw std::logic_error ("Unsupported variable type");
 
     mValues.push_back (std::make_pair (type, QString::fromUtf8 (enums[type].c_str())));

--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -695,6 +695,8 @@ protected:
     typedef TypesetBookImpl::Section Section;
     typedef TypesetBookImpl::Line    Line;
     typedef TypesetBookImpl::Run     Run;
+    bool mIsPageReset;
+    size_t mPage;
 
     struct TextFormat : ISubWidget
     {
@@ -745,6 +747,23 @@ protected:
         void destroyDrawItem() {};
     };
 
+    void resetPage()
+    {
+       mIsPageReset = true;
+       mPage = 0;
+    }
+
+    void setPage(size_t page)
+    {
+       mIsPageReset = false;
+       mPage = page;
+    }
+
+    bool isPageDifferent(size_t page)
+    {
+       return mIsPageReset || (mPage != page);
+    }
+
 public:
 
     typedef TypesetBookImpl::StyleImpl Style;
@@ -760,14 +779,13 @@ public:
 
 
     boost::shared_ptr <TypesetBookImpl> mBook;
-    size_t mPage;
 
     MyGUI::ILayerNode* mNode;
     ActiveTextFormats mActiveTextFormats;
 
     PageDisplay ()
     {
-        mPage = -1;
+        resetPage ();
         mViewTop = 0;
         mViewBottom = 0;
         mFocusItem = NULL;
@@ -901,7 +919,7 @@ public:
                 createActiveFormats (newBook);
 
                 mBook = newBook;
-                mPage = newPage;
+                setPage (newPage);
 
                 if (newPage < mBook->mPages.size ())
                 {
@@ -917,19 +935,19 @@ public:
             else
             {
                 mBook.reset ();
-                mPage = -1;
+                resetPage ();
                 mViewTop = 0;
                 mViewBottom = 0;
             }
         }
         else
-        if (mBook && mPage != newPage)
+        if (mBook && isPageDifferent (newPage))
         {
             if (mNode != NULL)
                 for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
                     mNode->outOfDate(i->second->mRenderItem);
 
-            mPage = newPage;
+            setPage (newPage);
 
             if (newPage < mBook->mPages.size ())
             {

--- a/apps/openmw/mwgui/companionwindow.hpp
+++ b/apps/openmw/mwgui/companionwindow.hpp
@@ -25,7 +25,7 @@ namespace MWGui
         ItemView* mItemView;
         SortFilterItemModel* mSortModel;
         CompanionItemModel* mModel;
-        size_t mSelectedItem;
+        int mSelectedItem;
 
         DragAndDrop* mDragAndDrop;
 

--- a/apps/openmw/mwgui/container.hpp
+++ b/apps/openmw/mwgui/container.hpp
@@ -62,7 +62,7 @@ namespace MWGui
         MWGui::ItemView* mItemView;
         SortFilterItemModel* mSortModel;
         ItemModel* mModel;
-        size_t mSelectedItem;
+        int mSelectedItem;
 
         MyGUI::Button* mDisposeCorpseButton;
         MyGUI::Button* mTakeButton;

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -510,7 +510,7 @@ namespace MWGui
 
     void DialogueWindow::onScrollbarMoved(MyGUI::ScrollBar *sender, size_t pos)
     {
-        mHistory->setPosition(0,-pos);
+        mHistory->setPosition(0, pos * -1);
     }
 
     void DialogueWindow::addResponse(const std::string &text, const std::string &title)

--- a/apps/openmw/mwgui/inventorywindow.hpp
+++ b/apps/openmw/mwgui/inventorywindow.hpp
@@ -52,7 +52,7 @@ namespace MWGui
             DragAndDrop* mDragAndDrop;
 
             bool mPreviewDirty;
-            size_t mSelectedItem;
+            int mSelectedItem;
 
             MWWorld::Ptr mPtr;
 

--- a/apps/openmw/mwgui/spellicons.hpp
+++ b/apps/openmw/mwgui/spellicons.hpp
@@ -42,6 +42,8 @@ namespace MWGui
 
         std::map <int, std::vector<MagicEffectInfo> > mEffectSources;
 
+        virtual ~EffectSourceVisitor() {}
+
         virtual void visit (MWMechanics::EffectKey key,
                                  const std::string& sourceName, const std::string& casterHandle,
                             float magnitude, float remainingTime = -1);

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -146,8 +146,8 @@ namespace MWMechanics
               || weapon.get<ESM::Weapon>()->mBase->mData.mFlags & ESM::Weapon::Magical))
             damage *= multiplier;
 
-        if (weapon.get<ESM::Weapon>()->mBase->mData.mFlags & ESM::Weapon::Silver
-                & actor.getClass().isNpc() && actor.getClass().getNpcStats(actor).isWerewolf())
+        if ((weapon.get<ESM::Weapon>()->mBase->mData.mFlags & ESM::Weapon::Silver)
+                && actor.getClass().isNpc() && actor.getClass().getNpcStats(actor).isWerewolf())
             damage *= MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fWereWolfSilverWeaponDamageMult")->getFloat();
 
         if (damage == 0 && attacker.getRefData().getHandle() == "player")

--- a/apps/openmw/mwmechanics/levelledlist.hpp
+++ b/apps/openmw/mwmechanics/levelledlist.hpp
@@ -70,7 +70,7 @@ namespace MWMechanics
                     return getLevelledItem(ref.getPtr().get<ESM::CreatureLevList>()->mBase, failChance);
             }
         }
-        catch (std::logic_error& e)
+        catch (std::logic_error&)
         {
             // Vanilla doesn't fail on nonexistent items in levelled lists
             std::cerr << "Warning: ignoring nonexistent item '" << item << "'" << std::endl;

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -267,7 +267,7 @@ void LocalMap::render(const float x, const float y,
         // initialize to (0, 0, 0, 1)
         for (int p=0; p<sFogOfWarResolution*sFogOfWarResolution; ++p)
         {
-            buffer[p] = (255 << 24);
+            buffer[p] = 0xFF000000;
         }
 
         memcpy(tex2->getBuffer()->lock(HardwareBuffer::HBL_DISCARD), &buffer[0], sFogOfWarResolution*sFogOfWarResolution*4);

--- a/apps/openmw/mwrender/occlusionquery.cpp
+++ b/apps/openmw/mwrender/occlusionquery.cpp
@@ -35,7 +35,7 @@ OcclusionQuery::OcclusionQuery(OEngine::Render::OgreRenderer* renderer, SceneNod
 
         mSupported = (mSunTotalAreaQuery != 0) && (mSunVisibleAreaQuery != 0);
     }
-    catch (Ogre::Exception& e)
+    catch (Ogre::Exception&)
     {
         mSupported = false;
     }

--- a/apps/openmw/mwrender/weaponanimation.hpp
+++ b/apps/openmw/mwrender/weaponanimation.hpp
@@ -33,6 +33,7 @@ namespace MWRender
     {
     public:
         WeaponAnimation() : mPitchFactor(0) {}
+        virtual ~WeaponAnimation() {}
 
         virtual void attachArrow(MWWorld::Ptr actor);
         virtual void releaseArrow(MWWorld::Ptr actor);

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -295,7 +295,7 @@ namespace MWScript
                     {
                         store = MWBase::Environment::get().getWorld()->getInterior(cellID);
                     }
-                    catch(std::exception &e)
+                    catch(std::exception&)
                     {
                         const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);
                         if(cell)
@@ -395,7 +395,7 @@ namespace MWScript
                     {
                         store = MWBase::Environment::get().getWorld()->getInterior(cellID);
                     }
-                    catch(std::exception &e)
+                    catch(std::exception&)
                     {
                         const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);
                         if(cell)

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -204,7 +204,7 @@ void FFmpeg_Decoder::open(const std::string &fname)
 
         mFrame = avcodec_alloc_frame();
     }
-    catch(std::exception &e)
+    catch(std::exception&)
     {
         if (mFormatCtx->pb->buffer != NULL)
         {

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -288,7 +288,7 @@ OpenAL_SoundStream::OpenAL_SoundStream(OpenAL_Output &output, ALuint src, Decode
 
         mOutput.mActiveSounds.push_back(this);
     }
-    catch(std::exception &e)
+    catch(std::exception&)
     {
         alDeleteBuffers(sNumBuffers, mBuffers);
         alGetError();
@@ -471,7 +471,7 @@ bool OpenAL_SoundStream::process()
 
         mIsFinished = finished;
     }
-    catch(std::exception &e) {
+    catch(std::exception&) {
         std::cout<< "Error updating stream \""<<mDecoder->getName()<<"\"" <<std::endl;
         mSamplesQueued = 0;
         mIsFinished = true;
@@ -781,7 +781,7 @@ ALuint OpenAL_Output::getBuffer(const std::string &fname)
     {
         decoder->open(fname);
     }
-    catch(Ogre::FileNotFoundException &e)
+    catch(Ogre::FileNotFoundException&)
     {
         std::string::size_type pos = fname.rfind('.');
         if(pos == std::string::npos)
@@ -859,7 +859,7 @@ MWBase::SoundPtr OpenAL_Output::playSound(const std::string &fname, float vol, f
         buf = getBuffer(fname);
         sound.reset(new OpenAL_Sound(*this, src, buf, Ogre::Vector3(0.0f), vol, basevol, pitch, 1.0f, 1000.0f, flags));
     }
-    catch(std::exception &e)
+    catch(std::exception&)
     {
         mFreeSources.push_back(src);
         if(buf && alIsBuffer(buf))
@@ -898,7 +898,7 @@ MWBase::SoundPtr OpenAL_Output::playSound3D(const std::string &fname, const Ogre
         buf = getBuffer(fname);
         sound.reset(new OpenAL_Sound3D(*this, src, buf, pos, vol, basevol, pitch, min, max, flags));
     }
-    catch(std::exception &e)
+    catch(std::exception&)
     {
         mFreeSources.push_back(src);
         if(buf && alIsBuffer(buf))
@@ -940,7 +940,7 @@ MWBase::SoundPtr OpenAL_Output::streamSound(DecoderPtr decoder, float volume, fl
     {
         sound.reset(new OpenAL_SoundStream(*this, src, decoder, volume, pitch, flags));
     }
-    catch(std::exception &e)
+    catch(std::exception&)
     {
         mFreeSources.push_back(src);
         throw;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -321,7 +321,7 @@ namespace MWSound
             sound = mOutput->playSound(file, volume, basevol, pitch, mode|type, offset);
             mActiveSounds[sound] = std::make_pair(MWWorld::Ptr(), soundId);
         }
-        catch(std::exception &e)
+        catch(std::exception&)
         {
             //std::cout <<"Sound Error: "<<e.what()<< std::endl;
         }
@@ -349,7 +349,7 @@ namespace MWSound
             else
                 mActiveSounds[sound] = std::make_pair(ptr, soundId);
         }
-        catch(std::exception &e)
+        catch(std::exception&)
         {
             //std::cout <<"Sound Error: "<<e.what()<< std::endl;
         }

--- a/components/esm/inventorystate.hpp
+++ b/components/esm/inventorystate.hpp
@@ -20,6 +20,8 @@ namespace ESM
         // lights (slot)
         std::vector<std::pair<LightState, int> > mLights;
 
+        virtual ~InventoryState() {}
+
         virtual void load (ESMReader &esm);
         virtual void save (ESMWriter &esm) const;
     };

--- a/components/terrain/material.cpp
+++ b/components/terrain/material.cpp
@@ -181,7 +181,7 @@ namespace Terrain
                 // shadow. TODO: repeated, put in function
                 if (mShadows)
                 {
-                    for (Ogre::uint i = 0; i < (mSplitShadows ? 3 : 1); ++i)
+                    for (int i = 0; i < (mSplitShadows ? 3 : 1); ++i)
                     {
                         sh::MaterialInstanceTextureUnit* shadowTex = p->createTextureUnit ("shadowMap" + Ogre::StringConverter::toString(i));
                         shadowTex->setProperty ("content_type", sh::makeProperty<sh::StringValue> (new sh::StringValue("shadow")));
@@ -334,7 +334,7 @@ namespace Terrain
                     // shadow
                     if (shadows)
                     {
-                        for (Ogre::uint i = 0; i < (mSplitShadows ? 3 : 1); ++i)
+                        for (int i = 0; i < (mSplitShadows ? 3 : 1); ++i)
                         {
                             sh::MaterialInstanceTextureUnit* shadowTex = p->createTextureUnit ("shadowMap" + Ogre::StringConverter::toString(i));
                             shadowTex->setProperty ("content_type", sh::makeProperty<sh::StringValue> (new sh::StringValue("shadow")));


### PR DESCRIPTION
Most warnings are innocuous (wrong type-specifier for forward
declarations, conversion of literals into unsigned integers, warnings
about methods optimized out), but I believe actual bugs were revealed in
vartypedelegate.cpp and combat.cpp.
