### PR TITLE
Fix for compiler warnings and deprecated functions usage in videoplayer.

### DIFF
--- a/apps/openmw/mwrender/videoplayer.cpp
+++ b/apps/openmw/mwrender/videoplayer.cpp
@@ -983,9 +983,9 @@ int VideoState::stream_open(int stream_index, AVFormatContext *pFormatCtx)
     // Get a pointer to the codec context for the video stream
     codecCtx = pFormatCtx->streams[stream_index]->codec;
     codec = avcodec_find_decoder(codecCtx->codec_id);
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56,1,0)
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56,1,0)
     codecCtx->refcounted_frames = 1;
-#endif /* LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56,1,0) */
+#endif /* LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56,1,0) */
     if(!codec || (avcodec_open2(codecCtx, codec, NULL) < 0))
     {
         fprintf(stderr, "Unsupported codec!\n");


### PR DESCRIPTION
Fix for compiler warnings and deprecated functions usage in videoplayer.

Deprecated functions were:
- AVCodecContext::get_buffer
- AVCodecContext::release_buffer

Changed to:
AVCodecContext::get_buffer2 and setting AVCodecContext::refcounted_frames to 1
before call to avcodec_open2(), and release_buffer usage was removed.

Also changed places when some fileds were compared to AV_NOPTS_VALUE
- it's signed, so removed unsigned int casting, or changed casting
  to signed int.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
