### PR TITLE
.osg mesh format support

### DIFF
--- a/apps/opencs/model/world/resourcesmanager.cpp
+++ b/apps/opencs/model/world/resourcesmanager.cpp
@@ -19,7 +19,9 @@ void CSMWorld::ResourcesManager::setVFS(const VFS::Manager *vfs)
     mVFS = vfs;
     mResources.clear();
 
-    static const char * const sMeshTypes[] = { "nif", 0 };
+    // maybe we could go over the osgDB::Registry to list all supported node formats
+
+    static const char * const sMeshTypes[] = { "nif", "osg", "osgt", "osgb", "osgx", "osg2", 0 };
 
     addResources (Resources (vfs, "meshes", UniversalId::Type_Mesh, sMeshTypes));
     addResources (Resources (vfs, "icons", UniversalId::Type_Icon));

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -6,7 +6,7 @@
 #include <BulletCollision/CollisionShapes/btBoxShape.h>
 #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
 
-#include <components/nifbullet/bulletnifloader.hpp>
+#include <components/resource/bulletshape.hpp>
 
 #include "../mwworld/class.hpp"
 
@@ -17,7 +17,7 @@ namespace MWPhysics
 {
 
 
-Actor::Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<NifBullet::BulletShapeInstance> shape, btCollisionWorld* world)
+Actor::Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<Resource::BulletShapeInstance> shape, btCollisionWorld* world)
   : mCanWaterWalk(false), mWalkingOnWater(false)
   , mCollisionObject(0), mForce(0.f, 0.f, 0.f), mOnGround(false)
   , mInternalCollisionMode(true)

--- a/apps/openmw/mwphysics/actor.hpp
+++ b/apps/openmw/mwphysics/actor.hpp
@@ -13,7 +13,7 @@ class btCollisionWorld;
 class btCollisionShape;
 class btCollisionObject;
 
-namespace NifBullet
+namespace Resource
 {
     class BulletShapeInstance;
 }
@@ -43,7 +43,7 @@ namespace MWPhysics
     class Actor : public PtrHolder
     {
     public:
-        Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<NifBullet::BulletShapeInstance> shape, btCollisionWorld* world);
+        Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<Resource::BulletShapeInstance> shape, btCollisionWorld* world);
         ~Actor();
 
         /**

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -975,7 +975,7 @@ namespace MWPhysics
     void PhysicsSystem::addObject (const MWWorld::Ptr& ptr, const std::string& mesh)
     {
         osg::ref_ptr<NifBullet::BulletShapeInstance> shapeInstance = mShapeManager->createInstance(mesh);
-        if (!shapeInstance->getCollisionShape())
+        if (!shapeInstance || !shapeInstance->getCollisionShape())
             return;
 
         Object *obj = new Object(ptr, shapeInstance);
@@ -1114,9 +1114,10 @@ namespace MWPhysics
         }
     }
 
-    void PhysicsSystem::addActor (const MWWorld::Ptr& ptr, const std::string& mesh)
-    {
+    void PhysicsSystem::addActor (const MWWorld::Ptr& ptr, const std::string& mesh) {
         osg::ref_ptr<NifBullet::BulletShapeInstance> shapeInstance = mShapeManager->createInstance(mesh);
+        if (!shapeInstance)
+            return;
 
         Actor* actor = new Actor(ptr, shapeInstance, mCollisionWorld);
         mActors.insert(std::make_pair(ptr, actor));

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -605,7 +605,7 @@ namespace MWPhysics
     // ---------------------------------------------------------------
 
     PhysicsSystem::PhysicsSystem(Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Group> parentNode)
-        : mShapeManager(new Resource::BulletShapeManager(resourceSystem->getVFS()))
+        : mShapeManager(new Resource::BulletShapeManager(resourceSystem->getVFS(), resourceSystem->getSceneManager()))
         , mDebugDrawEnabled(false)
         , mTimeAccum(0.0f)
         , mWaterHeight(0)

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -17,9 +17,9 @@
 #include <BulletCollision/BroadphaseCollision/btDbvtBroadphase.h>
 #include <LinearMath/btQuickprof.h>
 
-#include <components/nifbullet/bulletshapemanager.hpp>
 #include <components/nifbullet/bulletnifloader.hpp>
 #include <components/resource/resourcesystem.hpp>
+#include <components/resource/bulletshapemanager.hpp>
 
 #include <components/esm/loadgmst.hpp>
 
@@ -520,7 +520,7 @@ namespace MWPhysics
     class Object : public PtrHolder
     {
     public:
-        Object(const MWWorld::Ptr& ptr, osg::ref_ptr<NifBullet::BulletShapeInstance> shapeInstance)
+        Object(const MWWorld::Ptr& ptr, osg::ref_ptr<Resource::BulletShapeInstance> shapeInstance)
             : mShapeInstance(shapeInstance)
         {
             mPtr = ptr;
@@ -599,13 +599,13 @@ namespace MWPhysics
 
     private:
         std::auto_ptr<btCollisionObject> mCollisionObject;
-        osg::ref_ptr<NifBullet::BulletShapeInstance> mShapeInstance;
+        osg::ref_ptr<Resource::BulletShapeInstance> mShapeInstance;
     };
 
     // ---------------------------------------------------------------
 
     PhysicsSystem::PhysicsSystem(Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Group> parentNode)
-        : mShapeManager(new NifBullet::BulletShapeManager(resourceSystem->getVFS()))
+        : mShapeManager(new Resource::BulletShapeManager(resourceSystem->getVFS()))
         , mDebugDrawEnabled(false)
         , mTimeAccum(0.0f)
         , mWaterHeight(0)
@@ -974,7 +974,7 @@ namespace MWPhysics
 
     void PhysicsSystem::addObject (const MWWorld::Ptr& ptr, const std::string& mesh)
     {
-        osg::ref_ptr<NifBullet::BulletShapeInstance> shapeInstance = mShapeManager->createInstance(mesh);
+        osg::ref_ptr<Resource::BulletShapeInstance> shapeInstance = mShapeManager->createInstance(mesh);
         if (!shapeInstance || !shapeInstance->getCollisionShape())
             return;
 
@@ -1115,7 +1115,7 @@ namespace MWPhysics
     }
 
     void PhysicsSystem::addActor (const MWWorld::Ptr& ptr, const std::string& mesh) {
-        osg::ref_ptr<NifBullet::BulletShapeInstance> shapeInstance = mShapeManager->createInstance(mesh);
+        osg::ref_ptr<Resource::BulletShapeInstance> shapeInstance = mShapeManager->createInstance(mesh);
         if (!shapeInstance)
             return;
 

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -21,7 +21,7 @@ namespace MWRender
     class DebugDrawer;
 }
 
-namespace NifBullet
+namespace Resource
 {
     class BulletShapeManager;
 }
@@ -154,7 +154,7 @@ namespace MWPhysics
             btCollisionDispatcher* mDispatcher;
             btCollisionWorld* mCollisionWorld;
 
-            std::auto_ptr<NifBullet::BulletShapeManager> mShapeManager;
+            std::auto_ptr<Resource::BulletShapeManager> mShapeManager;
 
             typedef std::map<MWWorld::Ptr, Object*> ObjectMap;
             ObjectMap mObjects;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -402,7 +402,7 @@ namespace MWRender
         animsrc.reset(new AnimSource);
         animsrc->mKeyframes = mResourceSystem->getSceneManager()->getKeyframes(kfname);
 
-        if (animsrc->mKeyframes->mTextKeys.empty() || animsrc->mKeyframes->mKeyframeControllers.empty())
+        if (!animsrc->mKeyframes || animsrc->mKeyframes->mTextKeys.empty() || animsrc->mKeyframes->mKeyframeControllers.empty())
             return;
 
         for (NifOsg::KeyframeHolder::KeyframeControllerMap::const_iterator it = animsrc->mKeyframes->mKeyframeControllers.begin();

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -37,7 +37,7 @@ add_component_dir (vfs
     )
 
 add_component_dir (resource
-    scenemanager texturemanager resourcesystem
+    scenemanager texturemanager resourcesystem bulletshapemanager bulletshape
     )
 
 add_component_dir (sceneutil
@@ -55,7 +55,7 @@ add_component_dir (nifosg
     )
 
 add_component_dir (nifbullet
-    bulletnifloader bulletshapemanager
+    bulletnifloader
     )
 
 add_component_dir (to_utf8

--- a/components/nifbullet/bulletnifloader.cpp
+++ b/components/nifbullet/bulletnifloader.cpp
@@ -40,21 +40,6 @@ btVector3 getbtVector(const osg::Vec3f &v)
 namespace NifBullet
 {
 
-// Subclass btBhvTriangleMeshShape to auto-delete the meshInterface
-struct TriangleMeshShape : public btBvhTriangleMeshShape
-{
-    TriangleMeshShape(btStridingMeshInterface* meshInterface, bool useQuantizedAabbCompression)
-        : btBvhTriangleMeshShape(meshInterface, useQuantizedAabbCompression)
-    {
-    }
-
-    virtual ~TriangleMeshShape()
-    {
-        delete getTriangleInfoMap();
-        delete m_meshInterface;
-    }
-};
-
 BulletNifLoader::BulletNifLoader()
     : mCompoundShape(NULL)
     , mStaticMesh(NULL)
@@ -65,9 +50,9 @@ BulletNifLoader::~BulletNifLoader()
 {
 }
 
-osg::ref_ptr<BulletShape> BulletNifLoader::load(const Nif::NIFFilePtr nif)
+osg::ref_ptr<Resource::BulletShape> BulletNifLoader::load(const Nif::NIFFilePtr nif)
 {
-    mShape = new BulletShape;
+    mShape = new Resource::BulletShape;
 
     mCompoundShape = NULL;
     mStaticMesh = NULL;
@@ -126,11 +111,11 @@ osg::ref_ptr<BulletShape> BulletNifLoader::load(const Nif::NIFFilePtr nif)
             {
                 btTransform trans;
                 trans.setIdentity();
-                mCompoundShape->addChildShape(trans, new TriangleMeshShape(mStaticMesh,true));
+                mCompoundShape->addChildShape(trans, new Resource::TriangleMeshShape(mStaticMesh,true));
             }
         }
         else if (mStaticMesh)
-            mShape->mCollisionShape = new TriangleMeshShape(mStaticMesh,true);
+            mShape->mCollisionShape = new Resource::TriangleMeshShape(mStaticMesh,true);
 
         return mShape;
     }
@@ -306,7 +291,7 @@ void BulletNifLoader::handleNiTriShape(const Nif::NiTriShape *shape, int flags, 
             childMesh->addTriangle(getbtVector(b1), getbtVector(b2), getbtVector(b3));
         }
 
-        TriangleMeshShape* childShape = new TriangleMeshShape(childMesh,true);
+        Resource::TriangleMeshShape* childShape = new Resource::TriangleMeshShape(childMesh,true);
 
         float scale = shape->trafo.scale;
         const Nif::Node* parent = shape;
@@ -344,95 +329,6 @@ void BulletNifLoader::handleNiTriShape(const Nif::NiTriShape *shape, int flags, 
             mStaticMesh->addTriangle(getbtVector(b1), getbtVector(b2), getbtVector(b3));
         }
     }
-}
-
-BulletShape::BulletShape()
-    : mCollisionShape(NULL)
-{
-
-}
-
-BulletShape::~BulletShape()
-{
-    deleteShape(mCollisionShape);
-}
-
-void BulletShape::deleteShape(btCollisionShape* shape)
-{
-    if(shape!=NULL)
-    {
-        if(shape->isCompound())
-        {
-            btCompoundShape* ms = static_cast<btCompoundShape*>(shape);
-            int a = ms->getNumChildShapes();
-            for(int i=0; i <a;i++)
-                deleteShape(ms->getChildShape(i));
-        }
-        delete shape;
-    }
-}
-
-btCollisionShape* BulletShape::duplicateCollisionShape(btCollisionShape *shape) const
-{
-    if(shape->isCompound())
-    {
-        btCompoundShape *comp = static_cast<btCompoundShape*>(shape);
-        btCompoundShape *newShape = new btCompoundShape;
-
-        int numShapes = comp->getNumChildShapes();
-        for(int i = 0;i < numShapes;++i)
-        {
-            btCollisionShape *child = duplicateCollisionShape(comp->getChildShape(i));
-            btTransform trans = comp->getChildTransform(i);
-            newShape->addChildShape(trans, child);
-        }
-
-        return newShape;
-    }
-
-    if(btBvhTriangleMeshShape* trishape = dynamic_cast<btBvhTriangleMeshShape*>(shape))
-    {
-#if BT_BULLET_VERSION >= 283
-        btScaledBvhTriangleMeshShape* newShape = new btScaledBvhTriangleMeshShape(trishape, btVector3(1.f, 1.f, 1.f));
-#else
-        // work around btScaledBvhTriangleMeshShape bug ( https://code.google.com/p/bullet/issues/detail?id=371 ) in older bullet versions
-        btTriangleMesh* oldMesh = static_cast<btTriangleMesh*>(trishape->getMeshInterface());
-        btTriangleMesh* newMesh = new btTriangleMesh(*oldMesh);
-        NifBullet::TriangleMeshShape* newShape = new NifBullet::TriangleMeshShape(newMesh, true);
-#endif
-        return newShape;
-    }
-
-    if (btBoxShape* boxshape = dynamic_cast<btBoxShape*>(shape))
-    {
-        return new btBoxShape(*boxshape);
-    }
-
-    throw std::logic_error(std::string("Unhandled Bullet shape duplication: ")+shape->getName());
-}
-
-btCollisionShape *BulletShape::getCollisionShape()
-{
-    return mCollisionShape;
-}
-
-osg::ref_ptr<BulletShapeInstance> BulletShape::makeInstance()
-{
-    osg::ref_ptr<BulletShapeInstance> instance (new BulletShapeInstance(this));
-    return instance;
-}
-
-BulletShapeInstance::BulletShapeInstance(osg::ref_ptr<BulletShape> source)
-    : BulletShape()
-    , mSource(source)
-{
-    mCollisionBoxHalfExtents = source->mCollisionBoxHalfExtents;
-    mCollisionBoxTranslate = source->mCollisionBoxTranslate;
-
-    mAnimatedShapes = source->mAnimatedShapes;
-
-    if (source->mCollisionShape)
-        mCollisionShape = duplicateCollisionShape(source->mCollisionShape);
 }
 
 } // namespace NifBullet

--- a/components/nifbullet/bulletnifloader.hpp
+++ b/components/nifbullet/bulletnifloader.hpp
@@ -13,6 +13,7 @@
 #include <osg/Referenced>
 
 #include <components/nif/niffile.hpp>
+#include <components/resource/bulletshape.hpp>
 
 class btTriangleMesh;
 class btCompoundShape;
@@ -27,48 +28,6 @@ namespace Nif
 
 namespace NifBullet
 {
-
-class BulletShapeInstance;
-class BulletShape : public osg::Referenced
-{
-public:
-    BulletShape();
-    virtual ~BulletShape();
-
-    btCollisionShape* mCollisionShape;
-
-    // Used for actors. Note, ideally actors would use a separate loader - as it is
-    // we have to keep a redundant copy of the actor model around in mCollisionShape, which isn't used.
-    // For now, use one file <-> one resource for simplicity.
-    osg::Vec3f mCollisionBoxHalfExtents;
-    osg::Vec3f mCollisionBoxTranslate;
-
-    // Stores animated collision shapes. If any collision nodes in the NIF are animated, then mCollisionShape
-    // will be a btCompoundShape (which consists of one or more child shapes).
-    // In this map, for each animated collision shape,
-    // we store the node's record index mapped to the child index of the shape in the btCompoundShape.
-    std::map<int, int> mAnimatedShapes;
-
-    osg::ref_ptr<BulletShapeInstance> makeInstance();
-
-    btCollisionShape* duplicateCollisionShape(btCollisionShape* shape) const;
-
-    btCollisionShape* getCollisionShape();
-
-private:
-    void deleteShape(btCollisionShape* shape);
-};
-
-// An instance of a BulletShape that may have its own unique scaling set on the mCollisionShape.
-// Vertex data is shallow-copied where possible. A ref_ptr to the original shape needs to be held to keep vertex pointers intact.
-class BulletShapeInstance : public BulletShape
-{
-public:
-    BulletShapeInstance(osg::ref_ptr<BulletShape> source);
-
-private:
-    osg::ref_ptr<BulletShape> mSource;
-};
 
 /**
 *Load bulletShape from NIF files.
@@ -91,7 +50,7 @@ public:
         abort();
     }
 
-    osg::ref_ptr<BulletShape> load(const Nif::NIFFilePtr file);
+    osg::ref_ptr<Resource::BulletShape> load(const Nif::NIFFilePtr file);
 
 private:
     bool findBoundingBox(const Nif::Node* node, int flags = 0);
@@ -106,7 +65,7 @@ private:
 
     btTriangleMesh* mStaticMesh;
 
-    osg::ref_ptr<BulletShape> mShape;
+    osg::ref_ptr<Resource::BulletShape> mShape;
 };
 
 }

--- a/components/nifbullet/bulletshapemanager.cpp
+++ b/components/nifbullet/bulletshapemanager.cpp
@@ -30,6 +30,13 @@ osg::ref_ptr<BulletShapeInstance> BulletShapeManager::createInstance(const std::
         Files::IStreamPtr file = mVFS->get(normalized);
 
         // TODO: add support for non-NIF formats
+        size_t extPos = normalized.find_last_of('.');
+        std::string ext;
+        if (extPos != std::string::npos && extPos+1 < normalized.size())
+            ext = normalized.substr(extPos+1);
+
+        if (ext != "nif")
+            return NULL;
 
         BulletNifLoader loader;
         // might be worth sharing NIFFiles with SceneManager in some way

--- a/components/resource/bulletshape.cpp
+++ b/components/resource/bulletshape.cpp
@@ -1,0 +1,102 @@
+#include "bulletshape.hpp"
+
+#include <stdexcept>
+
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionShapes/btTriangleMesh.h>
+#include <BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h>
+#include <BulletCollision/CollisionShapes/btCompoundShape.h>
+
+namespace Resource
+{
+
+BulletShape::BulletShape()
+    : mCollisionShape(NULL)
+{
+
+}
+
+BulletShape::~BulletShape()
+{
+    deleteShape(mCollisionShape);
+}
+
+void BulletShape::deleteShape(btCollisionShape* shape)
+{
+    if(shape!=NULL)
+    {
+        if(shape->isCompound())
+        {
+            btCompoundShape* ms = static_cast<btCompoundShape*>(shape);
+            int a = ms->getNumChildShapes();
+            for(int i=0; i <a;i++)
+                deleteShape(ms->getChildShape(i));
+        }
+        delete shape;
+    }
+}
+
+btCollisionShape* BulletShape::duplicateCollisionShape(btCollisionShape *shape) const
+{
+    if(shape->isCompound())
+    {
+        btCompoundShape *comp = static_cast<btCompoundShape*>(shape);
+        btCompoundShape *newShape = new btCompoundShape;
+
+        int numShapes = comp->getNumChildShapes();
+        for(int i = 0;i < numShapes;++i)
+        {
+            btCollisionShape *child = duplicateCollisionShape(comp->getChildShape(i));
+            btTransform trans = comp->getChildTransform(i);
+            newShape->addChildShape(trans, child);
+        }
+
+        return newShape;
+    }
+
+    if(btBvhTriangleMeshShape* trishape = dynamic_cast<btBvhTriangleMeshShape*>(shape))
+    {
+#if BT_BULLET_VERSION >= 283
+        btScaledBvhTriangleMeshShape* newShape = new btScaledBvhTriangleMeshShape(trishape, btVector3(1.f, 1.f, 1.f));
+#else
+        // work around btScaledBvhTriangleMeshShape bug ( https://code.google.com/p/bullet/issues/detail?id=371 ) in older bullet versions
+        btTriangleMesh* oldMesh = static_cast<btTriangleMesh*>(trishape->getMeshInterface());
+        btTriangleMesh* newMesh = new btTriangleMesh(*oldMesh);
+        TriangleMeshShape* newShape = new TriangleMeshShape(newMesh, true);
+#endif
+        return newShape;
+    }
+
+    if (btBoxShape* boxshape = dynamic_cast<btBoxShape*>(shape))
+    {
+        return new btBoxShape(*boxshape);
+    }
+
+    throw std::logic_error(std::string("Unhandled Bullet shape duplication: ")+shape->getName());
+}
+
+btCollisionShape *BulletShape::getCollisionShape()
+{
+    return mCollisionShape;
+}
+
+osg::ref_ptr<BulletShapeInstance> BulletShape::makeInstance()
+{
+    osg::ref_ptr<BulletShapeInstance> instance (new BulletShapeInstance(this));
+    return instance;
+}
+
+BulletShapeInstance::BulletShapeInstance(osg::ref_ptr<BulletShape> source)
+    : BulletShape()
+    , mSource(source)
+{
+    mCollisionBoxHalfExtents = source->mCollisionBoxHalfExtents;
+    mCollisionBoxTranslate = source->mCollisionBoxTranslate;
+
+    mAnimatedShapes = source->mAnimatedShapes;
+
+    if (source->mCollisionShape)
+        mCollisionShape = duplicateCollisionShape(source->mCollisionShape);
+}
+
+}

--- a/components/resource/bulletshape.hpp
+++ b/components/resource/bulletshape.hpp
@@ -1,0 +1,78 @@
+#ifndef OPENMW_COMPONENTS_RESOURCE_BULLETSHAPE_H
+#define OPENMW_COMPONENTS_RESOURCE_BULLETSHAPE_H
+
+#include <map>
+
+#include <osg/Referenced>
+#include <osg/ref_ptr>
+#include <osg/Vec3f>
+
+#include <BulletCollision/CollisionShapes/btBvhTriangleMeshShape.h>
+
+class btCollisionShape;
+
+namespace Resource
+{
+
+    class BulletShapeInstance;
+    class BulletShape : public osg::Referenced
+    {
+    public:
+        BulletShape();
+        virtual ~BulletShape();
+
+        btCollisionShape* mCollisionShape;
+
+        // Used for actors. Note, ideally actors would use a separate loader - as it is
+        // we have to keep a redundant copy of the actor model around in mCollisionShape, which isn't used.
+        // For now, use one file <-> one resource for simplicity.
+        osg::Vec3f mCollisionBoxHalfExtents;
+        osg::Vec3f mCollisionBoxTranslate;
+
+        // Stores animated collision shapes. If any collision nodes in the NIF are animated, then mCollisionShape
+        // will be a btCompoundShape (which consists of one or more child shapes).
+        // In this map, for each animated collision shape,
+        // we store the node's record index mapped to the child index of the shape in the btCompoundShape.
+        std::map<int, int> mAnimatedShapes;
+
+        osg::ref_ptr<BulletShapeInstance> makeInstance();
+
+        btCollisionShape* duplicateCollisionShape(btCollisionShape* shape) const;
+
+        btCollisionShape* getCollisionShape();
+
+    private:
+        void deleteShape(btCollisionShape* shape);
+    };
+
+
+    // An instance of a BulletShape that may have its own unique scaling set on the mCollisionShape.
+    // Vertex data is shallow-copied where possible. A ref_ptr to the original shape is held to keep vertex pointers intact.
+    class BulletShapeInstance : public BulletShape
+    {
+    public:
+        BulletShapeInstance(osg::ref_ptr<BulletShape> source);
+
+    private:
+        osg::ref_ptr<BulletShape> mSource;
+    };
+
+    // Subclass btBhvTriangleMeshShape to auto-delete the meshInterface
+    struct TriangleMeshShape : public btBvhTriangleMeshShape
+    {
+        TriangleMeshShape(btStridingMeshInterface* meshInterface, bool useQuantizedAabbCompression)
+            : btBvhTriangleMeshShape(meshInterface, useQuantizedAabbCompression)
+        {
+        }
+
+        virtual ~TriangleMeshShape()
+        {
+            delete getTriangleInfoMap();
+            delete m_meshInterface;
+        }
+    };
+
+
+}
+
+#endif

--- a/components/resource/bulletshapemanager.cpp
+++ b/components/resource/bulletshapemanager.cpp
@@ -114,7 +114,6 @@ osg::ref_ptr<BulletShapeInstance> BulletShapeManager::createInstance(const std::
     {
         Files::IStreamPtr file = mVFS->get(normalized);
 
-        // TODO: add support for non-NIF formats
         size_t extPos = normalized.find_last_of('.');
         std::string ext;
         if (extPos != std::string::npos && extPos+1 < normalized.size())

--- a/components/resource/bulletshapemanager.cpp
+++ b/components/resource/bulletshapemanager.cpp
@@ -4,7 +4,9 @@
 
 #include <components/nifbullet/bulletnifloader.hpp>
 
-namespace NifBullet
+#include "bulletshape.hpp"
+
+namespace Resource
 {
 
 BulletShapeManager::BulletShapeManager(const VFS::Manager* vfs)
@@ -38,7 +40,7 @@ osg::ref_ptr<BulletShapeInstance> BulletShapeManager::createInstance(const std::
         if (ext != "nif")
             return NULL;
 
-        BulletNifLoader loader;
+        NifBullet::BulletNifLoader loader;
         // might be worth sharing NIFFiles with SceneManager in some way
         shape = loader.load(Nif::NIFFilePtr(new Nif::NIFFile(file, normalized)));
 

--- a/components/resource/bulletshapemanager.cpp
+++ b/components/resource/bulletshapemanager.cpp
@@ -1,16 +1,99 @@
 #include "bulletshapemanager.hpp"
 
+#include <osg/NodeVisitor>
+#include <osg/Geode>
+#include <osg/TriangleFunctor>
+
+#include <BulletCollision/CollisionShapes/btTriangleMesh.h>
+
 #include <components/vfs/manager.hpp>
 
 #include <components/nifbullet/bulletnifloader.hpp>
 
 #include "bulletshape.hpp"
+#include "scenemanager.hpp"
+
 
 namespace Resource
 {
 
-BulletShapeManager::BulletShapeManager(const VFS::Manager* vfs)
+struct GetTriangleFunctor
+{
+    GetTriangleFunctor()
+        : mTriMesh(NULL)
+    {
+    }
+
+    void setTriMesh(btTriangleMesh* triMesh)
+    {
+        mTriMesh = triMesh;
+    }
+
+    void setMatrix(const osg::Matrixf& matrix)
+    {
+        mMatrix = matrix;
+    }
+
+    inline btVector3 toBullet(const osg::Vec3f& vec)
+    {
+        return btVector3(vec.x(), vec.y(), vec.z());
+    }
+
+    void inline operator()( const osg::Vec3 v1, const osg::Vec3 v2, const osg::Vec3 v3, bool _temp )
+    {
+        if (mTriMesh)
+            mTriMesh->addTriangle( toBullet(mMatrix.preMult(v1)), toBullet(mMatrix.preMult(v2)), toBullet(mMatrix.preMult(v3)));
+    }
+
+    btTriangleMesh* mTriMesh;
+    osg::Matrixf mMatrix;
+};
+
+/// Creates a BulletShape out of a Node hierarchy.
+class NodeToShapeVisitor : public osg::NodeVisitor
+{
+public:
+    NodeToShapeVisitor()
+        : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
+        , mTriangleMesh(NULL)
+    {
+
+    }
+
+    virtual void apply(osg::Geode& geode)
+    {
+        for (unsigned int i=0; i<geode.getNumDrawables(); ++i)
+            apply(*geode.getDrawable(i));
+    }
+
+    virtual void apply(osg::Drawable &drawable)
+    {
+        if (!mTriangleMesh)
+            mTriangleMesh = new btTriangleMesh;
+
+        osg::Matrixf worldMat = osg::computeLocalToWorld(getNodePath());
+        osg::TriangleFunctor<GetTriangleFunctor> functor;
+        functor.setTriMesh(mTriangleMesh);
+        functor.setMatrix(worldMat);
+        drawable.accept(functor);
+    }
+
+    osg::ref_ptr<BulletShape> getShape()
+    {
+        osg::ref_ptr<BulletShape> shape (new BulletShape);
+        TriangleMeshShape* meshShape = new TriangleMeshShape(mTriangleMesh, true);
+        shape->mCollisionShape = meshShape;
+        mTriangleMesh = NULL;
+        return shape;
+    }
+
+private:
+    btTriangleMesh* mTriangleMesh;
+};
+
+BulletShapeManager::BulletShapeManager(const VFS::Manager* vfs, SceneManager* sceneMgr)
     : mVFS(vfs)
+    , mSceneManager(sceneMgr)
 {
 
 }
@@ -37,12 +120,22 @@ osg::ref_ptr<BulletShapeInstance> BulletShapeManager::createInstance(const std::
         if (extPos != std::string::npos && extPos+1 < normalized.size())
             ext = normalized.substr(extPos+1);
 
-        if (ext != "nif")
-            return NULL;
+        if (ext == "nif")
+        {
+            NifBullet::BulletNifLoader loader;
+            // might be worth sharing NIFFiles with SceneManager in some way
+            shape = loader.load(Nif::NIFFilePtr(new Nif::NIFFile(file, normalized)));
+        }
+        else
+        {
+            // TODO: support .bullet shape files
 
-        NifBullet::BulletNifLoader loader;
-        // might be worth sharing NIFFiles with SceneManager in some way
-        shape = loader.load(Nif::NIFFilePtr(new Nif::NIFFile(file, normalized)));
+            osg::ref_ptr<const osg::Node> constNode (mSceneManager->getTemplate(normalized));
+            osg::ref_ptr<osg::Node> node (const_cast<osg::Node*>(constNode.get())); // const-trickery required because there is no const version of NodeVisitor
+            NodeToShapeVisitor visitor;
+            node->accept(visitor);
+            shape = visitor.getShape();
+        }
 
         mIndex[normalized] = shape;
     }

--- a/components/resource/bulletshapemanager.cpp
+++ b/components/resource/bulletshapemanager.cpp
@@ -80,6 +80,9 @@ public:
 
     osg::ref_ptr<BulletShape> getShape()
     {
+        if (!mTriangleMesh)
+            return osg::ref_ptr<BulletShape>();
+
         osg::ref_ptr<BulletShape> shape (new BulletShape);
         TriangleMeshShape* meshShape = new TriangleMeshShape(mTriangleMesh, true);
         shape->mCollisionShape = meshShape;
@@ -134,6 +137,8 @@ osg::ref_ptr<BulletShapeInstance> BulletShapeManager::createInstance(const std::
             NodeToShapeVisitor visitor;
             node->accept(visitor);
             shape = visitor.getShape();
+            if (!shape)
+                return osg::ref_ptr<BulletShapeInstance>();
         }
 
         mIndex[normalized] = shape;

--- a/components/resource/bulletshapemanager.hpp
+++ b/components/resource/bulletshapemanager.hpp
@@ -23,13 +23,14 @@ namespace Resource
     class BulletShapeManager
     {
     public:
-        BulletShapeManager(const VFS::Manager* vfs);
+        BulletShapeManager(const VFS::Manager* vfs, SceneManager* sceneMgr);
         ~BulletShapeManager();
 
         osg::ref_ptr<BulletShapeInstance> createInstance(const std::string& name);
 
     private:
         const VFS::Manager* mVFS;
+        SceneManager* mSceneManager;
 
         typedef std::map<std::string, osg::ref_ptr<BulletShape> > Index;
         Index mIndex;

--- a/components/resource/bulletshapemanager.hpp
+++ b/components/resource/bulletshapemanager.hpp
@@ -6,6 +6,8 @@
 
 #include <osg/ref_ptr>
 
+#include "bulletshape.hpp"
+
 namespace VFS
 {
     class Manager;
@@ -14,10 +16,6 @@ namespace VFS
 namespace Resource
 {
     class SceneManager;
-}
-
-namespace NifBullet
-{
 
     class BulletShape;
     class BulletShapeInstance;

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -130,7 +130,6 @@ namespace Resource
         {
             try
             {
-                mTextureManager->getTexture2D(filename, osg::Texture::CLAMP_TO_EDGE, osg::Texture::CLAMP_TO_EDGE);
                 return osgDB::ReaderWriter::ReadResult(mTextureManager->getImage(filename), osgDB::ReaderWriter::ReadResult::FILE_LOADED);
             }
             catch (std::exception& e)

--- a/components/resource/texturemanager.cpp
+++ b/components/resource/texturemanager.cpp
@@ -143,6 +143,57 @@ namespace Resource
         return true;
     }
 
+    osg::ref_ptr<osg::Image> TextureManager::getImage(const std::string &filename)
+    {
+        std::string normalized = filename;
+        mVFS->normalizeFilename(normalized);
+        std::map<std::string, osg::ref_ptr<osg::Image> >::iterator found = mImages.find(normalized);
+        if (found != mImages.end())
+            return found->second;
+        else
+        {
+            Files::IStreamPtr stream;
+            try
+            {
+                stream = mVFS->get(normalized.c_str());
+            }
+            catch (std::exception& e)
+            {
+                std::cerr << "Failed to open image: " << e.what() << std::endl;
+                return NULL;
+            }
+
+            osg::ref_ptr<osgDB::Options> opts (new osgDB::Options);
+            opts->setOptionString("dds_dxt1_detect_rgba"); // tx_creature_werewolf.dds isn't loading in the correct format without this option
+            size_t extPos = normalized.find_last_of('.');
+            std::string ext;
+            if (extPos != std::string::npos && extPos+1 < normalized.size())
+                ext = normalized.substr(extPos+1);
+            osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+            if (!reader)
+            {
+                std::cerr << "Error loading " << filename << ": no readerwriter for '" << ext << "' found" << std::endl;
+                return NULL;
+            }
+
+            osgDB::ReaderWriter::ReadResult result = reader->readImage(*stream, opts);
+            if (!result.success())
+            {
+                std::cerr << "Error loading " << filename << ": " << result.message() << " code " << result.status() << std::endl;
+                return NULL;
+            }
+
+            osg::Image* image = result.getImage();
+            if (!checkSupported(image, filename))
+            {
+                return NULL;
+            }
+
+            mImages.insert(std::make_pair(normalized, image));
+            return image;
+        }
+    }
+
     osg::ref_ptr<osg::Texture2D> TextureManager::getTexture2D(const std::string &filename, osg::Texture::WrapMode wrapS, osg::Texture::WrapMode wrapT)
     {
         std::string normalized = filename;

--- a/components/resource/texturemanager.hpp
+++ b/components/resource/texturemanager.hpp
@@ -34,7 +34,7 @@ namespace Resource
         osg::ref_ptr<osg::Texture2D> getTexture2D(const std::string& filename, osg::Texture::WrapMode wrapS, osg::Texture::WrapMode wrapT);
 
         /// Create or retrieve an Image
-        //osg::ref_ptr<osg::Image> getImage(const std::string& filename);
+        osg::ref_ptr<osg::Image> getImage(const std::string& filename);
 
         const VFS::Manager* getVFS() { return mVFS; }
 
@@ -49,7 +49,7 @@ namespace Resource
 
         typedef std::pair<std::pair<int, int>, std::string> MapKey;
 
-        std::map<std::string, osg::observer_ptr<osg::Image> > mImages;
+        std::map<std::string, osg::ref_ptr<osg::Image> > mImages;
 
         std::map<MapKey, osg::ref_ptr<osg::Texture2D> > mTextures;
 


### PR DESCRIPTION
Implemented basic support for the .osg mesh formats. Does not yet support all features that NIF's support, e.g. skeletal animations.

Documentation at: https://wiki.openmw.org/index.php?title=Native_Mesh_Format