### PR TITLE
Handle plugins that has 0x00 for levelled list types,

### DIFF
--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -222,7 +222,6 @@ namespace CSMWorld
             { ColumnId_HitSound, "Hit Sound" },
             { ColumnId_AreaSound, "Area Sound" },
             { ColumnId_BoltSound, "Bolt Sound" },
-            { ColumnId_OriginalCell, "Original Cell" },
 
             { ColumnId_PathgridPoints, "Points" },
             { ColumnId_PathgridIndex, "Index" },
@@ -267,13 +266,15 @@ namespace CSMWorld
             { ColumnId_LevelledList,"Levelled List" },
             { ColumnId_LevelledItemId,"Item ID" },
             { ColumnId_LevelledItemLevel,"Level" },
-            { ColumnId_LevelledItemType, "Type" },
+            { ColumnId_LevelledItemType, "Calculate all levels <= player" },
+            { ColumnId_LevelledItemTypeEach, "Select a new item each instance" },
             { ColumnId_LevelledItemChanceNone, "Chance None" },
 
             { ColumnId_PowerList, "Powers" },
             { ColumnId_SkillImpact, "Skills" },
 
             { ColumnId_InfoList, "Info List" },
+            { ColumnId_OriginalCell, "Original Cell" },
 
             { ColumnId_UseValue1, "Use value 1" },
             { ColumnId_UseValue2, "Use value 2" },

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -257,14 +257,15 @@ namespace CSMWorld
             ColumnId_LevelledItemId = 234,
             ColumnId_LevelledItemLevel = 235,
             ColumnId_LevelledItemType = 236,
-            ColumnId_LevelledItemChanceNone = 237,
+            ColumnId_LevelledItemTypeEach = 237,
+            ColumnId_LevelledItemChanceNone = 238,
 
-            ColumnId_PowerList = 238,
-            ColumnId_SkillImpact = 239, // impact from magic effects
+            ColumnId_PowerList = 239,
+            ColumnId_SkillImpact = 240, // impact from magic effects
 
-            ColumnId_InfoList = 240,
+            ColumnId_InfoList = 241,
 
-            ColumnId_OriginalCell = 241,
+            ColumnId_OriginalCell = 242,
 
             // Allocated to a separate value range, so we don't get a collision should we ever need
             // to extend the number of use values.

--- a/apps/opencs/model/world/commands.cpp
+++ b/apps/opencs/model/world/commands.cpp
@@ -21,9 +21,12 @@ CSMWorld::ModifyCommand::ModifyCommand (QAbstractItemModel& model, const QModelI
         // Replace proxy with actual model
         mIndex = proxy->mapToSource (index);
         mModel = proxy->sourceModel();
-    }
 
-    setText ("Modify " + mModel->headerData (mIndex.column(), Qt::Horizontal, Qt::DisplayRole).toString());
+        setText ("Modify " + dynamic_cast<CSMWorld::IdTree*>(mModel)->nestedHeaderData (
+                    mIndex.parent().column(), mIndex.column(), Qt::Horizontal, Qt::DisplayRole).toString());
+    }
+    else
+        setText ("Modify " + mModel->headerData (mIndex.column(), Qt::Horizontal, Qt::DisplayRole).toString());
 }
 
 void CSMWorld::ModifyCommand::redo()

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -2,6 +2,7 @@
 #define CSM_WOLRD_REFIDADAPTERIMP_H
 
 #include <map>
+#include <iostream>
 
 #include <QVariant>
 
@@ -1894,6 +1895,20 @@ namespace CSMWorld
                             record.get().mFlags == 0x02)
                     {
                         return QString("All Levels");
+                    }
+                    else if (mType == CSMWorld::UniversalId::Type_CreatureLevelledList &&
+                            record.get().mFlags == 0x00)
+                    {
+                        std::cerr << "Unknown creature leveled list type: " << record.get().mFlags
+                            << ", Using \"All Levels\""<< std::endl;
+                        return QString("All Levels");
+                    }
+                    else if (mType == CSMWorld::UniversalId::Type_ItemLevelledList &&
+                            record.get().mFlags == 0x00)
+                    {
+                        std::cerr << "Unknown item leveled list type: " << record.get().mFlags
+                            << ", Using \"Each\""<< std::endl;
+                        return QString("Each");
                     }
                     else
                         throw std::runtime_error("unknown leveled list type");

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -514,7 +514,9 @@ CSMWorld::RefIdCollection::RefIdCollection()
         new NestedListLevListRefIdAdapter<ESM::ItemLevList> (UniversalId::Type_ItemLevelledList)));
     mNestedAdapters.push_back (std::make_pair(&mColumns.back(), nestedListLevListMap));
     mColumns.back().addColumn(
-        new RefIdColumn (Columns::ColumnId_LevelledItemType, CSMWorld::ColumnBase::Display_String));
+        new RefIdColumn (Columns::ColumnId_LevelledItemTypeEach, CSMWorld::ColumnBase::Display_Boolean));
+    mColumns.back().addColumn(
+        new RefIdColumn (Columns::ColumnId_LevelledItemType, CSMWorld::ColumnBase::Display_Boolean));
     mColumns.back().addColumn(
         new RefIdColumn (Columns::ColumnId_LevelledItemChanceNone, CSMWorld::ColumnBase::Display_Integer));
 

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -29,8 +29,8 @@
 #include "../../model/world/record.hpp"
 #include "../../model/world/tablemimedata.hpp"
 #include "../../model/world/idtree.hpp"
-#include "../../model/doc/document.hpp"
 #include "../../model/world/commands.hpp"
+#include "../../model/doc/document.hpp"
 
 #include "recordstatusdelegate.hpp"
 #include "util.hpp"
@@ -444,7 +444,8 @@ void CSVWorld::EditWidget::remake(int row)
             if (mTable->hasChildren(mTable->index(row, i)) &&
                     !(flags & CSMWorld::ColumnBase::Flag_Dialogue_List))
             {
-                mNestedModels.push_back(new CSMWorld::NestedTableProxyModel (mTable->index(row, i), display, dynamic_cast<CSMWorld::IdTree*>(mTable)));
+                mNestedModels.push_back(new CSMWorld::NestedTableProxyModel (
+                            mTable->index(row, i), display, dynamic_cast<CSMWorld::IdTree*>(mTable)));
 
                 int idColumn = mTable->findColumnIndex (CSMWorld::Columns::ColumnId_Id);
                 int typeColumn = mTable->findColumnIndex (CSMWorld::Columns::ColumnId_RecordType);


### PR DESCRIPTION
 for example Ravenloft v5.02d, to use 0x01.

Unfortunately the fix spams the console with error messages.