### PR TITLE
Start script creator

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -67,7 +67,7 @@ opencs_hdrs_noqt (view/doc
 
 opencs_units (view/world
     table tablesubview scriptsubview util regionmapsubview tablebottombox creator genericcreator
-    cellcreator referenceablecreator referencecreator scenesubview
+    cellcreator referenceablecreator startscriptcreator referencecreator scenesubview
     infocreator scriptedit dialoguesubview previewsubview regionmap dragrecordtable nestedtable
     dialoguespinbox recordbuttonbar tableeditidaction scripterrortable extendedcommandconfigurator
     )

--- a/apps/opencs/view/world/genericcreator.cpp
+++ b/apps/opencs/view/world/genericcreator.cpp
@@ -47,6 +47,16 @@ std::string CSVWorld::GenericCreator::getId() const
     return mId->text().toUtf8().constData();
 }
 
+std::string CSVWorld::GenericCreator::getIdValidatorResult() const
+{
+    std::string errors;
+
+    if (!mId->hasAcceptableInput())
+        errors = mValidator->getError();
+
+    return errors;
+}
+
 void CSVWorld::GenericCreator::configureCreateCommand (CSMWorld::CreateCommand& command) const {}
 
 void CSVWorld::GenericCreator::pushCommand (std::auto_ptr<CSMWorld::CreateCommand> command,

--- a/apps/opencs/view/world/genericcreator.hpp
+++ b/apps/opencs/view/world/genericcreator.hpp
@@ -60,6 +60,8 @@ namespace CSVWorld
 
             virtual std::string getId() const;
 
+            virtual std::string getIdValidatorResult() const;
+
             /// Allow subclasses to add additional data to \a command.
             virtual void configureCreateCommand (CSMWorld::CreateCommand& command) const;
 

--- a/apps/opencs/view/world/startscriptcreator.cpp
+++ b/apps/opencs/view/world/startscriptcreator.cpp
@@ -1,16 +1,10 @@
 #include "startscriptcreator.hpp"
 
-StartScriptCreator::StartScriptCreator()
-{
-
-}
-
-
-CSVWORLD::StartScriptCreator::StartScriptCreator(CSMWorld::Data &data, QUndoStack &undoStack, const CSMWorld::UniversalId &id, bool relaxedIdRules):
+CSVWorld::StartScriptCreator::StartScriptCreator(CSMWorld::Data &data, QUndoStack &undoStack, const CSMWorld::UniversalId &id, bool relaxedIdRules):
     GenericCreator (data, undoStack, id, true)
 {}
 
-std::string CSVWORLD::StartScriptCreator::getErrors() const
+std::string CSVWorld::StartScriptCreator::getErrors() const
 {
     std::string errors;
 

--- a/apps/opencs/view/world/startscriptcreator.cpp
+++ b/apps/opencs/view/world/startscriptcreator.cpp
@@ -1,0 +1,26 @@
+#include "startscriptcreator.hpp"
+
+StartScriptCreator::StartScriptCreator()
+{
+
+}
+
+
+CSVWORLD::StartScriptCreator::StartScriptCreator(CSMWorld::Data &data, QUndoStack &undoStack, const CSMWorld::UniversalId &id, bool relaxedIdRules):
+    GenericCreator (data, undoStack, id, true)
+{}
+
+std::string CSVWORLD::StartScriptCreator::getErrors() const
+{
+    std::string errors;
+
+    errors = getIdValidatorResult();
+    if (errors.length() > 0)
+        return errors;
+    else if (getData().getScripts().searchId(getId()) == -1)
+        errors = "Script ID not found";
+    else if (getData().getStartScripts().searchId(getId()) > -1 )
+        errors = "Script with this ID already registered as Start Script";
+
+    return errors;
+}

--- a/apps/opencs/view/world/startscriptcreator.hpp
+++ b/apps/opencs/view/world/startscriptcreator.hpp
@@ -3,7 +3,7 @@
 
 #include "genericcreator.hpp"
 
-namespace CSVWORLD {
+namespace CSVWorld {
 
     class StartScriptCreator : public GenericCreator
     {
@@ -16,7 +16,7 @@ namespace CSVWORLD {
             virtual std::string getErrors() const;
             ///< Return formatted error descriptions for the current state of the creator. if an empty
             /// string is returned, there is no error.
-        };
+     };
 
 }
 

--- a/apps/opencs/view/world/startscriptcreator.hpp
+++ b/apps/opencs/view/world/startscriptcreator.hpp
@@ -1,0 +1,25 @@
+#ifndef STARTSCRIPTCREATOR_HPP
+#define STARTSCRIPTCREATOR_HPP
+
+#include "genericcreator.hpp"
+
+namespace CSVWORLD {
+
+    class StartScriptCreator : public GenericCreator
+    {
+        Q_OBJECT
+
+        public:
+            StartScriptCreator(CSMWorld::Data& data, QUndoStack& undoStack,
+                               const CSMWorld::UniversalId& id, bool relaxedIdRules = false);
+
+            virtual std::string getErrors() const;
+            ///< Return formatted error descriptions for the current state of the creator. if an empty
+            /// string is returned, there is no error.
+        };
+
+}
+
+
+
+#endif // STARTSCRIPTCREATOR_HPP

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -10,6 +10,7 @@
 #include "cellcreator.hpp"
 #include "referenceablecreator.hpp"
 #include "referencecreator.hpp"
+#include "startscriptcreator.hpp"
 #include "scenesubview.hpp"
 #include "dialoguecreator.hpp"
 #include "infocreator.hpp"
@@ -42,7 +43,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         CSMWorld::UniversalId::Type_BodyParts,
         CSMWorld::UniversalId::Type_SoundGens,
         CSMWorld::UniversalId::Type_Pathgrids,
-        CSMWorld::UniversalId::Type_StartScripts,
 
         CSMWorld::UniversalId::Type_None // end marker
     };
@@ -50,6 +50,9 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
     for (int i=0; sTableTypes[i]!=CSMWorld::UniversalId::Type_None; ++i)
         manager.add (sTableTypes[i],
             new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<GenericCreator> >);
+
+    manager.add (CSMWorld::UniversalId::Type_StartScripts,
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<StartScriptCreator> >);
 
     manager.add (CSMWorld::UniversalId::Type_Cells,
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<CellCreator> >);
@@ -123,7 +126,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         CSMWorld::UniversalId::Type_BodyPart,
         CSMWorld::UniversalId::Type_SoundGen,
         CSMWorld::UniversalId::Type_Pathgrid,
-        CSMWorld::UniversalId::Type_StartScript,
 
         CSMWorld::UniversalId::Type_None // end marker
     };
@@ -132,6 +134,10 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         manager.add (sTableTypes2[i],
             new CSVDoc::SubViewFactoryWithCreator<DialogueSubView,
             CreatorFactory<GenericCreator> > (false));
+
+    manager.add (CSMWorld::UniversalId::Type_StartScript,
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView,
+        CreatorFactory<StartScriptCreator> > (false));
 
     manager.add (CSMWorld::UniversalId::Type_Skill,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, NullCreatorFactory > (false));


### PR DESCRIPTION
My fix to this bug in opencs: https://bugs.openmw.org/issues/2938 
I have added a child class StartScriptsCreator of GenericCreator, which redefines getError() method, appropriately for adding start scripts. I have made getter for IDValidator results for use in it. Also I have added new creator to addSubviewFactories (simply by cut and paste, this part of code i can barely understand).
 I have checked my work on simple script, that MessageBox "Hello". It was succesfully added to Start Script list and printed a message at start of the game.