### PR TITLE
Fix LNK2019 link error on Visual Studio 2010 builds

### DIFF
--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -26,7 +26,7 @@ namespace MWMechanics
     class AiPackage;
     
     template< class Base > class DerivedClassStorage;
-    class AiTemporaryBase;
+    struct AiTemporaryBase;
     typedef DerivedClassStorage<AiTemporaryBase> AiState;
 
     /// \brief Sequence of AI-packages for a single actor


### PR DESCRIPTION
For some reason VS2010 (Haven't tested 2013) is REALLY pedantic about class/struct being two different things when it comes to function signatures
