### PR TITLE
Fix for script editor line focus

### DIFF
--- a/apps/opencs/view/doc/view.cpp
+++ b/apps/opencs/view/doc/view.cpp
@@ -485,6 +485,8 @@ void CSVDoc::View::addSubView (const CSMWorld::UniversalId& id, const std::strin
                (!isReferenceable && id == sb->getUniversalId()))
             {
                 sb->setFocus();
+                if (!hint.empty())
+                    sb->useHint (hint);
                 return;
             }
         }
@@ -515,8 +517,6 @@ void CSVDoc::View::addSubView (const CSMWorld::UniversalId& id, const std::strin
     assert(view);
     view->setParent(this);
     mSubViews.append(view); // only after assert
-    if (!hint.empty())
-        view->useHint (hint);
 
     int minWidth = userSettings.setting ("window/minimum-width", QString("325")).toInt();
     view->setMinimumWidth(minWidth);
@@ -538,6 +538,9 @@ void CSVDoc::View::addSubView (const CSMWorld::UniversalId& id, const std::strin
         this, SLOT (updateSubViewIndicies (SubView *)));
 
     view->show();
+
+    if (!hint.empty())
+        view->useHint (hint);
 }
 
 void CSVDoc::View::newView()

--- a/apps/opencs/view/world/scriptsubview.cpp
+++ b/apps/opencs/view/world/scriptsubview.cpp
@@ -68,6 +68,7 @@ void CSVWorld::ScriptSubView::useHint (const std::string& hint)
             if (cursor.movePosition (QTextCursor::Down, QTextCursor::MoveAnchor, line))
                 cursor.movePosition (QTextCursor::Right, QTextCursor::MoveAnchor, column);
 
+            mEditor->setFocus();
             mEditor->setTextCursor (cursor);
         }
     }


### PR DESCRIPTION
The feature "Editor: When clicking on a script error in the report window set cursor in script editor to the respective line/column" as described in the release notes was not working.
Changes:
- setFocus() on the script editor, otherwise setting the text cursor has no effect.
- setFocus() must be done after the widgets are created/shown, or the newly created widgets will "steal" the focus again.
- Missing useHint in case subviews are reused.