### PR TITLE
Do not read openmw.cfg from global path if one was found in the local path

### DIFF
--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -60,10 +60,14 @@ void ConfigurationManager::readConfiguration(boost::program_options::variables_m
     loadConfig(mFixedPath.getUserConfigPath(), variables, description);
     boost::program_options::notify(variables);
 
-    loadConfig(mFixedPath.getLocalPath(), variables, description);
+    // read either local or global config depending on type of installation
+    bool loaded = loadConfig(mFixedPath.getLocalPath(), variables, description);
     boost::program_options::notify(variables);
-    loadConfig(mFixedPath.getGlobalConfigPath(), variables, description);
-    boost::program_options::notify(variables);
+    if (!loaded)
+    {
+        loadConfig(mFixedPath.getGlobalConfigPath(), variables, description);
+        boost::program_options::notify(variables);
+    }
 
     mSilent = silent;
 }
@@ -126,7 +130,7 @@ void ConfigurationManager::processPaths(Files::PathContainer& dataDirs, bool cre
         boost::bind(&boost::filesystem::path::empty, _1)), dataDirs.end());
 }
 
-void ConfigurationManager::loadConfig(const boost::filesystem::path& path,
+bool ConfigurationManager::loadConfig(const boost::filesystem::path& path,
     boost::program_options::variables_map& variables,
     boost::program_options::options_description& description)
 {
@@ -145,13 +149,16 @@ void ConfigurationManager::loadConfig(const boost::filesystem::path& path,
 
             if (!mSilent)
                 std::cout << "done." << std::endl;
+            return true;
         }
         else
         {
             if (!mSilent)
                 std::cout << "failed." << std::endl;
+            return false;
         }
     }
+    return false;
 }
 
 const boost::filesystem::path& ConfigurationManager::getGlobalPath() const

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -58,7 +58,7 @@ struct ConfigurationManager
         typedef std::tr1::unordered_map<std::string, path_type_f> TokensMappingContainer;
     #endif
 
-        void loadConfig(const boost::filesystem::path& path,
+        bool loadConfig(const boost::filesystem::path& path,
             boost::program_options::variables_map& variables,
             boost::program_options::options_description& description);
 


### PR DESCRIPTION
Local builds should not read configuration that belong to a system wide installation. Doing so can result in runtime failures if the local build is a different OpenMW version than the system one.

As well, brings the code in line with settings-default.cfg reading logic https://github.com/OpenMW/openmw/blob/master/apps/openmw/engine.cpp#L304