### PR TITLE
Add appdata file for openmw and install it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,8 @@ configure_file(${OpenMW_SOURCE_DIR}/files/gamecontrollerdb.txt
 if (NOT WIN32 AND NOT APPLE)
     configure_file(${OpenMW_SOURCE_DIR}/files/openmw.desktop
         "${OpenMW_BINARY_DIR}/openmw.desktop")
+    configure_file(${OpenMW_SOURCE_DIR}/files/openmw.appdata.xml
+        "${OpenMW_BINARY_DIR}/openmw.appdata.xml")
     configure_file(${OpenMW_SOURCE_DIR}/files/openmw-cs.desktop
         "${OpenMW_BINARY_DIR}/openmw-cs.desktop")
 endif()
@@ -422,6 +424,7 @@ IF(NOT WIN32 AND NOT APPLE)
     # Install icon and desktop file
     INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw.desktop" DESTINATION "${DATAROOTDIR}/applications" COMPONENT "openmw")
     INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/launcher/images/openmw.png" DESTINATION "${ICONDIR}" COMPONENT "openmw")
+    INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw.appdata.xml" DESTINATION "${DATAROOTDIR}/appdata" COMPONENT "openmw")
     IF(BUILD_OPENCS)
         INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw-cs.desktop" DESTINATION "${DATAROOTDIR}/applications" COMPONENT "opencs")
         INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/opencs/openmw-cs.png" DESTINATION "${ICONDIR}" COMPONENT "opencs")

--- a/files/openmw.appdata.xml
+++ b/files/openmw.appdata.xml
@@ -8,13 +8,13 @@
  <summary>Unofficial open source engine re-implementation of the game Morrowind</summary>
  <description>
   <p>
-  OpenMW is a recreation of the engine for the popular role-playing game Morrowind by Bethesda Softworks. You need to own and install the original game for OpenMW to work.
+  OpenMW is a new engine for 2002's Game of the Year, The Elder Scrolls 3: Morrowind.
   </p>
   <p>
-  The main quests in Morrowind, Tribunal and Bloodmoon are all completable. Some issues with side quests are to be expected (but rare).
+  It aims to be a fully playable (and improved!), open source implementation of the game's engine and functionality (including mods). 
   </p>
   <p>
-  Pre-existing modifications created for the original Morrowind engine can be hit-and-miss, but a mod created for Morrowind may not necessarily run in OpenMW.
+  You will still need the original game data to play OpenMW.
   </p>
  </description>
 

--- a/files/openmw.appdata.xml
+++ b/files/openmw.appdata.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Alexandre Moine <nobrakal@gmail.com> -->
+<application>
+ <id type="desktop">openmw.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license> GPL-3.0 and MIT and zlib</project_license>
+ <name>OpenMW</name>
+ <summary>Unofficial open source engine re-implementation of the game Morrowind</summary>
+ <description>
+  <p>
+  OpenMW is a recreation of the engine for the popular role-playing game Morrowind by Bethesda Softworks. You need to own and install the original game for OpenMW to work.
+  </p>
+  <p>
+  The main quests in Morrowind, Tribunal and Bloodmoon are all completable. Some issues with side quests are to be expected (but rare).
+  </p>
+  <p>
+  Pre-existing modifications created for the original Morrowind engine can be hit-and-miss, but a mod created for Morrowind may not necessarily run in OpenMW.
+  </p>
+ </description>
+
+ <screenshots>
+  <screenshot type="default">
+   <image>http://wiki.openmw.org/images/b/b2/Openmw_0.11.1_launcher_1.png</image>
+   <caption>The OpenMW launcher</caption>
+  </screenshot>
+  <screenshot>
+   <image>http://wiki.openmw.org/images/f/f1/Screenshot_mournhold_plaza_0.35.png</image>
+   <caption>The Mournhold's plaza on OpenMW</caption>
+  </screenshot>
+  <screenshot>
+   <image>http://wiki.openmw.org/images/5/5b/Screenshot_Vivec_seen_from_Ebonheart_0.35.png</image>
+   <caption>Vivec seen from Ebonheart on OpenMW</caption>
+  </screenshot>
+ </screenshots>
+<updatecontact>nobrakal@gmail.com</updatecontact>
+ <url type="homepage">https://openmw.org</url>
+ <url type="bugtracker">https://bugs.openmw.org/</url>
+ <url type="faq">https://openmw.org/faq/</url>
+</application>


### PR DESCRIPTION
Hi,

For the need of Fedora (https://fedoraproject.org/wiki/Packaging:AppData), I create an appdata file, (a sub part of the AppStream project, you can find more informations here: http://www.freedesktop.org/software/appstream/docs/chap-AppStream-About.html#about-whatis) . 
The purpose of this file is to give more informations to any software center on OpenMW.

I add myself as updatecontact (contact for the evolution of the appdata spec), because I don't know if openmw have a mailing list.
I also use old screenshot beceause I can't find more recent (and none for openmw-cs).

I also add basic rules to install it on CMakeLists :)