### PR TITLE
Made the Region field for Cell record in dialogue subview editable

### DIFF
--- a/apps/opencs/model/world/tablemimedata.cpp
+++ b/apps/opencs/model/world/tablemimedata.cpp
@@ -222,7 +222,6 @@ namespace
         { CSMWorld::UniversalId::Type_Race, CSMWorld::ColumnBase::Display_Race },
         { CSMWorld::UniversalId::Type_Skill, CSMWorld::ColumnBase::Display_Skill },
         { CSMWorld::UniversalId::Type_Class, CSMWorld::ColumnBase::Display_Class },
-        { CSMWorld::UniversalId::Type_Class, CSMWorld::ColumnBase::Display_Class },
         { CSMWorld::UniversalId::Type_Faction, CSMWorld::ColumnBase::Display_Faction },
         { CSMWorld::UniversalId::Type_Sound, CSMWorld::ColumnBase::Display_Sound },
         { CSMWorld::UniversalId::Type_Region, CSMWorld::ColumnBase::Display_Region },

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -173,6 +173,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_Skill:
         case CSMWorld::ColumnBase::Display_Script:
         case CSMWorld::ColumnBase::Display_Race:
+        case CSMWorld::ColumnBase::Display_Region:
         case CSMWorld::ColumnBase::Display_Class:
         case CSMWorld::ColumnBase::Display_Faction:
         case CSMWorld::ColumnBase::Display_Miscellaneous:


### PR DESCRIPTION
 but not sure if this is the wanted behaviour, i.e. should it be QLineEdit or QTextEdit instead? (though they don't allow edits either it seems)  On the plus side, Region drag&drop works!

Also removed a duplicate UniversalId::Type_Class mapping in tablemimedata.cpp.
