### PR TITLE
Minor changes to ESM::RefNum

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -872,7 +872,7 @@ namespace MWClass
         {
             // Note we do not respawn moved references in the cell they were moved to. Instead they are respawned in the original cell.
             // This also means we cannot respawn dynamically placed references with no content file connection.
-            if (ptr.getCellRef().getRefNum().mContentFile != -1)
+            if (ptr.getCellRef().hasContentFile())
             {
                 if (ptr.getRefData().getCount() == 0)
                     ptr.getRefData().setCount(1);

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1331,7 +1331,7 @@ namespace MWClass
         {
             // Note we do not respawn moved references in the cell they were moved to. Instead they are respawned in the original cell.
             // This also means we cannot respawn dynamically placed references with no content file connection.
-            if (ptr.getCellRef().getRefNum().mContentFile != -1)
+            if (ptr.getCellRef().hasContentFile())
             {
                 if (ptr.getRefData().getCount() == 0)
                     ptr.getRefData().setCount(1);

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -37,6 +37,7 @@
 
 #include "actor.hpp"
 #include "summoning.hpp"
+#include "combat.hpp"
 
 namespace
 {
@@ -309,10 +310,10 @@ namespace MWMechanics
         // pure water creatures won't try to fight with the target on the ground
         // except that creature is already hostile
         if ((againstPlayer || !creatureStats.getAiSequence().isInCombat())
-                && ((actor1.getClass().isPureWaterCreature(actor1)
-                && !MWBase::Environment::get().getWorld()->isWading(actor2))
-                || (!actor1.getClass().canSwim(actor1) && MWBase::Environment::get().getWorld()->isSwimming(actor2)))) // creature can't swim to target
+            && !MWMechanics::isEnvironmentCompatible(actor1, actor2)) // creature can't swim to target
+        {
             return;
+        }
 
         bool aggressive;
 

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -23,6 +23,7 @@
 #include "character.hpp" // fixme: for getActiveWeapon
 
 #include "aicombataction.hpp"
+#include "combat.hpp"
 
 namespace
 {
@@ -206,12 +207,8 @@ namespace MWMechanics
         const MWWorld::Class& actorClass = actor.getClass();
         MWBase::World* world = MWBase::Environment::get().getWorld();
 
-        if (!actorClass.isNpc() &&
-            // 1. pure water creature and Player moved out of water
-            ((target == world->getPlayerPtr() &&
-            actorClass.isPureWaterCreature(actor) && !world->isWading(target))
-            // 2. creature can't swim to target
-            || (!actorClass.canSwim(actor) && world->isSwimming(target))))
+        // can't fight if attacker can't go where target is.  E.g. A fish can't attack person on land.
+        if (!actorClass.isNpc() && !MWMechanics::isEnvironmentCompatible(actor, target))
         {
             actorClass.getCreatureStats(actor).setAttackingOrSpell(false);
             return true;

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -367,4 +367,24 @@ namespace MWMechanics
         else
             sndMgr->playSound3D(victim, "Hand To Hand Hit", 1.0f, 1.0f);
     }
+
+    bool isEnvironmentCompatible(const MWWorld::Ptr& attacker, const MWWorld::Ptr& victim)
+    {
+        const MWWorld::Class& attackerClass = attacker.getClass();
+        MWBase::World* world = MWBase::Environment::get().getWorld();
+
+        // If attacker is fish, victim must be in water
+        if (attackerClass.isPureWaterCreature(attacker))
+        {
+            return world->isWading(victim);
+        }
+        
+        // If attacker can't swim, victim must not be in water
+        if (!attackerClass.canSwim(attacker))
+        {
+            return !world->isSwimming(victim);
+        }
+
+        return true;
+    }
 }

--- a/apps/openmw/mwmechanics/combat.hpp
+++ b/apps/openmw/mwmechanics/combat.hpp
@@ -34,6 +34,10 @@ void adjustWeaponDamage (float& damage, const MWWorld::Ptr& weapon);
 
 void getHandToHandDamage (const MWWorld::Ptr& attacker, const MWWorld::Ptr& victim, float& damage, bool& healthdmg);
 
+/// Can attacker operate in victim's environment?
+/// e.g. If attacker is a fish, is victim in water? Or, if attacker can't swim, is victim on land?
+bool isEnvironmentCompatible(const MWWorld::Ptr& attacker, const MWWorld::Ptr& victim);
+
 }
 
 #endif

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1035,7 +1035,7 @@ namespace MWScript
 
                 msg << "Content file: ";
 
-                if (ptr.getCellRef().getRefNum().mContentFile == -1)
+                if (!ptr.getCellRef().hasContentFile())
                     msg << "[None]" << std::endl;
                 else
                 {

--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -10,10 +10,14 @@ namespace MWWorld
         return mCellRef.mRefNum;
     }
 
+    bool CellRef::hasContentFile() const
+    {
+        return getRefNum().hasContentFile();
+    }
+
     void CellRef::unsetRefNum()
     {
-        mCellRef.mRefNum.mContentFile = -1;
-        mCellRef.mRefNum.mIndex = 0;
+        getRefNum().unset();
     }
 
     std::string CellRef::getRefId() const

--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -28,6 +28,9 @@ namespace MWWorld
         // Set RefNum to its default state.
         void unsetRefNum();
 
+        /// Does the RefNum have a content file?
+        bool hasContentFile() const;
+
         // Id of object being referenced
         std::string getRefId() const;
 

--- a/apps/openmw/mwworld/cellreflist.hpp
+++ b/apps/openmw/mwworld/cellreflist.hpp
@@ -28,7 +28,7 @@ namespace MWWorld
         {
             for (typename List::iterator iter (mList.begin()); iter!=mList.end(); ++iter)
                 if (!iter->mData.isDeletedByContentFile()
-                        && (iter->mRef.getRefNum().mContentFile != -1 || iter->mData.getCount() > 0)
+                        && (iter->mRef.hasContentFile() || iter->mData.getCount() > 0)
                         && iter->mRef.getRefId() == name)
                     return &*iter;
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -72,12 +72,12 @@ namespace
                 iter (collection.mList.begin());
                 iter!=collection.mList.end(); ++iter)
             {
-                if (!iter->mData.hasChanged() && !iter->mRef.hasChanged() && iter->mRef.getRefNum().mContentFile != -1)
+                if (!iter->mData.hasChanged() && !iter->mRef.hasChanged() && iter->mRef.hasContentFile())
                 {
                     // Reference that came from a content file and has not been changed -> ignore
                     continue;
                 }
-                if (iter->mData.getCount()==0 && iter->mRef.getRefNum().mContentFile==-1)
+                if (iter->mData.getCount()==0 && !iter->mRef.hasContentFile())
                 {
                     // Deleted reference that did not come from a content file -> ignore
                     continue;
@@ -102,7 +102,7 @@ namespace
         state.load (reader);
 
         // If the reference came from a content file, make sure this content file is loaded
-        if (state.mRef.mRefNum.mContentFile != -1)
+        if (state.mRef.mRefNum.hasContentFile())
         {
             std::map<int, int>::const_iterator iter =
                 contentFileMap.find (state.mRef.mRefNum.mContentFile);
@@ -121,7 +121,7 @@ namespace
         if (!record)
             return;
 
-        if (state.mRef.mRefNum.mContentFile != -1)
+        if (state.mRef.mRefNum.hasContentFile())
         {
             for (typename MWWorld::CellRefList<T>::List::iterator iter (collection.mList.begin());
                 iter!=collection.mList.end(); ++iter)
@@ -487,7 +487,7 @@ namespace MWWorld
             mCell->restore (esm[index], i);
 
             ESM::CellRef ref;
-            ref.mRefNum.mContentFile = -1;
+            ref.mRefNum.mContentFile = ESM::RefNum::RefNum_NoContentFile;
 
             // Get each reference in turn
             bool deleted = false;

--- a/apps/openmw/mwworld/manualref.hpp
+++ b/apps/openmw/mwworld/manualref.hpp
@@ -24,8 +24,7 @@ namespace MWWorld
                 const T* base = list.find(name);
 
                 ESM::CellRef cellRef;
-                cellRef.mRefNum.mIndex = 0;
-                cellRef.mRefNum.mContentFile = -1;
+                cellRef.mRefNum.unset();
                 cellRef.mRefID = name;
                 cellRef.mScale = 1;
                 cellRef.mFactionRank = 0;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1089,7 +1089,7 @@ namespace MWWorld
 
     void World::undeleteObject(const Ptr& ptr)
     {
-        if (ptr.getCellRef().getRefNum().mContentFile == -1)
+        if (!ptr.getCellRef().hasContentFile())
             return;
         if (ptr.getRefData().isDeleted())
         {
@@ -3206,7 +3206,7 @@ namespace MWWorld
         {
             // Can't reset actors that were moved to a different cell, because we don't know what cell they came from.
             // This could be fixed once we properly track actor cell changes, but may not be desirable behaviour anyhow.
-            if (ptr.getClass().isActor() && ptr.getCellRef().getRefNum().mContentFile != -1)
+            if (ptr.getClass().isActor() && ptr.getCellRef().hasContentFile())
             {
                 const ESM::Position& origPos = ptr.getCellRef().getPosition();
                 MWBase::Environment::get().getWorld()->moveObject(ptr, origPos.pos[0], origPos.pos[1], origPos.pos[2]);

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -129,8 +129,7 @@ void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory) cons
 
 void ESM::CellRef::blank()
 {
-    mRefNum.mIndex = 0;
-    mRefNum.mContentFile = -1;
+    mRefNum.unset();
     mRefID.clear();
     mScale = 1;
     mOwner.clear();

--- a/components/esm/cellref.hpp
+++ b/components/esm/cellref.hpp
@@ -13,8 +13,12 @@ namespace ESM
 
     struct RefNum
     {
-        int mIndex;
-        int mContentFile; // -1 no content file
+        unsigned int mIndex;
+        int mContentFile;
+
+        enum { RefNum_NoContentFile = -1 };
+        inline bool hasContentFile() const { return mContentFile != RefNum_NoContentFile; }
+        inline void unset() { mIndex = 0; mContentFile = RefNum_NoContentFile; }
     };
 
     /* Cell reference. This represents ONE object (of many) inside the


### PR DESCRIPTION
1. Changed mIndex to unsigned, to solve potential implementation defined behavior with right shift.
2. Refactoring to minimize use of magic number -1 to indicate "no Content File".