### PR TITLE
OpenCS FileDialog crash fix

### DIFF
--- a/apps/opencs/view/doc/filedialog.cpp
+++ b/apps/opencs/view/doc/filedialog.cpp
@@ -153,11 +153,13 @@ void CSVDoc::FileDialog::slotUpdateAcceptButton(const QString &name, bool)
 
     if (isNew)
         success = success && !(name.isEmpty());
-    else
+    else if (success)
     {
         ContentSelectorModel::EsmFile *file = mSelector->selectedFiles().back();
         mAdjusterWidget->setName (file->filePath(), !file->isGameFile());
     }
+    else
+        mAdjusterWidget->setName ("", true);
 
     ui.projectButtonBox->button (QDialogButtonBox::Ok)->setEnabled (success);
 }


### PR DESCRIPTION
The file dialog would crash when no game file is selected and an addon file with no dependency is checked, then unchecked.