### PR TITLE
Reset Console editbox before command execution

### DIFF
--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -294,6 +294,10 @@ namespace MWGui
             mCommandHistory.push_back(cm);
         mCurrent = mCommandHistory.end();
         mEditString.clear();
+
+        // Reset the command line before the command execution.
+        // It prevents re-triggering the acceptCommand() event during
+        // the actual command execution.
         mCommandLine->setCaption("");
 
         execute (cm);

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -296,8 +296,8 @@ namespace MWGui
         mEditString.clear();
 
         // Reset the command line before the command execution.
-        // It prevents re-triggering the acceptCommand() event during
-        // the actual command execution.
+        // It prevents the re-triggering of the acceptCommand() event for the same command 
+        // during the actual command execution
         mCommandLine->setCaption("");
 
         execute (cm);

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -294,10 +294,9 @@ namespace MWGui
             mCommandHistory.push_back(cm);
         mCurrent = mCommandHistory.end();
         mEditString.clear();
+        mCommandLine->setCaption("");
 
         execute (cm);
-
-        mCommandLine->setCaption("");
     }
 
     std::string Console::complete( std::string input, std::vector<std::string> &matches )


### PR DESCRIPTION
Should fix the bug #2593.

It seems that the accept event for Console command line was called multiple times during command execution, when GUI was disabled.

Test it!