### PR TITLE
Windows build fix

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -123,11 +123,11 @@ target_link_libraries(openmw
     ${OPENAL_LIBRARY}
     ${SOUND_INPUT_LIBRARY}
     ${BULLET_LIBRARIES}
-    ${MYGUI_LIBRARIES}
     ${SDL2_LIBRARY}
     "osg-ffmpeg-videoplayer"
     "oics"
     components
+    ${MYGUI_LIBRARIES}
 )
 
 if (ANDROID)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -180,6 +180,7 @@ target_link_libraries(components
     ${SDL2_LIBRARY}
     # For MyGUI platform
     ${OPENGL_gl_LIBRARY}
+    ${MYGUI_LIBRARIES}
 )
 
 if (WIN32)


### PR DESCRIPTION
gcc.exe (Rev5, Built by MSYS2 project) 4.9.2
