### PR TITLE
Increase stop/walk/run threshold for AI_follow (Fixes #2040)

### DIFF
--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -84,16 +84,16 @@ bool MWMechanics::AiFollow::execute (const MWWorld::Ptr& actor, AiState& state, 
     //Set the target destination from the actor
     ESM::Pathgrid::Point dest = target.getRefData().getPosition().pos;
 
-    if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2]) < 100) //Stop when you get close
+    if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2]) < 400) //Stop when you get close
         actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
     else {
         pathTo(actor, dest, duration); //Go to the destination
     }
 
     //Check if you're far away
-    if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2]) > 450)
+    if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2]) > 750)
         actor.getClass().getCreatureStats(actor).setMovementFlag(MWMechanics::CreatureStats::Flag_Run, true); //Make NPC run
-    else if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2])  < 325) //Have a bit of a dead zone, otherwise npc will constantly flip between running and not when right on the edge of the running threshhold
+    else if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2])  < 625) //Have a bit of a dead zone, otherwise npc will constantly flip between running and not when right on the edge of the running threshhold
         actor.getClass().getCreatureStats(actor).setMovementFlag(MWMechanics::CreatureStats::Flag_Run, false); //make NPC walk
 
     return false;


### PR DESCRIPTION
This is based on trial-and-error. 400 units is the lower bound where Almalexia's Hands stay put on their spaw points as they should.
