### PR TITLE
OpenGL framebuffer function dependency check

### DIFF
--- a/extern/sdl4ogre/sdlwindowhelper.cpp
+++ b/extern/sdl4ogre/sdlwindowhelper.cpp
@@ -4,7 +4,7 @@
 #include <OgreRoot.h>
 #include <OgreTextureManager.h>
 
-#include <GL/GL.h>
+#include <GL/gl.h>
 #include <OgreBuildSettings.h> /* OGRE_NO_GL_STATE_CACHE_SUPPORT */
 
 #include <SDL_syswm.h>
@@ -190,7 +190,7 @@ bool checkMinGLVersion(std::ostream& error)
         Ogre::String tmpStr = (const char*)pcVer;
         std::cout << "OpenGL GL_VERSION: " + tmpStr << std::endl;
 
-        error << "OpenGL: Missing required functions for Ogre 1.9:";
+        error << "OpenGL: Missing required functions for Ogre-1.9:";
         if (!glBindFramebufferPtr)
             error << " glBindFramebuffer";
         if (!glBindRenderbufferPtr)


### PR DESCRIPTION
EDIT: updated comments below, no longer checking OpenGL version.
## 

Checking for OpenGL minimum version is not a necessity, but the code was already written so rather than let it rot may as well submit.  Laptops with Nvidia switchable graphics often have old OpenGL versions especially when using the chipset graphics (e.g. 2.1.0 with chipset vs. 3.0.0 with 9300M GS discrete on my laptop)

Linux and MacOS not tested due to lack of build/test environments (will need an old machine with OpenGL version less than 3.0 to test properly).
