### PR TITLE
Don't try to play bad idle animations (Prevents Log spam)

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -160,12 +160,13 @@ namespace MWBase
             virtual void forceStateUpdate(const MWWorld::Ptr &ptr) = 0;
             ///< Forces an object to refresh its animation state.
 
-            virtual void playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number=1) = 0;
+            virtual bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number=1) = 0;
             ///< Run animation for a MW-reference. Calls to this function for references that are currently not
             /// in the scene should be ignored.
             ///
             /// \param mode 0 normal, 1 immediate start, 2 immediate loop
             /// \param count How many times the animation should be run
+            /// \return Success or error
 
             virtual void skipAnimation(const MWWorld::Ptr& ptr) = 0;
             ///< Skip the animation for the given MW-reference for one frame. Calls to this function for

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1,6 +1,7 @@
 #include "actors.hpp"
 
 #include <typeinfo>
+#include <iostream>
 
 #include <osg/PositionAttitudeTransform>
 
@@ -1241,11 +1242,18 @@ namespace MWMechanics
             iter->second->getCharacterController()->forceStateUpdate();
     }
 
-    void Actors::playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number)
+    bool Actors::playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number)
     {
         PtrActorMap::iterator iter = mActors.find(ptr);
         if(iter != mActors.end())
-            iter->second->getCharacterController()->playGroup(groupName, mode, number);
+        {
+            return iter->second->getCharacterController()->playGroup(groupName, mode, number);
+        }
+        else
+        {
+            std::cerr<< "Error in Actors::playAnimationGroup:  Unable to find " << ptr.getTypeName() << std::endl;
+            return false;
+        }
     }
     void Actors::skipAnimation(const MWWorld::Ptr& ptr)
     {

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -105,7 +105,7 @@ namespace MWMechanics
 
         void forceStateUpdate(const MWWorld::Ptr &ptr);
 
-        void playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number);
+        bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number);
         void skipAnimation(const MWWorld::Ptr& ptr);
         bool checkAnimationPlaying(const MWWorld::Ptr& ptr, const std::string& groupName);
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -1,6 +1,7 @@
 #include "aiwander.hpp"
 
 #include <cfloat>
+#include <iostream>
 
 #include <components/misc/rng.hpp>
 
@@ -621,12 +622,17 @@ namespace MWMechanics
         actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
     }
 
-    void AiWander::playIdle(const MWWorld::Ptr& actor, unsigned short idleSelect)
+    bool AiWander::playIdle(const MWWorld::Ptr& actor, unsigned short idleSelect)
     {
         if ((GroupIndex_MinIdle <= idleSelect) && (idleSelect <= GroupIndex_MaxIdle))
         {
             const std::string& groupName = sIdleSelectToGroupName[idleSelect - GroupIndex_MinIdle];
-            MWBase::Environment::get().getMechanicsManager()->playAnimationGroup(actor, groupName, 0, 1);
+            return MWBase::Environment::get().getMechanicsManager()->playAnimationGroup(actor, groupName, 0, 1);
+        }
+        else
+        {
+            std::cerr<< "Attempted to play out of range idle animation \""<<idleSelect<<"\" for " << actor.getCellRef().getRefId() << std::endl;
+            return false;
         }
     }
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -392,17 +392,23 @@ namespace MWMechanics
         short unsigned& idleAnimation = storage.mIdleAnimation;
         idleAnimation = getRandomIdle();
 
+        //If we should be moving
         if (!idleAnimation && mDistance)
         {
             storage.mState = Wander_MoveNow;
         }
         else
         {
-            // Play idle animation and recreate vanilla (broken?) behavior of resetting start time of AIWander:
+            //Recreate vanilla (broken?) behavior of resetting start time of AIWander:
             MWWorld::TimeStamp currentTime = MWBase::Environment::get().getWorld()->getTimeStamp();
             mStartTime = currentTime;
-            playIdle(actor, idleAnimation);
             storage.mState = Wander_IdleNow;
+        }
+
+        //If we aren't going to just stand
+        if(idleAnimation)
+        {
+            playIdle(actor, idleAnimation);
         }
     }
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -67,7 +67,7 @@ namespace MWMechanics
         AiWander::WanderState mState;
         
         unsigned short mIdleAnimation;
-        std::vector<unsigned short> mBadIdles; //Idle animations that when called cause errors
+        std::vector<unsigned short> mBadIdles; // Idle animations that when called cause errors
 
         PathFinder mPathFinder;
         
@@ -393,16 +393,13 @@ namespace MWMechanics
         short unsigned& idleAnimation = storage.mIdleAnimation;
         idleAnimation = getRandomIdle();
 
-        // If we should be moving
         if (!idleAnimation && mDistance)
         {
             storage.mState = Wander_MoveNow;
             return;
         }
-        // If we aren't going to just stand
         if(idleAnimation)
         {
-            // If the idle animation actually exists
             if(std::find(storage.mBadIdles.begin(), storage.mBadIdles.end(), idleAnimation)==storage.mBadIdles.end())
             {
                 if(!playIdle(actor, idleAnimation))
@@ -416,7 +413,6 @@ namespace MWMechanics
         // Recreate vanilla (broken?) behavior of resetting start time of AIWander:
         mStartTime = MWBase::Environment::get().getWorld()->getTimeStamp();
         storage.mState = Wander_IdleNow;
-        return;
     }
 
     void AiWander::evadeObstacles(const MWWorld::Ptr& actor, AiWanderStorage& storage, float duration)

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -407,7 +407,6 @@ namespace MWMechanics
             {
                 if(!playIdle(actor, idleAnimation))
                 {
-                    std::cerr<< "Unable to play idle animation "<<idleAnimation<<" for " << actor.getCellRef().getRefId() << std::endl;
                     storage.mBadIdles.push_back(idleAnimation);
                     storage.mState = Wander_ChooseAction;
                     return;

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -75,7 +75,10 @@ namespace MWMechanics
             void init();
             
             void stopWalking(const MWWorld::Ptr& actor, AiWanderStorage& storage);
-            void playIdle(const MWWorld::Ptr& actor, unsigned short idleSelect);
+
+            ///Have the given actor play an idle animation
+            ///@return Success or error
+            bool playIdle(const MWWorld::Ptr& actor, unsigned short idleSelect);
             bool checkIdle(const MWWorld::Ptr& actor, unsigned short idleSelect);
             short unsigned getRandomIdle();
             void setPathToAnAllowedNode(const MWWorld::Ptr& actor, AiWanderStorage& storage, const ESM::Position& actorPos);

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -76,8 +76,8 @@ namespace MWMechanics
             
             void stopWalking(const MWWorld::Ptr& actor, AiWanderStorage& storage);
 
-            ///Have the given actor play an idle animation
-            ///@return Success or error
+            /// Have the given actor play an idle animation
+            /// @return Success or error
             bool playIdle(const MWWorld::Ptr& actor, unsigned short idleSelect);
             bool checkIdle(const MWWorld::Ptr& actor, unsigned short idleSelect);
             short unsigned getRandomIdle();

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1866,10 +1866,13 @@ void CharacterController::update(float duration)
 }
 
 
-void CharacterController::playGroup(const std::string &groupname, int mode, int count)
+bool CharacterController::playGroup(const std::string &groupname, int mode, int count)
 {
     if(!mAnimation || !mAnimation->hasAnimation(groupname))
+    {
         std::cerr<< "Animation "<<groupname<<" not found for " << mPtr.getCellRef().getRefId() << std::endl;
+        return false;
+    }
     else
     {
         count = std::max(count, 1);
@@ -1894,6 +1897,7 @@ void CharacterController::playGroup(const std::string &groupname, int mode, int 
             mAnimQueue.push_back(std::make_pair(groupname, count-1));
         }
     }
+    return true;
 }
 
 void CharacterController::skipAnim()

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -225,7 +225,7 @@ public:
 
     void update(float duration);
 
-    void playGroup(const std::string &groupname, int mode, int count);
+    bool playGroup(const std::string &groupname, int mode, int count);
     void skipAnim();
     bool isAnimPlaying(const std::string &groupName);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -843,12 +843,12 @@ namespace MWMechanics
             mActors.forceStateUpdate(ptr);
     }
 
-    void MechanicsManager::playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number)
+    bool MechanicsManager::playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number)
     {
         if(ptr.getClass().isActor())
-            mActors.playAnimationGroup(ptr, groupName, mode, number);
+            return mActors.playAnimationGroup(ptr, groupName, mode, number);
         else
-            mObjects.playAnimationGroup(ptr, groupName, mode, number);
+            return mObjects.playAnimationGroup(ptr, groupName, mode, number);
     }
     void MechanicsManager::skipAnimation(const MWWorld::Ptr& ptr)
     {

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -137,7 +137,9 @@ namespace MWMechanics
 
             virtual void forceStateUpdate(const MWWorld::Ptr &ptr);
 
-            virtual void playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number);
+            /// Attempt to play an animation group
+            /// @return Success or error
+            virtual bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number);
             virtual void skipAnimation(const MWWorld::Ptr& ptr);
             virtual bool checkAnimationPlaying(const MWWorld::Ptr& ptr, const std::string &groupName);
 

--- a/apps/openmw/mwmechanics/objects.cpp
+++ b/apps/openmw/mwmechanics/objects.cpp
@@ -1,5 +1,7 @@
 #include "objects.hpp"
 
+#include <iostream>
+
 #include "movement.hpp"
 
 #include "../mwbase/environment.hpp"
@@ -77,11 +79,18 @@ void Objects::update(float duration, bool paused)
     }
 }
 
-void Objects::playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number)
+bool Objects::playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number)
 {
     PtrControllerMap::iterator iter = mObjects.find(ptr);
     if(iter != mObjects.end())
-        iter->second->playGroup(groupName, mode, number);
+    {
+        return iter->second->playGroup(groupName, mode, number);
+    }
+    else
+    {
+        std::cerr<< "Error in Objects::playAnimationGroup:  Unable to find " << ptr.getTypeName() << std::endl;
+        return false;
+    }
 }
 void Objects::skipAnimation(const MWWorld::Ptr& ptr)
 {

--- a/apps/openmw/mwmechanics/objects.hpp
+++ b/apps/openmw/mwmechanics/objects.hpp
@@ -38,7 +38,7 @@ namespace MWMechanics
         void update(float duration, bool paused);
         ///< Update object animations
 
-        void playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number);
+        bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number);
         void skipAnimation(const MWWorld::Ptr& ptr);
 
         void getObjectsInRange (const osg::Vec3f& position, float radius, std::vector<MWWorld::Ptr>& out);


### PR DESCRIPTION
This is mostly propagating the error up the stack so the game can do something about it.

Working on avoiding log spam from calling an animation that doesn't exist every frame.