### PR TITLE
Add commandline option to load a save game on startup

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -472,9 +472,13 @@ void OMW::Engine::go()
     // Play some good 'ol tunes
     MWBase::Environment::get().getSoundManager()->playPlaylist(std::string("Explore"));
 
-    // start in main menu
-    if (!mSkipMenu)
+    if (!mSaveGameFile.empty())
     {
+        MWBase::Environment::get().getStateManager()->loadGame(mSaveGameFile);
+    }
+    else if (!mSkipMenu)
+    {
+        // start in main menu
         MWBase::Environment::get().getWindowManager()->pushGuiMode (MWGui::GM_MainMenu);
         try
         {
@@ -621,4 +625,9 @@ void OMW::Engine::setScriptBlacklistUse (bool use)
 void OMW::Engine::enableFontExport(bool exportFonts)
 {
     mExportFonts = exportFonts;
+}
+
+void OMW::Engine::setSaveGameFile(const std::string &savegame)
+{
+    mSaveGameFile = savegame;
 }

--- a/apps/openmw/engine.hpp
+++ b/apps/openmw/engine.hpp
@@ -83,6 +83,7 @@ namespace OMW
             bool mScriptConsoleMode;
             std::string mStartupScript;
             int mActivationDistanceOverride;
+            std::string mSaveGameFile;
             // Grab mouse?
             bool mGrab;
 
@@ -203,6 +204,9 @@ namespace OMW
             void setScriptBlacklistUse (bool use);
 
             void enableFontExport(bool exportFonts);
+
+            /// Set the save game file to load after initialising the engine.
+            void setSaveGameFile(const std::string& savegame);
 
         private:
             Files::ConfigurationManager& mCfgMgr;

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -152,6 +152,9 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
         ("script-blacklist-use", bpo::value<bool>()->implicit_value(true)
             ->default_value(true), "enable script blacklisting")
 
+        ("load-savegame", bpo::value<std::string>()->default_value(""),
+            "load a save game file on game startup")
+
         ("skip-menu", bpo::value<bool>()->implicit_value(true)
             ->default_value(false), "skip main menu on game startup")
 
@@ -274,6 +277,7 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     engine.setWarningsMode (variables["script-warn"].as<int>());
     engine.setScriptBlacklist (variables["script-blacklist"].as<StringsVector>());
     engine.setScriptBlacklistUse (variables["script-blacklist-use"].as<bool>());
+    engine.setSaveGameFile (variables["load-savegame"].as<std::string>());
 
     // other settings
     engine.setSoundUsage(!variables["no-sound"].as<bool>());

--- a/apps/openmw/mwbase/statemanager.hpp
+++ b/apps/openmw/mwbase/statemanager.hpp
@@ -62,10 +62,13 @@ namespace MWBase
             ///
             /// \note Slot must belong to the current character.
 
-            virtual void loadGame (const MWState::Character *character, const MWState::Slot *slot) = 0;
-            ///< Load a saved game file from \a slot.
-            ///
-            /// \note \a slot must belong to \a character.
+            virtual void loadGame (const std::string& filepath) = 0;
+            ///< Load a saved game directly from the given file path. This will search the CharacterManager
+            /// for a Character containing this save file, and set this Character current if one was found.
+            /// Otherwise, a new Character will be created.
+
+            virtual void loadGame (const MWState::Character *character, const std::string& filepath) = 0;
+            ///< Load a saved game file belonging to the given character.
 
             ///Simple saver, writes over the file if already existing
             /** Used for quick save and autosave **/

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -246,7 +246,7 @@ namespace MWGui
         else
         {
             assert (mCurrentCharacter && mCurrentSlot);
-            MWBase::Environment::get().getStateManager()->loadGame (mCurrentCharacter, mCurrentSlot);
+            MWBase::Environment::get().getStateManager()->loadGame (mCurrentCharacter, mCurrentSlot->mPath.string());
         }
     }
 

--- a/apps/openmw/mwstate/character.cpp
+++ b/apps/openmw/mwstate/character.cpp
@@ -190,3 +190,8 @@ ESM::SavedGame MWState::Character::getSignature() const
 
     return slot.mProfile;
 }
+
+const boost::filesystem::path& MWState::Character::getPath() const
+{
+    return mPath;
+}

--- a/apps/openmw/mwstate/character.hpp
+++ b/apps/openmw/mwstate/character.hpp
@@ -54,11 +54,11 @@ namespace MWState
             /// \attention The \a slot pointer will be invalidated by this call.
 
             SlotIterator begin() const;
-            ///< First slot is the most recent. Other slots follow in descending order of save date.
-            ///
-            /// Any call to createSlot and updateSlot can invalidate the returned iterator.
+            ///<  Any call to createSlot and updateSlot can invalidate the returned iterator.
 
             SlotIterator end() const;
+
+            const boost::filesystem::path& getPath() const;
 
             ESM::SavedGame getSignature() const;
             ///< Return signature information for this character.

--- a/apps/openmw/mwstate/statemanagerimp.hpp
+++ b/apps/openmw/mwstate/statemanagerimp.hpp
@@ -61,10 +61,13 @@ namespace MWState
             /** Used for quickload **/
             virtual void quickLoad();
 
-            virtual void loadGame (const Character *character, const Slot *slot);
-            ///< Load a saved game file from \a slot.
-            ///
-            /// \note \a slot must belong to \a character.
+            virtual void loadGame (const std::string& filepath);
+            ///< Load a saved game directly from the given file path. This will search the CharacterManager
+            /// for a Character containing this save file, and set this Character current if one was found.
+            /// Otherwise, a new Character will be created.
+
+            virtual void loadGame (const Character *character, const std::string &filepath);
+            ///< Load a saved game file belonging to the given character.
 
             virtual Character *getCurrentCharacter (bool create = true);
             ///< \param create Create a new character, if there is no current character.


### PR DESCRIPTION
Added a command line argument for loading a specified save file on startup.

This makes it easier to deal with the various save files on the bug tracker that our testers are awesome enough to include.

Previous workflow:
* Download a save game file
* Figure out the save path depending on your OS
* Create a new directory in ```<Save path>``` and move the file there
* Start OpenMW
* Find the save in your list of characters
* Load the save file

Especially the "Find the save in your list of characters" step has gotten out of hand:
![](http://scrawl.bplaced.net/perm/screenshot_03-15-38.png)
I never bothered to delete saves, I like to keep them around in case they're needed later.

Improved workflow:
* Download a save game file
* Launch OpenMW with the argument ```--load-savegame <path>```

This should also be useful for players, since specifying the file on startup leaves you with only *one* loading sequence to watch instead of two. We might want to add a proper file extension to saved game files, so that we can create MIME associations with the user's operating system, i.e. being able to fire up OpenMW by double-clicking on a save game.