### PR TITLE
Added two make targets for Doxygen: "make doc" and "make doc_pages"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,17 +837,25 @@ if (APPLE)
 endif (APPLE)
 
 # Doxygen Target -- simply run 'make doc' or 'make doc_pages'
+# output directory for 'make doc'       is "${OpenMW_BINARY_DIR}/docs/Doxygen"
+# output directory for 'make doc_pages' is "${DOXYGEN_PAGES_OUTPUT_DIR}" if defined
+#                                       or "${OpenMW_BINARY_DIR}/docs/Pages" otherwise
 find_package(Doxygen)
-if(DOXYGEN_FOUND)
-    configure_file(${OpenMW_SOURCE_DIR}/docs/Doxyfile.in ${OpenMW_BINARY_DIR}/docs/Doxyfile @ONLY)
-    configure_file(${OpenMW_SOURCE_DIR}/docs/DoxyfilePages.in ${OpenMW_BINARY_DIR}/docs/DoxyfilePages @ONLY)
+if (DOXYGEN_FOUND)
+    # determine output directory for doc_pages
+    if (NOT DEFINED DOXYGEN_PAGES_OUTPUT_DIR)
+        set(DOXYGEN_PAGES_OUTPUT_DIR "${OpenMW_BINARY_DIR}/docs/Pages")
+    endif ()
+    configure_file(${OpenMW_SOURCE_DIR}/docs/Doxyfile.cmake ${OpenMW_BINARY_DIR}/docs/Doxyfile @ONLY)
+    configure_file(${OpenMW_SOURCE_DIR}/docs/DoxyfilePages.cmake ${OpenMW_BINARY_DIR}/docs/DoxyfilePages @ONLY)
     add_custom_target(doc
         ${DOXYGEN_EXECUTABLE} ${OpenMW_BINARY_DIR}/docs/Doxyfile
         WORKING_DIRECTORY ${OpenMW_BINARY_DIR}
-        COMMENT "Generating API documentation with Doxygen (from Doxyfile)" VERBATIM)
+        COMMENT "Generating Doxygen documentation at ${OpenMW_BINARY_DIR}/docs/Doxygen"
+        VERBATIM)
     add_custom_target(doc_pages
         ${DOXYGEN_EXECUTABLE} ${OpenMW_BINARY_DIR}/docs/DoxyfilePages
         WORKING_DIRECTORY ${OpenMW_BINARY_DIR}
-        COMMENT "Generating API documentation with Doxygen (from DoxyfilePages)" VERBATIM)
-endif(DOXYGEN_FOUND)
+        COMMENT "Generating documentation for the github-pages at ${DOXYGEN_PAGES_OUTPUT_DIR}" VERBATIM)
+endif ()
 

--- a/docs/Doxyfile.cmake
+++ b/docs/Doxyfile.cmake
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @OpenMW_SOURCE_DIR@/docs/Doxygen
+OUTPUT_DIRECTORY       = @OpenMW_BINARY_DIR@/docs/Doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -767,7 +767,7 @@ WARN_LOGFILE           =
 INPUT                  = @OpenMW_SOURCE_DIR@/apps \
                          @OpenMW_SOURCE_DIR@/components \
                          @OpenMW_SOURCE_DIR@/libs \
-                         @OpenMW_BINARY_DIR@/docs
+                         @OpenMW_BINARY_DIR@/docs/mainpage.hpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/DoxyfilePages.cmake
+++ b/docs/DoxyfilePages.cmake
@@ -38,7 +38,7 @@ PROJECT_NUMBER         =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @OpenMW_SOURCE_DIR@/doxygen
+OUTPUT_DIRECTORY       = @DOXYGEN_PAGES_OUTPUT_DIR@
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -576,7 +576,7 @@ WARN_LOGFILE           =
 INPUT                  = @OpenMW_SOURCE_DIR@/apps \
                          @OpenMW_SOURCE_DIR@/components \
                          @OpenMW_SOURCE_DIR@/libs \
-                         @OpenMW_BINARY_DIR@/docs
+                         @OpenMW_BINARY_DIR@/docs/mainpage.hpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is


### PR DESCRIPTION
My Motivations are the following:
- the online documentation is pretty outdated and i want to give every developer an easy tool to generate her own documentation
- "make doc" is more convenient than "doxygen ../docs/Doxyfile" - you don't need to use yet another tool
- improve consistency:  mainpage.hpp.cmake is now configured into the cmake binary directory (see line 63 of CMakeLists.txt)

**Attention:**
This patch will negatively affect backwards compatibility because Doxyfile is renamed to Doxyfile.in and DoxyfilePages is renamed to DoxyfilePages.in. Moreover, the location of mainpage.hpp has changed.
As a result "doxygen ../docs/Doxyfile" no longer works.
I can also provide a backwards compatible patch if required.
