### PR TITLE
Add saving land and land textures.  Should resolve Bug #2447.

### DIFF
--- a/apps/opencs/model/doc/saving.cpp
+++ b/apps/opencs/model/doc/saving.cpp
@@ -93,6 +93,10 @@ CSMDoc::Saving::Saving (Document& document, const boost::filesystem::path& proje
 
     appendStage (new WritePathgridCollectionStage (mDocument, mState));
 
+    appendStage (new WriteLandCollectionStage (mDocument, mState));
+
+    appendStage (new WriteLandTextureCollectionStage (mDocument, mState));
+
     // close file and clean up
     appendStage (new CloseSaveStage (mState));
 

--- a/apps/opencs/model/doc/savingstages.cpp
+++ b/apps/opencs/model/doc/savingstages.cpp
@@ -376,6 +376,8 @@ void CSMDoc::WriteLandCollectionStage::perform (int stage, Messages& messages)
         mState.getWriter().startRecord (record.mLand->sRecordId);
 
         record.mLand->save (mState.getWriter());
+        if(record.mLand->mLandData)
+            record.mLand->mLandData->save (mState.getWriter());
 
         mState.getWriter().endRecord (record.mLand->sRecordId);
     }

--- a/apps/opencs/model/doc/savingstages.cpp
+++ b/apps/opencs/model/doc/savingstages.cpp
@@ -353,6 +353,72 @@ void CSMDoc::WritePathgridCollectionStage::perform (int stage, Messages& message
 }
 
 
+CSMDoc::WriteLandCollectionStage::WriteLandCollectionStage (Document& document,
+    SavingState& state)
+: mDocument (document), mState (state)
+{}
+
+int CSMDoc::WriteLandCollectionStage::setup()
+{
+    return mDocument.getData().getLand().getSize();
+}
+
+void CSMDoc::WriteLandCollectionStage::perform (int stage, Messages& messages)
+{
+    const CSMWorld::Record<CSMWorld::Land>& land =
+        mDocument.getData().getLand().getRecord (stage);
+
+    if (land.mState==CSMWorld::RecordBase::State_Modified ||
+        land.mState==CSMWorld::RecordBase::State_ModifiedOnly)
+    {
+        CSMWorld::Land record = land.get();
+
+        mState.getWriter().startRecord (record.mLand->sRecordId);
+
+        record.mLand->save (mState.getWriter());
+
+        mState.getWriter().endRecord (record.mLand->sRecordId);
+    }
+    else if (land.mState==CSMWorld::RecordBase::State_Deleted)
+    {
+        /// \todo write record with delete flag
+    }
+}
+
+
+CSMDoc::WriteLandTextureCollectionStage::WriteLandTextureCollectionStage (Document& document,
+    SavingState& state)
+: mDocument (document), mState (state)
+{}
+
+int CSMDoc::WriteLandTextureCollectionStage::setup()
+{
+    return mDocument.getData().getLandTextures().getSize();
+}
+
+void CSMDoc::WriteLandTextureCollectionStage::perform (int stage, Messages& messages)
+{
+    const CSMWorld::Record<CSMWorld::LandTexture>& landTexture =
+        mDocument.getData().getLandTextures().getRecord (stage);
+
+    if (landTexture.mState==CSMWorld::RecordBase::State_Modified ||
+        landTexture.mState==CSMWorld::RecordBase::State_ModifiedOnly)
+    {
+        CSMWorld::LandTexture record = landTexture.get();
+
+        mState.getWriter().startRecord (record.sRecordId);
+
+        record.save (mState.getWriter());
+
+        mState.getWriter().endRecord (record.sRecordId);
+    }
+    else if (landTexture.mState==CSMWorld::RecordBase::State_Deleted)
+    {
+        /// \todo write record with delete flag
+    }
+}
+
+
 CSMDoc::CloseSaveStage::CloseSaveStage (SavingState& state)
 : mState (state)
 {}

--- a/apps/opencs/model/doc/savingstages.hpp
+++ b/apps/opencs/model/doc/savingstages.hpp
@@ -209,6 +209,40 @@ namespace CSMDoc
             ///< Messages resulting from this stage will be appended to \a messages.
     };
 
+
+    class WriteLandCollectionStage : public Stage
+    {
+            Document& mDocument;
+            SavingState& mState;
+
+        public:
+
+            WriteLandCollectionStage (Document& document, SavingState& state);
+
+            virtual int setup();
+            ///< \return number of steps
+
+            virtual void perform (int stage, Messages& messages);
+            ///< Messages resulting from this stage will be appended to \a messages.
+    };
+
+
+    class WriteLandTextureCollectionStage : public Stage
+    {
+            Document& mDocument;
+            SavingState& mState;
+
+        public:
+
+            WriteLandTextureCollectionStage (Document& document, SavingState& state);
+
+            virtual int setup();
+            ///< \return number of steps
+
+            virtual void perform (int stage, Messages& messages);
+            ///< Messages resulting from this stage will be appended to \a messages.
+    };
+
     class CloseSaveStage : public Stage
     {
             SavingState& mState;

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -745,7 +745,7 @@ bool CSMWorld::Data::continueLoading (CSMDoc::Messages& messages)
             if (index!=-1 && !mBase)
                 mLand.getRecord (index).mModified.mLand->loadData (
                     ESM::Land::DATA_VHGT | ESM::Land::DATA_VNML | ESM::Land::DATA_VCLR |
-                    ESM::Land::DATA_VTEX);
+                    ESM::Land::DATA_VTEX | ESM::Land::DATA_WNAM);
 
             break;
         }

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -11,7 +11,7 @@ namespace ESM
 void Land::LandData::save(ESMWriter &esm)
 {
     if (mDataTypes & Land::DATA_VNML) {
-        esm.writeHNT("VNML", mNormals, sizeof(VNML));
+        esm.writeHNT("VNML", mNormals, sizeof(mNormals));
     }
     if (mDataTypes & Land::DATA_VHGT) {
         VHGT offsets;


### PR DESCRIPTION
Only tested by examining the saved file with a binary editor (for LAND and LTEX).