### PR TITLE
Edit 'ID' in the dialogue sub-views (Feature #2565)

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -64,7 +64,7 @@ opencs_units (view/world
     table tablesubview scriptsubview util regionmapsubview tablebottombox creator genericcreator
     cellcreator referenceablecreator referencecreator scenesubview
     infocreator scriptedit dialoguesubview previewsubview regionmap dragrecordtable nestedtable
-    dialoguespinbox recordbuttonbar
+    dialoguespinbox recordbuttonbar tableeditidaction
     )
 
 opencs_units_noqt (view/world

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -374,7 +374,7 @@ void CSVWorld::IdContextMenu::addEditIdActionToMenu(const QString &text)
     {
         mContextMenu->addAction(mEditIdAction);
     }
-    else
+    else if (mContextMenu->actions().first() != mEditIdAction)
     {
         QAction *action = mContextMenu->actions().first();
         mContextMenu->insertAction(action, mEditIdAction);

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -338,16 +338,10 @@ CSVWorld::IdContextMenu::IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Di
     if (lineEdit != NULL)
     {
         mContextMenu = lineEdit->createStandardContextMenu();
-        mContextMenu->setParent(mWidget);
-        
-        QAction *action = mContextMenu->actions().first();
-        mContextMenu->insertAction(action, mEditIdAction);
-        mContextMenu->insertSeparator(action);
     }
     else
     {
         mContextMenu = new QMenu(mWidget);
-        mContextMenu->addAction(mEditIdAction);
     }
 }
 
@@ -368,12 +362,52 @@ QString CSVWorld::IdContextMenu::getWidgetValue() const
     return value;
 }
 
+void CSVWorld::IdContextMenu::addEditIdActionToMenu(const QString &text)
+{
+    mEditIdAction->setText(text);
+    if (mContextMenu->actions().isEmpty())
+    {
+        mContextMenu->addAction(mEditIdAction);
+    }
+    else
+    {
+        QAction *action = mContextMenu->actions().first();
+        mContextMenu->insertAction(action, mEditIdAction);
+        mContextMenu->insertSeparator(action);
+    }
+}
+
+void CSVWorld::IdContextMenu::removeEditIdActionFromMenu()
+{
+    if (mContextMenu->actions().isEmpty())
+    {
+        return;
+    }
+
+    if (mContextMenu->actions().first() == mEditIdAction)
+    {
+        mContextMenu->removeAction(mEditIdAction);
+        if (!mContextMenu->actions().isEmpty() && mContextMenu->actions().first()->isSeparator())
+        {
+            mContextMenu->removeAction(mContextMenu->actions().first());
+        }
+    }
+}
+
 void CSVWorld::IdContextMenu::showContextMenu(const QPoint &pos)
 {
     QString value = getWidgetValue();
     if (!value.isEmpty())
     {
-        mEditIdAction->setText("Edit '" + value + "'");
+        addEditIdActionToMenu("Edit '" + value + "'");
+    }
+    else
+    {
+        removeEditIdActionFromMenu();
+    }
+    
+    if (!mContextMenu->actions().isEmpty())
+    {
         mContextMenu->exec(mWidget->mapToGlobal(pos));
     }
 }

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -565,6 +565,11 @@ void CSVWorld::EditWidget::remake(int row)
 
                 tablesLayout->addWidget(label);
                 tablesLayout->addWidget(table);
+
+                connect(table, 
+                        SIGNAL(editRequest(const CSMWorld::UniversalId &, const std::string &)), 
+                        this, 
+                        SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)));
             }
             else if (!(flags & CSMWorld::ColumnBase::Flag_Dialogue_List))
             {

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -345,6 +345,11 @@ CSVWorld::IdContextMenu::IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Di
     }
 }
 
+void CSVWorld::IdContextMenu::excludeId(const std::string &id)
+{
+    mExcludedIds.insert(id);
+}
+
 QString CSVWorld::IdContextMenu::getWidgetValue() const
 {
     QLineEdit *lineEdit = qobject_cast<QLineEdit *>(mWidget);   
@@ -397,7 +402,8 @@ void CSVWorld::IdContextMenu::removeEditIdActionFromMenu()
 void CSVWorld::IdContextMenu::showContextMenu(const QPoint &pos)
 {
     QString value = getWidgetValue();
-    if (!value.isEmpty())
+    bool isExcludedId = mExcludedIds.find(value.toUtf8().constData()) != mExcludedIds.end();
+    if (!value.isEmpty() && !isExcludedId)
     {
         addEditIdActionToMenu("Edit '" + value + "'");
     }
@@ -595,7 +601,12 @@ void CSVWorld::EditWidget::remake(int row)
 
                     if (CSMWorld::ColumnBase::isId(display))
                     {
+                        int idColumn = mTable->findColumnIndex(CSMWorld::Columns::ColumnId_Id);
+                        QString id = mTable->data(mTable->index(row, idColumn)).toString();
+
                         IdContextMenu *menu = new IdContextMenu(editor, display);
+                        // Current ID is already opened, so no need to create Edit 'ID' action for it
+                        menu->excludeId(id.toUtf8().constData());
                         connect(menu,
                                 SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)),
                                 this,

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -332,6 +332,7 @@ CSVWorld::IdContextMenu::IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Di
             SLOT(showContextMenu(const QPoint &)));
 
     mEditIdAction = new QAction(this);
+    connect(mEditIdAction, SIGNAL(triggered()), this, SLOT(editIdRequest()));
 
     QLineEdit *lineEdit = qobject_cast<QLineEdit *>(mWidget);
     if (lineEdit != NULL)
@@ -352,8 +353,8 @@ CSVWorld::IdContextMenu::IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Di
 
 QString CSVWorld::IdContextMenu::getWidgetValue() const
 {
-    static QLineEdit *lineEdit = qobject_cast<QLineEdit *>(mWidget);   
-    static QLabel *label = qobject_cast<QLabel *>(mWidget);
+    QLineEdit *lineEdit = qobject_cast<QLineEdit *>(mWidget);   
+    QLabel *label = qobject_cast<QLabel *>(mWidget);
 
     QString value = "";
     if (lineEdit != NULL)
@@ -373,14 +374,14 @@ void CSVWorld::IdContextMenu::showContextMenu(const QPoint &pos)
     if (!value.isEmpty())
     {
         mEditIdAction->setText("Edit '" + value + "'");
-        
-        QAction *selectedAction = mContextMenu->exec(mWidget->mapToGlobal(pos));
-        if (selectedAction != NULL && selectedAction == mEditIdAction)
-        {
-            CSMWorld::UniversalId editId(mIdType, value.toUtf8().constData());
-            emit editIdRequest(editId, "");
-        }
+        mContextMenu->exec(mWidget->mapToGlobal(pos));
     }
+}
+
+void CSVWorld::IdContextMenu::editIdRequest()
+{
+    CSMWorld::UniversalId editId(mIdType, getWidgetValue().toUtf8().constData());
+    emit editIdRequest(editId, "");
 }
 
 /*
@@ -557,6 +558,15 @@ void CSVWorld::EditWidget::remake(int row)
                         editor->setEnabled(false);
                         label->setEnabled(false);
                     }
+
+                    if (CSMWorld::ColumnBase::isId(display))
+                    {
+                        IdContextMenu *menu = new IdContextMenu(editor, display);
+                        connect(menu,
+                                SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)),
+                                this,
+                                SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)));
+                    }
                 }
             }
             else
@@ -676,6 +686,11 @@ CSVWorld::SimpleDialogueSubView::SimpleDialogueSubView (const CSMWorld::Universa
     mEditWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
     dataChanged(mTable->getModelIndex (getUniversalId().getId(), 0));
+
+    connect(mEditWidget,
+            SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)),
+            this,
+            SIGNAL(focusId(const CSMWorld::UniversalId &, const std::string &)));
 }
 
 void CSVWorld::SimpleDialogueSubView::setEditLock (bool locked)

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -428,6 +428,28 @@ void CSVWorld::IdContextMenu::editIdRequest()
 =============================================================EditWidget=====================================================
 */
 
+void CSVWorld::EditWidget::createEditorContextMenu(QWidget *editor,
+                                                   CSMWorld::ColumnBase::Display display,
+                                                   int currentRow) const
+{
+    Q_ASSERT(editor != NULL);
+
+    if (CSMWorld::ColumnBase::isId(display) &&
+        CSMWorld::TableMimeData::convertEnums(display) != CSMWorld::UniversalId::Type_None)
+    {
+        int idColumn = mTable->findColumnIndex(CSMWorld::Columns::ColumnId_Id);
+        QString id = mTable->data(mTable->index(currentRow, idColumn)).toString();
+
+        IdContextMenu *menu = new IdContextMenu(editor, display);
+        // Current ID is already opened, so no need to create Edit 'ID' action for it
+        menu->excludeId(id.toUtf8().constData());
+        connect(menu,
+                SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)),
+                this,
+                SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)));
+    }
+}
+
 CSVWorld::EditWidget::~EditWidget()
 {
     for (unsigned i = 0; i < mNestedModels.size(); ++i)
@@ -604,19 +626,7 @@ void CSVWorld::EditWidget::remake(int row)
                         label->setEnabled(false);
                     }
 
-                    if (CSMWorld::ColumnBase::isId(display))
-                    {
-                        int idColumn = mTable->findColumnIndex(CSMWorld::Columns::ColumnId_Id);
-                        QString id = mTable->data(mTable->index(row, idColumn)).toString();
-
-                        IdContextMenu *menu = new IdContextMenu(editor, display);
-                        // Current ID is already opened, so no need to create Edit 'ID' action for it
-                        menu->excludeId(id.toUtf8().constData());
-                        connect(menu,
-                                SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)),
-                                this,
-                                SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)));
-                    }
+                    createEditorContextMenu(editor, display, row);
                 }
             }
             else
@@ -668,6 +678,8 @@ void CSVWorld::EditWidget::remake(int row)
                             editor->setEnabled(false);
                             label->setEnabled(false);
                         }
+
+                        createEditorContextMenu(editor, display, row);
                     }
                 }
                 mNestedTableMapper->setCurrentModelIndex(tree->index(0, 0, tree->index(row, i)));

--- a/apps/opencs/view/world/dialoguesubview.hpp
+++ b/apps/opencs/view/world/dialoguesubview.hpp
@@ -11,12 +11,14 @@
 
 #include "../../model/world/columnbase.hpp"
 #include "../../model/world/commanddispatcher.hpp"
+#include "../../model/world/universalid.hpp"
 
 class QDataWidgetMapper;
 class QSize;
 class QEvent;
 class QLabel;
 class QVBoxLayout;
+class QMenu;
 
 namespace CSMWorld
 {
@@ -147,6 +149,28 @@ namespace CSVWorld
     private slots:
         void editorDataCommited(QWidget* editor, const QModelIndex& index,
                                 CSMWorld::ColumnBase::Display display);
+    };
+
+    class IdContextMenu : public QObject
+    {
+            Q_OBJECT
+
+            QWidget *mWidget;
+            CSMWorld::UniversalId::Type mIdType;
+
+            QMenu *mContextMenu;
+            QAction *mEditIdAction;
+
+            QString getWidgetValue() const;
+
+        public:
+            IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Display display);
+
+        private slots:
+            void showContextMenu(const QPoint &pos);
+
+        signals:
+            void editIdRequest(const CSMWorld::UniversalId &id, const std::string &hint);
     };
 
     class EditWidget : public QScrollArea

--- a/apps/opencs/view/world/dialoguesubview.hpp
+++ b/apps/opencs/view/world/dialoguesubview.hpp
@@ -195,6 +195,9 @@ namespace CSVWorld
             CSMDoc::Document& mDocument;
             std::vector<CSMWorld::NestedTableProxyModel*> mNestedModels; //Plain, raw C pointers, deleted in the dtor
 
+            void createEditorContextMenu(QWidget *editor, 
+                                         CSMWorld::ColumnBase::Display display, 
+                                         int currentRow) const;
         public:
 
             EditWidget (QWidget *parent, int row, CSMWorld::IdTable* table,

--- a/apps/opencs/view/world/dialoguesubview.hpp
+++ b/apps/opencs/view/world/dialoguesubview.hpp
@@ -1,6 +1,7 @@
 #ifndef CSV_WORLD_DIALOGUESUBVIEW_H
 #define CSV_WORLD_DIALOGUESUBVIEW_H
 
+#include <set>
 #include <map>
 #include <memory>
 
@@ -151,12 +152,15 @@ namespace CSVWorld
                                 CSMWorld::ColumnBase::Display display);
     };
 
+    /// A context menu with "Edit 'ID'" action for editors in the dialogue subview
     class IdContextMenu : public QObject
     {
             Q_OBJECT
 
             QWidget *mWidget;
             CSMWorld::UniversalId::Type mIdType;
+            std::set<std::string> mExcludedIds;
+            ///< A list of IDs that should not have the Edit 'ID' action.
 
             QMenu *mContextMenu;
             QAction *mEditIdAction;
@@ -167,6 +171,8 @@ namespace CSVWorld
 
         public:
             IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Display display);
+
+            void excludeId(const std::string &id);
 
         private slots:
             void showContextMenu(const QPoint &pos);

--- a/apps/opencs/view/world/dialoguesubview.hpp
+++ b/apps/opencs/view/world/dialoguesubview.hpp
@@ -162,6 +162,8 @@ namespace CSVWorld
             QAction *mEditIdAction;
 
             QString getWidgetValue() const;
+            void addEditIdActionToMenu(const QString &text);
+            void removeEditIdActionFromMenu();
 
         public:
             IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Display display);

--- a/apps/opencs/view/world/dialoguesubview.hpp
+++ b/apps/opencs/view/world/dialoguesubview.hpp
@@ -168,6 +168,7 @@ namespace CSVWorld
 
         private slots:
             void showContextMenu(const QPoint &pos);
+            void editIdRequest();
 
         signals:
             void editIdRequest(const CSMWorld::UniversalId &id, const std::string &hint);
@@ -195,6 +196,9 @@ namespace CSVWorld
             virtual ~EditWidget();
 
             void remake(int row);
+
+        signals:
+            void editIdRequest(const CSMWorld::UniversalId &id, const std::string &hint);
     };
 
     class SimpleDialogueSubView : public CSVDoc::SubView

--- a/apps/opencs/view/world/nestedtable.hpp
+++ b/apps/opencs/view/world/nestedtable.hpp
@@ -22,12 +22,15 @@ namespace CSMDoc
 
 namespace CSVWorld
 {
+    class TableEditIdAction;
+
     class NestedTable : public DragRecordTable
     {
         Q_OBJECT
 
         QAction *mAddNewRowAction;
         QAction *mRemoveRowAction;
+        TableEditIdAction *mEditIdAction;
         CSMWorld::NestedTableProxyModel* mModel;
         CSMWorld::CommandDispatcher *mDispatcher;
 
@@ -46,6 +49,11 @@ namespace CSVWorld
         void removeRowActionTriggered();
 
         void addNewRowActionTriggered();
+
+        void editCell();
+
+    signals:
+        void editRequest(const CSMWorld::UniversalId &id, const std::string &hint);
     };
 }
 

--- a/apps/opencs/view/world/table.hpp
+++ b/apps/opencs/view/world/table.hpp
@@ -30,6 +30,7 @@ namespace CSMWorld
 namespace CSVWorld
 {
     class CommandDelegate;
+    class TableEditIdAction;
 
     ///< Table widget
     class Table : public DragRecordTable
@@ -57,15 +58,14 @@ namespace CSVWorld
             QAction *mMoveUpAction;
             QAction *mMoveDownAction;
             QAction *mViewAction;
-            QAction *mEditCellAction;
             QAction *mPreviewAction;
             QAction *mExtendedDeleteAction;
             QAction *mExtendedRevertAction;
+            TableEditIdAction *mEditIdAction;
             CSMWorld::IdTableProxyModel *mProxyModel;
             CSMWorld::IdTableBase *mModel;
             int mRecordStatusDisplay;
             CSMWorld::CommandDispatcher *mDispatcher;
-            CSMWorld::UniversalId mEditCellId;
             std::map<Qt::KeyboardModifiers, DoubleClickAction> mDoubleClickActions;
             bool mJumpToAddedRecord;
             bool mUnselectAfterJump;

--- a/apps/opencs/view/world/tableeditidaction.cpp
+++ b/apps/opencs/view/world/tableeditidaction.cpp
@@ -1,0 +1,42 @@
+#include "tableeditidaction.hpp"
+
+#include <QTableView>
+
+#include "../../model/world/tablemimedata.hpp"
+
+CSVWorld::TableEditIdAction::CellData CSVWorld::TableEditIdAction::getCellData(int row, int column) const
+{
+    QModelIndex index = mTable.model()->index(row, column);
+    if (index.isValid())
+    {
+        QVariant display = mTable.model()->data(index, CSMWorld::ColumnBase::Role_Display);
+        QString value = mTable.model()->data(index).toString();
+        return std::make_pair(static_cast<CSMWorld::ColumnBase::Display>(display.toInt()), value);
+    }
+    return std::make_pair(CSMWorld::ColumnBase::Display_None, "");
+}
+
+CSVWorld::TableEditIdAction::TableEditIdAction(const QTableView &table, QWidget *parent)
+    : QAction(parent),
+      mTable(table),
+      mCurrentId(CSMWorld::UniversalId::Type_None)
+{}
+
+void CSVWorld::TableEditIdAction::setCell(int row, int column)
+{
+    CellData data = getCellData(row, column);
+    mCurrentId = CSMWorld::UniversalId(CSMWorld::TableMimeData::convertEnums(data.first), 
+                                       data.second.toUtf8().constData());
+    setText("Edit '" + data.second + "'");
+}
+
+CSMWorld::UniversalId CSVWorld::TableEditIdAction::getCurrentId() const
+{
+    return mCurrentId;
+}
+
+bool CSVWorld::TableEditIdAction::isValidIdCell(int row, int column) const
+{
+    CellData data = getCellData(row, column);
+    return CSMWorld::ColumnBase::isId(data.first) && !data.second.isEmpty();
+}

--- a/apps/opencs/view/world/tableeditidaction.cpp
+++ b/apps/opencs/view/world/tableeditidaction.cpp
@@ -25,9 +25,13 @@ CSVWorld::TableEditIdAction::TableEditIdAction(const QTableView &table, QWidget 
 void CSVWorld::TableEditIdAction::setCell(int row, int column)
 {
     CellData data = getCellData(row, column);
-    mCurrentId = CSMWorld::UniversalId(CSMWorld::TableMimeData::convertEnums(data.first), 
-                                       data.second.toUtf8().constData());
-    setText("Edit '" + data.second + "'");
+    CSMWorld::UniversalId::Type idType = CSMWorld::TableMimeData::convertEnums(data.first);
+
+    if (idType != CSMWorld::UniversalId::Type_None)
+    {
+        mCurrentId = CSMWorld::UniversalId(idType, data.second.toUtf8().constData());
+        setText("Edit '" + data.second + "'");
+    }
 }
 
 CSMWorld::UniversalId CSVWorld::TableEditIdAction::getCurrentId() const
@@ -38,5 +42,8 @@ CSMWorld::UniversalId CSVWorld::TableEditIdAction::getCurrentId() const
 bool CSVWorld::TableEditIdAction::isValidIdCell(int row, int column) const
 {
     CellData data = getCellData(row, column);
-    return CSMWorld::ColumnBase::isId(data.first) && !data.second.isEmpty();
+    CSMWorld::UniversalId::Type idType = CSMWorld::TableMimeData::convertEnums(data.first);
+    return CSMWorld::ColumnBase::isId(data.first) && 
+           idType != CSMWorld::UniversalId::Type_None &&
+           !data.second.isEmpty();
 }

--- a/apps/opencs/view/world/tableeditidaction.hpp
+++ b/apps/opencs/view/world/tableeditidaction.hpp
@@ -1,0 +1,31 @@
+#ifndef CSVWORLD_TABLEEDITIDACTION_HPP
+#define CSVWORLD_TABLEEDITIDACTION_HPP
+
+#include <QAction>
+
+#include "../../model/world/columnbase.hpp"
+#include "../../model/world/universalid.hpp"
+
+class QTableView;
+
+namespace CSVWorld
+{
+    class TableEditIdAction : public QAction
+    {
+            const QTableView &mTable;
+            CSMWorld::UniversalId mCurrentId;
+
+            typedef std::pair<CSMWorld::ColumnBase::Display, QString> CellData;
+            CellData getCellData(int row, int column) const;
+
+        public:
+            TableEditIdAction(const QTableView &table, QWidget *parent = 0);
+
+            void setCell(int row, int column);
+
+            CSMWorld::UniversalId getCurrentId() const;
+            bool isValidIdCell(int row, int column) const;
+    };
+}
+
+#endif


### PR DESCRIPTION
LineEdits and Labels (that contain IDs) have an Edit 'ID' action in their context menus.
![context_menu_label](https://cloud.githubusercontent.com/assets/12299250/8502381/ea9eee5e-21b7-11e5-9899-28e55632f20a.png)
![context_menu_lineedit](https://cloud.githubusercontent.com/assets/12299250/8502412/4d5e0174-21b8-11e5-8daa-94e93890d1af.png)

**And a question:** What about nested tables?