### PR TITLE
bugfix/2400 - Correction to teleportation changes.

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2832,6 +2832,10 @@ namespace MWWorld
 
     MWWorld::Ptr World::getClosestMarker( const MWWorld::Ptr &ptr, const std::string &id )
     {
+        if ( ptr.getCell()->isExterior() ) {
+            return getClosestMarkerFromExteriorPosition(mPlayer->getLastKnownExteriorPosition(), id);
+        }
+
         // Search for a 'nearest' marker, counting each cell between the starting
         // cell and the exterior as a distance of 1.  If an exterior is found, jump
         // to the nearest exterior marker, without further interior searching.
@@ -2868,25 +2872,7 @@ namespace MWWorld
                     if (ref.mRef.getDestCell().empty())
                     {
                         Ogre::Vector3 worldPos = Ogre::Vector3(ref.mRef.getDoorDest().pos);
-                        float closestDistance = FLT_MAX;
-
-                        MWWorld::Ptr closestMarker;
-                        std::vector<MWWorld::Ptr> markers;
-                        mCells.getExteriorPtrs(id, markers);
-                        for (std::vector<MWWorld::Ptr>::iterator it2 = markers.begin(); it2 != markers.end(); ++it2)
-                        {
-                            ESM::Position pos = it2->getRefData().getPosition();
-                            Ogre::Vector3 markerPos = Ogre::Vector3(pos.pos);
-                            float distance = worldPos.squaredDistance(markerPos);
-                            if (distance < closestDistance)
-                            {
-                                closestDistance = distance;
-                                closestMarker = *it2;
-                            }
-
-                        }
-
-                        return closestMarker;
+                        return getClosestMarkerFromExteriorPosition(worldPos, id);
                     }
                     else
                     {
@@ -2900,6 +2886,29 @@ namespace MWWorld
 
         return MWWorld::Ptr();
     }
+
+    MWWorld::Ptr World::getClosestMarkerFromExteriorPosition( const Ogre::Vector3 worldPos, const std::string &id ) {
+        MWWorld::Ptr closestMarker;
+        float closestDistance = FLT_MAX;
+
+        std::vector<MWWorld::Ptr> markers;
+        mCells.getExteriorPtrs(id, markers);
+        for (std::vector<MWWorld::Ptr>::iterator it2 = markers.begin(); it2 != markers.end(); ++it2)
+        {
+            ESM::Position pos = it2->getRefData().getPosition();
+            Ogre::Vector3 markerPos = Ogre::Vector3(pos.pos);
+            float distance = worldPos.squaredDistance(markerPos);
+            if (distance < closestDistance)
+            {
+                closestDistance = distance;
+                closestMarker = *it2;
+            }
+
+        }
+
+        return closestMarker;
+    }
+
 
     void World::teleportToClosestMarker (const MWWorld::Ptr& ptr,
                                           const std::string& id)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3075,6 +3075,11 @@ namespace MWWorld
     void World::confiscateStolenItems(const Ptr &ptr)
     {
         MWWorld::Ptr prisonMarker = getClosestMarker( ptr, "prisonmarker" );
+        if ( prisonMarker.isEmpty() )
+        {
+            std::cerr << "Failed to confiscate items: no closest prison marker found." << std::endl;
+            return;
+        }
         std::string prisonName = prisonMarker.mRef->mRef.getDestCell();
         if ( prisonName.empty() )
         {

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -151,6 +151,7 @@ namespace MWWorld
             float feetToGameUnits(float feet);
 
             MWWorld::Ptr getClosestMarker( const MWWorld::Ptr &ptr, const std::string &id );
+            MWWorld::Ptr getClosestMarkerFromExteriorPosition( const Ogre::Vector3 worldPos, const std::string &id );
 
         public:
 


### PR DESCRIPTION
Related to OMW Bug #1533

I missed the check against the starting cell being an exterior when I implemented getClosestMarker for the teleportation / map changes.  This adds the check back in, and fixes the game crash on teleport / jail while in an exterior cell.  (Apparently my testing was just with coc and Mournhold interiors at the end of that change sequence.)