### PR TITLE
Made templated Nif readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ option(BUILD_OPENCS "build OpenMW Construction Set" ON)
 option(BUILD_WIZARD "build Installation Wizard" ON)
 option(BUILD_WITH_CODE_COVERAGE "Enable code coverage with gconv" OFF)
 option(BUILD_UNITTESTS "Enable Unittests with Google C++ Unittest and GMock frameworks" OFF)
-option(BUILD_NIFTEST "build nif file tester" OFF)
+option(BUILD_NIFTEST "build nif file tester" ON)
 option(BUILD_MYGUI_PLUGIN "build MyGUI plugin for OpenMW resources, to use with MyGUI tools" ON)
 
 # OS X deployment

--- a/components/nif/base.hpp
+++ b/components/nif/base.hpp
@@ -36,12 +36,12 @@ public:
     {
         next.read(nif);
 
-        flags = nif->getUShort();
+        flags = nif->get<unsigned short>();
 
-        frequency = nif->getFloat();
-        phase = nif->getFloat();
-        timeStart = nif->getFloat();
-        timeStop = nif->getFloat();
+        frequency = nif->get<float>();
+        phase = nif->get<float>();
+        timeStart = nif->get<float>();
+        timeStop = nif->get<float>();
 
         target.read(nif);
     }
@@ -81,7 +81,7 @@ public:
 
     void read(NIFStream *nif)
     {
-        name = nif->getString();
+        name = nif->get<std::string>();
         Controlled::read(nif);
     }
 };

--- a/components/nif/data.hpp
+++ b/components/nif/data.hpp
@@ -44,16 +44,16 @@ public:
         int verts = nif->getUShort();
 
         if(nif->getInt())
-            nif->getVector3s(vertices, verts);
+            vertices = nif->getItems<Ogre::Vector3>(verts);
 
         if(nif->getInt())
-            nif->getVector3s(normals, verts);
+            normals = nif->getItems<Ogre::Vector3>(verts);
 
         center = nif->getVector3();
         radius = nif->getFloat();
 
         if(nif->getInt())
-            nif->getVector4s(colors, verts);
+            colors = nif->getItems<Ogre::Vector4>(verts);
 
         // Only the first 6 bits are used as a count. I think the rest are
         // flags of some sort.
@@ -64,7 +64,7 @@ public:
         {
             uvlist.resize(uvs);
             for(int i = 0;i < uvs;i++)
-                nif->getVector2s(uvlist[i], verts);
+                uvlist[i] = nif->getItems<Ogre::Vector2>(verts);
         }
     }
 };
@@ -84,7 +84,7 @@ public:
         // We have three times as many vertices as triangles, so this
         // is always equal to tris*3.
         int cnt = nif->getInt();
-        nif->getShorts(triangles, cnt);
+        triangles = nif->getItems<short>(cnt);
 
         // Read the match list, which lists the vertices that are equal to
         // vertices. We don't actually need need this for anything, so
@@ -123,7 +123,7 @@ public:
         if(nif->getInt())
         {
             // Particle sizes
-            nif->getFloats(sizes, vertices.size());
+            sizes = nif->getItems<float>(vertices.size());
         }
     }
 };
@@ -140,7 +140,7 @@ public:
         if(nif->getInt())
         {
             // Rotation quaternions.
-            nif->getQuaternions(rotations, vertices.size());
+            rotations = nif->getItems<Ogre::Quaternion>(vertices.size());
         }
     }
 };
@@ -341,7 +341,7 @@ struct NiMorphData : public Record
         for(int i = 0;i < morphCount;i++)
         {
             mMorphs[i].mData.read(nif, true);
-            nif->getVector3s(mMorphs[i].mVertices, vertCount);
+            mMorphs[i].mVertices = nif->getItems<Ogre::Vector3>(vertCount);
         }
     }
 };

--- a/components/nif/nifstream.cpp
+++ b/components/nif/nifstream.cpp
@@ -143,4 +143,33 @@ void NIFStream::getQuaternions(std::vector<Ogre::Quaternion> &quat, size_t size)
         quat[i] = getQuaternion();
 }
 
+template <>
+char NIFStream::get<char>(){ return getChar(); }
+template <>
+short NIFStream::get<short>(){ return getShort(); }
+template <>
+unsigned short NIFStream::get<unsigned short>(){ return getUShort(); }
+template <>
+int NIFStream::get<int>(){ return getInt(); }
+template <>
+unsigned int NIFStream::get<unsigned int>(){ return getUInt(); }
+template <>
+float NIFStream::get<float>(){ return getFloat(); }
+
+template <>
+Ogre::Vector2 NIFStream::get<Ogre::Vector2>(){ return getVector2(); }
+template <>
+Ogre::Vector3 NIFStream::get<Ogre::Vector3>(){ return getVector3(); }
+template <>
+Ogre::Vector4 NIFStream::get<Ogre::Vector4>(){ return getVector4(); }
+template <>
+Ogre::Matrix3 NIFStream::get<Ogre::Matrix3>(){ return getMatrix3(); }
+template <>
+Ogre::Quaternion NIFStream::get<Ogre::Quaternion>(){ return getQuaternion(); }
+template <>
+Transformation NIFStream::get<Transformation>(){ return getTrafo(); }
+
+template <>
+std::string NIFStream::get<std::string>(){ return getString(); }
+
 }

--- a/components/nif/nifstream.cpp
+++ b/components/nif/nifstream.cpp
@@ -106,43 +106,6 @@ std::string NIFStream::getVersionString()
     return inp->getLine();
 }
 
-void NIFStream::getShorts(std::vector<short> &vec, size_t size)
-{
-    vec.resize(size);
-    for(size_t i = 0;i < vec.size();i++)
-        vec[i] = getShort();
-}
-void NIFStream::getFloats(std::vector<float> &vec, size_t size)
-{
-    vec.resize(size);
-    for(size_t i = 0;i < vec.size();i++)
-        vec[i] = getFloat();
-}
-void NIFStream::getVector2s(std::vector<Ogre::Vector2> &vec, size_t size)
-{
-    vec.resize(size);
-    for(size_t i = 0;i < vec.size();i++)
-        vec[i] = getVector2();
-}
-void NIFStream::getVector3s(std::vector<Ogre::Vector3> &vec, size_t size)
-{
-    vec.resize(size);
-    for(size_t i = 0;i < vec.size();i++)
-        vec[i] = getVector3();
-}
-void NIFStream::getVector4s(std::vector<Ogre::Vector4> &vec, size_t size)
-{
-    vec.resize(size);
-    for(size_t i = 0;i < vec.size();i++)
-        vec[i] = getVector4();
-}
-void NIFStream::getQuaternions(std::vector<Ogre::Quaternion> &quat, size_t size)
-{
-    quat.resize(size);
-    for(size_t i = 0;i < quat.size();i++)
-        quat[i] = getQuaternion();
-}
-
 template <>
 char NIFStream::get<char>(){ return getChar(); }
 template <>

--- a/components/nif/nifstream.hpp
+++ b/components/nif/nifstream.hpp
@@ -5,6 +5,8 @@
 
 #include <stdint.h>
 #include <stdexcept>
+#include <typeinfo>
+#include <string>
 
 #include <OgreDataStream.h>
 #include <OgreVector2.h>
@@ -86,7 +88,7 @@ public:
 
     //Templated functions to handle reads
     template <typename T>
-    T get(){throw std::runtime_error("Can not get this type of data from a NIF File!");}
+    T get(){throw std::runtime_error("Can not read a <"+std::string(typeid(T).name())+"> from a NIF File!  The get() function was called with the wrong template!");}
 
     ///Return a vector of whatever object is needed
     template <typename T>

--- a/components/nif/nifstream.hpp
+++ b/components/nif/nifstream.hpp
@@ -94,6 +94,20 @@ public:
     void getVector3s(std::vector<Ogre::Vector3> &vec, size_t size);
     void getVector4s(std::vector<Ogre::Vector4> &vec, size_t size);
     void getQuaternions(std::vector<Ogre::Quaternion> &quat, size_t size);
+
+    ///Return a vector of whatever object is needed
+    template <typename T>
+    std::vector<T> getItems(size_t number_of_items)
+    {
+        std::vector<T> items;
+        items.reserve(number_of_items);
+        for(size_t i=0; i < number_of_items; ++i)
+        {
+            items.push_back(get<T>());
+        }
+        return items;
+    }
+
 };
 
 }

--- a/components/nif/nifstream.hpp
+++ b/components/nif/nifstream.hpp
@@ -88,13 +88,6 @@ public:
     template <typename T>
     T get(){throw std::runtime_error("Can not get this type of data from a NIF File!");}
 
-    void getShorts(std::vector<short> &vec, size_t size);
-    void getFloats(std::vector<float> &vec, size_t size);
-    void getVector2s(std::vector<Ogre::Vector2> &vec, size_t size);
-    void getVector3s(std::vector<Ogre::Vector3> &vec, size_t size);
-    void getVector4s(std::vector<Ogre::Vector4> &vec, size_t size);
-    void getQuaternions(std::vector<Ogre::Quaternion> &quat, size_t size);
-
     ///Return a vector of whatever object is needed
     template <typename T>
     std::vector<T> getItems(size_t number_of_items)

--- a/components/nif/nifstream.hpp
+++ b/components/nif/nifstream.hpp
@@ -84,6 +84,10 @@ public:
     ///This is special since the version string doesn't start with a number, and ends with "\n"
     std::string getVersionString();
 
+    //Templated functions to handle reads
+    template <typename T>
+    T get(){throw std::runtime_error("Can not get this type of data from a NIF File!");}
+
     void getShorts(std::vector<short> &vec, size_t size);
     void getFloats(std::vector<float> &vec, size_t size);
     void getVector2s(std::vector<Ogre::Vector2> &vec, size_t size);

--- a/components/nif/tests/test.sh
+++ b/components/nif/tests/test.sh
@@ -9,7 +9,7 @@ find "$DATAFILESDIR" -iname *nif >> nifs.txt
 
 sed -e 's/.*/\"&\"/' nifs.txt > quoted_nifs.txt
 
-xargs --arg-file=quoted_nifs.txt ../../../niftest
+nice -n 10 xargs --arg-file=quoted_nifs.txt ../../../niftest
 
 rm nifs.txt
 rm quoted_nifs.txt


### PR DESCRIPTION
The code redundancy for the vector geters was just annoying.  Plus, this makes the option of a version dependent getter for nif file data a single function away should we decide to support multiple nif versions in the future.