### PR TITLE
AiWander uses points between PathGrid points (Fixes #1317)

### DIFF
--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -14,7 +14,9 @@
 
 #if defined(_WIN32)
 // For OutputDebugString
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 // makes __argc and __argv available on windows
 #include <cstdlib>

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -30,6 +30,12 @@ namespace MWMechanics
     static const int GREETING_SHOULD_START = 4; //how many reaction intervals should pass before NPC can greet player
     static const int GREETING_SHOULD_END = 10;
 
+    // to prevent overcrowding
+    static const int DESTINATION_TOLERANCE = 64;
+
+    // distance must be long enough that NPC will need to move to get there.
+    static const int MINIMUM_WANDER_DISTANCE = DESTINATION_TOLERANCE * 2;
+
     const std::string AiWander::sIdleSelectToGroupName[GroupIndex_MaxIdle - GroupIndex_MinIdle + 1] =
     {
         std::string("idle2"),
@@ -216,7 +222,7 @@ namespace MWMechanics
         // Are we there yet?
         bool& chooseAction = storage.mChooseAction;
         if(walking &&
-            storage.mPathFinder.checkPathCompleted(pos.pos[0], pos.pos[1], DestinationTolerance))
+            storage.mPathFinder.checkPathCompleted(pos.pos[0], pos.pos[1], DESTINATION_TOLERANCE))
         {
             stopWalking(actor, storage);
             moveNow = false;
@@ -659,7 +665,7 @@ namespace MWMechanics
 
     int AiWander::OffsetToPreventOvercrowding()
     {
-        return static_cast<int>(DestinationTolerance * (Misc::Rng::rollProbability() * 2.0f - 1.0f));
+        return static_cast<int>(DESTINATION_TOLERANCE * (Misc::Rng::rollProbability() * 2.0f - 1.0f));
     }
 
     void AiWander::getAllowedNodes(const MWWorld::Ptr& actor, const ESM::Cell* cell)
@@ -743,7 +749,7 @@ namespace MWMechanics
         float length = delta.length();
         delta.normalize();
 
-        int distance = std::max(mDistance / 2, MinimumWanderDistance);
+        int distance = std::max(mDistance / 2, MINIMUM_WANDER_DISTANCE);
         
         // must not travel longer than distance between waypoints or NPC goes past waypoint
         distance = std::min(distance, static_cast<int>(length));

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -118,6 +118,15 @@ namespace MWMechanics
                 GroupIndex_MaxIdle = 9
             };
 
+            /// convert point from local (i.e. cell) to world co-ordinates
+            void ToWorldCoordinates(ESM::Pathgrid::Point& point, const ESM::Cell * cell);
+
+            void SetCurrentNodeToClosestAllowedNode(osg::Vec3f npcPos);
+
+            void AddNonPathGridAllowedPoints(osg::Vec3f npcPos, const ESM::Pathgrid * pathGrid, int pointIndex);
+
+            void AddPointBetweenPathGridPoints(const ESM::Pathgrid::Point& start, const ESM::Pathgrid::Point& end);
+
             /// lookup table for converting idleSelect value to groupName
             static const std::string sIdleSelectToGroupName[GroupIndex_MaxIdle - GroupIndex_MinIdle + 1];
     };

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -118,6 +118,12 @@ namespace MWMechanics
                 GroupIndex_MaxIdle = 9
             };
 
+            // to prevent overcrowding
+            static const int DestinationTolerance = 64;
+
+            // distance must be long enough that NPC will need to move to get there.
+            static const int MinimumWanderDistance = DestinationTolerance * 2;
+
             /// convert point from local (i.e. cell) to world co-ordinates
             void ToWorldCoordinates(ESM::Pathgrid::Point& point, const ESM::Cell * cell);
 
@@ -129,6 +135,8 @@ namespace MWMechanics
 
             /// lookup table for converting idleSelect value to groupName
             static const std::string sIdleSelectToGroupName[GroupIndex_MaxIdle - GroupIndex_MinIdle + 1];
+
+            static int OffsetToPreventOvercrowding();
     };
     
     

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -118,12 +118,6 @@ namespace MWMechanics
                 GroupIndex_MaxIdle = 9
             };
 
-            // to prevent overcrowding
-            static const int DestinationTolerance = 64;
-
-            // distance must be long enough that NPC will need to move to get there.
-            static const int MinimumWanderDistance = DestinationTolerance * 2;
-
             /// convert point from local (i.e. cell) to world co-ordinates
             void ToWorldCoordinates(ESM::Pathgrid::Point& point, const ESM::Cell * cell);
 

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -19,6 +19,8 @@ namespace MWMechanics
         public:
             PathFinder();
 
+            static const int PathTolerance = 32;
+
             static float sgn(float val)
             {
                 if(val > 0)
@@ -35,7 +37,7 @@ namespace MWMechanics
 
             void clearPath();
 
-            bool checkPathCompleted(float x, float y, float tolerance=32.f);
+            bool checkPathCompleted(float x, float y, float tolerance = PathTolerance);
             ///< \Returns true if we are within \a tolerance units of the last path point.
 
             /// In degrees

--- a/apps/openmw/mwmechanics/pathgrid.cpp
+++ b/apps/openmw/mwmechanics/pathgrid.cpp
@@ -313,27 +313,27 @@ namespace MWMechanics
             return path; // for some reason couldn't build a path
 
         // reconstruct path to return, using world co-ordinates
-        float xCell = 0;
-        float yCell = 0;
+        int xCell = 0;
+        int yCell = 0;
         if (mIsExterior)
         {
-            xCell = static_cast<float>(mPathgrid->mData.mX * ESM::Land::REAL_SIZE);
-            yCell = static_cast<float>(mPathgrid->mData.mY * ESM::Land::REAL_SIZE);
+            xCell = mPathgrid->mData.mX * ESM::Land::REAL_SIZE;
+            yCell = mPathgrid->mData.mY * ESM::Land::REAL_SIZE;
         }
 
         while(graphParent[current] != -1)
         {
             ESM::Pathgrid::Point pt = mPathgrid->mPoints[current];
-            pt.mX += static_cast<int>(xCell);
-            pt.mY += static_cast<int>(yCell);
+            pt.mX += xCell;
+            pt.mY += yCell;
             path.push_front(pt);
             current = graphParent[current];
         }
 
         // add first node to path explicitly
         ESM::Pathgrid::Point pt = mPathgrid->mPoints[start];
-        pt.mX += static_cast<int>(xCell);
-        pt.mY += static_cast<int>(yCell);
+        pt.mX += xCell;
+        pt.mY += yCell;
         path.push_front(pt);
         return path;
     }


### PR DESCRIPTION
When there is only on PathGrid point within a NPC's wander distance, expand possible wander destinations by using positions between PathGrid points.
Also, assorted code re-factoring.