### PR TITLE
Bug no 1750

### DIFF
--- a/apps/opencs/model/world/collection.hpp
+++ b/apps/opencs/model/world/collection.hpp
@@ -7,7 +7,6 @@
 #include <cctype>
 #include <stdexcept>
 #include <functional>
-#include <iostream>
 
 #include <QVariant>
 
@@ -432,27 +431,18 @@ namespace CSMWorld
 
         const Record<ESXRecordT>& record2 = dynamic_cast<const Record<ESXRecordT>&> (record);
 
-        std::pair<std::map<std::string, int>::iterator, bool> insertResult =
-            mIndex.insert (std::make_pair (Misc::StringUtils::lowerCase (IdAccessorT().getId (record2.get())),
-                                           index));
+        mRecords.insert (mRecords.begin()+index, record2);
 
-        if(!insertResult.second) // duplicate index found, replace the current record
-        {
-            std::cerr << "Duplicate record found, using new: " + IdAccessorT().getId(record2.get()) << std::endl;
-            replace(insertResult.first->second, record2);
-            return;
-        }
-
-        // else update the index except for the record to be inserted
         if (index<static_cast<int> (mRecords.size())-1)
         {
-            std::string id = IdAccessorT().getId(record2.get());
-            for (std::map<std::string, int>::iterator iter (mIndex.begin()); iter!=mIndex.end(); ++iter)
-                 if (iter->second > index || (iter->second == index && iter->first != id))
+            for (std::map<std::string, int>::iterator iter (mIndex.begin()); iter!=mIndex.end();
+                ++iter)
+                 if (iter->second>=index)
                      ++(iter->second);
         }
 
-        mRecords.insert (mRecords.begin()+index, record2);
+        mIndex.insert (std::make_pair (Misc::StringUtils::lowerCase (IdAccessorT().getId (
+            record2.get())), index));
     }
 
     template<typename ESXRecordT, typename IdAccessorT>


### PR DESCRIPTION
Second attempt.

Sometimes getHNOString ("NAME") returns an empty string.  The id checks don't really work after that. One workaround is to check the id after the record is loaded.

Not sure if additional base or modified check needs to be made.  Don't really understand that part.
