### PR TITLE
Fixes for Info tables (mostly for their sorting)

### DIFF
--- a/apps/opencs/model/world/infocollection.cpp
+++ b/apps/opencs/model/world/infocollection.cpp
@@ -97,7 +97,8 @@ bool CSMWorld::InfoCollection::reorderRows (int baseIndex, const std::vector<int
         return false;
 
     // Check that topics match
-    if (getRecord (baseIndex).get().mTopicId!=getRecord (lastIndex).get().mTopicId)
+    if (!Misc::StringUtils::ciEqual(getRecord(baseIndex).get().mTopicId,
+                                    getRecord(lastIndex).get().mTopicId))
         return false;
 
     // reorder

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -16,7 +16,9 @@ namespace
 CSMWorld::InfoTableProxyModel::InfoTableProxyModel(CSMWorld::UniversalId::Type type, QObject *parent)
     : IdTableProxyModel(parent),
       mType(type),
-      mSourceModel(NULL)
+      mSourceModel(NULL),
+	  mInfoColumnId(type == UniversalId::Type_TopicInfos ? Columns::ColumnId_Topic : 
+                                                           Columns::ColumnId_Journal)
 {
     Q_ASSERT(type == UniversalId::Type_TopicInfos || type == UniversalId::Type_JournalInfos);
 }
@@ -54,26 +56,21 @@ bool CSMWorld::InfoTableProxyModel::lessThan(const QModelIndex &left, const QMod
 
 int CSMWorld::InfoTableProxyModel::getFirstInfoRow(int currentRow) const
 {
-    Columns::ColumnId columnId = Columns::ColumnId_Topic;
-    if (mType == UniversalId::Type_JournalInfos)
-    {
-        columnId = Columns::ColumnId_Journal;
-    }
-
-    int column = mSourceModel->findColumnIndex(columnId);
-    QString info = toLower(mSourceModel->data(mSourceModel->index(currentRow, column)).toString());
+    int row = currentRow;
+    int column = mSourceModel->findColumnIndex(mInfoColumnId);
+    QString info = toLower(mSourceModel->data(mSourceModel->index(row, column)).toString());
 
     if (mFirstRowCache.contains(info))
     {
         return mFirstRowCache[info];
     }
 
-    while (--currentRow >= 0 &&
-           toLower(mSourceModel->data(mSourceModel->index(currentRow, column)).toString()) == info);
-    ++currentRow;
+    while (--row >= 0 && 
+           toLower(mSourceModel->data(mSourceModel->index(row, column)).toString()) == info);
+    ++row;
 
-    mFirstRowCache[info] = currentRow;
-    return currentRow;
+    mFirstRowCache[info] = row;
+    return row;
 }
 
 void CSMWorld::InfoTableProxyModel::modelRowsChanged(const QModelIndex &/*parent*/, int /*start*/, int /*end*/)

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -9,7 +9,7 @@ namespace
 {
     QString toLower(const QString &str)
     {
-        return Misc::StringUtils::lowerCase(str.toStdString()).c_str();
+		return QString::fromUtf8(Misc::StringUtils::lowerCase(str.toStdString()).c_str());
     }
 }
 

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -43,6 +43,12 @@ bool CSMWorld::InfoTableProxyModel::lessThan(const QModelIndex &left, const QMod
 {
     QModelIndex first = mSourceModel->index(getFirstInfoRow(left.row()), left.column());
     QModelIndex second = mSourceModel->index(getFirstInfoRow(right.row()), right.column());
+
+    // If both indexes are belonged to the same Topic/Journal, compare their original rows only
+    if (first.row() == second.row())
+    {
+        return sortOrder() == Qt::AscendingOrder ? left.row() < right.row() : right.row() < left.row();
+    }
     return IdTableProxyModel::lessThan(first, second);
 }
 

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -15,11 +15,18 @@ void CSMWorld::InfoTableProxyModel::setSourceModel(QAbstractItemModel *sourceMod
 {
     IdTableProxyModel::setSourceModel(sourceModel);
     mSourceModel = dynamic_cast<IdTableBase *>(sourceModel);
-    connect(mSourceModel, 
-            SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)),
-            this, 
-            SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-    mFirstRowCache.clear();
+    if (mSourceModel != NULL)
+    {
+        connect(mSourceModel, 
+                SIGNAL(rowsInserted(const QModelIndex &, int, int)),
+                this, 
+                SLOT(modelRowsChanged(const QModelIndex &, int, int)));
+        connect(mSourceModel, 
+                SIGNAL(rowsRemoved(const QModelIndex &, int, int)),
+                this, 
+                SLOT(modelRowsChanged(const QModelIndex &, int, int)));
+        mFirstRowCache.clear();
+    }
 }
 
 bool CSMWorld::InfoTableProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
@@ -52,7 +59,7 @@ int CSMWorld::InfoTableProxyModel::getFirstInfoRow(int currentRow) const
     return currentRow + 1;
 }
 
-void CSMWorld::InfoTableProxyModel::modelDataChanged(const QModelIndex &/*topLeft*/, const QModelIndex &/*bottomRight*/)
+void CSMWorld::InfoTableProxyModel::modelRowsChanged(const QModelIndex &/*parent*/, int /*start*/, int /*end*/)
 {
     mFirstRowCache.clear();
 }

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -1,7 +1,17 @@
 #include "infotableproxymodel.hpp"
 
+#include <components/misc/stringops.hpp>
+
 #include "idtablebase.hpp"
 #include "columns.hpp"
+
+namespace
+{
+    QString toLower(const QString &str)
+    {
+        return Misc::StringUtils::lowerCase(str.toStdString()).c_str();
+    }
+}
 
 CSMWorld::InfoTableProxyModel::InfoTableProxyModel(CSMWorld::UniversalId::Type type, QObject *parent)
     : IdTableProxyModel(parent),
@@ -45,7 +55,7 @@ int CSMWorld::InfoTableProxyModel::getFirstInfoRow(int currentRow) const
     }
 
     int column = mSourceModel->findColumnIndex(columnId);
-    QString info = mSourceModel->data(mSourceModel->index(currentRow, column)).toString();
+    QString info = toLower(mSourceModel->data(mSourceModel->index(currentRow, column)).toString());
 
     if (mFirstRowCache.contains(info))
     {
@@ -53,10 +63,11 @@ int CSMWorld::InfoTableProxyModel::getFirstInfoRow(int currentRow) const
     }
 
     while (--currentRow >= 0 &&
-           mSourceModel->data(mSourceModel->index(currentRow, column)) == info);
+           toLower(mSourceModel->data(mSourceModel->index(currentRow, column)).toString()) == info);
+    ++currentRow;
 
-    mFirstRowCache[info] = currentRow + 1;
-    return currentRow + 1;
+    mFirstRowCache[info] = currentRow;
+    return currentRow;
 }
 
 void CSMWorld::InfoTableProxyModel::modelRowsChanged(const QModelIndex &/*parent*/, int /*start*/, int /*end*/)

--- a/apps/opencs/model/world/infotableproxymodel.hpp
+++ b/apps/opencs/model/world/infotableproxymodel.hpp
@@ -31,7 +31,7 @@ namespace CSMWorld
             virtual bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
 
         private slots:
-            void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+            void modelRowsChanged(const QModelIndex &parent, int start, int end);
     };
 }
 

--- a/apps/opencs/model/world/infotableproxymodel.hpp
+++ b/apps/opencs/model/world/infotableproxymodel.hpp
@@ -4,6 +4,7 @@
 #include <QHash>
 
 #include "idtableproxymodel.hpp"
+#include "columns.hpp"
 #include "universalid.hpp"
 
 namespace CSMWorld
@@ -16,6 +17,8 @@ namespace CSMWorld
 
             UniversalId::Type mType;
             IdTableBase *mSourceModel;
+            Columns::ColumnId mInfoColumnId;
+            ///< Contains ID for Topic or Journal ID
 
             mutable QHash<QString, int> mFirstRowCache;
 

--- a/apps/opencs/view/world/table.cpp
+++ b/apps/opencs/view/world/table.cpp
@@ -9,6 +9,8 @@
 #include <QString>
 #include <QtCore/qnamespace.h>
 
+#include <components/misc/stringops.hpp>
+
 #include "../../model/doc/document.hpp"
 
 #include "../../model/world/data.hpp"
@@ -128,17 +130,24 @@ void CSVWorld::Table::contextMenuEvent (QContextMenuEvent *event)
                 {
                     int row = mProxyModel->mapToSource (
                         mProxyModel->index (selectedRows.begin()->row(), 0)).row();
+                    QString curData = mModel->data(mModel->index(row, column)).toString();
 
-                    if (row>0 && mModel->data (mModel->index (row, column))==
-                        mModel->data (mModel->index (row-1, column)))
+                    if (row > 0)
                     {
-                        menu.addAction (mMoveUpAction);
+                        QString prevData = mModel->data(mModel->index(row - 1, column)).toString();
+                        if (Misc::StringUtils::ciEqual(curData.toStdString(), prevData.toStdString()))
+                        {
+                            menu.addAction(mMoveUpAction);
+                        }
                     }
 
-                    if (row<mModel->rowCount()-1 && mModel->data (mModel->index (row, column))==
-                        mModel->data (mModel->index (row+1, column)))
+                    if (row < mModel->rowCount() - 1)
                     {
-                        menu.addAction (mMoveDownAction);
+                        QString nextData = mModel->data(mModel->index(row + 1, column)).toString();
+                        if (Misc::StringUtils::ciEqual(curData.toStdString(), nextData.toStdString()))
+                        {
+                            menu.addAction(mMoveDownAction);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
What was done:
* Fix the incorrect position of a newly added row after the sorting
* Update the first row cache only after rows' insertion/deletion
* Ignore the letter case of topics in rows' reordering (Bug #2714)

**One issue is not resolved (for Info tables sorting)**: addition of a new row ignores the sort order, so the row is placed at the incorrect position (the model must be manually re-sorted to fix this). One obvious solution is to do the re-sorting automatically after a new row is inserted. But it breaks the "Jump to Added Record" behavior. Any suggestions for how to fix this?