### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+Description
+===========
+
+Your pull request description should include:
+
+* Summary of the changes made
+* Reasoning / motivation behind the change
+* What testing you have carried out to verify the change
+* If applicable, a link back to the bug report or forum discussion that prompted the change
+
+Other notes
+===========
+
+* Separate your work into multiple pull requests whenever possible. As a rule of thumb, each feature and each bugfix should go into a separate PR, unless they are closely related or dependent upon each other. Small pull requests are easier to review, and are less likely to require further changes before we can merge them. A "mega" pull request with lots of unrelated commits in it is likely to get held up in review for a long time.
+* Feel free to submit incomplete pull requests. Even if the work can not be merged yet, pull requests are a great place to collect early feedback. Just make sure to mark it as *[Incomplete]* or *[Do not merge yet]* in the title.
+* If you plan on contributing often, please read the [Developer Reference](https://wiki.openmw.org/index.php?title=Developer_Reference) on our wiki, especially the [Policies and Standards](https://wiki.openmw.org/index.php?title=Policies_and_Standards).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 Description
 ===========
 
-Your pull request description should include:
+Your pull request description should include (if applicable):
 
+* A link back to the bug report or forum discussion that prompted the change
 * Summary of the changes made
 * Reasoning / motivation behind the change
 * What testing you have carried out to verify the change
-* If applicable, a link back to the bug report or forum discussion that prompted the change
 
 Other notes
 ===========


### PR DESCRIPTION
This pull request will also serve as an example implementation of the proposed guidelines:

> * Summary of the changes made

Add a CONTRIBUTING.md file containing guidelines for pull requests.

> * Reasoning / motivation behind the change

The contents of CONTRIBUTING.md will show up in github's pull request UI. We should use it to display some guidelines on what we are looking for in a good PR, so that we will hopefully see an overall improvement in the quality of PRs.

> * What testing you have carried out to verify the change

Viewed the file on github to make sure the markdown syntax is correct, cross-checked with the rules on our [wiki](https://wiki.openmw.org/index.php?title=Developer_Reference).

> * If applicable, a link back to the bug report or forum discussion that prompted the change

None, the idea just crossed my mind.