### PR TITLE
gcd fix : current stats modified by a ratio instead of a diff

### DIFF
--- a/apps/openmw/mwmechanics/stat.cpp
+++ b/apps/openmw/mwmechanics/stat.cpp
@@ -141,8 +141,13 @@ namespace MWMechanics
     template<typename T>
     void DynamicStat<T>::modify (const T& diff, bool allowCurrentDecreaseBelowZero)
     {
-        mStatic.modify (diff);
-        setCurrent (getCurrent()+diff, allowCurrentDecreaseBelowZero);
+	double ratio;
+	if (mStatic.getModified()>0)
+	    ratio = getCurrent()/mStatic.getModified();
+	else
+	    ratio = 0;
+	mStatic.modify (diff);
+	setCurrent (mStatic.getModified()*ratio, allowCurrentDecreaseBelowZero);
     }
     template<typename T>
     void DynamicStat<T>::setCurrent (const T& value, bool allowDecreaseBelowZero)


### PR DESCRIPTION
This one took me quite some time. Contrary to what the mod status page says, gcd doesn't work well at all with openmw, current release at all. It shows a lot when using the mentor ring found at the beginning of the game :
 - start a new game with gcd
 - when gcd is initialized (you get the message), add the mentor ring to the inventory : player->additem ring_mentor_unique 1
 - then cast a spell so that mana points are not maximum anymore
 - then each time to put the ring on and then remove it you'll loose some spell points. If done enough times spell points can fall to 0 rather quickly.

After some digging in the scripts of gcd, it's because when the intelligence is modified, it expects that the ratio between current magicka and maximum magicka stays the same, which means that you can't do currentMagicka + diff as it was done until now.
So this patch just does that, it computes the ratio before changing current and modified states and then applies the ratio to get the new current value instead of adding diff like before.
Now gcd works !
