### PR TITLE
Tab extermination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ script:
  - cd ./build
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then ${ANALYZE}make -j2; fi
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "osx" ]; then make package; fi
-after_script:
  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./openmw_test_suite; fi
+ - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then cd .. && ./CI/check_tabs.sh; fi
 notifications:
   recipients:
     - corrmage+travis-ci@gmail.com

--- a/CI/check_tabs.sh
+++ b/CI/check_tabs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+OUTPUT=$(grep -nRP '\t' --include=\*.{cpp,hpp,c,h} apps components)
+
+if [[ $OUTPUT ]] ; then
+    echo "Error: Tab characters found!"
+    echo $OUTPUT
+    exit 1
+fi

--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -493,14 +493,14 @@ void Record<ESM::Book>::print()
     std::cout << "  Enchantment Points: " << mData.mData.mEnchant << std::endl;
     if (mPrintPlain)
     {
-    	std::cout << "  Text:" << std::endl;
-    	std::cout << "START--------------------------------------" << std::endl;
-    	std::cout << mData.mText << std::endl;
-    	std::cout << "END----------------------------------------" << std::endl;
+        std::cout << "  Text:" << std::endl;
+        std::cout << "START--------------------------------------" << std::endl;
+        std::cout << mData.mText << std::endl;
+        std::cout << "END----------------------------------------" << std::endl;
     }
     else
     {
-    	std::cout << "  Text: [skipped]" << std::endl;
+        std::cout << "  Text: [skipped]" << std::endl;
     }
 }
 
@@ -799,14 +799,14 @@ void Record<ESM::DialInfo>::print()
     {
         if (mPrintPlain)
         {
-        	std::cout << "  Result Script:" << std::endl;
-        	std::cout << "START--------------------------------------" << std::endl;
-        	std::cout << mData.mResultScript << std::endl;
-        	std::cout << "END----------------------------------------" << std::endl;
+            std::cout << "  Result Script:" << std::endl;
+            std::cout << "START--------------------------------------" << std::endl;
+            std::cout << mData.mResultScript << std::endl;
+            std::cout << "END----------------------------------------" << std::endl;
         }
         else
         {
-        	std::cout << "  Result Script: [skipped]" << std::endl;
+            std::cout << "  Result Script: [skipped]" << std::endl;
         }
     }
 }
@@ -1201,14 +1201,14 @@ void Record<ESM::Script>::print()
 
     if (mPrintPlain)
     {
-    	std::cout << "  Script:" << std::endl;
-    	std::cout << "START--------------------------------------" << std::endl;
-    	std::cout << mData.mScriptText << std::endl;
-    	std::cout << "END----------------------------------------" << std::endl;
+        std::cout << "  Script:" << std::endl;
+        std::cout << "START--------------------------------------" << std::endl;
+        std::cout << mData.mScriptText << std::endl;
+        std::cout << "END----------------------------------------" << std::endl;
     }
     else
     {
-    	std::cout << "  Script: [skipped]" << std::endl;
+        std::cout << "  Script: [skipped]" << std::endl;
     }
 }
 

--- a/apps/esmtool/record.hpp
+++ b/apps/esmtool/record.hpp
@@ -53,7 +53,7 @@ namespace EsmTool
         }
 
         void setPrintPlain(bool plain) {
-        	mPrintPlain = plain;
+            mPrintPlain = plain;
         }
 
         virtual void load(ESM::ESMReader &esm) = 0;

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -16,7 +16,7 @@ namespace
 CSMWorld::InfoTableProxyModel::InfoTableProxyModel(CSMWorld::UniversalId::Type type, QObject *parent)
     : IdTableProxyModel(parent),
       mType(type),
-	  mInfoColumnId(type == UniversalId::Type_TopicInfos ? Columns::ColumnId_Topic : 
+      mInfoColumnId(type == UniversalId::Type_TopicInfos ? Columns::ColumnId_Topic :
                                                            Columns::ColumnId_Journal),
       mInfoColumnIndex(-1),
       mLastAddedSourceRow(-1)

--- a/apps/opencs/view/widget/droplineedit.cpp
+++ b/apps/opencs/view/widget/droplineedit.cpp
@@ -35,7 +35,7 @@ void CSVWidget::DropLineEdit::dropEvent(QDropEvent *event)
     if (CSVWorld::DragDropUtils::canAcceptData(*event, mDropType))
     {
         CSMWorld::UniversalId id = CSVWorld::DragDropUtils::getAcceptedData(*event, mDropType);
-		setText(QString::fromUtf8(id.getId().c_str()));
+        setText(QString::fromUtf8(id.getId().c_str()));
         emit tableMimeDataDropped(id, CSVWorld::DragDropUtils::getTableMimeData(*event)->getDocumentPtr());
     }
 }

--- a/apps/openmw/android_commandLine.cpp
+++ b/apps/openmw/android_commandLine.cpp
@@ -7,21 +7,21 @@ int argcData;
 extern "C" void releaseArgv();
 
 void releaseArgv() {
-	delete[] argvData;
+    delete[] argvData;
 }
 
 JNIEXPORT void JNICALL Java_ui_activity_GameActivity_commandLine(JNIEnv *env,
-		jobject obj, jint argc, jobjectArray stringArray) {
-	jboolean iscopy;
-	argcData = (int) argc;
-	argvData = new const char *[argcData + 1];
-	argvData[0] = "openmw";
-	for (int i = 1; i < argcData + 1; i++) {
-		jstring string = (jstring) (env)->GetObjectArrayElement(stringArray,
-				i - 1);
-		argvData[i] = (env)->GetStringUTFChars(string, &iscopy);
-		(env)->DeleteLocalRef(string);
-	}
-	(env)->DeleteLocalRef(stringArray);
+    jobject obj, jint argc, jobjectArray stringArray) {
+    jboolean iscopy;
+    argcData = (int) argc;
+    argvData = new const char *[argcData + 1];
+    argvData[0] = "openmw";
+    for (int i = 1; i < argcData + 1; i++) {
+        jstring string = (jstring) (env)->GetObjectArrayElement(stringArray,
+                i - 1);
+        argvData[i] = (env)->GetStringUTFChars(string, &iscopy);
+        (env)->DeleteLocalRef(string);
+    }
+    (env)->DeleteLocalRef(stringArray);
 }
 

--- a/apps/openmw/android_main.c
+++ b/apps/openmw/android_main.c
@@ -16,22 +16,22 @@ extern const char **argvData;
 void releaseArgv();
 
 int Java_org_libsdl_app_SDLActivity_nativeInit(JNIEnv* env, jclass cls,
-		jobject obj) {
+        jobject obj) {
 
-	SDL_Android_Init(env, cls);
+    SDL_Android_Init(env, cls);
 
-	SDL_SetMainReady();
+    SDL_SetMainReady();
 
-	/* Run the application code! */
+    /* Run the application code! */
 
-	int status;
+    int status;
 
-	status = main(argcData+1, argvData);
-	releaseArgv();
-	/* Do not issue an exit or the whole application will terminate instead of just the SDL thread */
-	/* exit(status); */
+    status = main(argcData+1, argvData);
+    releaseArgv();
+    /* Do not issue an exit or the whole application will terminate instead of just the SDL thread */
+    /* exit(status); */
 
-	return status;
+    return status;
 }
 
 #endif /* __ANDROID__ */

--- a/apps/openmw/crashcatcher.cpp
+++ b/apps/openmw/crashcatcher.cpp
@@ -37,8 +37,8 @@ static const char pipe_err[] = "!!! Failed to create pipe\n";
 static const char fork_err[] = "!!! Failed to fork debug process\n";
 static const char exec_err[] = "!!! Failed to exec debug process\n";
 
-#ifndef PATH_MAX		/* Not all platforms (GNU Hurd) have this. */
-#	define PATH_MAX 256
+#ifndef PATH_MAX /* Not all platforms (GNU Hurd) have this. */
+#   define PATH_MAX 256
 #endif
 
 static char argv0[PATH_MAX];

--- a/apps/openmw/mwgui/debugwindow.cpp
+++ b/apps/openmw/mwgui/debugwindow.cpp
@@ -18,9 +18,9 @@ namespace
         float accumulated_time=0,parent_time = pit->Is_Root() ? CProfileManager::Get_Time_Since_Reset() : pit->Get_Current_Parent_Total_Time();
         int i,j;
         int frames_since_reset = CProfileManager::Get_Frame_Count_Since_Reset();
-        for (i=0;i<spacing;i++)	os << ".";
+        for (i=0;i<spacing;i++) os << ".";
         os << "----------------------------------\n";
-        for (i=0;i<spacing;i++)	os << ".";
+        for (i=0;i<spacing;i++) os << ".";
         std::string s = "Profiling: "+
                 std::string(pit->Get_Current_Parent_Name())+" (total running time: "+MyGUI::utility::toString(parent_time,3)+" ms) ---\n";
         os << s;
@@ -35,7 +35,7 @@ namespace
             accumulated_time += current_total_time;
             float fraction = parent_time > SIMD_EPSILON ? (current_total_time / parent_time) * 100 : 0.f;
 
-            for (j=0;j<spacing;j++)	os << ".";
+            for (j=0;j<spacing;j++) os << ".";
             double ms = (current_total_time / (double)frames_since_reset);
             s = MyGUI::utility::toString(i)+" -- "+pit->Get_Current_Name()+" ("+MyGUI::utility::toString(fraction,2)+" %) :: "+MyGUI::utility::toString(ms,3)+" ms / frame ("+MyGUI::utility::toString(pit->Get_Current_Total_Calls())+" calls)\n";
             os << s;
@@ -47,7 +47,7 @@ namespace
         {
             os << "what's wrong\n";
         }
-        for (i=0;i<spacing;i++)	os << ".";
+        for (i=0;i<spacing;i++) os << ".";
         double unaccounted=  parent_time > SIMD_EPSILON ? ((parent_time - accumulated_time) / parent_time) * 100 : 0.f;
         s = "Unaccounted: ("+MyGUI::utility::toString(unaccounted,3)+" %) :: "+MyGUI::utility::toString(parent_time - accumulated_time,3)+" ms\n";
         os << s;

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -109,7 +109,7 @@ namespace MWGui
 
         static std::string sSchoolNames[6];
 
-	int mHorizontalScrollIndex;
+        int mHorizontalScrollIndex;
 
 
         float mDelay;

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -605,7 +605,7 @@ namespace MWGui
             controller->eventRepeatClick += newDelegate(this, &MWScrollBar::repeatClick);
             controller->setEnabled(mEnableRepeat);
             controller->setRepeat(mRepeatTriggerTime, mRepeatStepTime);
-			MyGUI::ControllerManager::getInstance().addItem(this, controller);
+            MyGUI::ControllerManager::getInstance().addItem(this, controller);
         }
 
         void MWScrollBar::onDecreaseButtonReleased(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id)
@@ -621,7 +621,7 @@ namespace MWGui
             controller->eventRepeatClick += newDelegate(this, &MWScrollBar::repeatClick);
             controller->setEnabled(mEnableRepeat);
             controller->setRepeat(mRepeatTriggerTime, mRepeatStepTime);
-			MyGUI::ControllerManager::getInstance().addItem(this, controller);
+            MyGUI::ControllerManager::getInstance().addItem(this, controller);
         }
 
         void MWScrollBar::onIncreaseButtonReleased(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id)

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -102,9 +102,9 @@ namespace MWInput
         mControlSwitch["playerviewswitch"]    = true;
         mControlSwitch["vanitymode"]          = true;
 
-        		/* Joystick Init */
+        /* Joystick Init */
 
-		//Load controller mappings
+        // Load controller mappings
 #if SDL_VERSION_ATLEAST(2,0,2)
         if(controllerBindingsFile!="")
         {
@@ -112,10 +112,10 @@ namespace MWInput
         }
 #endif
 
-		//Open all presently connected sticks
-		int numSticks = SDL_NumJoysticks();
-		for(int i = 0; i < numSticks; i++)
-		{
+        // Open all presently connected sticks
+        int numSticks = SDL_NumJoysticks();
+        for(int i = 0; i < numSticks; i++)
+        {
             if(SDL_IsGameController(i))
             {
                 SDL_ControllerDeviceEvent evt;
@@ -126,7 +126,7 @@ namespace MWInput
             {
                 //ICS_LOG(std::string("Unusable controller plugged in: ")+SDL_JoystickNameForIndex(i));
             }
-		}
+        }
 
         float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
         if (uiScale != 0.f)

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -57,7 +57,7 @@ namespace
             osg::Vec3f dir = to - from;
             dir.z() = 0;
             dir.normalize();
-			float verticalOffset = 200; // instead of '200' here we want the height of the actor
+            float verticalOffset = 200; // instead of '200' here we want the height of the actor
             osg::Vec3f _from = from + dir*offsetXY + osg::Vec3f(0,0,1) * verticalOffset;
 
             // cast up-down ray and find height in world space of hit

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -747,7 +747,7 @@ namespace MWPhysics
         {
         }
 
-        virtual	btScalar addSingleResult(btCollisionWorld::LocalRayResult& rayResult,bool normalInWorldSpace)
+        virtual btScalar addSingleResult(btCollisionWorld::LocalRayResult& rayResult,bool normalInWorldSpace)
         {
             if (rayResult.m_collisionObject == mMe)
                 return 1.f;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -287,7 +287,7 @@ namespace MWWorld
 
         if (mPlayer)
         {
-	    mPlayer->clear();
+            mPlayer->clear();
             mPlayer->setCell(0);
             mPlayer->getPlayer().getRefData() = RefData();
             mPlayer->set(mStore.get<ESM::NPC>().find ("player"));

--- a/components/compiler/extensions0.hpp
+++ b/components/compiler/extensions0.hpp
@@ -44,7 +44,7 @@ namespace Compiler
 
     namespace Gui
     {
-        void registerExtensions (Extensions& extensions);	
+        void registerExtensions (Extensions& extensions);
     }
 
     namespace Misc

--- a/components/esm/loadmgef.hpp
+++ b/components/esm/loadmgef.hpp
@@ -31,9 +31,9 @@ struct MagicEffect
         CastTouch = 0x80, // Allows range - cast on touch.
         CastTarget = 0x100, // Allows range - cast on target.
         UncappedDamage = 0x1000, // Negates multiple cap behaviours. Allows an effect to reduce an attribute below zero; removes the normal minimum effect duration of 1 second.
-        NonRecastable = 0x4000,	// Does not land if parent spell is already affecting target. Shows "you cannot re-cast" message for self target.
+        NonRecastable = 0x4000, // Does not land if parent spell is already affecting target. Shows "you cannot re-cast" message for self target.
         Unreflectable = 0x10000, // Cannot be reflected, the effect always lands normally.
-        CasterLinked = 0x20000,	// Must quench if caster is dead, or not an NPC/creature. Not allowed in containter/door trap spells.
+        CasterLinked = 0x20000, // Must quench if caster is dead, or not an NPC/creature. Not allowed in containter/door trap spells.
 
         // Originally modifiable flags
         AllowSpellmaking = 0x200, // Can be used for spellmaking

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -52,11 +52,11 @@ struct ConfigurationManager
         typedef Files::FixedPath<> FixedPathType;
 
         typedef const boost::filesystem::path& (FixedPathType::*path_type_f)() const;
-	#if defined HAVE_UNORDERED_MAP
-            typedef std::unordered_map<std::string, path_type_f> TokensMappingContainer;
-	#else
-            typedef std::tr1::unordered_map<std::string, path_type_f> TokensMappingContainer;
-	#endif
+    #if defined HAVE_UNORDERED_MAP
+        typedef std::unordered_map<std::string, path_type_f> TokensMappingContainer;
+    #else
+        typedef std::tr1::unordered_map<std::string, path_type_f> TokensMappingContainer;
+    #endif
 
         void loadConfig(const boost::filesystem::path& path,
             boost::program_options::variables_map& variables,

--- a/components/sdlutil/sdlinputwrapper.hpp
+++ b/components/sdlutil/sdlinputwrapper.hpp
@@ -30,8 +30,8 @@ namespace SDLUtil
         void setControllerEventCallback(ControllerListener* listen) { mConListener = listen; }
 
         void capture(bool windowEventsOnly);
-		bool isModifierHeld(SDL_Keymod mod);
-		bool isKeyDown(SDL_Scancode key);
+        bool isModifierHeld(SDL_Keymod mod);
+        bool isKeyDown(SDL_Scancode key);
 
         void setMouseVisible (bool visible);
         void setMouseRelative(bool relative);


### PR DESCRIPTION
Removes tab characters for all source files in apps/ and components/. Adds a step to Travis-CI builds that checks for tab characters in source files, and fails the build if one is found.

The intent here is to notice mixed indentation *before* we merge a pull request. We should never merge a PR with tabs in it, because:
- The code won't line up depending on your editor's tab width.
- Removing tabs post-merge can create merge conflicts, and obscures the results of tools like git blame or git log with irrelevant changes.

Spotting & fixing tabs manually is annoying (and evidently, every once in a while something will slip through). So why not let travis handle it?

Testing performed:
- Added tab character, build fails https://travis-ci.org/scrawl/openmw/jobs/80709680