### PR TITLE
work around X server freeze in crashcatcher

### DIFF
--- a/apps/openmw/crashcatcher.cpp
+++ b/apps/openmw/crashcatcher.cpp
@@ -382,16 +382,17 @@ static void crash_handler(const char *logfile)
     fflush(stdout);
 
     if(crash_info.pid > 0)
-    {
         gdb_info(crash_info.pid);
-        kill(crash_info.pid, SIGKILL);
-    }
 
     if(logfile)
     {
         std::string message = "OpenMW has encountered a fatal error.\nCrash log saved to '" + std::string(logfile) + "'.\n Please report this to https://bugs.openmw.org !";
         SDL_ShowSimpleMessageBox(0, "Fatal Error", message.c_str(), NULL);
     }
+
+    if (crash_info.pid > 0)
+        kill(crash_info.pid, SIGKILL);
+
     exit(0);
 }
 

--- a/apps/openmw/crashcatcher.cpp
+++ b/apps/openmw/crashcatcher.cpp
@@ -382,16 +382,21 @@ static void crash_handler(const char *logfile)
     fflush(stdout);
 
     if(crash_info.pid > 0)
+    {
         gdb_info(crash_info.pid);
+        kill(crash_info.pid, SIGKILL);
+    }
+
+    // delay between killing of the crashed process and showing the message box to
+    // work around occasional X server lock-up. this can only be a bug in X11 since
+    // even faulty applications shouldn't be able to freeze the X server.
+    usleep(100000);
 
     if(logfile)
     {
         std::string message = "OpenMW has encountered a fatal error.\nCrash log saved to '" + std::string(logfile) + "'.\n Please report this to https://bugs.openmw.org !";
         SDL_ShowSimpleMessageBox(0, "Fatal Error", message.c_str(), NULL);
     }
-
-    if (crash_info.pid > 0)
-        kill(crash_info.pid, SIGKILL);
 
     exit(0);
 }


### PR DESCRIPTION
This change appears to fix a random X server lock-up that I get about 1 in 10 times when a crash is caught. I'm presuming it's a bug in the X server since faulty applications shouldn't be able to crash or freeze the X server under any circumstances. I am unsure why this particular change works around the issue but I'm not about to go digging in the X server code to find out. That thing is big and scary...