### PR TITLE
Use the 'SYSTEM' flag in include_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ if(USE_SYSTEM_TINYXML)
     message(STATUS "Found TinyXML: ${TINYXML_LIBRARIES} ${TINYXML_INCLUDE_DIR}")
     add_definitions (-DTIXML_USE_STL)
     if(TINYXML_LIBRARIES AND TINYXML_INCLUDE_DIR)
-        include_directories(${TINYXML_INCLUDE_DIR})
+        include_directories(SYSTEM ${TINYXML_INCLUDE_DIR})
         message(STATUS "Using system TinyXML library.")
     else()
         message(FATAL_ERROR "Detection of system TinyXML incomplete.")
@@ -272,15 +272,19 @@ endif ()
     endif(WIN32)
 endif(OGRE_STATIC)
 
-include_directories("."
+include_directories(SYSTEM
     ${OGRE_INCLUDE_DIR} ${OGRE_INCLUDE_DIR}/Ogre ${OGRE_INCLUDE_DIR}/OGRE ${OGRE_INCLUDE_DIRS} ${OGRE_PLUGIN_INCLUDE_DIRS}
     ${OGRE_INCLUDE_DIR}/Overlay ${OGRE_Overlay_INCLUDE_DIR}
     ${SDL2_INCLUDE_DIR}
     ${Boost_INCLUDE_DIR}
-    ${PLATFORM_INCLUDE_DIR}
     ${MYGUI_INCLUDE_DIRS}
     ${MYGUI_PLATFORM_INCLUDE_DIRS}
     ${OPENAL_INCLUDE_DIR}
+)
+
+include_directories(
+    .
+    ${PLATFORM_INCLUDE_DIR}
     ${LIBS_DIR}
 )
 

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -166,7 +166,8 @@ qt4_wrap_ui(OPENCS_UI_HDR ${OPENCS_UI})
 qt4_wrap_cpp(OPENCS_MOC_SRC ${OPENCS_HDR_QT})
 qt4_add_resources(OPENCS_RES_SRC ${OPENCS_RES})
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${BULLET_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(SYSTEM ${BULLET_INCLUDE_DIRS})
 
 if(APPLE)
     set (OPENCS_MAC_ICON ${CMAKE_SOURCE_DIR}/files/mac/opencs.icns)

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -119,7 +119,7 @@ endif ()
 
 # Sound stuff - here so CMake doesn't stupidly recompile EVERYTHING
 # when we change the backend.
-include_directories(${SOUND_INPUT_INCLUDES} ${BULLET_INCLUDE_DIRS})
+include_directories(SYSTEM ${SOUND_INPUT_INCLUDES} ${BULLET_INCLUDE_DIRS})
 
 target_link_libraries(openmw
     ${OGRE_LIBRARIES}

--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -7,8 +7,8 @@ find_package(GMock REQUIRED)
 
 if (GTEST_FOUND AND GMOCK_FOUND)
 
-    include_directories(${GTEST_INCLUDE_DIRS})
-    include_directories(${GMOCK_INCLUDE_DIRS})
+    include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
+    include_directories(SYSTEM ${GMOCK_INCLUDE_DIRS})
 
     file(GLOB UNITTEST_SRC_FILES
         components/misc/test_*.cpp

--- a/apps/wizard/CMakeLists.txt
+++ b/apps/wizard/CMakeLists.txt
@@ -99,7 +99,7 @@ include(${QT_USE_FILE})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if (OPENMW_USE_UNSHIELD)
-    include_directories(${LIBUNSHIELD_INCLUDE_DIR})
+    include_directories(SYSTEM ${LIBUNSHIELD_INCLUDE_DIR})
 endif()
 
 add_executable(openmw-wizard

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -139,7 +139,8 @@ if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 endif ()
 
-include_directories(${BULLET_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(SYSTEM ${BULLET_INCLUDE_DIRS})
 
 add_library(components STATIC ${COMPONENT_FILES} ${MOC_SRCS} ${ESM_UI_HDR})
 


### PR DESCRIPTION
The SYSTEM flag asks CMake to pass the necessary flags to the compiler to
disable warnings generated by external include files. With GCC and Clang, for
example, it means using -isystem instead if -I.

This commit does not touch the build scripts of external projects.
