### PR TITLE
Fix OpenCS window opening issue when config file doesn't exist

### DIFF
--- a/apps/opencs/view/doc/view.cpp
+++ b/apps/opencs/view/doc/view.cpp
@@ -375,17 +375,20 @@ CSVDoc::View::View (ViewManager& viewManager, CSMDoc::Document *document, int to
     : mViewManager (viewManager), mDocument (document), mViewIndex (totalViews-1),
       mViewTotal (totalViews)
 {
-    QString width = CSMSettings::UserSettings::instance().settingValue
-                                    ("window/default-width");
+    int width = CSMSettings::UserSettings::instance().settingValue
+                                    ("window/default-width").toInt();
 
-    QString height = CSMSettings::UserSettings::instance().settingValue
-                                    ("window/default-height");
+    int height = CSMSettings::UserSettings::instance().settingValue
+                                    ("window/default-height").toInt();
+
+    width = std::max(width, 300);
+    height = std::max(height, 300);
 
     // trick to get the window decorations and their sizes
     show();
     hide();
-    resize (width.toInt() - (frameGeometry().width() - geometry().width()),
-            height.toInt() - (frameGeometry().height() - geometry().height()));
+    resize (width - (frameGeometry().width() - geometry().width()),
+            height - (frameGeometry().height() - geometry().height()));
 
     mSubViewWindow.setDockOptions (QMainWindow::AllowNestedDocks);
 


### PR DESCRIPTION
https://bugs.openmw.org/issues/2226

As there wasn't any progress on this showstopper for a month I couldn't help but take a look at it.

The problem is that the settings implementation doesn't actually load the code-specified default values until the config window is opened. This results in the window size setting being read as "0", so OpenCS will attempt to create a zero size window (or possibly negative size after subtracting the frame dimensions).

A proper fix for actually loading the code defaults on startup, rather than on opening the settings window, should be done by someone familiar with the settings code.