### PR TITLE
Fix compile error due to "small" being already defined as a char.

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1262,16 +1262,16 @@ ObjectAnimation::ObjectAnimation(const MWWorld::Ptr& ptr, const std::string &mod
     Ogre::Vector3 extents = getWorldBounds().getSize();
     float size = std::max(std::max(extents.x, extents.y), extents.z);
 
-    bool small = (size < Settings::Manager::getInt("small object size", "Viewing distance")) &&
+    bool smallObject = (size < Settings::Manager::getInt("small object size", "Viewing distance")) &&
                  Settings::Manager::getBool("limit small object distance", "Viewing distance");
     // do not fade out doors. that will cause holes and look stupid
     if(ptr.getTypeName().find("Door") != std::string::npos)
-        small = false;
+        smallObject = false;
 
-    float dist = small ? Settings::Manager::getInt("small object distance", "Viewing distance") : 0.0f;
+    float dist = smallObject ? Settings::Manager::getInt("small object distance", "Viewing distance") : 0.0f;
     Ogre::Vector3 col = getEnchantmentColor(ptr);
     setRenderProperties(mObjectRoot, (mPtr.getTypeName() == typeid(ESM::Static).name()) ?
-                                     (small ? RV_StaticsSmall : RV_Statics) : RV_Misc,
+                                     (smallObject ? RV_StaticsSmall : RV_Statics) : RV_Misc,
                         RQG_Main, RQG_Alpha, dist, !ptr.getClass().getEnchantment(ptr).empty(), &col);
 }
 

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -84,11 +84,11 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh)
     extents *= ptr.getRefData().getBaseNode()->getScale();
     float size = std::max(std::max(extents.x, extents.y), extents.z);
 
-    bool small = (size < Settings::Manager::getInt("small object size", "Viewing distance")) &&
+    bool smallObject = (size < Settings::Manager::getInt("small object size", "Viewing distance")) &&
                  Settings::Manager::getBool("limit small object distance", "Viewing distance");
     // do not fade out doors. that will cause holes and look stupid
     if(ptr.getTypeName().find("Door") != std::string::npos)
-        small = false;
+        smallObject = false;
 
     if (mBounds.find(ptr.getCell()) == mBounds.end())
         mBounds[ptr.getCell()] = Ogre::AxisAlignedBox::BOX_NULL;
@@ -103,7 +103,7 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh)
     {
         Ogre::StaticGeometry* sg = 0;
 
-        if (small)
+        if (smallObject)
         {
             if(mStaticGeometrySmall.find(ptr.getCell()) == mStaticGeometrySmall.end())
             {
@@ -141,7 +141,7 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh)
         else
             sg->setRegionDimensions(Ogre::Vector3(1024,1024,1024));
 
-        sg->setVisibilityFlags(small ? RV_StaticsSmall : RV_Statics);
+        sg->setVisibilityFlags(smallObject ? RV_StaticsSmall : RV_Statics);
 
         sg->setCastShadows(true);
 


### PR DESCRIPTION
OpenMW would not build in Debug mode due to "small" being defined as a
char, then again as a bool variable. Renamed to "smallObject" to correct
the compile error.
