### PR TITLE
Magic effect verifier

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -41,7 +41,7 @@ opencs_units (model/tools
 opencs_units_noqt (model/tools
     mandatoryid skillcheck classcheck factioncheck racecheck soundcheck regioncheck
     birthsigncheck spellcheck referencecheck referenceablecheck scriptcheck bodypartcheck
-    startscriptcheck search searchoperation searchstage pathgridcheck soundgencheck
+    startscriptcheck search searchoperation searchstage pathgridcheck soundgencheck magiceffectcheck
     )
 
 

--- a/apps/opencs/model/tools/magiceffectcheck.cpp
+++ b/apps/opencs/model/tools/magiceffectcheck.cpp
@@ -1,0 +1,137 @@
+#include "magiceffectcheck.hpp"
+
+#include <components/misc/resourcehelpers.hpp>
+
+#include "../world/resources.hpp"
+#include "../world/data.hpp"
+
+namespace
+{
+    void addMessageIfNotEmpty(CSMDoc::Messages &messages, const CSMWorld::UniversalId &id, const std::string text)
+    {
+        if (!text.empty())
+        {
+            messages.push_back(std::make_pair(id, text));
+        }
+    }
+}
+
+bool CSMTools::MagicEffectCheckStage::isTextureExists(const std::string &texture, bool isIcon) const
+{
+    const CSMWorld::Resources &textures = isIcon ? mIcons : mTextures;
+    bool exists = false;
+
+    if (textures.searchId(texture) != -1)
+    {
+        exists = true;
+    }
+    else
+    {
+        std::string ddsTexture = texture;
+        if (Misc::ResourceHelpers::changeExtensionToDds(ddsTexture) && textures.searchId(ddsTexture) != -1)
+        {
+            exists = true;
+        }
+    }
+
+    return exists;
+}
+
+std::string CSMTools::MagicEffectCheckStage::checkReferenceable(const std::string &id, 
+                                                                const CSMWorld::UniversalId &type, 
+                                                                const std::string &column) const
+{
+    std::string error;
+    if (!id.empty())
+    {
+        CSMWorld::RefIdData::LocalIndex index = mReferenceables.getDataSet().searchId(id);
+        if (index.first == -1)
+        {
+            error = "No such " + column + " '" + id + "'";
+        }
+        else if (index.second != type.getType())
+        {
+            error = column + " is not of type " + type.getTypeName();
+        }
+    }
+    return error;
+}
+
+std::string CSMTools::MagicEffectCheckStage::checkSound(const std::string &id, const std::string &column) const
+{
+    std::string error;
+    if (!id.empty() && mSounds.searchId(id) == -1)
+    {
+        error = "No such " + column + " '" + id + "'";
+    }
+    return error;
+}
+
+CSMTools::MagicEffectCheckStage::MagicEffectCheckStage(const CSMWorld::IdCollection<ESM::MagicEffect> &effects,
+                                                       const CSMWorld::IdCollection<ESM::Sound> &sounds,
+                                                       const CSMWorld::RefIdCollection &referenceables,
+                                                       const CSMWorld::Resources &icons,
+                                                       const CSMWorld::Resources &textures)
+    : mMagicEffects(effects),
+      mSounds(sounds),
+      mReferenceables(referenceables),
+      mIcons(icons),
+      mTextures(textures)
+{}
+
+int CSMTools::MagicEffectCheckStage::setup()
+{
+    return mMagicEffects.getSize();
+}
+
+void CSMTools::MagicEffectCheckStage::perform(int stage, CSMDoc::Messages &messages)
+{
+    ESM::MagicEffect effect = mMagicEffects.getRecord(stage).get();
+    CSMWorld::UniversalId id(CSMWorld::UniversalId::Type_MagicEffect, effect.mId);
+    
+    if (effect.mData.mBaseCost < 0.0f)
+    {
+        messages.push_back(std::make_pair(id, "Base Cost is negative"));
+    }
+
+    if (effect.mIcon.empty())
+    {
+        messages.push_back(std::make_pair(id, "Icon is not specified"));
+    }
+    else if (!isTextureExists(effect.mIcon, true))
+    {
+        messages.push_back(std::make_pair(id, "No such Icon '" + effect.mIcon + "'"));
+    }
+
+    if (effect.mParticle.empty())
+    {
+        messages.push_back(std::make_pair(id, "Particle is not specified"));
+    }
+    else if (!isTextureExists(effect.mParticle, false))
+    {
+        messages.push_back(std::make_pair(id, "No such Particle '" + effect.mParticle + "'"));
+    }
+
+    addMessageIfNotEmpty(messages, 
+                         id, 
+                         checkReferenceable(effect.mCasting, CSMWorld::UniversalId::Type_Static, "Casting Object"));
+    addMessageIfNotEmpty(messages, 
+                         id,
+                         checkReferenceable(effect.mHit, CSMWorld::UniversalId::Type_Static, "Hit Object"));
+    addMessageIfNotEmpty(messages,
+                         id,
+                         checkReferenceable(effect.mArea, CSMWorld::UniversalId::Type_Static, "Area Object"));
+    addMessageIfNotEmpty(messages,
+                         id,
+                         checkReferenceable(effect.mBolt, CSMWorld::UniversalId::Type_Weapon, "Bolt Object"));
+
+    addMessageIfNotEmpty(messages, id, checkSound(effect.mCastSound, "Casting Sound"));
+    addMessageIfNotEmpty(messages, id, checkSound(effect.mHitSound, "Hit Sound"));
+    addMessageIfNotEmpty(messages, id, checkSound(effect.mAreaSound, "Area Sound"));
+    addMessageIfNotEmpty(messages, id, checkSound(effect.mBoltSound, "Bolt Sound"));
+
+    if (effect.mDescription.empty())
+    {
+        messages.push_back(std::make_pair(id, "Description is empty"));
+    }
+}

--- a/apps/opencs/model/tools/magiceffectcheck.cpp
+++ b/apps/opencs/model/tools/magiceffectcheck.cpp
@@ -103,11 +103,7 @@ void CSMTools::MagicEffectCheckStage::perform(int stage, CSMDoc::Messages &messa
         messages.push_back(std::make_pair(id, "No such Icon '" + effect.mIcon + "'"));
     }
 
-    if (effect.mParticle.empty())
-    {
-        messages.push_back(std::make_pair(id, "Particle is not specified"));
-    }
-    else if (!isTextureExists(effect.mParticle, false))
+    if (!effect.mParticle.empty() && !isTextureExists(effect.mParticle, false))
     {
         messages.push_back(std::make_pair(id, "No such Particle '" + effect.mParticle + "'"));
     }

--- a/apps/opencs/model/tools/magiceffectcheck.hpp
+++ b/apps/opencs/model/tools/magiceffectcheck.hpp
@@ -1,0 +1,50 @@
+#ifndef CSM_TOOLS_MAGICEFFECTCHECK_HPP
+#define CSM_TOOLS_MAGICEFFECTCHECK_HPP
+
+#include <components/esm/loadmgef.hpp>
+#include <components/esm/loadsoun.hpp>
+
+#include "../world/idcollection.hpp"
+#include "../world/refidcollection.hpp"
+
+#include "../doc/stage.hpp"
+
+namespace CSMWorld
+{
+    class Resources;
+}
+
+namespace CSMTools
+{
+    /// \brief VerifyStage: make sure that magic effect records are internally consistent
+    class MagicEffectCheckStage : public CSMDoc::Stage
+    {
+            const CSMWorld::IdCollection<ESM::MagicEffect> &mMagicEffects;
+            const CSMWorld::IdCollection<ESM::Sound> &mSounds;
+            const CSMWorld::RefIdCollection &mReferenceables;
+            const CSMWorld::Resources &mIcons;
+            const CSMWorld::Resources &mTextures;
+
+        private:
+            bool isTextureExists(const std::string &texture, bool isIcon) const;
+
+            std::string checkReferenceable(const std::string &id,
+                                           const CSMWorld::UniversalId &type,
+                                           const std::string &column) const;
+            std::string checkSound(const std::string &id, const std::string &column) const;
+
+        public:
+            MagicEffectCheckStage(const CSMWorld::IdCollection<ESM::MagicEffect> &effects,
+                                  const CSMWorld::IdCollection<ESM::Sound> &sounds,
+                                  const CSMWorld::RefIdCollection &referenceables,
+                                  const CSMWorld::Resources &icons,
+                                  const CSMWorld::Resources &textures);
+
+            virtual int setup();
+            ///< \return number of steps
+            virtual void perform (int stage, CSMDoc::Messages &messages);
+            ///< Messages resulting from this tage will be appended to \a messages.
+    };
+}
+
+#endif

--- a/apps/opencs/model/tools/tools.cpp
+++ b/apps/opencs/model/tools/tools.cpp
@@ -28,6 +28,7 @@
 #include "searchoperation.hpp"
 #include "pathgridcheck.hpp"
 #include "soundgencheck.hpp"
+#include "magiceffectcheck.hpp"
 
 CSMDoc::OperationHolder *CSMTools::Tools::get (int type)
 {
@@ -107,6 +108,12 @@ CSMDoc::OperationHolder *CSMTools::Tools::getVerifier()
         mVerifierOperation->appendStage (new SoundGenCheckStage (mData.getSoundGens(),
                                                                  mData.getSounds(),
                                                                  mData.getReferenceables()));
+
+        mVerifierOperation->appendStage (new MagicEffectCheckStage (mData.getMagicEffects(),
+                                                                    mData.getSounds(),
+                                                                    mData.getReferenceables(),
+                                                                    mData.getResources (CSMWorld::UniversalId::Type_Icons),
+                                                                    mData.getResources (CSMWorld::UniversalId::Type_Textures)));
 
         mVerifier.setOperation (mVerifierOperation);
     }

--- a/apps/opencs/view/doc/viewmanager.cpp
+++ b/apps/opencs/view/doc/viewmanager.cpp
@@ -97,7 +97,7 @@ CSVDoc::ViewManager::ViewManager (CSMDoc::DocumentManager& documentManager)
         { CSMWorld::ColumnBase::Display_MeshType, CSMWorld::Columns::ColumnId_MeshType, false },
         { CSMWorld::ColumnBase::Display_Gender, CSMWorld::Columns::ColumnId_Gender, true },
         { CSMWorld::ColumnBase::Display_SoundGeneratorType, CSMWorld::Columns::ColumnId_SoundGeneratorType, false },
-        { CSMWorld::ColumnBase::Display_School, CSMWorld::Columns::ColumnId_School, true },
+        { CSMWorld::ColumnBase::Display_School, CSMWorld::Columns::ColumnId_School, false },
         { CSMWorld::ColumnBase::Display_SkillImpact, CSMWorld::Columns::ColumnId_SkillImpact, true },
         { CSMWorld::ColumnBase::Display_EffectRange, CSMWorld::Columns::ColumnId_EffectRange, false },
         { CSMWorld::ColumnBase::Display_EffectId, CSMWorld::Columns::ColumnId_EffectId, false },


### PR DESCRIPTION
The verifier performs the following checks:
* Is the base cost negative?
* Is the icon specified? Does the icon exist? **required string field**
* Is the particle specified? Does the particle (texture) exist?  **required string field**
* Is the description not empty? **required string field**
* Does the object (hit/area/bolt/casting) exist and has a proper type?
* Does the sound (hit/area/bolt/casting) exist?

The verifier checks all magic effects, even some of them aren't presented in a content file (such as #138SummonWolf in Morrowind.esm). This leads to unrelated errors. Ignore such effects would be the right solution, but there is no way to distinguish them.

Also I don't know what to do with an empty School field. Is it correct to have a magic effect with no school specified?