### PR TITLE
fix setangle

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -268,7 +268,7 @@ namespace MWBase
 
             virtual void scaleObject (const MWWorld::Ptr& ptr, float scale) = 0;
 
-            virtual void rotateObject(const MWWorld::Ptr& ptr,float x,float y,float z, bool adjust = false) = 0;
+            virtual void rotateObject(const MWWorld::Ptr& ptr,float x,float y,float z, bool adjust = false, bool do_wrap = true) = 0;
 
             virtual void localRotateObject (const MWWorld::Ptr& ptr, float x, float y, float z) = 0;
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -98,19 +98,19 @@ namespace MWScript
                     {
                         localRot.rot[0] = 0;
                         ptr.getRefData().setLocalRotation(localRot);
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,angle,ay,az);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,angle,ay,az,false,false);
                     }
                     else if (axis == "y")
                     {
                         localRot.rot[1] = 0;
                         ptr.getRefData().setLocalRotation(localRot);
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,angle,az);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,angle,az,false,false);
                     }
                     else if (axis == "z")
                     {
                         localRot.rot[2] = 0;
                         ptr.getRefData().setLocalRotation(localRot);
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,angle);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,angle,false,false);
                     }
                     else
                         throw std::runtime_error ("invalid rotation axis: " + axis);
@@ -337,7 +337,7 @@ namespace MWScript
                         // See "Morrowind Scripting for Dummies (9th Edition)" pages 50 and 54 for reference.
                         if(ptr != MWMechanics::getPlayer())
                             zRot = zRot/60.0f;
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,zRot);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,zRot,false,false);
 
                         ptr.getClass().adjustPosition(ptr, false);
                     }
@@ -393,7 +393,7 @@ namespace MWScript
                     // See "Morrowind Scripting for Dummies (9th Edition)" pages 50 and 54 for reference.
                     if(ptr != MWMechanics::getPlayer())
                         zRot = zRot/60.0f;
-                    MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,zRot);
+                    MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,zRot,false,false);
                     ptr.getClass().adjustPosition(ptr, false);
                 }
         };
@@ -614,15 +614,15 @@ namespace MWScript
 
                     if (axis == "x")
                     {
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax+rotation,ay,az);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax+rotation,ay,az,false,true);
                     }
                     else if (axis == "y")
                     {
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay+rotation,az);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay+rotation,az,false,true);
                     }
                     else if (axis == "z")
                     {
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,az+rotation);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,az+rotation,false,true);
                     }
                     else
                         throw std::runtime_error ("invalid rotation axis: " + axis);
@@ -647,7 +647,7 @@ namespace MWScript
                     rot.rot[2] = 0;
                     ptr.getRefData().setLocalRotation(rot);
 
-                    MWBase::Environment::get().getWorld()->rotateObject(ptr, 0,0,0,true);
+                    MWBase::Environment::get().getWorld()->rotateObject(ptr, 0,0,0,true,true);
 
                     dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(
                         MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -67,7 +67,7 @@ namespace
             osg::Quat rot(z, osg::Vec3(0,0,-1));
             if (!ptr.getClass().isActor()) {
 		if (prio)
-		    rot = osg::Quat(y, osg::Vec3(0,-1,0)) * osg::Quat(x, osg::Vec3(-1,0,0)) * rot;
+		    rot = osg::Quat(y, osg::Vec3(-1,0,0)) * osg::Quat(x, osg::Vec3(0,-1,0)) * rot;
 		else
 		    rot = rot * osg::Quat(y, osg::Vec3(0,-1,0)) * osg::Quat(x, osg::Vec3(-1,0,0));
 	    }

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -67,7 +67,7 @@ namespace
             osg::Quat rot(z, osg::Vec3(0,0,-1));
             if (!ptr.getClass().isActor()) {
 		if (prio)
-		    rot = osg::Quat(y, osg::Vec3(-1,0,0)) * osg::Quat(x, osg::Vec3(0,-1,0)) * rot;
+		    rot = osg::Quat(y, osg::Vec3(0,-1,0)) * osg::Quat(x, osg::Vec3(-1,0,0)) * rot;
 		else
 		    rot = rot * osg::Quat(y, osg::Vec3(0,-1,0)) * osg::Quat(x, osg::Vec3(-1,0,0));
 	    }

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -53,8 +53,8 @@ namespace
 		if (prio)
 		    /* There are 2 ways to handle rotations, the setangle way
 		     * (prio = 1), or the usual way */
-		    worldRotQuat = osg::Quat(ptr.getRefData().getPosition().rot[1], osg::Vec3(0,-1,0)) *
-			osg::Quat(ptr.getRefData().getPosition().rot[0], osg::Vec3(-1,0,0)) * worldRotQuat;
+		    worldRotQuat = osg::Quat(ptr.getRefData().getPosition().rot[0], osg::Vec3(-1,0,0)) *
+			osg::Quat(ptr.getRefData().getPosition().rot[1], osg::Vec3(0,-1,0)) * worldRotQuat;
 		else
 		    worldRotQuat = worldRotQuat * osg::Quat(ptr.getRefData().getPosition().rot[1], osg::Vec3(0,-1,0)) *
 			osg::Quat(ptr.getRefData().getPosition().rot[0], osg::Vec3(-1,0,0));

--- a/apps/openmw/mwworld/scene.hpp
+++ b/apps/openmw/mwworld/scene.hpp
@@ -107,7 +107,7 @@ namespace MWWorld
             void removeObjectFromScene (const Ptr& ptr);
             ///< Remove an object from the scene, but not from the world model.
 
-            void updateObjectLocalRotation (const Ptr& ptr);
+            void updateObjectLocalRotation (const Ptr& ptr,int prio = 0);
             void updateObjectScale(const Ptr& ptr);
 
             bool isCellActive(const CellStore &cell);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1207,7 +1207,7 @@ namespace MWWorld
         mWorldScene->updateObjectScale(ptr);
     }
 
-    void World::rotateObjectImp (const Ptr& ptr, const osg::Vec3f& rot, bool adjust)
+    void World::rotateObjectImp (const Ptr& ptr, const osg::Vec3f& rot, bool adjust,bool do_wrap)
     {
         const float pi = static_cast<float>(osg::PI);
 
@@ -1226,24 +1226,30 @@ namespace MWWorld
             objRot[2] = rot.z();
         }
 
-        if(ptr.getClass().isActor())
-        {
-            /* HACK? Actors shouldn't really be rotating around X (or Y), but
-             * currently it's done so for rotating the camera, which needs
-             * clamping.
-             */
-            const float half_pi = pi/2.f;
+        if (do_wrap) {
+            /* Some mods use setangle/getangle to set and test angles, so
+             * wraping must be disabled for these. But some other mods expect
+             * the angle of the player to remain between usual degree values
+             * so here they must be wraped ! */
+            if(ptr.getClass().isActor())
+            {
+                /* HACK? Actors shouldn't really be rotating around X (or Y), but
+                 * currently it's done so for rotating the camera, which needs
+                 * clamping.
+                 */
+                const float half_pi = pi/2.f;
 
-            if(objRot[0] < -half_pi)     objRot[0] = -half_pi;
-            else if(objRot[0] > half_pi) objRot[0] =  half_pi;
-        }
-        else
-        {
-            wrap(objRot[0]);
-        }
+                if(objRot[0] < -half_pi)     objRot[0] = -half_pi;
+                else if(objRot[0] > half_pi) objRot[0] =  half_pi;
+            }
+            else
+            {
+                wrap(objRot[0]);
+            }
 
-        wrap(objRot[1]);
-        wrap(objRot[2]);
+            wrap(objRot[1]);
+            wrap(objRot[2]);
+        }
 
         ptr.getRefData().setPosition(pos);
 
@@ -1312,12 +1318,12 @@ namespace MWWorld
         moveObject(actor, actor.getCell(), traced.x(), traced.y(), traced.z());
     }
 
-    void World::rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust)
+    void World::rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust,bool do_wrap)
     {
         rotateObjectImp(ptr, osg::Vec3f(osg::DegreesToRadians(x),
                                            osg::DegreesToRadians(y),
                                            osg::DegreesToRadians(z)),
-                        adjust);
+                        adjust,do_wrap);
     }
 
     MWWorld::Ptr World::safePlaceObject(const MWWorld::Ptr& ptr, MWWorld::CellStore* cell, ESM::Position pos)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1248,7 +1248,7 @@ namespace MWWorld
         ptr.getRefData().setPosition(pos);
 
         if(ptr.getRefData().getBaseNode() != 0)
-            mWorldScene->updateObjectLocalRotation(ptr);
+            mWorldScene->updateObjectLocalRotation(ptr,1);
     }
 
     void World::localRotateObject (const Ptr& ptr, float x, float y, float z)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -111,7 +111,7 @@ namespace MWWorld
             void updateWeather(float duration, bool paused = false);
             int getDaysPerMonth (int month) const;
 
-            void rotateObjectImp (const Ptr& ptr, const osg::Vec3f& rot, bool adjust);
+            void rotateObjectImp (const Ptr& ptr, const osg::Vec3f& rot, bool adjust, bool do_wrap);
 
             Ptr moveObjectImp (const Ptr& ptr, float x, float y, float z);
             ///< @return an updated Ptr in case the Ptr's cell changes
@@ -351,7 +351,7 @@ namespace MWWorld
 
             /// World rotates object, uses degrees
             /// \param adjust indicates rotation should be set or adjusted
-            virtual void rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust = false);
+            virtual void rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust = false, bool do_wrap = true);
 
             /// Local rotates object, uses degrees
             virtual void localRotateObject (const Ptr& ptr, float x, float y, float z);


### PR DESCRIPTION
Apparently setangle uses a different rotation order as the default one used in game, discussed extensively in the forum.
Tested mainly in "book rotate"
