### PR TITLE
Do not rebuild the dialogue subview unless required.

### DIFF
--- a/apps/opencs/model/world/columnbase.cpp
+++ b/apps/opencs/model/world/columnbase.cpp
@@ -138,8 +138,8 @@ bool CSMWorld::NestableColumn::hasChildren() const
 }
 
 CSMWorld::NestedChildColumn::NestedChildColumn (int id,
-    CSMWorld::ColumnBase::Display display, bool isEditable)
-    : NestableColumn (id, display, CSMWorld::ColumnBase::Flag_Dialogue) , mIsEditable(isEditable)
+    CSMWorld::ColumnBase::Display display, int flags, bool isEditable)
+    : NestableColumn (id, display, flags) , mIsEditable(isEditable)
 {}
 
 bool CSMWorld::NestedChildColumn::isEditable () const

--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -184,7 +184,7 @@ namespace CSMWorld
     template<typename ESXRecordT>
     struct NestedParentColumn : public Column<ESXRecordT>
     {
-        NestedParentColumn (int id, int flags = Flag_Dialogue) : Column<ESXRecordT> (id,
+        NestedParentColumn (int id, int flags = ColumnBase::Flag_Dialogue) : Column<ESXRecordT> (id,
                 ColumnBase::Display_NestedHeader, flags)
         {}
 
@@ -202,7 +202,7 @@ namespace CSMWorld
     struct NestedChildColumn : public NestableColumn
     {
         NestedChildColumn (int id,
-                Display display, int flags = Flag_Dialogue, bool isEditable = true);
+                Display display, int flags = ColumnBase::Flag_Dialogue, bool isEditable = true);
 
         virtual bool isEditable() const;
 

--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -25,7 +25,8 @@ namespace CSMWorld
         {
             Flag_Table = 1, // column should be displayed in table view
             Flag_Dialogue = 2, // column should be displayed in dialogue view
-            Flag_Dialogue_List = 4 // column should be diaplyed in dialogue view
+            Flag_Dialogue_List = 4, // column should be diaplyed in dialogue view
+            Flag_Dialogue_Refresh = 8 // refresh dialogue view if this column is modified
         };
 
         enum Display
@@ -183,7 +184,7 @@ namespace CSMWorld
     template<typename ESXRecordT>
     struct NestedParentColumn : public Column<ESXRecordT>
     {
-        NestedParentColumn (int id, int flags = ColumnBase::Flag_Dialogue) : Column<ESXRecordT> (id,
+        NestedParentColumn (int id, int flags = Flag_Dialogue) : Column<ESXRecordT> (id,
                 ColumnBase::Display_NestedHeader, flags)
         {}
 
@@ -200,7 +201,8 @@ namespace CSMWorld
 
     struct NestedChildColumn : public NestableColumn
     {
-        NestedChildColumn (int id, Display display, bool isEditable = true);
+        NestedChildColumn (int id,
+                Display display, int flags = Flag_Dialogue, bool isEditable = true);
 
         virtual bool isEditable() const;
 

--- a/apps/opencs/model/world/columnimp.hpp
+++ b/apps/opencs/model/world/columnimp.hpp
@@ -467,7 +467,8 @@ namespace CSMWorld
         int mMask;
         bool mInverted;
 
-        FlagColumn (int columnId, int mask, int flags = Flag_Table | Flag_Dialogue, bool inverted = false)
+        FlagColumn (int columnId, int mask,
+                int flags = ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue, bool inverted = false)
         : Column<ESXRecordT> (columnId, ColumnBase::Display_Boolean, flags), mMask (mask),
           mInverted (inverted)
         {}

--- a/apps/opencs/model/world/columnimp.hpp
+++ b/apps/opencs/model/world/columnimp.hpp
@@ -467,8 +467,8 @@ namespace CSMWorld
         int mMask;
         bool mInverted;
 
-        FlagColumn (int columnId, int mask, bool inverted = false)
-        : Column<ESXRecordT> (columnId, ColumnBase::Display_Boolean), mMask (mask),
+        FlagColumn (int columnId, int mask, int flags = Flag_Table | Flag_Dialogue, bool inverted = false)
+        : Column<ESXRecordT> (columnId, ColumnBase::Display_Boolean, flags), mMask (mask),
           mInverted (inverted)
         {}
 

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -141,7 +141,8 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     index = mRaces.getColumns()-1;
     mRaces.addAdapter (std::make_pair(&mRaces.getColumn(index), new RaceAttributeAdapter()));
     mRaces.getNestableColumn(index)->addColumn(
-        new NestedChildColumn (Columns::ColumnId_RaceAttributes, ColumnBase::Display_String, false));
+        new NestedChildColumn (Columns::ColumnId_RaceAttributes, ColumnBase::Display_String,
+            ColumnBase::Flag_Dialogue, false));
     mRaces.getNestableColumn(index)->addColumn(
         new NestedChildColumn (Columns::ColumnId_RaceMaleValue, ColumnBase::Display_Integer));
     mRaces.getNestableColumn(index)->addColumn(
@@ -287,8 +288,10 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     mCells.addColumn (new FixedRecordTypeColumn<Cell> (UniversalId::Type_Cell));
     mCells.addColumn (new NameColumn<Cell>);
     mCells.addColumn (new FlagColumn<Cell> (Columns::ColumnId_SleepForbidden, ESM::Cell::NoSleep));
-    mCells.addColumn (new FlagColumn<Cell> (Columns::ColumnId_InteriorWater, ESM::Cell::HasWater));
-    mCells.addColumn (new FlagColumn<Cell> (Columns::ColumnId_InteriorSky, ESM::Cell::QuasiEx));
+    mCells.addColumn (new FlagColumn<Cell> (Columns::ColumnId_InteriorWater, ESM::Cell::HasWater,
+        ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue | ColumnBase::Flag_Dialogue_Refresh));
+    mCells.addColumn (new FlagColumn<Cell> (Columns::ColumnId_InteriorSky, ESM::Cell::QuasiEx,
+        ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue | ColumnBase::Flag_Dialogue_Refresh));
     mCells.addColumn (new RegionColumn<Cell>);
     mCells.addColumn (new RefNumCounterColumn<Cell>);
     // Misc Cell data
@@ -297,7 +300,8 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     index = mCells.getColumns()-1;
     mCells.addAdapter (std::make_pair(&mCells.getColumn(index), new CellListAdapter ()));
     mCells.getNestableColumn(index)->addColumn(
-        new NestedChildColumn (Columns::ColumnId_Interior, ColumnBase::Display_Boolean));
+        new NestedChildColumn (Columns::ColumnId_Interior, ColumnBase::Display_Boolean,
+        ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue | ColumnBase::Flag_Dialogue_Refresh));
     mCells.getNestableColumn(index)->addColumn(
         new NestedChildColumn (Columns::ColumnId_Ambient, ColumnBase::Display_Integer));
     mCells.getNestableColumn(index)->addColumn(
@@ -346,7 +350,8 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     mBodyParts.addColumn (new BodyPartTypeColumn<ESM::BodyPart>);
     mBodyParts.addColumn (new VampireColumn<ESM::BodyPart>);
     mBodyParts.addColumn (new FlagColumn<ESM::BodyPart> (Columns::ColumnId_Female, ESM::BodyPart::BPF_Female));
-    mBodyParts.addColumn (new FlagColumn<ESM::BodyPart> (Columns::ColumnId_Playable, ESM::BodyPart::BPF_NotPlayable, true));
+    mBodyParts.addColumn (new FlagColumn<ESM::BodyPart> (Columns::ColumnId_Playable,
+        ESM::BodyPart::BPF_NotPlayable, ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue, true));
     mBodyParts.addColumn (new MeshTypeColumn<ESM::BodyPart>);
     mBodyParts.addColumn (new ModelColumn<ESM::BodyPart>);
     mBodyParts.addColumn (new RaceColumn<ESM::BodyPart>);
@@ -393,7 +398,8 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     // new objects deleted in dtor of NestableColumn
     // WARNING: The order of the columns below are assumed in PathgridPointListAdapter
     mPathgrids.getNestableColumn(index)->addColumn(
-            new NestedChildColumn (Columns::ColumnId_PathgridIndex, ColumnBase::Display_Integer, false));
+            new NestedChildColumn (Columns::ColumnId_PathgridIndex, ColumnBase::Display_Integer,
+                ColumnBase::Flag_Dialogue, false));
     mPathgrids.getNestableColumn(index)->addColumn(
             new NestedChildColumn (Columns::ColumnId_PathgridPosX, ColumnBase::Display_Integer));
     mPathgrids.getNestableColumn(index)->addColumn(
@@ -405,7 +411,8 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     index = mPathgrids.getColumns()-1;
     mPathgrids.addAdapter (std::make_pair(&mPathgrids.getColumn(index), new PathgridEdgeListAdapter ()));
     mPathgrids.getNestableColumn(index)->addColumn(
-            new NestedChildColumn (Columns::ColumnId_PathgridEdgeIndex, ColumnBase::Display_Integer, false));
+            new NestedChildColumn (Columns::ColumnId_PathgridEdgeIndex, ColumnBase::Display_Integer,
+                ColumnBase::Flag_Dialogue, false));
     mPathgrids.getNestableColumn(index)->addColumn(
             new NestedChildColumn (Columns::ColumnId_PathgridEdge0, ColumnBase::Display_Integer));
     mPathgrids.getNestableColumn(index)->addColumn(

--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -74,8 +74,7 @@ bool CSMWorld::IdTable::setData (const QModelIndex &index, const QVariant &value
     {
         mIdCollection->setData (index.row(), index.column(), value);
 
-        emit dataChanged (CSMWorld::IdTable::index (index.row(), 0),
-            CSMWorld::IdTable::index (index.row(), mIdCollection->getColumns()-1));
+        emit dataChanged (index, index);
 
         return true;
     }

--- a/apps/opencs/model/world/idtree.cpp
+++ b/apps/opencs/model/world/idtree.cpp
@@ -74,7 +74,7 @@ QVariant CSMWorld::IdTree::nestedHeaderData(int section, int subSection, Qt::Ori
         return tr(parentColumn->nestedColumn(subSection).getTitle().c_str());
 
     if (role==ColumnBase::Role_Flags)
-        return idCollection()->getColumn (section).mFlags;
+        return parentColumn->nestedColumn(subSection).mFlags;
 
     if (role==ColumnBase::Role_Display)
         return parentColumn->nestedColumn(subSection).mDisplayType;
@@ -92,8 +92,8 @@ bool CSMWorld::IdTree::setData (const QModelIndex &index, const QVariant &value,
 
             mNestedCollection->setNestedData(parentAddress.first, parentAddress.second, value, index.row(), index.column());
 
-            emit dataChanged (CSMWorld::IdTree::index (parentAddress.first, 0),
-                              CSMWorld::IdTree::index (parentAddress.first, idCollection()->getColumns()-1));
+            emit dataChanged (index, index);
+
             return true;
         }
         else

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -1976,7 +1976,7 @@ namespace CSMWorld
             {
                 switch (subColIndex)
                 {
-                    case 0: return QVariant(QVariant::UserType); // disable the checkbox editor
+                    case 0: return QVariant(); // disable the checkbox editor
                     case 1: return record.get().mFlags & ESM::CreatureLevList::AllLevels;
                     case 2: return static_cast<int> (record.get().mChanceNone);
                     default:

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -245,7 +245,8 @@ CSMWorld::RefIdCollection::RefIdCollection()
         actorsColumns.mServices.insert (std::make_pair (&mColumns.back(), sServiceTable[i].mFlag));
     }
 
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_AutoCalc, ColumnBase::Display_Boolean));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_AutoCalc, ColumnBase::Display_Boolean,
+            ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue | ColumnBase::Flag_Dialogue_Refresh));
     const RefIdColumn *autoCalc = &mColumns.back();
 
     mColumns.push_back (RefIdColumn (Columns::ColumnId_ApparatusType,


### PR DESCRIPTION
Should resolve Bug #2581.

The loss of focus was caused by each text change (i.e. character entry) to a QPlainTextEdit resulting in dataChanged() signal which in turn rebuilt the dialogue subview.  Changes in this commit include:

- Do not send signal to update entire row if only a single item has changed.
- Do not rebuild the dialogue subview unless the data item that triggers a conditional display is changed.
- Add column flags to indicate whether the data in this column should rebuild the dialogue subview.
- Return the correct flags for nested columns
- Disable, rather than grey out, checkbox that does not apply to creature levelled list