### PR TITLE
Morrowind.ini import progress bar. (Fixes #2344)

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -238,24 +238,8 @@ void Launcher::MainDialog::changePage(QListWidgetItem *current, QListWidgetItem 
         current = previous;
 
     int currentIndex = iconWidget->row(current);
-//    int previousIndex = iconWidget->row(previous);
-
     pagesWidget->setCurrentIndex(currentIndex);
-
-    //    DataFilesPage *previousPage = dynamic_cast<DataFilesPage *>(pagesWidget->widget(previousIndex));
-    //    DataFilesPage *currentPage = dynamic_cast<DataFilesPage *>(pagesWidget->widget(currentIndex));
-
-    //    //special call to update/save data files page list view when it's displayed/hidden.
-    //    if (previousPage)
-    //    {
-    //        if (previousPage->objectName() == "DataFilesPage")
-    //            previousPage->saveSettings();
-    //    }
-    //    else if (currentPage)
-    //    {
-    //        if (currentPage->objectName() == "DataFilesPage")
-    //            currentPage->loadSettings();
-    //    }
+    mSettingsPage->resetProgressBar();
 }
 
 bool Launcher::MainDialog::setupLauncherSettings()

--- a/apps/launcher/settingspage.cpp
+++ b/apps/launcher/settingspage.cpp
@@ -4,7 +4,6 @@
 #include <QMessageBox>
 #include <QDebug>
 #include <QDir>
-#include <QTimer>
 
 #include <components/files/configurationmanager.hpp>
 

--- a/apps/launcher/settingspage.cpp
+++ b/apps/launcher/settingspage.cpp
@@ -229,8 +229,7 @@ void Launcher::SettingsPage::importerFinished(int exitCode, QProcess::ExitStatus
 void Launcher::SettingsPage::resetProgressBar()
 {
     // set progress bar to 0 %
-    progressBar->setMaximum(1);
-    progressBar->setValue(0);
+    progressBar->reset();
 }
 
 void Launcher::SettingsPage::updateOkButton(const QString &text)

--- a/apps/launcher/settingspage.cpp
+++ b/apps/launcher/settingspage.cpp
@@ -95,7 +95,7 @@ Launcher::SettingsPage::~SettingsPage()
 
 void Launcher::SettingsPage::on_wizardButton_clicked()
 {
-    saveSettings();
+    mMain->writeSettings();
 
     if (!mWizardInvoker->startProcess(QLatin1String("openmw-wizard"), false))
         return;
@@ -103,7 +103,7 @@ void Launcher::SettingsPage::on_wizardButton_clicked()
 
 void Launcher::SettingsPage::on_importerButton_clicked()
 {
-    saveSettings();
+    mMain->writeSettings();
 
     // Create the file if it doesn't already exist, else the importer will fail
     QString path(QString::fromUtf8(mCfgMgr.getUserConfigPath().string().c_str()));

--- a/apps/launcher/settingspage.hpp
+++ b/apps/launcher/settingspage.hpp
@@ -29,6 +29,9 @@ namespace Launcher
 
         void saveSettings();
         bool loadSettings();
+        
+        /// set progress bar on page to 0%
+        void resetProgressBar();
 
     private slots:
 
@@ -56,7 +59,6 @@ namespace Launcher
 
         MainDialog *mMain;
         TextInputDialog *mProfileDialog;
-
 
     };
 }

--- a/components/config/launchersettings.cpp
+++ b/components/config/launchersettings.cpp
@@ -105,6 +105,12 @@ void Config::LauncherSettings::setContentList(const GameSettings& gameSettings)
     // obtain content list from game settings (if present)
     const QStringList files(gameSettings.getContentList());
 
+    // if openmw.cfg has no content, exit so we don't create an empty content list.
+    if (files.isEmpty())
+    {
+        return;
+    }
+
     // if any existing profile in launcher matches the content list, make that profile the default
     foreach(const QString &listName, getContentLists())
     {

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -489,6 +489,19 @@ void ContentSelectorModel::ContentModel::addFiles(const QString &path)
     sortFiles();
 }
 
+QStringList ContentSelectorModel::ContentModel::gameFiles() const
+{
+    QStringList gameFiles;
+    foreach(const ContentSelectorModel::EsmFile *file, mFiles)
+    {
+        if (file->isGameFile())
+        {
+            gameFiles.append(file->fileName());
+        }
+    }
+    return gameFiles;
+}
+
 void ContentSelectorModel::ContentModel::sortFiles()
 {
     //first, sort the model such that all dependencies are ordered upstream (gamefile) first.
@@ -589,7 +602,7 @@ void ContentSelectorModel::ContentModel::checkForLoadOrderErrors()
 QList<ContentSelectorModel::LoadOrderError> ContentSelectorModel::ContentModel::checkForLoadOrderErrors(const EsmFile *file, int row) const
 {
     QList<LoadOrderError> errors = QList<LoadOrderError>();
-    foreach(QString dependentfileName, file->gameFiles())
+    foreach(const QString &dependentfileName, file->gameFiles())
     {
         const EsmFile* dependentFile = item(dependentfileName);
 

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -110,15 +110,14 @@ Qt::ItemFlags ContentSelectorModel::ContentModel::flags(const QModelIndex &index
     if (!file)
         return Qt::NoItemFlags;
 
-    //game files can always be checked
+    //game files are not shown
     if (file->isGameFile())
-        return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable;
+        return Qt::NoItemFlags;
 
     Qt::ItemFlags returnFlags;
-    bool allDependenciesFound = true;
     bool gamefileChecked = false;
 
-    //addon can be checked if its gamefile is and all other dependencies exist
+    // addon can be checked if its gamefile is
     foreach (const QString &fileName, file->gameFiles())
     {
         bool depFound = false;
@@ -144,16 +143,11 @@ Qt::ItemFlags ContentSelectorModel::ContentModel::flags(const QModelIndex &index
             if (gamefileChecked || !(dependency->isGameFile()))
                 break;
         }
-
-        allDependenciesFound = allDependenciesFound && depFound;
     }
 
     if (gamefileChecked)
     {
-        if (allDependenciesFound)
-            returnFlags = returnFlags | Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemIsDragEnabled;
-        else
-            returnFlags = Qt::ItemIsSelectable;
+        returnFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsUserCheckable | Qt::ItemIsDragEnabled;
     }
 
     return returnFlags;
@@ -468,7 +462,7 @@ void ContentSelectorModel::ContentModel::addFiles(const QString &path)
             file->setDescription(QString::fromUtf8(fileReader.getDesc().c_str()));
 
             // HACK
-            // Bloodmoon.esm requires Tribunal.esm, but this requirement is missing 
+            // Load order constraint of Bloodmoon.esm needing Tribunal.esm is missing 
             // from the file supplied by Bethesda, so we have to add it ourselves
             if (file->fileName().compare("Bloodmoon.esm", Qt::CaseInsensitive) == 0)
             {

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -536,13 +536,13 @@ bool ContentSelectorModel::ContentModel::isLoadOrderError(const EsmFile *file) c
     return mPluginsWithLoadOrderError.contains(file->filePath());
 }
 
-void ContentSelectorModel::ContentModel::setContentList(const QStringList &fileList, bool isChecked)
+void ContentSelectorModel::ContentModel::setContentList(const QStringList &fileList)
 {
     mPluginsWithLoadOrderError.clear();
     int previousPosition = -1;
     foreach (const QString &filepath, fileList)
     {
-        if (setCheckState(filepath, isChecked))
+        if (setCheckState(filepath, true))
         {
             // as necessary, move plug-ins in visible list to match sequence of supplied filelist
             const EsmFile* file = item(filepath);

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -467,6 +467,14 @@ void ContentSelectorModel::ContentModel::addFiles(const QString &path)
             file->setFilePath       (info.absoluteFilePath());
             file->setDescription(QString::fromUtf8(fileReader.getDesc().c_str()));
 
+            // HACK
+            // Bloodmoon.esm requires Tribunal.esm, but this requirement is missing 
+            // from the file supplied by Bethesda, so we have to add it ourselves
+            if (file->fileName().compare("Bloodmoon.esm", Qt::CaseInsensitive) == 0)
+            {
+                file->addGameFile(QString::fromUtf8("Tribunal.esm"));
+            }
+
             // Put the file in the table
             addFile(file);
 

--- a/components/contentselector/model/contentmodel.hpp
+++ b/components/contentselector/model/contentmodel.hpp
@@ -47,6 +47,7 @@ namespace ContentSelectorModel
 
         QModelIndex indexFromItem(const EsmFile *item) const;
         const EsmFile *item(const QString &name) const;
+        QStringList gameFiles() const;
 
         bool isEnabled (QModelIndex index) const;
         bool isChecked(const QString &filepath) const;

--- a/components/contentselector/model/contentmodel.hpp
+++ b/components/contentselector/model/contentmodel.hpp
@@ -51,7 +51,7 @@ namespace ContentSelectorModel
         bool isEnabled (QModelIndex index) const;
         bool isChecked(const QString &filepath) const;
         bool setCheckState(const QString &filepath, bool isChecked);
-        void setContentList(const QStringList &fileList, bool isChecked);
+        void setContentList(const QStringList &fileList);
         ContentFileList checkedItems() const;
         void uncheckAll();
 

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -113,7 +113,7 @@ void ContentSelectorView::ContentSelector::setContentList(const QStringList &lis
         slotCurrentGameFileIndexChanged (ui.gameFileView->currentIndex());
     }
     else
-        mContentModel->setContentList(list, true);
+        mContentModel->setContentList(list);
 }
 
 ContentSelectorModel::ContentFileList

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -10,6 +10,7 @@
 #include <QGridLayout>
 #include <QMessageBox>
 #include <QModelIndex>
+#include <QDir>
 #include <assert.h>
 
 ContentSelectorView::ContentSelector::ContentSelector(QWidget *parent) :
@@ -33,13 +34,7 @@ void ContentSelectorView::ContentSelector::buildGameFileView()
 {
     ui.gameFileView->setVisible (true);
 
-    mGameFileProxyModel = new QSortFilterProxyModel(this);
-    mGameFileProxyModel->setFilterRegExp(QString::number((int)ContentSelectorModel::ContentType_GameFile));
-    mGameFileProxyModel->setFilterRole (Qt::UserRole);
-    mGameFileProxyModel->setSourceModel (mContentModel);
-
     ui.gameFileView->setPlaceholderText(QString("Select a game file..."));
-    ui.gameFileView->setModel(mGameFileProxyModel);
 
     connect (ui.gameFileView, SIGNAL (currentIndexChanged(int)),
              this, SLOT (slotCurrentGameFileIndexChanged(int)));
@@ -129,6 +124,15 @@ void ContentSelectorView::ContentSelector::addFiles(const QString &path)
 {
     mContentModel->addFiles(path);
 
+    // add any game files to the combo box
+    foreach(const QString gameFileName, mContentModel->gameFiles())
+    {
+        if (ui.gameFileView->findText(gameFileName) == -1)
+        {
+            ui.gameFileView->addItem(gameFileName);
+        }
+    }
+
     if (ui.gameFileView->currentIndex() != -1)
         ui.gameFileView->setCurrentIndex(-1);
 
@@ -150,27 +154,31 @@ void ContentSelectorView::ContentSelector::slotCurrentGameFileIndexChanged(int i
 {
     static int oldIndex = -1;
 
-    QAbstractItemModel *const model = ui.gameFileView->model();
-    QSortFilterProxyModel *proxy = dynamic_cast<QSortFilterProxyModel *>(model);
-
-    if (proxy)
-        proxy->setDynamicSortFilter(false);
-
     if (index != oldIndex)
     {
         if (oldIndex > -1)
-            model->setData(model->index(oldIndex, 0), false, Qt::UserRole + 1);
+        {
+            setGameFileSelected(oldIndex, false);
+        }
 
         oldIndex = index;
 
-        model->setData(model->index(index, 0), true, Qt::UserRole + 1);
+        setGameFileSelected(index, true);
         mContentModel->checkForLoadOrderErrors();
     }
 
-    if (proxy)
-        proxy->setDynamicSortFilter(true);
-
     emit signalCurrentGamefileIndexChanged (index);
+}
+
+void ContentSelectorView::ContentSelector::setGameFileSelected(int index, bool selected)
+{
+    QString fileName = ui.gameFileView->itemText(index);
+    const ContentSelectorModel::EsmFile* file = mContentModel->item(fileName);
+    if (file != NULL)
+    {
+        QModelIndex index(mContentModel->indexFromItem(file));
+        mContentModel->setData(index, selected, Qt::UserRole + 1);
+    }
 }
 
 void ContentSelectorView::ContentSelector::slotAddonTableItemActivated(const QModelIndex &index)

--- a/components/contentselector/view/contentselector.hpp
+++ b/components/contentselector/view/contentselector.hpp
@@ -19,7 +19,6 @@ namespace ContentSelectorView
     protected:
 
         ContentSelectorModel::ContentModel *mContentModel;
-        QSortFilterProxyModel *mGameFileProxyModel;
         QSortFilterProxyModel *mAddonProxyModel;
 
     public:
@@ -52,6 +51,7 @@ namespace ContentSelectorView
         void buildContentModel();
         void buildGameFileView();
         void buildAddonView();
+        void setGameFileSelected(int index, bool selected);
 
     signals:
         void signalCurrentGamefileIndexChanged (int);

--- a/files/ui/settingspage.ui
+++ b/files/ui/settingspage.ui
@@ -131,6 +131,13 @@
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QProgressBar" name="progressBar">
+          <property name="maximum">
+           <number>4</number>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
1. Show a "bouncing ball" Progress bar when importing from morrowind.ini.
2. Removed dialog that asks for content list name when import game files from morrowind.ini. Instead, name is time stamp.
3. Removed commented out code.
4. Additional bugfix. No longer create a empty content list when OpenMW.cfg has no content files.