### PR TITLE
Don't reset god mode, scripts enabled and sky enabled flags when loading a save game

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -204,6 +204,10 @@ namespace MWWorld
         mLevitationEnabled = true;
         mTeleportEnabled = true;
 
+        mGodMode = false;
+        mScriptsEnabled = true;
+        mSky = true;
+
         // Rebuild player
         setupPlayer();
 
@@ -297,9 +301,6 @@ namespace MWWorld
 
         mDoorStates.clear();
 
-        mGodMode = false;
-        mScriptsEnabled = true;
-        mSky = true;
         mTeleportEnabled = true;
         mLevitationEnabled = true;
 


### PR DESCRIPTION
These flags aren't stored in the save file, so it makes no sense to reset them to their default each time a save game is loaded. Instead, reset on "new game".

I like to keep god mode on for testing, the previous behaviour was a bit annoying in that respect.