### PR TITLE
Partly implement Feature #1067

### DIFF
--- a/components/nif/niffile.hpp
+++ b/components/nif/niffile.hpp
@@ -155,6 +155,7 @@ struct KeyListT {
     static const int sLinearInterpolation = 1;
     static const int sQuadraticInterpolation = 2;
     static const int sTBCInterpolation = 3;
+    static const int sXYZInterpolation = 4;
 
     int mInterpolationType;
     VecType mKeys;
@@ -199,6 +200,38 @@ struct KeyListT {
                 key.mContinuity = nif->getFloat();
             }
         }
+        //\FIXME This now reads the correct amount of data in the file, but doesn't actually do anything with it.
+        else if(mInterpolationType == sXYZInterpolation)
+        {
+            if (count != 1)
+            {
+                nif->file->fail("count should always be '1' for XYZ_ROTATION_KEY.  Retrieved Value: "+Ogre::StringConverter::toString(count));
+                return;
+            }
+            //KeyGroup (see http://niftools.sourceforge.net/doc/nif/NiKeyframeData.html)
+            //Chomp unknown and possibly unused float
+            nif->getFloat();
+            for(size_t i=0;i<3;++i)
+            {
+                unsigned int numKeys = nif->getInt();
+                if(numKeys != 0)
+                {
+                    int interpolationTypeAgain = nif->getInt();
+                    if( interpolationTypeAgain != sLinearInterpolation)
+                    {
+                        nif->file->fail("XYZ_ROTATION_KEY's KeyGroup keyType must be '1' (Linear Interpolation).  Retrieved Value: "+Ogre::StringConverter::toString(interpolationTypeAgain));
+                        return;
+                    }
+                    for(size_t j = 0;j < numKeys;j++)
+                    {
+                        //For now just chomp these
+                        nif->getFloat();
+                        nif->getFloat();
+                    }
+                }
+                nif->file->warn("XYZ_ROTATION_KEY read, but not used!");
+            }
+    }
         else if (mInterpolationType == 0)
         {
             if (count != 0)


### PR DESCRIPTION
Read NIF interpolation type 4 (XYZ_ROTATION_KEY) 

Don't actually do anything with it yet, but without this the "MW Containers Animated" mod made containers inaccessible.
