### PR TITLE
Check for the order of ESM::DialInfo::mId before inserting a new reco…

### DIFF
--- a/apps/opencs/model/world/infocollection.cpp
+++ b/apps/opencs/model/world/infocollection.cpp
@@ -28,7 +28,7 @@ void CSMWorld::InfoCollection::load (const Info& record, bool base)
         {
             index = getInfoIndex (record2.get().mPrev, topic);
 
-            if (index!=-1)
+            if (index!=-1 && getRecord(index).get().mId < record2.get().mId )
                 ++index;
         }
 


### PR DESCRIPTION
…rd.  Should resolve Bug #2569.

The solution is to make the index order match the map storage order.  But that means for some records the index of the next topic is smaller than the index of the previous topic.  I don't know if this will cause any issues.