### PR TITLE
Add FFMPEG to include path for OpenMW

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -113,7 +113,10 @@ endif ()
 
 # Sound stuff - here so CMake doesn't stupidly recompile EVERYTHING
 # when we change the backend.
-include_directories(${SOUND_INPUT_INCLUDES})
+include_directories(
+    ${SOUND_INPUT_INCLUDES}
+    ${FFMPEG_INCLUDE_DIRS}
+)
 
 target_link_libraries(openmw
     ${OPENSCENEGRAPH_LIBRARIES}


### PR DESCRIPTION
I'm a bit confused; `mwsound/ffmpeg_decoder.hpp/cpp` requires FFMPEG headers to compile, how did this work in the first place?