### PR TITLE
Dialogue:  Use std::set for known topics in the manager.

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.hpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.hpp
@@ -4,7 +4,7 @@
 #include "../mwbase/dialoguemanager.hpp"
 
 #include <map>
-#include <list>
+#include <set>
 
 #include <components/compiler/streamerrorhandler.hpp>
 #include <components/translation/translation.hpp>
@@ -23,13 +23,13 @@ namespace MWDialogue
     class DialogueManager : public MWBase::DialogueManager
     {
             std::map<std::string, ESM::Dialogue> mDialogueMap;
-            std::map<std::string, bool> mKnownTopics;// Those are the topics the player knows.
+            std::set<std::string> mKnownTopics;// Those are the topics the player knows.
 
             // Modified faction reactions. <Faction1, <Faction2, Difference> >
             typedef std::map<std::string, std::map<std::string, int> > ModFactionReactionMap;
             ModFactionReactionMap mChangedFactionReaction;
 
-            std::list<std::string> mActorKnownTopics;
+            std::set<std::string> mActorKnownTopics;
 
             Translation::Storage& mTranslationDataStorage;
             MWScript::CompilerContext mCompilerContext;


### PR DESCRIPTION
There were three different data structures being used for topic lists
in this code.  (map< string, true >, list< string >, and vector< string >)
Switch the local topic lists to set< string >.  This supports everything
the list and map were doing, reduces the variety of data structures, and
makes count (a more efficient search) available.

The vector has not changed, since it's tied to the ESM modules, and must
meet other requirements.

Patch prepared because it took too long to scan the code and verify that the map never contained any values but true.  (And a map of anything to 'true' is just a verbose form of a set...)

The mActorKnownTopics list was only used to populate the mKnownTopics map, so the loss of order in that data structure has no effect.