### PR TITLE
OS X CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
 script:
  - cd ./build
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make -j4; fi
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && ["${TRAVIS_OS_NAME}" = "osx"]; then make package; fi
 after_script:
  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./openmw_test_suite; fi
 notifications:

--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -6,4 +6,4 @@ export CC=clang
 brew tap openmw/openmw
 brew update
 brew unlink boost
-brew install openmw-mygui openmw-bullet openmw-sdl2 openmw-ffmpeg qt unshield
+brew install openmw-mygui openmw-bullet openmw-sdl2 openmw-ffmpeg openmw/openmw/qt unshield


### PR DESCRIPTION
1. Use Qt from our repo to avoid SourceForge download errors
2. Run `make package` on OS X to catch packaging errors early