### PR TITLE
Global Map Arrow Orientation

### DIFF
--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -754,10 +754,6 @@ namespace MWGui
 
     void MapWindow::globalMapUpdatePlayer ()
     {
-        Ogre::Quaternion orient = MWBase::Environment::get().getWorld ()->getPlayerPtr().getRefData ().getBaseNode ()->_getDerivedOrientation ();
-        Ogre::Vector2 dir (orient.yAxis ().x, orient.yAxis().y);
-        float globalPlayerArrowAngle = std::atan2(dir.x, dir.y);
-
         // For interiors, position is set by WindowManager via setGlobalMapPlayerPosition
         if (MWBase::Environment::get().getWorld ()->isCellExterior ())
         {
@@ -775,14 +771,6 @@ namespace MWGui
             MyGUI::IntPoint viewoffs(0.5*viewsize.width - worldX, 0.5*viewsize.height - worldY);
             mGlobalMap->setViewOffset(viewoffs);
         }
-        else
-            globalPlayerArrowAngle -= M_PI/2; // If we're indoors, apparently the angle is +90 degrees off.
-
-        // Always rotate the global map compass
-        MyGUI::ISubWidget* main = mPlayerArrowGlobal->getSubWidgetMain();
-        MyGUI::RotatingSkin* rotatingSubskin = main->castType<MyGUI::RotatingSkin>();
-        rotatingSubskin->setCenter(MyGUI::IntPoint(16,16));
-        rotatingSubskin->setAngle(globalPlayerArrowAngle);
     }
 
     void MapWindow::notifyPlayerUpdate ()
@@ -803,6 +791,15 @@ namespace MWGui
         MyGUI::IntSize viewsize = mGlobalMap->getSize();
         MyGUI::IntPoint viewoffs(0.5*viewsize.width - x, 0.5*viewsize.height - y);
         mGlobalMap->setViewOffset(viewoffs);
+    }
+
+    void MapWindow::setGlobalMapPlayerDir(const float x, const float y)
+    {
+        MyGUI::ISubWidget* main = mPlayerArrowGlobal->getSubWidgetMain();
+        MyGUI::RotatingSkin* rotatingSubskin = main->castType<MyGUI::RotatingSkin>();
+        rotatingSubskin->setCenter(MyGUI::IntPoint(16,16));
+        float angle = std::atan2(x,y);
+        rotatingSubskin->setAngle(angle);
     }
 
     void MapWindow::clear()

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -180,6 +180,7 @@ namespace MWGui
         void cellExplored(int x, int y);
 
         void setGlobalMapPlayerPosition (float worldX, float worldY);
+        void setGlobalMapPlayerDir(const float x, const float y);
 
         virtual void open();
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -909,6 +909,7 @@ namespace MWGui
     void WindowManager::setPlayerDir(const float x, const float y)
     {
         mMap->setPlayerDir(x,y);
+        mMap->setGlobalMapPlayerDir(x, y);
         mHud->setPlayerDir(x,y);
     }
 


### PR DESCRIPTION
Resolving https://bugs.openmw.org/issues/1912

Though I noticed, why did I have to add the -90 degrees correction when you're indoors?
