### PR TITLE
More Ogre + recent Boost build fixes

### DIFF
--- a/apps/opencs/view/render/cell.hpp
+++ b/apps/opencs/view/render/cell.hpp
@@ -9,7 +9,9 @@
 
 #include <OgreVector3.h>
 
+#ifndef Q_MOC_RUN
 #include <components/terrain/terraingrid.hpp>
+#endif
 
 #include "object.hpp"
 

--- a/apps/opencs/view/render/object.hpp
+++ b/apps/opencs/view/render/object.hpp
@@ -3,7 +3,9 @@
 
 #include <boost/shared_ptr.hpp>
 
+#ifndef Q_MOC_RUN
 #include <components/nifogre/ogrenifloader.hpp>
+#endif
 
 class QModelIndex;
 


### PR DESCRIPTION
I'd apparently unchecked my OpenCS build by mistake when testing, so missed this error at first.

Should fix moc failing with error
`boost/type_traits/detail/has_binary_operator.hp(50): Parse error at "BOOST_JOIN"`.