### PR TITLE
Save file versioning

### DIFF
--- a/apps/essimporter/importer.cpp
+++ b/apps/essimporter/importer.cpp
@@ -327,7 +327,7 @@ namespace ESSImport
 
         ESM::ESMWriter writer;
 
-        writer.setFormat (ESM::Header::CurrentFormat);
+        writer.setFormat (ESM::SavedGame::sCurrentFormat);
 
         std::ofstream stream(mOutFile.c_str(), std::ios::binary);
         // all unused

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -798,27 +798,25 @@ namespace MWClass
 
         const ESM::CreatureState& state2 = dynamic_cast<const ESM::CreatureState&> (state);
 
-        ensureCustomData(ptr);
-
-        // If we do the following instead we get a sizable speedup, but this causes compatibility issues
-        // with 0.30 savegames, where some state in CreatureStats was not saved yet,
-        // and therefore needs to be loaded from ESM records. TODO: re-enable this in a future release.
-        /*
-        if (!ptr.getRefData().getCustomData())
+        if (state.mVersion > 0)
         {
-            // Create a CustomData, but don't fill it from ESM records (not needed)
-            std::auto_ptr<CreatureCustomData> data (new CreatureCustomData);
+            if (!ptr.getRefData().getCustomData())
+            {
+                // Create a CustomData, but don't fill it from ESM records (not needed)
+                std::auto_ptr<CreatureCustomData> data (new CreatureCustomData);
 
-            MWWorld::LiveCellRef<ESM::Creature> *ref = ptr.get<ESM::Creature>();
+                MWWorld::LiveCellRef<ESM::Creature> *ref = ptr.get<ESM::Creature>();
 
-            if (ref->mBase->mFlags & ESM::Creature::Weapon)
-                data->mContainerStore = new MWWorld::InventoryStore();
-            else
-                data->mContainerStore = new MWWorld::ContainerStore();
+                if (ref->mBase->mFlags & ESM::Creature::Weapon)
+                    data->mContainerStore = new MWWorld::InventoryStore();
+                else
+                    data->mContainerStore = new MWWorld::ContainerStore();
 
-            ptr.getRefData().setCustomData (data.release());
+                ptr.getRefData().setCustomData (data.release());
+            }
         }
-        */
+        else
+            ensureCustomData(ptr); // in openmw 0.30 savegames not all state was saved yet, so need to load it regardless.
 
         CreatureCustomData& customData = dynamic_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData());
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1233,18 +1233,17 @@ namespace MWClass
 
         const ESM::NpcState& state2 = dynamic_cast<const ESM::NpcState&> (state);
 
-        ensureCustomData(ptr);
-        // If we do the following instead we get a sizable speedup, but this causes compatibility issues
-        // with 0.30 savegames, where some state in CreatureStats was not saved yet,
-        // and therefore needs to be loaded from ESM records. TODO: re-enable this in a future release.
-        /*
-        if (!ptr.getRefData().getCustomData())
+        if (state.mVersion > 0)
         {
-            // Create a CustomData, but don't fill it from ESM records (not needed)
-            std::auto_ptr<NpcCustomData> data (new NpcCustomData);
-            ptr.getRefData().setCustomData (data.release());
+            if (!ptr.getRefData().getCustomData())
+            {
+                // Create a CustomData, but don't fill it from ESM records (not needed)
+                std::auto_ptr<NpcCustomData> data (new NpcCustomData);
+                ptr.getRefData().setCustomData (data.release());
+            }
         }
-        */
+        else
+            ensureCustomData(ptr); // in openmw 0.30 savegames not all state was saved yet, so need to load it regardless.
 
         NpcCustomData& customData = dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData());
 

--- a/apps/openmw/mwstate/character.cpp
+++ b/apps/openmw/mwstate/character.cpp
@@ -29,9 +29,6 @@ void MWState::Character::addSlot (const boost::filesystem::path& path, const std
     ESM::ESMReader reader;
     reader.open (slot.mPath.string());
 
-    if (reader.getFormat()>ESM::Header::CurrentFormat)
-        return; // format is too new -> ignore
-
     if (reader.getRecName()!=ESM::REC_SAVE)
         return; // invalid save file -> ignore
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -216,11 +216,10 @@ void MWState::StateManager::saveGame (const std::string& description, const Slot
             ++iter)
             writer.addMaster (*iter, 0); // not using the size information anyway -> use value of 0
 
-        writer.setFormat (ESM::Header::CurrentFormat);
-
-        writer.setVersion(1);
+        writer.setFormat (ESM::SavedGame::sCurrentFormat);
 
         // all unused
+        writer.setVersion(0);
         writer.setType(0);
         writer.setAuthor("");
         writer.setDescription("");

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -325,8 +325,6 @@ void MWState::StateManager::loadGame(const std::string& filepath)
     // have to peek into the save file to get the player name
     ESM::ESMReader reader;
     reader.open (filepath);
-    if (reader.getFormat()>ESM::Header::CurrentFormat)
-        return; // format is too new -> ignore
     if (reader.getRecName()!=ESM::REC_SAVE)
         return; // invalid save file -> ignore
     reader.getRecHeader();
@@ -347,6 +345,9 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
 
         ESM::ESMReader reader;
         reader.open (filepath);
+
+        if (reader.getFormat() > ESM::SavedGame::sCurrentFormat)
+            throw std::runtime_error("This save file was created using a newer version of OpenMW and is thus not supported. Please upgrade to the newest OpenMW version to load this file.");
 
         std::map<int, int> contentFileMap = buildContentFileIndexMap (reader);
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -218,8 +218,9 @@ void MWState::StateManager::saveGame (const std::string& description, const Slot
 
         writer.setFormat (ESM::Header::CurrentFormat);
 
+        writer.setVersion(1);
+
         // all unused
-        writer.setVersion(0);
         writer.setType(0);
         writer.setAuthor("");
         writer.setDescription("");

--- a/components/esm/objectstate.cpp
+++ b/components/esm/objectstate.cpp
@@ -6,6 +6,8 @@
 
 void ESM::ObjectState::load (ESMReader &esm)
 {
+    mVersion = esm.getVer();
+
     mRef.loadData(esm);
 
     mHasLocals = 0;

--- a/components/esm/objectstate.cpp
+++ b/components/esm/objectstate.cpp
@@ -6,7 +6,7 @@
 
 void ESM::ObjectState::load (ESMReader &esm)
 {
-    mVersion = esm.getVer();
+    mVersion = esm.getFormat();
 
     mRef.loadData(esm);
 

--- a/components/esm/objectstate.hpp
+++ b/components/esm/objectstate.hpp
@@ -29,7 +29,9 @@ namespace ESM
         // Is there any class-specific state following the ObjectState
         bool mHasCustomState;
 
-        ObjectState() : mHasCustomState(true)
+        unsigned int mVersion;
+
+        ObjectState() : mHasCustomState(true), mVersion(0)
         {}
 
         /// @note Does not load the CellRef ID, it should already be loaded before calling this method

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -6,6 +6,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
+int ESM::SavedGame::sCurrentFormat = 1;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {

--- a/components/esm/savedgame.hpp
+++ b/components/esm/savedgame.hpp
@@ -15,6 +15,8 @@ namespace ESM
     {
         static unsigned int sRecordId;
 
+        static int sCurrentFormat;
+
         struct TimeStamp
         {
             float mGameHour;


### PR DESCRIPTION
The first commit introduces the version field for savegames. The second commit makes use of this field by going down a more efficient code path for non-legacy files. Improves save file loading speed by 50% in my tests.