### PR TITLE
Bug 1047 Fix

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -163,7 +163,7 @@ namespace MWGui
             std::string::const_iterator i = text.begin ();
             KeywordSearchT::Match match;
 
-            while (i != text.end () && keywordSearch->search (i, text.end (), match, false))
+            while (i != text.end () && keywordSearch->search (i, text.end (), match, text.begin ()))
             {
                 if (i != match.mBeg)
                     addTopicLink (typesetter, 0, i - text.begin (), match.mBeg - text.begin ());

--- a/apps/openmw/mwgui/journalviewmodel.cpp
+++ b/apps/openmw/mwgui/journalviewmodel.cpp
@@ -178,7 +178,7 @@ struct JournalViewModelImpl : JournalViewModel
 
                 KeywordSearchT::Match match;
 
-                while (i != utf8text.end () && mModel->mKeywordSearch.search (i, utf8text.end (), match))
+                while (i != utf8text.end () && mModel->mKeywordSearch.search (i, utf8text.end (), match, utf8text.begin()))
                 {
                     if (i != match.mBeg)
                         visitor (0, i - utf8text.begin (), match.mBeg - utf8text.begin ());

--- a/apps/openmw/mwgui/keywordsearch.hpp
+++ b/apps/openmw/mwgui/keywordsearch.hpp
@@ -66,18 +66,18 @@ public:
         return false;
     }
 
-    bool search (Point beg, Point end, Match & match, bool matchSubword = true)
+    bool search (Point beg, Point end, Match & match, Point start)
     {
-        char prev = ' ';
         for (Point i = beg; i != end; ++i)
         {
             // check if previous character marked start of new word
-            if (!matchSubword && isalpha(prev))
+            if (i != start)
             {
-                prev = *i;
-                continue;
+                Point prev = i;
+                --prev; 
+                if(isalpha(*prev))
+                    continue;
             }
-            prev = *i;
 
             // check first character
             typename Entry::childen_t::iterator candidate = mRoot.mChildren.find (std::tolower (*i, mLocale));


### PR DESCRIPTION
Dialog links can no longer be highlighted if they appear in the
middle of the word. This is achieved by confirming that the
character before a match is not alphabetic, so that words
following hyphens can still potentially match.
