### PR TITLE
Patch for COC Spawn Issue.

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2383,6 +2383,7 @@ namespace MWWorld
     bool World::findInteriorPosition(const std::string &name, ESM::Position &pos)
     {
         typedef MWWorld::CellRefList<ESM::Door>::List DoorList;
+        typedef MWWorld::CellRefList<ESM::Static>::List StaticList;
 
         pos.rot[0] = pos.rot[1] = pos.rot[2] = 0;
         pos.pos[0] = pos.pos[1] = pos.pos[2] = 0;
@@ -2427,6 +2428,13 @@ namespace MWWorld
                 }
             }
         }
+        // Fall back to the first static location.
+        const StaticList &statics = cellStore->get<ESM::Static>().mList;
+        if ( statics.begin() != statics.end() ) {
+            pos = statics.begin()->mRef.getPosition();
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
OMW Bug #1079
Fall back to the first static's position, if there are no door markers.

This seems to work well for isolated cells from Morrowind.esm.  Differences noticed in testing:
1)  Magar Volas spawn is different.  However, the original engine spawns the player into a light stand, leaving the player stuck.  This algorithm drops the player in a corner, and they can walk.
2)  Character Stuff Wonderland spawns inside of the barrel, instead of on top of it.  Player is stuck.  However, even from the spawn point that original Morrowind uses, the player would still be stuck, since the collision code prevents the player from exiting the column in the middle of the room.
3)  Spawn point in "ken's test hole" matches, but the player still falls into infinity.  Original engine oddly enough lets the player walk around until they jump, then lets the player fall into the pit.

1) and 3) seem like "don't care" items.  Without collision handling changes, 2) doesn't seems to matter.  In general, this should leave the coc command usable for isolated interiors, even if it's not an exact match.

I did experiment with driving the searches from the cell refNum values, but this actually matched original behavior less.  I looked into checking the 'persistent' flag, but it's not supported on most ESM object types currently.  Also, the volume of code needed to scan all the object lists in the cell, even with templates, seemed a bit much for a marginal improvement to player placement for a debugging command.

Cells reviewed:
Character Stuff Wonderland
Clutter Warehouse - Everything Must Go!
ken's test hole
redoran interior
redoran interior2
ToddTest
Magas Volar

(edited for spelling)