### PR TITLE
Change content file selection behaviour

### DIFF
--- a/apps/opencs/view/doc/filedialog.cpp
+++ b/apps/opencs/view/doc/filedialog.cpp
@@ -125,13 +125,17 @@ void CSVDoc::FileDialog::buildOpenFileView()
 
     if(!mDialogBuilt)
     {
-        connect (mSelector, SIGNAL (signalAddonFileSelected (int)), this, SLOT (slotUpdateAcceptButton (int)));
-        connect (mSelector, SIGNAL (signalAddonFileUnselected (int)), this, SLOT (slotUpdateAcceptButton (int)));
+        connect (mSelector, SIGNAL (signalAddonDataChanged (const QModelIndex&, const QModelIndex&)), this, SLOT (slotAddonDataChanged(const QModelIndex&, const QModelIndex&)));
     }
         connect (ui.projectButtonBox, SIGNAL (accepted()), this, SLOT (slotOpenFile()));
 }
 
-void CSVDoc::FileDialog::slotUpdateAcceptButton (int)
+void CSVDoc::FileDialog::slotAddonDataChanged(const QModelIndex &topleft, const QModelIndex &bottomright)
+{
+    slotUpdateAcceptButton(0);
+}
+
+void CSVDoc::FileDialog::slotUpdateAcceptButton(int)
 {
     QString name = "";
 

--- a/apps/opencs/view/doc/filedialog.hpp
+++ b/apps/opencs/view/doc/filedialog.hpp
@@ -70,6 +70,7 @@ namespace CSVDoc
         void slotUpdateAcceptButton (int);
         void slotUpdateAcceptButton (const QString &, bool);
         void slotRejected();
+        void slotAddonDataChanged(const QModelIndex& topleft, const QModelIndex& bottomright);
     };
 }
 #endif // FILEDIALOG_HPP

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -106,7 +106,7 @@ Qt::ItemFlags ContentSelectorModel::ContentModel::flags(const QModelIndex &index
 
     //game files can always be checked
     if (file->isGameFile())
-        return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+        return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
 
     Qt::ItemFlags returnFlags;
     bool allDependenciesFound = true;
@@ -145,7 +145,7 @@ Qt::ItemFlags ContentSelectorModel::ContentModel::flags(const QModelIndex &index
     if (gamefileChecked)
     {
         if (allDependenciesFound)
-            returnFlags = returnFlags | Qt::ItemIsEnabled | Qt::ItemIsSelectable | mDragDropFlags;
+            returnFlags = returnFlags | Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | mDragDropFlags;
         else
             returnFlags = Qt::ItemIsSelectable;
     }

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -58,7 +58,8 @@ void ContentSelectorView::ContentSelector::buildAddonView()
 
     ui.addonView->setModel(mAddonProxyModel);
 
-    connect(ui.addonView, SIGNAL(clicked(const QModelIndex &)), this, SLOT(slotAddonTableItemClicked(const QModelIndex &)));
+    connect(ui.addonView, SIGNAL(activated(const QModelIndex&)), this, SLOT(slotAddonTableItemActivated(const QModelIndex&)));
+    connect(mContentModel, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), this, SIGNAL(signalAddonDataChanged(QModelIndex,QModelIndex)));
 }
 
 void ContentSelectorView::ContentSelector::setProfileContent(const QStringList &fileList)
@@ -181,7 +182,7 @@ void ContentSelectorView::ContentSelector::slotCurrentGameFileIndexChanged(int i
     emit signalCurrentGamefileIndexChanged (index);
 }
 
-void ContentSelectorView::ContentSelector::slotAddonTableItemClicked(const QModelIndex &index)
+void ContentSelectorView::ContentSelector::slotAddonTableItemActivated(const QModelIndex &index)
 {
     QModelIndex sourceIndex = mAddonProxyModel->mapToSource (index);
 
@@ -194,10 +195,4 @@ void ContentSelectorView::ContentSelector::slotAddonTableItemClicked(const QMode
         checkState = Qt::Checked;
 
     mContentModel->setData(sourceIndex, checkState, Qt::CheckStateRole);
-
-    if (checkState == Qt::Checked)
-        emit signalAddonFileSelected (index.row());
-    else
-        emit signalAddonFileUnselected (index.row());
-
 }

--- a/components/contentselector/view/contentselector.hpp
+++ b/components/contentselector/view/contentselector.hpp
@@ -55,13 +55,13 @@ namespace ContentSelectorView
 
     signals:
         void signalCurrentGamefileIndexChanged (int);
-        void signalAddonFileSelected (int);
-        void signalAddonFileUnselected (int);
+
+        void signalAddonDataChanged (const QModelIndex& topleft, const QModelIndex& bottomright);
 
     private slots:
 
         void slotCurrentGameFileIndexChanged(int index);
-        void slotAddonTableItemClicked(const QModelIndex &index);
+        void slotAddonTableItemActivated(const QModelIndex& index);
     };
 }
 


### PR DESCRIPTION
Previously content files were toggled when clicked with the mouse. This is a problem since files are toggled when you only wanted to drag-and-drop them to change the load order.
Now they are toggled when activated (ie double-click or pressed Enter while selected), or when the checkbox next to them is clicked.