### PR TITLE
Task #2793. Changed a settings variable responsible for number of loaded exterior cells.

### DIFF
--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -327,7 +327,7 @@ namespace MWWorld
         std::string loadingExteriorText = "#{sLoadingMessage3}";
         loadingListener->setLabel(loadingExteriorText);
 
-        const int halfGridSize = Settings::Manager::getInt("exterior grid size", "Cells")/2;
+        const int halfGridSize = Settings::Manager::getInt("exterior cell load distance", "Cells");
 
         CellStoreCollection::iterator active = mActiveCells.begin();
         while (active!=mActiveCells.end())

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -101,7 +101,7 @@ local map widget size = 512
 local map hud widget size = 256
 
 [Cells]
-exterior grid size = 3
+exterior cell load distance = 1
 
 [Camera]
 near clip = 5


### PR DESCRIPTION
Changed a settings variable responsible for number of loaded exterior cells.
https://bugs.openmw.org/issues/2793

Tested for few values. Maybe I should add some greater-than-0 check?