### PR TITLE
getSoundPlaying fix

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -168,8 +168,8 @@ namespace MWSound
         SoundMap::const_iterator snditer = mActiveSounds.begin();
         while(snditer != mActiveSounds.end())
         {
-            if(snditer->second.first == ptr && snditer->second.second == id)
-                return snditer->first->isPlaying();
+            if(snditer->second.first == ptr && snditer->second.second == id && snditer->first->isPlaying())
+                return true;
             ++snditer;
         }
         return false;


### PR DESCRIPTION
@kcat 

This change fixes an issue with the drowning sound, where sometimes the sound is playing more than once at the same time, thus louder than it should be. To reproduce, just go underwater and drown. The issue may be framerate dependent, it happens for me at about 120 fps.

The code playing the drown sound looks like this:

<pre>
                if(!sndmgr->getSoundPlaying(ptr, "drown"))
                    sndmgr->playSound3D(ptr, "drown", 1.0f, 1.0f);
</pre>

This doesn't work correctly for two reasons:
1. SoundManager::updateSounds (responsible for removing sounds that have finished playing from the mActiveSounds map) is run [at most 30 times per second](https://github.com/OpenMW/openmw/blob/master/apps/openmw/mwsound/soundmanagerimp.cpp#L628).
2. SoundManager::isPlaying doesn't correctly handle multiple sounds with the same Ptr/id. It just returns the isPlaying() of the first matching sound. Instead we should check if <i>any</i> of the sounds matching the Ptr/id are playing.
What happens then is:
1. The drowning update plays the drowning sound.
2. The sound finishes playing after the sound manager update, but just before the next drowning update. Now we go to play another drowning sound. Note the first (no longer playing) sound isn't removed from the mActiveSounds map yet.
3. (no SoundManager update at this point, because of the 30 fps check)
4. The next drowning update checks to see if the sound is still playing. Because there's still a "zombie" sound in the map that hasn't been removed, isPlaying() wrongly returns false. A new drowning sound is played on top of the last one that's still playing.

To fix the issue, getSoundPlaying will now return true if any of the sounds with the given Ptr/id are playing.
