### PR TITLE
Remove defunct option for building without FFmpeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,6 @@ option(BUILD_OPENCS "build OpenMW Construction Set" ON)
 option(BUILD_WITH_CODE_COVERAGE "Enable code coverage with gconv" OFF)
 option(BUILD_UNITTESTS "Enable Unittests with Google C++ Unittest ang GMock frameworks" OFF)
 
-# Sound source selection
-option(USE_FFMPEG "use ffmpeg for sound" ON)
-
 # OS X deployment
 option(OPENMW_OSX_DEPLOYMENT OFF)
 
@@ -138,32 +135,10 @@ set(OPENMW_LIBS ${OENGINE_ALL})
 set(OPENMW_LIBS_HEADER)
 
 # Sound setup
-set(GOT_SOUND_INPUT 0)
-set(SOUND_INPUT_INCLUDES "")
-set(SOUND_INPUT_LIBRARY "")
-set(SOUND_DEFINE "")
-if (USE_FFMPEG)
-    set(FFmpeg_FIND_COMPONENTS AVCODEC AVFORMAT AVUTIL SWSCALE)
-    find_package(FFmpeg)
-    if (FFMPEG_FOUND)
-        set(SOUND_INPUT_INCLUDES ${SOUND_INPUT_INCLUDES} ${FFMPEG_INCLUDE_DIRS})
-        set(SOUND_INPUT_LIBRARY ${SOUND_INPUT_LIBRARY} ${FFMPEG_LIBRARIES} ${SWSCALE_LIBRARIES})
-        set(SOUND_DEFINE ${SOUND_DEFINE} -DOPENMW_USE_FFMPEG)
-        set(GOT_SOUND_INPUT 1)
-    endif (FFMPEG_FOUND)
-endif (USE_FFMPEG)
-
-if (NOT GOT_SOUND_INPUT)
-    message(WARNING "--------------------")
-    message(WARNING "Failed to find any sound input packages")
-    message(WARNING "--------------------")
-endif (NOT GOT_SOUND_INPUT)
-
-if (NOT FFMPEG_FOUND)
-    message(WARNING "--------------------")
-    message(WARNING "FFmpeg not found, video playback will be disabled")
-    message(WARNING "--------------------")
-endif (NOT FFMPEG_FOUND)
+set(FFmpeg_FIND_COMPONENTS AVCODEC AVFORMAT AVUTIL SWSCALE)
+find_package(FFmpeg REQUIRED)
+set(SOUND_INPUT_INCLUDES ${FFMPEG_INCLUDE_DIRS})
+set(SOUND_INPUT_LIBRARY ${FFMPEG_LIBRARIES} ${SWSCALE_LIBRARIES})
 
 # TinyXML
 option(USE_SYSTEM_TINYXML "Use system TinyXML library instead of internal." OFF)

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -99,7 +99,6 @@ add_executable(openmw
 # Sound stuff - here so CMake doesn't stupidly recompile EVERYTHING
 # when we change the backend.
 include_directories(${SOUND_INPUT_INCLUDES} ${BULLET_INCLUDE_DIRS})
-add_definitions(${SOUND_DEFINE})
 
 target_link_libraries(openmw
     ${OGRE_LIBRARIES}

--- a/apps/openmw/mwrender/videoplayer.cpp
+++ b/apps/openmw/mwrender/videoplayer.cpp
@@ -26,8 +26,6 @@ typedef SSIZE_T ssize_t;
 namespace MWRender
 {
 
-#ifdef OPENMW_USE_FFMPEG
-
 extern "C"
 {
     #include <libavcodec/avcodec.h>
@@ -1072,27 +1070,6 @@ void VideoState::deinit()
         avformat_close_input(&this->format_ctx);
     }
 }
-
-#else // defined OPENMW_USE_FFMPEG
-
-class VideoState
-{
-public:
-    VideoState() { }
-
-    void init(const std::string& resourceName)
-    {
-        throw std::runtime_error("FFmpeg not supported, cannot play \""+resourceName+"\"");
-    }
-    void deinit() { }
-
-    void close() { }
-
-    bool update()
-    { return false; }
-};
-
-#endif // defined OPENMW_USE_FFMPEG
 
 
 VideoPlayer::VideoPlayer()

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -1,6 +1,3 @@
-#ifdef OPENMW_USE_FFMPEG
-
-
 #include "ffmpeg_decoder.hpp"
 
 // auto_ptr
@@ -375,5 +372,3 @@ FFmpeg_Decoder::~FFmpeg_Decoder()
 }
 
 }
-
-#endif

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -17,14 +17,9 @@
 
 #include "openal_output.hpp"
 #define SOUND_OUT "OpenAL"
-/* Set up the sound manager to use FFMPEG for input.
- * The OPENMW_USE_x macros are set in CMakeLists.txt.
-*/
-#ifdef OPENMW_USE_FFMPEG
 #include "ffmpeg_decoder.hpp"
 #ifndef SOUND_IN
 #define SOUND_IN "FFmpeg"
-#endif
 #endif
 
 


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/1716
- Added REQUIRED to find_package(FFmpeg)
- Removed USE_FFMPEG option from CMakeLists.txt
- Always use FFmpeg for sound input
- Removed SOUND_DEFINE from CMakeLists.txt
- Removed #else branch from videoplayer.cpp with dummy VideoState code
  (FFmpeg is now guaranteed to exist and the code was incomplete)
- Remove #ifdef OPENMW_USE_FFMPEG in ffmpeg_decoder.cpp, it is guaranteed to be used
- Remove #ifdef OPENMW_USE_FFMPEG from soundmanagerimp.cpp, it is guaranteed to be used
