### PR TITLE
Animation refactoring & fixes

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -43,6 +43,7 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/player.hpp"
 
 namespace
 {
@@ -1169,6 +1170,10 @@ bool CharacterController::updateWeaponState()
                 // Unset casting flag, otherwise pressing the mouse button down would
                 // continue casting every frame if there is no animation
                 mAttackingOrSpell = false;
+                if (mPtr == MWBase::Environment::get().getWorld()->getPlayerPtr())
+                {
+                    MWBase::Environment::get().getWorld()->getPlayer().setAttackingOrSpell(false);
+                }
 
                 const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1374,15 +1374,6 @@ bool CharacterController::updateWeaponState()
                 mAnimation->attachArrow();
 
             mUpperBodyState = UpperCharState_WeapEquiped;
-            //don't allow to continue playing hit animation on UpperBody after actor had attacked during it
-            if(mHitState == CharState_Hit)
-            {
-                mAnimation->changeBlendMask(mCurrentHit, MWRender::Animation::BlendMask_LowerBody);
-                //commenting out following 2 lines will give a bit different combat dynamics(slower)
-                mHitState = CharState_None;
-                mCurrentHit.clear();
-                mPtr.getClass().getCreatureStats(mPtr).setHitRecovery(false);
-            }
         }
         else if(mUpperBodyState == UpperCharState_UnEquipingWeap)
             mUpperBodyState = UpperCharState_Nothing;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1788,14 +1788,17 @@ void CharacterController::update(float duration)
             }
         }
 
-        // bipedal means hand-to-hand could be used (which is handled in updateWeaponState). an existing InventoryStore means an actual weapon could be used.
-        if(cls.isBipedal(mPtr) || cls.hasInventoryStore(mPtr))
-            forcestateupdate = updateWeaponState() || forcestateupdate;
-        else
-            forcestateupdate = updateCreatureState() || forcestateupdate;
-
         if (!mSkipAnim)
+        {
+            // bipedal means hand-to-hand could be used (which is handled in updateWeaponState). an existing InventoryStore means an actual weapon could be used.
+            if(cls.isBipedal(mPtr) || cls.hasInventoryStore(mPtr))
+                forcestateupdate = updateWeaponState() || forcestateupdate;
+            else
+                forcestateupdate = updateCreatureState() || forcestateupdate;
+
             refreshCurrentAnims(idlestate, movestate, jumpstate, forcestateupdate);
+        }
+
         if (inJump)
             mMovementAnimationControlled = false;
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -270,7 +270,9 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
             {
                 mHitState = CharState_Block;
                 mCurrentHit = "shield";
-                mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::BlendMask_All, true, 1, "block start", "block stop", 0.0f, 0);
+                MWRender::Animation::AnimPriority priorityBlock (Priority_Hit);
+                priorityBlock.mPriority[MWRender::Animation::BoneGroup_LeftArm] = Priority_Block;
+                mAnimation->play(mCurrentHit, priorityBlock, MWRender::Animation::BlendMask_All, true, 1, "block start", "block stop", 0.0f, 0);
             }
 
             // Cancel upper body animations
@@ -1148,7 +1150,7 @@ bool CharacterController::updateWeaponState()
     bool animPlaying;
     if(mAttackingOrSpell)
     {
-        if(mUpperBodyState == UpperCharState_WeapEquiped && mHitState == CharState_None)
+        if(mUpperBodyState == UpperCharState_WeapEquiped && (mHitState == CharState_None || mHitState == CharState_Block))
         {
             MWBase::Environment::get().getWorld()->breakInvisibility(mPtr);
             mAttackType.clear();
@@ -2029,12 +2031,13 @@ void CharacterController::setAttackingOrSpell(bool attackingOrSpell)
 
 bool CharacterController::readyToPrepareAttack() const
 {
-    return mHitState == CharState_None && mUpperBodyState  <= UpperCharState_WeapEquiped;
+    return (mHitState == CharState_None || mHitState == CharState_Block)
+            && mUpperBodyState  <= UpperCharState_WeapEquiped;
 }
 
 bool CharacterController::readyToStartAttack() const
 {
-    if (mHitState != CharState_None)
+    if (mHitState != CharState_None && mHitState != CharState_Block)
         return false;
 
     if (mPtr.getClass().hasInventoryStore(mPtr) || mPtr.getClass().isBipedal(mPtr))

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -251,26 +251,26 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
             {
                 mHitState = CharState_KnockOut;
                 mCurrentHit = "knockout";
-                mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::Group_All, false, 1, "start", "stop", 0.0f, ~0ul);
+                mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::BlendMask_All, false, 1, "start", "stop", 0.0f, ~0ul);
                 mPtr.getClass().getCreatureStats(mPtr).setKnockedDown(true);
             }
             else if(knockdown)
             {
                 mHitState = CharState_KnockDown;
                 mCurrentHit = "knockdown";
-                mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::Group_All, true, 1, "start", "stop", 0.0f, 0);
+                mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::BlendMask_All, true, 1, "start", "stop", 0.0f, 0);
             }
             else if (recovery)
             {
                 mHitState = CharState_Hit;
                 mCurrentHit = chooseRandomGroup("hit");
-                mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::Group_All, true, 1, "start", "stop", 0.0f, 0);
+                mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::BlendMask_All, true, 1, "start", "stop", 0.0f, 0);
             }
             else if (block)
             {
                 mHitState = CharState_Block;
                 mCurrentHit = "shield";
-                mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::Group_All, true, 1, "block start", "block stop", 0.0f, 0);
+                mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::BlendMask_All, true, 1, "block start", "block stop", 0.0f, 0);
             }
 
             // Cancel upper body animations
@@ -303,7 +303,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
         {
             mHitState = CharState_KnockDown;
             mAnimation->disable(mCurrentHit);
-            mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::Group_All, true, 1, "loop stop", "stop", 0.0f, 0);
+            mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::BlendMask_All, true, 1, "loop stop", "stop", 0.0f, 0);
         }
     }
 
@@ -314,7 +314,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
     if(force && mJumpState != JumpState_None)
     {
         std::string jump;
-        MWRender::Animation::Group jumpgroup = MWRender::Animation::Group_All;
+        MWRender::Animation::BlendMask jumpmask = MWRender::Animation::BlendMask_All;
         if(mJumpState != JumpState_None)
         {
             jump = "jump";
@@ -323,7 +323,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
                 jump += weap->shortgroup;
                 if(!mAnimation->hasAnimation(jump))
                 {
-                    jumpgroup = MWRender::Animation::Group_LowerBody;
+                    jumpmask = MWRender::Animation::BlendMask_LowerBody;
                     jump = "jump";
                 }
             }
@@ -336,7 +336,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
             mAnimation->disable(mCurrentJump);
             mCurrentJump = jump;
             if (mAnimation->hasAnimation("jump"))
-                mAnimation->play(mCurrentJump, Priority_Jump, jumpgroup, false,
+                mAnimation->play(mCurrentJump, Priority_Jump, jumpmask, false,
                              1.0f, ((mode!=2)?"start":"loop start"), "stop", 0.0f, ~0ul);
         }
         else
@@ -344,7 +344,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
             mAnimation->disable(mCurrentJump);
             mCurrentJump.clear();
             if (mAnimation->hasAnimation("jump"))
-                mAnimation->play(jump, Priority_Jump, jumpgroup, true,
+                mAnimation->play(jump, Priority_Jump, jumpmask, true,
                              1.0f, "loop stop", "stop", 0.0f, 0);
         }
     }
@@ -354,7 +354,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
         mMovementState = movement;
 
         std::string movement;
-        MWRender::Animation::Group movegroup = MWRender::Animation::Group_All;
+        MWRender::Animation::BlendMask movemask = MWRender::Animation::BlendMask_All;
         const StateInfo *movestate = std::find_if(sMovementList, sMovementListEnd, FindCharState(mMovementState));
         if(movestate != sMovementListEnd)
         {
@@ -364,7 +364,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
                 movement += weap->shortgroup;
                 if(!mAnimation->hasAnimation(movement))
                 {
-                    movegroup = MWRender::Animation::Group_LowerBody;
+                    movemask = MWRender::Animation::BlendMask_LowerBody;
                     movement = movestate->groupname;
                 }
             }
@@ -386,7 +386,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
                 }
                 else
                 {
-                    movegroup = MWRender::Animation::Group_LowerBody;
+                    movemask = MWRender::Animation::BlendMask_LowerBody;
                     movement.erase(swimpos, 4);
                     if(!mAnimation->hasAnimation(movement))
                         movement.clear();
@@ -447,7 +447,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
                 }
             }
 
-            mAnimation->play(mCurrentMovement, Priority_Movement, movegroup, false,
+            mAnimation->play(mCurrentMovement, Priority_Movement, movemask, false,
                              speedmult, ((mode!=2)?"start":"loop start"), "stop", 0.0f, ~0ul);
         }
     }
@@ -486,7 +486,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
         mAnimation->disable(mCurrentIdle);
         mCurrentIdle = idle;
         if(!mCurrentIdle.empty())
-            mAnimation->play(mCurrentIdle, Priority_Default, MWRender::Animation::Group_All, false,
+            mAnimation->play(mCurrentIdle, Priority_Default, MWRender::Animation::BlendMask_All, false,
                              1.0f, "start", "stop", 0.0f, ~0ul, true);
     }
 
@@ -602,7 +602,7 @@ void CharacterController::playDeath(float startpoint, CharacterState death)
     mCurrentJump = "";
     mMovementAnimationControlled = true;
 
-    mAnimation->play(mCurrentDeath, Priority_Death, MWRender::Animation::Group_All,
+    mAnimation->play(mCurrentDeath, Priority_Death, MWRender::Animation::BlendMask_All,
                     false, 1.0f, "start", "stop", startpoint, 0);
 }
 
@@ -868,10 +868,10 @@ void CharacterController::updateIdleStormState()
         mAnimation->getInfo("idlestorm", &complete);
 
         if (complete == 0)
-            mAnimation->play("idlestorm", Priority_Storm, MWRender::Animation::Group_RightArm, false,
+            mAnimation->play("idlestorm", Priority_Storm, MWRender::Animation::BlendMask_RightArm, false,
                              1.0f, "start", "loop start", 0.0f, 0);
         else if (complete == 1)
-            mAnimation->play("idlestorm", Priority_Storm, MWRender::Animation::Group_RightArm, false,
+            mAnimation->play("idlestorm", Priority_Storm, MWRender::Animation::BlendMask_RightArm, false,
                              1.0f, "loop start", "loop stop", 0.0f, ~0ul);
     }
     else
@@ -882,7 +882,7 @@ void CharacterController::updateIdleStormState()
             {
                 if (mAnimation->getCurrentTime("idlestorm") < mAnimation->getTextKeyTime("idlestorm: loop stop"))
                 {
-                    mAnimation->play("idlestorm", Priority_Storm, MWRender::Animation::Group_RightArm, true,
+                    mAnimation->play("idlestorm", Priority_Storm, MWRender::Animation::BlendMask_RightArm, true,
                                      1.0f, "loop stop", "stop", 0.0f, 0);
                 }
             }
@@ -989,7 +989,7 @@ bool CharacterController::updateCreatureState()
             if (!mCurrentWeapon.empty())
             {
                 mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::Group_All, true,
+                                 MWRender::Animation::BlendMask_All, true,
                                  1, startKey, stopKey,
                                  0.0f, 0);
                 mUpperBodyState = UpperCharState_StartToMinAttack;
@@ -1064,7 +1064,7 @@ bool CharacterController::updateWeaponState()
         {
             getWeaponGroup(mWeaponType, weapgroup);
             mAnimation->play(weapgroup, Priority_Weapon,
-                             MWRender::Animation::Group_UpperBody, true,
+                             MWRender::Animation::BlendMask_UpperBody, true,
                              1.0f, "unequip start", "unequip stop", 0.0f, 0);
             mUpperBodyState = UpperCharState_UnEquipingWeap;
         }
@@ -1075,7 +1075,7 @@ bool CharacterController::updateWeaponState()
             mAnimation->setWeaponGroup(weapgroup);
 
             mAnimation->play(weapgroup, Priority_Weapon,
-                             MWRender::Animation::Group_UpperBody, true,
+                             MWRender::Animation::BlendMask_UpperBody, true,
                              1.0f, "equip start", "equip stop", 0.0f, 0);
             mUpperBodyState = UpperCharState_EquipingWeap;
 
@@ -1192,7 +1192,7 @@ bool CharacterController::updateWeaponState()
                     }
 
                     mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                     MWRender::Animation::Group_UpperBody, true,
+                                     MWRender::Animation::BlendMask_UpperBody, true,
                                      weapSpeed, mAttackType+" start", mAttackType+" stop",
                                      0.0f, 0);
                     mUpperBodyState = UpperCharState_CastingSpell;
@@ -1224,7 +1224,7 @@ bool CharacterController::updateWeaponState()
                         Security(mPtr).probeTrap(target, item, resultMessage, resultSound);
                 }
                 mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::Group_UpperBody, true,
+                                 MWRender::Animation::BlendMask_UpperBody, true,
                                  1.0f, "start", "stop", 0.0, 0);
                 mUpperBodyState = UpperCharState_FollowStartToFollowStop;
 
@@ -1251,7 +1251,7 @@ bool CharacterController::updateWeaponState()
                 }
 
                 mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::Group_UpperBody, false,
+                                 MWRender::Animation::BlendMask_UpperBody, false,
                                  weapSpeed, mAttackType+" start", mAttackType+" min attack",
                                  0.0f, 0);
                 mUpperBodyState = UpperCharState_StartToMinAttack;
@@ -1302,7 +1302,7 @@ bool CharacterController::updateWeaponState()
 
             mAnimation->disable(mCurrentWeapon);
             mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                             MWRender::Animation::Group_UpperBody, false,
+                             MWRender::Animation::BlendMask_UpperBody, false,
                              weapSpeed, mAttackType+" max attack", mAttackType+" min hit",
                              1.0f-complete, 0);
 
@@ -1374,7 +1374,7 @@ bool CharacterController::updateWeaponState()
             //don't allow to continue playing hit animation on UpperBody after actor had attacked during it
             if(mHitState == CharState_Hit)
             {
-                mAnimation->changeGroups(mCurrentHit, MWRender::Animation::Group_LowerBody);
+                mAnimation->changeBlendMask(mCurrentHit, MWRender::Animation::BlendMask_LowerBody);
                 //commenting out following 2 lines will give a bit different combat dynamics(slower)
                 mHitState = CharState_None;
                 mCurrentHit.clear();
@@ -1398,7 +1398,7 @@ bool CharacterController::updateWeaponState()
                 //hack to avoid body pos desync when jumping/sneaking in 'max attack' state
                 if(!mAnimation->isPlaying(mCurrentWeapon))
                     mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                        MWRender::Animation::Group_UpperBody, false,
+                        MWRender::Animation::BlendMask_UpperBody, false,
                         0, mAttackType+" min attack", mAttackType+" max attack", 0.999f, 0);
                 break;
             case UpperCharState_MaxAttackToMinHit:
@@ -1441,11 +1441,11 @@ bool CharacterController::updateWeaponState()
             mAnimation->disable(mCurrentWeapon);
             if (mUpperBodyState == UpperCharState_FollowStartToFollowStop)
                 mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::Group_UpperBody, true,
+                                 MWRender::Animation::BlendMask_UpperBody, true,
                                  weapSpeed, start, stop, 0.0f, 0);
             else
                 mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::Group_UpperBody, false,
+                                 MWRender::Animation::BlendMask_UpperBody, false,
                                  weapSpeed, start, stop, 0.0f, 0);
         }
     }
@@ -1459,11 +1459,11 @@ bool CharacterController::updateWeaponState()
              MWBase::Environment::get().getWorld()->isSwimming(mPtr) ||
              cls.getCreatureStats(mPtr).getMovementFlag(CreatureStats::Flag_Sneak))
         {
-            mAnimation->changeGroups(mCurrentWeapon, MWRender::Animation::Group_UpperBody);
+            mAnimation->changeBlendMask(mCurrentWeapon, MWRender::Animation::BlendMask_UpperBody);
         }
         else
         {
-            mAnimation->changeGroups(mCurrentWeapon, MWRender::Animation::Group_All);
+            mAnimation->changeBlendMask(mCurrentWeapon, MWRender::Animation::BlendMask_All);
         }
     }
 
@@ -1475,7 +1475,7 @@ bool CharacterController::updateWeaponState()
                 && updateCarriedLeftVisible(mWeaponType))
 
         {
-            mAnimation->play("torch", Priority_Torch, MWRender::Animation::Group_LeftArm,
+            mAnimation->play("torch", Priority_Torch, MWRender::Animation::BlendMask_LeftArm,
                 false, 1.0f, "start", "stop", 0.0f, (~(size_t)0), true);
         }
         else if (mAnimation->isPlaying("torch"))
@@ -1505,7 +1505,7 @@ void CharacterController::update(float duration)
                 mAnimQueue.pop_front();
 
                 mAnimation->play(mAnimQueue.front().first, Priority_Default,
-                                 MWRender::Animation::Group_All, false,
+                                 MWRender::Animation::BlendMask_All, false,
                                  1.0f, "start", "stop", 0.0f, mAnimQueue.front().second);
             }
         }
@@ -1786,7 +1786,7 @@ void CharacterController::update(float duration)
                 mAnimQueue.pop_front();
 
                 mAnimation->play(mAnimQueue.front().first, Priority_Default,
-                                 MWRender::Animation::Group_All, false,
+                                 MWRender::Animation::BlendMask_All, false,
                                  1.0f, "start", "stop", 0.0f, mAnimQueue.front().second);
             }
         }
@@ -1894,7 +1894,7 @@ void CharacterController::playGroup(const std::string &groupname, int mode, int 
 
             mIdleState = CharState_SpecialIdle;
             mAnimation->play(groupname, Priority_Default,
-                             MWRender::Animation::Group_All, false, 1.0f,
+                             MWRender::Animation::BlendMask_All, false, 1.0f,
                              ((mode==2) ? "loop start" : "start"), "stop", 0.0f, count-1);
         }
         else if(mode == 0)

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1051,6 +1051,9 @@ bool CharacterController::updateWeaponState()
         }
     }
 
+    MWRender::Animation::AnimPriority priorityWeapon(Priority_Weapon);
+    priorityWeapon.mPriority[MWRender::Animation::BoneGroup_LowerBody] = 0;
+
     bool forcestateupdate = false;
     if(weaptype != mWeaponType && mHitState != CharState_KnockDown && mHitState != CharState_KnockOut
                                 && mHitState != CharState_Hit)
@@ -1063,8 +1066,8 @@ bool CharacterController::updateWeaponState()
         if(weaptype == WeapType_None)
         {
             getWeaponGroup(mWeaponType, weapgroup);
-            mAnimation->play(weapgroup, Priority_Weapon,
-                             MWRender::Animation::BlendMask_UpperBody, true,
+            mAnimation->play(weapgroup, priorityWeapon,
+                             MWRender::Animation::BlendMask_All, true,
                              1.0f, "unequip start", "unequip stop", 0.0f, 0);
             mUpperBodyState = UpperCharState_UnEquipingWeap;
         }
@@ -1074,8 +1077,8 @@ bool CharacterController::updateWeaponState()
             mAnimation->showWeapons(false);
             mAnimation->setWeaponGroup(weapgroup);
 
-            mAnimation->play(weapgroup, Priority_Weapon,
-                             MWRender::Animation::BlendMask_UpperBody, true,
+            mAnimation->play(weapgroup, priorityWeapon,
+                             MWRender::Animation::BlendMask_All, true,
                              1.0f, "equip start", "equip stop", 0.0f, 0);
             mUpperBodyState = UpperCharState_EquipingWeap;
 
@@ -1191,8 +1194,8 @@ bool CharacterController::updateWeaponState()
                         case 2: mAttackType = "target"; break;
                     }
 
-                    mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                     MWRender::Animation::BlendMask_UpperBody, true,
+                    mAnimation->play(mCurrentWeapon, priorityWeapon,
+                                     MWRender::Animation::BlendMask_All, true,
                                      weapSpeed, mAttackType+" start", mAttackType+" stop",
                                      0.0f, 0);
                     mUpperBodyState = UpperCharState_CastingSpell;
@@ -1223,8 +1226,8 @@ bool CharacterController::updateWeaponState()
                     else if(item.getTypeName() == typeid(ESM::Probe).name())
                         Security(mPtr).probeTrap(target, item, resultMessage, resultSound);
                 }
-                mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::BlendMask_UpperBody, true,
+                mAnimation->play(mCurrentWeapon, priorityWeapon,
+                                 MWRender::Animation::BlendMask_All, true,
                                  1.0f, "start", "stop", 0.0, 0);
                 mUpperBodyState = UpperCharState_FollowStartToFollowStop;
 
@@ -1250,8 +1253,8 @@ bool CharacterController::updateWeaponState()
                         determineAttackType();
                 }
 
-                mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::BlendMask_UpperBody, false,
+                mAnimation->play(mCurrentWeapon, priorityWeapon,
+                                 MWRender::Animation::BlendMask_All, false,
                                  weapSpeed, mAttackType+" start", mAttackType+" min attack",
                                  0.0f, 0);
                 mUpperBodyState = UpperCharState_StartToMinAttack;
@@ -1301,8 +1304,8 @@ bool CharacterController::updateWeaponState()
             mAttackStrength = attackStrength;
 
             mAnimation->disable(mCurrentWeapon);
-            mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                             MWRender::Animation::BlendMask_UpperBody, false,
+            mAnimation->play(mCurrentWeapon, priorityWeapon,
+                             MWRender::Animation::BlendMask_All, false,
                              weapSpeed, mAttackType+" max attack", mAttackType+" min hit",
                              1.0f-complete, 0);
 
@@ -1397,8 +1400,8 @@ bool CharacterController::updateWeaponState()
             case UpperCharState_MinAttackToMaxAttack:
                 //hack to avoid body pos desync when jumping/sneaking in 'max attack' state
                 if(!mAnimation->isPlaying(mCurrentWeapon))
-                    mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                        MWRender::Animation::BlendMask_UpperBody, false,
+                    mAnimation->play(mCurrentWeapon, priorityWeapon,
+                        MWRender::Animation::BlendMask_All, false,
                         0, mAttackType+" min attack", mAttackType+" max attack", 0.999f, 0);
                 break;
             case UpperCharState_MaxAttackToMinHit:
@@ -1440,30 +1443,13 @@ bool CharacterController::updateWeaponState()
         {
             mAnimation->disable(mCurrentWeapon);
             if (mUpperBodyState == UpperCharState_FollowStartToFollowStop)
-                mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::BlendMask_UpperBody, true,
+                mAnimation->play(mCurrentWeapon, priorityWeapon,
+                                 MWRender::Animation::BlendMask_All, true,
                                  weapSpeed, start, stop, 0.0f, 0);
             else
-                mAnimation->play(mCurrentWeapon, Priority_Weapon,
-                                 MWRender::Animation::BlendMask_UpperBody, false,
+                mAnimation->play(mCurrentWeapon, priorityWeapon,
+                                 MWRender::Animation::BlendMask_All, false,
                                  weapSpeed, start, stop, 0.0f, 0);
-        }
-    }
-
-     //if playing combat animation and lowerbody is not busy switch to whole body animation
-    if((weaptype != WeapType_None || mUpperBodyState == UpperCharState_UnEquipingWeap) && animPlaying)
-    {
-        if( mMovementState != CharState_None ||
-             mJumpState != JumpState_None ||
-             mHitState != CharState_None ||
-             MWBase::Environment::get().getWorld()->isSwimming(mPtr) ||
-             cls.getCreatureStats(mPtr).getMovementFlag(CreatureStats::Flag_Sneak))
-        {
-            mAnimation->changeBlendMask(mCurrentWeapon, MWRender::Animation::BlendMask_UpperBody);
-        }
-        else
-        {
-            mAnimation->changeBlendMask(mCurrentWeapon, MWRender::Animation::BlendMask_All);
         }
     }
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -32,6 +32,7 @@ enum Priority {
     Priority_Movement,
     Priority_Hit,
     Priority_Weapon,
+    Priority_Block,
     Priority_Knockdown,
     Priority_Torch,
     Priority_Storm,

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -186,7 +186,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
 
     void determineAttackType();
 
-    void refreshCurrentAnims(CharacterState idle, CharacterState movement, bool force=false);
+    void refreshCurrentAnims(CharacterState idle, CharacterState movement, JumpingState jump, bool force=false);
 
     void clearAnimQueue();
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -461,7 +461,7 @@ namespace MWRender
             mTextKeyListener->handleTextKey(groupname, key, map);
     }
 
-    void Animation::play(const std::string &groupname, AnimPriority priority, int blendMask, bool autodisable, float speedmult,
+    void Animation::play(const std::string &groupname, const AnimPriority& priority, int blendMask, bool autodisable, float speedmult,
                          const std::string &start, const std::string &stop, float startpoint, size_t loops, bool loopfallback)
     {
         if(!mObjectRoot || mAnimSources.empty())

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -461,7 +461,7 @@ namespace MWRender
             mTextKeyListener->handleTextKey(groupname, key, map);
     }
 
-    void Animation::play(const std::string &groupname, int priority, int blendMask, bool autodisable, float speedmult,
+    void Animation::play(const std::string &groupname, AnimPriority priority, int blendMask, bool autodisable, float speedmult,
                          const std::string &start, const std::string &stop, float startpoint, size_t loops, bool loopfallback)
     {
         if(!mObjectRoot || mAnimSources.empty())
@@ -472,8 +472,6 @@ namespace MWRender
             resetActiveGroups();
             return;
         }
-
-        priority = std::max(0, priority);
 
         AnimStateMap::iterator stateiter = mStates.begin();
         while(stateiter != mStates.end())
@@ -653,7 +651,7 @@ namespace MWRender
                 if(!(state->second.mBlendMask&(1<<blendMask)))
                     continue;
 
-                if(active == mStates.end() || active->second.mPriority < state->second.mPriority)
+                if(active == mStates.end() || active->second.mPriority.mPriority[blendMask] < state->second.mPriority.mPriority[blendMask])
                     active = state;
             }
 
@@ -690,6 +688,7 @@ namespace MWRender
         addControllers();
     }
 
+    // TODO: remove
     void Animation::changeBlendMask(const std::string &groupname, int mask)
     {
         AnimStateMap::iterator stateiter = mStates.find(groupname);
@@ -1208,9 +1207,10 @@ namespace MWRender
     {
         for (AnimStateMap::const_iterator stateiter = mStates.begin(); stateiter != mStates.end(); ++stateiter)
         {
-            if((stateiter->second.mPriority > MWMechanics::Priority_Movement
-                    && stateiter->second.mPriority < MWMechanics::Priority_Torch)
-                    || stateiter->second.mPriority == MWMechanics::Priority_Death)
+            if (stateiter->second.mPriority.contains(int(MWMechanics::Priority_Hit))
+                    || stateiter->second.mPriority.contains(int(MWMechanics::Priority_Weapon))
+                    || stateiter->second.mPriority.contains(int(MWMechanics::Priority_Knockdown))
+                    || stateiter->second.mPriority.contains(int(MWMechanics::Priority_Death)))
                 return false;
         }
         return true;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -598,23 +598,20 @@ namespace MWRender
         state.setTime(state.mStartTime + ((state.mStopTime - state.mStartTime) * startpoint));
 
         // mLoopStartTime and mLoopStopTime normally get assigned when encountering these keys while playing the animation
-        // (see handleTextKey). But if startpoint is already past these keys, we need to assign them now.
-        if(state.getTime() > state.mStartTime)
+        // (see handleTextKey). But if startpoint is already past these keys, or start time is == stop time, we need to assign them now.
+        const std::string loopstarttag = groupname+": loop start";
+        const std::string loopstoptag = groupname+": loop stop";
+
+        NifOsg::TextKeyMap::const_reverse_iterator key(groupend);
+        for (; key != startkey && key != keys.rend(); ++key)
         {
-            const std::string loopstarttag = groupname+": loop start";
-            const std::string loopstoptag = groupname+": loop stop";
+            if (key->first > state.getTime())
+                continue;
 
-            NifOsg::TextKeyMap::const_reverse_iterator key(groupend);
-            for (; key != startkey && key != keys.rend(); ++key)
-            {
-                if (key->first > state.getTime())
-                    continue;
-
-                if (key->second == loopstarttag)
-                    state.mLoopStartTime = key->first;
-                else if (key->second == loopstoptag)
-                    state.mLoopStopTime = key->first;
-            }
+            if (key->second == loopstarttag)
+                state.mLoopStartTime = key->first;
+            else if (key->second == loopstoptag)
+                state.mLoopStopTime = key->first;
         }
 
         return true;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -688,21 +688,6 @@ namespace MWRender
         addControllers();
     }
 
-    // TODO: remove
-    void Animation::changeBlendMask(const std::string &groupname, int mask)
-    {
-        AnimStateMap::iterator stateiter = mStates.find(groupname);
-        if(stateiter != mStates.end())
-        {
-            if(stateiter->second.mBlendMask != mask)
-            {
-                stateiter->second.mBlendMask = mask;
-                resetActiveGroups();
-            }
-            return;
-        }
-    }
-
     void Animation::stopLooping(const std::string& groupname)
     {
         AnimStateMap::iterator stateiter = mStates.find(groupname);

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -118,6 +118,35 @@ protected:
 
     struct AnimSource;
 
+    /// Holds an animation priority value for each distinct bone blendmask.
+    struct AnimPriority
+    {
+        /// Convenience constructor, initialises all priorities to the same value.
+        AnimPriority(int priority)
+        {
+            for (unsigned int i=0; i<sNumBlendMasks; ++i)
+                mPriority[i] = priority;
+        }
+
+        bool operator == (const AnimPriority& other) const
+        {
+            for (unsigned int i=0; i<sNumBlendMasks; ++i)
+                if (other.mPriority[i] != mPriority[i])
+                    return false;
+            return true;
+        }
+
+        bool contains(int priority) const
+        {
+            for (unsigned int i=0; i<sNumBlendMasks; ++i)
+                if (priority == mPriority[i])
+                    return true;
+            return false;
+        }
+
+        int mPriority[sNumBlendMasks];
+    };
+
     struct AnimState {
         boost::shared_ptr<AnimSource> mSource;
         float mStartTime;
@@ -132,7 +161,7 @@ protected:
         bool mPlaying;
         size_t mLoopCount;
 
-        int mPriority;
+        AnimPriority mPriority;
         int mBlendMask;
         bool mAutoDisable;
 
@@ -319,7 +348,7 @@ public:
      * \param loopFallback Allow looping an animation that has no loop keys, i.e. fall back to use
      *                     the "start" and "stop" keys for looping?
      */
-    void play(const std::string &groupname, int priority, int blendMask, bool autodisable,
+    void play(const std::string &groupname, AnimPriority priority, int blendMask, bool autodisable,
               float speedmult, const std::string &start, const std::string &stop,
               float startpoint, size_t loops, bool loopfallback=false);
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -67,9 +67,15 @@ typedef boost::shared_ptr<PartHolder> PartHolderPtr;
 class Animation
 {
 public:
+    enum BoneGroup {
+        BoneGroup_LowerBody = 0,
+        BoneGroup_Torso,
+        BoneGroup_LeftArm,
+        BoneGroup_RightArm
+    };
+
     enum BlendMask {
         BlendMask_LowerBody = 1<<0,
-
         BlendMask_Torso = 1<<1,
         BlendMask_LeftArm = 1<<2,
         BlendMask_RightArm = 1<<3,
@@ -78,47 +84,10 @@ public:
 
         BlendMask_All = BlendMask_LowerBody | BlendMask_UpperBody
     };
-
-    class TextKeyListener
-    {
-    public:
-        virtual void handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key,
-                           const std::multimap<float, std::string>& map) = 0;
-    };
-
-    void setTextKeyListener(TextKeyListener* listener);
-
-protected:
-    /* This is the number of *discrete* groups. */
+    /* This is the number of *discrete* blend masks. */
     static const size_t sNumBlendMasks = 4;
 
-    class AnimationTime : public SceneUtil::ControllerSource
-    {
-    private:
-        boost::shared_ptr<float> mTimePtr;
-
-    public:
-
-        void setTimePtr(boost::shared_ptr<float> time)
-        { mTimePtr = time; }
-        boost::shared_ptr<float> getTimePtr() const
-        { return mTimePtr; }
-
-        virtual float getValue(osg::NodeVisitor* nv);
-    };
-
-    class NullAnimationTime : public SceneUtil::ControllerSource
-    {
-    public:
-        virtual float getValue(osg::NodeVisitor *nv)
-        {
-            return 0.f;
-        }
-    };
-
-    struct AnimSource;
-
-    /// Holds an animation priority value for each distinct bone blendmask.
+    /// Holds an animation priority value for each BoneGroup.
     struct AnimPriority
     {
         /// Convenience constructor, initialises all priorities to the same value.
@@ -146,6 +115,42 @@ protected:
 
         int mPriority[sNumBlendMasks];
     };
+
+    class TextKeyListener
+    {
+    public:
+        virtual void handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key,
+                           const std::multimap<float, std::string>& map) = 0;
+    };
+
+    void setTextKeyListener(TextKeyListener* listener);
+
+protected:
+    class AnimationTime : public SceneUtil::ControllerSource
+    {
+    private:
+        boost::shared_ptr<float> mTimePtr;
+
+    public:
+
+        void setTimePtr(boost::shared_ptr<float> time)
+        { mTimePtr = time; }
+        boost::shared_ptr<float> getTimePtr() const
+        { return mTimePtr; }
+
+        virtual float getValue(osg::NodeVisitor* nv);
+    };
+
+    class NullAnimationTime : public SceneUtil::ControllerSource
+    {
+    public:
+        virtual float getValue(osg::NodeVisitor *nv)
+        {
+            return 0.f;
+        }
+    };
+
+    struct AnimSource;
 
     struct AnimState {
         boost::shared_ptr<AnimSource> mSource;

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -67,16 +67,16 @@ typedef boost::shared_ptr<PartHolder> PartHolderPtr;
 class Animation
 {
 public:
-    enum Group {
-        Group_LowerBody = 1<<0,
+    enum BlendMask {
+        BlendMask_LowerBody = 1<<0,
 
-        Group_Torso = 1<<1,
-        Group_LeftArm = 1<<2,
-        Group_RightArm = 1<<3,
+        BlendMask_Torso = 1<<1,
+        BlendMask_LeftArm = 1<<2,
+        BlendMask_RightArm = 1<<3,
 
-        Group_UpperBody = Group_Torso | Group_LeftArm | Group_RightArm,
+        BlendMask_UpperBody = BlendMask_Torso | BlendMask_LeftArm | BlendMask_RightArm,
 
-        Group_All = Group_LowerBody | Group_UpperBody
+        BlendMask_All = BlendMask_LowerBody | BlendMask_UpperBody
     };
 
     class TextKeyListener
@@ -90,7 +90,7 @@ public:
 
 protected:
     /* This is the number of *discrete* groups. */
-    static const size_t sNumGroups = 4;
+    static const size_t sNumBlendMasks = 4;
 
     class AnimationTime : public SceneUtil::ControllerSource
     {
@@ -133,12 +133,12 @@ protected:
         size_t mLoopCount;
 
         int mPriority;
-        int mGroups;
+        int mBlendMask;
         bool mAutoDisable;
 
         AnimState() : mStartTime(0.0f), mLoopStartTime(0.0f), mLoopStopTime(0.0f), mStopTime(0.0f),
                       mTime(new float), mSpeedMult(1.0f), mPlaying(false), mLoopCount(0),
-                      mPriority(0), mGroups(0), mAutoDisable(true)
+                      mPriority(0), mBlendMask(0), mAutoDisable(true)
         {
         }
         ~AnimState();
@@ -176,7 +176,7 @@ protected:
     typedef std::multimap<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback> > ControllerMap;
     ControllerMap mActiveControllers;
 
-    boost::shared_ptr<AnimationTime> mAnimationTimePtr[sNumGroups];
+    boost::shared_ptr<AnimationTime> mAnimationTimePtr[sNumBlendMasks];
 
     // Stored in all lowercase for a case-insensitive lookup
     typedef std::map<std::string, osg::ref_ptr<osg::MatrixTransform> > NodeMap;
@@ -213,7 +213,7 @@ protected:
      */
     void resetActiveGroups();
 
-    size_t detectAnimGroup(osg::Node* node);
+    size_t detectBlendMask(osg::Node* node);
 
     /* Updates the position of the accum root node for the given time, and
      * returns the wanted movement vector from the previous time. */
@@ -304,7 +304,7 @@ public:
      * \param priority Priority of the animation. The animation will play on
      *                 bone groups that don't have another animation set of a
      *                 higher priority.
-     * \param groups Bone groups to play the animation on.
+     * \param blendMask Bone groups to play the animation on.
      * \param autodisable Automatically disable the animation when it stops
      *                    playing.
      * \param speedmult Speed multiplier for the animation.
@@ -319,7 +319,7 @@ public:
      * \param loopFallback Allow looping an animation that has no loop keys, i.e. fall back to use
      *                     the "start" and "stop" keys for looping?
      */
-    void play(const std::string &groupname, int priority, int groups, bool autodisable,
+    void play(const std::string &groupname, int priority, int blendMask, bool autodisable,
               float speedmult, const std::string &start, const std::string &stop,
               float startpoint, size_t loops, bool loopfallback=false);
 
@@ -358,7 +358,7 @@ public:
      * \param groupname Animation group to disable.
      */
     void disable(const std::string &groupname);
-    void changeGroups(const std::string &groupname, int group);
+    void changeBlendMask(const std::string &groupname, int mask);
 
     /** Retrieves the velocity (in units per second) that the animation will move. */
     float getVelocity(const std::string &groupname) const;

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -353,7 +353,7 @@ public:
      * \param loopFallback Allow looping an animation that has no loop keys, i.e. fall back to use
      *                     the "start" and "stop" keys for looping?
      */
-    void play(const std::string &groupname, AnimPriority priority, int blendMask, bool autodisable,
+    void play(const std::string &groupname, const AnimPriority& priority, int blendMask, bool autodisable,
               float speedmult, const std::string &start, const std::string &stop,
               float startpoint, size_t loops, bool loopfallback=false);
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -392,7 +392,6 @@ public:
      * \param groupname Animation group to disable.
      */
     void disable(const std::string &groupname);
-    void changeBlendMask(const std::string &groupname, int mask);
 
     /** Retrieves the velocity (in units per second) that the animation will move. */
     float getVelocity(const std::string &groupname) const;

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -241,13 +241,13 @@ namespace MWRender
         mAnimation->showCarriedLeft(showCarriedLeft);
 
         mCurrentAnimGroup = groupname;
-        mAnimation->play(mCurrentAnimGroup, 1, Animation::Group_All, false, 1.0f, "start", "stop", 0.0f, 0);
+        mAnimation->play(mCurrentAnimGroup, 1, Animation::BlendMask_All, false, 1.0f, "start", "stop", 0.0f, 0);
 
         MWWorld::ContainerStoreIterator torch = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
         if(torch != inv.end() && torch->getTypeName() == typeid(ESM::Light).name() && showCarriedLeft)
         {
             if(!mAnimation->getInfo("torch"))
-                mAnimation->play("torch", 2, MWRender::Animation::Group_LeftArm, false,
+                mAnimation->play("torch", 2, Animation::BlendMask_LeftArm, false,
                                  1.0f, "start", "stop", 0.0f, ~0ul, true);
         }
         else if(mAnimation->getInfo("torch"))
@@ -357,7 +357,7 @@ namespace MWRender
 
     void RaceSelectionPreview::onSetup ()
     {
-        mAnimation->play("idle", 1, Animation::Group_All, false, 1.0f, "start", "stop", 0.0f, 0);
+        mAnimation->play("idle", 1, Animation::BlendMask_All, false, 1.0f, "start", "stop", 0.0f, 0);
         mAnimation->runAnimation(0.f);
 
         // attach camera to follow the head node


### PR DESCRIPTION
For review by @kcat 

* Rename Animation::Group to Animation::BlendMask. The term group was already used elsewhere.
* Extended the animation state priority system, now supports separate priority values for each bone group.
* Refactor weapon animations to use the new priority system in place of the changeGroups hack.
* Allow attacks during block animations, continue playing the block animation on the LeftArm.