### PR TITLE
More audio cleanups and crash fix

### DIFF
--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -107,6 +107,14 @@ namespace MWBase
             virtual SoundPtr playTrack(const MWSound::DecoderPtr& decoder, PlayType type) = 0;
             ///< Play a 2D audio track, using a custom decoder
 
+            virtual void stopTrack(SoundPtr sound) = 0;
+            ///< Stop the given audio track from playing
+
+            virtual double getTrackTimeDelay(SoundPtr sound) = 0;
+            ///< Retives the time delay, in seconds, of the audio track (must be a sound
+            /// returned by \ref playTrack). Only intended to be called by the track
+            /// decoder's read method.
+
             virtual SoundPtr playSound(const std::string& soundId, float volume, float pitch,
                                        PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal,
                                        float offset=0) = 0;
@@ -122,6 +130,9 @@ namespace MWBase
             virtual MWBase::SoundPtr playSound3D(const osg::Vec3f& initialPos, const std::string& soundId,
                                                  float volume, float pitch, PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal, float offset=0) = 0;
             ///< Play a 3D sound at \a initialPos. If the sound should be moving, it must be updated using Sound::setPosition.
+
+            virtual void stopSound(SoundPtr sound) = 0;
+            ///< Stop the given sound from playing
 
             virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId) = 0;
             ///< Stop the given object from playing the given sound,

--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -15,6 +15,7 @@ namespace MWWorld
 namespace MWSound
 {
     class Sound;
+    class Stream;
     struct Sound_Decoder;
     typedef boost::shared_ptr<Sound_Decoder> DecoderPtr;
 }
@@ -22,6 +23,7 @@ namespace MWSound
 namespace MWBase
 {
     typedef boost::shared_ptr<MWSound::Sound> SoundPtr;
+    typedef boost::shared_ptr<MWSound::Stream> SoundStreamPtr;
 
     /// \brief Interface for sound manager (implemented in MWSound)
     class SoundManager
@@ -104,13 +106,13 @@ namespace MWBase
             /// and get an average loudness value (scale [0,1]) at the current time position.
             /// If the actor is not saying anything, returns 0.
 
-            virtual SoundPtr playTrack(const MWSound::DecoderPtr& decoder, PlayType type) = 0;
+            virtual SoundStreamPtr playTrack(const MWSound::DecoderPtr& decoder, PlayType type) = 0;
             ///< Play a 2D audio track, using a custom decoder
 
-            virtual void stopTrack(SoundPtr sound) = 0;
+            virtual void stopTrack(SoundStreamPtr stream) = 0;
             ///< Stop the given audio track from playing
 
-            virtual double getTrackTimeDelay(SoundPtr sound) = 0;
+            virtual double getTrackTimeDelay(SoundStreamPtr stream) = 0;
             ///< Retives the time delay, in seconds, of the audio track (must be a sound
             /// returned by \ref playTrack). Only intended to be called by the track
             /// decoder's read method.
@@ -166,7 +168,7 @@ namespace MWBase
 
             virtual void setListenerPosDir(const osg::Vec3f &pos, const osg::Vec3f &dir, const osg::Vec3f &up) = 0;
 
-            virtual void updatePtr (const MWWorld::Ptr& old, const MWWorld::Ptr& updated) = 0;
+            virtual void updatePtr(const MWWorld::Ptr& old, const MWWorld::Ptr& updated) = 0;
 
             virtual void clear() = 0;
     };

--- a/apps/openmw/mwsound/movieaudiofactory.cpp
+++ b/apps/openmw/mwsound/movieaudiofactory.cpp
@@ -61,7 +61,7 @@ namespace MWSound
         virtual double getAudioClock()
         {
             return (double)getSampleOffset()/(double)mAVStream->codec->sample_rate -
-                   mAudioTrack->getStreamDelay();
+                   MWBase::Environment::get().getSoundManager()->getTrackTimeDelay(mAudioTrack);
         }
 
         virtual void adjustAudioSettings(AVSampleFormat& sampleFormat, uint64_t& channelLayout, int& sampleRate)
@@ -86,6 +86,8 @@ namespace MWSound
     public:
         ~MovieAudioDecoder()
         {
+            if(mAudioTrack.get())
+                MWBase::Environment::get().getSoundManager()->stopTrack(mAudioTrack);
             mAudioTrack.reset();
             mDecoderBridge.reset();
         }

--- a/apps/openmw/mwsound/movieaudiofactory.cpp
+++ b/apps/openmw/mwsound/movieaudiofactory.cpp
@@ -92,7 +92,7 @@ namespace MWSound
             mDecoderBridge.reset();
         }
 
-        MWBase::SoundPtr mAudioTrack;
+        MWBase::SoundStreamPtr mAudioTrack;
         boost::shared_ptr<MWSoundDecoderBridge> mDecoderBridge;
     };
 
@@ -163,7 +163,8 @@ namespace MWSound
         boost::shared_ptr<MWSound::MovieAudioDecoder> decoder(new MWSound::MovieAudioDecoder(videoState));
         decoder->setupFormat();
 
-        MWBase::SoundPtr sound = MWBase::Environment::get().getSoundManager()->playTrack(decoder->mDecoderBridge, MWBase::SoundManager::Play_TypeMovie);
+        MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+        MWBase::SoundStreamPtr sound = sndMgr->playTrack(decoder->mDecoderBridge, MWBase::SoundManager::Play_TypeMovie);
         if (!sound.get())
         {
             decoder.reset();

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -776,9 +776,9 @@ bool OpenAL_Output::isSoundPlaying(MWBase::SoundPtr sound)
 }
 
 
-MWBase::SoundPtr OpenAL_Output::streamSound(DecoderPtr decoder, float basevol, float pitch, int flags)
+MWBase::SoundStreamPtr OpenAL_Output::streamSound(DecoderPtr decoder, float basevol, float pitch, int flags)
 {
-    boost::shared_ptr<Sound> sound;
+    MWBase::SoundStreamPtr sound;
     OpenAL_SoundStream *stream = 0;
     ALuint source;
 
@@ -810,7 +810,7 @@ MWBase::SoundPtr OpenAL_Output::streamSound(DecoderPtr decoder, float basevol, f
         alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
         throwALerror();
 
-        sound.reset(new Sound(osg::Vec3f(0.0f, 0.0f, 0.0f), 1.0f, basevol, pitch, 1.0f, 1000.0f, flags));
+        sound.reset(new Stream(osg::Vec3f(0.0f, 0.0f, 0.0f), 1.0f, basevol, pitch, 1.0f, 1000.0f, flags));
         stream = new OpenAL_SoundStream(source, decoder);
         mStreamThread->add(stream);
         sound->mHandle = stream;
@@ -826,9 +826,9 @@ MWBase::SoundPtr OpenAL_Output::streamSound(DecoderPtr decoder, float basevol, f
     return sound;
 }
 
-MWBase::SoundPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos, float volume, float basevol, float pitch, float mindist, float maxdist, int flags)
+MWBase::SoundStreamPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos, float volume, float basevol, float pitch, float mindist, float maxdist, int flags)
 {
-    boost::shared_ptr<Sound> sound;
+    MWBase::SoundStreamPtr sound;
     OpenAL_SoundStream *stream = 0;
     ALuint source;
 
@@ -862,7 +862,7 @@ MWBase::SoundPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const osg::Vec
         alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
         throwALerror();
 
-        sound.reset(new Sound(pos, volume, basevol, pitch, mindist, maxdist, flags));
+        sound.reset(new Stream(pos, volume, basevol, pitch, mindist, maxdist, flags));
         stream = new OpenAL_SoundStream(source, decoder);
         mStreamThread->add(stream);
         sound->mHandle = stream;
@@ -878,7 +878,7 @@ MWBase::SoundPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const osg::Vec
     return sound;
 }
 
-void OpenAL_Output::stopStream(MWBase::SoundPtr sound)
+void OpenAL_Output::stopStream(MWBase::SoundStreamPtr sound)
 {
     if(!sound->mHandle)
         return;
@@ -897,7 +897,7 @@ void OpenAL_Output::stopStream(MWBase::SoundPtr sound)
     delete stream;
 }
 
-double OpenAL_Output::getStreamDelay(MWBase::SoundPtr sound)
+double OpenAL_Output::getStreamDelay(MWBase::SoundStreamPtr sound)
 {
     if(!sound->mHandle)
         return 0.0;
@@ -905,7 +905,7 @@ double OpenAL_Output::getStreamDelay(MWBase::SoundPtr sound)
     return stream->getStreamDelay();
 }
 
-double OpenAL_Output::getStreamOffset(MWBase::SoundPtr sound)
+double OpenAL_Output::getStreamOffset(MWBase::SoundStreamPtr sound)
 {
     if(!sound->mHandle)
         return 0.0;
@@ -914,7 +914,7 @@ double OpenAL_Output::getStreamOffset(MWBase::SoundPtr sound)
     return stream->getStreamOffset();
 }
 
-bool OpenAL_Output::isStreamPlaying(MWBase::SoundPtr sound)
+bool OpenAL_Output::isStreamPlaying(MWBase::SoundStreamPtr sound)
 {
     if(!sound->mHandle)
         return false;

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -659,6 +659,8 @@ MWBase::SoundPtr OpenAL_Output::playSound(Sound_Handle data, float vol, float ba
     mFreeSources.pop_front();
 
     try {
+        sound.reset(new Sound(vol, basevol, pitch, flags));
+
         alSourcef(source, AL_REFERENCE_DISTANCE, 1.0f);
         alSourcef(source, AL_MAX_DISTANCE, 1000.0f);
         alSourcef(source, AL_ROLLOFF_FACTOR, 0.0f);
@@ -684,7 +686,6 @@ MWBase::SoundPtr OpenAL_Output::playSound(Sound_Handle data, float vol, float ba
         alSourcePlay(source);
         throwALerror();
 
-        sound.reset(new Sound(osg::Vec3f(0.f, 0.f, 0.f), vol, basevol, pitch, 1.0f, 1000.0f, flags));
         sound->mHandle = MAKE_PTRID(source);
         mActiveSounds.push_back(sound);
     }
@@ -708,6 +709,8 @@ MWBase::SoundPtr OpenAL_Output::playSound3D(Sound_Handle data, const osg::Vec3f 
     mFreeSources.pop_front();
 
     try {
+        sound.reset(new Sound(pos, vol, basevol, pitch, mindist, maxdist, flags));
+
         alSourcef(source, AL_REFERENCE_DISTANCE, mindist);
         alSourcef(source, AL_MAX_DISTANCE, maxdist);
         alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
@@ -735,7 +738,6 @@ MWBase::SoundPtr OpenAL_Output::playSound3D(Sound_Handle data, const osg::Vec3f 
         alSourcePlay(source);
         throwALerror();
 
-        sound.reset(new Sound(pos, vol, basevol, pitch, mindist, maxdist, flags));
         sound->mHandle = MAKE_PTRID(source);
         mActiveSounds.push_back(sound);
     }
@@ -817,6 +819,8 @@ MWBase::SoundStreamPtr OpenAL_Output::streamSound(DecoderPtr decoder, float base
     if((flags&MWBase::SoundManager::Play_Loop))
         std::cout <<"Warning: cannot loop stream \""<<decoder->getName()<<"\""<< std::endl;
     try {
+        sound.reset(new Stream(1.0f, basevol, pitch, flags));
+
         alSourcef(source, AL_REFERENCE_DISTANCE, 1.0f);
         alSourcef(source, AL_MAX_DISTANCE, 1000.0f);
         alSourcef(source, AL_ROLLOFF_FACTOR, 0.0f);
@@ -837,7 +841,6 @@ MWBase::SoundStreamPtr OpenAL_Output::streamSound(DecoderPtr decoder, float base
         alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
         throwALerror();
 
-        sound.reset(new Stream(osg::Vec3f(0.0f, 0.0f, 0.0f), 1.0f, basevol, pitch, 1.0f, 1000.0f, flags));
         stream = new OpenAL_SoundStream(source, decoder);
         mStreamThread->add(stream);
         sound->mHandle = stream;
@@ -867,6 +870,8 @@ MWBase::SoundStreamPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const os
     if((flags&MWBase::SoundManager::Play_Loop))
         std::cout <<"Warning: cannot loop stream \""<<decoder->getName()<<"\""<< std::endl;
     try {
+        sound.reset(new Stream(pos, volume, basevol, pitch, mindist, maxdist, flags));
+
         alSourcef(source, AL_REFERENCE_DISTANCE, mindist);
         alSourcef(source, AL_MAX_DISTANCE, maxdist);
         alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
@@ -889,7 +894,6 @@ MWBase::SoundStreamPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const os
         alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
         throwALerror();
 
-        sound.reset(new Stream(pos, volume, basevol, pitch, mindist, maxdist, flags));
         stream = new OpenAL_SoundStream(source, decoder);
         mStreamThread->add(stream);
         sound->mHandle = stream;

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -157,17 +157,14 @@ static ALenum getALFormat(ChannelConfig chans, SampleType type)
 //
 // A streaming OpenAL sound.
 //
-class OpenAL_SoundStream : public Sound
+class OpenAL_SoundStream
 {
     static const ALuint sNumBuffers = 6;
     static const ALfloat sBufferLength;
 
-protected:
-    OpenAL_Output &mOutput;
-
+private:
     ALuint mSource;
 
-private:
     ALuint mBuffers[sNumBuffers];
     ALint mCurrentBufIdx;
 
@@ -189,33 +186,17 @@ private:
     friend class OpenAL_Output;
 
 public:
-    OpenAL_SoundStream(OpenAL_Output &output, ALuint src, DecoderPtr decoder, const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags);
-    virtual ~OpenAL_SoundStream();
+    OpenAL_SoundStream(ALuint src, DecoderPtr decoder);
+    ~OpenAL_SoundStream();
 
-    virtual void stop();
-    virtual bool isPlaying();
-    virtual double getTimeOffset();
-    virtual double getStreamDelay() const;
-    virtual void applyUpdates();
+    bool isPlaying();
+    double getStreamDelay() const;
+    double getStreamOffset() const;
 
-    void play();
     bool process();
     ALint refillQueue();
 };
 const ALfloat OpenAL_SoundStream::sBufferLength = 0.125f;
-
-class OpenAL_SoundStream3D : public OpenAL_SoundStream
-{
-    OpenAL_SoundStream3D(const OpenAL_SoundStream3D &rhs);
-    OpenAL_SoundStream3D& operator=(const OpenAL_SoundStream3D &rhs);
-
-public:
-    OpenAL_SoundStream3D(OpenAL_Output &output, ALuint src, DecoderPtr decoder, const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
-      : OpenAL_SoundStream(output, src, decoder, pos, vol, basevol, pitch, mindist, maxdist, flags)
-    { }
-
-    virtual void applyUpdates();
-};
 
 
 //
@@ -329,13 +310,9 @@ private:
 };
 
 
-OpenAL_SoundStream::OpenAL_SoundStream(OpenAL_Output &output, ALuint src, DecoderPtr decoder, const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
-  : Sound(pos, vol, basevol, pitch, mindist, maxdist, flags)
-  , mOutput(output), mSource(src), mCurrentBufIdx(0), mFrameSize(0), mSilence(0)
-  , mDecoder(decoder), mIsFinished(true)
+OpenAL_SoundStream::OpenAL_SoundStream(ALuint src, DecoderPtr decoder)
+  : mSource(src), mCurrentBufIdx(0), mFrameSize(0), mSilence(0), mDecoder(decoder), mIsFinished(false)
 {
-    throwALerror();
-
     alGenBuffers(sNumBuffers, mBuffers);
     throwALerror();
     try
@@ -358,8 +335,6 @@ OpenAL_SoundStream::OpenAL_SoundStream(OpenAL_Output &output, ALuint src, Decode
         mFrameSize = framesToBytes(1, chans, type);
         mBufferSize = static_cast<ALuint>(sBufferLength*srate);
         mBufferSize *= mFrameSize;
-
-        mOutput.mActiveStreams.push_back(this);
     }
     catch(std::exception&)
     {
@@ -367,84 +342,26 @@ OpenAL_SoundStream::OpenAL_SoundStream(OpenAL_Output &output, ALuint src, Decode
         alGetError();
         throw;
     }
+    mIsFinished = false;
 }
 OpenAL_SoundStream::~OpenAL_SoundStream()
 {
-    mOutput.mStreamThread->remove(this);
-
-    alSourceStop(mSource);
-    alSourcei(mSource, AL_BUFFER, 0);
-
-    mOutput.mFreeSources.push_back(mSource);
     alDeleteBuffers(sNumBuffers, mBuffers);
     alGetError();
 
     mDecoder->close();
-
-    mOutput.mActiveStreams.erase(std::find(mOutput.mActiveStreams.begin(),
-                                           mOutput.mActiveStreams.end(), this));
-}
-
-void OpenAL_SoundStream::play()
-{
-    alSourceStop(mSource);
-    alSourcei(mSource, AL_BUFFER, 0);
-    throwALerror();
-
-    mIsFinished = false;
-    mOutput.mStreamThread->add(this);
-}
-
-void OpenAL_SoundStream::stop()
-{
-    mOutput.mStreamThread->remove(this);
-    mIsFinished = true;
-
-    alSourceStop(mSource);
-    alSourcei(mSource, AL_BUFFER, 0);
-    throwALerror();
-
-    mDecoder->rewind();
 }
 
 bool OpenAL_SoundStream::isPlaying()
 {
     ALint state;
 
-    boost::lock_guard<boost::mutex> lock(mOutput.mStreamThread->mMutex);
     alGetSourcei(mSource, AL_SOURCE_STATE, &state);
     throwALerror();
 
     if(state == AL_PLAYING || state == AL_PAUSED)
         return true;
     return !mIsFinished;
-}
-
-double OpenAL_SoundStream::getTimeOffset()
-{
-    ALint state = AL_STOPPED;
-    ALint offset;
-    double t;
-
-    boost::lock_guard<boost::mutex> lock(mOutput.mStreamThread->mMutex);
-    alGetSourcei(mSource, AL_SAMPLE_OFFSET, &offset);
-    alGetSourcei(mSource, AL_SOURCE_STATE, &state);
-    if(state == AL_PLAYING || state == AL_PAUSED)
-    {
-        ALint queued;
-        alGetSourcei(mSource, AL_BUFFERS_QUEUED, &queued);
-        ALint inqueue = mBufferSize/mFrameSize*queued - offset;
-        t = (double)(mDecoder->getSampleOffset() - inqueue) / (double)mSampleRate;
-    }
-    else
-    {
-        /* Underrun, or not started yet. The decoder offset is where we'll play
-         * next. */
-        t = (double)mDecoder->getSampleOffset() / (double)mSampleRate;
-    }
-
-    throwALerror();
-    return t;
 }
 
 double OpenAL_SoundStream::getStreamDelay() const
@@ -467,41 +384,30 @@ double OpenAL_SoundStream::getStreamDelay() const
     return d;
 }
 
-void OpenAL_SoundStream::updateAll(bool local)
+double OpenAL_SoundStream::getStreamOffset() const
 {
-    alSourcef(mSource, AL_REFERENCE_DISTANCE, mMinDistance);
-    alSourcef(mSource, AL_MAX_DISTANCE, mMaxDistance);
-    if(local)
+    ALint state = AL_STOPPED;
+    ALint offset;
+    double t;
+
+    alGetSourcei(mSource, AL_SAMPLE_OFFSET, &offset);
+    alGetSourcei(mSource, AL_SOURCE_STATE, &state);
+    if(state == AL_PLAYING || state == AL_PAUSED)
     {
-        alSourcef(mSource, AL_ROLLOFF_FACTOR, 0.0f);
-        alSourcei(mSource, AL_SOURCE_RELATIVE, AL_TRUE);
+        ALint queued;
+        alGetSourcei(mSource, AL_BUFFERS_QUEUED, &queued);
+        ALint inqueue = mBufferSize/mFrameSize*queued - offset;
+        t = (double)(mDecoder->getSampleOffset() - inqueue) / (double)mSampleRate;
     }
     else
     {
-        alSourcef(mSource, AL_ROLLOFF_FACTOR, 1.0f);
-        alSourcei(mSource, AL_SOURCE_RELATIVE, AL_FALSE);
-    }
-    alSourcei(mSource, AL_LOOPING, AL_FALSE);
-
-    applyUpdates();
-}
-
-void OpenAL_SoundStream::applyUpdates()
-{
-    ALfloat gain = mVolume*mBaseVolume;
-    ALfloat pitch = mPitch;
-    if(!(mFlags&MWBase::SoundManager::Play_NoEnv) && mOutput.mLastEnvironment == Env_Underwater)
-    {
-        gain *= 0.9f;
-        pitch *= 0.7f;
+        /* Underrun, or not started yet. The decoder offset is where we'll play
+         * next. */
+        t = (double)mDecoder->getSampleOffset() / (double)mSampleRate;
     }
 
-    alSourcef(mSource, AL_GAIN, gain);
-    alSourcef(mSource, AL_PITCH, pitch);
-    alSource3f(mSource, AL_POSITION, mPos[0], mPos[1], mPos[2]);
-    alSource3f(mSource, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
-    alSource3f(mSource, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
     throwALerror();
+    return t;
 }
 
 bool OpenAL_SoundStream::process()
@@ -560,172 +466,6 @@ ALint OpenAL_SoundStream::refillQueue()
     }
 
     return queued;
-}
-
-void OpenAL_SoundStream3D::applyUpdates()
-{
-    ALfloat gain = mVolume*mBaseVolume;
-    ALfloat pitch = mPitch;
-    if((mPos - mOutput.mPos).length2() > mMaxDistance*mMaxDistance)
-        gain = 0.0f;
-    else if(!(mFlags&MWBase::SoundManager::Play_NoEnv) && mOutput.mLastEnvironment == Env_Underwater)
-    {
-        gain *= 0.9f;
-        pitch *= 0.7f;
-    }
-
-    alSourcef(mSource, AL_GAIN, gain);
-    alSourcef(mSource, AL_PITCH, pitch);
-    alSource3f(mSource, AL_POSITION, mPos[0], mPos[1], mPos[2]);
-    alSource3f(mSource, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
-    alSource3f(mSource, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
-    throwALerror();
-}
-
-
-//
-// A regular 2D OpenAL sound
-//
-class OpenAL_Sound : public Sound
-{
-protected:
-    OpenAL_Output &mOutput;
-
-    ALuint mSource;
-
-    friend class OpenAL_Output;
-
-    void updateAll(bool local);
-
-private:
-    OpenAL_Sound(const OpenAL_Sound &rhs);
-    OpenAL_Sound& operator=(const OpenAL_Sound &rhs);
-
-public:
-    OpenAL_Sound(OpenAL_Output &output, ALuint src, const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags);
-    virtual ~OpenAL_Sound();
-
-    virtual void stop();
-    virtual bool isPlaying();
-    virtual double getTimeOffset();
-    virtual void applyUpdates();
-};
-
-//
-// A regular 3D OpenAL sound
-//
-class OpenAL_Sound3D : public OpenAL_Sound
-{
-    OpenAL_Sound3D(const OpenAL_Sound &rhs);
-    OpenAL_Sound3D& operator=(const OpenAL_Sound &rhs);
-
-public:
-    OpenAL_Sound3D(OpenAL_Output &output, ALuint src, const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
-      : OpenAL_Sound(output, src, pos, vol, basevol, pitch, mindist, maxdist, flags)
-    { }
-
-    virtual void applyUpdates();
-};
-
-OpenAL_Sound::OpenAL_Sound(OpenAL_Output &output, ALuint src, const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
-  : Sound(pos, vol, basevol, pitch, mindist, maxdist, flags)
-  , mOutput(output), mSource(src)
-{
-    mOutput.mActiveSounds.push_back(this);
-}
-OpenAL_Sound::~OpenAL_Sound()
-{
-    alSourceStop(mSource);
-    alSourcei(mSource, AL_BUFFER, 0);
-
-    mOutput.mFreeSources.push_back(mSource);
-
-    mOutput.mActiveSounds.erase(std::find(mOutput.mActiveSounds.begin(),
-                                          mOutput.mActiveSounds.end(), this));
-}
-
-void OpenAL_Sound::stop()
-{
-    alSourceStop(mSource);
-    throwALerror();
-}
-
-bool OpenAL_Sound::isPlaying()
-{
-    ALint state;
-
-    alGetSourcei(mSource, AL_SOURCE_STATE, &state);
-    throwALerror();
-
-    return state==AL_PLAYING || state==AL_PAUSED;
-}
-
-double OpenAL_Sound::getTimeOffset()
-{
-    ALfloat t;
-
-    alGetSourcef(mSource, AL_SEC_OFFSET, &t);
-    throwALerror();
-
-    return t;
-}
-
-void OpenAL_Sound::updateAll(bool local)
-{
-    alSourcef(mSource, AL_REFERENCE_DISTANCE, mMinDistance);
-    alSourcef(mSource, AL_MAX_DISTANCE, mMaxDistance);
-    if(local)
-    {
-        alSourcef(mSource, AL_ROLLOFF_FACTOR, 0.0f);
-        alSourcei(mSource, AL_SOURCE_RELATIVE, AL_TRUE);
-    }
-    else
-    {
-        alSourcef(mSource, AL_ROLLOFF_FACTOR, 1.0f);
-        alSourcei(mSource, AL_SOURCE_RELATIVE, AL_FALSE);
-    }
-    alSourcei(mSource, AL_LOOPING, (mFlags&MWBase::SoundManager::Play_Loop) ? AL_TRUE : AL_FALSE);
-
-    applyUpdates();
-}
-
-void OpenAL_Sound::applyUpdates()
-{
-    ALfloat gain = mVolume*mBaseVolume;
-    ALfloat pitch = mPitch;
-
-    if(!(mFlags&MWBase::SoundManager::Play_NoEnv) && mOutput.mLastEnvironment == Env_Underwater)
-    {
-        gain *= 0.9f;
-        pitch *= 0.7f;
-    }
-
-    alSourcef(mSource, AL_GAIN, gain);
-    alSourcef(mSource, AL_PITCH, pitch);
-    alSource3f(mSource, AL_POSITION, mPos[0], mPos[1], mPos[2]);
-    alSource3f(mSource, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
-    alSource3f(mSource, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
-    throwALerror();
-}
-
-void OpenAL_Sound3D::applyUpdates()
-{
-    ALfloat gain = mVolume*mBaseVolume;
-    ALfloat pitch = mPitch;
-    if((mPos - mOutput.mPos).length2() > mMaxDistance*mMaxDistance)
-        gain = 0.0f;
-    else if(!(mFlags&MWBase::SoundManager::Play_NoEnv) && mOutput.mLastEnvironment == Env_Underwater)
-    {
-        gain *= 0.9f;
-        pitch *= 0.7f;
-    }
-
-    alSourcef(mSource, AL_GAIN, gain);
-    alSourcef(mSource, AL_PITCH, pitch);
-    alSource3f(mSource, AL_POSITION, mPos[0], mPos[1], mPos[2]);
-    alSource3f(mSource, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
-    alSource3f(mSource, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
-    throwALerror();
 }
 
 
@@ -881,15 +621,16 @@ void OpenAL_Output::unloadSound(Sound_Handle data)
     SoundVec::const_iterator iter = mActiveSounds.begin();
     for(;iter != mActiveSounds.end();++iter)
     {
-        if(!(*iter)->mSource)
+        if(!(*iter)->mHandle)
             continue;
 
+        ALuint source = GET_PTRID((*iter)->mHandle);
         ALint srcbuf;
-        alGetSourcei((*iter)->mSource, AL_BUFFER, &srcbuf);
+        alGetSourcei(source, AL_BUFFER, &srcbuf);
         if((ALuint)srcbuf == buffer)
         {
-            alSourceStop((*iter)->mSource);
-            alSourcei((*iter)->mSource, AL_BUFFER, 0);
+            alSourceStop(source);
+            alSourcei(source, AL_BUFFER, 0);
         }
     }
     alDeleteBuffers(1, &buffer);
@@ -907,121 +648,279 @@ size_t OpenAL_Output::getSoundDataSize(Sound_Handle data) const
 }
 
 
-MWBase::SoundPtr OpenAL_Output::playSound(Sound_Handle data, float vol, float basevol, float pitch, int flags,float offset)
+MWBase::SoundPtr OpenAL_Output::playSound(Sound_Handle data, float vol, float basevol, float pitch, int flags, float offset)
 {
-    boost::shared_ptr<OpenAL_Sound> sound;
-    ALuint src;
+    boost::shared_ptr<Sound> sound;
+    ALuint source;
 
     if(mFreeSources.empty())
         fail("No free sources");
-    src = mFreeSources.front();
+    source = mFreeSources.front();
     mFreeSources.pop_front();
 
     try {
-        sound.reset(new OpenAL_Sound(*this, src, osg::Vec3f(0.f, 0.f, 0.f), vol, basevol, pitch, 1.0f, 1000.0f, flags));
+        alSourcef(source, AL_REFERENCE_DISTANCE, 1.0f);
+        alSourcef(source, AL_MAX_DISTANCE, 1000.0f);
+        alSourcef(source, AL_ROLLOFF_FACTOR, 0.0f);
+        alSourcei(source, AL_SOURCE_RELATIVE, AL_TRUE);
+        alSourcei(source, AL_LOOPING, (flags&MWBase::SoundManager::Play_Loop) ? AL_TRUE : AL_FALSE);
+
+        ALfloat gain = vol*basevol;
+        if(!(flags&MWBase::SoundManager::Play_NoEnv) && mLastEnvironment == Env_Underwater)
+        {
+            gain *= 0.9f;
+            pitch *= 0.7f;
+        }
+
+        alSourcef(source, AL_GAIN, gain);
+        alSourcef(source, AL_PITCH, pitch);
+        alSource3f(source, AL_POSITION, 0.0f, 0.0f, 0.0f);
+        alSource3f(source, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
+        alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
+
+        alSourcef(source, AL_SEC_OFFSET, offset/pitch);
+        alSourcei(source, AL_BUFFER, GET_PTRID(data));
+
+        alSourcePlay(source);
+        throwALerror();
+
+        sound.reset(new Sound(osg::Vec3f(0.f, 0.f, 0.f), vol, basevol, pitch, 1.0f, 1000.0f, flags));
+        sound->mHandle = MAKE_PTRID(source);
+        mActiveSounds.push_back(sound);
     }
-    catch(std::exception&)
-    {
-        mFreeSources.push_back(src);
+    catch(std::exception&) {
+        mFreeSources.push_back(source);
         throw;
     }
-
-    sound->updateAll(true);
-    alSourcei(src, AL_BUFFER, GET_PTRID(data));
-    alSourcef(src, AL_SEC_OFFSET, offset/pitch);
-
-    alSourcePlay(src);
-    throwALerror();
 
     return sound;
 }
 
 MWBase::SoundPtr OpenAL_Output::playSound3D(Sound_Handle data, const osg::Vec3f &pos, float vol, float basevol, float pitch,
-                                            float min, float max, int flags, float offset)
+                                            float mindist, float maxdist, int flags, float offset)
 {
-    boost::shared_ptr<OpenAL_Sound> sound;
-    ALuint src;
+    boost::shared_ptr<Sound> sound;
+    ALuint source;
 
     if(mFreeSources.empty())
         fail("No free sources");
-    src = mFreeSources.front();
+    source = mFreeSources.front();
     mFreeSources.pop_front();
 
     try {
-        sound.reset(new OpenAL_Sound3D(*this, src, pos, vol, basevol, pitch, min, max, flags));
+        alSourcef(source, AL_REFERENCE_DISTANCE, mindist);
+        alSourcef(source, AL_MAX_DISTANCE, maxdist);
+        alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
+        alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
+        alSourcei(source, AL_LOOPING, (flags&MWBase::SoundManager::Play_Loop) ? AL_TRUE : AL_FALSE);
+
+        ALfloat gain = vol*basevol;
+        if((pos - mPos).length2() > maxdist*maxdist)
+            gain = 0.0f;
+        if(!(flags&MWBase::SoundManager::Play_NoEnv) && mLastEnvironment == Env_Underwater)
+        {
+            gain *= 0.9f;
+            pitch *= 0.7f;
+        }
+
+        alSourcef(source, AL_GAIN, gain);
+        alSourcef(source, AL_PITCH, pitch);
+        alSourcefv(source, AL_POSITION, pos.ptr());
+        alSource3f(source, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
+        alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
+
+        alSourcef(source, AL_SEC_OFFSET, offset/pitch);
+        alSourcei(source, AL_BUFFER, GET_PTRID(data));
+
+        alSourcePlay(source);
+        throwALerror();
+
+        sound.reset(new Sound(pos, vol, basevol, pitch, mindist, maxdist, flags));
+        sound->mHandle = MAKE_PTRID(source);
+        mActiveSounds.push_back(sound);
     }
-    catch(std::exception&)
-    {
-        mFreeSources.push_back(src);
+    catch(std::exception&) {
+        mFreeSources.push_back(source);
         throw;
     }
 
-    sound->updateAll(false);
-    alSourcei(src, AL_BUFFER, GET_PTRID(data));
-    alSourcef(src, AL_SEC_OFFSET, offset/pitch);
+    return sound;
+}
 
-    alSourcePlay(src);
+void OpenAL_Output::stopSound(MWBase::SoundPtr sound)
+{
+    if(!sound->mHandle)
+        return;
+
+    ALuint source = GET_PTRID(sound->mHandle);
+    sound->mHandle = 0;
+
+    alSourceStop(source);
+    alSourcei(source, AL_BUFFER, 0);
+
+    mFreeSources.push_back(source);
+    mActiveSounds.erase(std::find(mActiveSounds.begin(), mActiveSounds.end(), sound));
+}
+
+bool OpenAL_Output::isSoundPlaying(MWBase::SoundPtr sound)
+{
+    if(!sound->mHandle)
+        return false;
+    ALuint source = GET_PTRID(sound->mHandle);
+    ALint state;
+
+    alGetSourcei(source, AL_SOURCE_STATE, &state);
     throwALerror();
 
-    return sound;
+    return state == AL_PLAYING || state == AL_PAUSED;
 }
 
 
 MWBase::SoundPtr OpenAL_Output::streamSound(DecoderPtr decoder, float basevol, float pitch, int flags)
 {
-    boost::shared_ptr<OpenAL_SoundStream> sound;
-    ALuint src;
+    boost::shared_ptr<Sound> sound;
+    OpenAL_SoundStream *stream = 0;
+    ALuint source;
 
     if(mFreeSources.empty())
         fail("No free sources");
-    src = mFreeSources.front();
+    source = mFreeSources.front();
     mFreeSources.pop_front();
 
     if((flags&MWBase::SoundManager::Play_Loop))
         std::cout <<"Warning: cannot loop stream \""<<decoder->getName()<<"\""<< std::endl;
-    try
-    {
-        sound.reset(new OpenAL_SoundStream(*this, src, decoder, osg::Vec3f(0.0f, 0.0f, 0.0f), 1.0f, basevol, pitch, 1.0f, 1000.0f, flags));
+    try {
+        alSourcef(source, AL_REFERENCE_DISTANCE, 1.0f);
+        alSourcef(source, AL_MAX_DISTANCE, 1000.0f);
+        alSourcef(source, AL_ROLLOFF_FACTOR, 0.0f);
+        alSourcei(source, AL_SOURCE_RELATIVE, AL_TRUE);
+        alSourcei(source, AL_LOOPING, AL_FALSE);
+
+        ALfloat gain = basevol;
+        if(!(flags&MWBase::SoundManager::Play_NoEnv) && mLastEnvironment == Env_Underwater)
+        {
+            gain *= 0.9f;
+            pitch *= 0.7f;
+        }
+
+        alSourcef(source, AL_GAIN, gain);
+        alSourcef(source, AL_PITCH, pitch);
+        alSource3f(source, AL_POSITION, 0.0f, 0.0f, 0.0f);
+        alSource3f(source, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
+        alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
+        throwALerror();
+
+        sound.reset(new Sound(osg::Vec3f(0.0f, 0.0f, 0.0f), 1.0f, basevol, pitch, 1.0f, 1000.0f, flags));
+        stream = new OpenAL_SoundStream(source, decoder);
+        mStreamThread->add(stream);
+        sound->mHandle = stream;
+        mActiveStreams.push_back(sound);
     }
-    catch(std::exception&)
-    {
-        mFreeSources.push_back(src);
+    catch(std::exception&) {
+        mStreamThread->remove(stream);
+        delete stream;
+        mFreeSources.push_back(source);
         throw;
     }
 
-    sound->updateAll(true);
-
-    sound->play();
     return sound;
 }
 
-
-MWBase::SoundPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos, float volume, float basevol, float pitch, float min, float max, int flags)
+MWBase::SoundPtr OpenAL_Output::streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos, float volume, float basevol, float pitch, float mindist, float maxdist, int flags)
 {
-    boost::shared_ptr<OpenAL_SoundStream> sound;
-    ALuint src;
+    boost::shared_ptr<Sound> sound;
+    OpenAL_SoundStream *stream = 0;
+    ALuint source;
 
     if(mFreeSources.empty())
         fail("No free sources");
-    src = mFreeSources.front();
+    source = mFreeSources.front();
     mFreeSources.pop_front();
 
     if((flags&MWBase::SoundManager::Play_Loop))
         std::cout <<"Warning: cannot loop stream \""<<decoder->getName()<<"\""<< std::endl;
-    try
-    {
-        sound.reset(new OpenAL_SoundStream3D(*this, src, decoder, pos, volume, basevol, pitch, min, max, flags));
+    try {
+        alSourcef(source, AL_REFERENCE_DISTANCE, mindist);
+        alSourcef(source, AL_MAX_DISTANCE, maxdist);
+        alSourcef(source, AL_ROLLOFF_FACTOR, 1.0f);
+        alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
+        alSourcei(source, AL_LOOPING, AL_FALSE);
+
+        ALfloat gain = volume*basevol;
+        if((pos - mPos).length2() > maxdist*maxdist)
+            gain = 0.0f;
+        if(!(flags&MWBase::SoundManager::Play_NoEnv) && mLastEnvironment == Env_Underwater)
+        {
+            gain *= 0.9f;
+            pitch *= 0.7f;
+        }
+
+        alSourcef(source, AL_GAIN, gain);
+        alSourcef(source, AL_PITCH, pitch);
+        alSourcefv(source, AL_POSITION, pos.ptr());
+        alSource3f(source, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
+        alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
+        throwALerror();
+
+        sound.reset(new Sound(pos, volume, basevol, pitch, mindist, maxdist, flags));
+        stream = new OpenAL_SoundStream(source, decoder);
+        mStreamThread->add(stream);
+        sound->mHandle = stream;
+        mActiveStreams.push_back(sound);
     }
-    catch(std::exception&)
-    {
-        mFreeSources.push_back(src);
+    catch(std::exception&) {
+        mStreamThread->remove(stream);
+        delete stream;
+        mFreeSources.push_back(source);
         throw;
     }
 
-    sound->updateAll(false);
-
-    sound->play();
     return sound;
+}
+
+void OpenAL_Output::stopStream(MWBase::SoundPtr sound)
+{
+    if(!sound->mHandle)
+        return;
+    OpenAL_SoundStream *stream = reinterpret_cast<OpenAL_SoundStream*>(sound->mHandle);
+    ALuint source = stream->mSource;
+
+    sound->mHandle = 0;
+    mStreamThread->remove(stream);
+
+    alSourceStop(source);
+    alSourcei(source, AL_BUFFER, 0);
+
+    mFreeSources.push_back(source);
+    mActiveStreams.erase(std::find(mActiveStreams.begin(), mActiveStreams.end(), sound));
+
+    delete stream;
+}
+
+double OpenAL_Output::getStreamDelay(MWBase::SoundPtr sound)
+{
+    if(!sound->mHandle)
+        return 0.0;
+    OpenAL_SoundStream *stream = reinterpret_cast<OpenAL_SoundStream*>(sound->mHandle);
+    return stream->getStreamDelay();
+}
+
+double OpenAL_Output::getStreamOffset(MWBase::SoundPtr sound)
+{
+    if(!sound->mHandle)
+        return 0.0;
+    OpenAL_SoundStream *stream = reinterpret_cast<OpenAL_SoundStream*>(sound->mHandle);
+    boost::lock_guard<boost::mutex> lock(mStreamThread->mMutex);
+    return stream->getStreamOffset();
+}
+
+bool OpenAL_Output::isStreamPlaying(MWBase::SoundPtr sound)
+{
+    if(!sound->mHandle)
+        return false;
+    OpenAL_SoundStream *stream = reinterpret_cast<OpenAL_SoundStream*>(sound->mHandle);
+    boost::lock_guard<boost::mutex> lock(mStreamThread->mMutex);
+    return stream->isPlaying();
 }
 
 
@@ -1060,14 +959,17 @@ void OpenAL_Output::pauseSounds(int types)
     SoundVec::const_iterator sound = mActiveSounds.begin();
     for(;sound != mActiveSounds.end();++sound)
     {
-        if(*sound && (*sound)->mSource && ((*sound)->getPlayType()&types))
-            sources.push_back((*sound)->mSource);
+        if(*sound && (*sound)->mHandle && ((*sound)->getPlayType()&types))
+            sources.push_back(GET_PTRID((*sound)->mHandle));
     }
     StreamVec::const_iterator stream = mActiveStreams.begin();
     for(;stream != mActiveStreams.end();++stream)
     {
-        if(*stream && (*stream)->mSource && ((*stream)->getPlayType()&types))
-            sources.push_back((*stream)->mSource);
+        if(*stream && (*stream)->mHandle && ((*stream)->getPlayType()&types))
+        {
+            OpenAL_SoundStream *strm = reinterpret_cast<OpenAL_SoundStream*>((*stream)->mHandle);
+            sources.push_back(strm->mSource);
+        }
     }
     if(!sources.empty())
     {
@@ -1082,14 +984,17 @@ void OpenAL_Output::resumeSounds(int types)
     SoundVec::const_iterator sound = mActiveSounds.begin();
     for(;sound != mActiveSounds.end();++sound)
     {
-        if(*sound && (*sound)->mSource && ((*sound)->getPlayType()&types))
-            sources.push_back((*sound)->mSource);
+        if(*sound && (*sound)->mHandle && ((*sound)->getPlayType()&types))
+            sources.push_back(GET_PTRID((*sound)->mHandle));
     }
     StreamVec::const_iterator stream = mActiveStreams.begin();
     for(;stream != mActiveStreams.end();++stream)
     {
-        if(*stream && (*stream)->mSource && ((*stream)->getPlayType()&types))
-            sources.push_back((*stream)->mSource);
+        if(*stream && (*stream)->mHandle && ((*stream)->getPlayType()&types))
+        {
+            OpenAL_SoundStream *strm = reinterpret_cast<OpenAL_SoundStream*>((*stream)->mHandle);
+            sources.push_back(strm->mSource);
+        }
     }
     if(!sources.empty())
     {

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -26,7 +26,7 @@ namespace MWSound
 
         typedef std::vector<MWBase::SoundPtr> SoundVec;
         SoundVec mActiveSounds;
-        typedef std::vector<MWBase::SoundPtr> StreamVec;
+        typedef std::vector<MWBase::SoundStreamPtr> StreamVec;
         StreamVec mActiveStreams;
 
         Environment mLastEnvironment;
@@ -45,13 +45,13 @@ namespace MWSound
         virtual void stopSound(MWBase::SoundPtr sound);
         virtual bool isSoundPlaying(MWBase::SoundPtr sound);
 
-        virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags);
-        virtual MWBase::SoundPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
-                                               float vol, float basevol, float pitch, float min, float max, int flags);
-        virtual void stopStream(MWBase::SoundPtr sound);
-        virtual double getStreamDelay(MWBase::SoundPtr sound);
-        virtual double getStreamOffset(MWBase::SoundPtr sound);
-        virtual bool isStreamPlaying(MWBase::SoundPtr sound);
+        virtual MWBase::SoundStreamPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags);
+        virtual MWBase::SoundStreamPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
+                                                     float vol, float basevol, float pitch, float min, float max, int flags);
+        virtual void stopStream(MWBase::SoundStreamPtr sound);
+        virtual double getStreamDelay(MWBase::SoundStreamPtr sound);
+        virtual double getStreamOffset(MWBase::SoundStreamPtr sound);
+        virtual bool isStreamPlaying(MWBase::SoundStreamPtr sound);
 
         virtual void startUpdate();
         virtual void finishUpdate();

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -53,9 +53,8 @@ namespace MWSound
         virtual bool isSoundPlaying(MWBase::SoundPtr sound);
         virtual void updateSound(MWBase::SoundPtr sound);
 
-        virtual MWBase::SoundStreamPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags);
-        virtual MWBase::SoundStreamPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
-                                                     float vol, float basevol, float pitch, float min, float max, int flags);
+        virtual void streamSound(DecoderPtr decoder, MWBase::SoundStreamPtr sound);
+        virtual void streamSound3D(DecoderPtr decoder, MWBase::SoundStreamPtr sound);
         virtual void stopStream(MWBase::SoundStreamPtr sound);
         virtual double getStreamDelay(MWBase::SoundStreamPtr sound);
         virtual double getStreamOffset(MWBase::SoundStreamPtr sound);

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -52,6 +52,7 @@ namespace MWSound
                                              float vol, float basevol, float pitch, float min, float max, int flags, float offset);
         virtual void stopSound(MWBase::SoundPtr sound);
         virtual bool isSoundPlaying(MWBase::SoundPtr sound);
+        virtual void updateSound(MWBase::SoundPtr sound);
 
         virtual MWBase::SoundStreamPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags);
         virtual MWBase::SoundStreamPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
@@ -60,6 +61,7 @@ namespace MWSound
         virtual double getStreamDelay(MWBase::SoundStreamPtr sound);
         virtual double getStreamOffset(MWBase::SoundStreamPtr sound);
         virtual bool isStreamPlaying(MWBase::SoundStreamPtr sound);
+        virtual void updateStream(MWBase::SoundStreamPtr sound);
 
         virtual void startUpdate();
         virtual void finishUpdate();

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -16,9 +16,6 @@ namespace MWSound
     class SoundManager;
     class Sound;
 
-    class OpenAL_Sound;
-    class OpenAL_SoundStream;
-
     class OpenAL_Output : public Sound_Output
     {
         ALCdevice *mDevice;
@@ -27,9 +24,9 @@ namespace MWSound
         typedef std::deque<ALuint> IDDq;
         IDDq mFreeSources;
 
-        typedef std::vector<OpenAL_Sound*> SoundVec;
+        typedef std::vector<MWBase::SoundPtr> SoundVec;
         SoundVec mActiveSounds;
-        typedef std::vector<OpenAL_SoundStream*> StreamVec;
+        typedef std::vector<MWBase::SoundPtr> StreamVec;
         StreamVec mActiveStreams;
 
         Environment mLastEnvironment;
@@ -45,9 +42,16 @@ namespace MWSound
         virtual MWBase::SoundPtr playSound(Sound_Handle data, float vol, float basevol, float pitch, int flags, float offset);
         virtual MWBase::SoundPtr playSound3D(Sound_Handle data, const osg::Vec3f &pos,
                                              float vol, float basevol, float pitch, float min, float max, int flags, float offset);
+        virtual void stopSound(MWBase::SoundPtr sound);
+        virtual bool isSoundPlaying(MWBase::SoundPtr sound);
+
         virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags);
         virtual MWBase::SoundPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
                                                float vol, float basevol, float pitch, float min, float max, int flags);
+        virtual void stopStream(MWBase::SoundPtr sound);
+        virtual double getStreamDelay(MWBase::SoundPtr sound);
+        virtual double getStreamOffset(MWBase::SoundPtr sound);
+        virtual bool isStreamPlaying(MWBase::SoundPtr sound);
 
         virtual void startUpdate();
         virtual void finishUpdate();

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -47,9 +47,8 @@ namespace MWSound
         virtual void unloadSound(Sound_Handle data);
         virtual size_t getSoundDataSize(Sound_Handle data) const;
 
-        virtual MWBase::SoundPtr playSound(Sound_Handle data, float vol, float basevol, float pitch, int flags, float offset);
-        virtual MWBase::SoundPtr playSound3D(Sound_Handle data, const osg::Vec3f &pos,
-                                             float vol, float basevol, float pitch, float min, float max, int flags, float offset);
+        virtual void playSound(MWBase::SoundPtr sound, Sound_Handle data, float offset);
+        virtual void playSound3D(MWBase::SoundPtr sound, Sound_Handle data, float offset);
         virtual void stopSound(MWBase::SoundPtr sound);
         virtual bool isSoundPlaying(MWBase::SoundPtr sound);
         virtual void updateSound(MWBase::SoundPtr sound);

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -35,6 +35,11 @@ namespace MWSound
         struct StreamThread;
         std::auto_ptr<StreamThread> mStreamThread;
 
+        void initCommon2D(ALuint source, const osg::Vec3f &pos, ALfloat gain, ALfloat pitch, bool loop, bool useenv);
+        void initCommon3D(ALuint source, const osg::Vec3f &pos, ALfloat mindist, ALfloat maxdist, ALfloat gain, ALfloat pitch, bool loop, bool useenv);
+
+        void updateCommon(ALuint source, const osg::Vec3f &pos, ALfloat maxdist, ALfloat gain, ALfloat pitch, bool useenv, bool is3d);
+
         OpenAL_Output& operator=(const OpenAL_Output &rhs);
         OpenAL_Output(const OpenAL_Output &rhs);
 

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -29,8 +29,16 @@ namespace MWSound
         typedef std::vector<MWBase::SoundStreamPtr> StreamVec;
         StreamVec mActiveStreams;
 
-        Environment mLastEnvironment;
+        osg::Vec3f mListenerPos;
+        Environment mListenerEnv;
 
+        struct StreamThread;
+        std::auto_ptr<StreamThread> mStreamThread;
+
+        OpenAL_Output& operator=(const OpenAL_Output &rhs);
+        OpenAL_Output(const OpenAL_Output &rhs);
+
+    public:
         virtual std::vector<std::string> enumerate();
         virtual void init(const std::string &devname="");
         virtual void deinit();
@@ -63,20 +71,8 @@ namespace MWSound
 
         virtual void loadLoudnessAsync(DecoderPtr decoder, Sound_Loudness *loudness);
 
-        OpenAL_Output& operator=(const OpenAL_Output &rhs);
-        OpenAL_Output(const OpenAL_Output &rhs);
-
         OpenAL_Output(SoundManager &mgr);
         virtual ~OpenAL_Output();
-
-        struct StreamThread;
-        std::auto_ptr<StreamThread> mStreamThread;
-
-        friend class OpenAL_Sound;
-        friend class OpenAL_Sound3D;
-        friend class OpenAL_SoundStream;
-        friend class OpenAL_SoundStream3D;
-        friend class SoundManager;
     };
 #ifndef DEFAULT_OUTPUT
 #define DEFAULT_OUTPUT(x) ::MWSound::OpenAL_Output((x))

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -10,7 +10,6 @@ namespace MWSound
         Sound& operator=(const Sound &rhs);
         Sound(const Sound &rhs);
 
-    protected:
         osg::Vec3f mPos;
         float mVolume; /* NOTE: Real volume = mVolume*mBaseVolume */
         float mBaseVolume;
@@ -21,12 +20,13 @@ namespace MWSound
 
         float mFadeOutTime;
 
+    protected:
+        void *mHandle;
+
+        friend class Sound_Output;
+        friend class OpenAL_Output;
+
     public:
-        virtual void stop() = 0;
-        virtual bool isPlaying() = 0;
-        virtual double getTimeOffset() = 0;
-        virtual double getStreamDelay() const { return 0.0; }
-        virtual void applyUpdates() = 0;
         void setPosition(const osg::Vec3f &pos) { mPos = pos; }
         void setVolume(float volume) { mVolume = volume; }
         void setBaseVolume(float volume) { mBaseVolume = volume; }
@@ -47,16 +47,11 @@ namespace MWSound
         bool getIs3D() const { return mFlags&Play_3D; }
 
         Sound(const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
-          : mPos(pos)
-          , mVolume(vol)
-          , mBaseVolume(basevol)
-          , mPitch(pitch)
-          , mMinDistance(mindist)
-          , mMaxDistance(maxdist)
-          , mFlags(flags)
-          , mFadeOutTime(0.0f)
+          : mPos(pos), mVolume(vol), mBaseVolume(basevol), mPitch(pitch)
+          , mMinDistance(mindist), mMaxDistance(maxdist), mFlags(flags)
+          , mFadeOutTime(0.0f), mHandle(0)
         { }
-        virtual ~Sound() { }
+        ~Sound() { }
     };
 }
 

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -1,7 +1,7 @@
 #ifndef GAME_SOUND_SOUND_H
 #define GAME_SOUND_SOUND_H
 
-#include "soundmanagerimp.hpp"
+#include "sound_output.hpp"
 
 namespace MWSound
 {
@@ -20,7 +20,7 @@ namespace MWSound
         float mFadeOutTime;
 
     protected:
-        void *mHandle;
+        Sound_Instance mHandle;
 
         friend class Sound_Output;
         friend class OpenAL_Output;

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -22,7 +22,6 @@ namespace MWSound
     protected:
         Sound_Instance mHandle;
 
-        friend class Sound_Output;
         friend class OpenAL_Output;
 
     public:
@@ -43,11 +42,13 @@ namespace MWSound
         const osg::Vec3f &getPosition() const { return mPos; }
         float getRealVolume() const { return mVolume * mBaseVolume; }
         float getPitch() const { return mPitch; }
+        float getMinDistance() const { return mMinDistance; }
         float getMaxDistance() const { return mMaxDistance; }
 
         MWBase::SoundManager::PlayType getPlayType() const
         { return (MWBase::SoundManager::PlayType)(mFlags&MWBase::SoundManager::Play_TypeMask); }
         bool getUseEnv() const { return !(mFlags&MWBase::SoundManager::Play_NoEnv); }
+        bool getIsLooping() const { return mFlags&MWBase::SoundManager::Play_Loop; }
         bool getDistanceCull() const { return mFlags&MWBase::SoundManager::Play_RemoveAtDistance; }
         bool getIs3D() const { return mFlags&Play_3D; }
 

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -40,8 +40,14 @@ namespace MWSound
             }
         }
 
+        const osg::Vec3f &getPosition() const { return mPos; }
+        float getRealVolume() const { return mVolume * mBaseVolume; }
+        float getPitch() const { return mPitch; }
+        float getMaxDistance() const { return mMaxDistance; }
+
         MWBase::SoundManager::PlayType getPlayType() const
         { return (MWBase::SoundManager::PlayType)(mFlags&MWBase::SoundManager::Play_TypeMask); }
+        bool getUseEnv() const { return !(mFlags&MWBase::SoundManager::Play_NoEnv); }
         bool getDistanceCull() const { return mFlags&MWBase::SoundManager::Play_RemoveAtDistance; }
         bool getIs3D() const { return mFlags&Play_3D; }
 

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -5,8 +5,7 @@
 
 namespace MWSound
 {
-    class Sound
-    {
+    class Sound {
         Sound& operator=(const Sound &rhs);
         Sound(const Sound &rhs);
 
@@ -51,7 +50,17 @@ namespace MWSound
           , mMinDistance(mindist), mMaxDistance(maxdist), mFlags(flags)
           , mFadeOutTime(0.0f), mHandle(0)
         { }
-        ~Sound() { }
+    };
+
+    // Same as above, but it's a different type since the output handles them differently
+    class Stream : public Sound {
+        Stream& operator=(const Stream &rhs);
+        Stream(const Stream &rhs);
+
+    public:
+        Stream(const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
+          : Sound(pos, vol, basevol, pitch, mindist, maxdist, flags)
+        { }
     };
 }
 

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -56,6 +56,11 @@ namespace MWSound
           , mMinDistance(mindist), mMaxDistance(maxdist), mFlags(flags)
           , mFadeOutTime(0.0f), mHandle(0)
         { }
+        Sound(float vol, float basevol, float pitch, int flags)
+          : mPos(0.0f, 0.0f, 0.0f), mVolume(vol), mBaseVolume(basevol), mPitch(pitch)
+          , mMinDistance(1.0f), mMaxDistance(1000.0f), mFlags(flags)
+          , mFadeOutTime(0.0f), mHandle(0)
+        { }
     };
 
     // Same as above, but it's a different type since the output handles them differently
@@ -66,6 +71,9 @@ namespace MWSound
     public:
         Stream(const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
           : Sound(pos, vol, basevol, pitch, mindist, maxdist, flags)
+        { }
+        Stream(float vol, float basevol, float pitch, int flags)
+          : Sound(vol, basevol, pitch, flags)
         { }
     };
 }

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -37,9 +37,8 @@ namespace MWSound
         virtual bool isSoundPlaying(MWBase::SoundPtr sound) = 0;
         virtual void updateSound(MWBase::SoundPtr sound) = 0;
 
-        virtual MWBase::SoundStreamPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags) = 0;
-        virtual MWBase::SoundStreamPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
-                                                     float vol, float basevol, float pitch, float min, float max, int flags) = 0;
+        virtual void streamSound(DecoderPtr decoder, MWBase::SoundStreamPtr sound) = 0;
+        virtual void streamSound3D(DecoderPtr decoder, MWBase::SoundStreamPtr sound) = 0;
         virtual void stopStream(MWBase::SoundStreamPtr sound) = 0;
         virtual double getStreamDelay(MWBase::SoundStreamPtr sound) = 0;
         virtual double getStreamOffset(MWBase::SoundStreamPtr sound) = 0;

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -3,10 +3,9 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "soundmanagerimp.hpp"
-
-#include "../mwworld/ptr.hpp"
 
 namespace MWSound
 {
@@ -17,6 +16,8 @@ namespace MWSound
 
     // An opaque handle for the implementation's sound buffers.
     typedef void *Sound_Handle;
+    // An opaque handle for the implementation's sound instances.
+    typedef void *Sound_Instance;
 
     class Sound_Output
     {

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -64,12 +64,9 @@ namespace MWSound
 
     protected:
         bool mInitialized;
-        osg::Vec3f mPos;
 
         Sound_Output(SoundManager &mgr)
-          : mManager(mgr)
-          , mInitialized(false)
-          , mPos(0.0f, 0.0f, 0.0f)
+          : mManager(mgr), mInitialized(false)
         { }
     public:
         virtual ~Sound_Output() { }

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -31,11 +31,8 @@ namespace MWSound
         virtual void unloadSound(Sound_Handle data) = 0;
         virtual size_t getSoundDataSize(Sound_Handle data) const = 0;
 
-        /// @param offset Number of seconds into the sound to start playback.
-        virtual MWBase::SoundPtr playSound(Sound_Handle data, float vol, float basevol, float pitch, int flags, float offset) = 0;
-        /// @param offset Number of seconds into the sound to start playback.
-        virtual MWBase::SoundPtr playSound3D(Sound_Handle data, const osg::Vec3f &pos,
-                                             float vol, float basevol, float pitch, float min, float max, int flags, float offset) = 0;
+        virtual void playSound(MWBase::SoundPtr sound, Sound_Handle data, float offset) = 0;
+        virtual void playSound3D(MWBase::SoundPtr sound, Sound_Handle data, float offset) = 0;
         virtual void stopSound(MWBase::SoundPtr sound) = 0;
         virtual bool isSoundPlaying(MWBase::SoundPtr sound) = 0;
         virtual void updateSound(MWBase::SoundPtr sound) = 0;

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -38,13 +38,13 @@ namespace MWSound
         virtual void stopSound(MWBase::SoundPtr sound) = 0;
         virtual bool isSoundPlaying(MWBase::SoundPtr sound) = 0;
 
-        virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags) = 0;
-        virtual MWBase::SoundPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
-                                               float vol, float basevol, float pitch, float min, float max, int flags) = 0;
-        virtual void stopStream(MWBase::SoundPtr sound) = 0;
-        virtual double getStreamDelay(MWBase::SoundPtr sound) = 0;
-        virtual double getStreamOffset(MWBase::SoundPtr sound) = 0;
-        virtual bool isStreamPlaying(MWBase::SoundPtr sound) = 0;
+        virtual MWBase::SoundStreamPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags) = 0;
+        virtual MWBase::SoundStreamPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
+                                                     float vol, float basevol, float pitch, float min, float max, int flags) = 0;
+        virtual void stopStream(MWBase::SoundStreamPtr sound) = 0;
+        virtual double getStreamDelay(MWBase::SoundStreamPtr sound) = 0;
+        virtual double getStreamOffset(MWBase::SoundStreamPtr sound) = 0;
+        virtual bool isStreamPlaying(MWBase::SoundStreamPtr sound) = 0;
 
         virtual void startUpdate() = 0;
         virtual void finishUpdate() = 0;

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -35,9 +35,16 @@ namespace MWSound
         /// @param offset Number of seconds into the sound to start playback.
         virtual MWBase::SoundPtr playSound3D(Sound_Handle data, const osg::Vec3f &pos,
                                              float vol, float basevol, float pitch, float min, float max, int flags, float offset) = 0;
+        virtual void stopSound(MWBase::SoundPtr sound) = 0;
+        virtual bool isSoundPlaying(MWBase::SoundPtr sound) = 0;
+
         virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags) = 0;
         virtual MWBase::SoundPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
                                                float vol, float basevol, float pitch, float min, float max, int flags) = 0;
+        virtual void stopStream(MWBase::SoundPtr sound) = 0;
+        virtual double getStreamDelay(MWBase::SoundPtr sound) = 0;
+        virtual double getStreamOffset(MWBase::SoundPtr sound) = 0;
+        virtual bool isStreamPlaying(MWBase::SoundPtr sound) = 0;
 
         virtual void startUpdate() = 0;
         virtual void finishUpdate() = 0;

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -37,6 +37,7 @@ namespace MWSound
                                              float vol, float basevol, float pitch, float min, float max, int flags, float offset) = 0;
         virtual void stopSound(MWBase::SoundPtr sound) = 0;
         virtual bool isSoundPlaying(MWBase::SoundPtr sound) = 0;
+        virtual void updateSound(MWBase::SoundPtr sound) = 0;
 
         virtual MWBase::SoundStreamPtr streamSound(DecoderPtr decoder, float basevol, float pitch, int flags) = 0;
         virtual MWBase::SoundStreamPtr streamSound3D(DecoderPtr decoder, const osg::Vec3f &pos,
@@ -45,6 +46,7 @@ namespace MWSound
         virtual double getStreamDelay(MWBase::SoundStreamPtr sound) = 0;
         virtual double getStreamOffset(MWBase::SoundStreamPtr sound) = 0;
         virtual bool isStreamPlaying(MWBase::SoundStreamPtr sound) = 0;
+        virtual void updateStream(MWBase::SoundStreamPtr sound) = 0;
 
         virtual void startUpdate() = 0;
         virtual void finishUpdate() = 0;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -241,7 +241,7 @@ namespace MWSound
         return decoder;
     }
 
-    MWBase::SoundPtr SoundManager::playVoice(DecoderPtr decoder, const osg::Vec3f &pos, bool playlocal)
+    MWBase::SoundStreamPtr SoundManager::playVoice(DecoderPtr decoder, const osg::Vec3f &pos, bool playlocal)
     {
         MWBase::World* world = MWBase::Environment::get().getWorld();
         static const float fAudioMinDistanceMult = world->getStore().get<ESM::GameSetting>().find("fAudioMinDistanceMult")->getFloat();
@@ -392,7 +392,7 @@ namespace MWSound
                 mPendingSaySounds[ptr] = std::make_pair(decoder, loudness);
             else
             {
-                MWBase::SoundPtr sound = playVoice(decoder, objpos, (ptr == MWMechanics::getPlayer()));
+                MWBase::SoundStreamPtr sound = playVoice(decoder, objpos, (ptr == MWMechanics::getPlayer()));
                 mActiveSaySounds[ptr] = std::make_pair(sound, loudness);
             }
         }
@@ -407,7 +407,7 @@ namespace MWSound
         SaySoundMap::const_iterator snditer = mActiveSaySounds.find(ptr);
         if(snditer != mActiveSaySounds.end())
         {
-            MWBase::SoundPtr sound = snditer->second.first;
+            MWBase::SoundStreamPtr sound = snditer->second.first;
             Sound_Loudness *loudness = snditer->second.second;
             float sec = mOutput->getStreamOffset(sound);
             return loudness->getLoudnessAtTime(sec);
@@ -432,7 +432,7 @@ namespace MWSound
                 mPendingSaySounds[MWWorld::Ptr()] = std::make_pair(decoder, loudness);
             else
             {
-                MWBase::SoundPtr sound = playVoice(decoder, osg::Vec3f(), true);
+                MWBase::SoundStreamPtr sound = playVoice(decoder, osg::Vec3f(), true);
                 mActiveSaySounds[MWWorld::Ptr()] = std::make_pair(sound, loudness);
             }
         }
@@ -466,9 +466,9 @@ namespace MWSound
     }
 
 
-    MWBase::SoundPtr SoundManager::playTrack(const DecoderPtr& decoder, PlayType type)
+    MWBase::SoundStreamPtr SoundManager::playTrack(const DecoderPtr& decoder, PlayType type)
     {
-        MWBase::SoundPtr track;
+        MWBase::SoundStreamPtr track;
         if(!mOutput->isInitialized())
             return track;
         try
@@ -482,14 +482,14 @@ namespace MWSound
         return track;
     }
 
-    void SoundManager::stopTrack(MWBase::SoundPtr sound)
+    void SoundManager::stopTrack(MWBase::SoundStreamPtr stream)
     {
-        mOutput->stopStream(sound);
+        mOutput->stopStream(stream);
     }
 
-    double SoundManager::getTrackTimeDelay(MWBase::SoundPtr sound)
+    double SoundManager::getTrackTimeDelay(MWBase::SoundStreamPtr stream)
     {
-        return mOutput->getStreamDelay(sound);
+        return mOutput->getStreamDelay(stream);
     }
 
 
@@ -876,7 +876,7 @@ namespace MWSound
                     const ESM::Position &pos = ptr.getRefData().getPosition();
                     const osg::Vec3f objpos(pos.asVec3());
 
-                    MWBase::SoundPtr sound = playVoice(decoder,
+                    MWBase::SoundStreamPtr sound = playVoice(decoder,
                         objpos, (ptr == MWMechanics::getPlayer())
                     );
                     mActiveSaySounds[ptr] = std::make_pair(sound, loudness);
@@ -895,7 +895,7 @@ namespace MWSound
         while(sayiter != mActiveSaySounds.end())
         {
             MWWorld::Ptr ptr = sayiter->first;
-            MWBase::SoundPtr sound = sayiter->second.first;
+            MWBase::SoundStreamPtr sound = sayiter->second.first;
             if(!ptr.isEmpty() && sound->getIs3D())
             {
                 const ESM::Position &pos = ptr.getRefData().getPosition();
@@ -963,7 +963,7 @@ namespace MWSound
         SaySoundMap::iterator sayiter = mActiveSaySounds.begin();
         for(;sayiter != mActiveSaySounds.end();++sayiter)
         {
-            MWBase::SoundPtr sound = sayiter->second.first;
+            MWBase::SoundStreamPtr sound = sayiter->second.first;
             sound->setBaseVolume(volumeFromType(sound->getPlayType()));
         }
         if(mMusic)

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -508,9 +508,8 @@ namespace MWSound
             Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
             float basevol = volumeFromType(type);
 
-            sound = mOutput->playSound(sfx->mHandle,
-                volume * sfx->mVolume, basevol, pitch, mode|type|Play_2D, offset
-            );
+            sound.reset(new Sound(volume * sfx->mVolume, basevol, pitch, mode|type|Play_2D));
+            mOutput->playSound(sound, sfx->mHandle, offset);
             if(sfx->mUses++ == 0)
             {
                 SoundList::iterator iter = std::find(mUnusedBuffers.begin(), mUnusedBuffers.end(), sfx);
@@ -522,6 +521,7 @@ namespace MWSound
         catch(std::exception&)
         {
             //std::cout <<"Sound Error: "<<e.what()<< std::endl;
+            sound.reset();
         }
         return sound;
     }
@@ -544,14 +544,16 @@ namespace MWSound
                 return MWBase::SoundPtr();
 
             if(!(mode&Play_NoPlayerLocal) && ptr == MWMechanics::getPlayer())
-                sound = mOutput->playSound(sfx->mHandle,
-                    volume * sfx->mVolume, basevol, pitch, mode|type|Play_2D, offset
-                );
+            {
+                sound.reset(new Sound(volume * sfx->mVolume, basevol, pitch, mode|type|Play_2D));
+                mOutput->playSound(sound, sfx->mHandle, offset);
+            }
             else
-                sound = mOutput->playSound3D(sfx->mHandle,
-                    objpos, volume * sfx->mVolume, basevol, pitch, sfx->mMinDist, sfx->mMaxDist,
-                    mode|type|Play_3D, offset
-                );
+            {
+                sound.reset(new Sound(objpos, volume * sfx->mVolume, basevol, pitch,
+                                      sfx->mMinDist, sfx->mMaxDist, mode|type|Play_3D));
+                mOutput->playSound3D(sound, sfx->mHandle, offset);
+            }
             if(sfx->mUses++ == 0)
             {
                 SoundList::iterator iter = std::find(mUnusedBuffers.begin(), mUnusedBuffers.end(), sfx);
@@ -563,6 +565,7 @@ namespace MWSound
         catch(std::exception&)
         {
             //std::cout <<"Sound Error: "<<e.what()<< std::endl;
+            sound.reset();
         }
         return sound;
     }
@@ -579,10 +582,9 @@ namespace MWSound
             Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
             float basevol = volumeFromType(type);
 
-            sound = mOutput->playSound3D(sfx->mHandle,
-                initialPos, volume * sfx->mVolume, basevol, pitch, sfx->mMinDist, sfx->mMaxDist,
-                mode|type|Play_3D, offset
-            );
+            sound.reset(new Sound(initialPos, volume * sfx->mVolume, basevol, pitch,
+                                  sfx->mMinDist, sfx->mMaxDist, mode|type|Play_3D));
+            mOutput->playSound3D(sound, sfx->mHandle, offset);
             if(sfx->mUses++ == 0)
             {
                 SoundList::iterator iter = std::find(mUnusedBuffers.begin(), mUnusedBuffers.end(), sfx);
@@ -594,6 +596,7 @@ namespace MWSound
         catch(std::exception &)
         {
             //std::cout <<"Sound Error: "<<e.what()<< std::endl;
+            sound.reset();
         }
         return sound;
     }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -853,6 +853,7 @@ namespace MWSound
                 {
                     sound->updateFade(duration);
 
+                    mOutput->updateSound(sound);
                     ++sndidx;
                 }
             }
@@ -918,6 +919,7 @@ namespace MWSound
             {
                 sound->updateFade(duration);
 
+                mOutput->updateStream(sound);
                 ++sayiter;
             }
         }
@@ -958,6 +960,7 @@ namespace MWSound
             {
                 MWBase::SoundPtr sound = sndidx->first;
                 sound->setBaseVolume(volumeFromType(sound->getPlayType()));
+                mOutput->updateSound(sound);
             }
         }
         SaySoundMap::iterator sayiter = mActiveSaySounds.begin();
@@ -965,10 +968,12 @@ namespace MWSound
         {
             MWBase::SoundStreamPtr sound = sayiter->second.first;
             sound->setBaseVolume(volumeFromType(sound->getPlayType()));
+            mOutput->updateStream(sound);
         }
         if(mMusic)
         {
             mMusic->setBaseVolume(volumeFromType(mMusic->getPlayType()));
+            mOutput->updateStream(mMusic);
         }
         mOutput->finishUpdate();
     }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -890,13 +890,17 @@ namespace MWSound
                     DecoderPtr decoder = penditer->second.first;
                     decoder->rewind();
 
+                    MWBase::SoundStreamPtr sound;
                     MWWorld::Ptr ptr = penditer->first;
-                    const ESM::Position &pos = ptr.getRefData().getPosition();
-                    const osg::Vec3f objpos(pos.asVec3());
+                    if(ptr == MWWorld::Ptr())
+                        sound = playVoice(decoder, osg::Vec3f(), true);
+                    else
+                    {
+                        const ESM::Position &pos = ptr.getRefData().getPosition();
+                        const osg::Vec3f objpos(pos.asVec3());
 
-                    MWBase::SoundStreamPtr sound = playVoice(decoder,
-                        objpos, (ptr == MWMechanics::getPlayer())
-                    );
+                        sound = playVoice(decoder, objpos, (ptr == MWMechanics::getPlayer()));
+                    }
                     mActiveSaySounds[ptr] = std::make_pair(sound, loudness);
                 }
                 catch(std::exception &e) {

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -116,7 +116,6 @@ namespace MWSound
         MWBase::SoundPtr playVoice(DecoderPtr decoder, const osg::Vec3f &pos, bool playlocal);
 
         void streamMusicFull(const std::string& filename);
-        bool updateSound(MWBase::SoundPtr sound, const MWWorld::Ptr &ptr, float duration);
         void updateSounds(float duration);
         void updateRegionSound(float duration);
 
@@ -174,6 +173,14 @@ namespace MWSound
         virtual MWBase::SoundPtr playTrack(const DecoderPtr& decoder, PlayType type);
         ///< Play a 2D audio track, using a custom decoder
 
+        virtual void stopTrack(MWBase::SoundPtr sound);
+        ///< Stop the given audio track from playing
+
+        virtual double getTrackTimeDelay(MWBase::SoundPtr sound);
+        ///< Retives the time delay, in seconds, of the audio track (must be a sound
+        /// returned by \ref playTrack). Only intended to be called by the track
+        /// decoder's read method.
+
         virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal, float offset=0);
         ///< Play a sound, independently of 3D-position
         ///< @param offset Number of seconds into the sound to start playback.
@@ -188,6 +195,9 @@ namespace MWSound
                                              float volume, float pitch, PlayType type, PlayMode mode, float offset=0);
         ///< Play a 3D sound at \a initialPos. If the sound should be moving, it must be updated using Sound::setPosition.
         ///< @param offset Number of seconds into the sound to start playback.
+
+        virtual void stopSound(MWBase::SoundPtr sound);
+        ///< Stop the given sound from playing
 
         virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId);
         ///< Stop the given object from playing the given sound,

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -79,9 +79,6 @@ namespace MWSound
         typedef std::deque<Sound_Buffer*> SoundList;
         SoundList mUnusedBuffers;
 
-        MWBase::SoundStreamPtr mMusic;
-        std::string mCurrentPlaylist;
-
         typedef std::pair<MWBase::SoundPtr,Sound_Buffer*> SoundBufferRefPair;
         typedef std::vector<SoundBufferRefPair> SoundBufferRefPairList;
         typedef std::map<MWWorld::Ptr,SoundBufferRefPairList> SoundMap;
@@ -95,7 +92,11 @@ namespace MWSound
         typedef std::map<MWWorld::Ptr,DecoderLoudnessPair> SayDecoderMap;
         SayDecoderMap mPendingSaySounds;
 
-        MWBase::SoundPtr mUnderwaterSound;
+        typedef std::vector<MWBase::SoundStreamPtr> TrackList;
+        TrackList mActiveTracks;
+
+        MWBase::SoundStreamPtr mMusic;
+        std::string mCurrentPlaylist;
 
         bool mListenerUnderwater;
         osg::Vec3f mListenerPos;
@@ -103,6 +104,8 @@ namespace MWSound
         osg::Vec3f mListenerUp;
 
         int mPausedSoundTypes;
+
+        MWBase::SoundPtr mUnderwaterSound;
 
         Sound_Buffer *insertSound(const std::string &soundId, const ESM::Sound *sound);
 

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -79,7 +79,7 @@ namespace MWSound
         typedef std::deque<Sound_Buffer*> SoundList;
         SoundList mUnusedBuffers;
 
-        boost::shared_ptr<Sound> mMusic;
+        MWBase::SoundStreamPtr mMusic;
         std::string mCurrentPlaylist;
 
         typedef std::pair<MWBase::SoundPtr,Sound_Buffer*> SoundBufferRefPair;
@@ -87,7 +87,7 @@ namespace MWSound
         typedef std::map<MWWorld::Ptr,SoundBufferRefPairList> SoundMap;
         SoundMap mActiveSounds;
 
-        typedef std::pair<MWBase::SoundPtr,Sound_Loudness*> SoundLoudnessPair;
+        typedef std::pair<MWBase::SoundStreamPtr,Sound_Loudness*> SoundLoudnessPair;
         typedef std::map<MWWorld::Ptr,SoundLoudnessPair> SaySoundMap;
         SaySoundMap mActiveSaySounds;
 
@@ -113,7 +113,7 @@ namespace MWSound
         // to start streaming
         DecoderPtr loadVoice(const std::string &voicefile, Sound_Loudness **lipdata);
 
-        MWBase::SoundPtr playVoice(DecoderPtr decoder, const osg::Vec3f &pos, bool playlocal);
+        MWBase::SoundStreamPtr playVoice(DecoderPtr decoder, const osg::Vec3f &pos, bool playlocal);
 
         void streamMusicFull(const std::string& filename);
         void updateSounds(float duration);
@@ -170,13 +170,13 @@ namespace MWSound
         /// and get an average loudness value (scale [0,1]) at the current time position.
         /// If the actor is not saying anything, returns 0.
 
-        virtual MWBase::SoundPtr playTrack(const DecoderPtr& decoder, PlayType type);
+        virtual MWBase::SoundStreamPtr playTrack(const DecoderPtr& decoder, PlayType type);
         ///< Play a 2D audio track, using a custom decoder
 
-        virtual void stopTrack(MWBase::SoundPtr sound);
+        virtual void stopTrack(MWBase::SoundStreamPtr stream);
         ///< Stop the given audio track from playing
 
-        virtual double getTrackTimeDelay(MWBase::SoundPtr sound);
+        virtual double getTrackTimeDelay(MWBase::SoundStreamPtr stream);
         ///< Retives the time delay, in seconds, of the audio track (must be a sound
         /// returned by \ref playTrack). Only intended to be called by the track
         /// decoder's read method.

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -190,7 +190,7 @@ namespace MWWorld
             {
                 MWBase::Environment::get().getWorld()->explodeSpell(pos, it->mEffects, caster, ESM::RT_Target, it->mSpellId, it->mSourceName);
 
-                it->mSound->stop();
+                MWBase::Environment::get().getSoundManager()->stopSound(it->mSound);
                 mParent->removeChild(it->mNode);
 
                 it = mMagicBolts.erase(it);
@@ -264,7 +264,7 @@ namespace MWWorld
         for (std::vector<MagicBoltState>::iterator it = mMagicBolts.begin(); it != mMagicBolts.end(); ++it)
         {
             mParent->removeChild(it->mNode);
-            it->mSound->stop();
+            MWBase::Environment::get().getSoundManager()->stopSound(it->mSound);
         }
         mMagicBolts.clear();
     }

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -738,7 +738,7 @@ void WeatherManager::update(float duration, bool paused)
 void WeatherManager::stopSounds()
 {
     if (mAmbientSound.get())
-        mAmbientSound->stop();
+        MWBase::Environment::get().getSoundManager()->stopSound(mAmbientSound);
     mAmbientSound.reset();
     mPlayingSoundID.clear();
 }


### PR DESCRIPTION
* Separates Sound objects from the output implementation.
* Fixes a crash during chargen, caused by some say() calls not associated with a ```Ptr```.