### PR TITLE
Add record state tracking to the ModifyCommand (Fix #2555)

### DIFF
--- a/apps/opencs/model/world/commands.hpp
+++ b/apps/opencs/model/world/commands.hpp
@@ -31,6 +31,10 @@ namespace CSMWorld
             QVariant mNew;
             QVariant mOld;
 
+            bool mHasRecordState;
+            QModelIndex mRecordStateIndex;
+            CSMWorld::RecordBase::State mOldRecordState;
+
         public:
 
             ModifyCommand (QAbstractItemModel& model, const QModelIndex& index, const QVariant& new_,


### PR DESCRIPTION
Now the ModifyCommand also restores the record state when undoing.

I think it needs some review from more experienced developers and, perhaps, some more testing (On my machine all goes well (Win7 x64, OpenMW x86 build)). I don't know is the dynamic_cast the best solution for this, but I don't see another solution that doesn't require rewriting the current structure of the ModifyCommand.

Since the ModifyCommand receives general QAbstractItemModel I used additional variable to ensure that the model is really IdTable's successor and has a record state column. Is it redundant or not?