### PR TITLE
Change color of crosshair to red when object is owned

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -6,8 +6,6 @@
 #include <list>
 #include <stdint.h>
 
-#include "../mwworld/ptr.hpp"
-
 namespace osg
 {
     class Vec3f;
@@ -25,6 +23,7 @@ namespace MWWorld
 {
     class Ptr;
     class CellStore;
+    class CellRef;
 }
 
 namespace Loading

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -6,6 +6,8 @@
 #include <list>
 #include <stdint.h>
 
+#include "../mwworld/ptr.hpp"
+
 namespace osg
 {
     class Vec3f;
@@ -211,6 +213,8 @@ namespace MWBase
 
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid) = 0;
+            
+            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim) = 0;
     };
 }
 

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -219,7 +219,6 @@ namespace MWBase
             virtual void unsetSelectedWeapon() = 0;
 
             virtual void showCrosshair(bool show) = 0;
-            virtual void setCrosshairOwned(bool owned) = 0;
             virtual bool getSubtitlesEnabled() = 0;
             virtual bool toggleGui() = 0;
 

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -219,6 +219,7 @@ namespace MWBase
             virtual void unsetSelectedWeapon() = 0;
 
             virtual void showCrosshair(bool show) = 0;
+            virtual void setCrosshairOwned(bool owned) = 0;
             virtual bool getSubtitlesEnabled() = 0;
             virtual bool toggleGui() = 0;
 

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -518,7 +518,21 @@ namespace MWGui
     {
         mCrosshair->setVisible (visible);
     }
-
+    
+    void HUD::setCrosshairOwned(bool owned)
+    {
+        MyGUI::Colour red = MyGUI::Colour(1.0, 0, 0);
+        MyGUI::Colour white = MyGUI::Colour(1.0, 1.0, 1.0);
+        if(owned)
+        {
+            mCrosshair->setColour(red);
+        }
+        else
+        {
+            mCrosshair->setColour(white);
+        }
+    }
+    
     void HUD::setHmsVisible(bool visible)
     {
         mHealth->setVisible(visible);

--- a/apps/openmw/mwgui/hud.hpp
+++ b/apps/openmw/mwgui/hud.hpp
@@ -47,6 +47,7 @@ namespace MWGui
         void unsetSelectedWeapon();
 
         void setCrosshairVisible(bool visible);
+        void setCrosshairOwned(bool owned);
 
         void onFrame(float dt);
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -300,8 +300,6 @@ namespace MWGui
                 mDynamicToolTipBox->setVisible(true);
                 
             }
-            
-            checkOwned();
         }
     }
 
@@ -351,27 +349,23 @@ namespace MWGui
         return tooltipSize;
     }
     
-    void ToolTips::checkOwned()
+    bool ToolTips::checkOwned()
     {
-        if(Settings::Manager::getBool("show owned", "Game"))
+        // true=owned, false=notOwned
+        if(!mFocusObject.isEmpty())
         {
-            MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
+            MWWorld::CellRef& cellref = mFocusObject.getCellRef();
+            MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
+            MWWorld::Ptr victim;
             
-            if(!mFocusObject.isEmpty())
-            {
-                MWWorld::CellRef& cellref = mFocusObject.getCellRef();
-                MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
-                MWWorld::Ptr victim;
-                
-                MWBase::MechanicsManager* mm = MWBase::Environment::get().getMechanicsManager();
-                bool allowed = mm->isAllowedToUse(ptr, cellref, victim); // 0 - owned, 1 - not owned
+            MWBase::MechanicsManager* mm = MWBase::Environment::get().getMechanicsManager();
+            bool allowed = mm->isAllowedToUse(ptr, cellref, victim); 
 
-                wm->setCrosshairOwned(!allowed);
-            }
-            else
-            {
-                wm->setCrosshairOwned(false);
-            }
+            return !allowed;
+        }
+        else
+        {
+            return false;
         }
     }
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -17,7 +17,6 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
 #include "../mwmechanics/spellcasting.hpp"
-#include "../mwmechanics/mechanicsmanagerimp.hpp"
 
 #include "mapwindow.hpp"
 #include "inventorywindow.hpp"
@@ -364,7 +363,7 @@ namespace MWGui
                 MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
                 MWWorld::Ptr victim;
                 
-                MWMechanics::MechanicsManager* mm = new MWMechanics::MechanicsManager;
+                MWBase::MechanicsManager* mm = MWBase::Environment::get().getMechanicsManager();
                 bool allowed = mm->isAllowedToUse(ptr, cellref, victim); // 0 - owned, 1 - not owned
 
                 wm->setCrosshairOwned(!allowed);

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -299,7 +299,10 @@ namespace MWGui
                         tooltipSize.height);
 
                 mDynamicToolTipBox->setVisible(true);
+                
             }
+            
+            checkOwned();
         }
     }
 
@@ -344,29 +347,30 @@ namespace MWGui
                 info.icon = "";
             tooltipSize = createToolTip(info);
             
-            // start owned check
+        }
+
+        return tooltipSize;
+    }
+    
+    void ToolTips::checkOwned()
+    {
+        MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
+        
+        if(!mFocusObject.isEmpty())
+        {
             MWWorld::CellRef& cellref = mFocusObject.getCellRef();
             MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
             MWWorld::Ptr victim;
             
             MWMechanics::MechanicsManager* mm = new MWMechanics::MechanicsManager;
             bool allowed = mm->isAllowedToUse(ptr, cellref, victim); // 0 - owned, 1 - not owned
-            
-            MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
-            if(allowed)
-            {
-                // if 'item' is not owned
-                wm->showCrosshair(true);
-            }
-            else
-            {
-                // if 'item' is owned
-                wm->showCrosshair(false);
-            }
-            
-        }
 
-        return tooltipSize;
+            wm->setCrosshairOwned(!allowed);
+        }
+        else
+        {
+            wm->setCrosshairOwned(false);
+        }
     }
 
     MyGUI::IntSize ToolTips::createToolTip(const MWGui::ToolTipInfo& info)

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -17,6 +17,7 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
 #include "../mwmechanics/spellcasting.hpp"
+#include "../mwmechanics/mechanicsmanagerimp.hpp"
 
 #include "mapwindow.hpp"
 #include "inventorywindow.hpp"
@@ -342,6 +343,27 @@ namespace MWGui
             if (!image)
                 info.icon = "";
             tooltipSize = createToolTip(info);
+            
+            // start owned check
+            MWWorld::CellRef& cellref = mFocusObject.getCellRef();
+            MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
+            MWWorld::Ptr victim;
+            
+            MWMechanics::MechanicsManager* mm = new MWMechanics::MechanicsManager;
+            bool allowed = mm->isAllowedToUse(ptr, cellref, victim); // 0 - owned, 1 - not owned
+            
+            MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
+            if(allowed)
+            {
+                // if 'item' is not owned
+                wm->showCrosshair(true);
+            }
+            else
+            {
+                // if 'item' is owned
+                wm->showCrosshair(false);
+            }
+            
         }
 
         return tooltipSize;

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -354,22 +354,25 @@ namespace MWGui
     
     void ToolTips::checkOwned()
     {
-        MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
-        
-        if(!mFocusObject.isEmpty())
+        if(Settings::Manager::getBool("show owned", "Game"))
         {
-            MWWorld::CellRef& cellref = mFocusObject.getCellRef();
-            MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
-            MWWorld::Ptr victim;
+            MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
             
-            MWMechanics::MechanicsManager* mm = new MWMechanics::MechanicsManager;
-            bool allowed = mm->isAllowedToUse(ptr, cellref, victim); // 0 - owned, 1 - not owned
+            if(!mFocusObject.isEmpty())
+            {
+                MWWorld::CellRef& cellref = mFocusObject.getCellRef();
+                MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
+                MWWorld::Ptr victim;
+                
+                MWMechanics::MechanicsManager* mm = new MWMechanics::MechanicsManager;
+                bool allowed = mm->isAllowedToUse(ptr, cellref, victim); // 0 - owned, 1 - not owned
 
-            wm->setCrosshairOwned(!allowed);
-        }
-        else
-        {
-            wm->setCrosshairOwned(false);
+                wm->setCrosshairOwned(!allowed);
+            }
+            else
+            {
+                wm->setCrosshairOwned(false);
+            }
         }
     }
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -298,7 +298,6 @@ namespace MWGui
                         tooltipSize.height);
 
                 mDynamicToolTipBox->setVisible(true);
-                
             }
         }
     }
@@ -343,7 +342,6 @@ namespace MWGui
             if (!image)
                 info.icon = "";
             tooltipSize = createToolTip(info);
-            
         }
 
         return tooltipSize;
@@ -351,10 +349,9 @@ namespace MWGui
     
     bool ToolTips::checkOwned()
     {
-        // true=owned, false=notOwned
         if(!mFocusObject.isEmpty())
         {
-            MWWorld::CellRef& cellref = mFocusObject.getCellRef();
+            const MWWorld::CellRef& cellref = mFocusObject.getCellRef();
             MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
             MWWorld::Ptr victim;
             

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -95,6 +95,9 @@ namespace MWGui
 
         MyGUI::IntSize getToolTipViaPtr (bool image=true);
         ///< @return requested tooltip size
+        
+        void checkOwned();
+        /// Checks if object is owned and sets correct crosshair mode 
 
         MyGUI::IntSize createToolTip(const ToolTipInfo& info);
         ///< @return requested tooltip size

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -89,8 +89,8 @@ namespace MWGui
         static void createMagicEffectToolTip(MyGUI::Widget* widget, short id);
         
         bool checkOwned();
-        /// Checks if object is owned and sets correct crosshair mode 
-
+        /// Returns True if taking mFocusObject would be crime
+ 
     private:
         MyGUI::Widget* mDynamicToolTipBox;
 

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -87,6 +87,9 @@ namespace MWGui
         static void createRaceToolTip(MyGUI::Widget* widget, const ESM::Race* playerRace);
         static void createClassToolTip(MyGUI::Widget* widget, const ESM::Class& playerClass);
         static void createMagicEffectToolTip(MyGUI::Widget* widget, short id);
+        
+        bool checkOwned();
+        /// Checks if object is owned and sets correct crosshair mode 
 
     private:
         MyGUI::Widget* mDynamicToolTipBox;
@@ -95,9 +98,6 @@ namespace MWGui
 
         MyGUI::IntSize getToolTipViaPtr (bool image=true);
         ///< @return requested tooltip size
-        
-        void checkOwned();
-        /// Checks if object is owned and sets correct crosshair mode 
 
         MyGUI::IntSize createToolTip(const ToolTipInfo& info);
         ///< @return requested tooltip size

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -187,6 +187,7 @@ namespace MWGui
       , mRestAllowed(true)
       , mFPS(0.0f)
       , mFallbackMap(fallbackMap)
+      , mShowOwned(false)
     {
         float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
         mGuiPlatform = new osgMyGUI::Platform(viewer, guiRoot, resourceSystem->getTextureManager(), uiScale);
@@ -261,6 +262,8 @@ namespace MWGui
 
         MyGUI::ClipboardManager::getInstance().eventClipboardChanged += MyGUI::newDelegate(this, &WindowManager::onClipboardChanged);
         MyGUI::ClipboardManager::getInstance().eventClipboardRequested += MyGUI::newDelegate(this, &WindowManager::onClipboardRequested);
+        
+        mShowOwned = Settings::Manager::getBool("show owned", "Game");
     }
 
     void WindowManager::initUI()
@@ -1039,7 +1042,7 @@ namespace MWGui
     {
         mToolTips->setFocusObject(focus);
         
-        if(Settings::Manager::getBool("show owned", "Game") && mHud)
+        if(mShowOwned && mHud)
         {
             bool owned = mToolTips->checkOwned();
             mHud->setCrosshairOwned(owned);  

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1038,6 +1038,12 @@ namespace MWGui
     void WindowManager::setFocusObject(const MWWorld::Ptr& focus)
     {
         mToolTips->setFocusObject(focus);
+        
+        if(Settings::Manager::getBool("show owned", "Game") && mHud)
+        {
+            bool owned = mToolTips->checkOwned();
+            mHud->setCrosshairOwned(owned);  
+        }
     }
 
     void WindowManager::setFocusObjectScreenCoords(float min_x, float min_y, float max_x, float max_y)
@@ -1422,12 +1428,6 @@ namespace MWGui
     {
         if (mHud)
             mHud->setCrosshairVisible (show && mCrosshairEnabled);
-    }
-    
-    void WindowManager::setCrosshairOwned (bool owned)
-    {
-        if (mHud)
-            mHud->setCrosshairOwned (owned);
     }
 
     void WindowManager::activateQuickKey (int index)

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1423,6 +1423,12 @@ namespace MWGui
         if (mHud)
             mHud->setCrosshairVisible (show && mCrosshairEnabled);
     }
+    
+    void WindowManager::setCrosshairOwned (bool owned)
+    {
+        if (mHud)
+            mHud->setCrosshairOwned (owned);
+    }
 
     void WindowManager::activateQuickKey (int index)
     {

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -486,6 +486,8 @@ namespace MWGui
     float mFPS;
 
     std::map<std::string, std::string> mFallbackMap;
+    
+    bool mShowOwned;
 
     /**
      * Called when MyGUI tries to retrieve a tag's value. Tags must be denoted in #{tag} notation and will be replaced upon setting a user visible text/property.

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -233,6 +233,7 @@ namespace MWGui
     virtual void unsetSelectedWeapon();
 
     virtual void showCrosshair(bool show);
+    virtual void setCrosshairOwned(bool owned);
     virtual bool getSubtitlesEnabled();
 
     /// Turn visibility of *all* GUI elements on or off (HUD and all windows, except the console)

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -233,7 +233,6 @@ namespace MWGui
     virtual void unsetSelectedWeapon();
 
     virtual void showCrosshair(bool show);
-    virtual void setCrosshairOwned(bool owned);
     virtual bool getSubtitlesEnabled();
 
     /// Turn visibility of *all* GUI elements on or off (HUD and all windows, except the console)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -175,13 +175,15 @@ namespace MWMechanics
 
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid);
+            
+            /// @return is \a ptr allowed to take/use \a cellref or is it a crime?
+            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim);
 
         private:
             void reportCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
                                       OffenseType type, int arg=0);
 
-            /// @return is \a ptr allowed to take/use \a cellref or is it a crime?
-            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim);
+
     };
 }
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -162,6 +162,9 @@ best attack = false
 
 difficulty = 0
 
+# change crosshair color when pointing on owned object
+show owned = false
+
 [Saves]
 character =
 # Save when resting


### PR DESCRIPTION
This pull request makes it easy to tell if taking object will be crime or not. When pointing on owned object the crosshair turns red.

You need to add "show owned = true" under [Game] is settings.cfg for this to be enabled.

This is the first time I'm messing with OpenMW code, so I hope that it doesn't break anything...