### PR TITLE
Valgrind fixes

### DIFF
--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -172,7 +172,8 @@ NIFFile::ptr NIFFile::create (const std::string &name) { return LoadedCache::cre
 
 /// Open a NIF stream. The name is used for error messages.
 NIFFile::NIFFile(const std::string &name, psudo_private_modifier)
-    : filename(name)
+    : ver(0)
+    , filename(name)
 {
     parse();
 }

--- a/components/nif/niffile.hpp
+++ b/components/nif/niffile.hpp
@@ -161,6 +161,8 @@ struct KeyListT {
     unsigned int mInterpolationType;
     VecType mKeys;
 
+    KeyListT() : mInterpolationType(sLinearInterpolation) {}
+
     //Read in a KeyGroup (see http://niftools.sourceforge.net/doc/nif/NiKeyframeData.html)
     void read(NIFStream *nif, bool force=false)
     {


### PR DESCRIPTION
Valgrind: Added constructor for KeyListT class, and added initialization of ver member field in NIFFile class.
