### PR TITLE
Savegame mime type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,8 @@ configure_file(${OpenMW_SOURCE_DIR}/files/opencs/defaultfilters
 if (NOT WIN32 AND NOT APPLE)
     configure_file(${OpenMW_SOURCE_DIR}/files/openmw.desktop
         "${OpenMW_BINARY_DIR}/openmw.desktop")
+    configure_file(${OpenMW_SOURCE_DIR}/files/openmw-mimeinfo.xml
+        "${OpenMW_BINARY_DIR}/openmw-mimeinfo.xml")
     configure_file(${OpenMW_SOURCE_DIR}/files/opencs.desktop
         "${OpenMW_BINARY_DIR}/opencs.desktop")
 endif()
@@ -451,6 +453,7 @@ IF(NOT WIN32 AND NOT APPLE)
 
     # Install icon and desktop file
     INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw.desktop" DESTINATION "${DATAROOTDIR}/applications" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ COMPONENT "openmw")
+    INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw-mimeinfo.xml" DESTINATION "${DATAROOTDIR}/mime/packages" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ COMPONENT "openmw")
     INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/launcher/images/openmw.png" DESTINATION "${ICONDIR}" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ COMPONENT "openmw")
     IF(BUILD_OPENCS)
         INSTALL(FILES "${OpenMW_BINARY_DIR}/opencs.desktop" DESTINATION "${DATAROOTDIR}/applications" PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ COMPONENT "opencs")

--- a/apps/openmw/mwstate/character.cpp
+++ b/apps/openmw/mwstate/character.cpp
@@ -61,7 +61,8 @@ void MWState::Character::addSlot (const ESM::SavedGame& profile)
             stream << "_";
     }
 
-    slot.mPath = mPath / stream.str();
+    const std::string ext = ".omwsave";
+    slot.mPath = mPath / (stream.str() + ext);
 
     // Append an index if necessary to ensure a unique file
     int i=0;
@@ -70,7 +71,7 @@ void MWState::Character::addSlot (const ESM::SavedGame& profile)
            std::ostringstream test;
            test << stream.str();
            test << " - " << ++i;
-           slot.mPath = mPath / test.str();
+           slot.mPath = mPath / (test.str() + ext);
     }
 
     slot.mProfile = profile;

--- a/files/openmw-mimeinfo.xml
+++ b/files/openmw-mimeinfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+
+  <mime-type type="application/x-openmw-savegame">
+    <icon name="openmw" />
+    <generic-icon name="applications-games"/>
+    <comment>OpenMW Savegame</comment>
+    <glob weight="60" pattern="*.omwsave"/>
+  </mime-type>
+
+</mime-info>

--- a/files/openmw.desktop
+++ b/files/openmw.desktop
@@ -8,3 +8,16 @@ TryExec=omwlauncher
 Exec=omwlauncher
 Icon=openmw
 Categories=Game;RolePlaying;
+
+[Desktop Entry]
+Type=Application
+Name=OpenMW
+GenericName=Role Playing Game
+Comment=An engine replacement for The Elder Scrolls III: Morrowind
+Keywords=Morrowind;Reimplementation Mods;esm;bsa;
+Exec=openmw --load-savegame=%f
+Icon=openmw
+Categories=Game;RolePlaying;
+Terminal=false
+NoDisplay=true
+MimeType=application/x-openmw-savegame;


### PR DESCRIPTION
Use an .omwsave extension for savegame files. Register a mimetype for freedesktop.org-compliant systems. 
This allows us to load .omwsave files by clicking on them in a file manager. In a system install of OpenMW, this should work automatically.
For testing this with a local build, you have to do the following:
<pre>
cp files/openmw.desktop ~/.local/share/applications/
cp files/openmw-mimeinfo.xml ~/.local/share/mime/packages/
update-mime-database ~/.local/share/mime
update-desktop-database ~/.local/share/applications
</pre>
Then create a script called "openmw" in your $PATH, which changes to the build folder and runs the executable:
```
#!/bin/bash
cd <Build folder>
./openmw $*
```