### PR TITLE
OS X: use TGA, PNG & JPEG plugins instead of ImageIO plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,9 +748,10 @@ if (APPLE)
 
     set(ABSOLUTE_PLUGINS "")
     set(USED_OSG_PLUGINS
-                        osgdb_tga
                         osgdb_dds
-                        osgdb_imageio
+                        osgdb_jpeg
+                        osgdb_png
+                        osgdb_tga
                       )
 
     foreach (PLUGIN_NAME ${USED_OSG_PLUGINS})


### PR DESCRIPTION
Context: https://forum.openmw.org/viewtopic.php?f=20&t=2949&start=220#p35531