### PR TITLE
Enchantment error handling fix (Fixes #2959)

### DIFF
--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -1,5 +1,7 @@
 #include "spellmodel.hpp"
 
+#include <iostream>
+
 #include <boost/lexical_cast.hpp>
 
 #include "../mwbase/environment.hpp"
@@ -79,8 +81,13 @@ namespace MWGui
             const std::string enchantId = item.getClass().getEnchantment(item);
             if (enchantId.empty())
                 continue;
-            const ESM::Enchantment* enchant =
-                esmStore.get<ESM::Enchantment>().find(item.getClass().getEnchantment(item));
+            const ESM::Enchantment* enchant = esmStore.get<ESM::Enchantment>().search(enchantId);
+            if (!enchant)
+            {
+                std::cerr << "Can't find enchantment '" << enchantId << "' on item " << item.getCellRef().getRefId() << std::endl;
+                continue;
+            }
+
             if (enchant->mData.mType != ESM::Enchantment::WhenUsed && enchant->mData.mType != ESM::Enchantment::CastOnce)
                 continue;
 

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -645,8 +645,15 @@ void MWWorld::InventoryStore::updateRechargingItems()
     {
         if (it->getClass().getEnchantment(*it) != "")
         {
-            const ESM::Enchantment* enchantment = MWBase::Environment::get().getWorld()->getStore().get<ESM::Enchantment>().find(
-                        it->getClass().getEnchantment(*it));
+            std::string enchantmentId = it->getClass().getEnchantment(*it);
+            const ESM::Enchantment* enchantment = MWBase::Environment::get().getWorld()->getStore().get<ESM::Enchantment>().search(
+                        enchantmentId);
+            if (!enchantment)
+            {
+                std::cerr << "Can't find enchantment '" << enchantmentId << "' on item " << it->getCellRef().getRefId() << std::endl;
+                continue;
+            }
+
             if (enchantment->mData.mType == ESM::Enchantment::WhenUsed
                     || enchantment->mData.mType == ESM::Enchantment::WhenStrikes)
                 mRechargingItems.push_back(std::make_pair(it, static_cast<float>(enchantment->mData.mCharge)));


### PR DESCRIPTION
https://bugs.openmw.org/issues/2959

Catch errors about missing enchantments before they propagate up the stack and interrupt the whole frame update.