### PR TITLE
Fix for bug 1196.

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -569,10 +569,10 @@ namespace MWInput
     {
         bool guiMode = false;
 
-        if (id == SDL_BUTTON_LEFT || id == SDL_BUTTON_RIGHT) // MyGUI has no use for these events
+        if (id == SDL_BUTTON_LEFT || id == SDL_BUTTON_RIGHT) // MyGUI only uses these mouse events
         {
-            MyGUI::InputManager::getInstance().injectMousePress(mMouseX, mMouseY, sdlButtonToMyGUI(id));
-            guiMode = guiMode && MWBase::Environment::get().getWindowManager()->isGuiMode();
+            guiMode = MWBase::Environment::get().getWindowManager()->isGuiMode();
+            guiMode = MyGUI::InputManager::getInstance().injectMousePress(mMouseX, mMouseY, sdlButtonToMyGUI(id)) && guiMode;
             if (MyGUI::InputManager::getInstance ().getMouseFocusWidget () != 0)
             {
                 MyGUI::Button* b = MyGUI::InputManager::getInstance ().getMouseFocusWidget ()->castType<MyGUI::Button>(false);
@@ -596,8 +596,8 @@ namespace MWInput
         {
             mInputBinder->mouseReleased (arg, id);
         } else {
-            bool guiMode = MyGUI::InputManager::getInstance().injectMouseRelease(mMouseX, mMouseY, sdlButtonToMyGUI(id));
-            guiMode = guiMode && MWBase::Environment::get().getWindowManager()->isGuiMode();
+            bool guiMode = MWBase::Environment::get().getWindowManager()->isGuiMode();
+            guiMode = MyGUI::InputManager::getInstance().injectMouseRelease(mMouseX, mMouseY, sdlButtonToMyGUI(id)) && guiMode;
 
             if(mInputBinder->detectingBindingState()) return; // don't allow same mouseup to bind as initiated bind
 

--- a/extern/oics/ICSChannel.cpp
+++ b/extern/oics/ICSChannel.cpp
@@ -84,7 +84,7 @@ namespace ICS
     
         mValue = value;
 
-        if(previousValue != value)
+        if(previousValue != value && mEnabled)
         {
             notifyListeners(previousValue);
         }
@@ -130,9 +130,6 @@ namespace ICS
 
 	void Channel::update()
 	{
-        if(!mEnabled)
-            return;
-
         if(this->getControlsCount() == 1)
 		{
 			ControlChannelBinderItem ccBinderItem = mAttachedControls.back();


### PR DESCRIPTION
This bug would cause the player to jump when jump was assigned to
Space and they closed a dialog with Space. I tested vanilla
MW for behaviour and found that Jump was the only basic input which
MW does not allow when closing dialogs (i.e. if Space is assigned to
move forward, MW will move you forward after closing the dialog).

There were two reasons for the bug:
1) OpenMW GUI does not consume UI events
2) Jump occurs so long as key is down (not only on first key down)

To minimally fix the bug, I made it so that keypress events can be
consumed by the GUI and not passed along to the player control
input manager (1). However, if the player holds space, they will still
jump (as the subsequent key held events will be captured and cause
a jump).

Unfortunately, there is no idiomatic way that I could find in the
OpenMW input manager to perform events only on key down. Instead,
I introduced a variable which tracks whether the jump key has been
pressed for the first time within the current frame (2).

Note: I was initially concerned that limiting the jump event to
KeyDown and not Key Hold would cause issues with swimming,
levitating, or variable height jumping. However, after a bunch
of testing in vanilla MW and exploration of the OpenMW codebase
I could find nothing suggesting the need to capture the jump
key being held.
