### PR TITLE
Explicitly instantiate unnecessarily complex templates

### DIFF
--- a/apps/essimporter/convertplayer.cpp
+++ b/apps/essimporter/convertplayer.cpp
@@ -1,5 +1,7 @@
 #include "convertplayer.hpp"
 
+#include <components/misc/stringops.hpp>
+
 namespace ESSImport
 {
 

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -10,6 +10,7 @@
 #include <components/esm/loaddial.hpp>
 #include <components/esm/loadinfo.hpp>
 #include <components/esm/dialoguestate.hpp>
+#include <components/esm/esmwriter.hpp>
 
 #include <components/compiler/exception.hpp>
 #include <components/compiler/errorhandler.hpp>

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -10,6 +10,8 @@
 
 #include <osg/Texture2D>
 
+#include <components/misc/stringops.hpp>
+
 #include <components/myguiplatform/myguitexture.hpp>
 
 #include <components/settings/settings.hpp>

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -16,6 +16,8 @@
 
 #include <components/settings/settings.hpp>
 
+#include <components/misc/stringops.hpp>
+
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/soundmanager.hpp"

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -12,6 +12,7 @@
 #include <MyGUI_FactoryManager.h>
 
 #include <components/esm/globalmap.hpp>
+#include <components/esm/esmwriter.hpp>
 #include <components/settings/settings.hpp>
 #include <components/myguiplatform/myguitexture.hpp>
 

--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -5,6 +5,7 @@
 #include <MyGUI_Gui.h>
 #include <MyGUI_ImageBox.h>
 
+#include <components/esm/esmwriter.hpp>
 #include <components/esm/quickkeys.hpp>
 
 #include "../mwworld/inventorystore.hpp"

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -22,6 +22,9 @@
 
 #include <components/sdlutil/sdlcursormanager.hpp>
 
+#include <components/esm/esmreader.hpp>
+#include <components/esm/esmwriter.hpp>
+
 #include <components/fontloader/fontloader.hpp>
 
 #include <components/resource/resourcesystem.hpp>

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -4,6 +4,8 @@
 
 #include <osg/PositionAttitudeTransform>
 
+#include <components/esm/esmreader.hpp>
+#include <components/esm/esmwriter.hpp>
 #include <components/esm/loadnpc.hpp>
 
 #include "../mwworld/esmstore.hpp"

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -7,6 +7,7 @@
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/loadnpc.hpp>
+#include <components/esm/esmreader.hpp>
 
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/class.hpp"

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 
 #include <components/esm/creaturestats.hpp>
+#include <components/esm/esmreader.hpp>
+#include <components/esm/esmwriter.hpp>
 
 #include "../mwworld/esmstore.hpp"
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -6,6 +6,7 @@
 
 #include <components/misc/rng.hpp>
 
+#include <components/esm/esmwriter.hpp>
 #include <components/esm/stolenitems.hpp>
 
 #include "../mwworld/esmstore.hpp"

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -5,6 +5,7 @@
 
 #include <components/esm/loadspel.hpp>
 #include <components/esm/spellstate.hpp>
+#include <components/misc/rng.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"

--- a/apps/openmw/mwmechanics/stat.cpp
+++ b/apps/openmw/mwmechanics/stat.cpp
@@ -1,28 +1,276 @@
-
 #include "stat.hpp"
 
-void MWMechanics::AttributeValue::writeState (ESM::StatState<int>& state) const
+#include <components/esm/statstate.hpp>
+
+namespace MWMechanics
 {
-    state.mBase = mBase;
-    state.mMod = mModifier;
-    state.mDamage = mDamage;
+    template<typename T>
+    Stat<T>::Stat() : mBase (0), mModified (0) {}
+    template<typename T>
+    Stat<T>::Stat(T base) : mBase (base), mModified (base) {}
+    template<typename T>
+    Stat<T>::Stat(T base, T modified) : mBase (base), mModified (modified) {}
+
+    template<typename T>
+    const T& Stat<T>::getBase() const
+    {
+        return mBase;
+    }
+
+    template<typename T>
+    T Stat<T>::getModified() const
+    {
+        return std::max(static_cast<T>(0), mModified);
+    }
+    template<typename T>
+    T Stat<T>::getModifier() const
+    {
+        return mModified-mBase;
+    }
+    template<typename T>
+    void Stat<T>::set (const T& value)
+    {
+        mBase = mModified = value;
+    }
+    template<typename T>
+    void Stat<T>::modify(const T& diff)
+    {
+        mBase += diff;
+        if(mBase >= static_cast<T>(0))
+            mModified += diff;
+        else
+        {
+            mModified += diff - mBase;
+            mBase = static_cast<T>(0);
+        }
+    }
+    template<typename T>
+    void Stat<T>::setBase (const T& value)
+    {
+        T diff = value - mBase;
+        mBase = value;
+        mModified += diff;
+    }
+    template<typename T>
+    void Stat<T>::setModified (T value, const T& min, const T& max)
+    {
+        T diff = value - mModified;
+
+        if (mBase+diff<min)
+        {
+            value = min + (mModified - mBase);
+            diff = value - mModified;
+        }
+        else if (mBase+diff>max)
+        {
+            value = max + (mModified - mBase);
+            diff = value - mModified;
+        }
+
+        mModified = value;
+        mBase += diff;
+    }
+    template<typename T>
+    void Stat<T>::setModifier (const T& modifier)
+    {
+        mModified = mBase + modifier;
+    }
+
+    template<typename T>
+    void Stat<T>::writeState (ESM::StatState<T>& state) const
+    {
+        state.mBase = mBase;
+        state.mMod = mModified;
+    }
+    template<typename T>
+    void Stat<T>::readState (const ESM::StatState<T>& state)
+    {
+        mBase = state.mBase;
+        mModified = state.mMod;
+    }
+
+
+    template<typename T>
+    DynamicStat<T>::DynamicStat() : mStatic (0), mCurrent (0) {}
+    template<typename T>
+    DynamicStat<T>::DynamicStat(T base) : mStatic (base), mCurrent (base) {}
+    template<typename T>
+    DynamicStat<T>::DynamicStat(T base, T modified, T current) : mStatic(base, modified), mCurrent (current) {}
+    template<typename T>
+    DynamicStat<T>::DynamicStat(const Stat<T> &stat, T current) : mStatic(stat), mCurrent (current) {}
+
+
+    template<typename T>
+    const T& DynamicStat<T>::getBase() const
+    {
+        return mStatic.getBase();
+    }
+    template<typename T>
+    T DynamicStat<T>::getModified() const
+    {
+        return mStatic.getModified();
+    }
+    template<typename T>
+    const T& DynamicStat<T>::getCurrent() const
+    {
+        return mCurrent;
+    }
+
+    template<typename T>
+    void DynamicStat<T>::set (const T& value)
+    {
+        mStatic.set (value);
+        mCurrent = value;
+    }
+    template<typename T>
+    void DynamicStat<T>::setBase (const T& value)
+    {
+        mStatic.setBase (value);
+
+        if (mCurrent>getModified())
+            mCurrent = getModified();
+    }
+    template<typename T>
+    void DynamicStat<T>::setModified (T value, const T& min, const T& max)
+    {
+        mStatic.setModified (value, min, max);
+
+        if (mCurrent>getModified())
+            mCurrent = getModified();
+    }
+    template<typename T>
+    void DynamicStat<T>::modify (const T& diff, bool allowCurrentDecreaseBelowZero)
+    {
+        mStatic.modify (diff);
+        setCurrent (getCurrent()+diff, allowCurrentDecreaseBelowZero);
+    }
+    template<typename T>
+    void DynamicStat<T>::setCurrent (const T& value, bool allowDecreaseBelowZero)
+    {
+        if (value > mCurrent)
+        {
+            // increase
+            mCurrent = value;
+
+            if (mCurrent > getModified())
+                mCurrent = getModified();
+        }
+        else if (value > 0 || allowDecreaseBelowZero)
+        {
+            // allowed decrease
+            mCurrent = value;
+        }
+        else if (mCurrent > 0)
+        {
+            // capped decrease
+            mCurrent = 0;
+        }
+    }
+    template<typename T>
+    void DynamicStat<T>::setModifier (const T& modifier, bool allowCurrentDecreaseBelowZero)
+    {
+        T diff =  modifier - mStatic.getModifier();
+        mStatic.setModifier (modifier);
+        setCurrent (getCurrent()+diff, allowCurrentDecreaseBelowZero);
+    }
+
+    template<typename T>
+    void DynamicStat<T>::writeState (ESM::StatState<T>& state) const
+    {
+        mStatic.writeState (state);
+        state.mCurrent = mCurrent;
+    }
+    template<typename T>
+    void DynamicStat<T>::readState (const ESM::StatState<T>& state)
+    {
+        mStatic.readState (state);
+        mCurrent = state.mCurrent;
+    }
+
+    AttributeValue::AttributeValue() :
+        mBase(0), mModifier(0), mDamage(0)
+    {
+    }
+
+    int AttributeValue::getModified() const
+    {
+        return std::max(0, mBase - (int) mDamage + mModifier);
+    }
+    int AttributeValue::getBase() const
+    {
+        return mBase;
+    }
+    int AttributeValue::getModifier() const
+    {
+        return mModifier;
+    }
+
+    void AttributeValue::setBase(int base)
+    {
+        mBase = std::max(0, base);
+    }
+
+    void AttributeValue::setModifier(int mod)
+    {
+        mModifier = mod;
+    }
+
+    void AttributeValue::damage(float damage)
+    {
+        mDamage += std::min(damage, (float)getModified());
+    }
+    void AttributeValue::restore(float amount)
+    {
+        mDamage -= std::min(mDamage, amount);
+    }
+
+    float AttributeValue::getDamage() const
+    {
+        return mDamage;
+    }
+
+    void AttributeValue::writeState (ESM::StatState<int>& state) const
+    {
+        state.mBase = mBase;
+        state.mMod = mModifier;
+        state.mDamage = mDamage;
+    }
+
+    void AttributeValue::readState (const ESM::StatState<int>& state)
+    {
+        mBase = state.mBase;
+        mModifier = state.mMod;
+        mDamage = state.mDamage;
+    }
+
+    SkillValue::SkillValue() :
+        mProgress(0)
+    {
+    }
+
+    float SkillValue::getProgress() const
+    {
+        return mProgress;
+    }
+    void SkillValue::setProgress(float progress)
+    {
+        mProgress = progress;
+    }
+
+    void SkillValue::writeState (ESM::StatState<int>& state) const
+    {
+        AttributeValue::writeState (state);
+        state.mProgress = mProgress;
+    }
+
+    void SkillValue::readState (const ESM::StatState<int>& state)
+    {
+        AttributeValue::readState (state);
+        mProgress = state.mProgress;
+    }
 }
 
-void MWMechanics::AttributeValue::readState (const ESM::StatState<int>& state)
-{
-    mBase = state.mBase;
-    mModifier = state.mMod;
-    mDamage = state.mDamage;
-}
-
-void MWMechanics::SkillValue::writeState (ESM::StatState<int>& state) const
-{
-    AttributeValue::writeState (state);
-    state.mProgress = mProgress;
-}
-
-void MWMechanics::SkillValue::readState (const ESM::StatState<int>& state)
-{
-    AttributeValue::readState (state);
-    mProgress = state.mProgress;
-}
+template class MWMechanics::Stat<int>;
+template class MWMechanics::Stat<float>;
+template class MWMechanics::DynamicStat<int>;
+template class MWMechanics::DynamicStat<float>;

--- a/apps/openmw/mwmechanics/stat.hpp
+++ b/apps/openmw/mwmechanics/stat.hpp
@@ -1,6 +1,7 @@
 #ifndef GAME_MWMECHANICS_STAT_H
 #define GAME_MWMECHANICS_STAT_H
 
+#include <algorithm>
 #include <limits>
 
 #include <components/esm/statstate.hpp>

--- a/apps/openmw/mwmechanics/stat.hpp
+++ b/apps/openmw/mwmechanics/stat.hpp
@@ -4,7 +4,11 @@
 #include <algorithm>
 #include <limits>
 
-#include <components/esm/statstate.hpp>
+namespace ESM
+{
+    template<typename T>
+    struct StatState;
+}
 
 namespace MWMechanics
 {
@@ -17,87 +21,28 @@ namespace MWMechanics
         public:
             typedef T Type;
 
-            Stat() : mBase (0), mModified (0) {}
-            Stat(T base) : mBase (base), mModified (base) {}
-            Stat(T base, T modified) : mBase (base), mModified (modified) {}
+            Stat();
+            Stat(T base);
+            Stat(T base, T modified);
 
-            const T& getBase() const
-            {
-                return mBase;
-            }
+            const T& getBase() const;
 
-            T getModified() const
-            {
-                return std::max(static_cast<T>(0), mModified);
-            }
-
-            T getModifier() const
-            {
-                return mModified-mBase;
-            }
+            T getModified() const;
+            T getModifier() const;
 
             /// Set base and modified to \a value.
-            void set (const T& value)
-            {
-                mBase = mModified = value;
-            }
-
-            void modify(const T& diff)
-            {
-                mBase += diff;
-                if(mBase >= static_cast<T>(0))
-                    mModified += diff;
-                else
-                {
-                    mModified += diff - mBase;
-                    mBase = static_cast<T>(0);
-                }
-            }
+            void set (const T& value);
+            void modify(const T& diff);
 
             /// Set base and adjust modified accordingly.
-            void setBase (const T& value)
-            {
-                T diff = value - mBase;
-                mBase = value;
-                mModified += diff;
-            }
+            void setBase (const T& value);
 
             /// Set modified value an adjust base accordingly.
-            void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max())
-            {
-                T diff = value - mModified;
+            void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max());
+            void setModifier (const T& modifier);
 
-                if (mBase+diff<min)
-                {
-                    value = min + (mModified - mBase);
-                    diff = value - mModified;
-                }
-                else if (mBase+diff>max)
-                {
-                    value = max + (mModified - mBase);
-                    diff = value - mModified;
-                }
-
-                mModified = value;
-                mBase += diff;
-            }
-
-            void setModifier (const T& modifier)
-            {
-                mModified = mBase + modifier;
-            }
-
-            void writeState (ESM::StatState<T>& state) const
-            {
-                state.mBase = mBase;
-                state.mMod = mModified;
-            }
-
-            void readState (const ESM::StatState<T>& state)
-            {
-                mBase = state.mBase;
-                mModified = state.mMod;
-            }
+            void writeState (ESM::StatState<T>& state) const;
+            void readState (const ESM::StatState<T>& state);
     };
 
     template<typename T>
@@ -122,98 +67,32 @@ namespace MWMechanics
         public:
             typedef T Type;
 
-            DynamicStat() : mStatic (0), mCurrent (0) {}
-            DynamicStat(T base) : mStatic (base), mCurrent (base) {}
-            DynamicStat(T base, T modified, T current) : mStatic(base, modified), mCurrent (current) {}
-            DynamicStat(const Stat<T> &stat, T current) : mStatic(stat), mCurrent (current) {}
+            DynamicStat();
+            DynamicStat(T base);
+            DynamicStat(T base, T modified, T current);
+            DynamicStat(const Stat<T> &stat, T current);
 
-            const T& getBase() const
-            {
-                return mStatic.getBase();
-            }
-
-            T getModified() const
-            {
-                return mStatic.getModified();
-            }
-
-            const T& getCurrent() const
-            {
-                return mCurrent;
-            }
+            const T& getBase() const;
+            T getModified() const;
+            const T& getCurrent() const;
 
             /// Set base, modified and current to \a value.
-            void set (const T& value)
-            {
-                mStatic.set (value);
-                mCurrent = value;
-            }
+            void set (const T& value);
 
             /// Set base and adjust modified accordingly.
-            void setBase (const T& value)
-            {
-                mStatic.setBase (value);
-
-                if (mCurrent>getModified())
-                    mCurrent = getModified();
-            }
+            void setBase (const T& value);
 
             /// Set modified value an adjust base accordingly.
-            void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max())
-            {
-                mStatic.setModified (value, min, max);
-
-                if (mCurrent>getModified())
-                    mCurrent = getModified();
-            }
+            void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max());
 
             /// Change modified relatively.
-            void modify (const T& diff, bool allowCurrentDecreaseBelowZero=false)
-            {
-                mStatic.modify (diff);
-                setCurrent (getCurrent()+diff, allowCurrentDecreaseBelowZero);
-            }
+            void modify (const T& diff, bool allowCurrentDecreaseBelowZero=false);
 
-            void setCurrent (const T& value, bool allowDecreaseBelowZero = false)
-            {
-                if (value > mCurrent)
-                {
-                    // increase
-                    mCurrent = value;
+            void setCurrent (const T& value, bool allowDecreaseBelowZero = false);
+            void setModifier (const T& modifier, bool allowCurrentDecreaseBelowZero=false);
 
-                    if (mCurrent > getModified())
-                        mCurrent = getModified();
-                }
-                else if (value > 0 || allowDecreaseBelowZero)
-                {
-                    // allowed decrease
-                    mCurrent = value;
-                }
-                else if (mCurrent > 0)
-                {
-                    // capped decrease
-                    mCurrent = 0;
-                }
-            }
-
-            void setModifier (const T& modifier, bool allowCurrentDecreaseBelowZero=false)
-            {
-                T diff =  modifier - mStatic.getModifier();
-                mStatic.setModifier (modifier);
-                setCurrent (getCurrent()+diff, allowCurrentDecreaseBelowZero);
-            }
-
-            void writeState (ESM::StatState<T>& state) const
-            {
-                mStatic.writeState (state);
-                state.mCurrent = mCurrent;
-            }
-
-            void readState (const ESM::StatState<T>& state)
-            {
-                mStatic.readState (state);
-                mCurrent = state.mCurrent;
-            }
+            void writeState (ESM::StatState<T>& state) const;
+            void readState (const ESM::StatState<T>& state);
     };
 
     template<typename T>
@@ -237,26 +116,25 @@ namespace MWMechanics
         float mDamage; // needs to be float to allow continuous damage
 
     public:
-        AttributeValue() : mBase(0), mModifier(0), mDamage(0) {}
+        AttributeValue();
 
-        int getModified() const { return std::max(0, mBase - (int) mDamage + mModifier); }
-        int getBase() const { return mBase; }
-        int getModifier() const {  return mModifier; }
+        int getModified() const;
+        int getBase() const;
+        int getModifier() const;
 
-        void setBase(int base) { mBase = std::max(0, base); }
+        void setBase(int base);
 
-        void setModifier(int mod) { mModifier = mod; }
+        void setModifier(int mod);
 
         // Maximum attribute damage is limited to the modified value.
         // Note: I think MW applies damage directly to mModified, since you can also
         // "restore" drained attributes. We need to rewrite the magic effect system to support this.
-        void damage(float damage) { mDamage += std::min(damage, (float)getModified()); }
-        void restore(float amount) { mDamage -= std::min(mDamage, amount); }
+        void damage(float damage);
+        void restore(float amount);
 
-        float getDamage() const { return mDamage; }
+        float getDamage() const;
 
         void writeState (ESM::StatState<int>& state) const;
-
         void readState (const ESM::StatState<int>& state);
     };
 
@@ -264,12 +142,11 @@ namespace MWMechanics
     {
         float mProgress;
     public:
-        SkillValue() : mProgress(0) {}
-        float getProgress() const { return mProgress; }
-        void setProgress(float progress) { mProgress = progress; }
+        SkillValue();
+        float getProgress() const;
+        void setProgress(float progress);
 
         void writeState (ESM::StatState<int>& state) const;
-
         void readState (const ESM::StatState<int>& state);
     };
 

--- a/apps/openmw/mwscript/globalscripts.cpp
+++ b/apps/openmw/mwscript/globalscripts.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include <components/misc/stringops.hpp>
+#include <components/esm/esmwriter.hpp>
 #include <components/esm/globalscript.hpp>
 
 #include "../mwworld/esmstore.hpp"

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -6,6 +6,8 @@
 #include <components/esm/cellid.hpp>
 #include <components/esm/loadcell.hpp>
 
+#include <components/loadinglistener/loadinglistener.hpp>
+
 #include <components/misc/stringops.hpp>
 
 #include <components/settings/settings.hpp>

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -4,6 +4,7 @@
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/defs.hpp>
 #include <components/esm/cellstate.hpp>
+#include <components/loadinglistener/loadinglistener.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -5,6 +5,7 @@
 
 #include <components/esm/cellstate.hpp>
 #include <components/esm/cellid.hpp>
+#include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/objectstate.hpp>
 #include <components/esm/containerstate.hpp>

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -8,6 +8,7 @@
 #include <components/loadinglistener/loadinglistener.hpp>
 
 #include <components/esm/esmreader.hpp>
+#include <components/esm/esmwriter.hpp>
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENMW_MWWORLD_ESMSTORE_H
 #define OPENMW_MWWORLD_ESMSTORE_H
 
+#include <sstream>
 #include <stdexcept>
 
 #include <components/esm/records.hpp>

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -6,6 +6,7 @@
 
 #include <components/esm/loadench.hpp>
 #include <components/esm/inventorystate.hpp>
+#include <components/misc/rng.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -2,6 +2,7 @@
 
 #include <osg/PositionAttitudeTransform>
 
+#include <components/esm/esmwriter.hpp>
 #include <components/esm/projectilestate.hpp>
 #include <components/resource/resourcesystem.hpp>
 #include <components/resource/scenemanager.hpp>

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -3,6 +3,7 @@
 #include <limits>
 
 #include <components/nif/niffile.hpp>
+#include <components/loadinglistener/loadinglistener.hpp>
 #include <components/misc/resourcehelpers.hpp>
 #include <components/settings/settings.hpp>
 #include <components/resource/resourcesystem.hpp>

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -2,126 +2,1105 @@
 #include "esmstore.hpp"
 
 #include <components/esm/esmreader.hpp>
+#include <components/esm/esmwriter.hpp>
 
-namespace MWWorld {
+#include <components/loadinglistener/loadinglistener.hpp>
+#include <components/misc/rng.hpp>
 
-void Store<ESM::Cell>::handleMovedCellRefs(ESM::ESMReader& esm, ESM::Cell* cell)
+#include <stdexcept>
+#include <sstream>
+
+namespace
 {
-    //Handling MovedCellRefs, there is no way to do it inside loadcell
-    while (esm.isNextSub("MVRF")) {
-        ESM::CellRef ref;
-        ESM::MovedCellRef cMRef;
-        cell->getNextMVRF(esm, cMRef);
-
-        ESM::Cell *cellAlt = const_cast<ESM::Cell*>(searchOrCreate(cMRef.mTarget[0], cMRef.mTarget[1]));
-
-        // Get regular moved reference data. Adapted from CellStore::loadRefs. Maybe we can optimize the following
-        //  implementation when the oher implementation works as well.
-        bool deleted = false;
-        cell->getNextRef(esm, ref, deleted);
-
-        // Add data required to make reference appear in the correct cell.
-        // We should not need to test for duplicates, as this part of the code is pre-cell merge.
-        cell->mMovedRefs.push_back(cMRef);
-        // But there may be duplicates here!
-        if (!deleted)
-        {
-            ESM::CellRefTracker::iterator iter = std::find(cellAlt->mLeasedRefs.begin(), cellAlt->mLeasedRefs.end(), ref.mRefNum);
-            if (iter == cellAlt->mLeasedRefs.end())
-              cellAlt->mLeasedRefs.push_back(ref);
-            else
-              *iter = ref;
-        }
-    }
-}
-
-void Store<ESM::Cell>::load(ESM::ESMReader &esm, const std::string &id)
-{
-    // Don't automatically assume that a new cell must be spawned. Multiple plugins write to the same cell,
-    //  and we merge all this data into one Cell object. However, we can't simply search for the cell id,
-    //  as many exterior cells do not have a name. Instead, we need to search by (x,y) coordinates - and they
-    //  are not available until both cells have been loaded at least partially!
-
-    // All cells have a name record, even nameless exterior cells.
-    std::string idLower = Misc::StringUtils::lowerCase(id);
-    ESM::Cell cell;
-    cell.mName = id;
-
-    // Load the (x,y) coordinates of the cell, if it is an exterior cell,
-    // so we can find the cell we need to merge with
-    cell.loadData(esm);
-
-    if(cell.mData.mFlags & ESM::Cell::Interior)
+    template<typename T>
+    class GetRecords
     {
-        // Store interior cell by name, try to merge with existing parent data.
-        ESM::Cell *oldcell = const_cast<ESM::Cell*>(search(idLower));
-        if (oldcell) {
-            // merge new cell into old cell
-            // push the new references on the list of references to manage (saveContext = true)
-            oldcell->mData = cell.mData;
-            oldcell->mName = cell.mName; // merge name just to be sure (ID will be the same, but case could have been changed)
-            oldcell->loadCell(esm, true);
-        } else
+        const std::string mFind;
+        std::vector<const T*> *mRecords;
+
+    public:
+        GetRecords(const std::string &str, std::vector<const T*> *records)
+          : mFind(Misc::StringUtils::lowerCase(str)), mRecords(records)
+        { }
+
+        void operator()(const T *item)
         {
-            // spawn a new cell
-            cell.loadCell(esm, true);
-
-            mInt[idLower] = cell;
+            if(Misc::StringUtils::ciCompareLen(mFind, item->mId, mFind.size()) == 0)
+                mRecords->push_back(item);
         }
-    }
-    else
+    };
+
+    struct Compare
     {
-        // Store exterior cells by grid position, try to merge with existing parent data.
-        ESM::Cell *oldcell = const_cast<ESM::Cell*>(search(cell.getGridX(), cell.getGridY()));
-        if (oldcell) {
-            // merge new cell into old cell
-            oldcell->mData = cell.mData;
-            oldcell->mName = cell.mName;
-            oldcell->loadCell(esm, false);
-
-            // handle moved ref (MVRF) subrecords
-            handleMovedCellRefs (esm, &cell);
-
-            // push the new references on the list of references to manage
-            oldcell->postLoad(esm);
-
-            // merge lists of leased references, use newer data in case of conflict
-            for (ESM::MovedCellRefTracker::const_iterator it = cell.mMovedRefs.begin(); it != cell.mMovedRefs.end(); ++it) {
-                // remove reference from current leased ref tracker and add it to new cell
-                ESM::MovedCellRefTracker::iterator itold = std::find(oldcell->mMovedRefs.begin(), oldcell->mMovedRefs.end(), it->mRefNum);
-                if (itold != oldcell->mMovedRefs.end()) {
-                    ESM::MovedCellRef target0 = *itold;
-                    ESM::Cell *wipecell = const_cast<ESM::Cell*>(search(target0.mTarget[0], target0.mTarget[1]));
-                    ESM::CellRefTracker::iterator it_lease = std::find(wipecell->mLeasedRefs.begin(), wipecell->mLeasedRefs.end(), it->mRefNum);
-                    wipecell->mLeasedRefs.erase(it_lease);
-                    *itold = *it;
-                }
-                else
-                    oldcell->mMovedRefs.push_back(*it);
+        bool operator()(const ESM::Land *x, const ESM::Land *y) {
+            if (x->mX == y->mX) {
+                return x->mY < y->mY;
             }
-
-            // We don't need to merge mLeasedRefs of cell / oldcell. This list is filled when another cell moves a
-            // reference to this cell, so the list for the new cell should be empty. The list for oldcell,
-            // however, could have leased refs in it and so should be kept.
-        } else
-        {
-            // spawn a new cell
-            cell.loadCell(esm, false);
-
-            // handle moved ref (MVRF) subrecords
-            handleMovedCellRefs (esm, &cell);
-
-            // push the new references on the list of references to manage
-            cell.postLoad(esm);
-
-            mExt[std::make_pair(cell.mData.mX, cell.mData.mY)] = cell;
+            return x->mX < y->mX;
         }
+    };
+}
+
+namespace MWWorld
+{
+    template<typename T> 
+    IndexedStore<T>::IndexedStore()
+    {
+    }
+    template<typename T>        
+    typename IndexedStore<T>::iterator IndexedStore<T>::begin() const
+    {
+        return mStatic.begin();
+    }
+    template<typename T>    
+    typename IndexedStore<T>::iterator IndexedStore<T>::end() const
+    {
+        return mStatic.end();
+    }
+    template<typename T>
+    void IndexedStore<T>::load(ESM::ESMReader &esm)
+    {
+        T record;
+        record.load(esm);
+
+        // Try to overwrite existing record
+        std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(record.mIndex, record));
+        if (!ret.second)
+            ret.first->second = record;
+    }
+    template<typename T>
+    int IndexedStore<T>::getSize() const
+    {
+        return mStatic.size();
+    }
+    template<typename T>
+    void IndexedStore<T>::setUp()
+    {
+    }
+    template<typename T>
+    const T *IndexedStore<T>::search(int index) const
+    {
+        typename Static::const_iterator it = mStatic.find(index);
+        if (it != mStatic.end())
+            return &(it->second);
+        return NULL;
+    }
+    template<typename T>
+    const T *IndexedStore<T>::find(int index) const
+    {
+        const T *ptr = search(index);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << T::getRecordType() << " with index " << index << " not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+
+    // Need to instantiate these before they're used
+    template class IndexedStore<ESM::MagicEffect>;
+    template class IndexedStore<ESM::Skill>;
+
+    template<typename T>
+    Store<T>::Store()
+    {
+    }
+
+    template<typename T>
+    Store<T>::Store(const Store<T>& orig)
+        : mStatic(orig.mStatic)
+    {
+    }
+
+    template<typename T>
+    void Store<T>::clearDynamic()
+    {
+        // remove the dynamic part of mShared
+        assert(mShared.size() >= mStatic.size());
+        mShared.erase(mShared.begin() + mStatic.size(), mShared.end());
+        mDynamic.clear();
+    }
+
+    template<typename T>
+    const T *Store<T>::search(const std::string &id) const
+    {
+        T item;
+        item.mId = Misc::StringUtils::lowerCase(id);
+
+        typename Dynamic::const_iterator dit = mDynamic.find(item.mId);
+        if (dit != mDynamic.end()) {
+            return &dit->second;
+        }
+
+        typename std::map<std::string, T>::const_iterator it = mStatic.find(item.mId);
+
+        if (it != mStatic.end() && Misc::StringUtils::ciEqual(it->second.mId, id)) {
+            return &(it->second);
+        }
+
+        return 0;
+    }
+    template<typename T>
+    bool Store<T>::isDynamic(const std::string &id) const
+    {
+        typename Dynamic::const_iterator dit = mDynamic.find(id);
+        return (dit != mDynamic.end());
+    }
+    template<typename T>
+    const T *Store<T>::searchRandom(const std::string &id) const
+    {
+        std::vector<const T*> results;
+        std::for_each(mShared.begin(), mShared.end(), GetRecords<T>(id, &results));
+        if(!results.empty())
+            return results[Misc::Rng::rollDice(results.size())];
+        return NULL;
+    }
+    template<typename T>
+    const T *Store<T>::find(const std::string &id) const
+    {
+        const T *ptr = search(id);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << T::getRecordType() << " '" << id << "' not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    template<typename T>
+    const T *Store<T>::findRandom(const std::string &id) const
+    {
+        const T *ptr = searchRandom(id);
+        if(ptr == 0)
+        {
+            std::ostringstream msg;
+            msg << T::getRecordType() << " starting with '"<<id<<"' not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    template<typename T>
+    void Store<T>::load(ESM::ESMReader &esm, const std::string &id) 
+    {
+        std::string idLower = Misc::StringUtils::lowerCase(id);
+
+        std::pair<typename Static::iterator, bool> inserted = mStatic.insert(std::make_pair(idLower, T()));
+        if (inserted.second)
+            mShared.push_back(&inserted.first->second);
+
+        inserted.first->second.mId = idLower;
+        inserted.first->second.load(esm);
+    }
+    template<typename T>
+    void Store<T>::setUp()
+    {
+    }
+
+    template<typename T>
+    typename Store<T>::iterator Store<T>::begin() const
+    {
+        return mShared.begin(); 
+    }
+    template<typename T>
+    typename Store<T>::iterator Store<T>::end() const
+    {
+        return mShared.end();
+    }
+
+    template<typename T>
+    size_t Store<T>::getSize() const
+    {
+        return mShared.size();
+    }
+
+    template<typename T>
+    int Store<T>::getDynamicSize() const
+    {
+        return mDynamic.size();
+    }
+    template<typename T>
+    void Store<T>::listIdentifier(std::vector<std::string> &list) const
+    {
+        list.reserve(list.size() + getSize());
+        typename std::vector<T *>::const_iterator it = mShared.begin();
+        for (; it != mShared.end(); ++it) {
+            list.push_back((*it)->mId);
+        }
+    }
+    template<typename T>
+    T *Store<T>::insert(const T &item)
+    {
+        std::string id = Misc::StringUtils::lowerCase(item.mId);
+        std::pair<typename Dynamic::iterator, bool> result =
+            mDynamic.insert(std::pair<std::string, T>(id, item));
+        T *ptr = &result.first->second;
+        if (result.second) {
+            mShared.push_back(ptr);
+        } else {
+            *ptr = item;
+        }
+        return ptr;
+    }
+    template<typename T>
+    T *Store<T>::insertStatic(const T &item)
+    {
+        std::string id = Misc::StringUtils::lowerCase(item.mId);
+        std::pair<typename Static::iterator, bool> result =
+            mStatic.insert(std::pair<std::string, T>(id, item));
+        T *ptr = &result.first->second;
+        if (result.second) {
+            mShared.push_back(ptr);
+        } else {
+            *ptr = item;
+        }
+        return ptr;
+    }
+    template<typename T>
+    bool Store<T>::eraseStatic(const std::string &id)
+    {
+        T item;
+        item.mId = Misc::StringUtils::lowerCase(id);
+
+        typename std::map<std::string, T>::iterator it = mStatic.find(item.mId);
+
+        if (it != mStatic.end() && Misc::StringUtils::ciEqual(it->second.mId, id)) {
+            // delete from the static part of mShared
+            typename std::vector<T *>::iterator sharedIter = mShared.begin();
+            typename std::vector<T *>::iterator end = sharedIter + mStatic.size();
+
+            while (sharedIter != mShared.end() && sharedIter != end) {
+                if((*sharedIter)->mId == item.mId) {
+                    mShared.erase(sharedIter);
+                    break;
+                }
+                ++sharedIter;
+            }
+            mStatic.erase(it);
+        }
+
+        return true;
+    }
+
+    template<typename T>
+    bool Store<T>::erase(const std::string &id)
+    {
+        std::string key = Misc::StringUtils::lowerCase(id);
+        typename Dynamic::iterator it = mDynamic.find(key);
+        if (it == mDynamic.end()) {
+            return false;
+        }
+        mDynamic.erase(it);
+
+        // have to reinit the whole shared part
+        assert(mShared.size() >= mStatic.size());
+        mShared.erase(mShared.begin() + mStatic.size(), mShared.end());
+        for (it = mDynamic.begin(); it != mDynamic.end(); ++it) {
+            mShared.push_back(&it->second);
+        }
+        return true;
+    }
+    template<typename T>
+    bool Store<T>::erase(const T &item)
+    {
+        return erase(item.mId);
+    }
+    template<typename T>
+    void Store<T>::write (ESM::ESMWriter& writer, Loading::Listener& progress) const
+    {
+        for (typename Dynamic::const_iterator iter (mDynamic.begin()); iter!=mDynamic.end();
+             ++iter)
+        {
+            writer.startRecord (T::sRecordId);
+            writer.writeHNString ("NAME", iter->second.mId);
+            iter->second.save (writer);
+            writer.endRecord (T::sRecordId);
+        }
+    }
+    template<typename T>
+    void Store<T>::read(ESM::ESMReader& reader, const std::string& id)
+    {
+        T record;
+        record.mId = id;
+        record.load (reader);
+        insert (record);
+    }
+
+
+    // LandTexture
+    //=========================================================================
+    Store<ESM::LandTexture>::Store()
+    {
+        mStatic.push_back(LandTextureList());
+        LandTextureList &ltexl = mStatic[0];
+        // More than enough to hold Morrowind.esm. Extra lists for plugins will we
+        //  added on-the-fly in a different method.
+        ltexl.reserve(128);
+    }
+    const ESM::LandTexture *Store<ESM::LandTexture>::search(size_t index, size_t plugin) const
+    {
+        assert(plugin < mStatic.size());
+        const LandTextureList &ltexl = mStatic[plugin];
+
+        assert(index < ltexl.size());
+        return &ltexl.at(index);
+    }
+    const ESM::LandTexture *Store<ESM::LandTexture>::find(size_t index, size_t plugin) const
+    {
+        const ESM::LandTexture *ptr = search(index, plugin);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << "Land texture with index " << index << " not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    size_t Store<ESM::LandTexture>::getSize() const
+    {
+        return mStatic.size();
+    }
+    size_t Store<ESM::LandTexture>::getSize(size_t plugin) const
+    {
+        assert(plugin < mStatic.size());
+        return mStatic[plugin].size();
+    }
+    void Store<ESM::LandTexture>::load(ESM::ESMReader &esm, const std::string &id, size_t plugin)
+    {
+        ESM::LandTexture lt;
+        lt.load(esm);
+        lt.mId = id;
+
+        // Make sure we have room for the structure
+        if (plugin >= mStatic.size()) {
+            mStatic.resize(plugin+1);
+        }
+        LandTextureList &ltexl = mStatic[plugin];
+        if(lt.mIndex + 1 > (int)ltexl.size())
+            ltexl.resize(lt.mIndex+1);
+
+        // Store it
+        ltexl[lt.mIndex] = lt;
+    }
+    void Store<ESM::LandTexture>::load(ESM::ESMReader &esm, const std::string &id)
+    {
+        load(esm, id, esm.getIndex());
+    }
+    Store<ESM::LandTexture>::iterator Store<ESM::LandTexture>::begin(size_t plugin) const
+    {
+        assert(plugin < mStatic.size());
+        return mStatic[plugin].begin();
+    }
+    Store<ESM::LandTexture>::iterator Store<ESM::LandTexture>::end(size_t plugin) const
+    {
+        assert(plugin < mStatic.size());
+        return mStatic[plugin].end();
+    }
+
+    
+    // Land
+    //=========================================================================
+    Store<ESM::Land>::~Store()
+    {
+        for (std::vector<ESM::Land *>::const_iterator it =
+                         mStatic.begin(); it != mStatic.end(); ++it)
+        {
+            delete *it;
+        }
+
+    }
+    size_t Store<ESM::Land>::getSize() const
+    {
+        return mStatic.size();
+    }
+    Store<ESM::Land>::iterator Store<ESM::Land>::begin() const
+    {
+        return iterator(mStatic.begin());
+    }
+    Store<ESM::Land>::iterator Store<ESM::Land>::end() const
+    {
+        return iterator(mStatic.end());
+    }
+    ESM::Land *Store<ESM::Land>::search(int x, int y) const
+    {
+        ESM::Land land;
+        land.mX = x, land.mY = y;
+
+        std::vector<ESM::Land *>::const_iterator it =
+            std::lower_bound(mStatic.begin(), mStatic.end(), &land, Compare());
+
+        if (it != mStatic.end() && (*it)->mX == x && (*it)->mY == y) {
+            return const_cast<ESM::Land *>(*it);
+        }
+        return 0;
+    }
+    ESM::Land *Store<ESM::Land>::find(int x, int y) const
+    {
+        ESM::Land *ptr = search(x, y);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << "Land at (" << x << ", " << y << ") not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    void Store<ESM::Land>::load(ESM::ESMReader &esm, const std::string &id)
+    {
+        ESM::Land *ptr = new ESM::Land();
+        ptr->load(esm);
+
+        // Same area defined in multiple plugins? -> last plugin wins
+        // Can't use search() because we aren't sorted yet - is there any other way to speed this up?
+        for (std::vector<ESM::Land*>::iterator it = mStatic.begin(); it != mStatic.end(); ++it)
+        {
+            if ((*it)->mX == ptr->mX && (*it)->mY == ptr->mY)
+            {
+                delete *it;
+                mStatic.erase(it);
+                break;
+            }
+        }
+
+        mStatic.push_back(ptr);
+    }
+    void Store<ESM::Land>::setUp()
+    {
+        std::sort(mStatic.begin(), mStatic.end(), Compare());
+    }
+
+
+    // Cell
+    //=========================================================================
+
+    const ESM::Cell *Store<ESM::Cell>::search(const ESM::Cell &cell) const
+    {
+        if (cell.isExterior()) {
+            return search(cell.getGridX(), cell.getGridY());
+        }
+        return search(cell.mName);
+    }
+    void Store<ESM::Cell>::handleMovedCellRefs(ESM::ESMReader& esm, ESM::Cell* cell)
+    {
+        //Handling MovedCellRefs, there is no way to do it inside loadcell
+        while (esm.isNextSub("MVRF")) {
+            ESM::CellRef ref;
+            ESM::MovedCellRef cMRef;
+            cell->getNextMVRF(esm, cMRef);
+
+            ESM::Cell *cellAlt = const_cast<ESM::Cell*>(searchOrCreate(cMRef.mTarget[0], cMRef.mTarget[1]));
+
+            // Get regular moved reference data. Adapted from CellStore::loadRefs. Maybe we can optimize the following
+            //  implementation when the oher implementation works as well.
+            bool deleted = false;
+            cell->getNextRef(esm, ref, deleted);
+
+            // Add data required to make reference appear in the correct cell.
+            // We should not need to test for duplicates, as this part of the code is pre-cell merge.
+            cell->mMovedRefs.push_back(cMRef);
+            // But there may be duplicates here!
+            if (!deleted)
+            {
+                ESM::CellRefTracker::iterator iter = std::find(cellAlt->mLeasedRefs.begin(), cellAlt->mLeasedRefs.end(), ref.mRefNum);
+                if (iter == cellAlt->mLeasedRefs.end())
+                  cellAlt->mLeasedRefs.push_back(ref);
+                else
+                  *iter = ref;
+            }
+        }
+    }
+    const ESM::Cell *Store<ESM::Cell>::search(const std::string &id) const
+    {
+        ESM::Cell cell;
+        cell.mName = Misc::StringUtils::lowerCase(id);
+
+        std::map<std::string, ESM::Cell>::const_iterator it = mInt.find(cell.mName);
+
+        if (it != mInt.end() && Misc::StringUtils::ciEqual(it->second.mName, id)) {
+            return &(it->second);
+        }
+
+        DynamicInt::const_iterator dit = mDynamicInt.find(cell.mName);
+        if (dit != mDynamicInt.end()) {
+            return &dit->second;
+        }
+
+        return 0;
+    }
+    const ESM::Cell *Store<ESM::Cell>::search(int x, int y) const
+    {
+        ESM::Cell cell;
+        cell.mData.mX = x, cell.mData.mY = y;
+
+        std::pair<int, int> key(x, y);
+        DynamicExt::const_iterator it = mExt.find(key);
+        if (it != mExt.end()) {
+            return &(it->second);
+        }
+
+        DynamicExt::const_iterator dit = mDynamicExt.find(key);
+        if (dit != mDynamicExt.end()) {
+            return &dit->second;
+        }
+
+        return 0;
+    }
+    const ESM::Cell *Store<ESM::Cell>::searchOrCreate(int x, int y)
+    {
+        std::pair<int, int> key(x, y);
+        DynamicExt::const_iterator it = mExt.find(key);
+        if (it != mExt.end()) {
+            return &(it->second);
+        }
+
+        DynamicExt::const_iterator dit = mDynamicExt.find(key);
+        if (dit != mDynamicExt.end()) {
+            return &dit->second;
+        }
+
+        ESM::Cell newCell;
+        newCell.mData.mX = x;
+        newCell.mData.mY = y;
+        newCell.mData.mFlags = ESM::Cell::HasWater;
+        newCell.mAmbi.mAmbient = 0;
+        newCell.mAmbi.mSunlight = 0;
+        newCell.mAmbi.mFog = 0;
+        newCell.mAmbi.mFogDensity = 0;
+        return &mExt.insert(std::make_pair(key, newCell)).first->second;
+    }
+    const ESM::Cell *Store<ESM::Cell>::find(const std::string &id) const
+    {
+        const ESM::Cell *ptr = search(id);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << "Interior cell '" << id << "' not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    const ESM::Cell *Store<ESM::Cell>::find(int x, int y) const
+    {
+        const ESM::Cell *ptr = search(x, y);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << "Exterior at (" << x << ", " << y << ") not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    void Store<ESM::Cell>::setUp()
+    {
+        typedef DynamicExt::iterator ExtIterator;
+        typedef std::map<std::string, ESM::Cell>::iterator IntIterator;
+
+        mSharedInt.clear();
+        mSharedInt.reserve(mInt.size());
+        for (IntIterator it = mInt.begin(); it != mInt.end(); ++it) {
+            mSharedInt.push_back(&(it->second));
+        }
+
+        mSharedExt.clear();
+        mSharedExt.reserve(mExt.size());
+        for (ExtIterator it = mExt.begin(); it != mExt.end(); ++it) {
+            mSharedExt.push_back(&(it->second));
+        }
+    }
+    void Store<ESM::Cell>::load(ESM::ESMReader &esm, const std::string &id)
+    {
+        // Don't automatically assume that a new cell must be spawned. Multiple plugins write to the same cell,
+        //  and we merge all this data into one Cell object. However, we can't simply search for the cell id,
+        //  as many exterior cells do not have a name. Instead, we need to search by (x,y) coordinates - and they
+        //  are not available until both cells have been loaded at least partially!
+
+        // All cells have a name record, even nameless exterior cells.
+        std::string idLower = Misc::StringUtils::lowerCase(id);
+        ESM::Cell cell;
+        cell.mName = id;
+
+        // Load the (x,y) coordinates of the cell, if it is an exterior cell,
+        // so we can find the cell we need to merge with
+        cell.loadData(esm);
+
+        if(cell.mData.mFlags & ESM::Cell::Interior)
+        {
+            // Store interior cell by name, try to merge with existing parent data.
+            ESM::Cell *oldcell = const_cast<ESM::Cell*>(search(idLower));
+            if (oldcell) {
+                // merge new cell into old cell
+                // push the new references on the list of references to manage (saveContext = true)
+                oldcell->mData = cell.mData;
+                oldcell->mName = cell.mName; // merge name just to be sure (ID will be the same, but case could have been changed)
+                oldcell->loadCell(esm, true);
+            } else
+            {
+                // spawn a new cell
+                cell.loadCell(esm, true);
+
+                mInt[idLower] = cell;
+            }
+        }
+        else
+        {
+            // Store exterior cells by grid position, try to merge with existing parent data.
+            ESM::Cell *oldcell = const_cast<ESM::Cell*>(search(cell.getGridX(), cell.getGridY()));
+            if (oldcell) {
+                // merge new cell into old cell
+                oldcell->mData = cell.mData;
+                oldcell->mName = cell.mName;
+                oldcell->loadCell(esm, false);
+
+                // handle moved ref (MVRF) subrecords
+                handleMovedCellRefs (esm, &cell);
+
+                // push the new references on the list of references to manage
+                oldcell->postLoad(esm);
+
+                // merge lists of leased references, use newer data in case of conflict
+                for (ESM::MovedCellRefTracker::const_iterator it = cell.mMovedRefs.begin(); it != cell.mMovedRefs.end(); ++it) {
+                    // remove reference from current leased ref tracker and add it to new cell
+                    ESM::MovedCellRefTracker::iterator itold = std::find(oldcell->mMovedRefs.begin(), oldcell->mMovedRefs.end(), it->mRefNum);
+                    if (itold != oldcell->mMovedRefs.end()) {
+                        ESM::MovedCellRef target0 = *itold;
+                        ESM::Cell *wipecell = const_cast<ESM::Cell*>(search(target0.mTarget[0], target0.mTarget[1]));
+                        ESM::CellRefTracker::iterator it_lease = std::find(wipecell->mLeasedRefs.begin(), wipecell->mLeasedRefs.end(), it->mRefNum);
+                        wipecell->mLeasedRefs.erase(it_lease);
+                        *itold = *it;
+                    }
+                    else
+                        oldcell->mMovedRefs.push_back(*it);
+                }
+
+                // We don't need to merge mLeasedRefs of cell / oldcell. This list is filled when another cell moves a
+                // reference to this cell, so the list for the new cell should be empty. The list for oldcell,
+                // however, could have leased refs in it and so should be kept.
+            } else
+            {
+                // spawn a new cell
+                cell.loadCell(esm, false);
+
+                // handle moved ref (MVRF) subrecords
+                handleMovedCellRefs (esm, &cell);
+
+                // push the new references on the list of references to manage
+                cell.postLoad(esm);
+
+                mExt[std::make_pair(cell.mData.mX, cell.mData.mY)] = cell;
+            }
+        }
+    }
+    Store<ESM::Cell>::iterator Store<ESM::Cell>::intBegin() const
+    {
+        return iterator(mSharedInt.begin());
+    }
+    Store<ESM::Cell>::iterator Store<ESM::Cell>::intEnd() const
+    {
+        return iterator(mSharedInt.end());
+    }
+    Store<ESM::Cell>::iterator Store<ESM::Cell>::extBegin() const
+    {
+        return iterator(mSharedExt.begin());
+    }
+    Store<ESM::Cell>::iterator Store<ESM::Cell>::extEnd() const
+    {
+        return iterator(mSharedExt.end());
+    }
+    const ESM::Cell *Store<ESM::Cell>::searchExtByName(const std::string &id) const
+    {
+        ESM::Cell *cell = 0;
+        std::vector<ESM::Cell *>::const_iterator it = mSharedExt.begin();
+        for (; it != mSharedExt.end(); ++it) {
+            if (Misc::StringUtils::ciEqual((*it)->mName, id)) {
+                if ( cell == 0 ||
+                    ( (*it)->mData.mX > cell->mData.mX ) ||
+                    ( (*it)->mData.mX == cell->mData.mX && (*it)->mData.mY > cell->mData.mY ) )
+                {
+                    cell = *it;
+                }
+            }
+        }
+        return cell;
+    }
+    const ESM::Cell *Store<ESM::Cell>::searchExtByRegion(const std::string &id) const
+    {
+        ESM::Cell *cell = 0;
+        std::vector<ESM::Cell *>::const_iterator it = mSharedExt.begin();
+        for (; it != mSharedExt.end(); ++it) {
+            if (Misc::StringUtils::ciEqual((*it)->mRegion, id)) {
+                if ( cell == 0 ||
+                    ( (*it)->mData.mX > cell->mData.mX ) ||
+                    ( (*it)->mData.mX == cell->mData.mX && (*it)->mData.mY > cell->mData.mY ) )
+                {
+                    cell = *it;
+                }
+            }
+        }
+        return cell;
+    }
+    size_t Store<ESM::Cell>::getSize() const
+    {
+        return mSharedInt.size() + mSharedExt.size();
+    }
+    void Store<ESM::Cell>::listIdentifier(std::vector<std::string> &list) const
+    {
+        list.reserve(list.size() + mSharedInt.size());
+
+        std::vector<ESM::Cell *>::const_iterator it = mSharedInt.begin();
+        for (; it != mSharedInt.end(); ++it) {
+            list.push_back((*it)->mName);
+        }
+    }
+    ESM::Cell *Store<ESM::Cell>::insert(const ESM::Cell &cell)
+    {
+        if (search(cell) != 0) {
+            std::ostringstream msg;
+            msg << "Failed to create ";
+            msg << ((cell.isExterior()) ? "exterior" : "interior");
+            msg << " cell";
+
+            throw std::runtime_error(msg.str());
+        }
+        ESM::Cell *ptr;
+        if (cell.isExterior()) {
+            std::pair<int, int> key(cell.getGridX(), cell.getGridY());
+
+            // duplicate insertions are avoided by search(ESM::Cell &)
+            std::pair<DynamicExt::iterator, bool> result =
+                mDynamicExt.insert(std::make_pair(key, cell));
+
+            ptr = &result.first->second;
+            mSharedExt.push_back(ptr);
+        } else {
+            std::string key = Misc::StringUtils::lowerCase(cell.mName);
+
+            // duplicate insertions are avoided by search(ESM::Cell &)
+            std::pair<DynamicInt::iterator, bool> result =
+                mDynamicInt.insert(std::make_pair(key, cell));
+
+            ptr = &result.first->second;
+            mSharedInt.push_back(ptr);
+        }
+        return ptr;
+    }
+    bool Store<ESM::Cell>::erase(const ESM::Cell &cell)
+    {
+        if (cell.isExterior()) {
+            return erase(cell.getGridX(), cell.getGridY());
+        }
+        return erase(cell.mName);
+    }
+    bool Store<ESM::Cell>::erase(const std::string &id)
+    {
+        std::string key = Misc::StringUtils::lowerCase(id);
+        DynamicInt::iterator it = mDynamicInt.find(key);
+
+        if (it == mDynamicInt.end()) {
+            return false;
+        }
+        mDynamicInt.erase(it);
+        mSharedInt.erase(
+            mSharedInt.begin() + mSharedInt.size(),
+            mSharedInt.end()
+        );
+
+        for (it = mDynamicInt.begin(); it != mDynamicInt.end(); ++it) {
+            mSharedInt.push_back(&it->second);
+        }
+
+        return true;
+    }
+    bool Store<ESM::Cell>::erase(int x, int y)
+    {
+        std::pair<int, int> key(x, y);
+        DynamicExt::iterator it = mDynamicExt.find(key);
+
+        if (it == mDynamicExt.end()) {
+            return false;
+        }
+        mDynamicExt.erase(it);
+        mSharedExt.erase(
+            mSharedExt.begin() + mSharedExt.size(),
+            mSharedExt.end()
+        );
+
+        for (it = mDynamicExt.begin(); it != mDynamicExt.end(); ++it) {
+            mSharedExt.push_back(&it->second);
+        }
+
+        return true;
+    }
+
+    
+    // Pathgrid
+    //=========================================================================
+
+    Store<ESM::Pathgrid>::Store()
+        : mCells(NULL)
+    {
+    }
+
+    void Store<ESM::Pathgrid>::setCells(Store<ESM::Cell>& cells)
+    {
+        mCells = &cells;
+    }
+    void Store<ESM::Pathgrid>::load(ESM::ESMReader &esm, const std::string &id)
+    {
+        ESM::Pathgrid pathgrid;
+        pathgrid.load(esm);
+
+        // Unfortunately the Pathgrid record model does not specify whether the pathgrid belongs to an interior or exterior cell.
+        // For interior cells, mCell is the cell name, but for exterior cells it is either the cell name or if that doesn't exist, the cell's region name.
+        // mX and mY will be (0,0) for interior cells, but there is also an exterior cell with the coordinates of (0,0), so that doesn't help.
+        // Check whether mCell is an interior cell. This isn't perfect, will break if a Region with the same name as an interior cell is created.
+        // A proper fix should be made for future versions of the file format.
+        bool interior = mCells->search(pathgrid.mCell) != NULL;
+
+        // Try to overwrite existing record
+        if (interior)
+        {
+            std::pair<Interior::iterator, bool> ret = mInt.insert(std::make_pair(pathgrid.mCell, pathgrid));
+            if (!ret.second)
+                ret.first->second = pathgrid;
+        }
+        else
+        {
+            std::pair<Exterior::iterator, bool> ret = mExt.insert(std::make_pair(std::make_pair(pathgrid.mData.mX, pathgrid.mData.mY), pathgrid));
+            if (!ret.second)
+                ret.first->second = pathgrid;
+        }
+    }
+    size_t Store<ESM::Pathgrid>::getSize() const
+    {
+        return mInt.size() + mExt.size();
+    }
+    void Store<ESM::Pathgrid>::setUp()
+    {
+    }
+    const ESM::Pathgrid *Store<ESM::Pathgrid>::search(int x, int y) const
+    {
+        Exterior::const_iterator it = mExt.find(std::make_pair(x,y));
+        if (it != mExt.end())
+            return &(it->second);
+        return NULL;
+    }
+    const ESM::Pathgrid *Store<ESM::Pathgrid>::search(const std::string& name) const
+    {
+        Interior::const_iterator it = mInt.find(name);
+        if (it != mInt.end())
+            return &(it->second);
+        return NULL;
+    }
+    const ESM::Pathgrid *Store<ESM::Pathgrid>::find(int x, int y) const
+    {
+        const ESM::Pathgrid* pathgrid = search(x,y);
+        if (!pathgrid)
+        {
+            std::ostringstream msg;
+            msg << "Pathgrid in cell '" << x << " " << y << "' not found";
+            throw std::runtime_error(msg.str());
+        }
+        return pathgrid;
+    }
+    const ESM::Pathgrid* Store<ESM::Pathgrid>::find(const std::string& name) const
+    {
+        const ESM::Pathgrid* pathgrid = search(name);
+        if (!pathgrid)
+        {
+            std::ostringstream msg;
+            msg << "Pathgrid in cell '" << name << "' not found";
+            throw std::runtime_error(msg.str());
+        }
+        return pathgrid;
+    }
+    const ESM::Pathgrid *Store<ESM::Pathgrid>::search(const ESM::Cell &cell) const
+    {
+        if (!(cell.mData.mFlags & ESM::Cell::Interior))
+            return search(cell.mData.mX, cell.mData.mY);
+        else
+            return search(cell.mName);
+    }
+    const ESM::Pathgrid *Store<ESM::Pathgrid>::find(const ESM::Cell &cell) const
+    {
+        if (!(cell.mData.mFlags & ESM::Cell::Interior))
+            return find(cell.mData.mX, cell.mData.mY);
+        else
+            return find(cell.mName);
+    }
+
+
+    // Skill
+    //=========================================================================
+    
+    Store<ESM::Skill>::Store()
+    {
+    }
+
+
+    // Magic effect
+    //=========================================================================
+
+    Store<ESM::MagicEffect>::Store()
+    {
+    }
+
+
+    // Attribute
+    //=========================================================================
+
+    Store<ESM::Attribute>::Store()
+    {
+        mStatic.reserve(ESM::Attribute::Length);
+    }
+    const ESM::Attribute *Store<ESM::Attribute>::search(size_t index) const
+    {
+        if (index >= mStatic.size()) {
+            return 0;
+        }
+        return &mStatic.at(index);
+    }
+
+    const ESM::Attribute *Store<ESM::Attribute>::find(size_t index) const
+    {
+        const ESM::Attribute *ptr = search(index);
+        if (ptr == 0) {
+            std::ostringstream msg;
+            msg << "Attribute with index " << index << " not found";
+            throw std::runtime_error(msg.str());
+        }
+        return ptr;
+    }
+    void Store<ESM::Attribute>::setUp()
+    {
+        for (int i = 0; i < ESM::Attribute::Length; ++i) {
+            mStatic.push_back(
+                ESM::Attribute(
+                    ESM::Attribute::sAttributeIds[i],
+                    ESM::Attribute::sGmstAttributeIds[i],
+                    ESM::Attribute::sGmstAttributeDescIds[i]
+                )
+            );
+        }
+    }
+    size_t Store<ESM::Attribute>::getSize() const
+    {
+        return mStatic.size();
+    }
+    Store<ESM::Attribute>::iterator Store<ESM::Attribute>::begin() const
+    {
+        return mStatic.begin();
+    }
+    Store<ESM::Attribute>::iterator Store<ESM::Attribute>::end() const
+    {
+        return mStatic.end();
+    }
+
+    
+    // Dialogue
+    //=========================================================================
+
+
+    template<>
+    inline void Store<ESM::Dialogue>::setUp()
+    {
+        // DialInfos marked as deleted are kept during the loading phase, so that the linked list
+        // structure is kept intact for inserting further INFOs. Delete them now that loading is done.
+        for (Static::iterator it = mStatic.begin(); it != mStatic.end(); ++it)
+        {
+            ESM::Dialogue& dial = it->second;
+            dial.clearDeletedInfos();
+        }
+
+        mShared.clear();
+        mShared.reserve(mStatic.size());
+        std::map<std::string, ESM::Dialogue>::iterator it = mStatic.begin();
+        for (; it != mStatic.end(); ++it) {
+            mShared.push_back(&(it->second));
+        }
+    }
+
+    template <>
+    inline void Store<ESM::Dialogue>::load(ESM::ESMReader &esm, const std::string &id) {
+        std::string idLower = Misc::StringUtils::lowerCase(id);
+
+        std::map<std::string, ESM::Dialogue>::iterator it = mStatic.find(idLower);
+        if (it == mStatic.end()) {
+            it = mStatic.insert( std::make_pair( idLower, ESM::Dialogue() ) ).first;
+            it->second.mId = id; // don't smash case here, as this line is printed
+        }
+
+        it->second.load(esm);
+    }
+
+
+    // Script
+    //=========================================================================
+
+    template <>
+    inline void Store<ESM::Script>::load(ESM::ESMReader &esm, const std::string &id) {
+        ESM::Script scpt;
+        scpt.load(esm);
+        Misc::StringUtils::toLower(scpt.mId);
+
+        std::pair<typename Static::iterator, bool> inserted = mStatic.insert(std::make_pair(scpt.mId, scpt));
+        if (inserted.second)
+            mShared.push_back(&inserted.first->second);
+        else
+            inserted.first->second = scpt;
+    }
+
+
+    // StartScript
+    //=========================================================================
+
+    template <>
+    inline void Store<ESM::StartScript>::load(ESM::ESMReader &esm, const std::string &id)
+    {
+        ESM::StartScript s;
+        s.load(esm);
+        s.mId = Misc::StringUtils::toLower(s.mId);
+        std::pair<typename Static::iterator, bool> inserted = mStatic.insert(std::make_pair(s.mId, s));
+        if (inserted.second)
+            mShared.push_back(&inserted.first->second);
+        else
+            inserted.first->second = s;
     }
 }
 
-void Store<ESM::LandTexture>::load(ESM::ESMReader &esm, const std::string &id)
-{
-    load(esm, id, esm.getIndex());
-}
+template class MWWorld::Store<ESM::Activator>;
+template class MWWorld::Store<ESM::Apparatus>;
+template class MWWorld::Store<ESM::Armor>;
+template class MWWorld::Store<ESM::Attribute>;
+template class MWWorld::Store<ESM::BirthSign>;
+template class MWWorld::Store<ESM::BodyPart>;
+template class MWWorld::Store<ESM::Book>;
+template class MWWorld::Store<ESM::Cell>;
+template class MWWorld::Store<ESM::Class>;
+template class MWWorld::Store<ESM::Clothing>;
+template class MWWorld::Store<ESM::Container>;
+template class MWWorld::Store<ESM::Creature>;
+template class MWWorld::Store<ESM::CreatureLevList>;
+template class MWWorld::Store<ESM::Dialogue>;
+template class MWWorld::Store<ESM::Door>;
+template class MWWorld::Store<ESM::Enchantment>;
+template class MWWorld::Store<ESM::Faction>;
+template class MWWorld::Store<ESM::GameSetting>;
+template class MWWorld::Store<ESM::Global>;
+template class MWWorld::Store<ESM::Ingredient>;
+template class MWWorld::Store<ESM::ItemLevList>;
+template class MWWorld::Store<ESM::Land>;
+template class MWWorld::Store<ESM::LandTexture>;
+template class MWWorld::Store<ESM::Light>;
+template class MWWorld::Store<ESM::Lockpick>;
+template class MWWorld::Store<ESM::MagicEffect>;
+template class MWWorld::Store<ESM::Miscellaneous>;
+template class MWWorld::Store<ESM::NPC>;
+template class MWWorld::Store<ESM::Pathgrid>;
+template class MWWorld::Store<ESM::Potion>;
+template class MWWorld::Store<ESM::Probe>;
+template class MWWorld::Store<ESM::Race>;
+template class MWWorld::Store<ESM::Region>;
+template class MWWorld::Store<ESM::Repair>;
+template class MWWorld::Store<ESM::Script>;
+template class MWWorld::Store<ESM::Skill>;
+template class MWWorld::Store<ESM::Sound>;
+template class MWWorld::Store<ESM::SoundGenerator>;
+template class MWWorld::Store<ESM::Spell>;
+template class MWWorld::Store<ESM::StartScript>;
+template class MWWorld::Store<ESM::Static>;
+template class MWWorld::Store<ESM::Weapon>;
 
-}

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -4,16 +4,18 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <stdexcept>
-#include <sstream>
-
-#include <components/misc/rng.hpp>
-
-#include <components/esm/esmwriter.hpp>
-
-#include <components/loadinglistener/loadinglistener.hpp>
 
 #include "recordcmp.hpp"
+
+namespace ESM
+{
+    struct Land;
+}
+
+namespace Loading
+{
+    class Listener;
+}
 
 namespace MWWorld
 {
@@ -35,6 +37,30 @@ namespace MWWorld
 
         virtual void read (ESM::ESMReader& reader, const std::string& id) {}
         ///< Read into dynamic storage
+    };
+
+    template <class T>
+    class IndexedStore
+    {
+    protected:
+        typedef typename std::map<int, T> Static;
+        Static mStatic;
+
+    public:
+        typedef typename std::map<int, T>::const_iterator iterator;
+
+        IndexedStore();
+
+        iterator begin() const;
+        iterator end() const;
+
+        void load(ESM::ESMReader &esm);
+
+        int getSize() const;
+        void setUp();
+
+        const T *search(int index) const;
+        const T *find(int index) const;
     };
 
     template <class T>
@@ -110,274 +136,53 @@ namespace MWWorld
         typedef std::map<std::string, T> Dynamic;
         typedef std::map<std::string, T> Static;
 
-        class GetRecords {
-            const std::string mFind;
-            std::vector<const T*> *mRecords;
-
-        public:
-            GetRecords(const std::string &str, std::vector<const T*> *records)
-              : mFind(Misc::StringUtils::lowerCase(str)), mRecords(records)
-            { }
-
-            void operator()(const T *item)
-            {
-                if(Misc::StringUtils::ciCompareLen(mFind, item->mId, mFind.size()) == 0)
-                    mRecords->push_back(item);
-            }
-        };
-
-
         friend class ESMStore;
 
     public:
-        Store()
-        {}
-
-        Store(const Store<T> &orig)
-          : mStatic(orig.mData)
-        {}
+        Store();
+        Store(const Store<T> &orig);
 
         typedef SharedIterator<T> iterator;
 
         // setUp needs to be called again after
-        virtual void clearDynamic()
-        {
-            // remove the dynamic part of mShared
-            assert(mShared.size() >= mStatic.size());
-            mShared.erase(mShared.begin() + mStatic.size(), mShared.end());
-            mDynamic.clear();
-        }
+        virtual void clearDynamic();
+        void setUp();
 
-        const T *search(const std::string &id) const {
-            T item;
-            item.mId = Misc::StringUtils::lowerCase(id);
-
-            typename Dynamic::const_iterator dit = mDynamic.find(item.mId);
-            if (dit != mDynamic.end()) {
-                return &dit->second;
-            }
-
-            typename std::map<std::string, T>::const_iterator it = mStatic.find(item.mId);
-
-            if (it != mStatic.end() && Misc::StringUtils::ciEqual(it->second.mId, id)) {
-                return &(it->second);
-            }
-
-            return 0;
-        }
+        const T *search(const std::string &id) const;
 
         /**
          * Does the record with this ID come from the dynamic store?
          */
-        bool isDynamic(const std::string &id) const {
-            typename Dynamic::const_iterator dit = mDynamic.find(id);
-            return (dit != mDynamic.end());
-        }
+        bool isDynamic(const std::string &id) const;
 
         /** Returns a random record that starts with the named ID, or NULL if not found. */
-        const T *searchRandom(const std::string &id) const
-        {
-            std::vector<const T*> results;
-            std::for_each(mShared.begin(), mShared.end(), GetRecords(id, &results));
-            if(!results.empty())
-                return results[Misc::Rng::rollDice(results.size())];
-            return NULL;
-        }
+        const T *searchRandom(const std::string &id) const;
 
-        const T *find(const std::string &id) const {
-            const T *ptr = search(id);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << T::getRecordType() << " '" << id << "' not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
+        const T *find(const std::string &id) const;
 
         /** Returns a random record that starts with the named ID. An exception is thrown if none
          * are found. */
-        const T *findRandom(const std::string &id) const
-        {
-            const T *ptr = searchRandom(id);
-            if(ptr == 0)
-            {
-                std::ostringstream msg;
-                msg << T::getRecordType() << " starting with '"<<id<<"' not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
+        const T *findRandom(const std::string &id) const;
 
-        void load(ESM::ESMReader &esm, const std::string &id) {
-            std::string idLower = Misc::StringUtils::lowerCase(id);
+        iterator begin() const;
+        iterator end() const;
 
-            std::pair<typename Static::iterator, bool> inserted = mStatic.insert(std::make_pair(idLower, T()));
-            if (inserted.second)
-                mShared.push_back(&inserted.first->second);
+        size_t getSize() const;
+        int getDynamicSize() const;
 
-            inserted.first->second.mId = idLower;
-            inserted.first->second.load(esm);
-        }
+        void listIdentifier(std::vector<std::string> &list) const;
 
-        void setUp() {
-        }
+        T *insert(const T &item);
+        T *insertStatic(const T &item);
 
-        iterator begin() const {
-            return mShared.begin();
-        }
+        bool eraseStatic(const std::string &id);
+        bool erase(const std::string &id);
+        bool erase(const T &item);
 
-        iterator end() const {
-            return mShared.end();
-        }
-
-        size_t getSize() const {
-            return mShared.size();
-        }
-
-        int getDynamicSize() const
-        {
-            return static_cast<int> (mDynamic.size()); // truncated from unsigned __int64 if _MSC_VER && _WIN64
-        }
-
-        void listIdentifier(std::vector<std::string> &list) const {
-            list.reserve(list.size() + getSize());
-            typename std::vector<T *>::const_iterator it = mShared.begin();
-            for (; it != mShared.end(); ++it) {
-                list.push_back((*it)->mId);
-            }
-        }
-
-        T *insert(const T &item) {
-            std::string id = Misc::StringUtils::lowerCase(item.mId);
-            std::pair<typename Dynamic::iterator, bool> result =
-                mDynamic.insert(std::pair<std::string, T>(id, item));
-            T *ptr = &result.first->second;
-            if (result.second) {
-                mShared.push_back(ptr);
-            } else {
-                *ptr = item;
-            }
-            return ptr;
-        }
-
-        T *insertStatic(const T &item) {
-            std::string id = Misc::StringUtils::lowerCase(item.mId);
-            std::pair<typename Static::iterator, bool> result =
-                mStatic.insert(std::pair<std::string, T>(id, item));
-            T *ptr = &result.first->second;
-            if (result.second) {
-                mShared.push_back(ptr);
-            } else {
-                *ptr = item;
-            }
-            return ptr;
-        }
-
-
-        bool eraseStatic(const std::string &id) {
-            T item;
-            item.mId = Misc::StringUtils::lowerCase(id);
-
-            typename std::map<std::string, T>::iterator it = mStatic.find(item.mId);
-
-            if (it != mStatic.end() && Misc::StringUtils::ciEqual(it->second.mId, id)) {
-                // delete from the static part of mShared
-                typename std::vector<T *>::iterator sharedIter = mShared.begin();
-                typename std::vector<T *>::iterator end = sharedIter + mStatic.size();
-
-                while (sharedIter != mShared.end() && sharedIter != end) {
-                    if((*sharedIter)->mId == item.mId) {
-                        mShared.erase(sharedIter);
-                        break;
-                    }
-                    ++sharedIter;
-                }
-                mStatic.erase(it);
-            }
-
-            return true;
-        }
-
-        bool erase(const std::string &id) {
-            std::string key = Misc::StringUtils::lowerCase(id);
-            typename Dynamic::iterator it = mDynamic.find(key);
-            if (it == mDynamic.end()) {
-                return false;
-            }
-            mDynamic.erase(it);
-
-            // have to reinit the whole shared part
-            assert(mShared.size() >= mStatic.size());
-            mShared.erase(mShared.begin() + mStatic.size(), mShared.end());
-            for (it = mDynamic.begin(); it != mDynamic.end(); ++it) {
-                mShared.push_back(&it->second);
-            }
-            return true;
-        }
-
-        bool erase(const T &item) {
-            return erase(item.mId);
-        }
-
-        void write (ESM::ESMWriter& writer, Loading::Listener& progress) const
-        {
-            for (typename Dynamic::const_iterator iter (mDynamic.begin()); iter!=mDynamic.end();
-                 ++iter)
-            {
-                writer.startRecord (T::sRecordId);
-                writer.writeHNString ("NAME", iter->second.mId);
-                iter->second.save (writer);
-                writer.endRecord (T::sRecordId);
-            }
-        }
-
-        void read (ESM::ESMReader& reader, const std::string& id)
-        {
-            T record;
-            record.mId = id;
-            record.load (reader);
-            insert (record);
-        }
+        void load(ESM::ESMReader &esm, const std::string &id);
+        void write(ESM::ESMWriter& writer, Loading::Listener& progress) const;
+        void read(ESM::ESMReader& reader, const std::string& id);
     };
-
-    template <>
-    inline void Store<ESM::Dialogue>::load(ESM::ESMReader &esm, const std::string &id) {
-        std::string idLower = Misc::StringUtils::lowerCase(id);
-
-        std::map<std::string, ESM::Dialogue>::iterator it = mStatic.find(idLower);
-        if (it == mStatic.end()) {
-            it = mStatic.insert( std::make_pair( idLower, ESM::Dialogue() ) ).first;
-            it->second.mId = id; // don't smash case here, as this line is printed
-        }
-
-        it->second.load(esm);
-    }
-
-    template <>
-    inline void Store<ESM::Script>::load(ESM::ESMReader &esm, const std::string &id) {
-        ESM::Script scpt;
-        scpt.load(esm);
-        Misc::StringUtils::toLower(scpt.mId);
-
-        std::pair<typename Static::iterator, bool> inserted = mStatic.insert(std::make_pair(scpt.mId, scpt));
-        if (inserted.second)
-            mShared.push_back(&inserted.first->second);
-        else
-            inserted.first->second = scpt;
-    }
-
-    template <>
-    inline void Store<ESM::StartScript>::load(ESM::ESMReader &esm, const std::string &id)
-    {
-        ESM::StartScript s;
-        s.load(esm);
-        s.mId = Misc::StringUtils::toLower(s.mId);
-        std::pair<typename Static::iterator, bool> inserted = mStatic.insert(std::make_pair(s.mId, s));
-        if (inserted.second)
-            mShared.push_back(&inserted.first->second);
-        else
-            inserted.first->second = s;
-    }
 
     template <>
     class Store<ESM::LandTexture> : public StoreBase
@@ -387,73 +192,23 @@ namespace MWWorld
         std::vector<LandTextureList> mStatic;
 
     public:
-        Store<ESM::LandTexture>() {
-            mStatic.push_back(LandTextureList());
-            LandTextureList &ltexl = mStatic[0];
-            // More than enough to hold Morrowind.esm. Extra lists for plugins will we
-            //  added on-the-fly in a different method.
-            ltexl.reserve(128);
-        }
+        Store();
 
         typedef std::vector<ESM::LandTexture>::const_iterator iterator;
 
         // Must be threadsafe! Called from terrain background loading threads.
         // Not a big deal here, since ESM::LandTexture can never be modified or inserted/erased
-        const ESM::LandTexture *search(size_t index, size_t plugin) const {
-            assert(plugin < mStatic.size());
-            const LandTextureList &ltexl = mStatic[plugin];
+        const ESM::LandTexture *search(size_t index, size_t plugin) const;
+        const ESM::LandTexture *find(size_t index, size_t plugin) const;
 
-            assert(index < ltexl.size());
-            return &ltexl.at(index);
-        }
+        size_t getSize() const;
+        size_t getSize(size_t plugin) const;
 
-        const ESM::LandTexture *find(size_t index, size_t plugin) const {
-            const ESM::LandTexture *ptr = search(index, plugin);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << "Land texture with index " << index << " not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
-
-        size_t getSize() const {
-            return mStatic.size();
-        }
-
-        size_t getSize(size_t plugin) const {
-            assert(plugin < mStatic.size());
-            return mStatic[plugin].size();
-        }
-
-        void load(ESM::ESMReader &esm, const std::string &id, size_t plugin) {
-            ESM::LandTexture lt;
-            lt.load(esm);
-            lt.mId = id;
-
-            // Make sure we have room for the structure
-            if (plugin >= mStatic.size()) {
-                mStatic.resize(plugin+1);
-            }
-            LandTextureList &ltexl = mStatic[plugin];
-            if(lt.mIndex + 1 > (int)ltexl.size())
-                ltexl.resize(lt.mIndex+1);
-
-            // Store it
-            ltexl[lt.mIndex] = lt;
-        }
-
+        void load(ESM::ESMReader &esm, const std::string &id, size_t plugin);
         void load(ESM::ESMReader &esm, const std::string &id);
 
-        iterator begin(size_t plugin) const {
-            assert(plugin < mStatic.size());
-            return mStatic[plugin].begin();
-        }
-
-        iterator end(size_t plugin) const {
-            assert(plugin < mStatic.size());
-            return mStatic[plugin].end();
-        }
+        iterator begin(size_t plugin) const;
+        iterator end(size_t plugin) const;
     };
 
     template <>
@@ -461,88 +216,22 @@ namespace MWWorld
     {
         std::vector<ESM::Land *> mStatic;
 
-        struct Compare
-        {
-            bool operator()(const ESM::Land *x, const ESM::Land *y) {
-                if (x->mX == y->mX) {
-                    return x->mY < y->mY;
-                }
-                return x->mX < y->mX;
-            }
-        };
-
     public:
         typedef SharedIterator<ESM::Land> iterator;
 
-        virtual ~Store<ESM::Land>()
-        {
-            for (std::vector<ESM::Land *>::const_iterator it =
-                             mStatic.begin(); it != mStatic.end(); ++it)
-            {
-                delete *it;
-            }
+        virtual ~Store();
 
-        }
-
-        size_t getSize() const {
-            return mStatic.size();
-        }
-
-        iterator begin() const {
-            return iterator(mStatic.begin());
-        }
-
-        iterator end() const {
-            return iterator(mStatic.end());
-        }
+        size_t getSize() const;
+        iterator begin() const;
+        iterator end() const;
 
         // Must be threadsafe! Called from terrain background loading threads.
         // Not a big deal here, since ESM::Land can never be modified or inserted/erased
-        ESM::Land *search(int x, int y) const {
-            ESM::Land land;
-            land.mX = x, land.mY = y;
+        ESM::Land *search(int x, int y) const;
+        ESM::Land *find(int x, int y) const;
 
-            std::vector<ESM::Land *>::const_iterator it =
-                std::lower_bound(mStatic.begin(), mStatic.end(), &land, Compare());
-
-            if (it != mStatic.end() && (*it)->mX == x && (*it)->mY == y) {
-                return const_cast<ESM::Land *>(*it);
-            }
-            return 0;
-        }
-
-        ESM::Land *find(int x, int y) const{
-            ESM::Land *ptr = search(x, y);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << "Land at (" << x << ", " << y << ") not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
-
-        void load(ESM::ESMReader &esm, const std::string &id) {
-            ESM::Land *ptr = new ESM::Land();
-            ptr->load(esm);
-
-            // Same area defined in multiple plugins? -> last plugin wins
-            // Can't use search() because we aren't sorted yet - is there any other way to speed this up?
-            for (std::vector<ESM::Land*>::iterator it = mStatic.begin(); it != mStatic.end(); ++it)
-            {
-                if ((*it)->mX == ptr->mX && (*it)->mY == ptr->mY)
-                {
-                    delete *it;
-                    mStatic.erase(it);
-                    break;
-                }
-            }
-
-            mStatic.push_back(ptr);
-        }
-
-        void setUp() {
-            std::sort(mStatic.begin(), mStatic.end(), Compare());
-        }
+        void load(ESM::ESMReader &esm, const std::string &id);
+        void setUp();
     };
 
     template <>
@@ -576,261 +265,44 @@ namespace MWWorld
         DynamicInt mDynamicInt;
         DynamicExt mDynamicExt;
 
-        const ESM::Cell *search(const ESM::Cell &cell) const {
-            if (cell.isExterior()) {
-                return search(cell.getGridX(), cell.getGridY());
-            }
-            return search(cell.mName);
-        }
-
+        const ESM::Cell *search(const ESM::Cell &cell) const;
         void handleMovedCellRefs(ESM::ESMReader& esm, ESM::Cell* cell);
 
     public:
         typedef SharedIterator<ESM::Cell> iterator;
 
-        const ESM::Cell *search(const std::string &id) const {
-            ESM::Cell cell;
-            cell.mName = Misc::StringUtils::lowerCase(id);
+        const ESM::Cell *search(const std::string &id) const;
+        const ESM::Cell *search(int x, int y) const;
+        const ESM::Cell *searchOrCreate(int x, int y);
 
-            std::map<std::string, ESM::Cell>::const_iterator it = mInt.find(cell.mName);
+        const ESM::Cell *find(const std::string &id) const;
+        const ESM::Cell *find(int x, int y) const;
 
-            if (it != mInt.end() && Misc::StringUtils::ciEqual(it->second.mName, id)) {
-                return &(it->second);
-            }
+        void setUp();
 
-            DynamicInt::const_iterator dit = mDynamicInt.find(cell.mName);
-            if (dit != mDynamicInt.end()) {
-                return &dit->second;
-            }
-
-            return 0;
-        }
-
-        const ESM::Cell *search(int x, int y) const {
-            ESM::Cell cell;
-            cell.mData.mX = x, cell.mData.mY = y;
-
-            std::pair<int, int> key(x, y);
-            DynamicExt::const_iterator it = mExt.find(key);
-            if (it != mExt.end()) {
-                return &(it->second);
-            }
-
-            DynamicExt::const_iterator dit = mDynamicExt.find(key);
-            if (dit != mDynamicExt.end()) {
-                return &dit->second;
-            }
-
-            return 0;
-        }
-
-        const ESM::Cell *searchOrCreate(int x, int y) {
-            std::pair<int, int> key(x, y);
-            DynamicExt::const_iterator it = mExt.find(key);
-            if (it != mExt.end()) {
-                return &(it->second);
-            }
-
-            DynamicExt::const_iterator dit = mDynamicExt.find(key);
-            if (dit != mDynamicExt.end()) {
-                return &dit->second;
-            }
-
-            ESM::Cell newCell;
-            newCell.mData.mX = x;
-            newCell.mData.mY = y;
-            newCell.mData.mFlags = ESM::Cell::HasWater;
-            newCell.mAmbi.mAmbient = 0;
-            newCell.mAmbi.mSunlight = 0;
-            newCell.mAmbi.mFog = 0;
-            newCell.mAmbi.mFogDensity = 0;
-            return &mExt.insert(std::make_pair(key, newCell)).first->second;
-        }
-
-        const ESM::Cell *find(const std::string &id) const {
-            const ESM::Cell *ptr = search(id);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << "Interior cell '" << id << "' not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
-
-        const ESM::Cell *find(int x, int y) const {
-            const ESM::Cell *ptr = search(x, y);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << "Exterior at (" << x << ", " << y << ") not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
-
-        void setUp() {
-            typedef DynamicExt::iterator ExtIterator;
-            typedef std::map<std::string, ESM::Cell>::iterator IntIterator;
-
-            mSharedInt.clear();
-            mSharedInt.reserve(mInt.size());
-            for (IntIterator it = mInt.begin(); it != mInt.end(); ++it) {
-                mSharedInt.push_back(&(it->second));
-            }
-
-            mSharedExt.clear();
-            mSharedExt.reserve(mExt.size());
-            for (ExtIterator it = mExt.begin(); it != mExt.end(); ++it) {
-                mSharedExt.push_back(&(it->second));
-            }
-        }
-
-        // HACK: Method implementation had to be moved to a separate cpp file, as we would otherwise get
-        //  errors related to the compare operator used in std::find for ESM::MovedCellRefTracker::find.
-        //  There some nasty three-way cyclic header dependency involved, which I could only fix by moving
-        //  this method.
         void load(ESM::ESMReader &esm, const std::string &id);
 
-        iterator intBegin() const {
-            return iterator(mSharedInt.begin());
-        }
-
-        iterator intEnd() const {
-            return iterator(mSharedInt.end());
-        }
-
-        iterator extBegin() const {
-            return iterator(mSharedExt.begin());
-        }
-
-        iterator extEnd() const {
-            return iterator(mSharedExt.end());
-        }
+        iterator intBegin() const;
+        iterator intEnd() const;
+        iterator extBegin() const;
+        iterator extEnd() const;
 
         // Return the northernmost cell in the easternmost column.
-        const ESM::Cell *searchExtByName(const std::string &id) const {
-            ESM::Cell *cell = 0;
-            std::vector<ESM::Cell *>::const_iterator it = mSharedExt.begin();
-            for (; it != mSharedExt.end(); ++it) {
-                if (Misc::StringUtils::ciEqual((*it)->mName, id)) {
-                    if ( cell == 0 ||
-                        ( (*it)->mData.mX > cell->mData.mX ) ||
-                        ( (*it)->mData.mX == cell->mData.mX && (*it)->mData.mY > cell->mData.mY ) )
-                    {
-                        cell = *it;
-                    }
-                }
-            }
-            return cell;
-        }
+        const ESM::Cell *searchExtByName(const std::string &id) const;
 
         // Return the northernmost cell in the easternmost column.
-        const ESM::Cell *searchExtByRegion(const std::string &id) const {
-            ESM::Cell *cell = 0;
-            std::vector<ESM::Cell *>::const_iterator it = mSharedExt.begin();
-            for (; it != mSharedExt.end(); ++it) {
-                if (Misc::StringUtils::ciEqual((*it)->mRegion, id)) {
-                    if ( cell == 0 ||
-                        ( (*it)->mData.mX > cell->mData.mX ) ||
-                        ( (*it)->mData.mX == cell->mData.mX && (*it)->mData.mY > cell->mData.mY ) )
-                    {
-                        cell = *it;
-                    }
-                }
-            }
-            return cell;
-        }
+        const ESM::Cell *searchExtByRegion(const std::string &id) const;
 
-        size_t getSize() const {
-            return mSharedInt.size() + mSharedExt.size();
-        }
+        size_t getSize() const;
 
-        void listIdentifier(std::vector<std::string> &list) const {
-            list.reserve(list.size() + mSharedInt.size());
+        void listIdentifier(std::vector<std::string> &list) const;
 
-            std::vector<ESM::Cell *>::const_iterator it = mSharedInt.begin();
-            for (; it != mSharedInt.end(); ++it) {
-                list.push_back((*it)->mName);
-            }
-        }
+        ESM::Cell *insert(const ESM::Cell &cell);
 
-        ESM::Cell *insert(const ESM::Cell &cell) {
-            if (search(cell) != 0) {
-                std::ostringstream msg;
-                msg << "Failed to create ";
-                msg << ((cell.isExterior()) ? "exterior" : "interior");
-                msg << " cell";
+        bool erase(const ESM::Cell &cell);
+        bool erase(const std::string &id);
 
-                throw std::runtime_error(msg.str());
-            }
-            ESM::Cell *ptr;
-            if (cell.isExterior()) {
-                std::pair<int, int> key(cell.getGridX(), cell.getGridY());
-
-                // duplicate insertions are avoided by search(ESM::Cell &)
-                std::pair<DynamicExt::iterator, bool> result =
-                    mDynamicExt.insert(std::make_pair(key, cell));
-
-                ptr = &result.first->second;
-                mSharedExt.push_back(ptr);
-            } else {
-                std::string key = Misc::StringUtils::lowerCase(cell.mName);
-
-                // duplicate insertions are avoided by search(ESM::Cell &)
-                std::pair<DynamicInt::iterator, bool> result =
-                    mDynamicInt.insert(std::make_pair(key, cell));
-
-                ptr = &result.first->second;
-                mSharedInt.push_back(ptr);
-            }
-            return ptr;
-        }
-
-        bool erase(const ESM::Cell &cell) {
-            if (cell.isExterior()) {
-                return erase(cell.getGridX(), cell.getGridY());
-            }
-            return erase(cell.mName);
-        }
-
-        bool erase(const std::string &id) {
-            std::string key = Misc::StringUtils::lowerCase(id);
-            DynamicInt::iterator it = mDynamicInt.find(key);
-
-            if (it == mDynamicInt.end()) {
-                return false;
-            }
-            mDynamicInt.erase(it);
-            mSharedInt.erase(
-                mSharedInt.begin() + mSharedInt.size(),
-                mSharedInt.end()
-            );
-
-            for (it = mDynamicInt.begin(); it != mDynamicInt.end(); ++it) {
-                mSharedInt.push_back(&it->second);
-            }
-
-            return true;
-        }
-
-        bool erase(int x, int y) {
-            std::pair<int, int> key(x, y);
-            DynamicExt::iterator it = mDynamicExt.find(key);
-
-            if (it == mDynamicExt.end()) {
-                return false;
-            }
-            mDynamicExt.erase(it);
-            mSharedExt.erase(
-                mSharedExt.begin() + mSharedExt.size(),
-                mSharedExt.end()
-            );
-
-            for (it = mDynamicExt.begin(); it != mDynamicExt.end(); ++it) {
-                mSharedExt.push_back(&it->second);
-            }
-
-            return true;
-        }
+        bool erase(int x, int y);
     };
 
     template <>
@@ -847,165 +319,33 @@ namespace MWWorld
 
     public:
 
-        Store<ESM::Pathgrid>()
-            : mCells(NULL)
-        {
-        }
+        Store<ESM::Pathgrid>();
 
-        void setCells(Store<ESM::Cell>& cells)
-        {
-            mCells = &cells;
-        }
+        void setCells(Store<ESM::Cell>& cells);
+        void load(ESM::ESMReader &esm, const std::string &id);
+        size_t getSize() const;
 
-        void load(ESM::ESMReader &esm, const std::string &id) {
-            ESM::Pathgrid pathgrid;
-            pathgrid.load(esm);
+        void setUp();
 
-            // Unfortunately the Pathgrid record model does not specify whether the pathgrid belongs to an interior or exterior cell.
-            // For interior cells, mCell is the cell name, but for exterior cells it is either the cell name or if that doesn't exist, the cell's region name.
-            // mX and mY will be (0,0) for interior cells, but there is also an exterior cell with the coordinates of (0,0), so that doesn't help.
-            // Check whether mCell is an interior cell. This isn't perfect, will break if a Region with the same name as an interior cell is created.
-            // A proper fix should be made for future versions of the file format.
-            bool interior = mCells->search(pathgrid.mCell) != NULL;
-
-            // Try to overwrite existing record
-            if (interior)
-            {
-                std::pair<Interior::iterator, bool> ret = mInt.insert(std::make_pair(pathgrid.mCell, pathgrid));
-                if (!ret.second)
-                    ret.first->second = pathgrid;
-            }
-            else
-            {
-                std::pair<Exterior::iterator, bool> ret = mExt.insert(std::make_pair(std::make_pair(pathgrid.mData.mX, pathgrid.mData.mY), pathgrid));
-                if (!ret.second)
-                    ret.first->second = pathgrid;
-            }
-        }
-
-        size_t getSize() const {
-            return mInt.size() + mExt.size();
-        }
-
-        void setUp() {
-        }
-
-        const ESM::Pathgrid *search(int x, int y) const {
-            Exterior::const_iterator it = mExt.find(std::make_pair(x,y));
-            if (it != mExt.end())
-                return &(it->second);
-            return NULL;
-        }
-
-        const ESM::Pathgrid *search(const std::string& name) const {
-            Interior::const_iterator it = mInt.find(name);
-            if (it != mInt.end())
-                return &(it->second);
-            return NULL;
-        }
-
-        const ESM::Pathgrid *find(int x, int y) const {
-            const ESM::Pathgrid* pathgrid = search(x,y);
-            if (!pathgrid)
-            {
-                std::ostringstream msg;
-                msg << "Pathgrid in cell '" << x << " " << y << "' not found";
-                throw std::runtime_error(msg.str());
-            }
-            return pathgrid;
-        }
-
-        const ESM::Pathgrid* find(const std::string& name) const {
-            const ESM::Pathgrid* pathgrid = search(name);
-            if (!pathgrid)
-            {
-                std::ostringstream msg;
-                msg << "Pathgrid in cell '" << name << "' not found";
-                throw std::runtime_error(msg.str());
-            }
-            return pathgrid;
-        }
-
-        const ESM::Pathgrid *search(const ESM::Cell &cell) const {
-            if (!(cell.mData.mFlags & ESM::Cell::Interior))
-                return search(cell.mData.mX, cell.mData.mY);
-            else
-                return search(cell.mName);
-        }
-
-        const ESM::Pathgrid *find(const ESM::Cell &cell) const {
-            if (!(cell.mData.mFlags & ESM::Cell::Interior))
-                return find(cell.mData.mX, cell.mData.mY);
-            else
-                return find(cell.mName);
-        }
+        const ESM::Pathgrid *search(int x, int y) const;
+        const ESM::Pathgrid *search(const std::string& name) const;
+        const ESM::Pathgrid *find(int x, int y) const;
+        const ESM::Pathgrid* find(const std::string& name) const;
+        const ESM::Pathgrid *search(const ESM::Cell &cell) const;
+        const ESM::Pathgrid *find(const ESM::Cell &cell) const;
     };
 
-    template <class T>
-    class IndexedStore
-    {
-    protected:
-        typedef typename std::map<int, T> Static;
-        Static mStatic;
-
-    public:
-        typedef typename std::map<int, T>::const_iterator iterator;
-
-        IndexedStore() {}
-
-        iterator begin() const {
-            return mStatic.begin();
-        }
-
-        iterator end() const {
-            return mStatic.end();
-        }
-
-        void load(ESM::ESMReader &esm) {
-            T record;
-            record.load(esm);
-
-            // Try to overwrite existing record
-            std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(record.mIndex, record));
-            if (!ret.second)
-                ret.first->second = record;
-        }
-
-        int getSize() const {
-            return mStatic.size();
-        }
-
-        void setUp() {
-        }
-
-        const T *search(int index) const {
-            typename Static::const_iterator it = mStatic.find(index);
-            if (it != mStatic.end())
-                return &(it->second);
-            return NULL;
-        }
-
-        const T *find(int index) const {
-            const T *ptr = search(index);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << T::getRecordType() << " with index " << index << " not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
-    };
 
     template <>
     struct Store<ESM::Skill> : public IndexedStore<ESM::Skill>
     {
-        Store() {}
+        Store();
     };
 
     template <>
     struct Store<ESM::MagicEffect> : public IndexedStore<ESM::MagicEffect>
     {
-        Store() {}
+        Store();
     };
 
     template <>
@@ -1016,70 +356,18 @@ namespace MWWorld
     public:
         typedef std::vector<ESM::Attribute>::const_iterator iterator;
 
-        Store() {
-            mStatic.reserve(ESM::Attribute::Length);
-        }
+        Store();
 
-        const ESM::Attribute *search(size_t index) const {
-            if (index >= mStatic.size()) {
-                return 0;
-            }
-            return &mStatic.at(index);
-        }
+        const ESM::Attribute *search(size_t index) const;
+        const ESM::Attribute *find(size_t index) const;
 
-        const ESM::Attribute *find(size_t index) const {
-            const ESM::Attribute *ptr = search(index);
-            if (ptr == 0) {
-                std::ostringstream msg;
-                msg << "Attribute with index " << index << " not found";
-                throw std::runtime_error(msg.str());
-            }
-            return ptr;
-        }
+        void setUp();
 
-        void setUp() {
-            for (int i = 0; i < ESM::Attribute::Length; ++i) {
-                mStatic.push_back(
-                    ESM::Attribute(
-                        ESM::Attribute::sAttributeIds[i],
-                        ESM::Attribute::sGmstAttributeIds[i],
-                        ESM::Attribute::sGmstAttributeDescIds[i]
-                    )
-                );
-            }
-        }
-
-        size_t getSize() const {
-            return mStatic.size();
-        }
-
-        iterator begin() const {
-            return mStatic.begin();
-        }
-
-        iterator end() const {
-            return mStatic.end();
-        }
+        size_t getSize() const;
+        iterator begin() const;
+        iterator end() const;
     };
 
-    template<>
-    inline void Store<ESM::Dialogue>::setUp()
-    {
-        // DialInfos marked as deleted are kept during the loading phase, so that the linked list
-        // structure is kept intact for inserting further INFOs. Delete them now that loading is done.
-        for (Static::iterator it = mStatic.begin(); it != mStatic.end(); ++it)
-        {
-            ESM::Dialogue& dial = it->second;
-            dial.clearDeletedInfos();
-        }
-
-        mShared.clear();
-        mShared.reserve(mStatic.size());
-        std::map<std::string, ESM::Dialogue>::iterator it = mStatic.begin();
-        for (; it != mStatic.end(); ++it) {
-            mShared.push_back(&(it->second));
-        }
-    }
 
 } //end namespace
 

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -5,6 +5,7 @@
 
 #include <components/misc/rng.hpp>
 
+#include <components/esm/esmwriter.hpp>
 #include <components/esm/weatherstate.hpp>
 
 #include "../mwbase/environment.hpp"

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -12,6 +12,9 @@
 #include <osg/ComputeBoundsVisitor>
 #include <osg/PositionAttitudeTransform>
 
+#include <components/esm/esmreader.hpp>
+#include <components/esm/esmwriter.hpp>
+
 #include <components/misc/rng.hpp>
 
 #include <components/files/collections.hpp>

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -20,6 +20,7 @@
 #include <components/files/collections.hpp>
 #include <components/compiler/locals.hpp>
 #include <components/esm/cellid.hpp>
+#include <components/esm/esmreader.hpp>
 #include <components/misc/resourcehelpers.hpp>
 #include <components/resource/resourcesystem.hpp>
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -52,6 +52,11 @@ namespace MWRender
     class Camera;
 }
 
+namespace ToUTF8
+{
+    class Utf8Encoder;
+}
+
 struct ContentLoader;
 
 namespace MWWorld

--- a/components/esm/creaturestats.cpp
+++ b/components/esm/creaturestats.cpp
@@ -1,4 +1,6 @@
 #include "creaturestats.hpp"
+#include "esmreader.hpp"
+#include "esmwriter.hpp"
 
 void ESM::CreatureStats::load (ESMReader &esm)
 {

--- a/components/esm/statstate.cpp
+++ b/components/esm/statstate.cpp
@@ -1,0 +1,52 @@
+#include "statstate.hpp"
+
+#include "esmreader.hpp"
+#include "esmwriter.hpp"
+
+namespace ESM
+{
+    template<typename T>
+    StatState<T>::StatState() : mBase(0), mMod(0), mCurrent(0), mDamage(0), mProgress(0) {}
+
+    template<typename T>
+    void StatState<T>::load(ESMReader &esm)
+    {
+        esm.getHNT(mBase, "STBA");
+
+        mMod = 0;
+        esm.getHNOT(mMod, "STMO");
+        mCurrent = 0;
+        esm.getHNOT(mCurrent, "STCU");
+
+        // mDamage was changed to a float; ensure backwards compatibility
+        T oldDamage = 0;
+        esm.getHNOT(oldDamage, "STDA");
+        mDamage = static_cast<float>(oldDamage);
+
+        esm.getHNOT(mDamage, "STDF");
+
+        mProgress = 0;
+        esm.getHNOT(mProgress, "STPR");
+    }
+
+    template<typename T>
+    void StatState<T>::save(ESMWriter &esm) const
+    {
+        esm.writeHNT("STBA", mBase);
+
+        if (mMod != 0)
+            esm.writeHNT("STMO", mMod);
+
+        if (mCurrent)
+            esm.writeHNT("STCU", mCurrent);
+
+        if (mDamage)
+            esm.writeHNT("STDF", mDamage);
+
+        if (mProgress)
+            esm.writeHNT("STPR", mProgress);
+    }
+
+    template class StatState<int>;
+    template class StatState<float>;
+}

--- a/components/esm/statstate.cpp
+++ b/components/esm/statstate.cpp
@@ -46,7 +46,7 @@ namespace ESM
         if (mProgress)
             esm.writeHNT("STPR", mProgress);
     }
-
-    template class StatState<int>;
-    template class StatState<float>;
 }
+
+template struct ESM::StatState<int>;
+template struct ESM::StatState<float>;

--- a/components/esm/statstate.hpp
+++ b/components/esm/statstate.hpp
@@ -1,11 +1,11 @@
 #ifndef OPENMW_ESM_STATSTATE_H
 #define OPENMW_ESM_STATSTATE_H
 
-#include "esmreader.hpp"
-#include "esmwriter.hpp"
-
 namespace ESM
 {
+    class ESMReader;
+    class ESMWriter;
+
     // format 0, saved games only
 
     template<typename T>
@@ -23,48 +23,6 @@ namespace ESM
         void load (ESMReader &esm);
         void save (ESMWriter &esm) const;
     };
-
-    template<typename T>
-    StatState<T>::StatState() : mBase (0), mMod (0), mCurrent (0), mDamage (0), mProgress (0) {}
-
-    template<typename T>
-    void StatState<T>::load (ESMReader &esm)
-    {
-        esm.getHNT (mBase, "STBA");
-
-        mMod = 0;
-        esm.getHNOT (mMod, "STMO");
-        mCurrent = 0;
-        esm.getHNOT (mCurrent, "STCU");
-
-        // mDamage was changed to a float; ensure backwards compatibility
-        T oldDamage = 0;
-        esm.getHNOT(oldDamage, "STDA");
-        mDamage = static_cast<float>(oldDamage);
-
-        esm.getHNOT (mDamage, "STDF");
-
-        mProgress = 0;
-        esm.getHNOT (mProgress, "STPR");
-    }
-
-    template<typename T>
-    void StatState<T>::save (ESMWriter &esm) const
-    {
-        esm.writeHNT ("STBA", mBase);
-
-        if (mMod != 0)
-            esm.writeHNT ("STMO", mMod);
-
-        if (mCurrent)
-            esm.writeHNT ("STCU", mCurrent);
-
-        if (mDamage)
-            esm.writeHNT ("STDF", mDamage);
-
-        if (mProgress)
-            esm.writeHNT ("STPR", mProgress);
-    }
 }
 
 #endif


### PR DESCRIPTION
As part if getting a working AppVeyor build of OpenMW, I'm working on getting the build time down. Right now the AppVeyor builds time out after 40 minuters.

One large compile time improvement can be had from reducing the number of headers included, so that's what I'm working towards by moving templates to explicit instantiations.

I'm mainly opening this PR for Travis right now, but should be mergable soon.