### PR TITLE
Changed relative includes to library header format

### DIFF
--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -28,8 +28,6 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/fstream.hpp>
 
-#include "../files/constrainedfilestream.hpp"
-
 using namespace std;
 using namespace Bsa;
 

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -7,7 +7,7 @@
 #include <QTextCodec>
 #include <QDebug>
 
-#include "components/esm/esmreader.hpp"
+#include <components/esm/esmreader.hpp>
 
 ContentSelectorModel::ContentModel::ContentModel(QObject *parent, QIcon warningIcon) :
     QAbstractTableModel(parent),

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -1,6 +1,6 @@
 #include "contentselector.hpp"
 
-#include "../model/esmfile.hpp"
+#include <components/contentselector/model/esmfile.hpp>
 
 #include <QSortFilterProxyModel>
 

--- a/components/contentselector/view/contentselector.hpp
+++ b/components/contentselector/view/contentselector.hpp
@@ -4,7 +4,7 @@
 #include <QDialog>
 
 #include "ui_contentselector.h"
-#include "../model/contentmodel.hpp"
+#include <components/contentselector/model/contentmodel.hpp>
 
 class QSortFilterProxyModel;
 

--- a/components/nifbullet/bulletnifloader.cpp
+++ b/components/nifbullet/bulletnifloader.cpp
@@ -12,12 +12,11 @@
 
 #include <components/misc/stringops.hpp>
 
-#include "../nif/niffile.hpp"
-#include "../nif/node.hpp"
-#include "../nif/data.hpp"
-#include "../nif/property.hpp"
-#include "../nif/controller.hpp"
-#include "../nif/extra.hpp"
+#include <components/nif/node.hpp>
+#include <components/nif/data.hpp>
+#include <components/nif/property.hpp>
+#include <components/nif/controller.hpp>
+#include <components/nif/extra.hpp>
 
 
 namespace


### PR DESCRIPTION
I was playing around with http://www.flourish.org/cinclude2dot/cinclude2dot and found these.  They were the only relative include paths, besides to_utf8/tests, in all of components.