### PR TITLE
Set range of spinbox types in dialogsubview.

### DIFF
--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -2,6 +2,8 @@
 #include "util.hpp"
 
 #include <stdexcept>
+#include <climits>
+#include <cfloat>
 
 #include <QUndoStack>
 #include <QMetaProperty>
@@ -157,16 +159,22 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
             return new QLineEdit(parent);
 
         case CSMWorld::ColumnBase::Display_Integer:
-
-            return new QSpinBox(parent);
+        {
+            QSpinBox *sb = new QSpinBox(parent);
+            sb->setRange(INT_MIN, INT_MAX);
+            return sb;
+        }
 
         case CSMWorld::ColumnBase::Display_Var:
 
             return new QLineEdit(parent);
 
         case CSMWorld::ColumnBase::Display_Float:
-
-            return new QDoubleSpinBox(parent);
+        {
+            QDoubleSpinBox *dsb = new QDoubleSpinBox(parent);
+            dsb->setRange(FLT_MIN, FLT_MAX);
+            return dsb;
+        }
 
         case CSMWorld::ColumnBase::Display_LongString:
         {


### PR DESCRIPTION
Should fix #2161.  Currently there is no validation of inputs (e.g. checking for negative values).

Question: are INT types in OpenMW meant to be 32bit?
EDIT: according to morrowind scripting for dummies there are short, long and float.
But we only have Display_Integer type (i.e. does not distinguish between short and long)
