### PR TITLE
Fix Windows builds

### DIFF
--- a/components/myguiplatform/scalinglayer.cpp
+++ b/components/myguiplatform/scalinglayer.cpp
@@ -1,6 +1,7 @@
 #include "scalinglayer.hpp"
 
 #include <MyGUI_RenderManager.h>
+#include <algorithm>
 
 namespace osgMyGUI
 {


### PR DESCRIPTION
MSVC Explicitly requires <algorithm> for std::min and/or max