### PR TITLE
Windows build fix

### DIFF
--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -5,7 +5,7 @@
 
 namespace ESM
 {
-    class ObjectState;
+    struct ObjectState;
 }
 
 namespace MWWorld


### PR DESCRIPTION
The MSVC linker is really pedantic with this, functions compiled as taking a class can't be linked with functions giving a struct, because of the name mangling I'm guessing...

`unresolved external symbol "protected: void __thiscall MWWorld::LiveCellRefBase::loadImp(class ESM::ObjectState const &)" (?loadImp@LiveCellRefBase@MWWorld@@IAEXABVObjectState@ESM@@@Z)`
