### PR TITLE
For bug #1710.  Change the ID type of mime data for filterbox drop event...

### DIFF
--- a/apps/opencs/model/world/tablemimedata.cpp
+++ b/apps/opencs/model/world/tablemimedata.cpp
@@ -68,26 +68,6 @@ std::vector< CSMWorld::UniversalId > CSMWorld::TableMimeData::getData() const
     return mUniversalId;
 }
 
-std::vector< CSMWorld::UniversalId > CSMWorld::TableMimeData::getRefTypeData() const
-{
-    std::vector<CSMWorld::UniversalId> ref_data;
-
-    std::vector<CSMWorld::UniversalId>::const_iterator it = mUniversalId.begin();
-    for(; it != mUniversalId.end(); ++it)
-    {
-        if(isReferencable(it->getType()))
-        {
-            // change the type
-            ref_data.push_back(CSMWorld::UniversalId(
-                        CSMWorld::UniversalId::Type_Referenceable, it->getId()));
-        }
-        else
-            ref_data.push_back(*it);
-    }
-
-    return ref_data;
-}
-
 bool CSMWorld::TableMimeData::isReferencable(CSMWorld::ColumnBase::Display type) const
 {
 return (  type == CSMWorld::ColumnBase::Display_Activator
@@ -111,7 +91,7 @@ return (  type == CSMWorld::ColumnBase::Display_Activator
        || type == CSMWorld::ColumnBase::Display_Static
        || type == CSMWorld::ColumnBase::Display_Weapon);
 }
-bool CSMWorld::TableMimeData::isReferencable(CSMWorld::UniversalId::Type type) const
+bool CSMWorld::TableMimeData::isReferencable(CSMWorld::UniversalId::Type type)
 {
      return (  type == CSMWorld::UniversalId::Type_Activator
             || type == CSMWorld::UniversalId::Type_Potion

--- a/apps/opencs/model/world/tablemimedata.hpp
+++ b/apps/opencs/model/world/tablemimedata.hpp
@@ -43,9 +43,6 @@ namespace CSMWorld
 
             std::vector<UniversalId> getData() const;
 
-            // change Id type to Type_Referenceable where possible
-            std::vector<UniversalId> getRefTypeData() const;
-
             bool holdsType(UniversalId::Type type) const;
 
             bool holdsType(CSMWorld::ColumnBase::Display type) const;
@@ -62,8 +59,8 @@ namespace CSMWorld
 
             static CSMWorld::ColumnBase::Display convertEnums(CSMWorld::UniversalId::Type type);
 
+            static bool isReferencable(CSMWorld::UniversalId::Type type);
         private:
-            bool isReferencable(CSMWorld::UniversalId::Type type) const;
             bool isReferencable(CSMWorld::ColumnBase::Display type) const;
 
     };

--- a/apps/opencs/view/filter/filterbox.cpp
+++ b/apps/opencs/view/filter/filterbox.cpp
@@ -39,7 +39,7 @@ void CSVFilter::FilterBox::dropEvent (QDropEvent* event)
     if (!mime) // May happen when non-records (e.g. plain text) are dragged and dropped
         return;
 
-    std::vector<CSMWorld::UniversalId> data = mime->getRefTypeData();
+    std::vector<CSMWorld::UniversalId> data = mime->getData();
 
     emit recordDropped(data, event->proposedAction());
 }

--- a/apps/opencs/view/world/tablesubview.cpp
+++ b/apps/opencs/view/world/tablesubview.cpp
@@ -111,14 +111,21 @@ void CSVWorld::TableSubView::createFilterRequest (std::vector< CSMWorld::Univers
 {
     std::vector<std::pair<std::string, std::vector<std::string> > > filterSource;
 
+    std::vector<std::string> refIdColumns = mTable->getColumnsWithDisplay(CSMWorld::TableMimeData::convertEnums(CSMWorld::UniversalId::Type_Referenceable));
+    bool hasRefIdDisplay = !refIdColumns.empty();
+
     for (std::vector<CSMWorld::UniversalId>::iterator it(types.begin()); it != types.end(); ++it)
     {
-        std::pair<std::string, std::vector<std::string> > pair(                         //splited long line
-            std::make_pair(it->getId(), mTable->getColumnsWithDisplay(CSMWorld::TableMimeData::convertEnums(it->getType()))));
-
-        if(!pair.second.empty())
+        CSMWorld::UniversalId::Type type = it->getType();
+        std::vector<std::string> col = mTable->getColumnsWithDisplay(CSMWorld::TableMimeData::convertEnums(type));
+        if(!col.empty())
         {
-            filterSource.push_back(pair);
+            filterSource.push_back(std::make_pair(it->getId(), col));
+        }
+
+        if(hasRefIdDisplay && CSMWorld::TableMimeData::isReferencable(type))
+        {
+            filterSource.push_back(std::make_pair(it->getId(), refIdColumns));
         }
     }
 


### PR DESCRIPTION
...s to Referenceable rather than using the ID's native type.

This PR does what was described in the bug report, but should be reviewed for two things:
1. Is this (i.e. change the id type to referenceable) what is wanted in all cases of drag&drop to a filterbox?
2. Is the fix in the correct class/place?
