### PR TITLE
Fix windows builds

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -104,10 +104,9 @@ namespace MWSound
             SoundBufferList::iterator sfxiter = mSoundBuffers.begin();
             for(;sfxiter != mSoundBuffers.end();++sfxiter)
             {
-                if((*sfxiter)->mHandle)
-                    mOutput->unloadSound((*sfxiter)->mHandle);
-                (*sfxiter)->mHandle = 0;
-                delete (*sfxiter);
+                if(sfxiter->mHandle)
+                    mOutput->unloadSound(sfxiter->mHandle);
+                sfxiter->mHandle = 0;
             }
             mUnusedBuffers.clear();
         }
@@ -146,8 +145,8 @@ namespace MWSound
         min = std::max(min, 1.0f);
         max = std::max(min, max);
 
-        Sound_Buffer *sfx = *mSoundBuffers.insert(mSoundBuffers.end(),
-            new Sound_Buffer("Sound/"+sound->mSound, volume, min, max)
+        Sound_Buffer *sfx = &*mSoundBuffers.insert(mSoundBuffers.end(),
+            Sound_Buffer("Sound/"+sound->mSound, volume, min, max)
         );
         mVFS->normalizeFilename(sfx->mResourceName);
 

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -40,6 +40,7 @@ namespace MWSound
         , mMusicVolume(1.0f)
         , mVoiceVolume(1.0f)
         , mFootstepsVolume(1.0f)
+        , mSoundBuffers(new SoundBufferList::element_type())
         , mBufferCacheSize(0)
         , mListenerUnderwater(false)
         , mListenerPos(0,0,0)
@@ -101,8 +102,8 @@ namespace MWSound
         clear();
         if(mOutput->isInitialized())
         {
-            SoundBufferList::iterator sfxiter = mSoundBuffers.begin();
-            for(;sfxiter != mSoundBuffers.end();++sfxiter)
+            SoundBufferList::element_type::iterator sfxiter = mSoundBuffers->begin();
+            for(;sfxiter != mSoundBuffers->end();++sfxiter)
             {
                 if(sfxiter->mHandle)
                     mOutput->unloadSound(sfxiter->mHandle);
@@ -145,7 +146,7 @@ namespace MWSound
         min = std::max(min, 1.0f);
         max = std::max(min, max);
 
-        Sound_Buffer *sfx = &*mSoundBuffers.insert(mSoundBuffers.end(),
+        Sound_Buffer *sfx = &*mSoundBuffers->insert(mSoundBuffers->end(),
             Sound_Buffer("Sound/"+sound->mSound, volume, min, max)
         );
         mVFS->normalizeFilename(sfx->mResourceName);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -104,9 +104,10 @@ namespace MWSound
             SoundBufferList::iterator sfxiter = mSoundBuffers.begin();
             for(;sfxiter != mSoundBuffers.end();++sfxiter)
             {
-                if(sfxiter->mHandle)
-                    mOutput->unloadSound(sfxiter->mHandle);
-                sfxiter->mHandle = 0;
+                if((*sfxiter)->mHandle)
+                    mOutput->unloadSound((*sfxiter)->mHandle);
+                (*sfxiter)->mHandle = 0;
+                delete (*sfxiter);
             }
             mUnusedBuffers.clear();
         }
@@ -145,8 +146,8 @@ namespace MWSound
         min = std::max(min, 1.0f);
         max = std::max(min, max);
 
-        Sound_Buffer *sfx = &*mSoundBuffers.insert(mSoundBuffers.end(),
-            Sound_Buffer("Sound/"+sound->mSound, volume, min, max)
+        Sound_Buffer *sfx = *mSoundBuffers.insert(mSoundBuffers.end(),
+            new Sound_Buffer("Sound/"+sound->mSound, volume, min, max)
         );
         mVFS->normalizeFilename(sfx->mResourceName);
 

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -56,7 +56,7 @@ namespace MWSound
         float mVoiceVolume;
         float mFootstepsVolume;
 
-        typedef std::deque<Sound_Buffer> SoundBufferList;
+        typedef std::deque<Sound_Buffer*> SoundBufferList;
         // List of sound buffers, grown as needed. New enties are added to the
         // back, allowing existing Sound_Buffer references/pointers to remain
         // valid.

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -56,7 +56,7 @@ namespace MWSound
         float mVoiceVolume;
         float mFootstepsVolume;
 
-        typedef std::deque<Sound_Buffer*> SoundBufferList;
+        typedef std::deque<Sound_Buffer> SoundBufferList;
         // List of sound buffers, grown as needed. New enties are added to the
         // back, allowing existing Sound_Buffer references/pointers to remain
         // valid.

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -57,7 +57,7 @@ namespace MWSound
         float mVoiceVolume;
         float mFootstepsVolume;
 
-        typedef std::auto_ptr<std::deque<Sound_Buffer>> SoundBufferList;
+        typedef std::auto_ptr<std::deque<Sound_Buffer> > SoundBufferList;
         // List of sound buffers, grown as needed. New enties are added to the
         // back, allowing existing Sound_Buffer references/pointers to remain
         // valid.

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -1,6 +1,7 @@
 #ifndef GAME_SOUND_SOUNDMANAGER_H
 #define GAME_SOUND_SOUNDMANAGER_H
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <deque>
@@ -56,7 +57,7 @@ namespace MWSound
         float mVoiceVolume;
         float mFootstepsVolume;
 
-        typedef std::deque<Sound_Buffer> SoundBufferList;
+        typedef std::auto_ptr<std::deque<Sound_Buffer>> SoundBufferList;
         // List of sound buffers, grown as needed. New enties are added to the
         // back, allowing existing Sound_Buffer references/pointers to remain
         // valid.


### PR DESCRIPTION
Can't instantiate a container (at least with MSVC) without knowing the exact size of the object being stored, forward-declares only work with pointers.
I couldn't see a simple way to remove the forward declare, so pointers and memory management it is.