### PR TITLE
Change color of both tooltip and crosshair when pointing on owned object

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,6 +52,7 @@ Programmers
     jeaye
     Jeffrey Haines (Jyby)
     Jengerer
+    Jiří Kuneš (kunesj)
     Joel Graff (graffy)
     John Blomberg (fstp)
     Jordan Ayers
@@ -59,7 +60,6 @@ Programmers
     Julien Voisin (jvoisin/ap0)
     Karl-Felix Glatzer (k1ll)
     Kevin Poitra (PuppyKevin)
-    kunesj
     Lars Söderberg (Lazaroth)
     lazydev
     Leon Saunders (emoose)

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -521,15 +521,13 @@ namespace MWGui
     
     void HUD::setCrosshairOwned(bool owned)
     {
-        MyGUI::Colour red = MyGUI::Colour(1.0, 0, 0);
-        MyGUI::Colour white = MyGUI::Colour(1.0, 1.0, 1.0);
         if(owned)
         {
-            mCrosshair->setColour(red);
+            mCrosshair->changeWidgetSkin("HUD_Crosshair_Owned");
         }
         else
         {
-            mCrosshair->setColour(white);
+            mCrosshair->changeWidgetSkin("HUD_Crosshair");
         }
     }
     

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -377,7 +377,7 @@ namespace MWGui
         {
             if(checkOwned())
             {
-                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_R");
+                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_Owned");
             }
             else
             {

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -369,6 +369,15 @@ namespace MWGui
     MyGUI::IntSize ToolTips::createToolTip(const MWGui::ToolTipInfo& info)
     {
         mDynamicToolTipBox->setVisible(true);
+        
+        if(checkOwned())
+        {
+            mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_R");
+        }
+        else
+        {
+            mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp");
+        }
 
         std::string caption = info.caption;
         std::string image = info.icon;

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -38,6 +38,7 @@ namespace MWGui
         , mLastMouseY(0)
         , mEnabled(true)
         , mFullHelp(false)
+        , mShowOwned(0)
     {
         getWidget(mDynamicToolTipBox, "DynamicToolTipBox");
 
@@ -55,6 +56,8 @@ namespace MWGui
         {
             mMainWidget->getChildAt(i)->setVisible(false);
         }
+        
+        mShowOwned = Settings::Manager::getInt("show owned", "Game");
     }
 
     void ToolTips::setEnabled(bool enabled)
@@ -370,13 +373,16 @@ namespace MWGui
     {
         mDynamicToolTipBox->setVisible(true);
         
-        if(checkOwned())
+        if(mShowOwned == 1 || mShowOwned == 3)
         {
-            mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_R");
-        }
-        else
-        {
-            mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp");
+            if(checkOwned())
+            {
+                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_R");
+            }
+            else
+            {
+                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp");
+            }
         }
 
         std::string caption = info.caption;

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -122,6 +122,8 @@ namespace MWGui
         bool mEnabled;
 
         bool mFullHelp;
+        
+        int mShowOwned;
     };
 }
 #endif

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1095,11 +1095,22 @@ namespace MWGui
     void WindowManager::onRetrieveTag(const MyGUI::UString& _tag, MyGUI::UString& _result)
     {
         std::string tag(_tag);
+        
+        std::string MyGuiPrefix = "setting=";
+        size_t MyGuiPrefixLength = MyGuiPrefix.length();
 
         std::string tokenToFind = "sCell=";
         size_t tokenLength = tokenToFind.length();
-
-        if (tag.compare(0, tokenLength, tokenToFind) == 0)
+        
+        if(tag.compare(0, MyGuiPrefixLength, MyGuiPrefix) == 0)
+        {
+            tag = tag.substr(MyGuiPrefixLength, tag.length());
+            std::string settingSection = tag.substr(0, tag.find(","));
+            std::string settingTag = tag.substr(tag.find(",")+1, tag.length());
+            
+            _result = Settings::Manager::getString(settingTag, settingSection);            
+        }
+        else if (tag.compare(0, tokenLength, tokenToFind) == 0)
         {
             _result = mTranslationDataStorage.translateCellName(tag.substr(tokenLength));
         }

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -187,7 +187,7 @@ namespace MWGui
       , mRestAllowed(true)
       , mFPS(0.0f)
       , mFallbackMap(fallbackMap)
-      , mShowOwned(false)
+      , mShowOwned(0)
       , mVersionDescription(versionDescription)
     {
         float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
@@ -264,7 +264,7 @@ namespace MWGui
         MyGUI::ClipboardManager::getInstance().eventClipboardChanged += MyGUI::newDelegate(this, &WindowManager::onClipboardChanged);
         MyGUI::ClipboardManager::getInstance().eventClipboardRequested += MyGUI::newDelegate(this, &WindowManager::onClipboardRequested);
 
-        mShowOwned = Settings::Manager::getBool("show owned", "Game");
+        mShowOwned = Settings::Manager::getInt("show owned", "Game");
     }
 
     void WindowManager::initUI()
@@ -1043,7 +1043,7 @@ namespace MWGui
     {
         mToolTips->setFocusObject(focus);
 
-        if(mShowOwned && mHud)
+        if(mHud && (mShowOwned == 2 || mShowOwned == 3))
         {
             bool owned = mToolTips->checkOwned();
             mHud->setCrosshairOwned(owned);

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -495,6 +495,7 @@ namespace MWGui
      * Called when MyGUI tries to retrieve a tag's value. Tags must be denoted in #{tag} notation and will be replaced upon setting a user visible text/property.
      * Supported syntax:
      * #{GMSTName}: retrieves String value of the GMST called GMSTName
+     * #{setting=CATEGORY_NAME,SETTING_NAME}: retrieves String value of SETTING_NAME under category CATEGORY_NAME from settings.cfg
      * #{sCell=CellID}: retrieves translated name of the given CellID (used only by some Morrowind localisations, in others cell ID is == cell name)
      * #{fontcolour=FontColourName}: retrieves the value of the fallback setting "FontColor_color_<FontColourName>" from openmw.cfg,
      *                              in the format "r g b a", float values in range 0-1. Useful for "Colour" and "TextColour" properties in skins.

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -487,7 +487,7 @@ namespace MWGui
 
     std::map<std::string, std::string> mFallbackMap;
     
-    bool mShowOwned;
+    int mShowOwned;
 
     std::string mVersionDescription;
 

--- a/files/mygui/openmw_hud.layout
+++ b/files/mygui/openmw_hud.layout
@@ -122,8 +122,7 @@
         </Widget>
 
         <!-- Crosshair -->
-        <Widget type="ImageBox" skin="ImageBox" position="0 0 32 32" align="Center Center" name="Crosshair">
-            <Property key="ImageTexture" value="textures\target.dds"/>
+        <Widget type="ImageBox" skin="HUD_Crosshair" position="0 0 32 32" align="Center Center" name="Crosshair">
         </Widget>
 
         <!-- Basic FPSCounter box -->

--- a/files/mygui/openmw_hud_box.skin.xml
+++ b/files/mygui/openmw_hud_box.skin.xml
@@ -32,16 +32,31 @@
 
     </Resource>
     
-    <Resource type="ResourceSkin" name="HUD_Box_NoTransp_R" size="40 40">
+    <Resource type="ResourceSkin" name="HUD_Box_NoTransp_Owned" size="40 40">
 
         <!-- The interior of the box -->
 
-        <Child type="Widget" skin="DialogBG_R" offset="0 0 40 40" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="DialogBG_Owned" offset="0 0 40 40" align="Stretch" name="Client"/>
 
         <!-- Borders -->
 
         <Child type="Widget" skin="MW_Box" offset="0 0 40 40" align="Left Stretch" name="Client"/>
 
+    </Resource>
+    
+    <!-- Defines crosshair color -->
+    <Resource type="ResourceSkin" name="HUD_Crosshair" size="32 32" texture="textures\target.dds">
+        <BasisSkin type="MainSkin" offset="0 0 32 32">
+            <State name="normal" offset="0 0 32 32"/>
+        </BasisSkin>
+    </Resource>
+    
+    <!-- Defines owned crosshair color -->
+    <Resource type="ResourceSkin" name="HUD_Crosshair_Owned" size="32 32" texture="textures\target.dds">
+        <Property key="Colour" value="0.9 0 0 1"/>
+        <BasisSkin type="MainSkin" offset="0 0 32 32">
+            <State name="normal" offset="0 0 32 32"/>
+        </BasisSkin>
     </Resource>
 
 </MyGUI>

--- a/files/mygui/openmw_hud_box.skin.xml
+++ b/files/mygui/openmw_hud_box.skin.xml
@@ -31,5 +31,17 @@
         <Child type="Widget" skin="MW_Box" offset="0 0 40 40" align="Left Stretch" name="Client"/>
 
     </Resource>
+    
+    <Resource type="ResourceSkin" name="HUD_Box_NoTransp_R" size="40 40">
+
+        <!-- The interior of the box -->
+
+        <Child type="Widget" skin="DialogBG_R" offset="0 0 40 40" align="Stretch" name="Client"/>
+
+        <!-- Borders -->
+
+        <Child type="Widget" skin="MW_Box" offset="0 0 40 40" align="Left Stretch" name="Client"/>
+
+    </Resource>
 
 </MyGUI>

--- a/files/mygui/openmw_hud_box.skin.xml
+++ b/files/mygui/openmw_hud_box.skin.xml
@@ -53,7 +53,7 @@
     
     <!-- Defines owned crosshair color -->
     <Resource type="ResourceSkin" name="HUD_Crosshair_Owned" size="32 32" texture="textures\target.dds">
-        <Property key="Colour" value="0.9 0 0 1"/>
+        <Property key="Colour" value="#{setting=GUI,color crosshair owned}"/>
         <BasisSkin type="MainSkin" offset="0 0 32 32">
             <State name="normal" offset="0 0 32 32"/>
         </BasisSkin>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -131,8 +131,7 @@
     
     <!-- Defines a owned background -->
     <Resource type="ResourceSkin" name="DialogBG_Owned" size="8 8" texture="white">
-        <Property key="Colour" value="0.2 0 0 1"/>
-        <!-- <Property key="Colour" value="#{setting=GUI,color background owned}"/> -->
+        <Property key="Colour" value="#{setting=GUI,color background owned}"/> 
         <BasisSkin type="MainSkin" offset="0 0 8 8">
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -129,9 +129,10 @@
         </BasisSkin>
     </Resource>
     
-    <!-- Defines a red background -->
-    <Resource type="ResourceSkin" name="DialogBG_R" size="8 8" texture="white">
+    <!-- Defines a owned background -->
+    <Resource type="ResourceSkin" name="DialogBG_Owned" size="8 8" texture="white">
         <Property key="Colour" value="0.2 0 0 1"/>
+        <!-- <Property key="Colour" value="#{setting=GUI,color background owned}"/> -->
         <BasisSkin type="MainSkin" offset="0 0 8 8">
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -131,7 +131,7 @@
     
     <!-- Defines a red background -->
     <Resource type="ResourceSkin" name="DialogBG_R" size="8 8" texture="white">
-        <Property key="Colour" value="0.3 0 0 1"/>
+        <Property key="Colour" value="0.2 0 0 1"/>
         <BasisSkin type="MainSkin" offset="0 0 8 8">
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -128,6 +128,14 @@
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>
     </Resource>
+    
+    <!-- Defines a red background -->
+    <Resource type="ResourceSkin" name="DialogBG_R" size="8 8" texture="white">
+        <Property key="Colour" value="0.3 0 0 1"/>
+        <BasisSkin type="MainSkin" offset="0 0 8 8">
+            <State name="normal" offset="0 0 8 8"/>
+        </BasisSkin>
+    </Resource>
 
     <!-- These define the dialog borders -->
     <Resource type="ResourceSkin" name="DB_B" size="512 4" texture="textures\menu_thick_border_bottom.dds">

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -162,8 +162,12 @@ best attack = false
 
 difficulty = 0
 
-# change crosshair color when pointing on owned object
-show owned = false
+# Change crosshair/toolTip color when pointing on owned object
+#0: nothing changed
+#1: tint toolTip
+#2: tint crosshair
+#3: both
+show owned = 0
 
 [Saves]
 character =

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -36,6 +36,10 @@ werewolf overlay = true
 
 stretch menu background = false
 
+# colour definitions (red green blue alpha)
+color background owned = 0.15 0 0 1
+color crosshair owned = 1 0.15 0.15 1
+
 [General]
 # Camera field of view
 field of view = 55


### PR DESCRIPTION
Related to #668 

Added some stuff that should have been in previous pull request...

1) Not just crosshair but tooltip changes colour now too

2) Changed settings to enable changing only crosshair or tooltip colour

```
[Game]
# Change crosshair/toolTip color when pointing on owned object
#0: nothing changed
#1: tint toolTip
#2: tint crosshair
#3: both
show owned = 0
```

3) Added colour settings to settings.cfg

```
[GUI]
# colour definitions (red green blue alpha)
color background owned = 0.15 0 0 1
color crosshair owned = 1 0.15 0.15 1
```

4) It's now possible to use values from settings.cfg in mygui xml files. ([thread](https://forum.openmw.org/viewtopic.php?f=6&t=2999))
Example:
```
<Property key="Colour" value="#{setting=GUI,color background owned}"/> 
```
will give you value (string) of "color background owned" under "[GUI]" section in settings.cfg

5) screenshot

![screenshot from 2015-07-18 22 15 03](https://cloud.githubusercontent.com/assets/7138527/8763449/534ecda8-2d9c-11e5-81ab-186d7ac4dc55.png)
 