### PR TITLE
Use marker_error.nif as replacement when a mesh fails to load

### DIFF
--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -233,7 +233,7 @@ namespace MWWorld
 
         if(result.second)
         {
-            std::cout << "loading cell " << cell->getCell()->getDescription() << std::endl;
+            std::cout << "Loading cell " << cell->getCell()->getDescription() << std::endl;
 
             float verts = ESM::Land::LAND_SIZE;
             float worldsize = ESM::Land::REAL_SIZE;

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -100,11 +100,20 @@ namespace Resource
         Index::iterator it = mIndex.find(normalized);
         if (it == mIndex.end())
         {
-            Files::IStreamPtr file = mVFS->get(normalized);
-
             // TODO: add support for non-NIF formats
+            osg::ref_ptr<osg::Node> loaded;
+            try
+            {
+                Files::IStreamPtr file = mVFS->get(normalized);
 
-            osg::ref_ptr<osg::Node> loaded = NifOsg::Loader::load(Nif::NIFFilePtr(new Nif::NIFFile(file, normalized)), mTextureManager);
+                loaded = NifOsg::Loader::load(Nif::NIFFilePtr(new Nif::NIFFile(file, normalized)), mTextureManager);
+            }
+            catch (std::exception& e)
+            {
+                std::cerr << "Failed to load '" << name << "': " << e.what() << ", using marker_error.nif instead" << std::endl;
+                Files::IStreamPtr file = mVFS->get("meshes/marker_error.nif");
+                loaded = NifOsg::Loader::load(Nif::NIFFilePtr(new Nif::NIFFile(file, normalized)), mTextureManager);
+            }
 
             osgDB::Registry::instance()->getOrCreateSharedStateManager()->share(loaded.get());
             // TODO: run SharedStateManager::prune on unload

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -38,12 +38,16 @@ namespace Resource
         ~SceneManager();
 
         /// Get a read-only copy of this scene "template"
+        /// @note If the given filename does not exist or fails to load, an error marker mesh will be used instead.
+        ///  If even the error marker mesh can not be found, an exception is thrown.
         osg::ref_ptr<const osg::Node> getTemplate(const std::string& name);
 
         /// Create an instance of the given scene template
+        /// @see getTemplate
         osg::ref_ptr<osg::Node> createInstance(const std::string& name);
 
         /// Create an instance of the given scene template and immediately attach it to a parent node
+        /// @see getTemplate
         osg::ref_ptr<osg::Node> createInstance(const std::string& name, osg::Group* parentNode);
 
         /// Attach the given scene instance to the given parent node


### PR DESCRIPTION
Via #694

Instead of showing nothing at all, show the error marker. Makes it easier to notice problems in a mod setup.