### PR TITLE
MSVC generates different symbols for class vs struct, confusing the linker

### DIFF
--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -5,7 +5,7 @@
 
 namespace ESM
 {
-    class ObjectState;
+    struct ObjectState;
 }
 
 namespace MWWorld


### PR DESCRIPTION
This one took forever to find...
