### PR TITLE
Fix calculation of selected blocks in ScriptEdit

### DIFF
--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -276,11 +276,11 @@ void CSVWorld::ScriptEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
     if(textCursor().hasSelection())
     {
         QString str = textCursor().selection().toPlainText();
-        int selectedLines = str.count("\n")+1;
+        int offset = str.count("\n");
         if(textCursor().position() < textCursor().anchor())
-            endBlock += selectedLines;
+            endBlock += offset;
         else
-            startBlock -= selectedLines;
+            startBlock -= offset;
     }
     painter.setBackgroundMode(Qt::OpaqueMode);
     QFont font = painter.font();


### PR DESCRIPTION
Fixes this:
![selbug](https://cloud.githubusercontent.com/assets/7346770/8524769/6f526f1c-23fd-11e5-92aa-4246ad53bddd.png)
