### PR TITLE
Bugfix/1533 - Teleportation in Mournhold

### DIFF
--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -187,7 +187,7 @@ namespace MWWorld
             }
 
             template <class T>
-            CellRefList<T>& getReadOnly() {
+            const CellRefList<T>& getReadOnly() {
                 throw std::runtime_error ("Read Only CellRefList access not available for type " + std::string(typeid(T).name()) );
             }
 
@@ -365,7 +365,7 @@ namespace MWWorld
     }
 
     template<>
-    inline CellRefList<ESM::Door>& CellStore::getReadOnly<ESM::Door>()
+    inline const CellRefList<ESM::Door>& CellStore::getReadOnly<ESM::Door>()
     {
         return mDoors;
     }

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -3,6 +3,8 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <string>
+#include <typeinfo>
 #include <boost/shared_ptr.hpp>
 
 #include "livecellref.hpp"
@@ -181,12 +183,12 @@ namespace MWWorld
 
             template <class T>
             CellRefList<T>& get() {
-                throw std::runtime_error ("Storage for this type not exist in cells");
+                throw std::runtime_error ("Storage for type " + std::string(typeid(T).name())+ " does not exist in cells");
             }
 
             template <class T>
             CellRefList<T>& getReadOnly() {
-                throw std::runtime_error ("Read Only access not available for this type");
+                throw std::runtime_error ("Read Only CellRefList access not available for type " + std::string(typeid(T).name()) );
             }
 
             bool isPointConnected(const int start, const int end) const;

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -184,6 +184,11 @@ namespace MWWorld
                 throw std::runtime_error ("Storage for this type not exist in cells");
             }
 
+            template <class T>
+            CellRefList<T>& getReadOnly() {
+                throw std::runtime_error ("Read Only access not available for this type");
+            }
+
             bool isPointConnected(const int start, const int end) const;
 
             std::list<ESM::Pathgrid::Point> aStarSearch(const int start, const int end) const;
@@ -355,6 +360,12 @@ namespace MWWorld
     {
         mHasState = true;
         return mWeapons;
+    }
+
+    template<>
+    inline CellRefList<ESM::Door>& CellStore::getReadOnly<ESM::Door>()
+    {
+        return mDoors;
     }
 
     bool operator== (const CellStore& left, const CellStore& right);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2799,13 +2799,13 @@ namespace MWWorld
                 MWWorld::CellStore *next = getInterior( *i );
                 if ( !next ) continue;
 
-                MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnly<ESM::Door>();
-                CellRefList<ESM::Door>::List& refList = doors.mList;
+                const MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnly<ESM::Door>();
+                const CellRefList<ESM::Door>::List& refList = doors.mList;
 
                 // Check if any door in the cell leads to an exterior directly
-                for (CellRefList<ESM::Door>::List::iterator it = refList.begin(); it != refList.end(); ++it)
+                for (CellRefList<ESM::Door>::List::const_iterator it = refList.begin(); it != refList.end(); ++it)
                 {
-                    MWWorld::LiveCellRef<ESM::Door>& ref = *it;
+                    const MWWorld::LiveCellRef<ESM::Door>& ref = *it;
                     if (!ref.mRef.getTeleport()) continue;
 
                     if (ref.mRef.getDestCell().empty())
@@ -2855,13 +2855,13 @@ namespace MWWorld
                     return closestMarker;
                 }
 
-                MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnly<ESM::Door>();
-                CellRefList<ESM::Door>::List& doorList = doors.mList;
+                const MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnly<ESM::Door>();
+                const CellRefList<ESM::Door>::List& doorList = doors.mList;
 
                 // Check if any door in the cell leads to an exterior directly
-                for (CellRefList<ESM::Door>::List::iterator it = doorList.begin(); it != doorList.end(); ++it)
+                for (CellRefList<ESM::Door>::List::const_iterator it = doorList.begin(); it != doorList.end(); ++it)
                 {
-                    MWWorld::LiveCellRef<ESM::Door>& ref = *it;
+                    const MWWorld::LiveCellRef<ESM::Door>& ref = *it;
 
                     if (!ref.mRef.getTeleport()) continue;
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -151,6 +151,8 @@ namespace MWWorld
 
             float feetToGameUnits(float feet);
 
+            MWWorld::Ptr getClosestMarker( const MWWorld::Ptr &ptr, const std::string &id );
+
         public:
 
             World (OEngine::Render::OgreRenderer& renderer,


### PR DESCRIPTION
This is a brute-force search to support intervention / prison behavior while in Mournhold.

Any feedback on if there are serious performance issues with the cell-loading used would be appreciated.  I'm not familiar enough with the cell loading / unloading to know if any caching / special handling of the needed data is appropriate.  I'd like to find a basically acceptable approach before cleaning it up the rest of the way.

A side effect of the changes is that the stolen_goods container list isn't needed anymore.  I found that the prison markers contain teleport links to the cell containing the evidence chest to use.

(The OMW Bug mentions edge cases for over-world marker handling, but that hasn't been changed here.)