### PR TITLE
Play_NoUnderwater sound flag

### DIFF
--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -35,14 +35,12 @@ namespace MWBase
                 Play_NoTrack = 1<<2, /* (3D only) Play the sound at the given object's position
                                       * but do not keep it updated (the sound will not move with
                                       * the object and will not stop when the object is deleted. */
-                Play_RemoveAtDistance = 1<<3, /* (3D only) If the listener gets further than 2000 units away
+                Play_RemoveAtDistance = 1<<3 /* (3D only) If the listener gets further than 2000 units away
                                                 from the sound source, the sound is removed.
                                                 This is weird stuff but apparently how vanilla works for sounds
                                                 played by the PlayLoopSound family of script functions. Perhaps we
                                                 can make this cut off a more subtle fade later, but have to
                                                 be careful to not change the overall volume of areas by too much. */
-                Play_LoopNoEnv = Play_Loop | Play_NoEnv,
-                Play_LoopRemoveAtDistance = Play_Loop | Play_RemoveAtDistance
             };
             enum PlayType {
                 Play_TypeSfx   = 1<<4, /* Normal SFX sound */
@@ -109,19 +107,19 @@ namespace MWBase
             ///< Play a 2D audio track, using a custom decoder
 
             virtual SoundPtr playSound(const std::string& soundId, float volume, float pitch,
-                                       PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal,
+                                       PlayType type=Play_TypeSfx, int mode=Play_Normal,
                                        float offset=0) = 0;
             ///< Play a sound, independently of 3D-position
             ///< @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
 
             virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
                                                  float volume, float pitch, PlayType type=Play_TypeSfx,
-                                                 PlayMode mode=Play_Normal, float offset=0) = 0;
+                                                 int mode=Play_Normal, float offset=0) = 0;
             ///< Play a 3D sound attached to an MWWorld::Ptr. Will be updated automatically with the Ptr's position, unless Play_NoTrack is specified.
             ///< @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
 
             virtual MWBase::SoundPtr playManualSound3D(const osg::Vec3f& initialPos, const std::string& soundId,
-                                                             float volume, float pitch, PlayType type, PlayMode mode, float offset=0) = 0;
+                                                             float volume, float pitch, PlayType type, int mode, float offset=0) = 0;
             ///< Play a 3D sound at \a initialPos. If the sound should be moving, it must be updated manually using Sound::setPosition.
 
             virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId) = 0;

--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -35,19 +35,20 @@ namespace MWBase
                 Play_NoTrack = 1<<2, /* (3D only) Play the sound at the given object's position
                                       * but do not keep it updated (the sound will not move with
                                       * the object and will not stop when the object is deleted. */
-                Play_RemoveAtDistance = 1<<3 /* (3D only) If the listener gets further than 2000 units away
+                Play_RemoveAtDistance = 1<<3, /* (3D only) If the listener gets further than 2000 units away
                                                 from the sound source, the sound is removed.
                                                 This is weird stuff but apparently how vanilla works for sounds
                                                 played by the PlayLoopSound family of script functions. Perhaps we
                                                 can make this cut off a more subtle fade later, but have to
                                                 be careful to not change the overall volume of areas by too much. */
+                Play_NoUnderwater = 1<<4 /* Do not play the sound when the listener is underwater */
             };
             enum PlayType {
-                Play_TypeSfx   = 1<<4, /* Normal SFX sound */
-                Play_TypeVoice = 1<<5, /* Voice sound */
-                Play_TypeFoot  = 1<<6, /* Footstep sound */
-                Play_TypeMusic = 1<<7, /* Music track */
-                Play_TypeMovie = 1<<8, /* Movie audio track */
+                Play_TypeSfx   = 1<<5, /* Normal SFX sound */
+                Play_TypeVoice = 1<<6, /* Voice sound */
+                Play_TypeFoot  = 1<<7, /* Footstep sound */
+                Play_TypeMusic = 1<<8, /* Music track */
+                Play_TypeMovie = 1<<9, /* Movie audio track */
                 Play_TypeMask  = Play_TypeSfx|Play_TypeVoice|Play_TypeFoot|Play_TypeMusic|Play_TypeMovie
             };
 

--- a/apps/openmw/mwscript/soundextensions.cpp
+++ b/apps/openmw/mwscript/soundextensions.cpp
@@ -118,10 +118,10 @@ namespace MWScript
                     std::string sound = runtime.getStringLiteral (runtime[0].mInteger);
                     runtime.pop();
 
-                    MWBase::Environment::get().getSoundManager()->playSound3D(ptr, sound, 1.0, 1.0,
-                                                                              MWBase::SoundManager::Play_TypeSfx,
-                                                                              mLoop ? MWBase::SoundManager::Play_LoopRemoveAtDistance
-                                                                                     : MWBase::SoundManager::Play_Normal);
+                    int mode = MWBase::SoundManager::Play_Normal;
+                    if (mLoop)
+                        mode = MWBase::SoundManager::Play_Loop|MWBase::SoundManager::Play_RemoveAtDistance;
+                    MWBase::Environment::get().getSoundManager()->playSound3D(ptr, sound, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx, mode);
                 }
         };
 
@@ -147,11 +147,10 @@ namespace MWScript
                     Interpreter::Type_Float pitch = runtime[0].mFloat;
                     runtime.pop();
 
-                    MWBase::Environment::get().getSoundManager()->playSound3D(ptr, sound, volume, pitch,
-                                                                              MWBase::SoundManager::Play_TypeSfx,
-                                                                              mLoop ? MWBase::SoundManager::Play_LoopRemoveAtDistance
-                                                                                    : MWBase::SoundManager::Play_Normal);
-
+                    int mode = MWBase::SoundManager::Play_Normal;
+                    if (mLoop)
+                        mode = MWBase::SoundManager::Play_Loop|MWBase::SoundManager::Play_RemoveAtDistance;
+                    MWBase::Environment::get().getSoundManager()->playSound3D(ptr, sound, volume, pitch, MWBase::SoundManager::Play_TypeSfx, mode);
                 }
         };
 

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -403,6 +403,10 @@ void OpenAL_SoundStream::update()
         gain *= 0.9f;
         pitch *= 0.7f;
     }
+    if ((mFlags&MWBase::SoundManager::Play_NoUnderwater) && mOutput.mLastEnvironment == Env_Underwater)
+    {
+        gain = 0.f;
+    }
 
     alSourcef(mSource, AL_GAIN, gain);
     alSourcef(mSource, AL_PITCH, pitch);
@@ -616,6 +620,10 @@ void OpenAL_Sound::update()
     {
         gain *= 0.9f;
         pitch *= 0.7f;
+    }
+    if ((mFlags&MWBase::SoundManager::Play_NoUnderwater) && mOutput.mLastEnvironment == Env_Underwater)
+    {
+        gain = 0.f;
     }
 
     alSourcef(mSource, AL_GAIN, gain);

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -645,6 +645,10 @@ void OpenAL_Sound3D::update()
         gain *= 0.9f;
         pitch *= 0.7f;
     }
+    if ((mFlags&MWBase::SoundManager::Play_NoUnderwater) && mOutput.mLastEnvironment == Env_Underwater)
+    {
+        gain = 0.f;
+    }
 
     alSourcef(mSource, AL_GAIN, gain);
     alSourcef(mSource, AL_PITCH, pitch);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -364,7 +364,7 @@ namespace MWSound
     }
 
 
-    MWBase::SoundPtr SoundManager::playSound(const std::string& soundId, float volume, float pitch, PlayType type, PlayMode mode, float offset)
+    MWBase::SoundPtr SoundManager::playSound(const std::string& soundId, float volume, float pitch, PlayType type, int mode, float offset)
     {
         MWBase::SoundPtr sound;
         if(!mOutput->isInitialized())
@@ -386,7 +386,7 @@ namespace MWSound
     }
 
     MWBase::SoundPtr SoundManager::playSound3D(const MWWorld::Ptr &ptr, const std::string& soundId,
-                                               float volume, float pitch, PlayType type, PlayMode mode, float offset)
+                                               float volume, float pitch, PlayType type, int mode, float offset)
     {
         MWBase::SoundPtr sound;
         if(!mOutput->isInitialized())
@@ -419,7 +419,7 @@ namespace MWSound
     }
 
     MWBase::SoundPtr SoundManager::playManualSound3D(const osg::Vec3f& initialPos, const std::string& soundId,
-                                                     float volume, float pitch, PlayType type, PlayMode mode, float offset)
+                                                     float volume, float pitch, PlayType type, int mode, float offset)
     {
         MWBase::SoundPtr sound;
         if(!mOutput->isInitialized())
@@ -640,7 +640,7 @@ namespace MWSound
             env = Env_Underwater;
             //play underwater sound
             if(!(mUnderwaterSound && mUnderwaterSound->isPlaying()))
-                mUnderwaterSound = playSound("Underwater", 1.0f, 1.0f, Play_TypeSfx, Play_LoopNoEnv);
+                mUnderwaterSound = playSound("Underwater", 1.0f, 1.0f, Play_TypeSfx, Play_Loop|Play_NoEnv);
         }
         else if(mUnderwaterSound)
         {

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -120,18 +120,18 @@ namespace MWSound
         virtual MWBase::SoundPtr playTrack(const DecoderPtr& decoder, PlayType type);
         ///< Play a 2D audio track, using a custom decoder
 
-        virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal, float offset=0);
+        virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayType type=Play_TypeSfx, int mode=Play_Normal, float offset=0);
         ///< Play a sound, independently of 3D-position
         ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
         virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
                                              float volume, float pitch, PlayType type=Play_TypeSfx,
-                                             PlayMode mode=Play_Normal, float offset=0);
+                                             int mode=Play_Normal, float offset=0);
         ///< Play a 3D sound attached to an MWWorld::Ptr. Will be updated automatically with the Ptr's position, unless Play_NoTrack is specified.
         ///< @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
 
         virtual MWBase::SoundPtr playManualSound3D(const osg::Vec3f& initialPos, const std::string& soundId,
-                                                         float volume, float pitch, PlayType type, PlayMode mode, float offset=0);
+                                                         float volume, float pitch, PlayType type, int mode, float offset=0);
         ///< Play a 3D sound at \a initialPos. If the sound should be moving, it must be updated manually using Sound::setPosition.
 
         ///< Play a sound from an object

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -714,7 +714,8 @@ void WeatherManager::update(float duration, bool paused)
     {
         stopSounds();
         if (!mResult.mAmbientLoopSoundID.empty())
-            mAmbientSound = MWBase::Environment::get().getSoundManager()->playSound(mResult.mAmbientLoopSoundID, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop);
+            mAmbientSound = MWBase::Environment::get().getSoundManager()->playSound(mResult.mAmbientLoopSoundID, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx,
+                                                                                    MWBase::SoundManager::Play_Loop|MWBase::SoundManager::Play_NoUnderwater);
 
         mPlayingSoundID = mResult.mAmbientLoopSoundID;
     }


### PR DESCRIPTION
@kcat 

Add the Play_NoUnderwater flag for sounds that should not be heard when the listener is underwater. Used for rain, ashstorm and blizzard sounds.
Change PlayMode enum argument to int so we don't have to create a new enum value for each possible combination of the bitflags.