### PR TITLE
Spell creation: do not add skill/attribute effects before selecting the skill or attribute

### DIFF
--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -524,16 +524,24 @@ namespace MWGui
 
     void EffectEditorBase::onSelectAttribute ()
     {
-        mAddEffectDialog.setVisible(true);
+        const ESM::MagicEffect* effect =
+            MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(mSelectedKnownEffectId);
+
+        mAddEffectDialog.newEffect(effect);
         mAddEffectDialog.setAttribute (mSelectAttributeDialog->getAttributeId());
+        mAddEffectDialog.setVisible(true);
         MWBase::Environment::get().getWindowManager ()->removeDialog (mSelectAttributeDialog);
         mSelectAttributeDialog = 0;
     }
 
     void EffectEditorBase::onSelectSkill ()
     {
+        const ESM::MagicEffect* effect =
+            MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(mSelectedKnownEffectId);
+
+        mAddEffectDialog.newEffect(effect);
+        mAddEffectDialog.setSkill (mSelectSkillDialog->getSkillId());
         mAddEffectDialog.setVisible(true);
-        mAddEffectDialog.setSkill (mSelectSkillDialog->getSkillId ());
         MWBase::Environment::get().getWindowManager ()->removeDialog (mSelectSkillDialog);
         mSelectSkillDialog = 0;
     }
@@ -558,11 +566,10 @@ namespace MWGui
         }
 
         int buttonId = *sender->getUserData<int>();
-        short effectId = mButtonMapping[buttonId];
-
+        mSelectedKnownEffectId = mButtonMapping[buttonId];
         for (std::vector<ESM::ENAMstruct>::const_iterator it = mEffects.begin(); it != mEffects.end(); ++it)
         {
-            if (it->mEffectID == effectId)
+            if (it->mEffectID == mSelectedKnownEffectId)
             {
                 MWBase::Environment::get().getWindowManager()->messageBox ("#{sOnetypeEffectMessage}");
                 return;
@@ -570,9 +577,7 @@ namespace MWGui
         }
 
         const ESM::MagicEffect* effect =
-            MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectId);
-
-        mAddEffectDialog.newEffect (effect);
+            MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(mSelectedKnownEffectId);
 
         if (effect->mData.mFlags & ESM::MagicEffect::TargetSkill)
         {
@@ -592,6 +597,7 @@ namespace MWGui
         }
         else
         {
+            mAddEffectDialog.newEffect(effect);
             mAddEffectDialog.setVisible(true);
         }
     }

--- a/apps/openmw/mwgui/spellcreationdialog.hpp
+++ b/apps/openmw/mwgui/spellcreationdialog.hpp
@@ -99,6 +99,7 @@ namespace MWGui
         SelectSkillDialog* mSelectSkillDialog;
 
         int mSelectedEffect;
+        short mSelectedKnownEffectId;
 
         std::vector<ESM::ENAMstruct> mEffects;
 


### PR DESCRIPTION
As of now, skill/attribute effects are applied as soon as you click the Fortify/Drain/Damage Skill/Attribute effect button, before you even select the spell or attribute. By canceling the selection dialog, you could end up with an odd unfinished effect like "Fortify Skill 1pt".
