### PR TITLE
Replace dynamic_cast's in MWClass

### DIFF
--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -202,7 +202,7 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<ContainerCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore;
+        return static_cast<ContainerCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore;
     }
 
     std::string Container::getScript (const MWWorld::Ptr& ptr) const
@@ -295,7 +295,7 @@ namespace MWClass
 
     void Container::readAdditionalState (const MWWorld::Ptr& ptr, const ESM::ObjectState& state) const
     {
-        const ESM::ContainerState& state2 = dynamic_cast<const ESM::ContainerState&> (state);
+        const ESM::ContainerState& state2 = static_cast<const ESM::ContainerState&> (state);
 
         if (!ptr.getRefData().getCustomData())
         {
@@ -304,17 +304,17 @@ namespace MWClass
             ptr.getRefData().setCustomData (data.release());
         }
 
-        dynamic_cast<ContainerCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore.
+        static_cast<ContainerCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore.
             readState (state2.mInventory);
     }
 
     void Container::writeAdditionalState (const MWWorld::Ptr& ptr, ESM::ObjectState& state) const
     {
-        ESM::ContainerState& state2 = dynamic_cast<ESM::ContainerState&> (state);
+        ESM::ContainerState& state2 = static_cast<ESM::ContainerState&> (state);
 
         ensureCustomData (ptr);
 
-        dynamic_cast<ContainerCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore.
+        static_cast<ContainerCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore.
             writeState (state2.mInventory);
     }
 }

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -193,7 +193,7 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData()).mCreatureStats;
+        return static_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData()).mCreatureStats;
     }
 
 
@@ -421,13 +421,13 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return *dynamic_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore;
+        return *static_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData()).mContainerStore;
     }
 
     MWWorld::InventoryStore& Creature::getInventoryStore(const MWWorld::Ptr &ptr) const
     {
         if (hasInventoryStore(ptr))
-            return dynamic_cast<MWWorld::InventoryStore&>(getContainerStore(ptr));
+            return static_cast<MWWorld::InventoryStore&>(getContainerStore(ptr));
         else
             throw std::runtime_error("this creature has no inventory store");
     }
@@ -511,7 +511,7 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData()).mMovement;
+        return static_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData()).mMovement;
     }
 
     MWGui::ToolTipInfo Creature::getToolTipInfo (const MWWorld::Ptr& ptr) const
@@ -691,7 +691,7 @@ namespace MWClass
         if (!state.mHasCustomState)
             return;
 
-        const ESM::CreatureState& state2 = dynamic_cast<const ESM::CreatureState&> (state);
+        const ESM::CreatureState& state2 = static_cast<const ESM::CreatureState&> (state);
 
         if (state.mVersion > 0)
         {
@@ -711,7 +711,7 @@ namespace MWClass
         else
             ensureCustomData(ptr); // in openmw 0.30 savegames not all state was saved yet, so need to load it regardless.
 
-        CreatureCustomData& customData = dynamic_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData());
+        CreatureCustomData& customData = static_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData());
 
         customData.mContainerStore->readState (state2.mInventory);
         customData.mCreatureStats.readState (state2.mCreatureStats);
@@ -720,7 +720,7 @@ namespace MWClass
     void Creature::writeAdditionalState (const MWWorld::Ptr& ptr, ESM::ObjectState& state)
         const
     {
-        ESM::CreatureState& state2 = dynamic_cast<ESM::CreatureState&> (state);
+        ESM::CreatureState& state2 = static_cast<ESM::CreatureState&> (state);
 
         if (!ptr.getRefData().getCustomData())
         {
@@ -730,7 +730,7 @@ namespace MWClass
 
         ensureCustomData (ptr);
 
-        CreatureCustomData& customData = dynamic_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData());
+        CreatureCustomData& customData = static_cast<CreatureCustomData&> (*ptr.getRefData().getCustomData());
 
         customData.mContainerStore->writeState (state2.mInventory);
         customData.mCreatureStats.writeState (state2.mCreatureStats);

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -65,7 +65,7 @@ namespace MWClass
         // Resume the door's opening/closing animation if it wasn't finished
         if (ptr.getRefData().getCustomData())
         {
-            const DoorCustomData& customData = dynamic_cast<const DoorCustomData&>(*ptr.getRefData().getCustomData());
+            const DoorCustomData& customData = static_cast<const DoorCustomData&>(*ptr.getRefData().getCustomData());
             if (customData.mDoorState > 0)
             {
                 MWBase::Environment::get().getWorld()->activateDoor(ptr, customData.mDoorState);
@@ -324,7 +324,7 @@ namespace MWClass
     int Door::getDoorState (const MWWorld::Ptr &ptr) const
     {
         ensureCustomData(ptr);
-        const DoorCustomData& customData = dynamic_cast<const DoorCustomData&>(*ptr.getRefData().getCustomData());
+        const DoorCustomData& customData = static_cast<const DoorCustomData&>(*ptr.getRefData().getCustomData());
         return customData.mDoorState;
     }
 
@@ -334,25 +334,25 @@ namespace MWClass
             throw std::runtime_error("load doors can't be moved");
 
         ensureCustomData(ptr);
-        DoorCustomData& customData = dynamic_cast<DoorCustomData&>(*ptr.getRefData().getCustomData());
+        DoorCustomData& customData = static_cast<DoorCustomData&>(*ptr.getRefData().getCustomData());
         customData.mDoorState = state;
     }
 
     void Door::readAdditionalState (const MWWorld::Ptr& ptr, const ESM::ObjectState& state) const
     {
         ensureCustomData(ptr);
-        DoorCustomData& customData = dynamic_cast<DoorCustomData&>(*ptr.getRefData().getCustomData());
+        DoorCustomData& customData = static_cast<DoorCustomData&>(*ptr.getRefData().getCustomData());
 
-        const ESM::DoorState& state2 = dynamic_cast<const ESM::DoorState&>(state);
+        const ESM::DoorState& state2 = static_cast<const ESM::DoorState&>(state);
         customData.mDoorState = state2.mDoorState;
     }
 
     void Door::writeAdditionalState (const MWWorld::Ptr& ptr, ESM::ObjectState& state) const
     {
         ensureCustomData(ptr);
-        const DoorCustomData& customData = dynamic_cast<const DoorCustomData&>(*ptr.getRefData().getCustomData());
+        const DoorCustomData& customData = static_cast<const DoorCustomData&>(*ptr.getRefData().getCustomData());
 
-        ESM::DoorState& state2 = dynamic_cast<ESM::DoorState&>(state);
+        ESM::DoorState& state2 = static_cast<ESM::DoorState&>(state);
         state2.mDoorState = customData.mDoorState;
     }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -446,14 +446,14 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mNpcStats;
+        return static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mNpcStats;
     }
 
     MWMechanics::NpcStats& Npc::getNpcStats (const MWWorld::Ptr& ptr) const
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mNpcStats;
+        return static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mNpcStats;
     }
 
 
@@ -780,7 +780,7 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mInventoryStore;
+        return static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mInventoryStore;
     }
 
     MWWorld::InventoryStore& Npc::getInventoryStore (const MWWorld::Ptr& ptr)
@@ -788,7 +788,7 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mInventoryStore;
+        return static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mInventoryStore;
     }
 
     std::string Npc::getScript (const MWWorld::Ptr& ptr) const
@@ -897,7 +897,7 @@ namespace MWClass
     {
         ensureCustomData (ptr);
 
-        return dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mMovement;
+        return static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData()).mMovement;
     }
 
     bool Npc::isEssential (const MWWorld::Ptr& ptr) const
@@ -1147,7 +1147,7 @@ namespace MWClass
         if (!state.mHasCustomState)
             return;
 
-        const ESM::NpcState& state2 = dynamic_cast<const ESM::NpcState&> (state);
+        const ESM::NpcState& state2 = static_cast<const ESM::NpcState&> (state);
 
         if (state.mVersion > 0)
         {
@@ -1161,7 +1161,7 @@ namespace MWClass
         else
             ensureCustomData(ptr); // in openmw 0.30 savegames not all state was saved yet, so need to load it regardless.
 
-        NpcCustomData& customData = dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData());
+        NpcCustomData& customData = static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData());
 
         customData.mInventoryStore.readState (state2.mInventory);
         customData.mNpcStats.readState (state2.mNpcStats);
@@ -1171,7 +1171,7 @@ namespace MWClass
     void Npc::writeAdditionalState (const MWWorld::Ptr& ptr, ESM::ObjectState& state)
         const
     {
-        ESM::NpcState& state2 = dynamic_cast<ESM::NpcState&> (state);
+        ESM::NpcState& state2 = static_cast<ESM::NpcState&> (state);
 
         if (!ptr.getRefData().getCustomData())
         {
@@ -1181,7 +1181,7 @@ namespace MWClass
 
         ensureCustomData (ptr);
 
-        NpcCustomData& customData = dynamic_cast<NpcCustomData&> (*ptr.getRefData().getCustomData());
+        NpcCustomData& customData = static_cast<NpcCustomData&> (*ptr.getRefData().getCustomData());
 
         customData.mInventoryStore.writeState (state2.mInventory);
         customData.mNpcStats.writeState (state2.mNpcStats);


### PR DESCRIPTION
I'm trying to eliminate per-frame dynamic_cast's and this was one of the hotspots. Almost 1% of the frame loop is spent in Class::getCreatureStats, Class::getContainerStore and similar functions.

Replacing with a static_cast can be deemed safe since only the MWClass sets the custom data, and it knows which custom data it's set. The only issue is if that assumption were to be violated for some reason, we would get a hard crash instead of a bad cast exception (though exceptions are likely to abort the save process, render the game unplayable or result in other issues anyway if they're not caught properly).

If static_cast's are a no go, my next best suggestion would be to hack a fast version of dynamic_cast using virtual functions:

<pre>
namespace MWClass
{
    class CreatureCustomData;
}

namespace MWWorld
{

    /// \brief Base class for the MW-class-specific part of RefData
    class CustomData
    {
        public:

            virtual ~CustomData() {}

            /// Would be overridden in CreatureCustomData to return this;
            virtual CreatureCustomData* asCreatureCustomData() { return 0; }

            virtual CustomData *clone() const = 0;
    };
</pre>
