### PR TITLE
Include cleanup / Compile time speedup

### DIFF
--- a/apps/opencs/model/world/pathgrid.cpp
+++ b/apps/opencs/model/world/pathgrid.cpp
@@ -1,4 +1,5 @@
-
+#include "cell.hpp"
+#include "idcollection.hpp"
 #include "pathgrid.hpp"
 
 #include <sstream>

--- a/apps/opencs/model/world/pathgrid.hpp
+++ b/apps/opencs/model/world/pathgrid.hpp
@@ -11,7 +11,7 @@ namespace CSMWorld
     struct Cell;
     template<typename T>
     struct IdAccessor;
-    template<typename T, typename AT = IdAccessor<T>>
+    template<typename T, typename AT = IdAccessor<T> >
     class IdCollection;
 
     /// \brief Wrapper for Pathgrid record

--- a/apps/opencs/model/world/pathgrid.hpp
+++ b/apps/opencs/model/world/pathgrid.hpp
@@ -6,11 +6,14 @@
 
 #include <components/esm/loadpgrd.hpp>
 
-#include "idcollection.hpp"
-#include "cell.hpp"
-
 namespace CSMWorld
 {
+    struct Cell;
+    template<typename T>
+    struct IdAccessor;
+    template<typename T, typename AT = IdAccessor<T>>
+    class IdCollection;
+
     /// \brief Wrapper for Pathgrid record
     ///
     /// \attention The mData.mX and mData.mY fields of the ESM::Pathgrid struct are not used.

--- a/apps/opencs/model/world/pathgrid.hpp
+++ b/apps/opencs/model/world/pathgrid.hpp
@@ -9,9 +9,7 @@
 namespace CSMWorld
 {
     struct Cell;
-    template<typename T>
-    struct IdAccessor;
-    template<typename T, typename AT = IdAccessor<T> >
+    template<typename T, typename AT>
     class IdCollection;
 
     /// \brief Wrapper for Pathgrid record

--- a/apps/opencs/model/world/subcellcollection.hpp
+++ b/apps/opencs/model/world/subcellcollection.hpp
@@ -9,9 +9,7 @@ namespace ESM
 namespace CSMWorld
 {
     struct Cell;
-    template<typename T>
-    struct IdAccessor;
-    template<typename T, typename AT = IdAccessor<T> >
+    template<typename T, typename AT>
     class IdCollection;
 
     /// \brief Single type collection of top level records that are associated with cells

--- a/apps/opencs/model/world/subcellcollection.hpp
+++ b/apps/opencs/model/world/subcellcollection.hpp
@@ -1,10 +1,19 @@
 #ifndef CSM_WOLRD_SUBCOLLECTION_H
 #define CSM_WOLRD_SUBCOLLECTION_H
 
-#include "idcollection.hpp"
+namespace ESM
+{
+    class ESMReader;
+}
 
 namespace CSMWorld
 {
+    struct Cell;
+    template<typename T>
+    struct IdAccessor;
+    template<typename T, typename AT = IdAccessor<T>>
+    class IdCollection;
+
     /// \brief Single type collection of top level records that are associated with cells
     template<typename ESXRecordT, typename IdAccessorT = IdAccessor<ESXRecordT> >
     class SubCellCollection : public IdCollection<ESXRecordT, IdAccessorT>

--- a/apps/opencs/model/world/subcellcollection.hpp
+++ b/apps/opencs/model/world/subcellcollection.hpp
@@ -11,7 +11,7 @@ namespace CSMWorld
     struct Cell;
     template<typename T>
     struct IdAccessor;
-    template<typename T, typename AT = IdAccessor<T>>
+    template<typename T, typename AT = IdAccessor<T> >
     class IdCollection;
 
     /// \brief Single type collection of top level records that are associated with cells

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -1,7 +1,7 @@
 #ifndef GAME_MWBASE_WINDOWMANAGER_H
 #define GAME_MWBASE_WINDOWMANAGER_H
 
-#include <cstdint>
+#include <stdint.h>
 #include <string>
 #include <vector>
 #include <map>

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -1,11 +1,11 @@
 #ifndef GAME_MWBASE_WINDOWMANAGER_H
 #define GAME_MWBASE_WINDOWMANAGER_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>
-
-#include "../mwmechanics/stat.hpp"
+#include <set>
 
 #include "../mwgui/mode.hpp"
 
@@ -40,6 +40,14 @@ namespace ESM
     class ESMReader;
     class ESMWriter;
     struct CellId;
+}
+
+namespace MWMechanics
+{
+    class AttributeValue;
+    template<typename T>
+    class DynamicStat;
+    class SkillValue;
 }
 
 namespace MWWorld

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -12,6 +12,7 @@
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/actiontake.hpp"
 #include "../mwworld/cellstore.hpp"
+#include "../mwworld/esmstore.hpp"
 #include "../mwworld/physicssystem.hpp"
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/nullaction.hpp"

--- a/apps/openmw/mwdialogue/scripttest.cpp
+++ b/apps/openmw/mwdialogue/scripttest.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "../mwworld/manualref.hpp"
+#include "../mwworld/esmstore.hpp"
 #include "../mwworld/class.hpp"
 
 #include "../mwbase/environment.hpp"

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -11,6 +11,7 @@
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 
+#include <components/misc/stringops.hpp>
 #include <components/widgets/imagebutton.hpp>
 #include <components/widgets/list.hpp>
 

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -14,6 +14,7 @@
 
 #include <SDL_video.h>
 
+#include <components/misc/stringops.hpp>
 #include <components/widgets/sharedstatebutton.hpp>
 #include <components/settings/settings.hpp>
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -16,6 +16,7 @@
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"
+#include "../mwworld/esmstore.hpp"
 
 #include "../mwmechanics/creaturestats.hpp"
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -42,6 +42,7 @@
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/esmstore.hpp"
 
+#include "../mwmechanics/stat.hpp"
 #include "../mwmechanics/npcstats.hpp"
 
 #include "../mwsound/soundmanagerimp.hpp"

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -12,6 +12,7 @@
 #include "../mwbase/windowmanager.hpp"
 
 #include <components/settings/settings.hpp>
+#include <components/to_utf8/to_utf8.hpp>
 
 #include "mapwindow.hpp"
 

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -17,6 +17,7 @@
 
 namespace ESM
 {
+    class Cell;
     namespace AiSequence
     {
         struct AiWander;

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -2,6 +2,7 @@
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"
+#include "../mwworld/esmstore.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "creaturestats.hpp"

--- a/apps/openmw/mwmechanics/levelledlist.hpp
+++ b/apps/openmw/mwmechanics/levelledlist.hpp
@@ -2,6 +2,7 @@
 #define OPENMW_MECHANICS_LEVELLEDLIST_H
 
 #include "../mwworld/ptr.hpp"
+#include "../mwworld/esmstore.hpp"
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwbase/world.hpp"

--- a/apps/openmw/mwmechanics/npcstats.hpp
+++ b/apps/openmw/mwmechanics/npcstats.hpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "stat.hpp"
-
 #include "creaturestats.hpp"
 
 namespace ESM

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -1,8 +1,6 @@
 #ifndef OPENMW_MECHANICS_OBSTACLE_H
 #define OPENMW_MECHANICS_OBSTACLE_H
 
-#include "../mwworld/cellstore.hpp"
-
 namespace MWWorld
 {
     class Ptr;

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -1,8 +1,6 @@
 #ifndef OPENMW_MECHANICS_OBSTACLE_H
 #define OPENMW_MECHANICS_OBSTACLE_H
 
-//#include "../mwbase/world.hpp"
-//#include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
 
 namespace MWWorld

--- a/apps/openmw/mwscript/animationextensions.cpp
+++ b/apps/openmw/mwscript/animationextensions.cpp
@@ -11,6 +11,7 @@
 #include <components/interpreter/runtime.hpp>
 #include <components/interpreter/opcodes.hpp>
 
+#include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "interpretercontext.hpp"

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -20,6 +20,7 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -14,6 +14,8 @@
 #include <components/interpreter/runtime.hpp>
 #include <components/interpreter/opcodes.hpp>
 
+#include <components/misc/stringops.hpp>
+
 #include <components/esm/loadskil.hpp>
 
 #include "../mwbase/environment.hpp"

--- a/apps/openmw/mwscript/controlextensions.cpp
+++ b/apps/openmw/mwscript/controlextensions.cpp
@@ -10,6 +10,7 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/inputmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/ptr.hpp"

--- a/apps/openmw/mwscript/dialogueextensions.cpp
+++ b/apps/openmw/mwscript/dialogueextensions.cpp
@@ -11,6 +11,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/journal.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwmechanics/npcstats.hpp"

--- a/apps/openmw/mwscript/guiextensions.cpp
+++ b/apps/openmw/mwscript/guiextensions.cpp
@@ -12,7 +12,7 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
-
+#include "../mwbase/world.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "interpretercontext.hpp"

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -17,6 +17,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/scriptmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/player.hpp"

--- a/apps/openmw/mwscript/ref.cpp
+++ b/apps/openmw/mwscript/ref.cpp
@@ -1,0 +1,29 @@
+#include "ref.hpp"
+
+#include <components/interpreter/runtime.hpp>
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
+
+#include "interpretercontext.hpp"
+
+MWWorld::Ptr MWScript::ExplicitRef::operator() (Interpreter::Runtime& runtime, bool required,
+    bool activeOnly) const
+{
+    std::string id = runtime.getStringLiteral(runtime[0].mInteger);
+    runtime.pop();
+
+    if (required)
+        return MWBase::Environment::get().getWorld()->getPtr(id, activeOnly);
+    else
+        return MWBase::Environment::get().getWorld()->searchPtr(id, activeOnly);
+}
+
+MWWorld::Ptr MWScript::ImplicitRef::operator() (Interpreter::Runtime& runtime, bool required,
+    bool activeOnly) const
+{
+    MWScript::InterpreterContext& context
+    = static_cast<MWScript::InterpreterContext&> (runtime.getContext());
+
+    return context.getReference(required);
+}

--- a/apps/openmw/mwscript/ref.hpp
+++ b/apps/openmw/mwscript/ref.hpp
@@ -3,14 +3,12 @@
 
 #include <string>
 
-#include <components/interpreter/runtime.hpp>
-
-#include "../mwbase/environment.hpp"
-#include "../mwbase/world.hpp"
-
 #include "../mwworld/ptr.hpp"
 
-#include "interpretercontext.hpp"
+namespace Interpreter
+{
+    class Runtime;
+}
 
 namespace MWScript
 {
@@ -18,31 +16,16 @@ namespace MWScript
     {
         static const bool implicit = false;
 
-        MWWorld::Ptr operator() (Interpreter::Runtime& runtime, bool required=true,
-            bool activeOnly = false) const
-        {
-            std::string id = runtime.getStringLiteral (runtime[0].mInteger);
-            runtime.pop();
-
-            if (required)
-                return MWBase::Environment::get().getWorld()->getPtr (id, activeOnly);
-            else
-                return MWBase::Environment::get().getWorld()->searchPtr (id, activeOnly);
-        }
+        MWWorld::Ptr operator() (Interpreter::Runtime& runtime, bool required = true,
+            bool activeOnly = false) const;
     };
 
     struct ImplicitRef
     {
         static const bool implicit = true;
 
-        MWWorld::Ptr operator() (Interpreter::Runtime& runtime, bool required=true,
-            bool activeOnly = false) const
-        {
-            MWScript::InterpreterContext& context
-                = static_cast<MWScript::InterpreterContext&> (runtime.getContext());
-
-            return context.getReference(required);
-        }
+        MWWorld::Ptr operator() (Interpreter::Runtime& runtime, bool required = true,
+            bool activeOnly = false) const;
     };
 }
 

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -18,6 +18,7 @@
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/player.hpp"

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -11,6 +11,7 @@
 
 #include "../mwbase/environment.hpp"
 
+#include "../mwworld/cellstore.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/player.hpp"

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -10,6 +10,7 @@
 #include <components/interpreter/opcodes.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/class.hpp"

--- a/apps/openmw/mwworld/manualref.cpp
+++ b/apps/openmw/mwworld/manualref.cpp
@@ -1,0 +1,67 @@
+#include "manualref.hpp"
+
+#include "esmstore.hpp"
+#include "cellstore.hpp"
+
+namespace
+{
+
+    template<typename T>
+    void create(const MWWorld::Store<T>& list, const std::string& name, boost::any& refValue, MWWorld::Ptr& ptrValue)
+    {
+        const T* base = list.find(name);
+
+        ESM::CellRef cellRef;
+        cellRef.mRefNum.unset();
+        cellRef.mRefID = name;
+        cellRef.mScale = 1;
+        cellRef.mFactionRank = 0;
+        cellRef.mChargeInt = -1;
+        cellRef.mGoldValue = 1;
+        cellRef.mEnchantmentCharge = -1;
+        cellRef.mTeleport = false;
+        cellRef.mLockLevel = 0;
+        cellRef.mReferenceBlocked = 0;
+
+        MWWorld::LiveCellRef<T> ref(cellRef, base);
+
+        refValue = ref;
+        ptrValue = MWWorld::Ptr(&boost::any_cast<MWWorld::LiveCellRef<T>&>(refValue), 0);
+    }
+}
+
+MWWorld::ManualRef::ManualRef(const MWWorld::ESMStore& store, const std::string& name, const int count)
+{
+    std::string lowerName = Misc::StringUtils::lowerCase(name);
+    switch (store.find(lowerName))
+    {
+    case ESM::REC_ACTI: create(store.get<ESM::Activator>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_ALCH: create(store.get<ESM::Potion>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_APPA: create(store.get<ESM::Apparatus>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_ARMO: create(store.get<ESM::Armor>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_BOOK: create(store.get<ESM::Book>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_CLOT: create(store.get<ESM::Clothing>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_CONT: create(store.get<ESM::Container>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_CREA: create(store.get<ESM::Creature>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_DOOR: create(store.get<ESM::Door>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_INGR: create(store.get<ESM::Ingredient>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_LEVC: create(store.get<ESM::CreatureLevList>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_LEVI: create(store.get<ESM::ItemLevList>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_LIGH: create(store.get<ESM::Light>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_LOCK: create(store.get<ESM::Lockpick>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_MISC: create(store.get<ESM::Miscellaneous>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_NPC_: create(store.get<ESM::NPC>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_PROB: create(store.get<ESM::Probe>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_REPA: create(store.get<ESM::Repair>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_STAT: create(store.get<ESM::Static>(), lowerName, mRef, mPtr); break;
+    case ESM::REC_WEAP: create(store.get<ESM::Weapon>(), lowerName, mRef, mPtr); break;
+
+    case 0:
+        throw std::logic_error("failed to create manual cell ref for " + lowerName + " (unknown ID)");
+
+    default:
+        throw std::logic_error("failed to create manual cell ref for " + lowerName + " (unknown type)");
+    }
+
+    mPtr.getRefData().setCount(count);
+}

--- a/apps/openmw/mwworld/manualref.hpp
+++ b/apps/openmw/mwworld/manualref.hpp
@@ -3,9 +3,7 @@
 
 #include <boost/any.hpp>
 
-#include "esmstore.hpp"
 #include "ptr.hpp"
-#include "cellstore.hpp"
 
 namespace MWWorld
 {
@@ -18,66 +16,8 @@ namespace MWWorld
             ManualRef (const ManualRef&);
             ManualRef& operator= (const ManualRef&);
 
-            template<typename T>
-            void create (const MWWorld::Store<T>& list, const std::string& name)
-            {
-                const T* base = list.find(name);
-
-                ESM::CellRef cellRef;
-                cellRef.mRefNum.unset();
-                cellRef.mRefID = name;
-                cellRef.mScale = 1;
-                cellRef.mFactionRank = 0;
-                cellRef.mChargeInt = -1;
-                cellRef.mGoldValue = 1;
-                cellRef.mEnchantmentCharge = -1;
-                cellRef.mTeleport = false;
-                cellRef.mLockLevel = 0;
-                cellRef.mReferenceBlocked = 0;
-
-                LiveCellRef<T> ref(cellRef, base);
-
-                mRef = ref;
-                mPtr = Ptr (&boost::any_cast<LiveCellRef<T>&> (mRef), 0);
-            }
-
         public:
-
-            ManualRef (const MWWorld::ESMStore& store, const std::string& name, const int count=1)
-            {
-                std::string lowerName = Misc::StringUtils::lowerCase (name);
-                switch (store.find (lowerName))
-                {
-                    case ESM::REC_ACTI: create (store.get<ESM::Activator>(), lowerName); break;
-                    case ESM::REC_ALCH: create (store.get<ESM::Potion>(), lowerName); break;
-                    case ESM::REC_APPA: create (store.get<ESM::Apparatus>(), lowerName); break;
-                    case ESM::REC_ARMO: create (store.get<ESM::Armor>(), lowerName); break;
-                    case ESM::REC_BOOK: create (store.get<ESM::Book>(), lowerName); break;
-                    case ESM::REC_CLOT: create (store.get<ESM::Clothing>(), lowerName); break;
-                    case ESM::REC_CONT: create (store.get<ESM::Container>(), lowerName); break;
-                    case ESM::REC_CREA: create (store.get<ESM::Creature>(), lowerName); break;
-                    case ESM::REC_DOOR: create (store.get<ESM::Door>(), lowerName); break;
-                    case ESM::REC_INGR: create (store.get<ESM::Ingredient>(), lowerName); break;
-                    case ESM::REC_LEVC: create (store.get<ESM::CreatureLevList>(), lowerName); break;
-                    case ESM::REC_LEVI: create (store.get<ESM::ItemLevList>(), lowerName); break;
-                    case ESM::REC_LIGH: create (store.get<ESM::Light>(), lowerName); break;
-                    case ESM::REC_LOCK: create (store.get<ESM::Lockpick>(), lowerName); break;
-                    case ESM::REC_MISC: create (store.get<ESM::Miscellaneous>(), lowerName); break;
-                    case ESM::REC_NPC_: create (store.get<ESM::NPC>(), lowerName); break;
-                    case ESM::REC_PROB: create (store.get<ESM::Probe>(), lowerName); break;
-                    case ESM::REC_REPA: create (store.get<ESM::Repair>(), lowerName); break;
-                    case ESM::REC_STAT: create (store.get<ESM::Static>(), lowerName); break;
-                    case ESM::REC_WEAP: create (store.get<ESM::Weapon>(), lowerName); break;
-
-                    case 0:
-                        throw std::logic_error ("failed to create manual cell ref for " + lowerName + " (unknown ID)");
-
-                    default:
-                        throw std::logic_error ("failed to create manual cell ref for " + lowerName + " (unknown type)");
-                }
-
-                mPtr.getRefData().setCount(count);
-            }
+            ManualRef(const MWWorld::ESMStore& store, const std::string& name, const int count = 1);
 
             const Ptr& getPtr() const
             {

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -9,6 +9,7 @@
 
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/class.hpp"
+#include "../mwworld/esmstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 
 #include "../mwbase/soundmanager.hpp"

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -44,6 +44,7 @@
 
 #include "player.hpp"
 #include "manualref.hpp"
+#include "cellstore.hpp"
 #include "cellfunctors.hpp"
 #include "containerstore.hpp"
 #include "inventorystore.hpp"


### PR DESCRIPTION
Browsing around trying to clean up more unnecessary including and build time slowdown.

OpenMW has many commonly used parts written as templates, and they're very often stored in member variables. So actually speeding that up is proving to be tricky.

I'm not perfectly sure if I'm ready for a merge of this yet, this is mainly for the travis build.