### PR TITLE
scale automatically documents to read (books, scrolls and journal)

### DIFF
--- a/apps/openmw/mwbase/inputmanager.hpp
+++ b/apps/openmw/mwbase/inputmanager.hpp
@@ -56,6 +56,7 @@ namespace MWBase
             /// Returns if the last used input device was a joystick or a keyboard
             /// @return true if joystick, false otherwise
             virtual bool joystickLastUsed() = 0;
+            virtual void setScale(float uiscale) = 0;
     };
 }
 

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -272,7 +272,7 @@ namespace MWBase
 
             virtual void enableRest() = 0;
             virtual bool getRestEnabled() = 0;
-            virtual bool getJournalAllowed() = 0; 
+            virtual bool getJournalAllowed() = 0;
 
             virtual bool getPlayerSleeping() = 0;
             virtual void wakeUpPlayer() = 0;
@@ -359,6 +359,9 @@ namespace MWBase
             virtual void requestMap(std::set<MWWorld::CellStore*> cells) = 0;
             virtual void removeCell(MWWorld::CellStore* cell) = 0;
             virtual void writeFog(MWWorld::CellStore* cell) = 0;
+            virtual void setScale(float scalingFactor) = 0;
+            virtual float getBookScale() = 0;
+            virtual float getScrollScale() = 0;
     };
 }
 

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -15,6 +15,7 @@
 #include <components/misc/stringops.hpp>
 #include <components/widgets/imagebutton.hpp>
 #include <components/widgets/list.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/soundmanager.hpp"
@@ -123,7 +124,7 @@ namespace
 
             {
                 MWGui::BookPage::ClickCallback callback;
-                
+
                 callback = boost::bind (&JournalWindowImpl::notifyTopicClicked, this, _1);
 
                 getPage (LeftBookPage)->adviseLinkClicked (callback);
@@ -135,7 +136,7 @@ namespace
 
             {
                 MWGui::BookPage::ClickCallback callback;
-                
+
                 callback = boost::bind (&JournalWindowImpl::notifyIndexLinkClicked, this, _1);
 
                 getPage (LeftTopicIndex)->adviseLinkClicked (callback);
@@ -199,6 +200,8 @@ namespace
 
         void open()
         {
+            MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
+            wm->setScale(wm->getBookScale());
             if (!MWBase::Environment::get().getWindowManager ()->getJournalAllowed ())
             {
                 MWBase::Environment::get().getWindowManager()->popGuiMode ();
@@ -228,6 +231,7 @@ namespace
 
         void close()
         {
+            MWBase::Environment::get().getWindowManager ()->setScale(Settings::Manager::getFloat("scaling factor", "GUI"));
             mModel->unload ();
 
             getPage (LeftBookPage)->showPage (Book (), 0);

--- a/apps/openmw/mwgui/windowbase.cpp
+++ b/apps/openmw/mwgui/windowbase.cpp
@@ -10,11 +10,15 @@
 
 #include "draganddrop.hpp"
 
-using namespace MWGui;
+    using namespace MWGui;
 
-WindowBase::WindowBase(const std::string& parLayout)
+    WindowBase::WindowBase(const std::string& parLayout)
   : Layout(parLayout)
 {
+    isBook = parLayout == "openmw_book.layout";
+    isScroll = parLayout == "openmw_scroll.layout";
+    uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
+    if (uiScale < 0.001) uiScale = 1.0;
 }
 
 void WindowBase::setVisible(bool visible)
@@ -48,13 +52,39 @@ bool WindowBase::isVisible()
 void WindowBase::center()
 {
     // Centre dialog
+    MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
+    float scale;
+    if (isBook)
+        scale = wm->getBookScale()/uiScale;
+    else if (isScroll)
+        scale = wm->getScrollScale()/uiScale;
+    else
+        scale = 1;
 
     MyGUI::IntSize gameWindowSize = MyGUI::RenderManager::getInstance().getViewSize();
 
     MyGUI::IntCoord coord = mMainWidget->getCoord();
-    coord.left = (gameWindowSize.width - coord.width)/2;
-    coord.top = (gameWindowSize.height - coord.height)/2;
+    coord.left = (gameWindowSize.width/scale - coord.width)/2;
+    coord.top = (gameWindowSize.height/scale - coord.height)/2;
     mMainWidget->setCoord(coord);
+}
+
+void WindowBase::open()
+{
+    if (isBook || isScroll) {
+        MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
+        if (isBook)
+            wm->setScale(wm->getBookScale());
+        else
+            wm->setScale(wm->getScrollScale());
+    }
+}
+
+void WindowBase::close()
+{
+    if (isBook || isScroll) {
+        MWBase::Environment::get().getWindowManager()->setScale(uiScale);
+    }
 }
 
 WindowModal::WindowModal(const std::string& parLayout)

--- a/apps/openmw/mwgui/windowbase.hpp
+++ b/apps/openmw/mwgui/windowbase.hpp
@@ -15,6 +15,9 @@ namespace MWGui
 
     class WindowBase: public Layout
     {
+        protected:
+            bool isBook,isScroll;
+            float uiScale;
         public:
         WindowBase(const std::string& parLayout);
 
@@ -22,9 +25,9 @@ namespace MWGui
         typedef MyGUI::delegates::CMultiDelegate1<WindowBase*> EventHandle_WindowBase;
 
         /// Notify that window has been made visible
-        virtual void open() {}
+        virtual void open();
         /// Notify that window has been hidden
-        virtual void close () {}
+        virtual void close ();
         /// Gracefully exits the window
         virtual void exit() {}
         /// Sets the visibility of the window

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1095,20 +1095,20 @@ namespace MWGui
     void WindowManager::onRetrieveTag(const MyGUI::UString& _tag, MyGUI::UString& _result)
     {
         std::string tag(_tag);
-        
+
         std::string MyGuiPrefix = "setting=";
         size_t MyGuiPrefixLength = MyGuiPrefix.length();
 
         std::string tokenToFind = "sCell=";
         size_t tokenLength = tokenToFind.length();
-        
+
         if(tag.compare(0, MyGuiPrefixLength, MyGuiPrefix) == 0)
         {
             tag = tag.substr(MyGuiPrefixLength, tag.length());
             std::string settingSection = tag.substr(0, tag.find(","));
             std::string settingTag = tag.substr(tag.find(",")+1, tag.length());
-            
-            _result = Settings::Manager::getString(settingTag, settingSection);            
+
+            _result = Settings::Manager::getString(settingTag, settingSection);
         }
         else if (tag.compare(0, tokenLength, tokenToFind) == 0)
         {
@@ -2061,6 +2061,31 @@ namespace MWGui
     void WindowManager::writeFog(MWWorld::CellStore *cell)
     {
         mLocalMapRender->saveFogOfWar(cell);
+    }
+
+    void WindowManager::setScale(float scalingFactor)
+    {
+        mGuiPlatform->getRenderManagerPtr()->setScale(scalingFactor);
+        MWBase::Environment::get().getInputManager()->setScale(scalingFactor);
+    }
+
+    static float get_ratio(osg::ref_ptr<osg::Viewport> vp,int w,int h)
+    {
+        float ratiox = vp->width()*.95/w;
+        float ratioy = vp->height() * .85/h;
+        if (ratiox < ratioy)
+            return ratiox;
+        return ratioy;
+    }
+
+    float WindowManager::getBookScale()
+    {
+        return get_ratio(mViewer->getCamera()->getViewport(),584,398);
+    }
+
+    float WindowManager::getScrollScale()
+    {
+        return get_ratio(mViewer->getCamera()->getViewport(),512,512);
     }
 
 }

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -489,7 +489,7 @@ namespace MWGui
     float mFPS;
 
     std::map<std::string, std::string> mFallbackMap;
-    
+
     int mShowOwned;
 
     std::string mVersionDescription;
@@ -521,6 +521,9 @@ namespace MWGui
     void createTextures();
     void createCursors();
     void setMenuTransparency(float value);
+    void setScale(float scalingFactor);
+    float getBookScale();
+    float getScrollScale();
   };
 }
 

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1576,6 +1576,12 @@ namespace MWInput
         loadControllerDefaults(true);
     }
 
+    void InputManager::setScale(float uiScale)
+    {
+        if (uiScale != 0.f)
+            mInvUiScalingFactor = 1.f / uiScale;
+    }
+
     MyGUI::MouseButton InputManager::sdlButtonToMyGUI(Uint8 button)
     {
         //The right button is the second button, according to MyGUI

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -152,6 +152,7 @@ namespace MWInput
 
         void clearAllKeyBindings (ICS::Control* control);
         void clearAllControllerBindings (ICS::Control* control);
+        void setScale(float uiscale);
 
     private:
         SDL_Window* mWindow;

--- a/components/myguiplatform/myguirendermanager.cpp
+++ b/components/myguiplatform/myguirendermanager.cpp
@@ -527,4 +527,12 @@ bool RenderManager::checkTexture(MyGUI::ITexture* _texture)
     return true;
 }
 
+void RenderManager::setScale(float scalingFactor)
+{
+    if (scalingFactor != 0.f)
+        mInvScalingFactor = 1.f / scalingFactor;
+    osg::ref_ptr<osg::Viewport> vp = mViewer->getCamera()->getViewport();
+    setViewSize(vp->width(), vp->height());
+}
+
 }

--- a/components/myguiplatform/myguirendermanager.hpp
+++ b/components/myguiplatform/myguirendermanager.hpp
@@ -54,6 +54,7 @@ public:
     RenderManager(osgViewer::Viewer *viewer, osg::Group *sceneroot, Resource::TextureManager* textureManager, float scalingFactor);
     virtual ~RenderManager();
 
+    void setScale(float scalingFactor);
     void initialise();
     void shutdown();
 


### PR DESCRIPTION
Quite a bit to explain this time.
A few days ago I found the topic about "journal size" on the forum there : https://forum.openmw.org/viewtopic.php?f=2&t=3093
so as mentioned in the topic, I tried gui "scaling factor = 2" on a 1680x1050 screen to test. It's excellent for books, but it looks bad for most gui screens (even the title screen) and it's horrible for the character status screen.
So I tried to make a patch for this.
My first idea was to try to use mainWidget->setScale(width*2,height*2) in Layout when the layout is one of these (book, scroll or journal). But it doesn't work, the place is reserved on screen, but apparently the sub widgets are not resized and the font doesn't change.
So option 2 : adapt gui scaling factor to work only for these cases. It was longer than what I thought, but in the end it works well. It adapts to the resolution used (I tested with a window that I manually reiszed to many resolutions) and to the current gui scaling factor. It works for books, scrolls and journal.

Morrowind does this automatically, it resizes everything to read to fullscreen, so I don't think we need a setting to enable/disable this.