### PR TITLE
Bugfix #2728

### DIFF
--- a/apps/opencs/model/world/idtableproxymodel.cpp
+++ b/apps/opencs/model/world/idtableproxymodel.cpp
@@ -112,10 +112,13 @@ void CSMWorld::IdTableProxyModel::refreshFilter()
     invalidateFilter();
 }
 
-void CSMWorld::IdTableProxyModel::sourceRowsInserted(const QModelIndex &/*parent*/, int /*start*/, int end)
+void CSMWorld::IdTableProxyModel::sourceRowsInserted(const QModelIndex &parent, int /*start*/, int end)
 {
     refreshFilter();
-    emit rowAdded(getRecordId(end).toUtf8().constData());
+    if (!parent.isValid())
+    {
+        emit rowAdded(getRecordId(end).toUtf8().constData());
+    }
 }
 
 void CSMWorld::IdTableProxyModel::sourceRowsRemoved(const QModelIndex &/*parent*/, int /*start*/, int /*end*/)

--- a/apps/opencs/model/world/idtableproxymodel.hpp
+++ b/apps/opencs/model/world/idtableproxymodel.hpp
@@ -27,6 +27,10 @@ namespace CSMWorld
             typedef std::map<Columns::ColumnId, std::vector<std::string> > EnumColumnCache;
             mutable EnumColumnCache mEnumColumnCache;
 
+        protected:
+
+            IdTableBase *mSourceModel;
+
         private:
 
             void updateColumnMap();
@@ -45,15 +49,23 @@ namespace CSMWorld
 
         protected:
 
-            bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
+            virtual bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
 
             virtual bool filterAcceptsRow (int sourceRow, const QModelIndex& sourceParent) const;
 
-        private slots:
+            QString getRecordId(int sourceRow) const;
 
-            void sourceRowsChanged(const QModelIndex &parent, int start, int end);
+        protected slots:
 
-            void sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+            virtual void sourceRowsInserted(const QModelIndex &parent, int start, int end);
+
+            virtual void sourceRowsRemoved(const QModelIndex &parent, int start, int end);
+
+            virtual void sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+
+        signals:
+
+            void rowAdded(const std::string &id);
     };
 }
 

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -77,13 +77,17 @@ void CSMWorld::InfoTableProxyModel::sourceRowsRemoved(const QModelIndex &/*paren
     mFirstRowCache.clear();
 }
 
-void CSMWorld::InfoTableProxyModel::sourceRowsInserted(const QModelIndex &/*parent*/, int /*start*/, int end)
+void CSMWorld::InfoTableProxyModel::sourceRowsInserted(const QModelIndex &parent, int /*start*/, int end)
 {
     refreshFilter();
-    mFirstRowCache.clear();
-    // We can't re-sort the model here, because the topic of the added row isn't set yet.
-    // Store the row index for using in the first dataChanged() after this row insertion.
-    mLastAddedSourceRow = end;
+
+    if (!parent.isValid())
+    {
+        mFirstRowCache.clear();
+        // We can't re-sort the model here, because the topic of the added row isn't set yet.
+        // Store the row index for using in the first dataChanged() after this row insertion.
+        mLastAddedSourceRow = end;
+    }
 }
 
 void CSMWorld::InfoTableProxyModel::sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)

--- a/apps/opencs/model/world/infotableproxymodel.hpp
+++ b/apps/opencs/model/world/infotableproxymodel.hpp
@@ -16,25 +16,29 @@ namespace CSMWorld
             Q_OBJECT
 
             UniversalId::Type mType;
-            IdTableBase *mSourceModel;
             Columns::ColumnId mInfoColumnId;
             ///< Contains ID for Topic or Journal ID
+            int mInfoColumnIndex;
+            int mLastAddedSourceRow;
 
             mutable QHash<QString, int> mFirstRowCache;
 
             int getFirstInfoRow(int currentRow) const;
             ///< Finds the first row with the same topic (journal entry) as in \a currentRow
+            ///< \a currentRow is a row of the source model.
 
         public:
             InfoTableProxyModel(UniversalId::Type type, QObject *parent = 0);
 
-            void setSourceModel(QAbstractItemModel *sourceModel);
+            virtual void setSourceModel(QAbstractItemModel *sourceModel);
 
         protected:
             virtual bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
 
-        private slots:
-            void modelRowsChanged(const QModelIndex &parent, int start, int end);
+        protected slots:
+            virtual void sourceRowsInserted(const QModelIndex &parent, int start, int end);
+            virtual void sourceRowsRemoved(const QModelIndex &parent, int start, int end);
+            virtual void sourceDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
     };
 }
 

--- a/apps/opencs/view/world/table.cpp
+++ b/apps/opencs/view/world/table.cpp
@@ -371,8 +371,10 @@ CSVWorld::Table::Table (const CSMWorld::UniversalId& id,
     connect (mProxyModel, SIGNAL (rowsRemoved (const QModelIndex&, int, int)),
         this, SLOT (tableSizeUpdate()));
 
-    connect (mProxyModel, SIGNAL (rowsInserted (const QModelIndex&, int, int)),
-        this, SLOT (rowsInsertedEvent(const QModelIndex&, int, int)));
+    //connect (mProxyModel, SIGNAL (rowsInserted (const QModelIndex&, int, int)),
+    //    this, SLOT (rowsInsertedEvent(const QModelIndex&, int, int)));
+    connect (mProxyModel, SIGNAL (rowAdded (const std::string &)), 
+        this, SLOT (rowAdded (const std::string &)));
 
     /// \note This signal could instead be connected to a slot that filters out changes not affecting
     /// the records status column (for permanence reasons)
@@ -714,12 +716,13 @@ std::vector< CSMWorld::UniversalId > CSVWorld::Table::getDraggedRecords() const
     return idToDrag;
 }
 
-void CSVWorld::Table::rowsInsertedEvent(const QModelIndex& parent, int start, int end)
+void CSVWorld::Table::rowAdded(const std::string &id)
 {
     tableSizeUpdate();
     if(mJumpToAddedRecord)
     {
-        selectRow(end);
+        int idColumn = mModel->findColumnIndex(CSMWorld::Columns::ColumnId_Id);
+        selectRow(mProxyModel->getModelIndex(id, idColumn).row());
 
         if(mUnselectAfterJump)
             clearSelection();

--- a/apps/opencs/view/world/table.hpp
+++ b/apps/opencs/view/world/table.hpp
@@ -140,7 +140,7 @@ namespace CSVWorld
 
             void updateUserSetting (const QString &name, const QStringList &list);
 
-            void rowsInsertedEvent(const QModelIndex& parent, int start, int end);
+            void rowAdded(const std::string &id);
     };
 }
 


### PR DESCRIPTION
InfoTableProxyModel informs about a row addition only after the model re-sorting (using a custom signal). We can't simply repeat the previous sorting, because an added row may be left in the wrong position (Qt uses a stable sorting). So we must sort the model by the Topic/Journal column firstly.