### PR TITLE
Reduce the number of jobs in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ./CI/before_script.osx.sh; fi
 script:
  - cd ./build
- - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then ${ANALYZE}make -j4; fi
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then ${ANALYZE}make -j2; fi
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "osx" ]; then make package; fi
 after_script:
  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./openmw_test_suite; fi


### PR DESCRIPTION
Hopefully this fixes the occasional out-of-memory problems, e.g. in https://travis-ci.org/OpenMW/openmw/jobs/66718430:

<pre>
g++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-4.6/README.Bugs> for instructions.
make[2]: *** [apps/openmw/CMakeFiles/openmw.dir/mwclass/npc.cpp.o] Error 4
make[2]: *** Waiting for unfinished jobs....
g++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-4.6/README.Bugs> for instructions.
make[2]: *** [apps/openmw/CMakeFiles/openmw.dir/mwworld/projectilemanager.cpp.o] Error 4
make[1]: *** [apps/openmw/CMakeFiles/openmw.dir/all] Error 2
make: *** [all] Error 2
</pre>

Note travis-CI virtual machines just have 2 cores according to http://docs.travis-ci.com/user/ci-environment/, so 4 jobs wouldn't improve build times anyway.