### PR TITLE
Ignore case when detecting legacy extensions (.esm or .exp).

### DIFF
--- a/apps/opencs/view/doc/adjusterwidget.cpp
+++ b/apps/opencs/view/doc/adjusterwidget.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -72,8 +73,11 @@ void CSVDoc::AdjusterWidget::setName (const QString& name, bool addon)
     {
         boost::filesystem::path path (name.toUtf8().data());
 
-        bool isLegacyPath = (path.extension() == ".esm" ||
-                             path.extension() == ".esp");
+        std::string extension = path.extension().string();
+        boost::algorithm::to_lower(extension);
+
+        bool isLegacyPath = (extension == ".esm" ||
+                             extension == ".esp");
 
         bool isFilePathChanged = (path.parent_path().string() != mLocalData.string());
 


### PR DESCRIPTION
Should resolve bug #2227.