### PR TITLE
Provide incremental update of SpellWindow (Fixes #2411)

### DIFF
--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -548,7 +548,6 @@ namespace MWGui
         WindowModal::open();
 
         mMagicList->setModel(new SpellModel(MWBase::Environment::get().getWorld()->getPlayerPtr()));
-        mMagicList->update();
     }
 
     void MagicSelectionDialog::onModelIndexSelected(SpellModel::ModelIndex index)

--- a/apps/openmw/mwgui/spellview.hpp
+++ b/apps/openmw/mwgui/spellview.hpp
@@ -56,11 +56,23 @@ namespace MWGui
 
         std::auto_ptr<SpellModel> mModel;
 
-        /// tracks an item in the spell view
-        /// element<0> is the left column GUI object (usually holds the name)
-        /// element<1> is the right column (charge or cost info)
-        /// element<2> is if line needs to be checked during incremental update
-        typedef boost::tuple<MyGUI::Widget*, MyGUI::Widget*, bool> LineInfo;
+        /// tracks a row in the spell view
+        struct LineInfo
+        {
+            /// the widget on the left side of the row
+            MyGUI::Widget* mLeftWidget;
+
+            /// the widget on the left side of the row (if there is one)
+            MyGUI::Widget* mRightWidget;
+
+            /// index to item in mModel that row is showing information for
+            SpellModel::ModelIndex mSpellIndex;
+
+            LineInfo(MyGUI::Widget* leftWidget, MyGUI::Widget* rightWidget, SpellModel::ModelIndex spellIndex);
+        };
+
+        /// magic number indicating LineInfo does not correspond to an item in mModel
+        enum { NoSpellIndex = -1 };
 
         std::vector< LineInfo > mLines;
 

--- a/apps/openmw/mwgui/spellview.hpp
+++ b/apps/openmw/mwgui/spellview.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENMW_GUI_SPELLVIEW_H
 #define OPENMW_GUI_SPELLVIEW_H
 
+#include <boost/tuple/tuple.hpp>
+
 #include <MyGUI_Widget.h>
 
 #include "spellmodel.hpp"
@@ -37,6 +39,9 @@ namespace MWGui
 
         void update();
 
+        /// simplified update called each frame
+        void incrementalUpdate();
+
         typedef MyGUI::delegates::CMultiDelegate1<SpellModel::ModelIndex> EventHandle_ModelIndex;
         /// Fired when a spell was clicked
         EventHandle_ModelIndex eventSpellClicked;
@@ -51,7 +56,13 @@ namespace MWGui
 
         std::auto_ptr<SpellModel> mModel;
 
-        std::vector< std::pair<MyGUI::Widget*, MyGUI::Widget*> > mLines;
+        /// tracks an item in the spell view
+        /// element<0> is the left column GUI object (usually holds the name)
+        /// element<1> is the right column (charge or cost info)
+        /// element<2> is if line needs to be checked during incremental update
+        typedef boost::tuple<MyGUI::Widget*, MyGUI::Widget*, bool> LineInfo;
+
+        std::vector< LineInfo > mLines;
 
         bool mShowCostColumn;
         bool mHighlightSelected;
@@ -62,6 +73,10 @@ namespace MWGui
 
         void onSpellSelected(MyGUI::Widget* _sender);
         void onMouseWheel(MyGUI::Widget* _sender, int _rel);
+
+        SpellModel::ModelIndex getSpellModelIndex(MyGUI::Widget* _sender);
+
+        static const char* sSpellModelIndex;
     };
 
 }

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -65,7 +65,6 @@ namespace MWGui
         mSpellIcons->updateWidgets(mEffectBox, false);
 
         mSpellView->setModel(new SpellModel(MWBase::Environment::get().getWorld()->getPlayerPtr()));
-        mSpellView->update();
     }
 
     void SpellWindow::onEnchantedItemSelected(MWWorld::Ptr item, bool alreadyEquipped)
@@ -170,7 +169,6 @@ namespace MWGui
     void SpellWindow::cycle(bool next)
     {
         mSpellView->setModel(new SpellModel(MWBase::Environment::get().getWorld()->getPlayerPtr()));
-        mSpellView->getModel()->update();
 
         SpellModel::ModelIndex selected = 0;
         for (SpellModel::ModelIndex i = 0; i<int(mSpellView->getModel()->getItemCount()); ++i)

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -28,6 +28,7 @@ namespace MWGui
         : WindowPinnableBase("openmw_spell_window.layout")
         , NoDrop(drag, mMainWidget)
         , mSpellView(NULL)
+        , mUpdateTimer(0.0f)
     {
         mSpellIcons = new SpellIcons();
 
@@ -58,6 +59,20 @@ namespace MWGui
     void SpellWindow::open()
     {
         updateSpells();
+    }
+
+    void SpellWindow::onFrame(float dt) 
+    { 
+        if (mMainWidget->getVisible())
+        {
+            NoDrop::onFrame(dt);
+            mUpdateTimer += dt;
+            if (0.5f < mUpdateTimer)
+            {
+                mUpdateTimer = 0;
+                mSpellView->incrementalUpdate();
+            }
+        }
     }
 
     void SpellWindow::updateSpells()

--- a/apps/openmw/mwgui/spellwindow.hpp
+++ b/apps/openmw/mwgui/spellwindow.hpp
@@ -19,7 +19,7 @@ namespace MWGui
 
         void updateSpells();
 
-        void onFrame(float dt) { NoDrop::onFrame(dt); }
+        void onFrame(float dt);
 
         /// Cycle to next/previous spell
         void cycle(bool next);
@@ -41,6 +41,9 @@ namespace MWGui
 
         SpellView* mSpellView;
         SpellIcons* mSpellIcons;
+
+    private:
+        float mUpdateTimer;
     };
 }
 


### PR DESCRIPTION
When SpellWindow is visible, every 0.5 seconds update the cost/changes for spells/enchanted items shown.
Also, check to see if more substantial update of the window is required.