### PR TITLE
scripts: recognize '+' also as a unary operator

### DIFF
--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -650,7 +650,12 @@ namespace Compiler
             mOperators.push_back ('m');
             mTokenLoc = loc;
             return true;
+        } else if (code ==Scanner::S_plus && mNextOperand) {
+            // Also unary, but +, just ignore it
+            mTokenLoc = loc;
+            return true;
         }
+
 
         if (code==Scanner::S_open)
         {


### PR DESCRIPTION
it fixes the armor sorter in "Blades safe house.esp"
