### PR TITLE
Clear selected spell when window manager is cleared

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1529,6 +1529,8 @@ namespace MWGui
         mCompanionWindow->resetReference();
         mConsole->resetReference();
 
+        mSelectedSpell.clear();
+
         mGuiModes.clear();
         MWBase::Environment::get().getInputManager()->changeInputMode(false);
         updateVisible();


### PR DESCRIPTION
The selected spell wasn't cleared properly and would continue to be selected after loading a save that had none selected. This caused severe problems with custom-made spells.
