### PR TITLE
Fix Windows builds

### DIFF
--- a/apps/opencs/view/render/editmode.cpp
+++ b/apps/opencs/view/render/editmode.cpp
@@ -1,5 +1,6 @@
 #include "editmode.hpp"
 
+#include "tagbase.hpp"
 #include "worldspacewidget.hpp"
 
 CSVRender::WorldspaceWidget& CSVRender::EditMode::getWorldspaceWidget()


### PR DESCRIPTION
Fixes
```
ref_ptr(35): C2027: use of undefined type 'CSVRender::TagBase' (B:\Programming\Projects\OpenMW\apps\opencs\view\render\editmode.cpp)
```