### PR TITLE
Fixes Bug #1348 "Evidence Chest unlocking when arrested."

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2542,7 +2542,7 @@ namespace MWWorld
                     store.remove(*it, it->getRefData().getCount(), ptr);
                 }
             }
-            closestChest.getClass().unlock(closestChest);
+            closestChest.getClass().lock(closestChest,50);
         }
     }
 


### PR DESCRIPTION
This bug is listed as closed, but the fix never got merged.
