### PR TITLE
Fix blindness and create a separate fader for it

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -335,8 +335,8 @@ namespace MWBase
             virtual void fadeScreenOut(const float time) = 0;
             /// Fade the screen to a specified percentage of black, over \a time seconds
             virtual void fadeScreenTo(const int percent, const float time) = 0;
-            /// Darken the screen by \a factor (1.0 = no darkening). Works independently from screen fading.
-            virtual void setScreenFactor (float factor) = 0;
+            /// Darken the screen to a specified percentage
+            virtual void setBlindness(const int percent) = 0;
 
             virtual void activateHitOverlay(bool interrupt=true) = 0;
             virtual void setWerewolfOverlay(bool set) = 0;

--- a/apps/openmw/mwgui/screenfader.cpp
+++ b/apps/openmw/mwgui/screenfader.cpp
@@ -98,12 +98,12 @@ namespace MWGui
 
     void ScreenFader::fadeIn(float time)
     {
-        queue(time, 0.f);
+        queue(time, 1.f);
     }
 
     void ScreenFader::fadeOut(const float time)
     {
-        queue(time, 1.f);
+        queue(time, 0.f);
     }
 
     void ScreenFader::fadeTo(const int percent, const float time)
@@ -114,6 +114,7 @@ namespace MWGui
     void ScreenFader::setFactor(float factor)
     {
         mFactor = factor;
+        applyAlpha();
     }
 
     void ScreenFader::setRepeat(bool repeat)

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -120,8 +120,9 @@ namespace MWGui
       , mCompanionWindow(NULL)
       , mVideoBackground(NULL)
       , mVideoWidget(NULL)
-      , mHitFader(NULL)
       , mWerewolfFader(NULL)
+      , mBlindnessFader(NULL)
+      , mHitFader(NULL)
       , mScreenFader(NULL)
       , mDebugWindow(NULL)
       , mTranslationDataStorage (translationDataStorage)
@@ -273,6 +274,7 @@ namespace MWGui
         trackWindow(mCompanionWindow, "companion");
 
         mWerewolfFader = new ScreenFader("textures\\werewolfoverlay.dds");
+        mBlindnessFader = new ScreenFader("black.png");
         std::string hitFaderTexture = "textures\\bm_player_hit_01.dds";
         // fall back to player_hit_01.dds if bm_player_hit_01.dds is not available
         // TODO: check if non-BM versions actually use player_hit_01.dds
@@ -877,8 +879,9 @@ namespace MWGui
         mConsole->checkReferenceAvailable();
         mCompanionWindow->onFrame();
 
-        mHitFader->update(frameDuration);
         mWerewolfFader->update(frameDuration);
+        mBlindnessFader->update(frameDuration);
+        mHitFader->update(frameDuration);
         mScreenFader->update(frameDuration);
 
         mDebugWindow->onFrame(frameDuration);
@@ -1741,13 +1744,13 @@ namespace MWGui
     void WindowManager::fadeScreenIn(const float time)
     {
         mScreenFader->clearQueue();
-        mScreenFader->fadeIn(time);
+        mScreenFader->fadeOut(time);
     }
 
     void WindowManager::fadeScreenOut(const float time)
     {
         mScreenFader->clearQueue();
-        mScreenFader->fadeOut(time);
+        mScreenFader->fadeIn(time);
     }
 
     void WindowManager::fadeScreenTo(const int percent, const float time)
@@ -1756,9 +1759,9 @@ namespace MWGui
         mScreenFader->fadeTo(percent, time);
     }
 
-    void WindowManager::setScreenFactor(float factor)
+    void WindowManager::setBlindness(const int percent)
     {
-        mScreenFader->setFactor(factor);
+        mBlindnessFader->notifyAlphaChanged(percent / 100.f);
     }
 
     void WindowManager::activateHitOverlay(bool interrupt)

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -330,8 +330,8 @@ namespace MWGui
     virtual void fadeScreenOut(const float time);
     /// Fade the screen to a specified percentage of black, over \a time seconds
     virtual void fadeScreenTo(const int percent, const float time);
-    /// Darken the screen by \a factor (1.0 = no darkening). Works independently from screen fading.
-    virtual void setScreenFactor (float factor);
+    /// Darken the screen to a specified percentage
+    virtual void setBlindness(const int percent);
 
     virtual void activateHitOverlay(bool interrupt);
     virtual void setWerewolfOverlay(bool set);
@@ -391,6 +391,7 @@ namespace MWGui
     MyGUI::ImageBox* mVideoBackground;
     VideoWidget* mVideoWidget;
     ScreenFader* mWerewolfFader;
+    ScreenFader* mBlindnessFader;
     ScreenFader* mHitFader;
     ScreenFader* mScreenFader;
     DebugWindow* mDebugWindow;

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -347,7 +347,7 @@ void RenderingManager::update (float duration, bool paused)
     MWWorld::Ptr player = world->getPlayerPtr();
 
     int blind = player.getClass().getCreatureStats(player).getMagicEffects().get(ESM::MagicEffect::Blind).getMagnitude();
-    MWBase::Environment::get().getWindowManager()->setScreenFactor(std::max(0.f, 1.f-(blind / 100.f)));
+    MWBase::Environment::get().getWindowManager()->setBlindness(std::max(0, std::min(100, blind)));
     setAmbientMode();
 
     if (player.getClass().getNpcStats(player).isWerewolf())


### PR DESCRIPTION
A separate fader object is necessary because the hit fader should be rendered after the blindness fader, but before the transition fader.
