### PR TITLE
AiCombat refactoring, more accurate attack timing

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -300,10 +300,6 @@ namespace MWMechanics
             currentCell = actor.getCell();
         }
 
-        MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(actor);
-        if (!anim) // shouldn't happen
-            return false;
-
         actorClass.getCreatureStats(actor).setMovementFlag(CreatureStats::Flag_Run, true);
 
         if (actionCooldown > 0)
@@ -312,11 +308,7 @@ namespace MWMechanics
         float rangeAttack = 0;
         float rangeFollow = 0;
         boost::shared_ptr<Action>& currentAction = storage.mCurrentAction;
-        // TODO: upperBodyReady() works fine for checking if we can start an attack,
-        // but doesn't work properly for checking if the attack is finished (as things like hit recovery or knockdown also play on the upper body)
-        // Only a minor problem, but can mess with the actionCooldown timer.
-        // To fix this the AI needs to be brought closer to the CharacterController, so we can simply check if a weapon animation is playing.
-        if (anim->upperBodyReady())
+        if (characterController.readyToPrepareAttack())
         {
             currentAction = prepareNextAction(actor, target);
             actionCooldown = currentAction->getActionCooldown();

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -333,9 +333,6 @@ namespace MWMechanics
         // Get weapon characteristics
         if (actorClass.hasInventoryStore(actor))
         {
-            // TODO: Check equipped weapon and equip a different one if we can't attack with it
-            // (e.g. no ammunition, or wrong type of ammunition equipped, etc. autoEquip is not very smart in this regard))
-
             //Get weapon speed and range
             MWWorld::ContainerStoreIterator weaponSlot =
                 MWMechanics::getActiveWeapon(actorClass.getCreatureStats(actor), actorClass.getInventoryStore(actor), &weaptype);

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -640,24 +640,6 @@ namespace MWMechanics
             }
         }
 
-        // TODO: Add a parameter to vary DURATION_SAME_SPOT?
-        if((distToTarget > rangeAttack || followTarget) &&
-            mObstacleCheck.check(actor, tReaction)) // check if evasive action needed
-        {
-            // probably walking into another NPC TODO: untested in combat situation
-            // TODO: diagonal should have same animation as walk forward
-            //       but doesn't seem to do that?
-            actor.getClass().getMovementSettings(actor).mPosition[0] = 1;
-            actor.getClass().getMovementSettings(actor).mPosition[1] = 0.1f;
-            // change the angle a bit, too
-            if(mPathFinder.isPathConstructed())
-                zTurn(actor, osg::DegreesToRadians(mPathFinder.getZAngleToNext(pos.pos[0] + 1, pos.pos[1])));
-
-            if(followTarget)
-                followTarget = false;
-            // FIXME: can fool actors to stay behind doors, etc.
-            // Related to Bug#1102 and to some degree #1155 as well
-        }
         return false;
     }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1259,6 +1259,8 @@ bool CharacterController::updateWeaponState()
         }
 
         animPlaying = mAnimation->getInfo(mCurrentWeapon, &complete);
+        if(mUpperBodyState == UpperCharState_MinAttackToMaxAttack && mHitState != CharState_KnockDown)
+            mAttackStrength = complete;
     }
     else
     {
@@ -2051,6 +2053,22 @@ void CharacterController::setAttackingOrSpell(bool attackingOrSpell)
 bool CharacterController::readyToPrepareAttack() const
 {
     return mHitState == CharState_None && mUpperBodyState  <= UpperCharState_WeapEquiped;
+}
+
+bool CharacterController::readyToStartAttack() const
+{
+    if (mHitState != CharState_None)
+        return false;
+
+    if (mPtr.getClass().hasInventoryStore(mPtr) || mPtr.getClass().isBipedal(mPtr))
+        return mUpperBodyState == UpperCharState_WeapEquiped;
+    else
+        return mUpperBodyState == UpperCharState_Nothing;
+}
+
+float CharacterController::getAttackStrength() const
+{
+    return mAttackStrength;
 }
 
 void CharacterController::setActive(bool active)

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1789,7 +1789,8 @@ void CharacterController::update(float duration)
             }
         }
 
-        if(cls.isBipedal(mPtr))
+        // bipedal means hand-to-hand could be used (which is handled in updateWeaponState). an existing InventoryStore means an actual weapon could be used.
+        if(cls.isBipedal(mPtr) || cls.hasInventoryStore(mPtr))
             forcestateupdate = updateWeaponState() || forcestateupdate;
         else
             forcestateupdate = updateCreatureState() || forcestateupdate;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2047,6 +2047,11 @@ void CharacterController::setAttackingOrSpell(bool attackingOrSpell)
     mAttackingOrSpell = attackingOrSpell;
 }
 
+bool CharacterController::readyToPrepareAttack() const
+{
+    return mHitState == CharState_None && mUpperBodyState  <= UpperCharState_WeapEquiped;
+}
+
 void CharacterController::setActive(bool active)
 {
     mAnimation->setActive(active);

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -240,6 +240,8 @@ public:
 
     void setAttackingOrSpell(bool attackingOrSpell);
 
+    bool readyToPrepareAttack() const;
+
     /// @see Animation::setActive
     void setActive(bool active);
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -241,6 +241,9 @@ public:
     void setAttackingOrSpell(bool attackingOrSpell);
 
     bool readyToPrepareAttack() const;
+    bool readyToStartAttack() const;
+
+    float getAttackStrength() const;
 
     /// @see Animation::setActive
     void setActive(bool active);
@@ -249,7 +252,6 @@ public:
     void setHeadTrackTarget(const MWWorld::Ptr& target);
 };
 
-    void getWeaponGroup(WeaponType weaptype, std::string &group);
     MWWorld::ContainerStoreIterator getActiveWeapon(CreatureStats &stats, MWWorld::InventoryStore &inv, WeaponType *weaptype);
 }
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -850,7 +850,6 @@ void NpcAnimation::addControllers()
     Animation::addControllers();
 
     mFirstPersonNeckController = NULL;
-    mHeadController = NULL;
     WeaponAnimation::deleteControllers();
 
     if (mViewMode == VM_FirstPerson)


### PR DESCRIPTION
Besides cleaning up the code, this is intended to address several problems.

* Fix the "stuck weapon" glitch as seen in the [0.33 release video](https://www.youtube.com/watch?v=bfq2j8bgQnM&t=5m50s). I don't know what caused it, but since I've rewritten the attack timing code from scratch I'm assuming the bug no longer exists.
* Correct timing of attacks, i.e. observing the animation state to see when an attack has completed. Similar handling for preparing and starting attacks, e.g. won't attempt to start attacking until the weapon equipping animation finished, or the actor recovered from a knockdown. 
* Handle the fCombatDelayCreature / fCombatDelayNpc timer, making the AI more balanced with respect to vanilla MW.