### PR TITLE
enable opengl es1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,14 +168,23 @@ endif (ANDROID)
 
 option(OPENGL_ES "enable opengl es support" FALSE )
 
+option(USE_QT "Use Qt in building" TRUE )
+
+if (NOT BUILD_LAUNCHER AND NOT BUILD_OPENCS)
+    set(USE_QT FALSE CACHE BOOL "disable Qt" FORCE )
+else()
+    set(USE_QT TRUE CACHE BOOL "enable Qt" FORCE )
+endif()
+
+add_definitions (-DUSE_QT)
+ 
 if (OPENGL_ES)
-    INCLUDE(cmake/FindOpenGLES.cmake)
+    find_package(OpenGLES)
     add_definitions (-DOPENGL_ES)
-    INCLUDE_DIRECTORIES(${OPENGLES_INCLUDE_DIR})
 endif (OPENGLES)
 
 # Dependencies
-if (NOT ANDROID)
+if (USE_QT)
     set(DESIRED_QT_VERSION 4 CACHE STRING "The QT version OpenMW should use (4 or 5)")
     message(STATUS "Using Qt${DESIRED_QT_VERSION}")
 
@@ -220,7 +229,7 @@ IF(BOOST_STATIC)
     set(Boost_USE_STATIC_LIBS   ON)
 endif()
 
-if (NOT ANDROID)
+if (USE_QT)
     find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgQt osgUtil osgFX)
 else()
     find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgUtil osgFX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,6 @@ endif(EXISTS ${PROJECT_SOURCE_DIR}/.git)
 # Macros
 include(OpenMWMacros)
 
-if (ANDROID)
-    set(CMAKE_FIND_ROOT_PATH ${OPENMW_DEPENDENCIES_DIR} "${CMAKE_FIND_ROOT_PATH}")
-endif (ANDROID)
-
 # doxygen main page
 
 configure_file ("${OpenMW_SOURCE_DIR}/docs/mainpage.hpp.cmake" "${OpenMW_BINARY_DIR}/docs/mainpage.hpp")
@@ -161,28 +157,24 @@ endif()
 
 if (ANDROID)
     set(CMAKE_FIND_ROOT_PATH ${OPENMW_DEPENDENCIES_DIR} "${CMAKE_FIND_ROOT_PATH}")
-    set(OSG_PLUGINS_DIR ${OSG_PLUGINS_DIR})
-    add_definitions (-DOSG_PLUGINS_DIR)
+    add_definitions (-DOSG_PLUGINS_DIR=${OSG_PLUGINS_DIR})
     set(OPENGL_ES TRUE CACHE BOOL "enable opengl es support for android" FORCE)
 endif (ANDROID)
 
 option(OPENGL_ES "enable opengl es support" FALSE )
 
-option(USE_QT "Use Qt in building" TRUE )
+if (OPENGL_ES)
+    add_definitions(-DOPENGL_ES)
+endif(OPENGL_ES)
 
 if (NOT BUILD_LAUNCHER AND NOT BUILD_OPENCS AND NOT BUILD_WIZARD)
-    set(USE_QT FALSE CACHE BOOL "disable Qt" FORCE )
+   set(USE_QT FALSE)
 else()
-    set(USE_QT TRUE CACHE BOOL "enable Qt" FORCE )
+   set(USE_QT TRUE)
 endif()
 
-add_definitions (-DUSE_QT)
+add_definitions(-DUSE_QT)
  
-if (OPENGL_ES)
-    find_package(OpenGLES)
-    add_definitions (-DOPENGL_ES)
-endif (OPENGLES)
-
 # Dependencies
 if (USE_QT)
     set(DESIRED_QT_VERSION 4 CACHE STRING "The QT version OpenMW should use (4 or 5)")
@@ -230,10 +222,11 @@ IF(BOOST_STATIC)
 endif()
 
 if (USE_QT)
-    find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgQt osgUtil osgFX)
-else()
-    find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgUtil osgFX)
+    set (OSG_QT osgQt)
 endif()
+
+find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle ${OSG_QT} osgUtil osgFX)
+
 include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
 
 if(OSG_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,6 @@ endif()
 
 if (ANDROID)
     set(CMAKE_FIND_ROOT_PATH ${OPENMW_DEPENDENCIES_DIR} "${CMAKE_FIND_ROOT_PATH}")
-    add_definitions (-DOSG_PLUGINS_DIR=${OSG_PLUGINS_DIR})
     set(OPENGL_ES TRUE CACHE BOOL "enable opengl es support for android" FORCE)
 endif (ANDROID)
 
@@ -172,8 +171,6 @@ if (NOT BUILD_LAUNCHER AND NOT BUILD_OPENCS AND NOT BUILD_WIZARD)
 else()
    set(USE_QT TRUE)
 endif()
-
-add_definitions(-DUSE_QT)
  
 # Dependencies
 if (USE_QT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ option(OPENGL_ES "enable opengl es support" FALSE )
 
 option(USE_QT "Use Qt in building" TRUE )
 
-if (NOT BUILD_LAUNCHER AND NOT BUILD_OPENCS)
+if (NOT BUILD_LAUNCHER AND NOT BUILD_OPENCS AND NOT BUILD_WIZARD)
     set(USE_QT FALSE CACHE BOOL "disable Qt" FORCE )
 else()
     set(USE_QT TRUE CACHE BOOL "enable Qt" FORCE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,20 +159,36 @@ if (WIN32)
     add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
 endif()
 
+if (ANDROID)
+    set(CMAKE_FIND_ROOT_PATH ${OPENMW_DEPENDENCIES_DIR} "${CMAKE_FIND_ROOT_PATH}")
+    set(OSG_PLUGINS_DIR ${OSG_PLUGINS_DIR})
+    add_definitions (-DOSG_PLUGINS_DIR)
+    set(OPENGL_ES TRUE CACHE BOOL "enable opengl es support for android" FORCE)
+endif (ANDROID)
+
+option(OPENGL_ES "enable opengl es support" FALSE )
+
+if (OPENGL_ES)
+    INCLUDE(cmake/FindOpenGLES.cmake)
+    add_definitions (-DOPENGL_ES)
+    INCLUDE_DIRECTORIES(${OPENGLES_INCLUDE_DIR})
+endif (OPENGLES)
+
 # Dependencies
+if (NOT ANDROID)
+    set(DESIRED_QT_VERSION 4 CACHE STRING "The QT version OpenMW should use (4 or 5)")
+    message(STATUS "Using Qt${DESIRED_QT_VERSION}")
 
-set(DESIRED_QT_VERSION 4 CACHE STRING "The QT version OpenMW should use (4 or 5)")
-message(STATUS "Using Qt${DESIRED_QT_VERSION}")
-
-if (DESIRED_QT_VERSION MATCHES 4)
-    find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtNetwork QtOpenGL)
-else()
-    find_package(Qt5Widgets REQUIRED)
-    find_package(Qt5Core REQUIRED)
-    find_package(Qt5Network REQUIRED)
-    find_package(Qt5OpenGL REQUIRED)
+    if (DESIRED_QT_VERSION MATCHES 4)
+        find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtNetwork QtOpenGL)
+    else()
+        find_package(Qt5Widgets REQUIRED)
+        find_package(Qt5Core REQUIRED)
+        find_package(Qt5Network REQUIRED)
+        find_package(Qt5OpenGL REQUIRED)
     # Instruct CMake to run moc automatically when needed.
     #set(CMAKE_AUTOMOC ON)
+    endif()
 endif()
 
 # Fix for not visible pthreads functions for linker with glibc 2.15
@@ -204,7 +220,11 @@ IF(BOOST_STATIC)
     set(Boost_USE_STATIC_LIBS   ON)
 endif()
 
-find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgQt osgUtil osgFX)
+if (NOT ANDROID)
+    find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgQt osgUtil osgFX)
+else()
+    find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle osgUtil osgFX)
+endif()
 include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
 
 if(OSG_STATIC)

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -155,34 +155,14 @@ if (ANDROID)
         android
         log
         dl
-        MyGUIEngineStatic
-        BulletCollision
-        LinearMath
         z
-        osg
-        osgDB
-        osgAnimation
-        osgText
-        osgUtil
-        osgShadow
         ${OPENSCENEGRAPH_LIBRARIES}
         ${OSG_PLUGINS}
-        ${Boost_SYSTEM_LIBRARY}
-        ${Boost_THREAD_LIBRARY}
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_PROGRAM_OPTIONS_LIBRARY}
         jpeg
         gif
-	png
+    	png
     )
 endif (ANDROID)
-
-
-if (OPENGL_ES)
-    target_link_libraries(openmw
-        ${OPENGLES_gl_LIBRARY}
-    )
-endif (OPENGL_ES)
 
 if (USE_SYSTEM_TINYXML)
     target_link_libraries(openmw ${TINYXML_LIBRARIES})

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -140,17 +140,50 @@ target_link_libraries(openmw
 )
 
 if (ANDROID)
+    set (OSG_PLUGINS
+        -Wl,--whole-archive
+        ${OSG_PLUGINS_DIR}/libosgdb_dds.a
+        ${OSG_PLUGINS_DIR}/libosgdb_bmp.a
+        ${OSG_PLUGINS_DIR}/libosgdb_tga.a
+        ${OSG_PLUGINS_DIR}/libosgdb_gif.a
+        ${OSG_PLUGINS_DIR}/libosgdb_jpeg.a
+        ${OSG_PLUGINS_DIR}/libosgdb_png.a
+        -Wl,--no-whole-archive
+    )
     target_link_libraries(openmw
         EGL
         android
         log
         dl
         MyGUIEngineStatic
-        cpufeatures
         BulletCollision
         LinearMath
+        z
+        osg
+        osgDB
+        osgAnimation
+        osgText
+        osgUtil
+        osgShadow
+        ${OPENSCENEGRAPH_LIBRARIES}
+        ${OSG_PLUGINS}
+        ${Boost_SYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        jpeg
+        gif
+	png
     )
 endif (ANDROID)
+
+
+if (OPENGL_ES)
+    target_link_libraries(openmw
+        ${OPENGLES_gl_LIBRARY}
+        ${OPENGLES2_gl_LIBRARY}
+    )
+endif (OPENGL_ES)
 
 if (USE_SYSTEM_TINYXML)
     target_link_libraries(openmw ${TINYXML_LIBRARIES})

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -181,7 +181,6 @@ endif (ANDROID)
 if (OPENGL_ES)
     target_link_libraries(openmw
         ${OPENGLES_gl_LIBRARY}
-        ${OPENGLES2_gl_LIBRARY}
     )
 endif (OPENGL_ES)
 

--- a/apps/openmw/android_main.c
+++ b/apps/openmw/android_main.c
@@ -1,4 +1,3 @@
-#include "../../SDL_internal.h"
 
 #ifdef __ANDROID__
 #include "SDL_main.h"

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -23,7 +23,7 @@
 #endif
 
 
-#if (defined(__APPLE__) || defined(__linux) || defined(__unix) || defined(__posix))
+#if (defined(__APPLE__) || (defined(__linux)  &&  !defined(ANDROID)) || (defined(__unix) &&  !defined(ANDROID)) || defined(__posix))
     #define USE_CRASH_CATCHER 1
 #else
     #define USE_CRASH_CATCHER 0

--- a/cmake/FindOpenGLES.cmake
+++ b/cmake/FindOpenGLES.cmake
@@ -1,0 +1,94 @@
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+# - Try to find OpenGLES
+# Once done this will define
+#  
+#  OPENGLES_FOUND        - system has OpenGLES
+#  OPENGLES_INCLUDE_DIR  - the GL include directory
+#  OPENGLES_LIBRARIES    - Link these to use OpenGLES
+
+IF (WIN32)
+  IF (CYGWIN)
+
+    FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h )
+
+    FIND_LIBRARY(OPENGLES_gl_LIBRARY libgles_cm )
+
+  ELSE (CYGWIN)
+
+    IF(BORLAND)
+      SET (OPENGLES_gl_LIBRARY import32 CACHE STRING "OpenGL ES 1.x library for win32")
+    ELSE(BORLAND)
+	  #MS compiler - todo - fix the following line:
+      SET (OPENGLES_gl_LIBRARY ${OGRE_SOURCE_DIR}/Dependencies/lib/release/libgles_cm.lib CACHE STRING "OpenGL ES 1.x library for win32")
+    ENDIF(BORLAND)
+
+  ENDIF (CYGWIN)
+
+ELSE (WIN32)
+
+  IF (APPLE)
+
+	#create_search_paths(/Developer/Platforms)
+	#findpkg_framework(OpenGLES)
+    #set(OPENGLES_gl_LIBRARY "-framework OpenGLES")
+
+  ELSE(APPLE)
+
+    FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h
+      /opt/vc/include
+      /opt/graphics/OpenGL/include
+      /usr/openwin/share/include
+      /usr/X11R6/include
+      /usr/include
+    )
+
+    FIND_LIBRARY(OPENGLES_gl_LIBRARY
+      NAMES GLES_CM GLESv1_CM
+      PATHS /opt/vc/lib
+            /opt/graphics/OpenGL/lib
+            /usr/openwin/lib
+            /usr/shlib /usr/X11R6/lib
+            /usr/lib
+    )
+
+    # On Unix OpenGL most certainly always requires X11.
+    # Feel free to tighten up these conditions if you don't 
+    # think this is always true.
+
+    #IF (OPENGLES_gl_LIBRARY)
+    #  IF(NOT X11_FOUND)
+    #    INCLUDE(FindX11)
+    #  ENDIF(NOT X11_FOUND)
+    #  IF (X11_FOUND)
+    #    SET (OPENGLES_LIBRARIES ${X11_LIBRARIES})
+    #  ENDIF (X11_FOUND)
+    #ENDIF (OPENGLES_gl_LIBRARY)
+
+  ENDIF(APPLE)
+ENDIF (WIN32)
+
+SET( OPENGLES_FOUND "NO" )
+IF(OPENGLES_gl_LIBRARY)
+
+    SET( OPENGLES_LIBRARIES ${OPENGLES_gl_LIBRARY} ${OPENGLES_LIBRARIES})
+
+    SET( OPENGLES_FOUND "YES" )
+
+ENDIF(OPENGLES_gl_LIBRARY)
+
+MARK_AS_ADVANCED(
+  OPENGLES_INCLUDE_DIR
+  OPENGLES_gl_LIBRARY
+)
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(OPENGLES REQUIRED_VARS OPENGLES_LIBRARIES OPENGLES_INCLUDE_DIR)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -139,7 +139,7 @@ add_component_dir (version
 set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui
     )
 
-if (NOT ANDROID)
+if (USE_QT)
     add_component_qt_dir (contentselector
         model/modelitem model/esmfile
         model/naturalsort model/contentmodel
@@ -176,55 +176,39 @@ include_directories(${BULLET_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(components STATIC ${COMPONENT_FILES} ${MOC_SRCS} ${ESM_UI_HDR})
 
-if (NOT ANDROID)
-    target_link_libraries(components 
-        ${Boost_SYSTEM_LIBRARY}
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_THREAD_LIBRARY}
-        ${Boost_PROGRAM_OPTIONS_LIBRARY}
-        ${OSG_LIBRARIES}
-        ${OPENTHREADS_LIBRARIES}
-        ${OSGPARTICLE_LIBRARIES}
-        ${OSGUTIL_LIBRARIES}
-        ${OSGDB_LIBRARIES}
-        ${OSGVIEWER_LIBRARIES}
-        ${OSGGA_LIBRARIES}
-        ${OSGFX_LIBRARIES}
-        ${OSGANIMATION_LIBRARIES}
-        ${BULLET_LIBRARIES}
-        ${SDL2_LIBRARY}
-        # For MyGUI platform
-        ${OPENGL_gl_LIBRARY}
-        ${MYGUI_LIBRARIES}
-        )
+if (OPENGL_ES)
+    set(GL_LIB ${OPENGLES_gl_LIBRARY})
 else()
-    target_link_libraries(components 
-        ${Boost_SYSTEM_LIBRARY}
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_THREAD_LIBRARY}
-        ${Boost_PROGRAM_OPTIONS_LIBRARY}
-        ${OSG_LIBRARIES}
-        ${OPENTHREADS_LIBRARIES}
-        ${OSGPARTICLE_LIBRARIES}
-        ${OSGUTIL_LIBRARIES}
-        ${OSGDB_LIBRARIES}
-        ${OSGVIEWER_LIBRARIES}
-        ${OSGGA_LIBRARIES}
-        ${OSGFX_LIBRARIES}
-        ${OSGANIMATION_LIBRARIES}
-        ${BULLET_LIBRARIES}
-        ${SDL2_LIBRARY}
-        # For MyGUI platform
-        ${MYGUI_LIBRARIES}
-        )
+    set(GL_LIB ${OPENGL_gl_LIBRARY})
 endif()
+
+target_link_libraries(components 
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${OSG_LIBRARIES}
+    ${OPENTHREADS_LIBRARIES}
+    ${OSGPARTICLE_LIBRARIES}
+    ${OSGUTIL_LIBRARIES}
+    ${OSGDB_LIBRARIES}
+    ${OSGVIEWER_LIBRARIES}
+    ${OSGGA_LIBRARIES}
+    ${OSGFX_LIBRARIES}
+    ${OSGANIMATION_LIBRARIES}
+    ${BULLET_LIBRARIES}
+    ${SDL2_LIBRARY}
+    # For MyGUI platform
+    ${GL_LIB}
+    ${MYGUI_LIBRARIES}
+    )
 
 if (WIN32)
     target_link_libraries(components
     ${Boost_LOCALE_LIBRARY})
 endif()
 
-if (NOT ANDROID)
+if (USE_QT)
     if (DESIRED_QT_VERSION MATCHES 4)
         target_link_libraries(components
         ${QT_QTCORE_LIBRARY}

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -20,7 +20,9 @@ else (GIT_CHECKOUT)
     configure_file(${VERSION_IN_FILE} ${VERSION_FILE})
 endif (GIT_CHECKOUT)
 
-find_package(OpenGL REQUIRED)
+if (NOT OPENGL_ES)
+    find_package(OpenGL REQUIRED)
+endif()
 
 # source files
 
@@ -137,29 +139,31 @@ add_component_dir (version
 set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui
     )
 
-add_component_qt_dir (contentselector
-    model/modelitem model/esmfile
-    model/naturalsort model/contentmodel
-    model/loadordererror
-    view/combobox view/contentselector
-    )
-add_component_qt_dir (config
-    gamesettings
-    launchersettings
-    settingsbase
-    )
+if (NOT ANDROID)
+    add_component_qt_dir (contentselector
+        model/modelitem model/esmfile
+        model/naturalsort model/contentmodel
+        model/loadordererror
+        view/combobox view/contentselector
+        )
+    add_component_qt_dir (config
+        gamesettings
+        launchersettings
+        settingsbase
+        )
 
-add_component_qt_dir (process
-    processinvoker
-)
+    add_component_qt_dir (process
+        processinvoker
+        )
 
-if (DESIRED_QT_VERSION MATCHES 4)
-    include(${QT_USE_FILE})
-    QT4_WRAP_UI(ESM_UI_HDR ${ESM_UI})
-    QT4_WRAP_CPP(MOC_SRCS ${COMPONENT_MOC_FILES})
-else()
-    QT5_WRAP_UI(ESM_UI_HDR ${ESM_UI})
-    QT5_WRAP_CPP(MOC_SRCS ${COMPONENT_MOC_FILES})
+    if (DESIRED_QT_VERSION MATCHES 4)
+        include(${QT_USE_FILE})
+        QT4_WRAP_UI(ESM_UI_HDR ${ESM_UI})
+        QT4_WRAP_CPP(MOC_SRCS ${COMPONENT_MOC_FILES})
+    else()
+        QT5_WRAP_UI(ESM_UI_HDR ${ESM_UI})
+        QT5_WRAP_CPP(MOC_SRCS ${COMPONENT_MOC_FILES})
+    endif()
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -172,38 +176,62 @@ include_directories(${BULLET_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(components STATIC ${COMPONENT_FILES} ${MOC_SRCS} ${ESM_UI_HDR})
 
-target_link_libraries(components 
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${OSG_LIBRARIES}
-    ${OPENTHREADS_LIBRARIES}
-    ${OSGPARTICLE_LIBRARIES}
-    ${OSGUTIL_LIBRARIES}
-    ${OSGDB_LIBRARIES}
-    ${OSGVIEWER_LIBRARIES}
-    ${OSGGA_LIBRARIES}
-    ${OSGFX_LIBRARIES}
-    ${OSGANIMATION_LIBRARIES}
-    ${BULLET_LIBRARIES}
-    ${SDL2_LIBRARY}
-    # For MyGUI platform
-    ${OPENGL_gl_LIBRARY}
-    ${MYGUI_LIBRARIES}
-)
+if (NOT ANDROID)
+    target_link_libraries(components 
+        ${Boost_SYSTEM_LIBRARY}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${OSG_LIBRARIES}
+        ${OPENTHREADS_LIBRARIES}
+        ${OSGPARTICLE_LIBRARIES}
+        ${OSGUTIL_LIBRARIES}
+        ${OSGDB_LIBRARIES}
+        ${OSGVIEWER_LIBRARIES}
+        ${OSGGA_LIBRARIES}
+        ${OSGFX_LIBRARIES}
+        ${OSGANIMATION_LIBRARIES}
+        ${BULLET_LIBRARIES}
+        ${SDL2_LIBRARY}
+        # For MyGUI platform
+        ${OPENGL_gl_LIBRARY}
+        ${MYGUI_LIBRARIES}
+        )
+else()
+    target_link_libraries(components 
+        ${Boost_SYSTEM_LIBRARY}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${OSG_LIBRARIES}
+        ${OPENTHREADS_LIBRARIES}
+        ${OSGPARTICLE_LIBRARIES}
+        ${OSGUTIL_LIBRARIES}
+        ${OSGDB_LIBRARIES}
+        ${OSGVIEWER_LIBRARIES}
+        ${OSGGA_LIBRARIES}
+        ${OSGFX_LIBRARIES}
+        ${OSGANIMATION_LIBRARIES}
+        ${BULLET_LIBRARIES}
+        ${SDL2_LIBRARY}
+        # For MyGUI platform
+        ${MYGUI_LIBRARIES}
+        )
+endif()
 
 if (WIN32)
     target_link_libraries(components
     ${Boost_LOCALE_LIBRARY})
 endif()
 
-if (DESIRED_QT_VERSION MATCHES 4)
-    target_link_libraries(components
-    ${QT_QTCORE_LIBRARY}
-    ${QT_QTGUI_LIBRARY})
-else()
-    qt5_use_modules(components Widgets Core)
+if (NOT ANDROID)
+    if (DESIRED_QT_VERSION MATCHES 4)
+        target_link_libraries(components
+        ${QT_QTCORE_LIBRARY}
+        ${QT_QTGUI_LIBRARY})
+    else()
+        qt5_use_modules(components Widgets Core)
+    endif()
 endif()
 
 if (GIT_CHECKOUT)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -20,7 +20,9 @@ else (GIT_CHECKOUT)
     configure_file(${VERSION_IN_FILE} ${VERSION_FILE})
 endif (GIT_CHECKOUT)
 
-if (NOT OPENGL_ES)
+if (OPENGL_ES)
+    find_package(OpenGLES REQUIRED)
+else()    
     find_package(OpenGL REQUIRED)
 endif()
 

--- a/components/sdlutil/sdlcursormanager.cpp
+++ b/components/sdlutil/sdlcursormanager.cpp
@@ -222,9 +222,6 @@ namespace SDLUtil
          #endif
 
         if (mCursorMap.find(name) != mCursorMap.end())
-             return;
-
-        if (mCursorMap.find(name) != mCursorMap.end())
             return;
 
         osg::ref_ptr<osg::Image> decompressed = decompress(image, static_cast<float>(rotDegrees));

--- a/components/sdlutil/sdlcursormanager.cpp
+++ b/components/sdlutil/sdlcursormanager.cpp
@@ -217,6 +217,13 @@ namespace SDLUtil
 
     void SDLCursorManager::_createCursorFromResource(const std::string& name, int rotDegrees, osg::Image* image, Uint8 size_x, Uint8 size_y, Uint8 hotspot_x, Uint8 hotspot_y)
     {
+         #ifdef ANDROID
+             return;
+         #endif
+
+        if (mCursorMap.find(name) != mCursorMap.end())
+             return;
+
         if (mCursorMap.find(name) != mCursorMap.end())
             return;
 

--- a/components/sdlutil/sdlgraphicswindow.cpp
+++ b/components/sdlutil/sdlgraphicswindow.cpp
@@ -92,7 +92,13 @@ void GraphicsWindowSDL2::init()
     // have to get the current one to be able to restore it afterward.
     SDL_Window *oldWin = SDL_GL_GetCurrentWindow();
     SDL_GLContext oldCtx = SDL_GL_GetCurrentContext();
-
+   
+#ifdef OPENGL_ES
+     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);    
+#endif
+    
     mContext = SDL_GL_CreateContext(mWindow);
     if(!mContext)
     {


### PR DESCRIPTION
In this PR set on GLES1 . It shows absolutely all objects, including water, sky , terrain. OSG must be build with GLES1 profile . SDL2 must be build wit gles1 .
PS : It works of course , only if set water shader to off in settings, because gles1 not support shaders , and textures of course must be unpacked , if videocard not support dxt compression.
It shows 60 fps on external locations in full-hd resolution. LOL . I use scrawl osg fork.