### PR TITLE
Fix physics to not trigger Bullet assert in Debug

### DIFF
--- a/apps/openmw/mwworld/physicssystem.cpp
+++ b/apps/openmw/mwworld/physicssystem.cpp
@@ -299,16 +299,32 @@ namespace MWWorld
                     continue; // velocity updated, calculate nextpos again
                 }
 
-                // trace to where character would go if there were no obstructions
-                tracer.doTrace(colobj, newPosition, nextpos, engine);
-
-                // check for obstructions
-                if(tracer.mFraction >= 1.0f)
+                if(!newPosition.positionCloses(nextpos, 0.00000001))
                 {
-                    newPosition = tracer.mEndPos; // ok to move, so set newPosition
+                    // trace to where character would go if there were no obstructions
+                    tracer.doTrace(colobj, newPosition, nextpos, engine);
+
+                    // check for obstructions
+                    if(tracer.mFraction >= 1.0f)
+                    {
+                        newPosition = tracer.mEndPos; // ok to move, so set newPosition
+                        remainingTime *= (1.0f-tracer.mFraction); // FIXME: remainingTime is no longer used so don't set it?
+                        break;
+                    }
+                }
+                else
+                {
+                    // The current position and next position are nearly the same, so just exit.
+                    // Note: Bullet can trigger an assert in debug modes if the positions
+                    // are the same, since that causes it to attempt to normalize a zero
+                    // length vector (which can also happen with nearly identical vectors, since
+                    // precision can be lost due to any math Bullet does internally). Since we
+                    // aren't performing any collision detection, we want to reject the next
+                    // position, so that we don't slowly move inside another object.
                     remainingTime *= (1.0f-tracer.mFraction); // FIXME: remainingTime is no longer used so don't set it?
                     break;
                 }
+
 
                 Ogre::Vector3 oldPosition = newPosition;
                 // We hit something. Try to step up onto it. (NOTE: stepMove does not allow stepping over)


### PR DESCRIPTION
When physics attempts to move by a very small amount, precision losses
caused Bullet to trigger an assert in debug from normalizing a zero
length vector.
