### PR TITLE
Fix build when using new boost with Ogre.

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -12,6 +12,9 @@
 
 #include <SDL.h>
 
+#include <OgreRoot.h>
+#include <OgreRenderSystem.h>
+
 #include <boost/math/common_factor.hpp>
 
 #include <components/files/configurationmanager.hpp>

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -3,8 +3,10 @@
 
 #include <QWidget>
 
+#ifndef Q_MOC_RUN
 #include <OgreRoot.h>
 #include <OgreRenderSystem.h>
+#endif
 
 #include <components/ogreinit/ogreinit.hpp>
 

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -3,16 +3,11 @@
 
 #include <QWidget>
 
-#ifndef Q_MOC_RUN
-#include <OgreRoot.h>
-#include <OgreRenderSystem.h>
-#endif
-
 #include <components/ogreinit/ogreinit.hpp>
-
 
 #include "ui_graphicspage.h"
 
+namespace Ogre { class Root; class RenderSystem; }
 
 namespace Files { struct ConfigurationManager; }
 


### PR DESCRIPTION
This fixes a [Parse error at "BOOST_JOIN"] if you're using - for instance - Boost 1.57.0