### PR TITLE
fix yorick's ring script

### DIFF
--- a/apps/openmw/mwgui/messagebox.cpp
+++ b/apps/openmw/mwgui/messagebox.cpp
@@ -117,8 +117,12 @@ namespace MWGui
 
     bool MessageBoxManager::createInteractiveMessageBox (const std::string& message, const std::vector<std::string>& buttons)
     {
+
         if(mInterMessageBoxe != NULL) {
-            throw std::runtime_error("There is a message box already");
+	    // Yorick's ring comes here, I guess it's because the script is
+	    // executed more than once, but anyway just deleting the old
+	    // box allows it to run
+	    delete mInterMessageBoxe;
         }
 
         mInterMessageBoxe = new InteractiveMessageBox(*this, message, buttons);


### PR DESCRIPTION
This is a script attached to a ring which executes when equipped and displays a messagebox to ask what to do. With openmw it stops with the throw because apparently the previous messagebox is still active. This is a simple workaround.
