### PR TITLE
ini importer sorts content files by date modified (Fixes #2346)

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -257,24 +257,8 @@ void Launcher::MainDialog::changePage(QListWidgetItem *current, QListWidgetItem 
         current = previous;
 
     int currentIndex = iconWidget->row(current);
-//    int previousIndex = iconWidget->row(previous);
-
     pagesWidget->setCurrentIndex(currentIndex);
-
-    //    DataFilesPage *previousPage = dynamic_cast<DataFilesPage *>(pagesWidget->widget(previousIndex));
-    //    DataFilesPage *currentPage = dynamic_cast<DataFilesPage *>(pagesWidget->widget(currentIndex));
-
-    //    //special call to update/save data files page list view when it's displayed/hidden.
-    //    if (previousPage)
-    //    {
-    //        if (previousPage->objectName() == "DataFilesPage")
-    //            previousPage->saveSettings();
-    //    }
-    //    else if (currentPage)
-    //    {
-    //        if (currentPage->objectName() == "DataFilesPage")
-    //            currentPage->loadSettings();
-    //    }
+    mSettingsPage->resetProgressBar();
 }
 
 bool Launcher::MainDialog::setupLauncherSettings()

--- a/apps/launcher/settingspage.cpp
+++ b/apps/launcher/settingspage.cpp
@@ -197,7 +197,10 @@ void Launcher::SettingsPage::importerStarted()
 void Launcher::SettingsPage::importerFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
     if (exitCode != 0 || exitStatus == QProcess::CrashExit)
+    {
+        giveImportFeedback(false);
         return;
+    }
 
     // Importer may have changed settings, so refresh
     mMain->reloadSettings();
@@ -225,8 +228,30 @@ void Launcher::SettingsPage::importerFinished(int exitCode, QProcess::ExitStatus
             mMain->reloadSettings();
         }
     }
+    else
+    {
+        giveImportFeedback(true);
+    }
 
     importerButton->setEnabled(true);
+}
+
+void Launcher::SettingsPage::giveImportFeedback(bool success)
+{
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("Importer finished"));
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    if (success)
+    {
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setText(tr("Settings were successfully imported."));
+    }
+    else
+    {
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setText(tr("Failed to import settings from INI file."));
+    }
+    msgBox.exec();
 }
 
 void Launcher::SettingsPage::updateOkButton(const QString &text)

--- a/apps/launcher/settingspage.hpp
+++ b/apps/launcher/settingspage.hpp
@@ -44,9 +44,14 @@ namespace Launcher
 
         void updateOkButton(const QString &text);
 
+        void onTimer();
+
     private:
-        /// Tell user how the import of the INI file went.
-        void giveImportFeedback(bool success);
+        /// Make progress bar move, to give user feedback
+        void simulateProgress();
+
+        /// after ini import runs, update settings
+        void reloadSettings();
 
         Process::ProcessInvoker *mWizardInvoker;
         Process::ProcessInvoker *mImporterInvoker;
@@ -58,7 +63,7 @@ namespace Launcher
 
         MainDialog *mMain;
         TextInputDialog *mProfileDialog;
-
+        QTimer *mTimer;
 
     };
 }

--- a/apps/launcher/settingspage.hpp
+++ b/apps/launcher/settingspage.hpp
@@ -29,6 +29,9 @@ namespace Launcher
 
         void saveSettings();
         bool loadSettings();
+        
+        /// set progress bar on page to 0%
+        void resetProgressBar();
 
     private slots:
 
@@ -44,14 +47,7 @@ namespace Launcher
 
         void updateOkButton(const QString &text);
 
-        void onTimer();
-
     private:
-        /// Make progress bar move, to give user feedback
-        void simulateProgress();
-
-        /// after ini import runs, update settings
-        void reloadSettings();
 
         Process::ProcessInvoker *mWizardInvoker;
         Process::ProcessInvoker *mImporterInvoker;
@@ -63,7 +59,6 @@ namespace Launcher
 
         MainDialog *mMain;
         TextInputDialog *mProfileDialog;
-        QTimer *mTimer;
 
     };
 }

--- a/apps/launcher/settingspage.hpp
+++ b/apps/launcher/settingspage.hpp
@@ -45,6 +45,8 @@ namespace Launcher
         void updateOkButton(const QString &text);
 
     private:
+        /// Tell user how the import of the INI file went.
+        void giveImportFeedback(bool success);
 
         Process::ProcessInvoker *mWizardInvoker;
         Process::ProcessInvoker *mImporterInvoker;

--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -849,8 +849,6 @@ void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, co
             Misc::StringUtils::toLower(filetype);
 
             if(filetype.compare("esm") == 0 || filetype.compare("esp") == 0) {
-                // Fixme? may need to use codecvt_type to tell filesystem::path that *entry is UTF-8 string
-                // Works on Engish Windows.  *Should* work on other languages & OS provided plug-in filename only uses ASCII characters.
                 boost::filesystem::path filepath(gameFilesDir);
                 filepath /= *entry;
                 contentFiles.push_back(std::make_pair(lastWriteTime(filepath, defaultTime), *entry));

--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <components/misc/stringops.hpp>
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
 namespace bfs = boost::filesystem;
@@ -660,7 +660,7 @@ std::string MwIniImporter::numberToString(int n) {
     return str.str();
 }
 
-MwIniImporter::multistrmap MwIniImporter::loadIniFile(const std::string& filename) const {
+MwIniImporter::multistrmap MwIniImporter::loadIniFile(const boost::filesystem::path&  filename) const {
     std::cout << "load ini file: " << filename << std::endl;
 
     std::string section("");
@@ -719,7 +719,7 @@ MwIniImporter::multistrmap MwIniImporter::loadIniFile(const std::string& filenam
     return map;
 }
 
-MwIniImporter::multistrmap MwIniImporter::loadCfgFile(const std::string& filename) {
+MwIniImporter::multistrmap MwIniImporter::loadCfgFile(const boost::filesystem::path& filename) {
     std::cout << "load cfg file: " << filename << std::endl;
 
     MwIniImporter::multistrmap map;
@@ -825,10 +825,14 @@ void MwIniImporter::importArchives(multistrmap &cfg, const multistrmap &ini) con
     }
 }
 
-void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini) const {
-    std::vector<std::string> contentFiles;
+void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, const boost::filesystem::path& iniFilename) const {
+    std::vector<std::pair<std::time_t, std::string>> contentFiles;
     std::string baseGameFile("Game Files:GameFile");
     std::string gameFile("");
+    std::time_t defaultTime = 0;
+
+    // assume the Game Files are all in a "Data Files" directory under the directory holding Morrowind.ini
+    const boost::filesystem::path gameFilesDir(iniFilename.parent_path() /= "Data Files");
 
     multistrmap::const_iterator it = ini.begin();
     for(int i=0; it != ini.end(); i++) {
@@ -845,18 +849,22 @@ void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini) co
             Misc::StringUtils::toLower(filetype);
 
             if(filetype.compare("esm") == 0 || filetype.compare("esp") == 0) {
-                contentFiles.push_back(*entry);
+                // Fixme? may need to use codecvt_type to tell filesystem::path that *entry is UTF-8 string
+                // Works on Engish Windows.  *Should* work on other languages & OS provided plug-in filename only uses ASCII characters.
+                boost::filesystem::path filepath(gameFilesDir);
+                filepath /= *entry;
+                contentFiles.push_back(std::make_pair(lastWriteTime(filepath, defaultTime), *entry));
             }
         }
-
-        gameFile = "";
     }
 
     cfg.erase("content");
     cfg.insert( std::make_pair("content", std::vector<std::string>() ) );
 
-    for(std::vector<std::string>::const_iterator it=contentFiles.begin(); it!=contentFiles.end(); ++it) {
-        cfg["content"].push_back(*it);
+    // this will sort files by time order first, then alphabetical (maybe), I suspect non ASCII filenames will be stuffed.
+    sort(contentFiles.begin(), contentFiles.end());
+    for(std::vector<std::pair<std::time_t, std::string>>::const_iterator it=contentFiles.begin(); it!=contentFiles.end(); ++it) {
+        cfg["content"].push_back(it->second);
     }
 }
 
@@ -872,4 +880,9 @@ void MwIniImporter::writeToFile(std::ostream &out, const multistrmap &cfg) {
 void MwIniImporter::setInputEncoding(const ToUTF8::FromType &encoding)
 {
   mEncoding = encoding;
+}
+
+std::time_t MwIniImporter::lastWriteTime(const boost::filesystem::path& filename, std::time_t defaultTime)
+{
+    return boost::filesystem::exists(filename) ? boost::filesystem::last_write_time(filename) : defaultTime;
 }

--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -826,7 +826,7 @@ void MwIniImporter::importArchives(multistrmap &cfg, const multistrmap &ini) con
 }
 
 void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, const boost::filesystem::path& iniFilename) const {
-    std::vector<std::pair<std::time_t, std::string>> contentFiles;
+    std::vector<std::pair<std::time_t, std::string> > contentFiles;
     std::string baseGameFile("Game Files:GameFile");
     std::string gameFile("");
     std::time_t defaultTime = 0;
@@ -863,7 +863,7 @@ void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, co
 
     // this will sort files by time order first, then alphabetical (maybe), I suspect non ASCII filenames will be stuffed.
     sort(contentFiles.begin(), contentFiles.end());
-    for(std::vector<std::pair<std::time_t, std::string>>::const_iterator it=contentFiles.begin(); it!=contentFiles.end(); ++it) {
+    for(std::vector<std::pair<std::time_t, std::string> >::const_iterator it=contentFiles.begin(); it!=contentFiles.end(); ++it) {
         cfg["content"].push_back(it->second);
     }
 }

--- a/apps/mwiniimporter/importer.hpp
+++ b/apps/mwiniimporter/importer.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <exception>
 #include <iosfwd>
+#include <boost/filesystem/path.hpp>
 
 #include <components/to_utf8/to_utf8.hpp>
 
@@ -17,17 +18,22 @@ class MwIniImporter {
     MwIniImporter();
     void    setInputEncoding(const ToUTF8::FromType& encoding);
     void    setVerbose(bool verbose);
-    multistrmap  loadIniFile(const std::string& filename) const;
-    static multistrmap  loadCfgFile(const std::string& filename);
+    multistrmap  loadIniFile(const boost::filesystem::path& filename) const;
+    static multistrmap  loadCfgFile(const boost::filesystem::path& filename);
     void    merge(multistrmap &cfg, const multistrmap &ini) const;
     void    mergeFallback(multistrmap &cfg, const multistrmap &ini) const;
-    void    importGameFiles(multistrmap &cfg, const multistrmap &ini) const;
+    void    importGameFiles(multistrmap &cfg, const multistrmap &ini, 
+        const boost::filesystem::path& iniFilename) const;
     void    importArchives(multistrmap &cfg, const multistrmap &ini) const;
     static void    writeToFile(std::ostream &out, const multistrmap &cfg);
 
   private:
     static void insertMultistrmap(multistrmap &cfg, const std::string& key, const std::string& value);
     static std::string numberToString(int n);
+
+    /// \return file's "last modified time", used in original MW to determine plug-in load order
+    static std::time_t lastWriteTime(const boost::filesystem::path& filename, std::time_t defaultTime);
+
     bool mVerbose;
     strmap mMergeMap;
     std::vector<std::string> mMergeFallback;

--- a/apps/mwiniimporter/main.cpp
+++ b/apps/mwiniimporter/main.cpp
@@ -93,8 +93,8 @@ int wmain(int argc, wchar_t *wargv[]) {
 
         bpo::notify(vm);
 
-        std::string iniFile = vm["ini"].as<std::string>();
-        std::string cfgFile = vm["cfg"].as<std::string>();
+        boost::filesystem::path iniFile(vm["ini"].as<std::string>());
+        boost::filesystem::path cfgFile(vm["cfg"].as<std::string>());
 
         // if no output is given, write back to cfg file
         std::string outputFile(vm["output"].as<std::string>());
@@ -123,7 +123,7 @@ int wmain(int argc, wchar_t *wargv[]) {
         importer.mergeFallback(cfg, ini);
 
         if(vm.count("game-files")) {
-            importer.importGameFiles(cfg, ini);
+            importer.importGameFiles(cfg, ini, iniFile);
         }
 
         if(!vm.count("no-archives")) {

--- a/components/config/launchersettings.cpp
+++ b/components/config/launchersettings.cpp
@@ -105,6 +105,12 @@ void Config::LauncherSettings::setContentList(const GameSettings& gameSettings)
     // obtain content list from game settings (if present)
     const QStringList files(gameSettings.getContentList());
 
+    // if openmw.cfg has no content, exit so we don't create an empty content list.
+    if (files.isEmpty())
+    {
+        return;
+    }
+
     // if any existing profile in launcher matches the content list, make that profile the default
     foreach(const QString &listName, getContentLists())
     {

--- a/files/ui/settingspage.ui
+++ b/files/ui/settingspage.ui
@@ -131,6 +131,13 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QProgressBar" name="progressBar">
+          <property name="maximum">
+           <number>4</number>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
Note, this is a partial fix.
It should work correctly for any OS that uses UTF-8 strings for filenames in OS calls.
It won't work correctly for content files that use non-ASCII characters on Windows.
But I think 
(a) the number of files falling into that case will be small.
(b) most people are only going to run the importer once.
(c) The fix is better than what we had.
(d) If someone wants to fix the problem fully, this gives them a starting point.