### PR TITLE
missing include in essimporter/main.cpp

### DIFF
--- a/apps/essimporter/main.cpp
+++ b/apps/essimporter/main.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>


### PR DESCRIPTION
error: 'cout' is not a member of 'std'
error: 'cerr' is not a member of 'std'
https://launchpadlibrarian.net/195402684/buildlog_ubuntu-trusty-amd64.openmw_0.34.0%2Bgit20150120.442-0~ubuntu14.04.1_FAILEDTOBUILD.txt.gz