### PR TITLE
Remove unused "skipOnZero" opcode

### DIFF
--- a/components/compiler/generator.cpp
+++ b/components/compiler/generator.cpp
@@ -150,10 +150,13 @@ namespace
         code.push_back (Compiler::Generator::segment0 (2, offset));
     }
 
+    /*
+    Currently unused
     void opSkipOnZero (Compiler::Generator::CodeContainer& code)
     {
         code.push_back (Compiler::Generator::segment5 (24));
     }
+    */
 
     void opSkipOnNonZero (Compiler::Generator::CodeContainer& code)
     {


### PR DESCRIPTION
This opcode is never generated by the compiler and thus causes a warning:

```
components/compiler/generator.cpp:153:10: warning: ‘void {anonymous}::opSkipOnZero(Compiler::Generator::CodeContainer&)’ defined but not used [-Wunused-function]
     void opSkipOnZero (Compiler::Generator::CodeContainer& code)
```