### PR TITLE
Quick fix for building on MSVC

### DIFF
--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -52,7 +52,7 @@ namespace NifOsg
         {
         }
 
-        ValueInterpolator(boost::shared_ptr<const MapT> keys, typename MapT::ValueType defaultVal = typename MapT::ValueType())
+        ValueInterpolator(boost::shared_ptr<const MapT> keys, typename MapT::ValueType defaultVal = MapT::ValueType())
             : mKeys(keys)
             , mDefaultVal(defaultVal)
         {

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -52,7 +52,11 @@ namespace NifOsg
         {
         }
 
+#ifdef _MSC_VER
         ValueInterpolator(boost::shared_ptr<const MapT> keys, typename MapT::ValueType defaultVal = MapT::ValueType())
+#else
+        ValueInterpolator(boost::shared_ptr<const MapT> keys, typename MapT::ValueType defaultVal = typename MapT::ValueType())
+#endif
             : mKeys(keys)
             , mDefaultVal(defaultVal)
         {


### PR DESCRIPTION
`components\nifosg\controller.hpp(55): C2899: typename cannot be used outside a template declaration`
Removing the second typename solves it, probably because that's technically in definition and not declaration.