### PR TITLE
Should be compared against uint only

### DIFF
--- a/components/esm/esmcommon.hpp
+++ b/components/esm/esmcommon.hpp
@@ -40,8 +40,8 @@ union NAME_T
   }
   bool operator!=(const std::string &str) const { return !((*this)==str); }
 
-  bool operator==(int v) const { return v == val; }
-  bool operator!=(int v) const { return v != val; }
+  bool operator==(uint32_t v) const { return v == val; }
+  bool operator!=(uint32_t v) const { return v != val; }
 
   std::string toString() const { return std::string(name, strnlen(name, LEN)); }
 


### PR DESCRIPTION
operator== and operator!= should compare against unit32_t only. 
Silcence compiler warning:
<code>warning: comparison between signed and unsigned integer expressions [-Wsign-compare]<code>