### PR TITLE
Werewolf skills fix

### DIFF
--- a/apps/essimporter/convertacdt.cpp
+++ b/apps/essimporter/convertacdt.cpp
@@ -41,9 +41,9 @@ namespace ESSImport
     {
         for (int i=0; i<ESM::Skill::Length; ++i)
         {
-            npcStats.mSkills[i].mRegular.mMod = actorData.mSkills[i][1];
-            npcStats.mSkills[i].mRegular.mCurrent = actorData.mSkills[i][1];
-            npcStats.mSkills[i].mRegular.mBase = actorData.mSkills[i][0];
+            npcStats.mSkills[i].mMod = actorData.mSkills[i][1];
+            npcStats.mSkills[i].mCurrent = actorData.mSkills[i][1];
+            npcStats.mSkills[i].mBase = actorData.mSkills[i][0];
         }
 
         npcStats.mTimeToStartDrowning = actorData.mACDT.mBreathMeter;

--- a/apps/essimporter/convertplayer.cpp
+++ b/apps/essimporter/convertplayer.cpp
@@ -18,7 +18,7 @@ namespace ESSImport
         for (int i=0; i<8; ++i)
             out.mObject.mNpcStats.mSkillIncrease[i] = pcdt.mPNAM.mSkillIncreases[i];
         for (int i=0; i<27; ++i)
-            out.mObject.mNpcStats.mSkills[i].mRegular.mProgress = pcdt.mPNAM.mSkillProgress[i];
+            out.mObject.mNpcStats.mSkills[i].mProgress = pcdt.mPNAM.mSkillProgress[i];
         out.mObject.mNpcStats.mLevelProgress = pcdt.mPNAM.mLevelProgress;
 
         if (pcdt.mPNAM.mDrawState & PCDT::DrawState_Weapon)

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -20,7 +20,7 @@ namespace MWMechanics
           mKnockdown(false), mKnockdownOneFrame(false), mKnockdownOverOneFrame(false),
           mHitRecovery(false), mBlock(false), mMovementFlags(0), mAttackStrength(0.f),
           mFallHeight(0), mRecalcMagicka(false), mLastRestock(0,0), mGoldPool(0), mActorId(-1),
-          mDeathAnimation(0), mIsWerewolf(false), mLevel (0)
+          mDeathAnimation(0), mLevel (0)
     {
         for (int i=0; i<4; ++i)
             mAiSettings[i] = 0;
@@ -55,7 +55,7 @@ namespace MWMechanics
         if (index < 0 || index > 7) {
             throw std::runtime_error("attribute index is out of range");
         }
-        return (!mIsWerewolf ? mAttributes[index] : mWerewolfAttributes[index]);
+        return mAttributes[index];
     }
 
     const DynamicStat<float> &CreatureStats::getHealth() const
@@ -139,14 +139,11 @@ namespace MWMechanics
             throw std::runtime_error("attribute index is out of range");
         }
 
-        const AttributeValue& currentValue = !mIsWerewolf ? mAttributes[index] : mWerewolfAttributes[index];
+        const AttributeValue& currentValue = mAttributes[index];
 
         if (value != currentValue)
         {
-            if(!mIsWerewolf)
-                mAttributes[index] = value;
-            else
-                mWerewolfAttributes[index] = value;
+            mAttributes[index] = value;
 
             if (index == ESM::Attribute::Intelligence)
                 mRecalcMagicka = true;

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -77,10 +77,6 @@ namespace MWMechanics
         std::vector<int> mSummonGraveyard;
 
     protected:
-        // These two are only set by NpcStats, but they are declared in CreatureStats to prevent using virtual methods.
-        bool mIsWerewolf;
-        AttributeValue mWerewolfAttributes[8];
-
         int mLevel;
 
     public:

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -447,16 +447,8 @@ void MWMechanics::NpcStats::writeState (ESM::NpcStats& state) const
     state.mDisposition = mDisposition;
 
     for (int i=0; i<ESM::Skill::Length; ++i)
-    {
-        mSkill[i].writeState (state.mSkills[i].mRegular);
-        //mWerewolfSkill[i].writeState (state.mSkills[i].mWerewolf);
-    }
-    /*
-    for (int i=0; i<ESM::Attribute::Length; ++i)
-    {
-        mWerewolfAttributes[i].writeState (state.mWerewolfAttributes[i]);
-    }
-    */
+        mSkill[i].writeState (state.mSkills[i]);
+
     state.mIsWerewolf = mIsWerewolf;
 
     state.mCrimeId = mCrimeId;
@@ -504,16 +496,7 @@ void MWMechanics::NpcStats::readState (const ESM::NpcStats& state)
     mDisposition = state.mDisposition;
 
     for (int i=0; i<ESM::Skill::Length; ++i)
-    {
-        mSkill[i].readState (state.mSkills[i].mRegular);
-        //mWerewolfSkill[i].readState (state.mSkills[i].mWerewolf);
-    }
-    /*
-    for (int i=0; i<ESM::Attribute::Length; ++i)
-    {
-        mWerewolfAttributes[i].readState (state.mWerewolfAttributes[i]);
-    }
-    */
+        mSkill[i].readState (state.mSkills[i]);
 
     mIsWerewolf = state.mIsWerewolf;
 

--- a/apps/openmw/mwmechanics/npcstats.hpp
+++ b/apps/openmw/mwmechanics/npcstats.hpp
@@ -22,7 +22,7 @@ namespace MWMechanics
     {
             int mDisposition;
             SkillValue mSkill[ESM::Skill::Length]; // SkillValue.mProgress used by the player only
-            SkillValue mWerewolfSkill[ESM::Skill::Length];
+
             int mReputation;
             int mCrimeId;
 
@@ -41,6 +41,8 @@ namespace MWMechanics
             /// Countdown to getting damage while underwater
             float mTimeToStartDrowning;
 
+            bool mIsWerewolf;
+
         public:
 
             NpcStats();
@@ -56,6 +58,7 @@ namespace MWMechanics
 
             const SkillValue& getSkill (int index) const;
             SkillValue& getSkill (int index);
+            void setSkill(int index, const SkillValue& value);
 
             const std::map<std::string, int>& getFactionRanks() const;
             /// Increase the rank in this faction by 1, if such a rank exists.

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -301,6 +301,12 @@ namespace MWWorld
             for (int i=0; i<ESM::Skill::Length; ++i)
                 mSaveSkills[i].readState(player.mSaveSkills[i]);
 
+            if (player.mObject.mNpcStats.mWerewolfDeprecatedData && player.mObject.mNpcStats.mIsWerewolf)
+            {
+                saveSkillsAttributes();
+                setWerewolfSkillsAttributes();
+            }
+
             getPlayer().getClass().getCreatureStats(getPlayer()).getAiSequence().clear();
 
             MWBase::World& world = *MWBase::Environment::get().getWorld();

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -271,6 +271,11 @@ namespace MWWorld
 
         player.mAutoMove = mAutoMove ? 1 : 0;
 
+        for (int i=0; i<ESM::Attribute::Length; ++i)
+            mSaveAttributes[i].writeState(player.mSaveAttributes[i]);
+        for (int i=0; i<ESM::Skill::Length; ++i)
+            mSaveSkills[i].writeState(player.mSaveSkills[i]);
+
         writer.startRecord (ESM::REC_PLAY);
         player.save (writer);
         writer.endRecord (ESM::REC_PLAY);
@@ -290,6 +295,11 @@ namespace MWWorld
             }
 
             mPlayer.load (player.mObject);
+
+            for (int i=0; i<ESM::Attribute::Length; ++i)
+                mSaveAttributes[i].readState(player.mSaveAttributes[i]);
+            for (int i=0; i<ESM::Skill::Length; ++i)
+                mSaveSkills[i].readState(player.mSaveSkills[i]);
 
             getPlayer().getClass().getCreatureStats(getPlayer()).getAiSequence().clear();
 

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -49,6 +49,55 @@ namespace MWWorld
         mPlayer.mData.setPosition(playerPos);
     }
 
+    void Player::saveSkillsAttributes()
+    {
+        MWMechanics::NpcStats& stats = getPlayer().getClass().getNpcStats(getPlayer());
+        for (int i=0; i<ESM::Skill::Length; ++i)
+            mSaveSkills[i] = stats.getSkill(i);
+        for (int i=0; i<ESM::Attribute::Length; ++i)
+            mSaveAttributes[i] = stats.getAttribute(i);
+    }
+
+    void Player::restoreSkillsAttributes()
+    {
+        MWMechanics::NpcStats& stats = getPlayer().getClass().getNpcStats(getPlayer());
+        for (int i=0; i<ESM::Skill::Length; ++i)
+            stats.setSkill(i, mSaveSkills[i]);
+        for (int i=0; i<ESM::Attribute::Length; ++i)
+            stats.setAttribute(i, mSaveAttributes[i]);
+    }
+
+    void Player::setWerewolfSkillsAttributes()
+    {
+        const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        MWMechanics::NpcStats& stats = getPlayer().getClass().getNpcStats(getPlayer());
+        for(size_t i = 0;i < ESM::Attribute::Length;++i)
+        {
+            // Oh, Bethesda. It's "Intelligence".
+            std::string name = "fWerewolf"+((i==ESM::Attribute::Intelligence) ? std::string("Intellegence") :
+                                            ESM::Attribute::sAttributeNames[i]);
+
+            MWMechanics::AttributeValue value = stats.getAttribute(i);
+            value.setBase(int(gmst.find(name)->getFloat()));
+            stats.setAttribute(i, value);
+        }
+
+        for(size_t i = 0;i < ESM::Skill::Length;i++)
+        {
+            // Acrobatics is set separately for some reason.
+            if(i == ESM::Skill::Acrobatics)
+                continue;
+
+            // "Mercantile"! >_<
+            std::string name = "fWerewolf"+((i==ESM::Skill::Mercantile) ? std::string("Merchantile") :
+                                            ESM::Skill::sSkillNames[i]);
+
+            MWMechanics::SkillValue value = stats.getSkill(i);
+            value.setBase(int(gmst.find(name)->getFloat()));
+            stats.setSkill(i, value);
+        }
+    }
+
     void Player::set(const ESM::NPC *player)
     {
         mPlayer.mBase = player;

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -6,6 +6,11 @@
 
 #include "../mwmechanics/drawstate.hpp"
 
+#include "../mwmechanics/stat.hpp"
+
+#include <components/esm/loadskil.hpp>
+#include <components/esm/attr.hpp>
+
 #include <OgreVector3.h>
 
 namespace ESM
@@ -50,9 +55,17 @@ namespace MWWorld
         int                     mCurrentCrimeId;    // the id assigned witnesses
         int                     mPaidCrimeId;      // the last id paid off (0 bounty)
 
+        // Saved skills and attributes prior to becoming a werewolf
+        MWMechanics::SkillValue mSaveSkills[ESM::Skill::Length];
+        MWMechanics::AttributeValue mSaveAttributes[ESM::Attribute::Length];
+
     public:
 
         Player(const ESM::NPC *player, const MWBase::World& world);
+
+        void saveSkillsAttributes();
+        void restoreSkillsAttributes();
+        void setWerewolfSkillsAttributes();
 
         // For mark/recall magic effects
         void markPosition (CellStore* markedCell, ESM::Position markedPosition);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2485,6 +2485,17 @@ namespace MWWorld
         if (npcStats.isWerewolf() == werewolf)
             return;
 
+        if (actor == getPlayerPtr())
+        {
+            if (werewolf)
+            {
+                mPlayer->saveSkillsAttributes();
+                mPlayer->setWerewolfSkillsAttributes();
+            }
+            else
+                mPlayer->restoreSkillsAttributes();
+        }
+
         npcStats.setWerewolf(werewolf);
 
         // This is a bit dangerous. Equipped items other than WerewolfRobe may reference

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -174,6 +174,17 @@ bool ESMReader::isNextSub(const char* name)
     return !mCtx.subCached;
 }
 
+bool ESMReader::peekNextSub(const char *name)
+{
+    if (!mCtx.leftRec)
+        return false;
+
+    getSubName();
+
+    mCtx.subCached = true;
+    return mCtx.subName == name;
+}
+
 // Read subrecord name. This gets called a LOT, so I've optimized it
 // slightly.
 void ESMReader::getSubName()

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -185,6 +185,8 @@ public:
    */
   bool isNextSub(const char* name);
 
+  bool peekNextSub(const char* name);
+
   // Read subrecord name. This gets called a LOT, so I've optimized it
   // slightly.
   void getSubName();

--- a/components/esm/npcstats.cpp
+++ b/components/esm/npcstats.cpp
@@ -1,4 +1,3 @@
-
 #include "npcstats.hpp"
 
 #include "esmreader.hpp"
@@ -31,18 +30,43 @@ void ESM::NpcStats::load (ESMReader &esm)
     esm.getHNOT (mDisposition, "DISP");
 
     for (int i=0; i<27; ++i)
+        mSkills[i].load (esm);
+
+    if (esm.peekNextSub("STBA"))
     {
-        mSkills[i].mRegular.load (esm);
-        mSkills[i].mWerewolf.load (esm);
+        // we have deprecated werewolf skills, stored interleaved
+        // Load into one big vector, then remove every 2nd value
+        mWerewolfDeprecatedData = true;
+        std::vector<ESM::StatState<int> > skills(mSkills, mSkills + sizeof(mSkills)/sizeof(mSkills[0]));
+
+        for (int i=0; i<27; ++i)
+        {
+            ESM::StatState<int> skill;
+            skill.load(esm);
+            skills.push_back(skill);
+        }
+
+        int i=0;
+        for (std::vector<ESM::StatState<int> >::iterator it = skills.begin(); it != skills.end(); ++i)
+        {
+            if (i%2 == 1)
+                it = skills.erase(it);
+            else
+                ++it;
+        }
+        assert(skills.size() == 27);
+        std::copy(skills.begin(), skills.end(), mSkills);
     }
 
+    // No longer used
     bool hasWerewolfAttributes = false;
     esm.getHNOT (hasWerewolfAttributes, "HWAT");
-
     if (hasWerewolfAttributes)
     {
+        ESM::StatState<int> dummy;
         for (int i=0; i<8; ++i)
-            mWerewolfAttributes[i].load (esm);
+            dummy.load(esm);
+        mWerewolfDeprecatedData = true;
     }
 
     mIsWerewolf = false;
@@ -112,10 +136,7 @@ void ESM::NpcStats::save (ESMWriter &esm) const
         esm.writeHNT ("DISP", mDisposition);
 
     for (int i=0; i<27; ++i)
-    {
-        mSkills[i].mRegular.save (esm);
-        mSkills[i].mWerewolf.save (esm);
-    }
+        mSkills[i].save (esm);
 
     if (mIsWerewolf)
         esm.writeHNT ("WOLF", mIsWerewolf);
@@ -147,6 +168,7 @@ void ESM::NpcStats::save (ESMWriter &esm) const
 
 void ESM::NpcStats::blank()
 {
+    mWerewolfDeprecatedData = false;
     mIsWerewolf = false;
     mDisposition = 0;
     mBounty = 0;

--- a/components/esm/npcstats.cpp
+++ b/components/esm/npcstats.cpp
@@ -117,10 +117,6 @@ void ESM::NpcStats::save (ESMWriter &esm) const
         mSkills[i].mWerewolf.save (esm);
     }
 
-    esm.writeHNT ("HWAT", true);
-    for (int i=0; i<8; ++i)
-        mWerewolfAttributes[i].save (esm);
-
     if (mIsWerewolf)
         esm.writeHNT ("WOLF", mIsWerewolf);
 

--- a/components/esm/npcstats.hpp
+++ b/components/esm/npcstats.hpp
@@ -16,12 +16,6 @@ namespace ESM
 
     struct NpcStats
     {
-        struct Skill
-        {
-            StatState<int> mRegular;
-            StatState<int> mWerewolf;
-        };
-
         struct Faction
         {
             bool mExpelled;
@@ -31,12 +25,13 @@ namespace ESM
             Faction();
         };
 
-        StatState<int> mWerewolfAttributes[8];
         bool mIsWerewolf;
+
+        bool mWerewolfDeprecatedData;
 
         std::map<std::string, Faction> mFactions; // lower case IDs
         int mDisposition;
-        Skill mSkills[27];
+        StatState<int> mSkills[27];
         int mBounty;
         int mReputation;
         int mWerewolfKills;

--- a/components/esm/player.cpp
+++ b/components/esm/player.cpp
@@ -31,6 +31,14 @@ void ESM::Player::load (ESMReader &esm)
     esm.getHNOT (mCurrentCrimeId, "CURD");
     mPaidCrimeId = -1;
     esm.getHNOT (mPaidCrimeId, "PAYD");
+
+    if (esm.hasMoreSubs())
+    {
+        for (int i=0; i<ESM::Attribute::Length; ++i)
+            mSaveAttributes[i].load(esm);
+        for (int i=0; i<ESM::Skill::Length; ++i)
+            mSaveSkills[i].load(esm);
+    }
 }
 
 void ESM::Player::save (ESMWriter &esm) const
@@ -54,4 +62,9 @@ void ESM::Player::save (ESMWriter &esm) const
 
     esm.writeHNT ("CURD", mCurrentCrimeId);
     esm.writeHNT ("PAYD", mPaidCrimeId);
+
+    for (int i=0; i<ESM::Attribute::Length; ++i)
+        mSaveAttributes[i].save(esm);
+    for (int i=0; i<ESM::Skill::Length; ++i)
+        mSaveSkills[i].save(esm);
 }

--- a/components/esm/player.hpp
+++ b/components/esm/player.hpp
@@ -7,6 +7,9 @@
 #include "cellid.hpp"
 #include "defs.hpp"
 
+#include "loadskil.hpp"
+#include "attr.hpp"
+
 namespace ESM
 {
     class ESMReader;
@@ -27,6 +30,9 @@ namespace ESM
         
         int mCurrentCrimeId;
         int mPaidCrimeId;
+
+        StatState<int> mSaveAttributes[ESM::Attribute::Length];
+        StatState<int> mSaveSkills[ESM::Skill::Length];
 
         void load (ESMReader &esm);
         void save (ESMWriter &esm) const;


### PR DESCRIPTION
From https://github.com/scrawl/openmw/pull/11

The fWerewolf* skills/attributes should only be used for the player. NPC werewolves keep their original skills/attributes. 