### PR TITLE
Fix for incorrect OpenCS verifier warnings

### DIFF
--- a/apps/opencs/model/tools/tools.cpp
+++ b/apps/opencs/model/tools/tools.cpp
@@ -58,9 +58,6 @@ CSMDoc::Operation *CSMTools::Tools::getVerifier()
         mandatoryIds.push_back ("GameHour");
         mandatoryIds.push_back ("Month");
         mandatoryIds.push_back ("PCRace");
-        mandatoryIds.push_back ("PCVampire");
-        mandatoryIds.push_back ("PCWerewolf");
-        mandatoryIds.push_back ("PCYear");
 
         mVerifier->appendStage (new MandatoryIdStage (mData.getGlobals(),
             CSMWorld::UniversalId (CSMWorld::UniversalId::Type_Globals), mandatoryIds));


### PR DESCRIPTION
- pcvampire and pcwerewolf are only set by scripts, so not actually required for new game files.
- I have no idea what "pcyear" is supposed to be, because I can not find it in any of the 3 official ESMs.