### PR TITLE
Editor: remove creature flag of unknown purpose from the UI

### DIFF
--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -109,7 +109,6 @@ namespace CSMWorld
             { ColumnId_OriginalCreature, "Original Creature" },
             { ColumnId_Biped, "Biped" },
             { ColumnId_HasWeapon, "Has Weapon" },
-            { ColumnId_NoMovement, "No Movement" },
             { ColumnId_Swims, "Swims" },
             { ColumnId_Flies, "Flies" },
             { ColumnId_Walks, "Walks" },

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -102,7 +102,7 @@ namespace CSMWorld
             ColumnId_OriginalCreature = 87,
             ColumnId_Biped = 88,
             ColumnId_HasWeapon = 89,
-            ColumnId_NoMovement = 90,
+            // unused
             ColumnId_Swims = 91,
             ColumnId_Flies = 92,
             ColumnId_Walks = 93,

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -321,7 +321,6 @@ CSMWorld::RefIdCollection::RefIdCollection()
     {
         { Columns::ColumnId_Biped, ESM::Creature::Bipedal },
         { Columns::ColumnId_HasWeapon, ESM::Creature::Weapon },
-        { Columns::ColumnId_NoMovement, ESM::Creature::None },
         { Columns::ColumnId_Swims, ESM::Creature::Swims },
         { Columns::ColumnId_Flies, ESM::Creature::Flies },
         { Columns::ColumnId_Walks, ESM::Creature::Walks },


### PR DESCRIPTION
The comment in loadcrea.hpp says:
<pre>
        None        = 0x008, // ?? This flag appears set for every creature in Morrowind.esm
</pre>