### PR TITLE
Increase the max view distance to something more reasonable for a high end machine.

### DIFF
--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -345,7 +345,7 @@
                             <UserString key="SettingName" value="viewing distance"/>
                             <UserString key="SettingValueType" value="Float"/>
                             <UserString key="SettingMin" value="2000"/>
-                            <UserString key="SettingMax" value="6666"/>
+                            <UserString key="SettingMax" value="30000"/>
                         </Widget>
                         <Widget type="TextBox" skin="SandText" position="4 178 332 18" align="Left Top">
                             <Property key="Caption" value="#{sNear}"/>


### PR DESCRIPTION
Exterior grid size must be at least 6 for the new maximum to work correctly.

Let the discussion begin.  While I'm not sure super far should be the default, this certainly improves the game experience.

Note:
In mwworld/scene.cpp: 330
halfGridSize is an int, and uses integer division on "exterior grid size"
This means odd numbers (like the original '3') should not be used in exterior grid size.

Ideally this should be another setting in the cfg file, but with a quick look I couldn't figure out how to get that to work correctly.