### PR TITLE
Fix to https://bugs.openmw.org/issues/2914

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -295,7 +295,7 @@ namespace MWMechanics
             creatureStats.getSpells().add(*it);
 
         // forced update and current value adjustments
-        //mActors.updateActor (ptr, 0);
+        mActors.updateActor (ptr, 0);
 
         for (int i=0; i<3; ++i)
         {


### PR DESCRIPTION
Quick fix to this bug: "Magicka not recalculated on character generation" -  https://bugs.openmw.org/issues/2914. I have expanded already existing NpcStats.updateHealth method to update all 3 dynamic stats.