### PR TITLE
SceneWidget windowHandle fix for Windows.

### DIFF
--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -86,8 +86,11 @@ namespace CSVRender
         }
 
         std::stringstream windowHandle;
+#ifdef WIN32
+        windowHandle << Ogre::StringConverter::toString((unsigned long)(this->winId()));
+#else
         windowHandle << this->winId();
-
+#endif
         std::stringstream windowTitle;
         static int count=0;
         windowTitle << ++count;


### PR DESCRIPTION
Ogre::StringConverter might be an overkill?  Anyway it works for Windows x64.
