### PR TITLE
For compiling in Windows with MSVC.

### DIFF
--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -39,7 +39,7 @@ struct RecordFactoryEntry {
 static std::pair<std::string,RecordFactoryEntry> makeEntry(std::string recName, Record* (*create_t) (), RecordType type)
 {
     RecordFactoryEntry anEntry = {create_t,type};
-    return std::make_pair<std::string,RecordFactoryEntry>(recName, anEntry);
+    return std::make_pair(recName, anEntry);
 }
 
 ///These are all the record types we know how to read.


### PR DESCRIPTION
Not tested with gcc, but should be ok.

EDIT: noticed that Ace's build with msvc-10 doesn't seem to have any compile issue, so maybe only msvc-11 and msvc-12 are affected?  Let me know if I should put #ifdef guards around the change.
