### PR TITLE
Minor change to improve generated STL code (only tested with MSVC 2012)....

### DIFF
--- a/extern/shiny/Main/Factory.cpp
+++ b/extern/shiny/Main/Factory.cpp
@@ -267,10 +267,11 @@ namespace sh
 
 	MaterialInstance* Factory::searchInstance (const std::string& name)
 	{
-		if (mMaterials.find(name) != mMaterials.end())
-				return &mMaterials.find(name)->second;
-
-		return NULL;
+		MaterialMap::iterator it = mMaterials.find(name);
+		if (it != mMaterials.end())
+			return &(it->second);
+                else
+			return NULL;
 	}
 
 	MaterialInstance* Factory::findInstance (const std::string& name)
@@ -434,8 +435,9 @@ namespace sh
 
 	std::string Factory::retrieveTextureAlias (const std::string& name)
 	{
-		if (mTextureAliases.find(name) != mTextureAliases.end())
-			return mTextureAliases[name];
+		TextureAliasMap::iterator it = mTextureAliases.find(name);
+		if (it != mTextureAliases.end())
+			return it->second;
 		else
 			return "";
 	}


### PR DESCRIPTION
...  More details in old forum post https://forum.openmw.org/viewtopic.php?f=6&t=2153#p24065 (generated assembler code included for comparison.

Below changes were tested once more with a Release build (/O2 /Ob2 optimization) using MSVC 2013 (using the suggestions here: http://msdn.microsoft.com/en-us/library/fsk896zz.aspx) to confirm the reduction in an STL call in the disassembled code.

There may be no improvements on linux systems - gcc may be smarter than MSVC with these constructs - don't know since untested.
