### PR TITLE
Installer work for Windows (Fixes #1621)

### DIFF
--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -290,7 +290,7 @@ public:
     std::streamsize write(const char *str, std::streamsize size)
     {
         // Make a copy for null termination
-        std::string tmp (str, size);
+        std::string tmp (str, static_cast<unsigned int>(size));
         // Write string to Visual Studio Debug output
         OutputDebugString (tmp.c_str ());
         return size;

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -343,7 +343,7 @@ namespace MWGui
             else
                 d = int(100 * (b - a) / a);
 
-            float clampedDisposition = std::max<float>(0,std::min<float>(MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr)
+            int clampedDisposition = std::max(0, std::min(MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr)
                 + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange(),100));
 
             const MWMechanics::CreatureStats &sellerStats = mPtr.getClass().getCreatureStats(mPtr);

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -524,9 +524,9 @@ namespace MWMechanics
         for(int i = 0;i < ESM::Attribute::Length;++i)
         {
             AttributeValue stat = creatureStats.getAttribute(i);
-            stat.setModifier(effects.get(EffectKey(ESM::MagicEffect::FortifyAttribute, i)).getMagnitude() -
+            stat.setModifier(static_cast<int>(effects.get(EffectKey(ESM::MagicEffect::FortifyAttribute, i)).getMagnitude() -
                              effects.get(EffectKey(ESM::MagicEffect::DrainAttribute, i)).getMagnitude() -
-                             effects.get(EffectKey(ESM::MagicEffect::AbsorbAttribute, i)).getMagnitude());
+                             effects.get(EffectKey(ESM::MagicEffect::AbsorbAttribute, i)).getMagnitude()));
 
             stat.damage(effects.get(EffectKey(ESM::MagicEffect::DamageAttribute, i)).getMagnitude() * duration);
             stat.restore(effects.get(EffectKey(ESM::MagicEffect::RestoreAttribute, i)).getMagnitude() * duration);
@@ -793,9 +793,9 @@ namespace MWMechanics
         for(int i = 0;i < ESM::Skill::Length;++i)
         {
             SkillValue& skill = npcStats.getSkill(i);
-            skill.setModifier(effects.get(EffectKey(ESM::MagicEffect::FortifySkill, i)).getMagnitude() -
+            skill.setModifier(static_cast<int>(effects.get(EffectKey(ESM::MagicEffect::FortifySkill, i)).getMagnitude() -
                              effects.get(EffectKey(ESM::MagicEffect::DrainSkill, i)).getMagnitude() -
-                             effects.get(EffectKey(ESM::MagicEffect::AbsorbSkill, i)).getMagnitude());
+                             effects.get(EffectKey(ESM::MagicEffect::AbsorbSkill, i)).getMagnitude()));
 
             skill.damage(effects.get(EffectKey(ESM::MagicEffect::DamageSkill, i)).getMagnitude() * duration);
             skill.restore(effects.get(EffectKey(ESM::MagicEffect::RestoreSkill, i)).getMagnitude() * duration);

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -267,7 +267,7 @@ namespace MWMechanics
         attackTerm += mageffects.get(ESM::MagicEffect::FortifyAttack).getMagnitude() -
                      mageffects.get(ESM::MagicEffect::Blind).getMagnitude();
 
-        return static_cast<int>((attackTerm - defenseTerm) + 0.5f);
+        return round(attackTerm - defenseTerm);
     }
 
     void applyElementalShields(const MWWorld::Ptr &attacker, const MWWorld::Ptr &victim)

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -30,7 +30,7 @@ int FFmpeg_Decoder::readPacket(void *user_data, uint8_t *buf, int buf_size)
         Ogre::DataStreamPtr stream = static_cast<FFmpeg_Decoder*>(user_data)->mDataStream;
         return stream->read(buf, buf_size);
     }
-    catch (std::exception& e)
+    catch (std::exception& )
     {
         return 0;
     }
@@ -43,7 +43,7 @@ int FFmpeg_Decoder::writePacket(void *user_data, uint8_t *buf, int buf_size)
         Ogre::DataStreamPtr stream = static_cast<FFmpeg_Decoder*>(user_data)->mDataStream;
         return stream->write(buf, buf_size);
     }
-    catch (std::exception& e)
+    catch (std::exception& )
     {
         return 0;
     }
@@ -57,11 +57,11 @@ int64_t FFmpeg_Decoder::seek(void *user_data, int64_t offset, int whence)
     if(whence == AVSEEK_SIZE)
         return stream->size();
     if(whence == SEEK_SET)
-        stream->seek(offset);
+        stream->seek(static_cast<size_t>(offset));
     else if(whence == SEEK_CUR)
-        stream->seek(stream->tell()+offset);
+        stream->seek(static_cast<size_t>(stream->tell()+offset));
     else if(whence == SEEK_END)
-        stream->seek(stream->size()+offset);
+        stream->seek(static_cast<size_t>(stream->size()+offset));
     else
         return -1;
 

--- a/apps/wizard/componentselectionpage.cpp
+++ b/apps/wizard/componentselectionpage.cpp
@@ -156,9 +156,13 @@ bool Wizard::ComponentSelectionPage::validatePage()
 
 int Wizard::ComponentSelectionPage::nextId() const
 {
+#ifdef OPENMW_USE_UNSHIELD
     if (isCommitPage()) {
         return MainWizard::Page_Installation;
     } else {
         return MainWizard::Page_Import;
     }
+#else
+    return MainWizard::Page_Import;
+#endif
 }

--- a/apps/wizard/existinginstallationpage.cpp
+++ b/apps/wizard/existinginstallationpage.cpp
@@ -29,11 +29,7 @@ void Wizard::ExistingInstallationPage::initializePage()
     QStringList paths(mWizard->mInstallations.keys());
 
     // Hide the default item if there are installations to choose from
-    if (paths.isEmpty()) {
-        installationsList->item(0)->setHidden(false);
-    } else {
-        installationsList->item(0)->setHidden(true);
-    }
+    installationsList->item(0)->setHidden(!paths.isEmpty());
 
     foreach (const QString &path, paths) {
         QListWidgetItem *item = new QListWidgetItem(path);

--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -62,6 +62,12 @@ Wizard::MainWizard::MainWizard(QWidget *parent) :
     setupLauncherSettings();
     setupInstallations();
     setupPages();
+
+    const boost::filesystem::path& installedPath = mCfgMgr.getInstallPath();
+    if (!installedPath.empty())
+    {
+        addInstallation(toQString(installedPath));
+    }
 }
 
 Wizard::MainWizard::~MainWizard()
@@ -71,7 +77,7 @@ Wizard::MainWizard::~MainWizard()
 
 void Wizard::MainWizard::setupLog()
 {
-    QString logPath(QString::fromUtf8(mCfgMgr.getLogPath().string().c_str()));
+    QString logPath(toQString(mCfgMgr.getLogPath()));
     logPath.append(QLatin1String("wizard.log"));
 
     QFile file(logPath);
@@ -93,7 +99,7 @@ void Wizard::MainWizard::setupLog()
 
 void Wizard::MainWizard::addLogText(const QString &text)
 {
-    QString logPath(QString::fromUtf8(mCfgMgr.getLogPath().string().c_str()));
+    QString logPath(toQString(mCfgMgr.getLogPath()));
     logPath.append(QLatin1String("wizard.log"));
 
     QFile file(logPath);
@@ -121,8 +127,8 @@ void Wizard::MainWizard::addLogText(const QString &text)
 
 void Wizard::MainWizard::setupGameSettings()
 {
-    QString userPath(QString::fromUtf8(mCfgMgr.getUserConfigPath().string().c_str()));
-    QString globalPath(QString::fromUtf8(mCfgMgr.getGlobalPath().string().c_str()));
+    QString userPath(toQString(mCfgMgr.getUserConfigPath()));
+    QString globalPath(toQString(mCfgMgr.getGlobalPath()));
     QString message(tr("<html><head/><body><p><b>Could not open %1 for reading</b></p> \
                     <p>Please make sure you have the right permissions \
                     and try again.</p></body></html>"));
@@ -181,7 +187,7 @@ void Wizard::MainWizard::setupGameSettings()
 
 void Wizard::MainWizard::setupLauncherSettings()
 {
-    QString path(QString::fromUtf8(mCfgMgr.getUserConfigPath().string().c_str()));
+    QString path(toQString(mCfgMgr.getUserConfigPath()));
     path.append(QLatin1String(Config::LauncherSettings::sLauncherConfigFileName));
 
     QString message(tr("<html><head/><body><p><b>Could not open %1 for reading</b></p> \
@@ -228,7 +234,7 @@ void Wizard::MainWizard::runSettingsImporter()
     QString path(field(QLatin1String("installation.path")).toString());
 
     // Create the file if it doesn't already exist, else the importer will fail
-    QString userPath(QString::fromUtf8(mCfgMgr.getUserConfigPath().string().c_str()));
+    QString userPath(toQString(mCfgMgr.getUserConfigPath()));
     QFile file(userPath + QLatin1String("openmw.cfg"));
 
     if (!file.exists()) {
@@ -387,7 +393,7 @@ void Wizard::MainWizard::writeSettings()
     mGameSettings.removeDataDir(path);
     mGameSettings.addDataDir(path);
 
-    QString userPath(QString::fromUtf8(mCfgMgr.getUserConfigPath().string().c_str()));
+    QString userPath(toQString(mCfgMgr.getUserConfigPath()));
     QDir dir(userPath);
 
     if (!dir.exists()) {
@@ -459,4 +465,9 @@ bool Wizard::MainWizard::findFiles(const QString &name, const QString &path)
     // TODO: add MIME handling to make sure the files are real
     return (dir.entryList().contains(name + QLatin1String(".esm"), Qt::CaseInsensitive)
             && dir.entryList().contains(name + QLatin1String(".bsa"), Qt::CaseInsensitive));
+}
+
+QString Wizard::MainWizard::toQString(const boost::filesystem::path& path)
+{
+    return QString::fromUtf8(path.string().c_str());
 }

--- a/apps/wizard/mainwizard.hpp
+++ b/apps/wizard/mainwizard.hpp
@@ -59,6 +59,8 @@ namespace Wizard
         void addLogText(const QString &text);
 
     private:
+        /// convert boost::filesystem::path to QString
+        QString toQString(const boost::filesystem::path& path);
 
         void setupLog();
         void setupGameSettings();

--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -79,7 +79,7 @@ void BSAFile::readHeader()
     bfs::ifstream input(bfs::path(filename), std::ios_base::binary);
 
     // Total archive size
-    size_t fsize = 0;
+    std::streamoff fsize = 0;
     if(input.seekg(0, std::ios_base::end))
     {
         fsize = input.tellg();

--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -324,7 +324,7 @@ namespace Compiler
                     mNextOperand = false;
                     mOperands.push_back ('l');
 
-                    return 2;
+                    return true;
                 }
             }
 

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -94,18 +94,8 @@ boost::filesystem::path WindowsPath::getInstallPath() const
 
     HKEY hKey;
 
-    BOOL f64 = FALSE;
-    LPCTSTR regkey;
-    if ((IsWow64Process(GetCurrentProcess(), &f64) && f64) || sizeof(void*) == 8)
-    {
-        regkey = "SOFTWARE\\Wow6432Node\\Bethesda Softworks\\Morrowind";
-    }
-    else
-    {
-        regkey = "SOFTWARE\\Bethesda Softworks\\Morrowind";
-    }
-
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT(regkey), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS)
+    LPCTSTR regkey = TEXT("SOFTWARE\\Bethesda Softworks\\Morrowind");
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, regkey, 0, KEY_READ | KEY_WOW64_32KEY, &hKey) == ERROR_SUCCESS)
     {
         //Key existed, let's try to read the install dir
         std::vector<char> buf(512);
@@ -115,6 +105,7 @@ boost::filesystem::path WindowsPath::getInstallPath() const
         {
             installPath = &buf[0];
         }
+        RegCloseKey(hKey);
     }
 
     return installPath;

--- a/extern/ogre-ffmpeg-videoplayer/videostate.cpp
+++ b/extern/ogre-ffmpeg-videoplayer/videostate.cpp
@@ -179,7 +179,7 @@ int VideoState::OgreResource_Read(void *user_data, uint8_t *buf, int buf_size)
     {
         return stream->read(buf, buf_size);
     }
-    catch (std::exception& e)
+    catch (std::exception& )
     {
         return 0;
     }
@@ -192,7 +192,7 @@ int VideoState::OgreResource_Write(void *user_data, uint8_t *buf, int buf_size)
     {
         return stream->write(buf, buf_size);
     }
-    catch (std::exception& e)
+    catch (std::exception& )
     {
         return 0;
     }
@@ -206,11 +206,11 @@ int64_t VideoState::OgreResource_Seek(void *user_data, int64_t offset, int whenc
     if(whence == AVSEEK_SIZE)
         return stream->size();
     if(whence == SEEK_SET)
-        stream->seek(offset);
+        stream->seek(static_cast<size_t>(offset));
     else if(whence == SEEK_CUR)
-        stream->seek(stream->tell()+offset);
+        stream->seek(static_cast<size_t>(stream->tell()+offset));
     else if(whence == SEEK_END)
-        stream->seek(stream->size()+offset);
+        stream->seek(static_cast<size_t>(stream->size() + offset));
     else
         return -1;
 
@@ -400,7 +400,7 @@ void VideoState::video_thread_loop(VideoState *self)
             self->pictq_mutex.unlock();
 
             self->frame_last_pts = packet->pts * av_q2d((*self->video_st)->time_base);
-            global_video_pkt_pts = self->frame_last_pts;
+            global_video_pkt_pts = static_cast<int64_t>(self->frame_last_pts);
             continue;
         }
 
@@ -412,9 +412,9 @@ void VideoState::video_thread_loop(VideoState *self)
 
         double pts = 0;
         if(packet->dts != AV_NOPTS_VALUE)
-            pts = packet->dts;
+            pts = static_cast<double>(packet->dts);
         else if(pFrame->opaque && *(int64_t*)pFrame->opaque != AV_NOPTS_VALUE)
-            pts = *(int64_t*)pFrame->opaque;
+            pts = static_cast<double>(*(int64_t*)pFrame->opaque);
         pts *= av_q2d((*self->video_st)->time_base);
 
         av_free_packet(packet);

--- a/extern/shiny/Platforms/Ogre/OgrePass.cpp
+++ b/extern/shiny/Platforms/Ogre/OgrePass.cpp
@@ -109,7 +109,7 @@ namespace sh
 		{
 			params->addSharedParameters (name);
 		}
-		catch (Ogre::Exception& e)
+		catch (Ogre::Exception& )
 		{
 			std::stringstream msg;
 			msg << "Could not create a shared parameter instance for '"

--- a/libs/openengine/bullet/BtOgre.cpp
+++ b/libs/openengine/bullet/BtOgre.cpp
@@ -150,7 +150,7 @@ namespace BtOgre {
                 if (i == mBoneIndex->end())
                 {
                     l = new Vector3Array;
-                    mBoneIndex->insert(BoneKeyIndex(currBone, l));
+                    mBoneIndex->insert(std::make_pair(currBone, l));
                 }
                 else
                 {

--- a/libs/openengine/bullet/BtOgreGP.h
+++ b/libs/openengine/bullet/BtOgreGP.h
@@ -27,7 +27,6 @@
 namespace BtOgre {
 
 typedef std::map<unsigned char, Vector3Array*> BoneIndex;
-typedef std::pair<unsigned short, Vector3Array*> BoneKeyIndex;
 
 class VertexIndexToShape
 {


### PR DESCRIPTION
1. Correctly reads Windows registry for vanilla MW install location.
2. Populates existing installation page with location of vanilla, when found.
3. On Windows, installer wizard now gets to Import page.
4. Also fixed a number of MSVC 2013 warnings.