### PR TITLE
Enum- and DataDisplayDelegate fixes

### DIFF
--- a/apps/opencs/view/world/datadisplaydelegate.cpp
+++ b/apps/opencs/view/world/datadisplaydelegate.cpp
@@ -62,16 +62,11 @@ void CSVWorld::DataDisplayDelegate::paint (QPainter *painter, const QStyleOption
         EnumDelegate::paint(painter, option, index);
     else
     {
-        unsigned int i = 0;
-
-        for (; i < mValues.size(); ++i)
+        int valueIndex = getValueIndex(index);
+        if (valueIndex != -1)
         {
-            if (mValues.at(i).first == index.data().toInt())
-                break;
+            paintIcon(painter, option, valueIndex);
         }
-
-        if (i < mValues.size() )
-            paintIcon (painter, option, i);
     }
 
     painter->restore();

--- a/apps/opencs/view/world/datadisplaydelegate.cpp
+++ b/apps/opencs/view/world/datadisplaydelegate.cpp
@@ -15,8 +15,6 @@ CSVWorld::DataDisplayDelegate::DataDisplayDelegate(const ValueList &values,
       mIcons (icons), mIconSize (QSize(16, 16)), mIconLeftOffset(3),
       mTextLeftOffset(8), mSettingKey (pageName + '/' + settingName)
 {
-    mTextAlignment.setAlignment (Qt::AlignLeft | Qt::AlignVCenter );
-
     buildPixmaps();
 
     QString value =
@@ -81,24 +79,28 @@ void CSVWorld::DataDisplayDelegate::paint (QPainter *painter, const QStyleOption
 
 void CSVWorld::DataDisplayDelegate::paintIcon (QPainter *painter, const QStyleOptionViewItem &option, int index) const
 {
-    //function-level statics
     QRect iconRect = option.rect;
     QRect textRect = iconRect;
 
-    const QString &text = mValues.at(index).second;
-
-    iconRect.setSize (mIconSize);
-    iconRect.translate(mIconLeftOffset, (option.rect.height() - iconRect.height())/2);
-
-    if (mDisplayMode == Mode_IconAndText )
+    iconRect.setLeft(iconRect.left() + mIconLeftOffset);
+    iconRect.setRight(option.rect.right());
+    if (mDisplayMode == Mode_IconAndText)
     {
-        textRect.translate (iconRect.width() + mTextLeftOffset, 0 );
-        painter->drawText (textRect, text, mTextAlignment);
-    }
-    else
-        iconRect.translate( (option.rect.width() - iconRect.width()) / 2, 0);
+        iconRect.setWidth(mIconSize.width());
+        textRect.setLeft(iconRect.right() + mTextLeftOffset);
+        textRect.setRight(option.rect.right());
 
-    painter->drawPixmap (iconRect, mPixmaps.at(index).second);
+        QString text = option.fontMetrics.elidedText(mValues.at(index).second, 
+                                                     option.textElideMode,
+                                                     textRect.width());
+        QApplication::style()->drawItemText(painter,
+                                            textRect,
+                                            Qt::AlignLeft | Qt::AlignVCenter,
+                                            option.palette,
+                                            true,
+                                            text);
+    }
+    QApplication::style()->drawItemPixmap(painter, iconRect, Qt::AlignCenter, mPixmaps.at(index).second);
 }
 
 void CSVWorld::DataDisplayDelegate::updateUserSetting (const QString &name,

--- a/apps/opencs/view/world/datadisplaydelegate.hpp
+++ b/apps/opencs/view/world/datadisplaydelegate.hpp
@@ -31,7 +31,7 @@ namespace CSVWorld
 
         std::vector <std::pair <int, QPixmap> > mPixmaps;
         QSize mIconSize;
-        int mIconLeftOffset;
+        int mHorizontalMargin;
         int mTextLeftOffset;
 
         QString mSettingKey;
@@ -45,11 +45,10 @@ namespace CSVWorld
 
         virtual void paint (QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
+        virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
         /// pass a QSize defining height / width of icon. Default is QSize (16,16).
         void setIconSize (const QSize& icon);
-
-        /// offset the horizontal position of the icon from the left edge of the cell.  Default is 3 pixels.
-        void setIconLeftOffset (int offset);
 
         /// offset the horizontal position of the text from the right edge of the icon.  Default is 8 pixels.
         void setTextLeftOffset (int offset);

--- a/apps/opencs/view/world/datadisplaydelegate.hpp
+++ b/apps/opencs/view/world/datadisplaydelegate.hpp
@@ -30,7 +30,6 @@ namespace CSVWorld
     private:
 
         std::vector <std::pair <int, QPixmap> > mPixmaps;
-        QTextOption mTextAlignment;
         QSize mIconSize;
         int mIconLeftOffset;
         int mTextLeftOffset;

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -469,8 +469,7 @@ void CSVWorld::EditWidget::remake(int row)
                     mTable->data (mTable->index (row, idColumn)).toString().toUtf8().constData());
 
                 NestedTable* table = new NestedTable(mDocument, id, mNestedModels.back(), this);
-                // FIXME: does not work well when enum delegates are used
-                //table->resizeColumnsToContents();
+                table->resizeColumnsToContents();
 
                 if(mTable->index(row, i).data().type() == QVariant::UserType)
                 {

--- a/apps/opencs/view/world/enumdelegate.cpp
+++ b/apps/opencs/view/world/enumdelegate.cpp
@@ -10,6 +10,24 @@
 
 #include "../../model/world/commands.hpp"
 
+int CSVWorld::EnumDelegate::getValueIndex(const QModelIndex &index, int role) const
+{
+    if (index.isValid() && index.data(role).isValid())
+    {
+        int value = index.data(role).toInt();
+
+        int size = static_cast<int>(mValues.size());
+        for (int i = 0; i < size; ++i)
+        {
+            if (value == mValues.at(i).first)
+            {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
 void CSVWorld::EnumDelegate::setModelDataImp (QWidget *editor, QAbstractItemModel *model,
     const QModelIndex& index) const
 {
@@ -67,60 +85,43 @@ QWidget *CSVWorld::EnumDelegate::createEditor(QWidget *parent, const QStyleOptio
 
 void CSVWorld::EnumDelegate::setEditorData (QWidget *editor, const QModelIndex& index, bool tryDisplay) const
 {
-    if (QComboBox *comboBox = dynamic_cast<QComboBox *> (editor))
+    if (QComboBox *comboBox = dynamic_cast<QComboBox *>(editor))
     {
-        QVariant data = index.data (Qt::EditRole);
-
-        if (tryDisplay && !data.isValid())
+        int role = Qt::EditRole;
+        if (tryDisplay && !index.data(role).isValid())
         {
-            data = index.data (Qt::DisplayRole);
-            if (!data.isValid())
+            role = Qt::DisplayRole;
+            if (!index.data(role).isValid())
             {
                 return;
             }
         }
 
-        int value = data.toInt();
-
-        std::size_t size = mValues.size();
-
-        for (std::size_t i=0; i<size; ++i)
-            if (mValues[i].first==value)
-            {
-                comboBox->setCurrentIndex (i);
-                break;
-            }
+        int valueIndex = getValueIndex(index, role);
+        if (valueIndex != -1)
+        {
+            comboBox->setCurrentIndex(valueIndex);
+        }
     }
 }
 
 void CSVWorld::EnumDelegate::paint (QPainter *painter, const QStyleOptionViewItem& option,
     const QModelIndex& index) const
 {
-    if (index.data().isValid())
+    int valueIndex = getValueIndex(index);
+    if (valueIndex != -1)
     {
-        QStyleOptionViewItemV4 option2 (option);
-
-        int value = index.data().toInt();
-
-        for (std::vector<std::pair<int, QString> >::const_iterator iter (mValues.begin());
-            iter!=mValues.end(); ++iter)
-            if (iter->first==value)
-            {
-                option2.text = iter->second;
-
-                QApplication::style()->drawControl (QStyle::CE_ItemViewItem, &option2, painter);
-
-                break;
-            }
+        QStyleOptionViewItemV4 itemOption(option);
+        itemOption.text = mValues.at(valueIndex).second;
+        QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &itemOption, painter);
     }
 }
 
 QSize CSVWorld::EnumDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    if (index.data().isValid())
+    int valueIndex = getValueIndex(index);
+    if (valueIndex != -1)
     {
-        int value = index.data().toInt();
-
         // Calculate the size hint as for a combobox.
         // So, the whole text is visible (isn't elided) when the editor is created
         QStyleOptionComboBox itemOption;
@@ -129,20 +130,11 @@ QSize CSVWorld::EnumDelegate::sizeHint(const QStyleOptionViewItem &option, const
         itemOption.rect = option.rect;
         itemOption.state = option.state;
 
-        std::vector<std::pair<int, QString> >::const_iterator current = mValues.begin();
-        std::vector<std::pair<int, QString> >::const_iterator end = mValues.end();
-        for (; current != end; ++current)
-        {
-            if (current->first == value)
-            {
-                QSize valueSize = QSize(itemOption.fontMetrics.width(current->second),
-                                        itemOption.fontMetrics.height());
-                itemOption.currentText = current->second;
-                return QApplication::style()->sizeFromContents(QStyle::CT_ComboBox, 
-                                                               &itemOption, 
-                                                               valueSize);
-            }
-        }
+        const QString &valueText = mValues.at(valueIndex).second;
+        QSize valueSize = QSize(itemOption.fontMetrics.width(valueText), itemOption.fontMetrics.height());
+
+        itemOption.currentText = valueText;
+        return QApplication::style()->sizeFromContents(QStyle::CT_ComboBox, &itemOption, valueSize);
     }
     return option.rect.size();
 }

--- a/apps/opencs/view/world/enumdelegate.cpp
+++ b/apps/opencs/view/world/enumdelegate.cpp
@@ -115,6 +115,37 @@ void CSVWorld::EnumDelegate::paint (QPainter *painter, const QStyleOptionViewIte
     }
 }
 
+QSize CSVWorld::EnumDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    if (index.data().isValid())
+    {
+        int value = index.data().toInt();
+
+        // Calculate the size hint as for a combobox.
+        // So, the whole text is visible (isn't elided) when the editor is created
+        QStyleOptionComboBox itemOption;
+        itemOption.fontMetrics = option.fontMetrics;
+        itemOption.palette = option.palette;
+        itemOption.rect = option.rect;
+        itemOption.state = option.state;
+
+        std::vector<std::pair<int, QString> >::const_iterator current = mValues.begin();
+        std::vector<std::pair<int, QString> >::const_iterator end = mValues.end();
+        for (; current != end; ++current)
+        {
+            if (current->first == value)
+            {
+                QSize valueSize = QSize(itemOption.fontMetrics.width(current->second),
+                                        itemOption.fontMetrics.height());
+                itemOption.currentText = current->second;
+                return QApplication::style()->sizeFromContents(QStyle::CT_ComboBox, 
+                                                               &itemOption, 
+                                                               valueSize);
+            }
+        }
+    }
+    return option.rect.size();
+}
 
 CSVWorld::EnumDelegateFactory::EnumDelegateFactory() {}
 

--- a/apps/opencs/view/world/enumdelegate.hpp
+++ b/apps/opencs/view/world/enumdelegate.hpp
@@ -19,6 +19,8 @@ namespace CSVWorld
 
             std::vector<std::pair<int, QString> > mValues;
 
+            int getValueIndex(const QModelIndex &index, int role = Qt::DisplayRole) const;
+
         private:
 
             virtual void setModelDataImp (QWidget *editor, QAbstractItemModel *model,

--- a/apps/opencs/view/world/enumdelegate.hpp
+++ b/apps/opencs/view/world/enumdelegate.hpp
@@ -46,6 +46,8 @@ namespace CSVWorld
             virtual void paint (QPainter *painter, const QStyleOptionViewItem& option,
                 const QModelIndex& index) const;
 
+            virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
     };
 
     class EnumDelegateFactory : public CommandDelegateFactory


### PR DESCRIPTION
Changes:
* Text in Modified and Record Type columns is always within the table cell

**Before:**
![before](https://cloud.githubusercontent.com/assets/12299250/8191912/940e5346-1473-11e5-96f3-322a8ce83512.PNG)
**Now:**
![now](https://cloud.githubusercontent.com/assets/12299250/8191926/a0141608-1473-11e5-8e6b-b580be2b80fe.PNG)

* Proper resizing of this columns (the content size + the size of the combo box arrow).

I don't know are there any problems with this on Linux or OSX. So, test it!
