### PR TITLE
Streamline AiWander::getRandomIdle()

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -151,6 +151,8 @@ namespace MWMechanics
             static const std::string sIdleSelectToGroupName[GroupIndex_MaxIdle - GroupIndex_MinIdle + 1];
 
             static int OffsetToPreventOvercrowding();
+
+            float fIdleChanceMultiplier;
     };
     
     


### PR DESCRIPTION
We were finding a GMST potentially hundreds of times each frame.
This should provide a decent speed boost in crowded areas.

I think I can do even better in the future, but that's a separate topic.
See https://forum.openmw.org/viewtopic.php?f=6&t=3019

Note:  This may cause merge conflicts with my other PR that touches AI wander.  I'll fix one of them after the other is merged.