### PR TITLE
Sort races for PcRace mapping (Fixes #2884)

### DIFF
--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -170,6 +170,7 @@ namespace MWWorld
         size_t getSize() const;
         int getDynamicSize() const;
 
+        /// @note The record identifiers are listed in the order that the records were defined by the content files.
         void listIdentifier(std::vector<std::string> &list) const;
 
         T *insert(const T &item);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1496,6 +1496,8 @@ namespace MWWorld
             std::vector<std::string> ids;
             getStore().get<ESM::Race>().listIdentifier(ids);
 
+            std::sort(ids.begin(), ids.end());
+
             unsigned int i=0;
 
             for (; i<ids.size(); ++i)


### PR DESCRIPTION
A regression from an earlier release. ```listIdentifier``` used to return records sorted by ID, but we changed that when autocalc was implemented (which depends on the original insertion order of records).