### PR TITLE
Make the jail progress last one second

### DIFF
--- a/apps/openmw/mwgui/jailscreen.cpp
+++ b/apps/openmw/mwgui/jailscreen.cpp
@@ -17,7 +17,7 @@ namespace MWGui
 {
     JailScreen::JailScreen()
         : WindowBase("openmw_jail_screen.layout"),
-          mTimeAdvancer(0.0125),
+          mTimeAdvancer(0.01),
           mDays(1),
           mFadeTimeRemaining(0)
     {
@@ -39,7 +39,7 @@ namespace MWGui
         mFadeTimeRemaining = 0.5;
 
         setVisible(false);
-        mProgressBar->setScrollRange(days*24+1);
+        mProgressBar->setScrollRange(100+1);
         mProgressBar->setScrollPosition(0);
         mProgressBar->setTrackSize(0);
     }
@@ -59,7 +59,7 @@ namespace MWGui
             MWBase::Environment::get().getWorld()->teleportToClosestMarker(player, "prisonmarker");
 
             setVisible(true);
-            mTimeAdvancer.run(mDays*24);
+            mTimeAdvancer.run(100);
         }
     }
 


### PR DESCRIPTION
I dug a bit deeper into vanilla and from what I can tell, the jail progress bar acts like a loading bar (the function to advance time is called individually for every single hour spent in prison). So I went ahead and shortened our progress bar filling time to 1 sec, independently of bounty amount.