### PR TITLE
Fix for comparison of enum values in IdTableProxyModel

### DIFF
--- a/apps/opencs/model/world/idtableproxymodel.cpp
+++ b/apps/opencs/model/world/idtableproxymodel.cpp
@@ -5,6 +5,18 @@
 
 #include "idtablebase.hpp"
 
+namespace
+{
+    std::string getEnumValue(const std::vector<std::string> &values, int index)
+    {
+        if (index < 0 || index >= static_cast<int>(values.size()))
+        {
+            return "";
+        }
+        return values[index];
+    }
+}
+
 void CSMWorld::IdTableProxyModel::updateColumnMap()
 {
     Q_ASSERT(mSourceModel != NULL);
@@ -93,7 +105,9 @@ bool CSMWorld::IdTableProxyModel::lessThan(const QModelIndex &left, const QModel
 
     if (valuesIt != mEnumColumnCache.end())
     {
-        return valuesIt->second[left.data().toInt()] < valuesIt->second[right.data().toInt()];
+        std::string first = getEnumValue(valuesIt->second, left.data().toInt());
+        std::string second = getEnumValue(valuesIt->second, right.data().toInt());
+        return first < second;
     }
     return QSortFilterProxyModel::lessThan(left, right);
 }


### PR DESCRIPTION
Some values in enum columns can contain -1 as an empty value index. The sorting must consider this case.