### PR TITLE
Change player draw state when quick-selecting weapon or spell.

### DIFF
--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -301,7 +301,7 @@ namespace MWGui
             MWWorld::Ptr item = *button->getUserData<MWWorld::Ptr>();
             MWBase::Environment::get().getWindowManager()->getInventoryWindow()->useItem(item);
             MWWorld::ContainerStoreIterator rightHand = store.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-            // draw weapon only if the item *is* a weapon
+            // change draw state only if the item is in player's right hand
             if (rightHand != store.end() && item == *rightHand)
             {
                 MWBase::Environment::get().getWorld()->getPlayer().setDrawState(MWMechanics::DrawState_Weapon);


### PR DESCRIPTION
Behavior is mostly similar to vanilla Morrowind - the only difference is that in vanilla Morrowind, quick selecting between weapons while one is already out would not play an animation, but would just instantly change the weapon model in the player's hand. Here, the weapon draw animation is played if a quick-selected weapon is different from the one in the player's hand.
