### PR TITLE
AiWander, use closest two points if distance is too small (Fixes #1317)

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -122,6 +122,13 @@ namespace MWMechanics
 
             /// lookup table for converting idleSelect value to groupName
             static const std::string sIdleSelectToGroupName[GroupIndex_MaxIdle - GroupIndex_MinIdle + 1];
+
+            /// record distances of pathgrid point nodes to actor
+            /// first value is distance between actor and node, second value is PathGrid node
+            typedef std::pair<float, const ESM::Pathgrid::Point*> PathDistance;
+
+            /// used to sort array of PathDistance objects into ascending order
+            static bool sortByDistance(const PathDistance& left, const PathDistance& right);
     };
     
     


### PR DESCRIPTION
In AiWander, if wander distance is set too small to get two points, take the closest two points.