### PR TITLE
Remove setting CMAKE_BUILD_TYPE to Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 project(OpenMW)
 
+# If the user doesn't supply a CMAKE_BUILD_TYPE via command line, choose one for them.
+IF(NOT CMAKE_BUILD_TYPE)
+    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+        "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
+        FORCE)
+ENDIF()
+
 if (APPLE)
     set(APP_BUNDLE_NAME "${CMAKE_PROJECT_NAME}.app")
 

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -4,8 +4,6 @@ set (OPENCS_SRC main.cpp
 
 opencs_units (. editor)
 
-set (CMAKE_BUILD_TYPE DEBUG)
-
 opencs_units (model/doc
     document operation saving documentmanager loader runner
     )

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,5 +1,4 @@
 project (Components)
-set (CMAKE_BUILD_TYPE DEBUG)
 
 # Version file
 set (VERSION_HPP_IN ${CMAKE_CURRENT_SOURCE_DIR}/version/version.hpp.cmake)


### PR DESCRIPTION
Setting was causing single-target configurations (ninja, make) to
incorrectly link vs debug runtimes on Windows.