### PR TITLE
Fixed bug in smoothTurn()

### DIFF
--- a/apps/openmw/mwmechanics/steering.cpp
+++ b/apps/openmw/mwmechanics/steering.cpp
@@ -14,14 +14,16 @@ bool smoothTurn(const MWWorld::Ptr& actor, float targetAngleRadians, int axis, f
 {
     float currentAngle (actor.getRefData().getPosition().rot[axis]);
     float diff (targetAngleRadians - currentAngle);
-    if (diff >= osg::DegreesToRadians(180.f))
+    if (std::abs(diff) >= osg::DegreesToRadians(180.f))
     {
-        // Turning the other way would be a better idea
-        diff = diff-osg::DegreesToRadians(360.f);
-    }
-    else if (diff <= osg::DegreesToRadians(-180.f))
-    {
-        diff = osg::DegreesToRadians(360.f)-diff;
+        if (diff >= 0)
+        {
+            diff = diff - osg::DegreesToRadians(360.f);
+        }
+        else
+        {
+            diff = osg::DegreesToRadians(360.f) + diff;
+        }
     }
     float absDiff = std::abs(diff);
 


### PR DESCRIPTION
Effect of bug was that when an actor was moving south, would randomly turn west.
Usually, just after passing a nav point.  Which could then trigger "running in circles".

Also, MWMechanics::AiPackage::pathTo() has code to "Stops the actor when it gets too close to a unloaded cell".
https://github.com/OpenMW/openmw/blob/master/apps/openmw/mwmechanics/aipackage.cpp#L34-61
Is this code needed?  My reasoning goes:
1. AI isn't processed if actor is more than 7168 units from Player.
2. Exterior cells are 8192 units long and wide.
3. Player is in the center cell of a 3 x 3 array.  Therefore, edges of outer cells must be at least 8192 units away from player.
4. Therefore, shutdown of Actor's AI will occur before actor can reach an unloaded exterior cell.

Or is there some special case I've missed?