### PR TITLE
Rebuild the list of available content files when opening the open/new dialogues.

### DIFF
--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -115,7 +115,7 @@ std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfi
 
     boost::program_options::notify(variables);
 
-    mCfgMgr.readConfiguration(variables, desc, /*quiet*/true);
+    mCfgMgr.readConfiguration(variables, desc, quiet);
 
     mDocumentManager.setEncoding (
         ToUTF8::calculateEncoding (variables["encoding"].as<std::string>()));

--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -95,7 +95,7 @@ void CS::Editor::setupDataFiles (const Files::PathContainer& dataDirs)
     }
 }
 
-std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfig()
+std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfig(bool quiet)
 {
     boost::program_options::variables_map variables;
     boost::program_options::options_description desc("Syntax: openmw-cs <options>\nAllowed options");
@@ -115,7 +115,7 @@ std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfi
 
     boost::program_options::notify(variables);
 
-    mCfgMgr.readConfiguration(variables, desc);
+    mCfgMgr.readConfiguration(variables, desc, /*quiet*/true);
 
     mDocumentManager.setEncoding (
         ToUTF8::calculateEncoding (variables["encoding"].as<std::string>()));
@@ -195,6 +195,11 @@ void CS::Editor::cancelCreateGame()
 void CS::Editor::createAddon()
 {
     mStartup.hide();
+
+    mFileDialog.clearFiles();
+    std::pair<Files::PathContainer, std::vector<std::string> > config = readConfig(/*quiet*/true);
+    setupDataFiles (config.first);
+
     mFileDialog.showDialog (CSVDoc::ContentAction_New);
 }
 
@@ -215,6 +220,11 @@ void CS::Editor::cancelFileDialog()
 void CS::Editor::loadDocument()
 {
     mStartup.hide();
+
+    mFileDialog.clearFiles();
+    std::pair<Files::PathContainer, std::vector<std::string> > config = readConfig(/*quiet*/true);
+    setupDataFiles (config.first);
+
     mFileDialog.showDialog (CSVDoc::ContentAction_Edit);
 }
 

--- a/apps/opencs/editor.hpp
+++ b/apps/opencs/editor.hpp
@@ -62,7 +62,7 @@ namespace CS
 
             void setupDataFiles (const Files::PathContainer& dataDirs);
 
-            std::pair<Files::PathContainer, std::vector<std::string> > readConfig();
+            std::pair<Files::PathContainer, std::vector<std::string> > readConfig(bool quiet=false);
             ///< \return data paths
 
             // not implemented

--- a/apps/opencs/view/doc/filedialog.cpp
+++ b/apps/opencs/view/doc/filedialog.cpp
@@ -33,6 +33,11 @@ void CSVDoc::FileDialog::addFiles(const QString &path)
     mSelector->addFiles(path);
 }
 
+void CSVDoc::FileDialog::clearFiles()
+{
+    mSelector->clearFiles();
+}
+
 QStringList CSVDoc::FileDialog::selectedFilePaths()
 {
     QStringList filePaths;
@@ -105,7 +110,6 @@ void CSVDoc::FileDialog::buildNewFileView()
 
         connect (mFileWidget, SIGNAL (nameChanged(const QString &, bool)),
                 this, SLOT (slotUpdateAcceptButton(const QString &, bool)));
-
     }
 
     ui.projectGroupBoxLayout->insertWidget (0, mFileWidget);
@@ -139,7 +143,7 @@ void CSVDoc::FileDialog::slotUpdateAcceptButton(int)
 {
     QString name = "";
 
-    if (mAction == ContentAction_New)
+    if (mFileWidget && mAction == ContentAction_New)
         name = mFileWidget->getName();
 
     slotUpdateAcceptButton (name, true);

--- a/apps/opencs/view/doc/filedialog.hpp
+++ b/apps/opencs/view/doc/filedialog.hpp
@@ -45,6 +45,7 @@ namespace CSVDoc
         void showDialog (ContentAction action);
 
         void addFiles (const QString &path);
+        void clearFiles ();
 
         QString filename() const;
         QStringList selectedFilePaths();

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -473,6 +473,13 @@ void ContentSelectorModel::ContentModel::addFiles(const QString &path)
     sortFiles();
 }
 
+void ContentSelectorModel::ContentModel::clearFiles()
+{
+    beginRemoveRows(QModelIndex(), 0, mFiles.count()-1);
+    mFiles.clear();
+    endRemoveRows();
+}
+
 QStringList ContentSelectorModel::ContentModel::gameFiles() const
 {
     QStringList gameFiles;

--- a/components/contentselector/model/contentmodel.hpp
+++ b/components/contentselector/model/contentmodel.hpp
@@ -44,6 +44,7 @@ namespace ContentSelectorModel
         bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent);
 
         void addFiles(const QString &path);
+        void clearFiles();
 
         QModelIndex indexFromItem(const EsmFile *item) const;
         const EsmFile *item(const QString &name) const;

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -150,6 +150,11 @@ void ContentSelectorView::ContentSelector::addFiles(const QString &path)
     mContentModel->uncheckAll();
 }
 
+void ContentSelectorView::ContentSelector::clearFiles()
+{
+    mContentModel->clearFiles();
+}
+
 QString ContentSelectorView::ContentSelector::currentFile() const
 {
     QModelIndex currentIdx = ui.addonView->currentIndex();

--- a/components/contentselector/view/contentselector.hpp
+++ b/components/contentselector/view/contentselector.hpp
@@ -29,6 +29,7 @@ namespace ContentSelectorView
         QString currentFile() const;
 
         void addFiles(const QString &path);
+        void clearFiles();
         void setProfileContent (const QStringList &fileList);
 
         void clearCheckStates();

--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -52,8 +52,11 @@ void ConfigurationManager::setupTokensMapping()
 }
 
 void ConfigurationManager::readConfiguration(boost::program_options::variables_map& variables,
-    boost::program_options::options_description& description)
+    boost::program_options::options_description& description, bool quiet)
 {
+    bool silent = mSilent;
+    mSilent = quiet;
+
     loadConfig(mFixedPath.getUserConfigPath(), variables, description);
     boost::program_options::notify(variables);
 
@@ -62,6 +65,7 @@ void ConfigurationManager::readConfiguration(boost::program_options::variables_m
     loadConfig(mFixedPath.getGlobalConfigPath(), variables, description);
     boost::program_options::notify(variables);
 
+    mSilent = silent;
 }
 
 void ConfigurationManager::processPaths(Files::PathContainer& dataDirs, bool create)

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -29,7 +29,7 @@ struct ConfigurationManager
     virtual ~ConfigurationManager();
 
     void readConfiguration(boost::program_options::variables_map& variables,
-        boost::program_options::options_description& description);
+        boost::program_options::options_description& description, bool quiet=false);
 
     void processPaths(Files::PathContainer& dataDirs, bool create = false);
     ///< \param create Try creating the directory, if it does not exist.


### PR DESCRIPTION
Should resolve Bug #2644.