### PR TITLE
OpenCS: improvements for drag'n'drop

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -75,7 +75,7 @@ opencs_units_noqt (view/world
 
 opencs_units (view/widget
     scenetoolbar scenetool scenetoolmode pushbutton scenetooltoggle scenetoolrun modebutton
-    scenetooltoggle2 completerpopup coloreditor colorpickerpopup
+    scenetooltoggle2 completerpopup coloreditor colorpickerpopup droplineedit
     )
 
 opencs_units (view/render

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -70,7 +70,7 @@ opencs_units (view/world
 opencs_units_noqt (view/world
     subviews enumdelegate vartypedelegate recordstatusdelegate idtypedelegate datadisplaydelegate
     scripthighlighter idvalidator dialoguecreator physicssystem idcompletiondelegate
-    colordelegate
+    colordelegate dragdroputils
     )
 
 opencs_units (view/widget

--- a/apps/opencs/model/world/nestedtableproxymodel.cpp
+++ b/apps/opencs/model/world/nestedtableproxymodel.cpp
@@ -192,4 +192,8 @@ void CSMWorld::NestedTableProxyModel::forwardDataChanged (const QModelIndex& top
         emit dataChanged(index(0,0),
                 index(mMainModel->rowCount(parent)-1, mMainModel->columnCount(parent)-1));
     }
+    else if (topLeft.parent() == parent && bottomRight.parent() == parent)
+    {
+        emit dataChanged(index(topLeft.row(), topLeft.column()), index(bottomRight.row(), bottomRight.column()));
+    }
 }

--- a/apps/opencs/model/world/tablemimedata.cpp
+++ b/apps/opencs/model/world/tablemimedata.cpp
@@ -264,6 +264,8 @@ namespace
         { CSMWorld::UniversalId::Type_Texture, CSMWorld::ColumnBase::Display_Texture },
         { CSMWorld::UniversalId::Type_Video, CSMWorld::ColumnBase::Display_Video },
         { CSMWorld::UniversalId::Type_Global, CSMWorld::ColumnBase::Display_GlobalVariable },
+        { CSMWorld::UniversalId::Type_BodyPart, CSMWorld::ColumnBase::Display_BodyPart },
+        { CSMWorld::UniversalId::Type_Enchantment, CSMWorld::ColumnBase::Display_Enchantment },
 
         { CSMWorld::UniversalId::Type_None, CSMWorld::ColumnBase::Display_None } // end marker
     };

--- a/apps/opencs/view/widget/droplineedit.cpp
+++ b/apps/opencs/view/widget/droplineedit.cpp
@@ -13,9 +13,16 @@ namespace
     }
 }
 
-CSVWidget::DropLineEdit::DropLineEdit(QWidget *parent, CSMWorld::UniversalId::Type type) 
+CSVWidget::DropLineEdit::DropLineEdit(CSMWorld::UniversalId::Type type, QWidget *parent) 
     : QLineEdit(parent),
       mDropType(type)
+{
+    setAcceptDrops(true);
+}
+
+CSVWidget::DropLineEdit::DropLineEdit(CSMWorld::ColumnBase::Display display, QWidget *parent)
+    : QLineEdit(parent),
+      mDropType(CSMWorld::TableMimeData::convertEnums(display))
 {
     setAcceptDrops(true);
 }

--- a/apps/opencs/view/widget/droplineedit.cpp
+++ b/apps/opencs/view/widget/droplineedit.cpp
@@ -3,33 +3,20 @@
 #include <QDropEvent>
 
 #include "../../model/world/tablemimedata.hpp"
+#include "../../model/world/universalid.hpp"
 
-namespace
-{
-    const CSMWorld::TableMimeData *getEventMimeData(QDropEvent *event)
-    {
-        Q_ASSERT(event != NULL);
-        return dynamic_cast<const CSMWorld::TableMimeData *>(event->mimeData());
-    }
-}
+#include "../world/dragdroputils.hpp"
 
-CSVWidget::DropLineEdit::DropLineEdit(CSMWorld::UniversalId::Type type, QWidget *parent) 
+CSVWidget::DropLineEdit::DropLineEdit(CSMWorld::ColumnBase::Display type, QWidget *parent)
     : QLineEdit(parent),
       mDropType(type)
 {
     setAcceptDrops(true);
 }
 
-CSVWidget::DropLineEdit::DropLineEdit(CSMWorld::ColumnBase::Display display, QWidget *parent)
-    : QLineEdit(parent),
-      mDropType(CSMWorld::TableMimeData::convertEnums(display))
-{
-    setAcceptDrops(true);
-}
-
 void CSVWidget::DropLineEdit::dragEnterEvent(QDragEnterEvent *event)
 {
-    if (canAcceptEventData(event))
+    if (CSVWorld::DragDropUtils::canAcceptData(*event, mDropType))
     {
         event->acceptProposedAction();
     }
@@ -37,7 +24,7 @@ void CSVWidget::DropLineEdit::dragEnterEvent(QDragEnterEvent *event)
 
 void CSVWidget::DropLineEdit::dragMoveEvent(QDragMoveEvent *event)
 {
-    if (canAcceptEventData(event))
+    if (CSVWorld::DragDropUtils::canAcceptData(*event, mDropType))
     {
         event->accept();
     }
@@ -45,48 +32,10 @@ void CSVWidget::DropLineEdit::dragMoveEvent(QDragMoveEvent *event)
 
 void CSVWidget::DropLineEdit::dropEvent(QDropEvent *event)
 {
-    const CSMWorld::TableMimeData *data = getEventMimeData(event);
-    if (data == NULL) // May happen when non-records (e.g. plain text) are dragged and dropped
+    if (CSVWorld::DragDropUtils::canAcceptData(*event, mDropType))
     {
-        return;
+        CSMWorld::UniversalId id = CSVWorld::DragDropUtils::getAcceptedData(*event, mDropType);
+        setText(id.getId().c_str());
+        emit tableMimeDataDropped(id, CSVWorld::DragDropUtils::getTableMimeData(*event)->getDocumentPtr());
     }
-
-    int dataIndex = getAcceptedDataIndex(*data);
-    if (dataIndex != -1)
-    {
-        std::vector<CSMWorld::UniversalId> idData = data->getData();
-        setText(idData[dataIndex].getId().c_str());
-        emit tableMimeDataDropped(idData[dataIndex], data->getDocumentPtr());
-    }
-}
-
-bool CSVWidget::DropLineEdit::canAcceptEventData(QDropEvent *event) const
-{
-    const CSMWorld::TableMimeData *data = getEventMimeData(event);
-    if (data == NULL) // May happen when non-records (e.g. plain text) are dragged and dropped
-    {
-        return false;
-    }
-    return getAcceptedDataIndex(*data) != -1;
-}
-
-int CSVWidget::DropLineEdit::getAcceptedDataIndex(const CSMWorld::TableMimeData &data) const
-{
-    if (mDropType == CSMWorld::UniversalId::Type_None)
-    {
-        return 0;
-    }
-
-    bool isReferenceable = mDropType == CSMWorld::UniversalId::Type_Referenceable;
-    std::vector<CSMWorld::UniversalId> idData = data.getData();
-    int size = static_cast<int>(idData.size());
-    for (int i = 0; i < size; ++i)
-    {
-        CSMWorld::UniversalId::Type type = idData[i].getType();
-        if (type == mDropType || isReferenceable && CSMWorld::TableMimeData::isReferencable(type))
-        {
-            return i;
-        }
-    }
-    return -1;
 }

--- a/apps/opencs/view/widget/droplineedit.cpp
+++ b/apps/opencs/view/widget/droplineedit.cpp
@@ -1,0 +1,82 @@
+#include "droplineedit.hpp"
+
+#include <QDropEvent>
+
+#include "../../model/world/tablemimedata.hpp"
+
+namespace
+{
+    const CSMWorld::TableMimeData *getEventMimeData(QDropEvent *event)
+    {
+        Q_ASSERT(event != NULL);
+        return dynamic_cast<const CSMWorld::TableMimeData *>(event->mimeData());
+    }
+}
+
+CSVWidget::DropLineEdit::DropLineEdit(QWidget *parent, CSMWorld::UniversalId::Type type) 
+    : QLineEdit(parent),
+      mDropType(type)
+{
+    setAcceptDrops(true);
+}
+
+void CSVWidget::DropLineEdit::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (canAcceptEventData(event))
+    {
+        event->acceptProposedAction();
+    }
+}
+
+void CSVWidget::DropLineEdit::dragMoveEvent(QDragMoveEvent *event)
+{
+    if (canAcceptEventData(event))
+    {
+        event->accept();
+    }
+}
+
+void CSVWidget::DropLineEdit::dropEvent(QDropEvent *event)
+{
+    const CSMWorld::TableMimeData *data = getEventMimeData(event);
+    if (data == NULL) // May happen when non-records (e.g. plain text) are dragged and dropped
+    {
+        return;
+    }
+
+    int dataIndex = getAcceptedDataIndex(*data);
+    if (dataIndex != -1)
+    {
+        setText(data->getData()[dataIndex].getId().c_str());
+        emit tableMimeDataDropped(data->getData(), data->getDocumentPtr());
+    }
+}
+
+bool CSVWidget::DropLineEdit::canAcceptEventData(QDropEvent *event) const
+{
+    const CSMWorld::TableMimeData *data = getEventMimeData(event);
+    if (data == NULL) // May happen when non-records (e.g. plain text) are dragged and dropped
+    {
+        return false;
+    }
+    return getAcceptedDataIndex(*data) != -1;
+}
+
+int CSVWidget::DropLineEdit::getAcceptedDataIndex(const CSMWorld::TableMimeData &data) const
+{
+    if (mDropType == CSMWorld::UniversalId::Type_None)
+    {
+        return 0;
+    }
+
+    std::vector<CSMWorld::UniversalId> idData = data.getData();
+    int size = static_cast<int>(idData.size());
+    for (int i = 0; i < size; ++i)
+    {
+        if (idData[i].getType() == mDropType)
+        {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/apps/opencs/view/widget/droplineedit.cpp
+++ b/apps/opencs/view/widget/droplineedit.cpp
@@ -54,8 +54,9 @@ void CSVWidget::DropLineEdit::dropEvent(QDropEvent *event)
     int dataIndex = getAcceptedDataIndex(*data);
     if (dataIndex != -1)
     {
-        setText(data->getData()[dataIndex].getId().c_str());
-        emit tableMimeDataDropped(data->getData(), data->getDocumentPtr());
+        std::vector<CSMWorld::UniversalId> idData = data->getData();
+        setText(idData[dataIndex].getId().c_str());
+        emit tableMimeDataDropped(idData[dataIndex], data->getDocumentPtr());
     }
 }
 
@@ -76,11 +77,13 @@ int CSVWidget::DropLineEdit::getAcceptedDataIndex(const CSMWorld::TableMimeData 
         return 0;
     }
 
+    bool isReferenceable = mDropType == CSMWorld::UniversalId::Type_Referenceable;
     std::vector<CSMWorld::UniversalId> idData = data.getData();
     int size = static_cast<int>(idData.size());
     for (int i = 0; i < size; ++i)
     {
-        if (idData[i].getType() == mDropType)
+        CSMWorld::UniversalId::Type type = idData[i].getType();
+        if (type == mDropType || isReferenceable && CSMWorld::TableMimeData::isReferencable(type))
         {
             return i;
         }

--- a/apps/opencs/view/widget/droplineedit.hpp
+++ b/apps/opencs/view/widget/droplineedit.hpp
@@ -1,0 +1,50 @@
+#ifndef CSV_WIDGET_DROPLINEEDIT_HPP
+#define CSV_WIDGET_DROPLINEEDIT_HPP
+
+#include <QLineEdit>
+
+#include "../../model/world/universalid.hpp"
+
+namespace CSMDoc
+{
+    class Document;
+}
+
+namespace CSMWorld
+{
+    class TableMimeData;
+}
+
+namespace CSVWidget
+{
+    class DropLineEdit : public QLineEdit
+    {
+            Q_OBJECT
+
+            CSMWorld::UniversalId::Type mDropType;
+            ///< The accepted ID type for this LineEdit.
+            ///< If \a mDropType has Type_None type, this LineEdit accepts all ID types
+
+            bool canAcceptEventData(QDropEvent *event) const;
+            ///< Checks whether the \a event contains CSMWorld::TableMimeData with a proper ID type
+
+            int getAcceptedDataIndex(const CSMWorld::TableMimeData &data) const;
+            ///< Checks whether the \a data has a proper type
+            ///< \return -1 if there is no suitable data (ID type)
+
+        public:
+            DropLineEdit(QWidget *parent = 0,
+                         CSMWorld::UniversalId::Type type = CSMWorld::UniversalId::Type_None);
+
+        protected:
+            void dragEnterEvent(QDragEnterEvent *event);
+            void dragMoveEvent(QDragMoveEvent *event);
+            void dropEvent(QDropEvent *event);
+
+        signals:
+            void tableMimeDataDropped(const std::vector<CSMWorld::UniversalId> &data, 
+                                      const CSMDoc::Document *document);
+    };
+}
+
+#endif

--- a/apps/opencs/view/widget/droplineedit.hpp
+++ b/apps/opencs/view/widget/droplineedit.hpp
@@ -3,6 +3,7 @@
 
 #include <QLineEdit>
 
+#include "../../model/world/columnbase.hpp"
 #include "../../model/world/universalid.hpp"
 
 namespace CSMDoc
@@ -33,8 +34,8 @@ namespace CSVWidget
             ///< \return -1 if there is no suitable data (ID type)
 
         public:
-            DropLineEdit(QWidget *parent = 0,
-                         CSMWorld::UniversalId::Type type = CSMWorld::UniversalId::Type_None);
+            DropLineEdit(CSMWorld::UniversalId::Type type, QWidget *parent = 0);
+            DropLineEdit(CSMWorld::ColumnBase::Display display, QWidget *parent = 0);
 
         protected:
             void dragEnterEvent(QDragEnterEvent *event);

--- a/apps/opencs/view/widget/droplineedit.hpp
+++ b/apps/opencs/view/widget/droplineedit.hpp
@@ -43,8 +43,7 @@ namespace CSVWidget
             void dropEvent(QDropEvent *event);
 
         signals:
-            void tableMimeDataDropped(const std::vector<CSMWorld::UniversalId> &data, 
-                                      const CSMDoc::Document *document);
+            void tableMimeDataDropped(const CSMWorld::UniversalId &id, const CSMDoc::Document *document);
     };
 }
 

--- a/apps/opencs/view/widget/droplineedit.hpp
+++ b/apps/opencs/view/widget/droplineedit.hpp
@@ -4,7 +4,6 @@
 #include <QLineEdit>
 
 #include "../../model/world/columnbase.hpp"
-#include "../../model/world/universalid.hpp"
 
 namespace CSMDoc
 {
@@ -14,6 +13,7 @@ namespace CSMDoc
 namespace CSMWorld
 {
     class TableMimeData;
+    class UniversalId;
 }
 
 namespace CSVWidget
@@ -22,20 +22,11 @@ namespace CSVWidget
     {
             Q_OBJECT
 
-            CSMWorld::UniversalId::Type mDropType;
-            ///< The accepted ID type for this LineEdit.
-            ///< If \a mDropType has Type_None type, this LineEdit accepts all ID types
-
-            bool canAcceptEventData(QDropEvent *event) const;
-            ///< Checks whether the \a event contains CSMWorld::TableMimeData with a proper ID type
-
-            int getAcceptedDataIndex(const CSMWorld::TableMimeData &data) const;
-            ///< Checks whether the \a data has a proper type
-            ///< \return -1 if there is no suitable data (ID type)
+            CSMWorld::ColumnBase::Display mDropType;
+            ///< The accepted Display type for this LineEdit.
 
         public:
-            DropLineEdit(CSMWorld::UniversalId::Type type, QWidget *parent = 0);
-            DropLineEdit(CSMWorld::ColumnBase::Display display, QWidget *parent = 0);
+            DropLineEdit(CSMWorld::ColumnBase::Display type, QWidget *parent = 0);
 
         protected:
             void dragEnterEvent(QDragEnterEvent *event);

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -130,52 +130,6 @@ QWidget* CSVWorld::DialogueDelegateDispatcherProxy::getEditor() const
     return mEditor;
 }
 
-void CSVWorld::DialogueDelegateDispatcherProxy::tableMimeDataDropped(const std::vector<CSMWorld::UniversalId>& data, const CSMDoc::Document* document)
-{
-    QLineEdit* lineEdit = qobject_cast<QLineEdit*>(mEditor);
-    {
-        if (!lineEdit || !mIndexWrapper.get())
-        {
-            return;
-        }
-    }
-    for (unsigned i = 0; i < data.size();  ++i)
-    {
-        CSMWorld::UniversalId::Type type = data[i].getType();
-        if (mDisplay == CSMWorld::ColumnBase::Display_Referenceable)
-        {
-            if (type == CSMWorld::UniversalId::Type_Activator
-                || type == CSMWorld::UniversalId::Type_Potion
-                || type == CSMWorld::UniversalId::Type_Apparatus
-                || type == CSMWorld::UniversalId::Type_Armor
-                || type == CSMWorld::UniversalId::Type_Book
-                || type == CSMWorld::UniversalId::Type_Clothing
-                || type == CSMWorld::UniversalId::Type_Container
-                || type == CSMWorld::UniversalId::Type_Creature
-                || type == CSMWorld::UniversalId::Type_Door
-                || type == CSMWorld::UniversalId::Type_Ingredient
-                || type == CSMWorld::UniversalId::Type_CreatureLevelledList
-                || type == CSMWorld::UniversalId::Type_ItemLevelledList
-                || type == CSMWorld::UniversalId::Type_Light
-                || type == CSMWorld::UniversalId::Type_Lockpick
-                || type == CSMWorld::UniversalId::Type_Miscellaneous
-                || type == CSMWorld::UniversalId::Type_Npc
-                || type == CSMWorld::UniversalId::Type_Probe
-                || type == CSMWorld::UniversalId::Type_Repair
-                || type == CSMWorld::UniversalId::Type_Static
-                || type == CSMWorld::UniversalId::Type_Weapon)
-            {
-                type = CSMWorld::UniversalId::Type_Referenceable;
-            }
-        }
-        if (mDisplay == CSMWorld::TableMimeData::convertEnums(type))
-        {
-            emit tableMimeDataDropped(mEditor, mIndexWrapper->mIndex, data[i], document);
-            emit editorDataCommited(mEditor, mIndexWrapper->mIndex, mDisplay);
-            break;
-        }
-    }
-}
 /*
 ==============================DialogueDelegateDispatcher==========================================
 */
@@ -311,12 +265,8 @@ QWidget* CSVWorld::DialogueDelegateDispatcher::makeEditor(CSMWorld::ColumnBase::
         {
             connect(editor, SIGNAL(editingFinished()), proxy, SLOT(editorDataCommited()));
 
-            connect(editor, SIGNAL(tableMimeDataDropped(const std::vector<CSMWorld::UniversalId>&, const CSMDoc::Document*)),
-                    proxy, SLOT(tableMimeDataDropped(const std::vector<CSMWorld::UniversalId>&, const CSMDoc::Document*)));
-
-            connect(proxy, SIGNAL(tableMimeDataDropped(QWidget*, const QModelIndex&, const CSMWorld::UniversalId&, const CSMDoc::Document*)),
-                    this, SIGNAL(tableMimeDataDropped(QWidget*, const QModelIndex&, const CSMWorld::UniversalId&, const CSMDoc::Document*)));
-
+            connect(editor, SIGNAL(tableMimeDataDropped(const CSMWorld::UniversalId&, const CSMDoc::Document*)),
+                    proxy, SLOT(editorDataCommited()));
         }
         else if (qobject_cast<QCheckBox*>(editor))
         {
@@ -387,9 +337,6 @@ mCommandDispatcher (commandDispatcher),
 mDocument (document)
 {
     remake (row);
-
-    connect(mDispatcher, SIGNAL(tableMimeDataDropped(QWidget*, const QModelIndex&, const CSMWorld::UniversalId&, const CSMDoc::Document*)),
-            this, SIGNAL(tableMimeDataDropped(QWidget*, const QModelIndex&, const CSMWorld::UniversalId&, const CSMDoc::Document*)));
 }
 
 void CSVWorld::EditWidget::remake(int row)
@@ -680,8 +627,6 @@ CSVWorld::DialogueSubView::DialogueSubView (const CSMWorld::UniversalId& id, CSM
 
     mEditWidget = new EditWidget(mainWidget,
             mTable->getModelIndex(mCurrentId, 0).row(), mTable, mCommandDispatcher, document, false);
-    connect(mEditWidget, SIGNAL(tableMimeDataDropped(QWidget*, const QModelIndex&, const CSMWorld::UniversalId&, const CSMDoc::Document*)),
-            this, SLOT(tableMimeDataDropped(QWidget*, const QModelIndex&, const CSMWorld::UniversalId&, const CSMDoc::Document*)));
 
     mMainLayout->addWidget(mEditWidget);
     mEditWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -841,17 +786,6 @@ void CSVWorld::DialogueSubView::rowsAboutToBeRemoved(const QModelIndex &parent, 
             mEditWidget = 0;
         }
         emit closeRequest(this);
-    }
-}
-
-void CSVWorld::DialogueSubView::tableMimeDataDropped (QWidget* editor,
-                                                      const QModelIndex& index,
-                                                      const CSMWorld::UniversalId& id,
-                                                      const CSMDoc::Document* document)
-{
-    if (document == &mDocument)
-    {
-        qobject_cast<CSVWidget::DropLineEdit*>(editor)->setText(id.getId().c_str());
     }
 }
 

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -34,6 +34,7 @@
 #include "../../model/doc/document.hpp"
 
 #include "../widget/coloreditor.hpp"
+#include "../widget/droplineedit.hpp"
 
 #include "recordstatusdelegate.hpp"
 #include "util.hpp"
@@ -306,7 +307,7 @@ QWidget* CSVWorld::DialogueDelegateDispatcher::makeEditor(CSMWorld::ColumnBase::
 
         // NOTE: For each entry in CSVWorld::CommandDelegate::createEditor() a corresponding entry
         // is required here
-        if (qobject_cast<DropLineEdit*>(editor))
+        if (qobject_cast<CSVWidget::DropLineEdit*>(editor))
         {
             connect(editor, SIGNAL(editingFinished()), proxy, SLOT(editorDataCommited()));
 
@@ -850,7 +851,7 @@ void CSVWorld::DialogueSubView::tableMimeDataDropped (QWidget* editor,
 {
     if (document == &mDocument)
     {
-        qobject_cast<DropLineEdit*>(editor)->setText(id.getId().c_str());
+        qobject_cast<CSVWidget::DropLineEdit*>(editor)->setText(id.getId().c_str());
     }
 }
 

--- a/apps/opencs/view/world/dialoguesubview.hpp
+++ b/apps/opencs/view/world/dialoguesubview.hpp
@@ -86,17 +86,11 @@ namespace CSVWorld
     public slots:
         void editorDataCommited();
         void setIndex(const QModelIndex& index);
-        void tableMimeDataDropped(const std::vector<CSMWorld::UniversalId>& data,
-                                  const CSMDoc::Document* document);
 
     signals:
         void editorDataCommited(QWidget* editor,
                                 const QModelIndex& index,
                                 CSMWorld::ColumnBase::Display display);
-
-        void tableMimeDataDropped(QWidget* editor, const QModelIndex& index,
-                                  const CSMWorld::UniversalId& id,
-                                  const CSMDoc::Document* document);
 
     };
 
@@ -153,11 +147,6 @@ namespace CSVWorld
     private slots:
         void editorDataCommited(QWidget* editor, const QModelIndex& index,
                                 CSMWorld::ColumnBase::Display display);
-
-    signals:
-        void tableMimeDataDropped(QWidget* editor, const QModelIndex& index,
-                                  const CSMWorld::UniversalId& id,
-                                  const CSMDoc::Document* document);
     };
 
     class EditWidget : public QScrollArea
@@ -182,11 +171,6 @@ namespace CSVWorld
             virtual ~EditWidget();
 
             void remake(int row);
-
-        signals:
-            void tableMimeDataDropped(QWidget* editor, const QModelIndex& index,
-                                      const CSMWorld::UniversalId& id,
-                                      const CSMDoc::Document* document);
     };
 
     class DialogueSubView : public CSVDoc::SubView
@@ -229,10 +213,6 @@ namespace CSVWorld
 
             void dataChanged(const QModelIndex & index);
             ///\brief we need to care for deleting currently edited record
-
-            void tableMimeDataDropped(QWidget* editor, const QModelIndex& index,
-                                      const CSMWorld::UniversalId& id,
-                                      const CSMDoc::Document* document);
 
             void requestFocus (const std::string& id);
 

--- a/apps/opencs/view/world/dragdroputils.cpp
+++ b/apps/opencs/view/world/dragdroputils.cpp
@@ -1,0 +1,26 @@
+#include "dragdroputils.hpp"
+
+#include <QDropEvent>
+
+#include "../../model/world/tablemimedata.hpp"
+
+const CSMWorld::TableMimeData *CSVWorld::DragDropUtils::getTableMimeData(const QDropEvent &event)
+{
+    return dynamic_cast<const CSMWorld::TableMimeData *>(event.mimeData());
+}
+
+bool CSVWorld::DragDropUtils::canAcceptData(const QDropEvent &event, CSMWorld::ColumnBase::Display type)
+{
+    const CSMWorld::TableMimeData *data = getTableMimeData(event);
+    return data != NULL && data->holdsType(type);
+}
+
+CSMWorld::UniversalId CSVWorld::DragDropUtils::getAcceptedData(const QDropEvent &event, 
+                                                               CSMWorld::ColumnBase::Display type)
+{
+    if (canAcceptData(event, type))
+    {
+        return getTableMimeData(event)->returnMatching(type);
+    }
+    return CSMWorld::UniversalId::Type_None;
+}

--- a/apps/opencs/view/world/dragdroputils.hpp
+++ b/apps/opencs/view/world/dragdroputils.hpp
@@ -1,0 +1,30 @@
+#ifndef CSV_WORLD_DRAGDROPUTILS_HPP
+#define CSV_WORLD_DRAGDROPUTILS_HPP
+
+#include "../../model/world/columnbase.hpp"
+
+class QDropEvent;
+
+namespace CSMWorld
+{
+    class TableMimeData;
+    class UniversalId;
+}
+
+namespace CSVWorld
+{
+    class DragDropUtils
+    {
+        public:
+            static const CSMWorld::TableMimeData *getTableMimeData(const QDropEvent &event);
+
+            static bool canAcceptData(const QDropEvent &event, CSMWorld::ColumnBase::Display type);
+            ///< Checks whether the \a event contains a valid CSMWorld::TableMimeData that holds the \a type
+
+            static CSMWorld::UniversalId getAcceptedData(const QDropEvent &event, CSMWorld::ColumnBase::Display type);
+            ///< Gets the accepted data from the \a event using the \a type
+            ///< \return Type_None if the \a event data doesn't holds the \a type
+    };
+}
+
+#endif

--- a/apps/opencs/view/world/dragrecordtable.cpp
+++ b/apps/opencs/view/world/dragrecordtable.cpp
@@ -12,7 +12,13 @@
 
 void CSVWorld::DragRecordTable::startDragFromTable (const CSVWorld::DragRecordTable& table)
 {
-    CSMWorld::TableMimeData* mime = new CSMWorld::TableMimeData (table.getDraggedRecords(), mDocument);
+    std::vector<CSMWorld::UniversalId> records = table.getDraggedRecords();
+    if (records.empty())
+    {
+        return;
+    }
+
+    CSMWorld::TableMimeData* mime = new CSMWorld::TableMimeData (records, mDocument);
 
     if (mime)
     {
@@ -27,7 +33,9 @@ CSVWorld::DragRecordTable::DragRecordTable (CSMDoc::Document& document, QWidget*
 QTableView(parent),
 mDocument(document),
 mEditLock(false)
-{}
+{
+    setAcceptDrops(true);
+}
 
 void CSVWorld::DragRecordTable::setEditLock (bool locked)
 {

--- a/apps/opencs/view/world/dragrecordtable.cpp
+++ b/apps/opencs/view/world/dragrecordtable.cpp
@@ -52,7 +52,10 @@ void CSVWorld::DragRecordTable::dragMoveEvent(QDragMoveEvent *event)
     QModelIndex index = indexAt(event->pos());
     if (CSVWorld::DragDropUtils::canAcceptData(*event, getIndexDisplayType(index)))
     {
-        event->accept();
+        if (index.flags() & Qt::ItemIsEditable)
+        {
+            event->accept();
+        }
     }
     else
     {

--- a/apps/opencs/view/world/dragrecordtable.hpp
+++ b/apps/opencs/view/world/dragrecordtable.hpp
@@ -4,6 +4,8 @@
 #include <QTableView>
 #include <QEvent>
 
+#include "../../model/world/columnbase.hpp"
+
 class QWidget;
 class QAction;
 
@@ -38,6 +40,11 @@ namespace CSVWorld
             void dragEnterEvent(QDragEnterEvent *event);
 
             void dragMoveEvent(QDragMoveEvent *event);
+
+            void dropEvent(QDropEvent *event);
+
+        private:
+            CSMWorld::ColumnBase::Display getIndexDisplayType(const QModelIndex &index) const;
     };
 }
 

--- a/apps/opencs/view/world/idcompletiondelegate.cpp
+++ b/apps/opencs/view/world/idcompletiondelegate.cpp
@@ -28,7 +28,7 @@ QWidget *CSVWorld::IdCompletionDelegate::createEditor(QWidget *parent,
     }
 
     CSMWorld::IdCompletionManager &completionManager = getDocument().getIdCompletionManager();
-    CSVWidget::DropLineEdit *editor = new CSVWidget::DropLineEdit(parent);
+    CSVWidget::DropLineEdit *editor = new CSVWidget::DropLineEdit(display, parent);
     editor->setCompleter(completionManager.getCompleter(display).get());
     return editor;
 }

--- a/apps/opencs/view/world/idcompletiondelegate.cpp
+++ b/apps/opencs/view/world/idcompletiondelegate.cpp
@@ -2,6 +2,8 @@
 
 #include "../../model/world/idcompletionmanager.hpp"
 
+#include "../widget/droplineedit.hpp"
+
 CSVWorld::IdCompletionDelegate::IdCompletionDelegate(CSMWorld::CommandDispatcher *dispatcher,
                                                      CSMDoc::Document& document,
                                                      QObject *parent)
@@ -26,7 +28,7 @@ QWidget *CSVWorld::IdCompletionDelegate::createEditor(QWidget *parent,
     }
 
     CSMWorld::IdCompletionManager &completionManager = getDocument().getIdCompletionManager();
-    DropLineEdit *editor = new DropLineEdit(parent);
+    CSVWidget::DropLineEdit *editor = new CSVWidget::DropLineEdit(parent);
     editor->setCompleter(completionManager.getCompleter(display).get());
     return editor;
 }

--- a/apps/opencs/view/world/nestedtable.cpp
+++ b/apps/opencs/view/world/nestedtable.cpp
@@ -14,8 +14,7 @@ CSVWorld::NestedTable::NestedTable(CSMDoc::Document& document,
                                    CSMWorld::UniversalId id,
                                    CSMWorld::NestedTableProxyModel* model,
                                    QWidget* parent)
-    : QTableView(parent),
-      mUndoStack(document.getUndoStack()),
+    : DragRecordTable(document, parent),
       mModel(model)
 {
     mDispatcher = new CSMWorld::CommandDispatcher (document, id, this);
@@ -47,8 +46,6 @@ CSVWorld::NestedTable::NestedTable(CSMDoc::Document& document,
 
     setModel(model);
 
-    setAcceptDrops(true);
-
     mAddNewRowAction = new QAction (tr ("Add new row"), this);
 
     connect(mAddNewRowAction, SIGNAL(triggered()),
@@ -60,12 +57,10 @@ CSVWorld::NestedTable::NestedTable(CSMDoc::Document& document,
             this, SLOT(removeRowActionTriggered()));
 }
 
-void CSVWorld::NestedTable::dragEnterEvent(QDragEnterEvent *event)
+std::vector<CSMWorld::UniversalId> CSVWorld::NestedTable::getDraggedRecords() const
 {
-}
-
-void CSVWorld::NestedTable::dragMoveEvent(QDragMoveEvent *event)
-{
+    // No drag support for nested tables
+    return std::vector<CSMWorld::UniversalId>();
 }
 
 void CSVWorld::NestedTable::contextMenuEvent (QContextMenuEvent *event)
@@ -84,16 +79,16 @@ void CSVWorld::NestedTable::contextMenuEvent (QContextMenuEvent *event)
 
 void CSVWorld::NestedTable::removeRowActionTriggered()
 {
-    mUndoStack.push(new CSMWorld::DeleteNestedCommand(*(mModel->model()),
-                                                      mModel->getParentId(),
-                                                      selectionModel()->selectedRows().begin()->row(),
-                                                      mModel->getParentColumn()));
+    mDocument.getUndoStack().push(new CSMWorld::DeleteNestedCommand(*(mModel->model()),
+                                                                    mModel->getParentId(),
+                                                                    selectionModel()->selectedRows().begin()->row(),
+                                                                    mModel->getParentColumn()));
 }
 
 void CSVWorld::NestedTable::addNewRowActionTriggered()
 {
-    mUndoStack.push(new CSMWorld::AddNestedCommand(*(mModel->model()),
-                                                   mModel->getParentId(),
-                                                   selectionModel()->selectedRows().size(),
-                                                   mModel->getParentColumn()));
+    mDocument.getUndoStack().push(new CSMWorld::AddNestedCommand(*(mModel->model()),
+                                                                 mModel->getParentId(),
+                                                                 selectionModel()->selectedRows().size(),
+                                                                 mModel->getParentColumn()));
 }

--- a/apps/opencs/view/world/nestedtable.hpp
+++ b/apps/opencs/view/world/nestedtable.hpp
@@ -1,10 +1,10 @@
 #ifndef CSV_WORLD_NESTEDTABLE_H
 #define CSV_WORLD_NESTEDTABLE_H
 
-#include <QTableView>
 #include <QEvent>
 
-class QUndoStack;
+#include "dragrecordtable.hpp"
+
 class QAction;
 class QContextMenuEvent;
 
@@ -22,13 +22,12 @@ namespace CSMDoc
 
 namespace CSVWorld
 {
-    class NestedTable : public QTableView
+    class NestedTable : public DragRecordTable
     {
         Q_OBJECT
 
         QAction *mAddNewRowAction;
         QAction *mRemoveRowAction;
-        QUndoStack& mUndoStack;
         CSMWorld::NestedTableProxyModel* mModel;
         CSMWorld::CommandDispatcher *mDispatcher;
 
@@ -38,10 +37,7 @@ namespace CSVWorld
                     CSMWorld::NestedTableProxyModel* model,
                     QWidget* parent = NULL);
 
-    protected:
-        void dragEnterEvent(QDragEnterEvent *event);
-
-        void dragMoveEvent(QDragMoveEvent *event);
+        virtual std::vector<CSMWorld::UniversalId> getDraggedRecords() const;
 
     private:
         void contextMenuEvent (QContextMenuEvent *event);

--- a/apps/opencs/view/world/table.cpp
+++ b/apps/opencs/view/world/table.cpp
@@ -697,36 +697,6 @@ void CSVWorld::Table::mouseMoveEvent (QMouseEvent* event)
     }
 }
 
-void CSVWorld::Table::dropEvent(QDropEvent *event)
-{
-    QModelIndex index = indexAt (event->pos());
-
-    if (!index.isValid())
-    {
-        return;
-    }
-
-    const CSMWorld::TableMimeData* mime = dynamic_cast<const CSMWorld::TableMimeData*> (event->mimeData());
-    if (!mime) // May happen when non-records (e.g. plain text) are dragged and dropped
-        return;
-
-    if (mime->fromDocument (mDocument))
-    {
-        CSMWorld::ColumnBase::Display display = static_cast<CSMWorld::ColumnBase::Display>
-                                                (mModel->headerData (index.column(), Qt::Horizontal, CSMWorld::ColumnBase::Role_Display).toInt());
-
-        if (mime->holdsType (display))
-        {
-            CSMWorld::UniversalId record (mime->returnMatching (display));
-
-            std::auto_ptr<CSMWorld::ModifyCommand> command (new CSMWorld::ModifyCommand
-                    (*mProxyModel, index, QVariant (QString::fromUtf8 (record.getId().c_str()))));
-
-            mDocument.getUndoStack().push (command.release());
-        }
-    } //TODO handle drops from different document
-}
-
 std::vector<std::string> CSVWorld::Table::getColumnsWithDisplay(CSMWorld::ColumnBase::Display display) const
 {
     const int count = mModel->columnCount();

--- a/apps/opencs/view/world/table.hpp
+++ b/apps/opencs/view/world/table.hpp
@@ -76,8 +76,6 @@ namespace CSVWorld
 
             void mouseMoveEvent(QMouseEvent *event);
 
-            void dropEvent(QDropEvent *event);
-
         protected:
 
             virtual void mouseDoubleClickEvent (QMouseEvent *event);

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -243,7 +243,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_String:
         // For other Display types (that represent record IDs) with drop support IdCompletionDelegate is used
 
-            return new CSVWidget::DropLineEdit(CSMWorld::UniversalId::Type_None, parent);
+            return new CSVWidget::DropLineEdit(display, parent);
 
         default:
 

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -17,7 +17,10 @@
 #include "../../model/world/commands.hpp"
 #include "../../model/world/tablemimedata.hpp"
 #include "../../model/world/commanddispatcher.hpp"
+
 #include "../widget/coloreditor.hpp"
+#include "../widget/droplineedit.hpp"
+
 #include "dialoguespinbox.hpp"
 #include "scriptedit.hpp"
 
@@ -250,7 +253,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_Video:
         case CSMWorld::ColumnBase::Display_GlobalVariable:
 
-            return new DropLineEdit(parent);
+            return new CSVWidget::DropLineEdit(parent);
 
         case CSMWorld::ColumnBase::Display_ScriptLines:
 
@@ -323,30 +326,4 @@ void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelInde
         editor->setProperty(n, v);
     }
 
-}
-
-CSVWorld::DropLineEdit::DropLineEdit(QWidget* parent) :
-QLineEdit(parent)
-{
-    setAcceptDrops(true);
-}
-
-void CSVWorld::DropLineEdit::dragEnterEvent(QDragEnterEvent *event)
-{
-    event->acceptProposedAction();
-}
-
-void CSVWorld::DropLineEdit::dragMoveEvent(QDragMoveEvent *event)
-{
-    event->accept();
-}
-
-void CSVWorld::DropLineEdit::dropEvent(QDropEvent *event)
-{
-    const CSMWorld::TableMimeData* data(dynamic_cast<const CSMWorld::TableMimeData*>(event->mimeData()));
-    if (!data) // May happen when non-records (e.g. plain text) are dragged and dropped
-        return;
-
-    emit tableMimeDataDropped(data->getData(), data->getDocumentPtr());
-    //WIP
 }

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -236,28 +236,14 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
 
             return new QCheckBox(parent);
 
-        case CSMWorld::ColumnBase::Display_String:
-        case CSMWorld::ColumnBase::Display_Skill:
-        case CSMWorld::ColumnBase::Display_Script:
-        case CSMWorld::ColumnBase::Display_Race:
-        case CSMWorld::ColumnBase::Display_Region:
-        case CSMWorld::ColumnBase::Display_Class:
-        case CSMWorld::ColumnBase::Display_Faction:
-        case CSMWorld::ColumnBase::Display_Miscellaneous:
-        case CSMWorld::ColumnBase::Display_Sound:
-        case CSMWorld::ColumnBase::Display_Mesh:
-        case CSMWorld::ColumnBase::Display_Icon:
-        case CSMWorld::ColumnBase::Display_Music:
-        case CSMWorld::ColumnBase::Display_SoundRes:
-        case CSMWorld::ColumnBase::Display_Texture:
-        case CSMWorld::ColumnBase::Display_Video:
-        case CSMWorld::ColumnBase::Display_GlobalVariable:
-
-            return new CSVWidget::DropLineEdit(CSMWorld::UniversalId::Type_None, parent);
-
         case CSMWorld::ColumnBase::Display_ScriptLines:
 
             return new ScriptEdit (mDocument, ScriptHighlighter::Mode_Console, parent);
+
+        case CSMWorld::ColumnBase::Display_String:
+        // For other Display types (that represent record IDs) with drop support IdCompletionDelegate is used
+
+            return new CSVWidget::DropLineEdit(CSMWorld::UniversalId::Type_None, parent);
 
         default:
 

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -253,7 +253,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_Video:
         case CSMWorld::ColumnBase::Display_GlobalVariable:
 
-            return new CSVWidget::DropLineEdit(parent);
+            return new CSVWidget::DropLineEdit(CSMWorld::UniversalId::Type_None, parent);
 
         case CSMWorld::ColumnBase::Display_ScriptLines:
 

--- a/apps/opencs/view/world/util.hpp
+++ b/apps/opencs/view/world/util.hpp
@@ -5,7 +5,6 @@
 
 #include <QAbstractTableModel>
 #include <QStyledItemDelegate>
-#include <QLineEdit>
 
 #include "../../model/world/columnbase.hpp"
 #include "../../model/doc/document.hpp"
@@ -89,24 +88,6 @@ namespace CSVWorld
 
             static const CommandDelegateFactoryCollection& get();
 
-    };
-
-    class DropLineEdit : public QLineEdit
-    {
-        Q_OBJECT
-
-        public:
-            DropLineEdit(QWidget *parent);
-
-        private:
-            void dragEnterEvent(QDragEnterEvent *event);
-
-            void dragMoveEvent(QDragMoveEvent *event);
-
-            void dropEvent(QDropEvent *event);
-
-        signals:
-            void tableMimeDataDropped(const std::vector<CSMWorld::UniversalId>& data, const CSMDoc::Document* document);
     };
 
     ///< \brief Use commands instead of manipulating the model directly


### PR DESCRIPTION
What was done:
* Rework DropLineEdit to accept drops of a specific type (Display)
* Drag events are accepted only for proper cells in tables views (a plus is appeared on right columns)
* Nested tables accept drops

\+ minor fixes.

Check if there are any issues.
