### PR TITLE
Disable video sounds for Windows x64

### DIFF
--- a/apps/openmw/mwrender/videoplayer.cpp
+++ b/apps/openmw/mwrender/videoplayer.cpp
@@ -970,7 +970,7 @@ void VideoState::init(const std::string& resourceName)
         MWBase::Environment::get().getSoundManager()->pauseSounds();
 
     this->external_clock_base = av_gettime();
-#ifdef WIN32
+#ifdef _WIN64
     // FIXME: Need FFmpeg FLTP audio support for BIK video format
     std::cout<<"Sound temporarily disabled for \""+resourceName+"\""<<std::endl;
 #else


### PR DESCRIPTION
We're not disabling video but sound, and only for x64 now.  Probably not worth merging if it will delay the release.
