### PR TITLE
Optimize World::getTimeStamp

### DIFF
--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -85,6 +85,13 @@ namespace MWWorld
             MWPhysics::PhysicsSystem *mPhysics;
             bool mSky;
 
+            ESM::Variant* mGameHour;
+            ESM::Variant* mDaysPassed;
+            ESM::Variant* mDay;
+            ESM::Variant* mMonth;
+            ESM::Variant* mYear;
+            ESM::Variant* mTimeScale;
+
             Cells mCells;
 
             std::string mCurrentWorldSpace;
@@ -134,6 +141,8 @@ namespace MWWorld
             ///< Run physics simulation and modify \a world accordingly.
 
             void ensureNeededRecords();
+
+            void fillGlobalVariables();
 
             /**
              * @brief loadContentFiles - Loads content files (esm,esp,omwgame,omwaddon)


### PR DESCRIPTION
World::getTimeStamp was searching through the globals store on every call. Not a big issue, but slow enough to show up in the profiler.