### PR TITLE
Duration in tooltips

### DIFF
--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -169,7 +169,7 @@ namespace MWClass
 
         std::string text;
 
-	text += "\nDuration: " + MWGui::ToolTips::toString(ptr.getClass().getRemainingUsageTime(ptr));
+	text += "\n#{sDuration}: " + MWGui::ToolTips::toString(ptr.getClass().getRemainingUsageTime(ptr));
         if (ref->mBase->mData.mWeight != 0)
         {
             text += "\n#{sWeight}: " + MWGui::ToolTips::toString(ref->mBase->mData.mWeight);

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -2,6 +2,7 @@
 
 #include <components/esm/loadligh.hpp>
 #include <components/esm/objectstate.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -169,7 +170,8 @@ namespace MWClass
 
         std::string text;
 
-	text += "\n#{sDuration}: " + MWGui::ToolTips::toString(ptr.getClass().getRemainingUsageTime(ptr));
+        if (Settings::Manager::getBool("show effect duration","Game"))
+            text += "\n#{sDuration}: " + MWGui::ToolTips::toString(ptr.getClass().getRemainingUsageTime(ptr));
         if (ref->mBase->mData.mWeight != 0)
         {
             text += "\n#{sWeight}: " + MWGui::ToolTips::toString(ref->mBase->mData.mWeight);

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -169,6 +169,7 @@ namespace MWClass
 
         std::string text;
 
+	text += "\nDuration: " + MWGui::ToolTips::toString(ptr.getClass().getRemainingUsageTime(ptr));
         if (ref->mBase->mData.mWeight != 0)
         {
             text += "\n#{sWeight}: " + MWGui::ToolTips::toString(ref->mBase->mData.mWeight);

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -133,6 +133,23 @@ namespace MWGui
                             MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "") :
                             MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "") );
                     }
+		    if (effectIt->mRemainingTime > -1) {
+			sourcesDescription += " #{sDuration}: ";
+			float duration = effectIt->mRemainingTime;
+			if (duration > 3600) {
+			    int hour = duration / 3600;
+			    duration -= hour*3600;
+			    sourcesDescription += MWGui::ToolTips::toString(hour) + "h";
+			}
+			if (duration > 60) {
+			    int minute = duration / 60;
+			    duration -= minute*60;
+			    sourcesDescription += MWGui::ToolTips::toString(minute) + "m";
+			}
+			if (duration > 0.1) {
+			    sourcesDescription += MWGui::ToolTips::toString(duration) + "s";
+			}
+		    }
                 }
             }
 

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -133,24 +133,24 @@ namespace MWGui
                             MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "") :
                             MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "") );
                     }
-		    if (effectIt->mRemainingTime > -1) {
-			sourcesDescription += " #{sDuration}: ";
-			float duration = effectIt->mRemainingTime;
-			if (duration > 3600) {
-			    int hour = duration / 3600;
-			    duration -= hour*3600;
-			    sourcesDescription += MWGui::ToolTips::toString(hour) + "h";
-			}
-			if (duration > 60) {
-			    int minute = duration / 60;
-			    duration -= minute*60;
-			    sourcesDescription += MWGui::ToolTips::toString(minute) + "m";
-			}
-			if (duration > 0.1) {
-			    sourcesDescription += MWGui::ToolTips::toString(duration) + "s";
-			}
-		    }
                 }
+		if (effectIt->mRemainingTime > -1) {
+		    sourcesDescription += " #{sDuration}: ";
+		    float duration = effectIt->mRemainingTime;
+		    if (duration > 3600) {
+			int hour = duration / 3600;
+			duration -= hour*3600;
+			sourcesDescription += MWGui::ToolTips::toString(hour) + "h";
+		    }
+		    if (duration > 60) {
+			int minute = duration / 60;
+			duration -= minute*60;
+			sourcesDescription += MWGui::ToolTips::toString(minute) + "m";
+		    }
+		    if (duration > 0.1) {
+			sourcesDescription += MWGui::ToolTips::toString(duration) + "s";
+		    }
+		}
             }
 
             if (remainingDuration > 0.f)

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -6,6 +6,7 @@
 #include <MyGUI_ImageBox.h>
 
 #include <components/esm/loadmgef.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
@@ -134,23 +135,24 @@ namespace MWGui
                             MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "") );
                     }
                 }
-		if (effectIt->mRemainingTime > -1) {
-		    sourcesDescription += " #{sDuration}: ";
-		    float duration = effectIt->mRemainingTime;
-		    if (duration > 3600) {
-			int hour = duration / 3600;
-			duration -= hour*3600;
-			sourcesDescription += MWGui::ToolTips::toString(hour) + "h";
-		    }
-		    if (duration > 60) {
-			int minute = duration / 60;
-			duration -= minute*60;
-			sourcesDescription += MWGui::ToolTips::toString(minute) + "m";
-		    }
-		    if (duration > 0.1) {
-			sourcesDescription += MWGui::ToolTips::toString(duration) + "s";
-		    }
-		}
+                if (effectIt->mRemainingTime > -1 &&
+                        Settings::Manager::getBool("show effect duration","Game")) {
+                    sourcesDescription += " #{sDuration}: ";
+                    float duration = effectIt->mRemainingTime;
+                    if (duration > 3600) {
+                        int hour = duration / 3600;
+                        duration -= hour*3600;
+                        sourcesDescription += MWGui::ToolTips::toString(hour) + "h";
+                    }
+                    if (duration > 60) {
+                        int minute = duration / 60;
+                        duration -= minute*60;
+                        sourcesDescription += MWGui::ToolTips::toString(minute) + "m";
+                    }
+                    if (duration > 0.1) {
+                        sourcesDescription += MWGui::ToolTips::toString(duration) + "s";
+                    }
+                }
             }
 
             if (remainingDuration > 0.f)

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -175,6 +175,8 @@ difficulty = 0
 #2: tint crosshair
 #3: both
 show owned = 0
+# Show the remaining duration of magic effects and lights
+show effect duration = false
 
 [Saves]
 character =


### PR DESCRIPTION
I know it's not in vanilla morrowind, it's in skyrim actually for spell effects, and you easily get used to it, so since it's easy to add to morrowind, here it is.
And I also added the duration for lights, because I had forgotten they just disappear after some time !
Now at least you'll know why they disappear... ! (I didn't know their default duration is only 120s, quite ridiculous !)
