### PR TITLE
Opening window and User Settings window cleanup

### DIFF
--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -236,6 +236,7 @@ void CS::Editor::showSettings()
     if (mSettings.isHidden())
         mSettings.show();
 
+    mSettings.move (QCursor::pos());
     mSettings.raise();
     mSettings.activateWindow();
 }

--- a/apps/opencs/view/doc/loader.cpp
+++ b/apps/opencs/view/doc/loader.cpp
@@ -8,7 +8,6 @@
 #include <QDialogButtonBox>
 #include <QCloseEvent>
 #include <QListWidget>
-#include <QMessageBox>
 
 #include "../../model/doc/document.hpp"
 
@@ -107,8 +106,6 @@ void CSVDoc::LoadingDocument::abort (const std::string& error)
     mAborted = true;
     mError->setText (QString::fromUtf8 (("<font color=red>Loading failed: " + error + "</font>").c_str()));
     mButtons->setStandardButtons (QDialogButtonBox::Close);
-    QMessageBox::critical(this, tr("OpenCS Loading Failed"),
-        QString::fromUtf8 (("Loading failed:\n" + error).c_str()));
 }
 
 void CSVDoc::LoadingDocument::addMessage (const std::string& message)

--- a/apps/opencs/view/doc/loader.cpp
+++ b/apps/opencs/view/doc/loader.cpp
@@ -8,6 +8,8 @@
 #include <QDialogButtonBox>
 #include <QCloseEvent>
 #include <QListWidget>
+#include <QMessageBox>
+#include <QApplication>
 
 #include "../../model/doc/document.hpp"
 
@@ -104,8 +106,10 @@ void CSVDoc::LoadingDocument::nextRecord (int records)
 void CSVDoc::LoadingDocument::abort (const std::string& error)
 {
     mAborted = true;
-    mError->setText (QString::fromUtf8 (("Loading failed: " + error).c_str()));
+    mError->setText (QString::fromUtf8 (("<font color=red>Loading failed: " + error + "</font>").c_str()));
     mButtons->setStandardButtons (QDialogButtonBox::Close);
+    QMessageBox::critical(this, tr("OpenCS Loading Failed"),
+        QString::fromUtf8 (("Loading failed:\n" + error).c_str()));
 }
 
 void CSVDoc::LoadingDocument::addMessage (const std::string& message)

--- a/apps/opencs/view/doc/loader.cpp
+++ b/apps/opencs/view/doc/loader.cpp
@@ -9,7 +9,6 @@
 #include <QCloseEvent>
 #include <QListWidget>
 #include <QMessageBox>
-#include <QApplication>
 
 #include "../../model/doc/document.hpp"
 


### PR DESCRIPTION
Feature #1325

- Added a critical pop-up window to notify users of failed file loading (sound on systems that support it, such as Windows)
- Made error text red to highlight error
- User settings window is created at current mouse location