### PR TITLE
Add handling DELE subrecords in Script records.

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -23,14 +23,14 @@ opencs_units (model/world
 
 
 opencs_units_noqt (model/world
-    universalid record commands columnbase scriptcontext cell refidcollection
+    universalid record commands columnbase scriptcontext cell refidcollection idcollection
     refidadapter refiddata refidadapterimp ref collectionbase refcollection columns infocollection tablemimedata cellcoordinates cellselection resources resourcesmanager scope
     pathgrid landtexture land nestedtablewrapper nestedcollection nestedcoladapterimp nestedinfocollection
     idcompletionmanager
     )
 
 opencs_hdrs_noqt (model/world
-    columnimp idcollection collection info subcellcollection
+    columnimp collection info subcellcollection
     )
 
 

--- a/apps/opencs/model/world/idcollection.cpp
+++ b/apps/opencs/model/world/idcollection.cpp
@@ -1,0 +1,52 @@
+#include "idcollection.hpp"
+
+namespace CSMWorld
+{
+    template<>
+    int IdCollection<ESM::Script, IdAccessor<ESM::Script> >::load (ESM::ESMReader& reader, bool base)
+    {
+        ESM::Script record;
+        std::string id = record.loadData(reader);
+
+        if (reader.isNextSub ("DELE"))
+        {
+            int index = Collection<ESM::Script, IdAccessor<ESM::Script> >::searchId (id);
+
+            //record.loadScript(reader);
+            reader.skipRecord();
+
+            if (index==-1)
+            {
+                // deleting a record that does not exist
+
+                // ignore it for now
+
+                /// \todo report the problem to the user
+            }
+            else if (base)
+            {
+                Collection<ESM::Script, IdAccessor<ESM::Script> >::removeRows (index, 1);
+            }
+            else
+            {
+                Record<ESM::Script> oldRecord = Collection<ESM::Script, IdAccessor<ESM::Script> >::getRecord (index);
+                //oldRecord.setModified(record); // keep the new one, too
+                oldRecord.mState = RecordBase::State_Deleted;
+                this->setRecord (index, oldRecord);
+            }
+
+            return -1;
+        }
+        else
+        {
+            int index = this->searchId (id);
+
+            if (index==-1)
+                IdAccessor<ESM::Script>().getId (record) = id;
+
+            record.loadScript(reader);
+
+            return load (record, base, index);
+        }
+    }
+}

--- a/apps/opencs/model/world/idcollection.hpp
+++ b/apps/opencs/model/world/idcollection.hpp
@@ -2,6 +2,7 @@
 #define CSM_WOLRD_IDCOLLECTION_H
 
 #include <components/esm/esmreader.hpp>
+#include <components/esm/loadscpt.hpp>
 
 #include "collection.hpp"
 
@@ -37,6 +38,9 @@ namespace CSMWorld
     {
         record.load (reader);
     }
+
+    template<>
+    int IdCollection<ESM::Script, IdAccessor<ESM::Script> >::load (ESM::ESMReader& reader, bool base);
 
     template<typename ESXRecordT, typename IdAccessorT>
     int IdCollection<ESXRecordT, IdAccessorT>::load (ESM::ESMReader& reader, bool base)

--- a/components/esm/loadscpt.cpp
+++ b/components/esm/loadscpt.cpp
@@ -58,11 +58,22 @@ namespace ESM
 
     void Script::load(ESMReader &esm)
     {
+        loadData(esm);
+        loadScript(esm);
+    }
+
+    std::string Script::loadData(ESMReader &esm)
+    {
         SCHD data;
         esm.getHNT(data, "SCHD", 52);
         mData = data.mData;
         mId = data.mName.toString();
 
+        return mId;
+    }
+
+    void Script::loadScript(ESMReader &esm)
+    {
         mVarNames.clear();
 
         while (esm.hasMoreSubs())
@@ -78,10 +89,13 @@ namespace ESM
                 case ESM::FourCC<'S','C','D','T'>::value:
                     // compiled script
                     mScriptData.resize(mData.mScriptDataSize);
-                    esm.getHExact(&mScriptData[0], mScriptData.size());
+                    esm.getHExact(&mScriptData[0], (int)mScriptData.size());
                     break;
                 case ESM::FourCC<'S','C','T','X'>::value:
                     mScriptText = esm.getHString();
+                    break;
+                case ESM::FourCC<'D','E','L','E'>::value:
+                    esm.skipHSub();
                     break;
                 default:
                     esm.fail("Unknown subrecord");

--- a/components/esm/loadscpt.hpp
+++ b/components/esm/loadscpt.hpp
@@ -54,6 +54,9 @@ public:
     void blank();
     ///< Set record to default state (does not touch the ID/index).
 
+    std::string loadData(ESMReader &esm);
+    void loadScript(ESMReader &esm);
+
 private:
     void loadSCVR(ESMReader &esm);
 };


### PR DESCRIPTION
Should resolve Bug #2211.  (Also related to Bug #2413)

- load() is split into two in order to handle DELE subrecords