### PR TITLE
Implement fatigue restoration to match Morrowind.

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -326,11 +326,9 @@ namespace MWMechanics
         // restore fatigue
         float fFatigueReturnBase = settings.find("fFatigueReturnBase")->getFloat ();
         float fFatigueReturnMult = settings.find("fFatigueReturnMult")->getFloat ();
-        float fEndFatigueMult = settings.find("fEndFatigueMult")->getFloat ();
 
-        float x = fFatigueReturnBase + fFatigueReturnMult * (1 - normalizedEncumbrance);
-        x *= fEndFatigueMult * endurance;
-
+        float x = fFatigueReturnBase + fFatigueReturnMult * endurance;
+        
         DynamicStat<float> fatigue = stats.getFatigue();
         fatigue.setCurrent (fatigue.getCurrent() + duration * x);
         stats.setFatigue (fatigue);


### PR DESCRIPTION
Fatigue restoration doesn't depend on encuberance or EndFatigueMult.

Fix for Bug #1673.
