### PR TITLE
Sky

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -23,6 +23,7 @@ add_openmw_dir (mwrender
     actors objects renderingmanager animation rotatecontroller sky npcanimation vismask
     creatureanimation effectmanager util renderinginterface pathgrid rendermode weaponanimation
     bulletdebugdraw globalmap characterpreview camera localmap water terrainstorage ripplesimulation
+    renderbin
     )
 
 add_openmw_dir (mwinput

--- a/apps/openmw/mwrender/renderbin.hpp
+++ b/apps/openmw/mwrender/renderbin.hpp
@@ -1,0 +1,20 @@
+#ifndef OPENMW_MWRENDER_RENDERBIN_H
+#define OPENMW_MWRENDER_RENDERBIN_H
+
+namespace MWRender
+{
+
+    /// Defines the render bin numbers used in the OpenMW scene graph. The bin with the lowest number is rendered first.
+    /// Beware of RenderBin nesting, in most cases you will want to use setNestRenderBins(false).
+    enum RenderBins
+    {
+        RenderBin_Sky = -1,
+        RenderBin_Default = 0,
+        RenderBin_Water = 9,
+        RenderBin_OcclusionQuery = 10,
+        RenderBin_SunGlare = 11
+    };
+
+}
+
+#endif

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -366,7 +366,6 @@ public:
     Sun(osg::Group* parentNode, Resource::TextureManager& textureManager)
         : CelestialBody(parentNode, 1.0f, 1)
         , mUpdater(new Updater)
-        , mInitialFlashScale(2.6f)
     {
         mTransform->addUpdateCallback(mUpdater);
 
@@ -496,7 +495,8 @@ private:
                                                                         osg::Texture::CLAMP);
 
         osg::ref_ptr<osg::PositionAttitudeTransform> transform (new osg::PositionAttitudeTransform);
-        transform->setScale(osg::Vec3f(mInitialFlashScale, mInitialFlashScale, mInitialFlashScale));
+        const float scale = 2.6f;
+        transform->setScale(osg::Vec3f(scale,scale,scale));
 
         mTransform->addChild(transform);
 
@@ -804,7 +804,6 @@ private:
     osg::ref_ptr<osg::Node> mSunGlareNode;
     osg::ref_ptr<osg::OcclusionQueryNode> mOcclusionQueryVisiblePixels;
     osg::ref_ptr<osg::OcclusionQueryNode> mOcclusionQueryTotalPixels;
-    float mInitialFlashScale;
 };
 
 class Moon : public CelestialBody

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -41,6 +41,7 @@
 #include "../mwworld/fallback.hpp"
 
 #include "vismask.hpp"
+#include "renderbin.hpp"
 
 namespace
 {
@@ -376,7 +377,7 @@ public:
         osg::ref_ptr<osg::PositionAttitudeTransform> queryTransform (new osg::PositionAttitudeTransform);
         queryTransform->setScale(osg::Vec3f(0.5f, 0.5f, 0.5f));
         // Need to render after the world geometry so we can correctly test for occlusions
-        queryTransform->getOrCreateStateSet()->setRenderBinDetails(10, "RenderBin");
+        queryTransform->getOrCreateStateSet()->setRenderBinDetails(RenderBin_OcclusionQuery, "RenderBin");
         queryTransform->getOrCreateStateSet()->setNestRenderBins(false);
 
         mTransform->addChild(queryTransform);
@@ -680,7 +681,7 @@ SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneMana
     mRootNode = skyroot;
 
     // By default render before the world is rendered
-    mRootNode->getOrCreateStateSet()->setRenderBinDetails(-1, "RenderBin");
+    mRootNode->getOrCreateStateSet()->setRenderBinDetails(RenderBin_Sky, "RenderBin");
 }
 
 void SkyManager::create()

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -402,6 +402,13 @@ public:
         destroySunGlare();
     }
 
+    void setColor(const osg::Vec4f& color)
+    {
+        mUpdater->mColor.r() = color.r();
+        mUpdater->mColor.g() = color.g();
+        mUpdater->mColor.b() = color.b();
+    }
+
     virtual void adjustTransparency(const float ratio)
     {
         mUpdater->mColor.a() = ratio;
@@ -576,7 +583,7 @@ private:
         osg::Vec4f mColor;
 
         Updater()
-            : mColor(1.f, 1.f, 1.f, 1.0f)
+            : mColor(1.f, 1.f, 1.f, 1.f)
         {
         }
 
@@ -588,7 +595,8 @@ private:
         virtual void apply(osg::StateSet* stateset, osg::NodeVisitor*)
         {
             osg::Material* mat = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
-            mat->setDiffuse(osg::Material::FRONT_AND_BACK, mColor);
+            mat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(0,0,0,mColor.a()));
+            mat->setEmission(osg::Material::FRONT_AND_BACK, osg::Vec4f(mColor.r(), mColor.g(), mColor.b(), 1));
         }
     };
 
@@ -1464,15 +1472,8 @@ void SkyManager::setWeather(const WeatherResult& weather)
     mMasser->adjustTransparency(weather.mGlareView);
     mSecunda->adjustTransparency(weather.mGlareView);
 
-    /*
-    float timeofday_angle = std::abs(mSun->getPosition().z/mSunGlare->getPosition().length());
-    float strength;
-    if (timeofday_angle <= 0.44)
-        strength = timeofday_angle/0.44f;
-    else
-        strength = 1.f;
-    */
-    mSun->adjustTransparency(weather.mGlareView);
+    mSun->setColor(weather.mSunDiscColor);
+    mSun->adjustTransparency(weather.mGlareView * weather.mSunDiscColor.a());
 
     float nextStarsOpacity = weather.mNightFade * weather.mGlareView;
     if(weather.mNight && mStarsOpacity != nextStarsOpacity)

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -359,14 +359,20 @@ class Sun : public CelestialBody
 public:
     Sun(osg::Group* parentNode, Resource::TextureManager& textureManager)
         : CelestialBody(parentNode, 1.0f, 1)
-        , mUpdater(new Updater(textureManager))
+        , mUpdater(new Updater)
     {
-        mGeode->addUpdateCallback(mUpdater);
+        mTransform->addUpdateCallback(mUpdater);
+
+        osg::ref_ptr<osg::Texture2D> sunTex = textureManager.getTexture2D("textures/tx_sun_05.dds",
+                                                                        osg::Texture::CLAMP,
+                                                                        osg::Texture::CLAMP);
+
+        mGeode->getOrCreateStateSet()->setTextureAttributeAndModes(0, sunTex, osg::StateAttribute::ON);
     }
 
     ~Sun()
     {
-        mGeode->removeUpdateCallback(mUpdater);
+        mTransform->removeUpdateCallback(mUpdater);
     }
 
     virtual void adjustTransparency(const float ratio)
@@ -387,22 +393,15 @@ public:
 private:
     struct Updater : public SceneUtil::StateSetUpdater
     {
-        Resource::TextureManager& mTextureManager;
         osg::Vec4f mColor;
 
-        Updater(Resource::TextureManager& textureManager)
-            : mTextureManager(textureManager)
-            , mColor(0.0f, 0.0f, 0.0f, 1.0f)
+        Updater()
+            : mColor(1.f, 1.f, 1.f, 1.0f)
         {
         }
 
         virtual void setDefaults(osg::StateSet* stateset)
         {
-            osg::ref_ptr<osg::Texture2D> tex = mTextureManager.getTexture2D("textures/tx_sun_05.dds",
-                                                                            osg::Texture::CLAMP,
-                                                                            osg::Texture::CLAMP);
-
-            stateset->setTextureAttributeAndModes(0, tex, osg::StateAttribute::ON);
             stateset->setAttributeAndModes(createUnlitMaterial(),
                                            osg::StateAttribute::ON | osg::StateAttribute::OVERRIDE);
         }

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -140,8 +140,7 @@ namespace MWRender
         void setMasserState(const MoonState& state);
         void setSecundaState(const MoonState& state);
 
-        void setGlare(const float glare);
-        void setGlareEnabled(bool enabled);
+        void setGlareTimeOfDayFade(float val);
 
     private:
         void create();

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -209,9 +209,6 @@ namespace MWRender
 
         float mRemainingTransitionTime;
 
-        float mGlare; // target
-        float mGlareFade; // actual
-
         bool mRainEnabled;
         std::string mRainEffect;
         float mRainSpeed;

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -48,8 +48,10 @@ namespace MWRender
 
         osg::Vec4f mSkyColor;
 
+        // sun light color
         osg::Vec4f mSunColor;
 
+        // alpha is the sun transparency
         osg::Vec4f mSunDiscColor;
 
         float mFogDepth;

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -21,6 +21,7 @@
 
 #include "vismask.hpp"
 #include "ripplesimulation.hpp"
+#include "renderbin.hpp"
 
 namespace
 {
@@ -86,7 +87,7 @@ namespace
         depth->setWriteMask(false);
         stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
 
-        stateset->setRenderBinDetails(9, "RenderBin");
+        stateset->setRenderBinDetails(MWRender::RenderBin_Water, "RenderBin");
 
         std::vector<osg::ref_ptr<osg::Texture2D> > textures;
         for (int i=0; i<32; ++i)

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -624,6 +624,14 @@ void WeatherManager::update(float duration, bool paused)
         mRendering.setSunDirection( final * -1 );
     }
 
+    float peakHour = mSunriseTime + (mSunsetTime - mSunriseTime) / 2;
+    if (time.getHour() < mSunriseTime || time.getHour() > mSunsetTime)
+        mRendering.getSkyManager()->setGlareTimeOfDayFade(0);
+    else if (time.getHour() < peakHour)
+        mRendering.getSkyManager()->setGlareTimeOfDayFade(1 - (peakHour - time.getHour()) / (peakHour - mSunriseTime));
+    else
+        mRendering.getSkyManager()->setGlareTimeOfDayFade(1 - (time.getHour() - peakHour) / (mSunsetTime - peakHour));
+
     mRendering.getSkyManager()->setMasserState(mMasser.calculateState(time));
     mRendering.getSkyManager()->setSecundaState(mSecunda.calculateState(time));
 

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -458,16 +458,16 @@ WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, const MWWo
     , mPlayingSoundID()
 {
     mWeatherSettings.reserve(10);
-    addWeather("Clear", fallback);
-    addWeather("Cloudy", fallback);
-    addWeather("Foggy", fallback);
-    addWeather("Overcast", fallback);
-    addWeather("Rain", fallback, "rain");
-    addWeather("Thunderstorm", fallback, "rain heavy");
-    addWeather("Ashstorm", fallback, "ashstorm", "meshes\\ashcloud.nif");
-    addWeather("Blight", fallback, "blight", "meshes\\blightcloud.nif");
-    addWeather("Snow", fallback, "", "meshes\\snow.nif");
-    addWeather("Blizzard", fallback, "BM Blizzard", "meshes\\blizzard.nif");
+    addWeather("Clear", fallback); // 0
+    addWeather("Cloudy", fallback); // 1
+    addWeather("Foggy", fallback); // 2
+    addWeather("Overcast", fallback); // 3
+    addWeather("Rain", fallback, "rain"); // 4
+    addWeather("Thunderstorm", fallback, "rain heavy"); // 5
+    addWeather("Ashstorm", fallback, "ashstorm", "meshes\\ashcloud.nif"); // 6
+    addWeather("Blight", fallback, "blight", "meshes\\blightcloud.nif"); // 7
+    addWeather("Snow", fallback, "", "meshes\\snow.nif"); // 8
+    addWeather("Blizzard", fallback, "BM Blizzard", "meshes\\blizzard.nif"); // 9
 
     Store<ESM::Region>::iterator it = store.get<ESM::Region>().begin();
     for(; it != store.get<ESM::Region>().end(); ++it)

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -75,7 +75,7 @@ namespace MWWorld
         float mLandFogDayDepth;
         float mLandFogNightDepth;
 
-        // Color modulation for the sun itself during sunset (not completely sure)
+        // Color modulation for the sun itself during sunset
         osg::Vec4f mSunDiscSunsetColor;
 
         // Used by scripts to animate signs, etc based on the wind (GetWindSpeed)
@@ -242,12 +242,7 @@ namespace MWWorld
         float mSunsetTime;
         float mSunriseDuration;
         float mSunsetDuration;
-        // Some useful values
-        /* TODO: Use pre-sunrise_time, pre-sunset_time,
-         * post-sunrise_time, and post-sunset_time to better
-         * describe sunrise/sunset time.
-         * These values are fallbacks attached to weather.
-         */
+        float mSunPreSunsetTime;
         float mNightStart;
         float mNightEnd;
         float mDayStart;

--- a/components/sceneutil/statesetupdater.hpp
+++ b/components/sceneutil/statesetupdater.hpp
@@ -6,7 +6,7 @@
 namespace SceneUtil
 {
 
-    /// @brief Implements efficient pre-frame updating of StateSets.
+    /// @brief Implements efficient per-frame updating of StateSets.
     /// @par With a naive update there would be race conditions when the OSG draw thread of the last frame
     ///     queues up a StateSet that we want to modify for the next frame. To solve this we could set the StateSet to
     ///     DYNAMIC data variance but that would undo all the benefits of the threading model - having the cull and draw


### PR DESCRIPTION
cc @slothlife 

Implement sun flare effects, with several improvements over the old (Ogre) implementation:
- More accurate occlusion query, using a circular shape that matches the sun rather than a square.
- Implement the full-screen glare effect that we were missing before (makes the screen look "warmer" when you look directly at the sun during peak hours).
- Multiple camera support. Not used at the moment, but who knows when we'll need it. Using OSG callbacks made this so easy to support that I saw no reason to tie the code to a specific camera.

Miscellaneous sky changes:
- Implement Sun Disc Sunset Color
- Fade the sun in/out during sunrise/sunset