### PR TITLE
Added Dawid Łakomy (Vedyimyn) as a new Polish news writer/translator

### DIFF
--- a/credits.txt
+++ b/credits.txt
@@ -105,12 +105,13 @@ Kenny Armstrong (artorius) - Fedora Linux
 Nikolay Kasyanov (corristo) - Mac OS X
 Sandy Carter (bwrsandman) - Arch Linux
 
-
 Public Relations and Translations:
 Alex McKibben (WeirdSexy) - Podcaster
 Artem Kotsynyak (greye) - Russian News Writer
 Jim Clauwaert (Zedd) - Public Outreach
 Julien Voisin (jvoisin/ap0) - French News Writer
+Okulo - English News Writer
+Nekochan - English News Writer
 Lukasz Gromanowski (lgro) - English News Writer
 Mickey Lyle (raevol) - Release Manager
 Pithorn - Chinese News Writer
@@ -122,7 +123,6 @@ Lukasz Gromanowski (Lgro) - Website Administrator
 Ryan Sardonic (Wry) - Wiki Editor
 sir_herrbatka - Forum Administrator
 
-
 Formula Research:
 Hrnchamd
 Epsilon
@@ -133,7 +133,6 @@ modred11
 Myckel
 natirips
 Sadler
-
 
 Artwork:
 Necrod - OpenMW Logo


### PR DESCRIPTION
Added Dawid Łakomy (Vedyimyn) as a new Polish news writer/translator

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
