### PR TITLE
Fix MSVC build due to missing M_PI define

### DIFF
--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -1,6 +1,7 @@
-#include "weather.hpp"
-
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include "weather.hpp"
 
 #include <components/esm/weatherstate.hpp>
 


### PR DESCRIPTION
Apparently the header guard on cmath only adds the defines if _USE_MATH_DEFINES is defined when cmath is included for the first time.

So enabling that define and moving cmath up to be the first include, so that nothing else includes it without the define set.