### PR TITLE
Dialogue Subview - undo fix and spinbox focus

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -63,6 +63,7 @@ opencs_units (view/world
     table tablesubview scriptsubview util regionmapsubview tablebottombox creator genericcreator
     cellcreator referenceablecreator referencecreator scenesubview
     infocreator scriptedit dialoguesubview previewsubview regionmap dragrecordtable nestedtable
+    dialoguespinbox
     )
 
 opencs_units_noqt (view/world

--- a/apps/opencs/view/world/dialoguespinbox.cpp
+++ b/apps/opencs/view/world/dialoguespinbox.cpp
@@ -1,0 +1,53 @@
+#include "dialoguespinbox.hpp"
+
+#include <QWheelEvent>
+
+CSVWorld::DialogueSpinBox::DialogueSpinBox(QWidget *parent) : QSpinBox(parent)
+{
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void CSVWorld::DialogueSpinBox::focusInEvent(QFocusEvent *event)
+{
+    setFocusPolicy(Qt::WheelFocus);
+    QSpinBox::focusInEvent(event);
+}
+
+void CSVWorld::DialogueSpinBox::focusOutEvent(QFocusEvent *event)
+{
+    setFocusPolicy(Qt::StrongFocus);
+    QSpinBox::focusOutEvent(event);
+}
+
+void CSVWorld::DialogueSpinBox::wheelEvent(QWheelEvent *event)
+{
+    if (!hasFocus())
+        event->ignore();
+    else
+        QSpinBox::wheelEvent(event);
+}
+
+CSVWorld::DialogueDoubleSpinBox::DialogueDoubleSpinBox(QWidget *parent) : QDoubleSpinBox(parent)
+{
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+void CSVWorld::DialogueDoubleSpinBox::focusInEvent(QFocusEvent *event)
+{
+    setFocusPolicy(Qt::WheelFocus);
+    QDoubleSpinBox::focusInEvent(event);
+}
+
+void CSVWorld::DialogueDoubleSpinBox::focusOutEvent(QFocusEvent *event)
+{
+    setFocusPolicy(Qt::StrongFocus);
+    QDoubleSpinBox::focusOutEvent(event);
+}
+
+void CSVWorld::DialogueDoubleSpinBox::wheelEvent(QWheelEvent *event)
+{
+    if (!hasFocus())
+        event->ignore();
+    else
+        QDoubleSpinBox::wheelEvent(event);
+}

--- a/apps/opencs/view/world/dialoguespinbox.hpp
+++ b/apps/opencs/view/world/dialoguespinbox.hpp
@@ -1,0 +1,40 @@
+#ifndef CSV_WORLD_DIALOGUESPINBOX_H
+#define CSV_WORLD_DIALOGUESPINBOX_H
+
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+
+namespace CSVWorld
+{
+    class DialogueSpinBox : public QSpinBox
+    {
+        Q_OBJECT
+
+        public:
+
+            DialogueSpinBox (QWidget *parent = 0);
+
+        protected:
+
+            virtual void focusInEvent(QFocusEvent *event);
+            virtual void focusOutEvent(QFocusEvent *event);
+            virtual void wheelEvent(QWheelEvent *event);
+    };
+
+    class DialogueDoubleSpinBox : public QDoubleSpinBox
+    {
+        Q_OBJECT
+
+        public:
+
+            DialogueDoubleSpinBox (QWidget *parent = 0);
+
+        protected:
+
+            virtual void focusInEvent(QFocusEvent *event);
+            virtual void focusOutEvent(QFocusEvent *event);
+            virtual void wheelEvent(QWheelEvent *event);
+    };
+}
+
+#endif // CSV_WORLD_DIALOGUESPINBOX_H

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -9,8 +9,6 @@
 #include <QMetaProperty>
 #include <QStyledItemDelegate>
 #include <QLineEdit>
-#include <QSpinBox>
-#include <QDoubleSpinBox>
 #include <QComboBox>
 #include <QCheckBox>
 #include <QPlainTextEdit>
@@ -19,7 +17,7 @@
 #include "../../model/world/commands.hpp"
 #include "../../model/world/tablemimedata.hpp"
 #include "../../model/world/commanddispatcher.hpp"
-
+#include "dialoguespinbox.hpp"
 #include "scriptedit.hpp"
 
 CSVWorld::NastyTableModelHack::NastyTableModelHack (QAbstractItemModel& model)
@@ -174,7 +172,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
 
         case CSMWorld::ColumnBase::Display_Integer:
         {
-            QSpinBox *sb = new QSpinBox(parent);
+            DialogueSpinBox *sb = new DialogueSpinBox(parent);
             sb->setRange(INT_MIN, INT_MAX);
             return sb;
         }
@@ -185,7 +183,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
 
         case CSMWorld::ColumnBase::Display_Float:
         {
-            QDoubleSpinBox *dsb = new QDoubleSpinBox(parent);
+            DialogueDoubleSpinBox *dsb = new DialogueDoubleSpinBox(parent);
             dsb->setRange(-FLT_MAX, FLT_MAX);
             dsb->setSingleStep(0.01f);
             dsb->setDecimals(3);


### PR DESCRIPTION
Two fixes:

- Fix undo not working for some dialogue items (Bug #2586)
- Spinbox types in dialogue to receive wheel events only when they have focus (Feature #2585)