### PR TITLE
Fix http://bugs.openmw.org/issues/768

### DIFF
--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -16,13 +16,19 @@ namespace Files
 
 static const char* const openmwCfgFile = "openmw.cfg";
 
+#if defined(_WIN32) || defined(__WINDOWS__)
+static const char* const applicationName = "OpenMW";
+#else
+static const char* const applicationName = "openmw";
+#endif
+
 const char* const mwToken = "?mw?";
 const char* const localToken = "?local?";
 const char* const userDataToken = "?userdata?";
 const char* const globalToken = "?global?";
 
 ConfigurationManager::ConfigurationManager()
-    : mFixedPath("openmw")
+    : mFixedPath(applicationName)
 {
     setupTokensMapping();
 


### PR DESCRIPTION
Changes application_name in configuration manager to OpenMW instead of openmw, if on windows. This shouldn't break anything since Windows uses case-insensitive filesystems. Strictly speaking the installation directory must be OpenMW now though (not sure whether this is the case).
