### PR TITLE
Ltex error handling

### DIFF
--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -37,9 +37,7 @@ namespace CSVRender
                 return ltex;
         }
 
-        std::stringstream error;
-        error << "Can't find LandTexture " << index << " from plugin " << plugin;
-        throw std::runtime_error(error.str());
+        return NULL;
     }
 
     void TerrainStorage::getBounds(float &minX, float &maxX, float &minY, float &maxY)

--- a/apps/openmw/mwrender/terrainstorage.cpp
+++ b/apps/openmw/mwrender/terrainstorage.cpp
@@ -69,7 +69,7 @@ namespace MWRender
     {
         const MWWorld::ESMStore &esmStore =
             MWBase::Environment::get().getWorld()->getStore();
-        return esmStore.get<ESM::LandTexture>().find(index, plugin);
+        return esmStore.get<ESM::LandTexture>().search(index, plugin);
     }
 
 }

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -32,6 +32,12 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
 
     ESM::Dialogue *dialogue = 0;
 
+    // Land texture loading needs to use a separate internal store for each plugin.
+    // We set the number of plugins here to avoid continual resizes during loading,
+    // and so we can properly verify if valid plugin indices are being passed to the
+    // LandTexture Store retrieval methods.
+    mLandTextures.resize(esm.getGlobalReaderList()->size());
+
     /// \todo Move this to somewhere else. ESMReader?
     // Cache parent esX files by tracking their indices in the global list of
     //  all files/readers used by the engine. This will greaty accelerate

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -351,8 +351,9 @@ namespace MWWorld
         assert(plugin < mStatic.size());
         const LandTextureList &ltexl = mStatic[plugin];
 
-        assert(index < ltexl.size());
-        return &ltexl.at(index);
+        if (index >= ltexl.size())
+            return NULL;
+        return &ltexl[index];
     }
     const ESM::LandTexture *Store<ESM::LandTexture>::find(size_t index, size_t plugin) const
     {
@@ -380,10 +381,8 @@ namespace MWWorld
 
         lt.load(esm, isDeleted);
 
-        // Make sure we have room for the structure
-        if (plugin >= mStatic.size()) {
-            mStatic.resize(plugin+1);
-        }
+        assert(plugin < mStatic.size());
+
         LandTextureList &ltexl = mStatic[plugin];
         if(lt.mIndex + 1 > (int)ltexl.size())
             ltexl.resize(lt.mIndex+1);
@@ -406,6 +405,11 @@ namespace MWWorld
     {
         assert(plugin < mStatic.size());
         return mStatic[plugin].end();
+    }
+    void Store<ESM::LandTexture>::resize(size_t num)
+    {
+        if (mStatic.size() < num)
+            mStatic.resize(num);
     }
     
     // Land

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -210,6 +210,9 @@ namespace MWWorld
         const ESM::LandTexture *search(size_t index, size_t plugin) const;
         const ESM::LandTexture *find(size_t index, size_t plugin) const;
 
+        /// Resize the internal store to hold at least \a num plugins.
+        void resize(size_t num);
+
         size_t getSize() const;
         size_t getSize(size_t plugin) const;
 

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -1,6 +1,7 @@
 #include "storage.hpp"
 
 #include <set>
+#include <iostream>
 
 #include <osg/Image>
 #include <osg/Plane>

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -299,11 +299,17 @@ namespace ESMTerrain
 
     std::string Storage::getTextureName(UniqueTextureId id)
     {
+        static const std::string defaultTexture = "textures\\_land_default.dds";
         if (id.first == 0)
-            return "textures\\_land_default.dds"; // Not sure if the default texture really is hardcoded?
+            return defaultTexture; // Not sure if the default texture really is hardcoded?
 
         // NB: All vtex ids are +1 compared to the ltex ids
         const ESM::LandTexture* ltex = getLandTexture(id.first-1, id.second);
+        if (!ltex)
+        {
+            std::cerr << "Unable to find land texture index " << id.first-1 << " in plugin " << id.second << ", using default texture instead" << std::endl;
+            return defaultTexture;
+        }
 
         // this is needed due to MWs messed up texture handling
         std::string texture = Misc::ResourceHelpers::correctTexturePath(ltex->mTexture, mVFS);


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3037

* Do not assert() for invalid land data in plugins: the resizing of LTEX store to the correct number of plugins was done in the load() method, but the load method won't be called if a plugin contains LAND records but doesn't contain LTEX records. For such plugins the Store<ESM::LandTexture>::search() function would fail an assertion, crashing the game. Invalid plugins should be handled via exceptions rather than assertions. The fix is to resize the LTEX store to the correct number of plugins before starting the load, which achieves the goal of eliminating the assertion fails for plugins containing invalid data, while keeping the possibility of assertion fails in case of internal errors (i.e. passing a totally invalid plugin index, that's never supposed to happen).

* Not found Land Texture records are no longer a fatal error. Log an error message and show the default land texture.