### PR TITLE
Compile fixes for Linux

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -21,6 +21,8 @@
 #include "spellcasting.hpp"
 #include "autocalcspell.hpp"
 
+#include <limits.h>
+
 namespace
 {
     /// @return is \a ptr allowed to take/use \a item or is it a crime?

--- a/extern/sdl4ogre/sdlwindowhelper.cpp
+++ b/extern/sdl4ogre/sdlwindowhelper.cpp
@@ -6,6 +6,7 @@
 
 #include <SDL_syswm.h>
 #include <SDL_endian.h>
+#include <stdexcept>
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
 #include "osx_utils.h"

--- a/libs/openengine/bullet/physic.hpp
+++ b/libs/openengine/bullet/physic.hpp
@@ -8,8 +8,7 @@
 #include <map>
 #include "BulletShapeLoader.h"
 #include "BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h"
-
-
+#include <boost/shared_ptr.hpp>
 
 class btRigidBody;
 class btBroadphaseInterface;


### PR DESCRIPTION
Hi,

 Trying to compile openwm under linux, I had to fix a few compilation errors.
Relevant system informations: Gentoo Linux
gcc (Gentoo 4.7.3-r1 p1.4, pie-0.5.5)
boost 1.52

I hope these fixes are compatible with other architectures.

I heard about openmw yesterday, I could not wait to try it on my box (despite the compile errors...). What you have done is impressive! (it reminds me of all the lost nights playing that game :) )
