### PR TITLE
Make SetDelete a no-op for items in containers (Fixes #2864)

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -256,6 +256,7 @@ namespace MWBase
             virtual void fixPosition (const MWWorld::Ptr& actor) = 0;
             ///< Attempt to fix position so that the Ptr is no longer inside collision geometry.
 
+            /// @note No-op for items in containers. Use ContainerStore::removeItem instead.
             virtual void deleteObject (const MWWorld::Ptr& ptr) = 0;
             virtual void undeleteObject (const MWWorld::Ptr& ptr) = 0;
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1050,7 +1050,7 @@ namespace MWWorld
 
     void World::deleteObject (const Ptr& ptr)
     {
-        if (!ptr.getRefData().isDeleted())
+        if (!ptr.getRefData().isDeleted() && ptr.getContainerStore() == NULL)
         {
             ptr.getRefData().setCount(0);
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -336,7 +336,9 @@ namespace MWWorld
             /// use the "Head" node as a basis.
             virtual std::pair<MWWorld::Ptr,osg::Vec3f> getHitContact(const MWWorld::Ptr &ptr, float distance);
 
+            /// @note No-op for items in containers. Use ContainerStore::removeItem instead.
             virtual void deleteObject (const Ptr& ptr);
+
             virtual void undeleteObject (const Ptr& ptr);
 
             virtual MWWorld::Ptr moveObject (const Ptr& ptr, float x, float y, float z);


### PR DESCRIPTION
For vanilla MW compatibility, SetDelete should be a no-op for items in containers. You can use RemoveItem instead.