### PR TITLE
scoped Input

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -666,11 +666,9 @@ namespace MWInput
             SDL_StopTextInput();
 
         bool consumed = SDL_IsTextInputActive();
-        if (kc != OIS::KC_UNASSIGNED)
-        {
-            bool guiFocus = MyGUI::InputManager::getInstance().injectKeyPress(MyGUI::KeyCode::Enum(kc), 0);
-            setPlayerControlsEnabled(!guiFocus);
-        }
+        bool guiFocus = MyGUI::InputManager::getInstance().injectKeyPress(MyGUI::KeyCode::Enum(kc), 0);
+        setPlayerControlsEnabled(!guiFocus);
+
         if (!mControlsDisabled && !consumed)
             mInputBinder->keyPressed (arg);
         mJoystickLastUsed = false;

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -665,11 +665,9 @@ namespace MWInput
                 && MWBase::Environment::get().getWindowManager()->getMode() == MWGui::GM_Console)
             SDL_StopTextInput();
 
-        bool consumed = false;
+        bool consumed = SDL_IsTextInputActive();
         if (kc != OIS::KC_UNASSIGNED)
         {
-            consumed = SDL_IsTextInputActive() &&
-                    ( !(SDLK_SCANCODE_MASK & arg.keysym.sym) && std::isprint(arg.keysym.sym)); // Little trick to check if key is printable
             bool guiFocus = MyGUI::InputManager::getInstance().injectKeyPress(MyGUI::KeyCode::Enum(kc), 0);
             setPlayerControlsEnabled(!guiFocus);
         }

--- a/extern/sdl4ogre/sdlinputwrapper.cpp
+++ b/extern/sdl4ogre/sdlinputwrapper.cpp
@@ -469,5 +469,7 @@ namespace SFO
         mKeyMap.insert( KeyMap::value_type(SDLK_LGUI, OIS::KC_LWIN) );
         mKeyMap.insert( KeyMap::value_type(SDLK_RGUI, OIS::KC_RWIN) );
         mKeyMap.insert( KeyMap::value_type(SDLK_APPLICATION, OIS::KC_APPS) );
+        mKeyMap.insert( KeyMap::value_type(SDLK_LEFTBRACKET, OIS::KC_LBRACKET) );
+        mKeyMap.insert( KeyMap::value_type(SDLK_RIGHTBRACKET, OIS::KC_RBRACKET) );
     }
 }


### PR DESCRIPTION
Not really sure what to write about a 2 line change but here is the link to the issue tracker:
https://bugs.openmw.org/issues/2409

**Edit**: I meant it fixes this part: "If you later write it into the console or save menu, the game won't crash, but it will switch your weapons even though you've selected a text field."
