### PR TITLE
Fishing academy

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -710,14 +710,23 @@ namespace MWDialogue
         if (map != mChangedFactionReaction.end() && map->second.find(fact2) != map->second.end())
             return map->second.at(fact2);
 
-        const ESM::Faction* faction = MWBase::Environment::get().getWorld()->getStore().get<ESM::Faction>().find(fact1);
+        try {
+            const ESM::Faction* faction = MWBase::Environment::get().getWorld()->getStore().get<ESM::Faction>().find(fact1);
 
-        std::map<std::string, int>::const_iterator it = faction->mReactions.begin();
-        for (; it != faction->mReactions.end(); ++it)
-        {
-            if (Misc::StringUtils::ciEqual(it->first, fact2))
+            std::map<std::string, int>::const_iterator it = faction->mReactions.begin();
+            for (; it != faction->mReactions.end(); ++it)
+            {
+                if (Misc::StringUtils::ciEqual(it->first, fact2))
                     return it->second;
+            }
         }
+        catch (const std::exception& e)
+        {
+            // Don't write anything, it creates too much useless output with
+            // some mods like fishing academy
+            // std::cerr << "Error in getFactionReaction: " << e.what() << std::endl;
+        }
+
         return 0;
     }
 

--- a/apps/openmw/mwscript/interpretercontext.cpp
+++ b/apps/openmw/mwscript/interpretercontext.cpp
@@ -601,9 +601,9 @@ namespace MWScript
         return mTargetId;
     }
 
-    void InterpreterContext::updatePtr(const MWWorld::Ptr& updated)
+    void InterpreterContext::updatePtr(const MWWorld::Ptr& base, const MWWorld::Ptr& updated)
     {
-        if (!mReference.isEmpty())
+        if (!mReference.isEmpty() && base == mReference)
             mReference = updated;
     }
 }

--- a/apps/openmw/mwscript/interpretercontext.hpp
+++ b/apps/openmw/mwscript/interpretercontext.hpp
@@ -167,7 +167,7 @@ namespace MWScript
             MWWorld::Ptr getReference(bool required=true);
             ///< Reference, that the script is running from (can be empty)
 
-            void updatePtr(const MWWorld::Ptr& updated);
+            void updatePtr(const MWWorld::Ptr& base, const MWWorld::Ptr& updated);
             ///< Update the Ptr stored in mReference, if there is one stored there. Should be called after the reference has been moved to a new cell.
 
             virtual std::string getTargetId() const;

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -160,15 +160,15 @@ namespace MWScript
 
                     if (axis=="x")
                     {
-                        runtime.push(osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]));
+                        runtime.push(osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0] + ptr.getRefData().getLocalRotation().rot[0]));
                     }
                     else if (axis=="y")
                     {
-                        runtime.push(osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]));
+                        runtime.push(osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1] + ptr.getRefData().getLocalRotation().rot[1]));
                     }
                     else if (axis=="z")
                     {
-                        runtime.push(osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[2]));
+                        runtime.push(osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[2] + ptr.getRefData().getLocalRotation().rot[2]));
                     }
                     else
                         throw std::runtime_error ("invalid rotation axis: " + axis);

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -200,7 +200,7 @@ namespace MWScript
                         runtime.push(ptr.getRefData().getPosition().pos[2]);
                     }
                     else
-                        throw std::runtime_error ("invalid axis: " + axis);
+                        throw std::runtime_error ("invalid axis: " + axis);                    
                 }
         };
 
@@ -212,8 +212,6 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = R()(runtime);
-                    bool need_update = (ptr ==
-                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     if (!ptr.isInCell())
                         return;
@@ -248,8 +246,7 @@ namespace MWScript
                     else
                         throw std::runtime_error ("invalid axis: " + axis);
 
-                    if (need_update)
-                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(updated);
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(updated);
                 }
         };
 
@@ -290,8 +287,6 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = R()(runtime);
-                    bool need_update = (ptr ==
-                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     if (ptr.getContainerStore())
                         return;
@@ -319,7 +314,7 @@ namespace MWScript
                     }
                     catch(std::exception&)
                     {
-                        const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);
+                        const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);                        
                         int cx,cy;
                         MWBase::Environment::get().getWorld()->positionToIndex(x,y,cx,cy);
                         store = MWBase::Environment::get().getWorld()->getExterior(cx,cy);
@@ -333,8 +328,7 @@ namespace MWScript
                     {
                         MWBase::Environment::get().getWorld()->moveObject(ptr,store,x,y,z);
                         ptr = MWWorld::Ptr(ptr.getBase(), store);
-                        if (need_update)
-                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
+                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
 
                         float ax = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]);
                         float ay = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]);
@@ -358,8 +352,6 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = R()(runtime);
-                    bool need_update = (ptr ==
-                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     if (!ptr.isInCell())
                         return;
@@ -392,8 +384,7 @@ namespace MWScript
                     {
                         ptr = MWBase::Environment::get().getWorld()->moveObject(ptr, x, y, z);
                     }
-                    if (need_update)
-                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
 
                     float ax = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]);
                     float ay = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]);
@@ -649,8 +640,6 @@ namespace MWScript
 
                     if (!ptr.isInCell())
                         return;
-                    bool need_update = (ptr ==
-                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     MWWorld::LocalRotation rot;
                     rot.rot[0] = 0;
@@ -660,10 +649,9 @@ namespace MWScript
 
                     MWBase::Environment::get().getWorld()->rotateObject(ptr, 0,0,0,true);
 
-                    if (need_update)
-                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(
-                                MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],
-                                    ptr.getCellRef().getPosition().pos[1], ptr.getCellRef().getPosition().pos[2]));
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(
+                        MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],
+                            ptr.getCellRef().getPosition().pos[1], ptr.getCellRef().getPosition().pos[2]));
 
                 }
         };
@@ -779,8 +767,8 @@ namespace MWScript
             interpreter.installSegment5(Compiler::Transformation::opcodePositionExplicit,new OpPosition<ExplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePositionCell,new OpPositionCell<ImplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePositionCellExplicit,new OpPositionCell<ExplicitRef>);
-            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItemCell,new OpPlaceItemCell<ImplicitRef>);
-            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItem,new OpPlaceItem<ImplicitRef>);
+            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItemCell,new OpPlaceItemCell<ImplicitRef>);            
+            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItem,new OpPlaceItem<ImplicitRef>);            
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtPc,new OpPlaceAt<ImplicitRef, true>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtMe,new OpPlaceAt<ImplicitRef, false>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtMeExplicit,new OpPlaceAt<ExplicitRef, false>);

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -200,7 +200,7 @@ namespace MWScript
                         runtime.push(ptr.getRefData().getPosition().pos[2]);
                     }
                     else
-                        throw std::runtime_error ("invalid axis: " + axis);                    
+                        throw std::runtime_error ("invalid axis: " + axis);
                 }
         };
 
@@ -212,6 +212,8 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = R()(runtime);
+                    bool need_update = (ptr ==
+                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     if (!ptr.isInCell())
                         return;
@@ -246,7 +248,8 @@ namespace MWScript
                     else
                         throw std::runtime_error ("invalid axis: " + axis);
 
-                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(updated);
+                    if (need_update)
+                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(updated);
                 }
         };
 
@@ -287,6 +290,8 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = R()(runtime);
+                    bool need_update = (ptr ==
+                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     if (ptr.getContainerStore())
                         return;
@@ -314,7 +319,7 @@ namespace MWScript
                     }
                     catch(std::exception&)
                     {
-                        const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);                        
+                        const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);
                         int cx,cy;
                         MWBase::Environment::get().getWorld()->positionToIndex(x,y,cx,cy);
                         store = MWBase::Environment::get().getWorld()->getExterior(cx,cy);
@@ -328,7 +333,8 @@ namespace MWScript
                     {
                         MWBase::Environment::get().getWorld()->moveObject(ptr,store,x,y,z);
                         ptr = MWWorld::Ptr(ptr.getBase(), store);
-                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
+                        if (need_update)
+                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
 
                         float ax = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]);
                         float ay = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]);
@@ -352,6 +358,8 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = R()(runtime);
+                    bool need_update = (ptr ==
+                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     if (!ptr.isInCell())
                         return;
@@ -384,7 +392,8 @@ namespace MWScript
                     {
                         ptr = MWBase::Environment::get().getWorld()->moveObject(ptr, x, y, z);
                     }
-                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
+                    if (need_update)
+                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
 
                     float ax = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]);
                     float ay = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]);
@@ -640,6 +649,8 @@ namespace MWScript
 
                     if (!ptr.isInCell())
                         return;
+                    bool need_update = (ptr ==
+                            dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).getReference(false));
 
                     MWWorld::LocalRotation rot;
                     rot.rot[0] = 0;
@@ -649,9 +660,10 @@ namespace MWScript
 
                     MWBase::Environment::get().getWorld()->rotateObject(ptr, 0,0,0,true);
 
-                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(
-                        MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],
-                            ptr.getCellRef().getPosition().pos[1], ptr.getCellRef().getPosition().pos[2]));
+                    if (need_update)
+                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(
+                                MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],
+                                    ptr.getCellRef().getPosition().pos[1], ptr.getCellRef().getPosition().pos[2]));
 
                 }
         };
@@ -767,8 +779,8 @@ namespace MWScript
             interpreter.installSegment5(Compiler::Transformation::opcodePositionExplicit,new OpPosition<ExplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePositionCell,new OpPositionCell<ImplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePositionCellExplicit,new OpPositionCell<ExplicitRef>);
-            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItemCell,new OpPlaceItemCell<ImplicitRef>);            
-            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItem,new OpPlaceItem<ImplicitRef>);            
+            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItemCell,new OpPlaceItemCell<ImplicitRef>);
+            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItem,new OpPlaceItem<ImplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtPc,new OpPlaceAt<ImplicitRef, true>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtMe,new OpPlaceAt<ImplicitRef, false>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtMeExplicit,new OpPlaceAt<ExplicitRef, false>);

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -200,7 +200,7 @@ namespace MWScript
                         runtime.push(ptr.getRefData().getPosition().pos[2]);
                     }
                     else
-                        throw std::runtime_error ("invalid axis: " + axis);                    
+                        throw std::runtime_error ("invalid axis: " + axis);
                 }
         };
 
@@ -246,7 +246,7 @@ namespace MWScript
                     else
                         throw std::runtime_error ("invalid axis: " + axis);
 
-                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(updated);
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr,updated);
                 }
         };
 
@@ -314,7 +314,7 @@ namespace MWScript
                     }
                     catch(std::exception&)
                     {
-                        const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);                        
+                        const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);
                         int cx,cy;
                         MWBase::Environment::get().getWorld()->positionToIndex(x,y,cx,cy);
                         store = MWBase::Environment::get().getWorld()->getExterior(cx,cy);
@@ -327,8 +327,9 @@ namespace MWScript
                     if(store)
                     {
                         MWBase::Environment::get().getWorld()->moveObject(ptr,store,x,y,z);
+                        MWWorld::Ptr base = ptr;
                         ptr = MWWorld::Ptr(ptr.getBase(), store);
-                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
+                        dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(base,ptr);
 
                         float ax = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]);
                         float ay = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]);
@@ -374,6 +375,7 @@ namespace MWScript
 
                     // another morrowind oddity: player will be moved to the exterior cell at this location,
                     // non-player actors will move within the cell they are in.
+                    MWWorld::Ptr base = ptr;
                     if (ptr == MWMechanics::getPlayer())
                     {
                         MWWorld::CellStore* cell = MWBase::Environment::get().getWorld()->getExterior(cx,cy);
@@ -384,7 +386,7 @@ namespace MWScript
                     {
                         ptr = MWBase::Environment::get().getWorld()->moveObject(ptr, x, y, z);
                     }
-                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr);
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(base,ptr);
 
                     float ax = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[0]);
                     float ay = osg::RadiansToDegrees(ptr.getRefData().getPosition().rot[1]);
@@ -649,7 +651,7 @@ namespace MWScript
 
                     MWBase::Environment::get().getWorld()->rotateObject(ptr, 0,0,0,true);
 
-                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr,
                         MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],
                             ptr.getCellRef().getPosition().pos[1], ptr.getCellRef().getPosition().pos[2]));
 
@@ -767,8 +769,8 @@ namespace MWScript
             interpreter.installSegment5(Compiler::Transformation::opcodePositionExplicit,new OpPosition<ExplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePositionCell,new OpPositionCell<ImplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePositionCellExplicit,new OpPositionCell<ExplicitRef>);
-            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItemCell,new OpPlaceItemCell<ImplicitRef>);            
-            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItem,new OpPlaceItem<ImplicitRef>);            
+            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItemCell,new OpPlaceItemCell<ImplicitRef>);
+            interpreter.installSegment5(Compiler::Transformation::opcodePlaceItem,new OpPlaceItem<ImplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtPc,new OpPlaceAt<ImplicitRef, true>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtMe,new OpPlaceAt<ImplicitRef, false>);
             interpreter.installSegment5(Compiler::Transformation::opcodePlaceAtMeExplicit,new OpPlaceAt<ExplicitRef, false>);

--- a/components/compiler/parser.cpp
+++ b/components/compiler/parser.cpp
@@ -102,9 +102,12 @@ namespace Compiler
     bool Parser::parseName (const std::string& name, const TokenLoc& loc,
         Scanner& scanner)
     {
-        if (!(mOptional && mEmpty))
+        if (!(mOptional && mEmpty)) {
+            if (loc.mLiteral == "fixme")
+                // Ignoring fixme for now
+                return true;
             reportSeriousError ("Unexpected name", loc);
-        else
+        } else
             scanner.putbackName (name, loc);
 
         return false;


### PR DESCRIPTION
Here are some small commits to fix problems with scripts in the fishing academy mod.
The mod still needs to be edited for syntax errors and also I couldn't find how the movement detection is reset to 0 in the vanilla game (a bgear variable needs to be set to 0 when the keys are released but I don't understand how it's done - just adding a single line fixes it in openmw).
With these changes almost everything works, the boats appear and can be moved, the collisions don't work though because apparently the setpos command doesn't check for collisions in openmw (as far as I can tell).
