### PR TITLE
Mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,9 +134,11 @@ endif()
 
 # Platform specific
 if (WIN32)
+    if(NOT MINGW)
     set(Boost_USE_STATIC_LIBS   ON)
     set(PLATFORM_INCLUDE_DIR "platform")
     add_definitions(-DBOOST_ALL_NO_LIB)
+    endif(NOT MINGW)
 
     # Suppress WinMain(), provided by SDL
     add_definitions(-DSDL_MAIN_HANDLED)

--- a/apps/mwiniimporter/CMakeLists.txt
+++ b/apps/mwiniimporter/CMakeLists.txt
@@ -18,6 +18,10 @@ target_link_libraries(openmw-iniimporter
     components
 )
 
+if (MINGW)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -municode")
+endif()
+
 if (BUILD_WITH_CODE_COVERAGE)
   add_definitions (--coverage)
   target_link_libraries(openmw-iniimporter gcov)

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
 // For OutputDebugString
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 // makes __argc and __argv available on windows
 #include <cstdlib>
 #endif

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1,6 +1,6 @@
 #include "worldimp.hpp"
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <boost/tr1/tr1/unordered_map>
 #elif defined HAVE_UNORDERED_MAP
 #include <unordered_map>

--- a/cmake/FindMyGUI.cmake
+++ b/cmake/FindMyGUI.cmake
@@ -19,7 +19,46 @@ include(PreprocessorUtils)
 # ENDIF (MYGUI_LIBRARIES AND MYGUI_INCLUDE_DIRS)
 
 IF (WIN32) #Windows
+
     MESSAGE(STATUS "Looking for MyGUI")
+
+    IF(MINGW)
+
+        FIND_PATH ( MYGUI_INCLUDE_DIRS MyGUI.h PATH_SUFFIXES MYGUI)
+        FIND_PATH ( MYGUI_PLATFORM_INCLUDE_DIRS MyGUI_OgrePlatform.h PATH_SUFFIXES MYGUI)
+        FIND_LIBRARY ( MYGUI_LIBRARIES_REL NAMES
+            libMyGUIEngine${CMAKE_SHARED_LIBRARY_SUFFIX}
+            libMyGUI.OgrePlatform${CMAKE_STATIC_LIBRARY_SUFFIX}
+            HINTS
+            ${MYGUI_LIB_DIR}
+            PATH_SUFFIXES "" release relwithdebinfo minsizerel )
+
+        FIND_LIBRARY ( MYGUI_LIBRARIES_DBG NAMES
+            libMyGUIEngine_d${CMAKE_SHARED_LIBRARY_SUFFIX}
+            libMyGUI.OgrePlatform_d${CMAKE_STATIC_LIBRARY_SUFFIX}
+            HINTS
+            ${MYGUI_LIB_DIR}
+            PATH_SUFFIXES "" debug )
+
+        FIND_LIBRARY ( MYGUI_PLATFORM_LIBRARIES_REL NAMES
+            libMyGUI.OgrePlatform${CMAKE_STATIC_LIBRARY_SUFFIX}
+            HINTS
+            ${MYGUI_LIB_DIR}
+            PATH_SUFFIXES "" release relwithdebinfo minsizerel )
+
+        FIND_LIBRARY ( MYGUI_PLATFORM_LIBRARIES_DBG NAMES
+            MyGUI.OgrePlatform_d${CMAKE_STATIC_LIBRARY_SUFFIX}
+            HINTS
+            ${MYGUI_LIB_DIR}
+            PATH_SUFFIXES "" debug )
+
+        make_library_set ( MYGUI_LIBRARIES )
+        make_library_set ( MYGUI_PLATFORM_LIBRARIES )
+
+        MESSAGE ("${MYGUI_LIBRARIES}")
+        MESSAGE ("${MYGUI_PLATFORM_LIBRARIES}")
+    ENDIF(MINGW)
+
     SET(MYGUISDK $ENV{MYGUI_HOME})
     IF (MYGUISDK)
         findpkg_begin ( "MYGUI" )

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -127,6 +127,9 @@ set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui
     )
 
 find_package(Qt4 COMPONENTS QtCore QtGui)
+if(MINGW)
+find_package(Bullet REQUIRED COMPONENTS Collision)
+endif()
 
 if(QT_QTGUI_LIBRARY AND QT_QTCORE_LIBRARY)
     add_component_qt_dir (contentselector
@@ -171,7 +174,7 @@ if (GIT_CHECKOUT)
 endif (GIT_CHECKOUT)
 
 if(MINGW)
-target_link_libraries(components ${QT_LIBRARIES})
+target_link_libraries(components ${QT_LIBRARIES} ${BULLET_LIBRARIES})
 endif()
 
 if (WIN32)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -170,6 +170,10 @@ if (GIT_CHECKOUT)
     add_dependencies (components git-version)
 endif (GIT_CHECKOUT)
 
+if (WIN32)
+target_link_libraries(components shlwapi)
+endif()
+
 # Fix for not visible pthreads functions for linker with glibc 2.15
 if (UNIX AND NOT APPLE)
 target_link_libraries(components ${CMAKE_THREAD_LIBS_INIT})

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -170,6 +170,10 @@ if (GIT_CHECKOUT)
     add_dependencies (components git-version)
 endif (GIT_CHECKOUT)
 
+if(MINGW)
+target_link_libraries(components ${QT_LIBRARIES})
+endif()
+
 if (WIN32)
 target_link_libraries(components shlwapi)
 endif()

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -1,7 +1,7 @@
 #ifndef COMPONENTS_FILES_CONFIGURATIONMANAGER_HPP
 #define COMPONENTS_FILES_CONFIGURATIONMANAGER_HPP
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <boost/tr1/tr1/unordered_map>
 #elif defined HAVE_UNORDERED_MAP
 #include <unordered_map>

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -6,9 +6,7 @@
 
 #include <windows.h>
 #include <shlobj.h>
-#include <Shlwapi.h>
-
-#pragma comment(lib, "Shlwapi.lib")
+#include <shlwapi.h>
 
 #include <boost/locale.hpp>
 namespace bconv = boost::locale::conv;

--- a/extern/ogre-ffmpeg-videoplayer/audiodecoder.hpp
+++ b/extern/ogre-ffmpeg-videoplayer/audiodecoder.hpp
@@ -21,8 +21,8 @@ extern "C"
     #endif
 }
 
-#ifdef _WIN32
-#include <BaseTsd.h>
+#if defined(_WIN32) && !defined(__MINGW32__)
+#include <basetsd.h>
 
 typedef SSIZE_T ssize_t;
 #endif

--- a/extern/oics/tinyxml.cpp
+++ b/extern/oics/tinyxml.cpp
@@ -32,7 +32,7 @@ distribution.
 #include "tinyxml.h"
 
 #ifdef _WIN32
-#include <Windows.h> // import MultiByteToWideChar
+#include <windows.h> // import MultiByteToWideChar
 #endif
 
 

--- a/extern/sdl4ogre/sdlwindowhelper.cpp
+++ b/extern/sdl4ogre/sdlwindowhelper.cpp
@@ -30,7 +30,7 @@ SDLWindowHelper::SDLWindowHelper (SDL_Window* window, int w, int h,
 
 	switch (wmInfo.subsystem)
 	{
-#ifdef WIN32
+#ifdef _WIN32
 	case SDL_SYSWM_WINDOWS:
 		// Windows code
 		winHandle = Ogre::StringConverter::toString((uintptr_t)wmInfo.info.win.window);


### PR DESCRIPTION
Changes necessary to compile OpenMW with the mingw-w64 compiler.

Ace verified that these do not break his VS builds: http://forum.openmw.org/viewtopic.php?f=6&t=2871#p32305

PS: There are some more mingw-w64 related changes necessary to compile OpenMW in my mingw_workarounds branch. I don't think these should be merged because they are workarounds for what i consider to be bugs on the mingw-w64 compiler side.