### PR TITLE
Include revision number in the "version" command line option (Closes #1711)

### DIFF
--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -184,6 +184,14 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     if (variables.count ("version"))
     {
         std::cout << "OpenMW version " << OPENMW_VERSION << std::endl;
+
+        std::string rev = OPENMW_VERSION_COMMITHASH;
+        std::string tag = OPENMW_VERSION_TAGHASH;
+        if (!rev.empty() && !tag.empty())
+        {
+            rev = rev.substr(0, 10);
+            std::cout << "Revision " << rev << std::endl;
+        }
         run = false;
     }
 


### PR DESCRIPTION
I blatantly copied this from the main menu.
