### PR TITLE
Fix comparison of integers of different signs

### DIFF
--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -111,7 +111,7 @@ void BSAFile::readHeader()
     // Each file must take up at least 21 bytes of data in the bsa. So
     // if files*21 overflows the file size then we are guaranteed that
     // the archive is corrupt.
-    if((filenum*21 > fsize -12) || (dirsize+8*filenum > fsize -12) )
+    if((filenum*21 > unsigned(fsize -12)) || (dirsize+8*filenum > unsigned(fsize -12)) )
         fail("Directory information larger than entire archive");
 
     // Read the offset info into a temporary buffer


### PR DESCRIPTION
Clang reported comparison of unsigned long with long. This cast should fix it.