### PR TITLE
OpenCS shows plug-ins with load order issues.

### DIFF
--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -6,13 +6,12 @@
 #include <QDir>
 #include <QTextCodec>
 #include <QDebug>
-#include <QBrush>
-#include <QIcon>
 
 #include "components/esm/esmreader.hpp"
 
-ContentSelectorModel::ContentModel::ContentModel(QObject *parent) :
+ContentSelectorModel::ContentModel::ContentModel(QObject *parent, QIcon warningIcon) :
     QAbstractTableModel(parent),
+    mWarningIcon(warningIcon),
     mMimeType ("application/omwcontent"),
     mMimeTypes (QStringList() << mMimeType),
     mColumnCount (1),
@@ -180,7 +179,7 @@ QVariant ContentSelectorModel::ContentModel::data(const QModelIndex &index, int 
     {
     case Qt::DecorationRole:
     {
-        return isLoadOrderError(file) ? QIcon::fromTheme("edit-delete") : QVariant();
+        return isLoadOrderError(file) ? mWarningIcon : QVariant();
     }
 
     case Qt::EditRole:

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -597,13 +597,16 @@ QList<ContentSelectorModel::LoadOrderError> ContentSelectorModel::ContentModel::
         {
             errors.append(LoadOrderError(LoadOrderError::ErrorCode_MissingDependency, dependentfileName));
         }
-        if (!isChecked(dependentFile->filePath()))
+        else
         {
-            errors.append(LoadOrderError(LoadOrderError::ErrorCode_InactiveDependency, dependentfileName));
-        }
-        if (row < indexFromItem(dependentFile).row())
-        {
-            errors.append(LoadOrderError(LoadOrderError::ErrorCode_LoadOrder, dependentfileName));
+            if (!isChecked(dependentFile->filePath()))
+            {
+                errors.append(LoadOrderError(LoadOrderError::ErrorCode_InactiveDependency, dependentfileName));
+            }
+            if (row < indexFromItem(dependentFile).row())
+            {
+                errors.append(LoadOrderError(LoadOrderError::ErrorCode_LoadOrder, dependentfileName));
+            }
         }
     }
     return errors;

--- a/components/contentselector/model/contentmodel.hpp
+++ b/components/contentselector/model/contentmodel.hpp
@@ -4,7 +4,7 @@
 #include <QAbstractTableModel>
 #include <QStringList>
 #include <QSet>
-
+#include <QIcon>
 #include "loadordererror.hpp"
 
 namespace ContentSelectorModel
@@ -23,7 +23,7 @@ namespace ContentSelectorModel
     {
         Q_OBJECT
     public:
-        explicit ContentModel(QObject *parent = 0);
+        explicit ContentModel(QObject *parent, QIcon warningIcon);
         ~ContentModel();
 
         void setEncoding(const QString &encoding);
@@ -57,6 +57,9 @@ namespace ContentSelectorModel
 
         void refreshModel();
 
+        /// Checks all plug-ins for load order errors and updates mPluginsWithLoadOrderError with plug-ins with issues
+        void checkForLoadOrderErrors();
+
     private:
 
         void addFile(EsmFile *file);
@@ -64,9 +67,6 @@ namespace ContentSelectorModel
         EsmFile *item(int row);
 
         void sortFiles();
-
-        /// Checks all plug-ins for load order errors and updates mPluginsWithLoadOrderError with plug-ins with issues
-        void checkForLoadOrderErrors();
 
         /// Checks a specific plug-in for load order errors
         /// \return all errors found for specific plug-in
@@ -82,6 +82,7 @@ namespace ContentSelectorModel
         QSet<QString> mPluginsWithLoadOrderError;
         QTextCodec *mCodec;
         QString mEncoding;
+        QIcon mWarningIcon;
 
     public:
 

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -24,7 +24,8 @@ ContentSelectorView::ContentSelector::ContentSelector(QWidget *parent) :
 
 void ContentSelectorView::ContentSelector::buildContentModel()
 {
-    mContentModel = new ContentSelectorModel::ContentModel(this);
+    QIcon warningIcon(ui.addonView->style()->standardIcon(QStyle::SP_MessageBoxWarning).pixmap(QSize(16, 15)));
+    mContentModel = new ContentSelectorModel::ContentModel(this, warningIcon);
 }
 
 void ContentSelectorView::ContentSelector::buildGameFileView()
@@ -161,6 +162,7 @@ void ContentSelectorView::ContentSelector::slotCurrentGameFileIndexChanged(int i
         oldIndex = index;
 
         model->setData(model->index(index, 0), true, Qt::UserRole + 1);
+        mContentModel->checkForLoadOrderErrors();
     }
 
     if (proxy)

--- a/libs/openengine/ogre/renderer.hpp
+++ b/libs/openengine/ogre/renderer.hpp
@@ -6,6 +6,7 @@
  */
 
 #include <string>
+#include <stdint.h>
 
 #include <OgreTexture.h>
 


### PR DESCRIPTION
1. FileDiaog in OpenCS now shows warning icon beside .esm./.esp files with load order problems.
2. omwlaucher -> replaced "stop" icon with "warning" icon for files with load order problems.