### PR TITLE
Fix #2557

### DIFF
--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -59,14 +59,16 @@ int main(int argc, char *argv[])
 
         Launcher::MainDialog mainWin;
 
-        if (!mainWin.showFirstRunDialog())
+        Launcher::FirstRunDialogResult result = mainWin.showFirstRunDialog();
+        if (result == Launcher::FirstRunDialogResultFailure)
             return 0;
 
     //    if (!mainWin.setup()) {
     //        return 0;
     //    }
 
-        mainWin.show();
+        if (result == Launcher::FirstRunDialogResultContinue)
+            mainWin.show();
 
         int returnValue = app.exec();
         SDL_Quit();

--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -148,10 +148,10 @@ void Launcher::MainDialog::createPages()
 
 }
 
-bool Launcher::MainDialog::showFirstRunDialog()
+Launcher::FirstRunDialogResult Launcher::MainDialog::showFirstRunDialog()
 {
     if (!setupLauncherSettings())
-        return false;
+        return FirstRunDialogResultFailure;
 
     if (mLauncherSettings.value(QString("General/firstrun"), QString("true")) == QLatin1String("true"))
     {
@@ -176,14 +176,14 @@ bool Launcher::MainDialog::showFirstRunDialog()
         if (msgBox.clickedButton() == wizardButton)
         {
             if (!mWizardInvoker->startProcess(QLatin1String("openmw-wizard"), false)) {
-                return false;
+                return FirstRunDialogResultFailure;
             } else {
-                return true;
+                return FirstRunDialogResultWizard;
             }
         }
     }
 
-    return setup();
+    return setup() ? FirstRunDialogResultContinue : FirstRunDialogResultFailure;
 }
 
 bool Launcher::MainDialog::setup()

--- a/apps/launcher/maindialog.hpp
+++ b/apps/launcher/maindialog.hpp
@@ -31,6 +31,12 @@ namespace Launcher
     class UnshieldThread;
     class SettingsPage;
 
+    typedef enum {
+        FirstRunDialogResultFailure,
+        FirstRunDialogResultContinue,
+        FirstRunDialogResultWizard
+    } FirstRunDialogResult;
+
 #ifndef WIN32
     bool expansions(Launcher::UnshieldThread& cd);
 #endif
@@ -44,7 +50,7 @@ namespace Launcher
         ~MainDialog();
 
         bool setup();
-        bool showFirstRunDialog();
+        FirstRunDialogResult showFirstRunDialog();
 
         bool reloadSettings();
         bool writeSettings();


### PR DESCRIPTION
Don’t show main dialog right away if wizard is selected.
It will show itself after wizard is finished/cancelled.