### PR TITLE
Scrollbars don't save their positions between window openings

### DIFF
--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -130,6 +130,7 @@ namespace MWGui
         mSortModel = new SortFilterItemModel(model);
         mSortModel->setFilter(SortFilterItemModel::Filter_OnlyIngredients);
         mItemView->setModel (mSortModel);
+        mItemView->resetScrollBars();
 
         mNameEdit->setCaption("");
 

--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -114,6 +114,7 @@ void CompanionWindow::open(const MWWorld::Ptr& npc)
     mModel = new CompanionItemModel(npc);
     mSortModel = new SortFilterItemModel(mModel);
     mItemView->setModel(mSortModel);
+    mItemView->resetScrollBars();
 
     setTitle(npc.getClass().getName(npc));
 }

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -151,6 +151,7 @@ namespace MWGui
         mSortModel = new SortFilterItemModel(mModel);
 
         mItemView->setModel (mSortModel);
+        mItemView->resetScrollBars();
 
         MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
 

--- a/apps/openmw/mwgui/itemselection.cpp
+++ b/apps/openmw/mwgui/itemselection.cpp
@@ -39,6 +39,7 @@ namespace MWGui
         mModel = new InventoryItemModel(container);
         mSortModel = new SortFilterItemModel(mModel);
         mItemView->setModel(mSortModel);
+        mItemView->resetScrollBars();
     }
 
     void ItemSelectionDialog::setCategory(int category)

--- a/apps/openmw/mwgui/itemview.cpp
+++ b/apps/openmw/mwgui/itemview.cpp
@@ -128,6 +128,11 @@ void ItemView::update()
     layoutWidgets();
 }
 
+void ItemView::resetScrollBars()
+{
+    mScrollView->setViewOffset(MyGUI::IntPoint(0, 0));
+}
+
 void ItemView::onSelectedItem(MyGUI::Widget *sender)
 {
     ItemModel::ModelIndex index = (*sender->getUserData<std::pair<ItemModel::ModelIndex, ItemModel*> >()).first;

--- a/apps/openmw/mwgui/itemview.hpp
+++ b/apps/openmw/mwgui/itemview.hpp
@@ -30,6 +30,8 @@ namespace MWGui
 
         void update();
 
+        void resetScrollBars();
+
     private:
         virtual void initialiseOverride();
 

--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -114,6 +114,8 @@ void MerchantRepair::onMouseWheel(MyGUI::Widget* _sender, int _rel)
 void MerchantRepair::open()
 {
     center();
+    // Reset scrollbars
+    mList->setViewOffset(MyGUI::IntPoint(0, 0));
 }
 
 void MerchantRepair::exit()

--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -548,6 +548,7 @@ namespace MWGui
         WindowModal::open();
 
         mMagicList->setModel(new SpellModel(MWBase::Environment::get().getWorld()->getPlayerPtr()));
+        mMagicList->resetScrollbars();
     }
 
     void MagicSelectionDialog::onModelIndexSelected(SpellModel::ModelIndex index)

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -44,6 +44,8 @@ Recharge::Recharge()
 void Recharge::open()
 {
     center();
+    // Reset scrollbars
+    mView->setViewOffset(MyGUI::IntPoint(0, 0));
 }
 
 void Recharge::exit()

--- a/apps/openmw/mwgui/repair.cpp
+++ b/apps/openmw/mwgui/repair.cpp
@@ -36,6 +36,8 @@ Repair::Repair()
 void Repair::open()
 {
     center();
+    // Reset scrollbars
+    mRepairView->setViewOffset(MyGUI::IntPoint(0, 0));
 }
 
 void Repair::exit()

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -8,6 +8,7 @@
 #include <MyGUI_ListBox.h>
 #include <MyGUI_ScrollView.h>
 #include <MyGUI_Gui.h>
+#include <MyGUI_TabControl.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/math/common_factor_rt.hpp>
@@ -170,6 +171,7 @@ namespace MWGui
 
         setTitle("#{sOptions}");
 
+        getWidget(mSettingsTab, "SettingsTab");
         getWidget(mOkButton, "OkButton");
         getWidget(mResolutionList, "ResolutionList");
         getWidget(mFullscreenButton, "FullscreenButton");
@@ -208,6 +210,7 @@ namespace MWGui
 
         mMainWidget->castType<MyGUI::Window>()->eventWindowChangeCoord += MyGUI::newDelegate(this, &SettingsWindow::onWindowResize);
 
+        mSettingsTab->eventTabChangeSelect += MyGUI::newDelegate(this, &SettingsWindow::onTabChanged);
         mOkButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onOkButtonClicked);
         mShaderModeButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onShaderModeToggled);
         mTextureFilteringButton->eventComboChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onTextureFilteringChanged);
@@ -273,6 +276,11 @@ namespace MWGui
 
         mKeyboardSwitch->setStateSelected(true);
         mControllerSwitch->setStateSelected(false);
+    }
+
+    void SettingsWindow::onTabChanged(MyGUI::TabControl* /*_sender*/, size_t /*index*/)
+    {
+        resetScrollbars();
     }
 
     void SettingsWindow::onOkButtonClicked(MyGUI::Widget* _sender)
@@ -480,6 +488,7 @@ namespace MWGui
         mKeyboardSwitch->setStateSelected(true);
         mControllerSwitch->setStateSelected(false);
         updateControlsBox();
+        resetScrollbars();
     }
 
     void SettingsWindow::onControllerSwitchClicked(MyGUI::Widget* _sender)
@@ -490,6 +499,7 @@ namespace MWGui
         mKeyboardSwitch->setStateSelected(false);
         mControllerSwitch->setStateSelected(true);
         updateControlsBox();
+        resetScrollbars();
     }
 
     void SettingsWindow::updateControlsBox()
@@ -584,6 +594,7 @@ namespace MWGui
     void SettingsWindow::open()
     {
         updateControlsBox ();
+        resetScrollbars();
     }
 
     void SettingsWindow::exit()
@@ -594,5 +605,11 @@ namespace MWGui
     void SettingsWindow::onWindowResize(MyGUI::Window *_sender)
     {
         updateControlsBox();
+    }
+
+    void SettingsWindow::resetScrollbars()
+    {
+        mResolutionList->setScrollPosition(0);
+        mControlsBox->setViewOffset(MyGUI::IntPoint(0, 0));
     }
 }

--- a/apps/openmw/mwgui/settingswindow.hpp
+++ b/apps/openmw/mwgui/settingswindow.hpp
@@ -22,6 +22,7 @@ namespace MWGui
             void updateControlsBox();
 
     protected:
+            MyGUI::TabControl* mSettingsTab;
             MyGUI::Button* mOkButton;
 
             // graphics
@@ -50,6 +51,7 @@ namespace MWGui
             MyGUI::Button* mControllerSwitch;
             bool mKeyboardMode; //if true, setting up the keyboard. Otherwise, it's controller
 
+            void onTabChanged(MyGUI::TabControl* _sender, size_t index);
             void onOkButtonClicked(MyGUI::Widget* _sender);
             void onFpsToggled(MyGUI::Widget* _sender);
             void onTextureFilteringChanged(MyGUI::ComboBox* _sender, size_t pos);
@@ -74,6 +76,9 @@ namespace MWGui
             void apply();
 
             void configureWidgets(MyGUI::Widget* widget);
+        
+        private:
+            void resetScrollbars();
     };
 }
 

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -551,6 +551,7 @@ namespace MWGui
             ++i;
         }
         mAvailableEffectsList->adjustSize ();
+        mAvailableEffectsList->scrollToTop();
 
         for (std::vector<short>::const_iterator it = knownEffects.begin(); it != knownEffects.end(); ++it)
         {

--- a/apps/openmw/mwgui/spellview.cpp
+++ b/apps/openmw/mwgui/spellview.cpp
@@ -311,4 +311,8 @@ namespace MWGui
             mScrollView->setViewOffset(MyGUI::IntPoint(0, static_cast<int>(mScrollView->getViewOffset().top + _rel*0.3f)));
     }
 
+    void SpellView::resetScrollbars()
+    {
+        mScrollView->setViewOffset(MyGUI::IntPoint(0, 0));
+    }
 }

--- a/apps/openmw/mwgui/spellview.hpp
+++ b/apps/openmw/mwgui/spellview.hpp
@@ -51,6 +51,8 @@ namespace MWGui
         virtual void setSize(const MyGUI::IntSize& _value);
         virtual void setCoord(const MyGUI::IntCoord& _value);
 
+        void resetScrollbars();
+
     private:
         MyGUI::ScrollView* mScrollView;
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -136,6 +136,7 @@ namespace MWGui
         mTradeModel = new TradeItemModel(new ContainerItemModel(itemSources, worldItems), mPtr);
         mSortModel = new SortFilterItemModel(mTradeModel);
         mItemView->setModel (mSortModel);
+        mItemView->resetScrollBars();
 
         updateLabels();
 


### PR DESCRIPTION
Windows and dialogs that reset scrollbars:
* Container
* Companion
* Alchemy
* Repair
* Spell Creation
* Enchanting
* Recharge
* Merchant Repair
* Quick Keys Menu (Item Menu, Magic Menu)
* Settings

Settings window also resets scrollbars on a tab changing.