### PR TITLE
Creation bar hints (Feature #1591)

### DIFF
--- a/apps/opencs/model/world/idcompletionmanager.cpp
+++ b/apps/opencs/model/world/idcompletionmanager.cpp
@@ -24,6 +24,7 @@ namespace
         types[CSMWorld::ColumnBase::Display_Faction             ] = CSMWorld::UniversalId::Type_Faction;
         types[CSMWorld::ColumnBase::Display_GlobalVariable      ] = CSMWorld::UniversalId::Type_Global;
         types[CSMWorld::ColumnBase::Display_Icon                ] = CSMWorld::UniversalId::Type_Icon;
+        types[CSMWorld::ColumnBase::Display_Journal             ] = CSMWorld::UniversalId::Type_Journal;
         types[CSMWorld::ColumnBase::Display_Mesh                ] = CSMWorld::UniversalId::Type_Mesh;
         types[CSMWorld::ColumnBase::Display_Miscellaneous       ] = CSMWorld::UniversalId::Type_Referenceable;
         types[CSMWorld::ColumnBase::Display_Npc                 ] = CSMWorld::UniversalId::Type_Referenceable;
@@ -37,6 +38,7 @@ namespace
         types[CSMWorld::ColumnBase::Display_Spell               ] = CSMWorld::UniversalId::Type_Spell;
         types[CSMWorld::ColumnBase::Display_Static              ] = CSMWorld::UniversalId::Type_Referenceable;
         types[CSMWorld::ColumnBase::Display_Texture             ] = CSMWorld::UniversalId::Type_Texture;
+        types[CSMWorld::ColumnBase::Display_Topic               ] = CSMWorld::UniversalId::Type_Topic;
         types[CSMWorld::ColumnBase::Display_Weapon              ] = CSMWorld::UniversalId::Type_Referenceable;
 
         return types;

--- a/apps/opencs/view/world/creator.cpp
+++ b/apps/opencs/view/world/creator.cpp
@@ -15,8 +15,8 @@ void CSVWorld::Creator::setScope (unsigned int scope)
 CSVWorld::CreatorFactoryBase::~CreatorFactoryBase() {}
 
 
-CSVWorld::Creator *CSVWorld::NullCreatorFactory::makeCreator (CSMWorld::Data& data,
-    QUndoStack& undoStack, const CSMWorld::UniversalId& id) const
+CSVWorld::Creator *CSVWorld::NullCreatorFactory::makeCreator (CSMDoc::Document& document, 
+                                                              const CSMWorld::UniversalId& id) const
 {
     return 0;
 }

--- a/apps/opencs/view/world/creator.hpp
+++ b/apps/opencs/view/world/creator.hpp
@@ -5,16 +5,12 @@
 
 #include <QWidget>
 
+#include "../../model/world/scope.hpp"
 #include "../../model/world/universalid.hpp"
 
-#include "../../model/world/scope.hpp"
-
-class QUndoStack;
-
-namespace CSMWorld
+namespace CSMDoc
 {
-    class Data;
-    class UniversalId;
+    class Document;
 }
 
 namespace CSVWorld
@@ -59,8 +55,7 @@ namespace CSVWorld
 
             virtual ~CreatorFactoryBase();
 
-            virtual Creator *makeCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id) const = 0;
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const = 0;
             ///< The ownership of the returned Creator is transferred to the caller.
             ///
             /// \note The function can return a 0-pointer, which means no UI for creating/deleting
@@ -72,8 +67,7 @@ namespace CSVWorld
     {
         public:
 
-            virtual Creator *makeCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id) const;
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const;
             ///< The ownership of the returned Creator is transferred to the caller.
             ///
             /// \note The function always returns 0.
@@ -84,8 +78,7 @@ namespace CSVWorld
     {
         public:
 
-            virtual Creator *makeCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id) const;
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const;
             ///< The ownership of the returned Creator is transferred to the caller.
             ///
             /// \note The function can return a 0-pointer, which means no UI for creating/deleting
@@ -93,10 +86,10 @@ namespace CSVWorld
     };
 
     template<class CreatorT, unsigned int scope>
-    Creator *CreatorFactory<CreatorT, scope>::makeCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-        const CSMWorld::UniversalId& id) const
+    Creator *CreatorFactory<CreatorT, scope>::makeCreator (CSMDoc::Document& document,
+                                                           const CSMWorld::UniversalId& id) const
     {
-        std::auto_ptr<CreatorT> creator (new CreatorT (data, undoStack, id));
+        std::auto_ptr<CreatorT> creator (new CreatorT (document.getData(), document.getUndoStack(), id));
 
         creator->setScope (scope);
 

--- a/apps/opencs/view/world/dialoguecreator.cpp
+++ b/apps/opencs/view/world/dialoguecreator.cpp
@@ -3,6 +3,8 @@
 
 #include <components/esm/loaddial.hpp>
 
+#include "../../model/doc/document.hpp"
+
 #include "../../model/world/data.hpp"
 #include "../../model/world/commands.hpp"
 #include "../../model/world/columns.hpp"
@@ -22,14 +24,14 @@ CSVWorld::DialogueCreator::DialogueCreator (CSMWorld::Data& data, QUndoStack& un
 : GenericCreator (data, undoStack, id, true), mType (type)
 {}
 
-CSVWorld::Creator *CSVWorld::TopicCreatorFactory::makeCreator (CSMWorld::Data& data,
-    QUndoStack& undoStack, const CSMWorld::UniversalId& id) const
+CSVWorld::Creator *CSVWorld::TopicCreatorFactory::makeCreator (CSMDoc::Document& document, 
+                                                               const CSMWorld::UniversalId& id) const
 {
-    return new DialogueCreator (data, undoStack, id, ESM::Dialogue::Topic);
+    return new DialogueCreator (document.getData(), document.getUndoStack(), id, ESM::Dialogue::Topic);
 }
 
-CSVWorld::Creator *CSVWorld::JournalCreatorFactory::makeCreator (CSMWorld::Data& data,
-    QUndoStack& undoStack, const CSMWorld::UniversalId& id) const
+CSVWorld::Creator *CSVWorld::JournalCreatorFactory::makeCreator (CSMDoc::Document& document, 
+                                                                 const CSMWorld::UniversalId& id) const
 {
-    return new DialogueCreator (data, undoStack, id, ESM::Dialogue::Journal);
+    return new DialogueCreator (document.getData(), document.getUndoStack(), id, ESM::Dialogue::Journal);
 }

--- a/apps/opencs/view/world/dialoguecreator.hpp
+++ b/apps/opencs/view/world/dialoguecreator.hpp
@@ -23,8 +23,7 @@ namespace CSVWorld
     {
         public:
 
-            virtual Creator *makeCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id) const;
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const;
             ///< The ownership of the returned Creator is transferred to the caller.
     };
 
@@ -32,8 +31,7 @@ namespace CSVWorld
     {
         public:
 
-            virtual Creator *makeCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id) const;
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const;
             ///< The ownership of the returned Creator is transferred to the caller.
     };
 }

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -685,8 +685,7 @@ CSVWorld::DialogueSubView::DialogueSubView (const CSMWorld::UniversalId& id, CSM
     mMainLayout->addWidget(mEditWidget);
     mEditWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
-    mMainLayout->addWidget (mBottom =
-        new TableBottomBox (creatorFactory, document.getData(), document.getUndoStack(), id, this));
+    mMainLayout->addWidget (mBottom = new TableBottomBox (creatorFactory, document, id, this));
 
     mBottom->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
 

--- a/apps/opencs/view/world/genericcreator.cpp
+++ b/apps/opencs/view/world/genericcreator.cpp
@@ -133,6 +133,15 @@ CSVWorld::GenericCreator::GenericCreator (CSMWorld::Data& data, QUndoStack& undo
   mClonedType (CSMWorld::UniversalId::Type_None), mScopes (CSMWorld::Scope_Content), mScope (0),
   mScopeLabel (0), mCloneMode (false)
 {
+    // If the collection ID has a parent type, use it instead.
+    // It will change IDs with Record/SubRecord class (used for creators in Dialogue subviews)
+    // to IDs with general RecordList class (used for creators in Table subviews).
+    CSMWorld::UniversalId::Type listParentType = CSMWorld::UniversalId::getParentType(mListId.getType());
+    if (listParentType != CSMWorld::UniversalId::Type_None)
+    {
+        mListId = listParentType;
+    }
+
     mLayout = new QHBoxLayout;
     mLayout->setContentsMargins (0, 0, 0, 0);
 

--- a/apps/opencs/view/world/genericcreator.hpp
+++ b/apps/opencs/view/world/genericcreator.hpp
@@ -13,10 +13,12 @@ class QLineEdit;
 class QHBoxLayout;
 class QComboBox;
 class QLabel;
+class QUndoStack;
 
 namespace CSMWorld
 {
     class CreateCommand;
+    class Data;
 }
 
 namespace CSVWorld

--- a/apps/opencs/view/world/infocreator.cpp
+++ b/apps/opencs/view/world/infocreator.cpp
@@ -50,8 +50,7 @@ CSVWorld::InfoCreator::InfoCreator (CSMWorld::Data& data, QUndoStack& undoStack,
 
     mTopic = new QLineEdit (this);
     CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Topic;
-    if (id.getType() == CSMWorld::UniversalId::Type_JournalInfo || // For Dialogue SubView
-        id.getType() == CSMWorld::UniversalId::Type_JournalInfos)  // For Table SubView
+    if (getCollectionId().getType() == CSMWorld::UniversalId::Type_JournalInfos)
     {
         displayType = CSMWorld::ColumnBase::Display_Journal;
     }

--- a/apps/opencs/view/world/infocreator.cpp
+++ b/apps/opencs/view/world/infocreator.cpp
@@ -9,10 +9,13 @@
 
 #include <components/misc/stringops.hpp>
 
+#include "../../model/doc/document.hpp"
+
 #include "../../model/world/data.hpp"
 #include "../../model/world/commands.hpp"
 #include "../../model/world/columns.hpp"
 #include "../../model/world/idtable.hpp"
+#include "../../model/world/idcompletionmanager.hpp"
 
 std::string CSVWorld::InfoCreator::getId() const
 {
@@ -39,13 +42,20 @@ void CSVWorld::InfoCreator::configureCreateCommand (CSMWorld::CreateCommand& com
 }
 
 CSVWorld::InfoCreator::InfoCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-    const CSMWorld::UniversalId& id)
+    const CSMWorld::UniversalId& id, CSMWorld::IdCompletionManager& completionManager)
 : GenericCreator (data, undoStack, id)
 {
     QLabel *label = new QLabel ("Topic", this);
     insertBeforeButtons (label, false);
 
     mTopic = new QLineEdit (this);
+    CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Topic;
+    if (id.getType() == CSMWorld::UniversalId::Type_JournalInfo || // For Dialogue SubView
+        id.getType() == CSMWorld::UniversalId::Type_JournalInfos)  // For Table SubView
+    {
+        displayType = CSMWorld::ColumnBase::Display_Journal;
+    }
+    mTopic->setCompleter(completionManager.getCompleter(displayType).get());
     insertBeforeButtons (mTopic, true);
 
     setManualEditing (false);
@@ -99,4 +109,13 @@ void CSVWorld::InfoCreator::focus()
 void CSVWorld::InfoCreator::topicChanged()
 {
     update();
+}
+
+CSVWorld::Creator *CSVWorld::InfoCreatorFactory::makeCreator(CSMDoc::Document& document, 
+                                                             const CSMWorld::UniversalId& id) const
+{
+    return new InfoCreator(document.getData(),
+                           document.getUndoStack(),
+                           id,
+                           document.getIdCompletionManager());
 }

--- a/apps/opencs/view/world/infocreator.hpp
+++ b/apps/opencs/view/world/infocreator.hpp
@@ -8,6 +8,7 @@ class QLineEdit;
 namespace CSMWorld
 {
     class InfoCollection;
+    class IdCompletionManager;
 }
 
 namespace CSVWorld
@@ -25,7 +26,7 @@ namespace CSVWorld
         public:
 
             InfoCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id);
+                const CSMWorld::UniversalId& id, CSMWorld::IdCompletionManager& completionManager);
 
             virtual void cloneMode (const std::string& originId,
                 const CSMWorld::UniversalId::Type type);
@@ -42,6 +43,14 @@ namespace CSVWorld
         private slots:
 
             void topicChanged();
+    };
+
+    class InfoCreatorFactory : public CreatorFactoryBase
+    {
+        public:
+
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const;
+            ///< The ownership of the returned Creator is transferred to the caller.
     };
 }
 

--- a/apps/opencs/view/world/referencecreator.cpp
+++ b/apps/opencs/view/world/referencecreator.cpp
@@ -4,10 +4,13 @@
 #include <QLabel>
 #include <QLineEdit>
 
+#include "../../model/doc/document.hpp"
+
 #include "../../model/world/data.hpp"
 #include "../../model/world/commands.hpp"
 #include "../../model/world/columns.hpp"
 #include "../../model/world/idtable.hpp"
+#include "../../model/world/idcompletionmanager.hpp"
 
 std::string CSVWorld::ReferenceCreator::getId() const
 {
@@ -71,13 +74,14 @@ int CSVWorld::ReferenceCreator::getRefNumCount() const
 }
 
 CSVWorld::ReferenceCreator::ReferenceCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-    const CSMWorld::UniversalId& id)
+    const CSMWorld::UniversalId& id, CSMWorld::IdCompletionManager &completionManager)
 : GenericCreator (data, undoStack, id)
 {
     QLabel *label = new QLabel ("Cell", this);
     insertBeforeButtons (label, false);
 
     mCell = new QLineEdit (this);
+    mCell->setCompleter(completionManager.getCompleter(CSMWorld::ColumnBase::Display_Cell).get());
     insertBeforeButtons (mCell, true);
 
     setManualEditing (false);
@@ -141,4 +145,13 @@ void CSVWorld::ReferenceCreator::cloneMode(const std::string& originId,
 
     CSVWorld::GenericCreator::cloneMode(originId, type);
     cellChanged(); //otherwise ok button will remain disabled
+}
+
+CSVWorld::Creator *CSVWorld::ReferenceCreatorFactory::makeCreator (CSMDoc::Document& document, 
+                                                                   const CSMWorld::UniversalId& id) const
+{
+    return new ReferenceCreator(document.getData(), 
+                                document.getUndoStack(), 
+                                id,
+                                document.getIdCompletionManager());
 }

--- a/apps/opencs/view/world/referencecreator.hpp
+++ b/apps/opencs/view/world/referencecreator.hpp
@@ -5,8 +5,14 @@
 
 class QLineEdit;
 
+namespace CSMWorld
+{
+    class IdCompletionManager;
+}
+
 namespace CSVWorld
 {
+
     class ReferenceCreator : public GenericCreator
     {
             Q_OBJECT
@@ -28,7 +34,7 @@ namespace CSVWorld
         public:
 
             ReferenceCreator (CSMWorld::Data& data, QUndoStack& undoStack,
-                const CSMWorld::UniversalId& id);
+                const CSMWorld::UniversalId& id, CSMWorld::IdCompletionManager &completionManager);
 
             virtual void cloneMode(const std::string& originId,
                                    const CSMWorld::UniversalId::Type type);
@@ -45,6 +51,14 @@ namespace CSVWorld
         private slots:
 
             void cellChanged();
+    };
+
+    class ReferenceCreatorFactory : public CreatorFactoryBase
+    {
+        public:
+
+            virtual Creator *makeCreator (CSMDoc::Document& document, const CSMWorld::UniversalId& id) const;
+            ///< The ownership of the returned Creator is transferred to the caller.
     };
 }
 

--- a/apps/opencs/view/world/scenesubview.cpp
+++ b/apps/opencs/view/world/scenesubview.cpp
@@ -33,9 +33,7 @@ CSVWorld::SceneSubView::SceneSubView (const CSMWorld::UniversalId& id, CSMDoc::D
 
     layout->setContentsMargins (QMargins (0, 0, 0, 0));
 
-    layout->addWidget (mBottom =
-        new TableBottomBox (NullCreatorFactory(), document.getData(), document.getUndoStack(), id,
-        this), 0);
+    layout->addWidget (mBottom = new TableBottomBox (NullCreatorFactory(), document, id, this), 0);
 
     mLayout->setContentsMargins (QMargins (0, 0, 0, 0));
 

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -59,7 +59,7 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<ReferenceableCreator> >);
 
     manager.add (CSMWorld::UniversalId::Type_References,
-        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<ReferenceCreator> >);
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, ReferenceCreatorFactory>);
 
     manager.add (CSMWorld::UniversalId::Type_Topics,
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, TopicCreatorFactory>);
@@ -147,7 +147,7 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<ReferenceableCreator> > (false));
 
     manager.add (CSMWorld::UniversalId::Type_Reference,
-        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<ReferenceCreator> > (false));
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, ReferenceCreatorFactory> (false));
 
     manager.add (CSMWorld::UniversalId::Type_Cell,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<CellCreator> > (false));

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -68,10 +68,10 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, JournalCreatorFactory>);
 
     manager.add (CSMWorld::UniversalId::Type_TopicInfos,
-        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<InfoCreator> >);
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, InfoCreatorFactory>);
 
     manager.add (CSMWorld::UniversalId::Type_JournalInfos,
-        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<InfoCreator> >);
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, InfoCreatorFactory>);
 
     // Subviews for resources tables
     manager.add (CSMWorld::UniversalId::Type_Meshes,
@@ -153,10 +153,10 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<CellCreator> > (false));
 
     manager.add (CSMWorld::UniversalId::Type_JournalInfo,
-        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<InfoCreator> > (false));
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, InfoCreatorFactory> (false));
 
     manager.add (CSMWorld::UniversalId::Type_TopicInfo,
-        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<InfoCreator> >(false));
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, InfoCreatorFactory>(false));
 
     manager.add (CSMWorld::UniversalId::Type_Topic,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, TopicCreatorFactory> (false));

--- a/apps/opencs/view/world/tablebottombox.cpp
+++ b/apps/opencs/view/world/tablebottombox.cpp
@@ -39,8 +39,10 @@ void CSVWorld::TableBottomBox::updateStatus()
     }
 }
 
-CSVWorld::TableBottomBox::TableBottomBox (const CreatorFactoryBase& creatorFactory,
-    CSMWorld::Data& data, QUndoStack& undoStack, const CSMWorld::UniversalId& id, QWidget *parent)
+CSVWorld::TableBottomBox::TableBottomBox (const CreatorFactoryBase& creatorFactory, 
+                                          CSMDoc::Document& document, 
+                                          const CSMWorld::UniversalId& id, 
+                                          QWidget *parent)
 : QWidget (parent), mShowStatusBar (false), mCreating (false)
 {
     for (int i=0; i<4; ++i)
@@ -61,7 +63,7 @@ CSVWorld::TableBottomBox::TableBottomBox (const CreatorFactoryBase& creatorFacto
 
     setLayout (mLayout);
 
-    mCreator = creatorFactory.makeCreator (data, undoStack, id);
+    mCreator = creatorFactory.makeCreator (document, id);
 
     if (mCreator)
     {

--- a/apps/opencs/view/world/tablebottombox.hpp
+++ b/apps/opencs/view/world/tablebottombox.hpp
@@ -9,10 +9,9 @@ class QStackedLayout;
 class QStatusBar;
 class QUndoStack;
 
-namespace CSMWorld
+namespace CSMDoc
 {
-    class Data;
-    class UniversalId;
+    class Document;
 }
 
 namespace CSVWorld
@@ -42,8 +41,10 @@ namespace CSVWorld
 
         public:
 
-            TableBottomBox (const CreatorFactoryBase& creatorFactory, CSMWorld::Data& data,
-                QUndoStack& undoStack, const CSMWorld::UniversalId& id, QWidget *parent = 0);
+            TableBottomBox (const CreatorFactoryBase& creatorFactory, 
+                            CSMDoc::Document& document, 
+                            const CSMWorld::UniversalId& id, 
+                            QWidget *parent = 0);
 
             virtual ~TableBottomBox();
 

--- a/apps/opencs/view/world/tablesubview.cpp
+++ b/apps/opencs/view/world/tablesubview.cpp
@@ -26,7 +26,7 @@ CSVWorld::TableSubView::TableSubView (const CSMWorld::UniversalId& id, CSMDoc::D
     layout->setContentsMargins (QMargins (0, 0, 0, 0));
 
     layout->addWidget (mBottom =
-        new TableBottomBox (creatorFactory, document.getData(), document.getUndoStack(), id, this), 0);
+        new TableBottomBox (creatorFactory, document, id, this), 0);
 
     layout->insertWidget (0, mTable =
         new Table (id, mBottom->canCreateAndDelete(), sorting, document), 2);


### PR DESCRIPTION
I've added an ID completion to creators for the following tables:
* Instances (Cell ID)
* Topic Infos (Topic ID)
* Journal Infos (Journal ID)

**Example:**
![creation_bar_completion](https://cloud.githubusercontent.com/assets/12299250/8252187/f8b749f0-168b-11e5-90d3-a7c31142ba26.png)

Also this PR contains a fix for the creation bar of Dialogue subview in Info tables. The short description of the relevant bug: when you enter the correct Topic/Journal ID in the creation bar, Create button doesn't become available.

**P.S.:** I hope I have correctly understood the task.