### PR TITLE
Object movement between cells

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -62,7 +62,7 @@ add_openmw_dir (mwsound
 
 add_openmw_dir (mwworld
     refdata worldimp scene globals class action nullaction actionteleport
-    containerstore actiontalk actiontake manualref player cellfunctors failedaction
+    containerstore actiontalk actiontake manualref player cellvisitors failedaction
     cells localscripts customdata inventorystore ptr actionopen actionread
     actionequip timestamp actionalchemy cellstore actionapply actioneat
     store esmstore recordcmp fallback actionrepair actionsoulgem livecellref actiondoor

--- a/apps/openmw/mwclass/activator.cpp
+++ b/apps/openmw/mwclass/activator.cpp
@@ -130,6 +130,7 @@ namespace MWClass
         MWWorld::LiveCellRef<ESM::Activator> *ref =
             ptr.get<ESM::Activator>();
 
-        return MWWorld::Ptr(&cell.get<ESM::Activator>().insert(*ref), &cell);
+        return MWWorld::Ptr();
+        //return MWWorld::Ptr(&cell.get<ESM::Activator>().insert(*ref), &cell);
     }
 }

--- a/apps/openmw/mwclass/activator.cpp
+++ b/apps/openmw/mwclass/activator.cpp
@@ -130,7 +130,6 @@ namespace MWClass
         MWWorld::LiveCellRef<ESM::Activator> *ref =
             ptr.get<ESM::Activator>();
 
-        return MWWorld::Ptr();
-        //return MWWorld::Ptr(&cell.get<ESM::Activator>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 }

--- a/apps/openmw/mwclass/apparatus.cpp
+++ b/apps/openmw/mwclass/apparatus.cpp
@@ -147,9 +147,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Apparatus> *ref =
             ptr.get<ESM::Apparatus>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Apparatus>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Apparatus::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/apparatus.cpp
+++ b/apps/openmw/mwclass/apparatus.cpp
@@ -147,8 +147,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Apparatus> *ref =
             ptr.get<ESM::Apparatus>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Apparatus>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Apparatus>().insert(*ref), &cell);
     }
 
     bool Apparatus::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -381,8 +381,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Armor> *ref =
             ptr.get<ESM::Armor>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Armor>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Armor>().insert(*ref), &cell);
     }
 
     int Armor::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -381,9 +381,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Armor> *ref =
             ptr.get<ESM::Armor>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Armor>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     int Armor::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/book.cpp
+++ b/apps/openmw/mwclass/book.cpp
@@ -186,9 +186,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Book> *ref =
             ptr.get<ESM::Book>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Book>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     int Book::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/book.cpp
+++ b/apps/openmw/mwclass/book.cpp
@@ -186,8 +186,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Book> *ref =
             ptr.get<ESM::Book>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Book>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Book>().insert(*ref), &cell);
     }
 
     int Book::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -275,8 +275,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Clothing> *ref =
             ptr.get<ESM::Clothing>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Clothing>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Clothing>().insert(*ref), &cell);
     }
 
     int Clothing::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -275,9 +275,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Clothing> *ref =
             ptr.get<ESM::Clothing>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Clothing>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     int Clothing::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -292,9 +292,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Container> *ref =
             ptr.get<ESM::Container>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Container>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     void Container::readAdditionalState (const MWWorld::Ptr& ptr, const ESM::ObjectState& state) const

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -292,8 +292,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Container> *ref =
             ptr.get<ESM::Container>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Container>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Container>().insert(*ref), &cell);
     }
 
     void Container::readAdditionalState (const MWWorld::Ptr& ptr, const ESM::ObjectState& state) const

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -599,8 +599,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Creature> *ref =
             ptr.get<ESM::Creature>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Creature>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Creature>().insert(*ref), &cell);
     }
 
     bool Creature::isBipedal(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -599,9 +599,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Creature> *ref =
             ptr.get<ESM::Creature>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Creature>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Creature::isBipedal(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -309,9 +309,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Door> *ref =
             ptr.get<ESM::Door>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Door>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     void Door::ensureCustomData(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -309,8 +309,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Door> *ref =
             ptr.get<ESM::Door>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Door>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Door>().insert(*ref), &cell);
     }
 
     void Door::ensureCustomData(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -184,8 +184,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Ingredient> *ref =
             ptr.get<ESM::Ingredient>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Ingredient>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Ingredient>().insert(*ref), &cell);
     }
 
     bool Ingredient::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -184,9 +184,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Ingredient> *ref =
             ptr.get<ESM::Ingredient>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Ingredient>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Ingredient::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -216,9 +216,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Light> *ref =
             ptr.get<ESM::Light>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Light>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Light::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -216,8 +216,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Light> *ref =
             ptr.get<ESM::Light>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Light>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Light>().insert(*ref), &cell);
     }
 
     bool Light::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -165,9 +165,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Lockpick> *ref =
             ptr.get<ESM::Lockpick>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Lockpick>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Lockpick::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -165,8 +165,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Lockpick> *ref =
             ptr.get<ESM::Lockpick>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Lockpick>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Lockpick>().insert(*ref), &cell);
     }
 
     bool Lockpick::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -194,6 +194,7 @@ namespace MWClass
     {
         MWWorld::Ptr newPtr;
 
+        /*
         const MWWorld::ESMStore &store =
             MWBase::Environment::get().getWorld()->getStore();
 
@@ -223,6 +224,7 @@ namespace MWClass
                 ptr.get<ESM::Miscellaneous>();
             newPtr = MWWorld::Ptr(&cell.get<ESM::Miscellaneous>().insert(*ref), &cell);
         }
+        */
         return newPtr;
     }
 

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -194,7 +194,6 @@ namespace MWClass
     {
         MWWorld::Ptr newPtr;
 
-        /*
         const MWWorld::ESMStore &store =
             MWBase::Environment::get().getWorld()->getStore();
 
@@ -216,15 +215,15 @@ namespace MWClass
             MWWorld::ManualRef newRef(store, base);
             MWWorld::LiveCellRef<ESM::Miscellaneous> *ref =
                 newRef.getPtr().get<ESM::Miscellaneous>();
-            newPtr = MWWorld::Ptr(&cell.get<ESM::Miscellaneous>().insert(*ref), &cell);
+
+            newPtr = MWWorld::Ptr(cell.insert(ref), &cell);
             newPtr.getCellRef().setGoldValue(goldAmount);
             newPtr.getRefData().setCount(1);
         } else {
             MWWorld::LiveCellRef<ESM::Miscellaneous> *ref =
                 ptr.get<ESM::Miscellaneous>();
-            newPtr = MWWorld::Ptr(&cell.get<ESM::Miscellaneous>().insert(*ref), &cell);
+            newPtr = MWWorld::Ptr(cell.insert(ref), &cell);
         }
-        */
         return newPtr;
     }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1129,8 +1129,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::NPC> *ref =
             ptr.get<ESM::NPC>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::NPC>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::NPC>().insert(*ref), &cell);
     }
 
     int Npc::getSkill(const MWWorld::Ptr& ptr, int skill) const

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1129,9 +1129,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::NPC> *ref =
             ptr.get<ESM::NPC>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::NPC>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     int Npc::getSkill(const MWWorld::Ptr& ptr, int skill) const

--- a/apps/openmw/mwclass/potion.cpp
+++ b/apps/openmw/mwclass/potion.cpp
@@ -177,8 +177,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Potion> *ref =
             ptr.get<ESM::Potion>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Potion>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Potion>().insert(*ref), &cell);
     }
 
     bool Potion::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/potion.cpp
+++ b/apps/openmw/mwclass/potion.cpp
@@ -177,9 +177,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Potion> *ref =
             ptr.get<ESM::Potion>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Potion>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Potion::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -164,8 +164,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Probe> *ref =
             ptr.get<ESM::Probe>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Probe>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Probe>().insert(*ref), &cell);
     }
 
     bool Probe::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -164,9 +164,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Probe> *ref =
             ptr.get<ESM::Probe>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Probe>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     bool Probe::canSell (const MWWorld::Ptr& item, int npcServices) const

--- a/apps/openmw/mwclass/repair.cpp
+++ b/apps/openmw/mwclass/repair.cpp
@@ -159,8 +159,9 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Repair> *ref =
             ptr.get<ESM::Repair>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Repair>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Repair>().insert(*ref), &cell);
     }
 
     boost::shared_ptr<MWWorld::Action> Repair::use (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/repair.cpp
+++ b/apps/openmw/mwclass/repair.cpp
@@ -159,9 +159,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Repair> *ref =
             ptr.get<ESM::Repair>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Repair>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     boost::shared_ptr<MWWorld::Action> Repair::use (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/static.cpp
+++ b/apps/openmw/mwclass/static.cpp
@@ -59,8 +59,7 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Static> *ref =
             ptr.get<ESM::Static>();
-        return MWWorld::Ptr();
 
-        //return MWWorld::Ptr(&cell.get<ESM::Static>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 }

--- a/apps/openmw/mwclass/static.cpp
+++ b/apps/openmw/mwclass/static.cpp
@@ -59,7 +59,8 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Static> *ref =
             ptr.get<ESM::Static>();
+        return MWWorld::Ptr();
 
-        return MWWorld::Ptr(&cell.get<ESM::Static>().insert(*ref), &cell);
+        //return MWWorld::Ptr(&cell.get<ESM::Static>().insert(*ref), &cell);
     }
 }

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -417,7 +417,8 @@ namespace MWClass
         MWWorld::LiveCellRef<ESM::Weapon> *ref =
             ptr.get<ESM::Weapon>();
 
-        return MWWorld::Ptr(&cell.get<ESM::Weapon>().insert(*ref), &cell);
+        return MWWorld::Ptr();
+        //return MWWorld::Ptr(&cell.get<ESM::Weapon>().insert(*ref), &cell);
     }
 
     int Weapon::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -417,8 +417,7 @@ namespace MWClass
         MWWorld::LiveCellRef<ESM::Weapon> *ref =
             ptr.get<ESM::Weapon>();
 
-        return MWWorld::Ptr();
-        //return MWWorld::Ptr(&cell.get<ESM::Weapon>().insert(*ref), &cell);
+        return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
     int Weapon::getEnchantmentPoints (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -44,6 +44,7 @@ namespace MWMechanics
             return MWWorld::Ptr(); // check interior cells only
 
         // Check all the doors in this cell
+        /*
         MWWorld::CellRefList<ESM::Door>& doors = cell->get<ESM::Door>();
         MWWorld::CellRefList<ESM::Door>::List& refList = doors.mList;
         MWWorld::CellRefList<ESM::Door>::List::iterator it = refList.begin();
@@ -66,6 +67,7 @@ namespace MWMechanics
                 return MWWorld::Ptr(&ref, actor.getCell()); // found, stop searching
             }
         }
+        */
         return MWWorld::Ptr(); // none found
     }
 

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -44,10 +44,9 @@ namespace MWMechanics
             return MWWorld::Ptr(); // check interior cells only
 
         // Check all the doors in this cell
-        /*
-        MWWorld::CellRefList<ESM::Door>& doors = cell->get<ESM::Door>();
-        MWWorld::CellRefList<ESM::Door>::List& refList = doors.mList;
-        MWWorld::CellRefList<ESM::Door>::List::iterator it = refList.begin();
+        const MWWorld::CellRefList<ESM::Door>& doors = cell->getReadOnlyDoors();
+        const MWWorld::CellRefList<ESM::Door>::List& refList = doors.mList;
+        MWWorld::CellRefList<ESM::Door>::List::const_iterator it = refList.begin();
         osg::Vec3f pos(actor.getRefData().getPosition().asVec3());
 
         /// TODO: How to check whether the actor is facing a door? Below code is for
@@ -60,14 +59,14 @@ namespace MWMechanics
         ///       opposite of the code in World::activateDoor() ::confused::
         for (; it != refList.end(); ++it)
         {
-            MWWorld::LiveCellRef<ESM::Door>& ref = *it;
+            const MWWorld::LiveCellRef<ESM::Door>& ref = *it;
             if((pos - ref.mData.getPosition().asVec3()).length2() < minSqr
                     && ref.mData.getPosition().rot[2] == ref.mRef.getPosition().rot[2])
             {
-                return MWWorld::Ptr(&ref, actor.getCell()); // found, stop searching
+                // FIXME cast
+                return MWWorld::Ptr(&const_cast<MWWorld::LiveCellRef<ESM::Door> &>(ref), actor.getCell()); // found, stop searching
             }
         }
-        */
         return MWWorld::Ptr(); // none found
     }
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -300,14 +300,16 @@ namespace MWScript
                     }
                     catch(std::exception&)
                     {
+                        // cell not found, move to exterior instead (vanilla PositionCell compatibility)
                         const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getExterior(cellID);
                         int cx,cy;
                         MWBase::Environment::get().getWorld()->positionToIndex(x,y,cx,cy);
                         store = MWBase::Environment::get().getWorld()->getExterior(cx,cy);
                         if(!cell)
                         {
-                            runtime.getContext().report ("unknown cell (" + cellID + ")");
-                            std::cerr << "unknown cell (" << cellID << ")\n";
+                            std::string error = "PositionCell: unknown interior cell (" + cellID + "), moving to exterior instead";
+                            runtime.getContext().report (error);
+                            std::cerr << error << std::endl;
                         }
                     }
                     if(store)

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -23,7 +23,7 @@ MWWorld::CellStore *MWWorld::Cells::getCellStore (const ESM::Cell *cell)
 
         if (result==mInteriors.end())
         {
-            result = mInteriors.insert (std::make_pair (lowerName, CellStore (cell))).first;
+            result = mInteriors.insert (std::make_pair (lowerName, CellStore (cell, mStore, mReader))).first;
         }
 
         return &result->second;
@@ -36,7 +36,7 @@ MWWorld::CellStore *MWWorld::Cells::getCellStore (const ESM::Cell *cell)
         if (result==mExteriors.end())
         {
             result = mExteriors.insert (std::make_pair (
-                std::make_pair (cell->getGridX(), cell->getGridY()), CellStore (cell))).first;
+                std::make_pair (cell->getGridX(), cell->getGridY()), CellStore (cell, mStore, mReader))).first;
 
         }
 
@@ -70,7 +70,7 @@ MWWorld::Ptr MWWorld::Cells::getPtrAndCache (const std::string& name, CellStore&
 void MWWorld::Cells::writeCell (ESM::ESMWriter& writer, CellStore& cell) const
 {
     if (cell.getState()!=CellStore::State_Loaded)
-        cell.load (mStore, mReader);
+        cell.load ();
 
     ESM::CellState cellState;
 
@@ -114,13 +114,13 @@ MWWorld::CellStore *MWWorld::Cells::getExterior (int x, int y)
         }
 
         result = mExteriors.insert (std::make_pair (
-            std::make_pair (x, y), CellStore (cell))).first;
+            std::make_pair (x, y), CellStore (cell, mStore, mReader))).first;
     }
 
     if (result->second.getState()!=CellStore::State_Loaded)
     {
         // Multiple plugin support for landscape data is much easier than for references. The last plugin wins.
-        result->second.load (mStore, mReader);
+        result->second.load ();
     }
 
     return &result->second;
@@ -135,12 +135,12 @@ MWWorld::CellStore *MWWorld::Cells::getInterior (const std::string& name)
     {
         const ESM::Cell *cell = mStore.get<ESM::Cell>().find(lowerName);
 
-        result = mInteriors.insert (std::make_pair (lowerName, CellStore (cell))).first;
+        result = mInteriors.insert (std::make_pair (lowerName, CellStore (cell, mStore, mReader))).first;
     }
 
     if (result->second.getState()!=CellStore::State_Loaded)
     {
-        result->second.load (mStore, mReader);
+        result->second.load ();
     }
 
     return &result->second;
@@ -158,13 +158,13 @@ MWWorld::Ptr MWWorld::Cells::getPtr (const std::string& name, CellStore& cell,
     bool searchInContainers)
 {
     if (cell.getState()==CellStore::State_Unloaded)
-        cell.preload (mStore, mReader);
+        cell.preload ();
 
     if (cell.getState()==CellStore::State_Preloaded)
     {
         if (cell.hasId (name))
         {
-            cell.load (mStore, mReader);
+            cell.load ();
         }
         else
             return Ptr();
@@ -333,7 +333,7 @@ bool MWWorld::Cells::readRecord (ESM::ESMReader& reader, uint32_t type,
             cellStore->readFog(reader);
 
         if (cellStore->getState()!=CellStore::State_Loaded)
-            cellStore->load (mStore, mReader);
+            cellStore->load ();
 
         cellStore->readReferences (reader, contentFileMap);
 

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -119,7 +119,6 @@ MWWorld::CellStore *MWWorld::Cells::getExterior (int x, int y)
 
     if (result->second.getState()!=CellStore::State_Loaded)
     {
-        // Multiple plugin support for landscape data is much easier than for references. The last plugin wins.
         result->second.load ();
     }
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -241,9 +241,9 @@ namespace MWWorld
         return MWWorld::Ptr(object.getBase(), cellToMoveTo);
     }
 
-    struct MergeFunctor
+    struct MergeVisitor
     {
-        MergeFunctor(std::vector<LiveCellRefBase*>& mergeTo, const std::map<LiveCellRefBase*, MWWorld::CellStore*>& movedHere,
+        MergeVisitor(std::vector<LiveCellRefBase*>& mergeTo, const std::map<LiveCellRefBase*, MWWorld::CellStore*>& movedHere,
                      const std::map<LiveCellRefBase*, MWWorld::CellStore*>& movedToAnotherCell)
             : mMergeTo(mergeTo)
             , mMovedHere(movedHere)
@@ -275,9 +275,9 @@ namespace MWWorld
     void CellStore::updateMergedRefs()
     {
         mMergedRefs.clear();
-        MergeFunctor functor(mMergedRefs, mMovedHere, mMovedToAnotherCell);
-        forEachInternal(functor);
-        functor.merge();
+        MergeVisitor visitor(mMergedRefs, mMovedHere, mMovedToAnotherCell);
+        forEachInternal(visitor);
+        visitor.merge();
     }
 
     CellStore::CellStore (const ESM::Cell *cell, const MWWorld::ESMStore& esmStore, std::vector<ESM::ESMReader>& readerList)
@@ -313,7 +313,7 @@ namespace MWWorld
         return const_cast<CellStore *> (this)->search (id).isEmpty();
     }
 
-    struct SearchFunctor
+    struct SearchVisitor
     {
         MWWorld::Ptr mFound;
         std::string mIdToFind;
@@ -332,12 +332,12 @@ namespace MWWorld
     {
         bool oldState = mHasState;
 
-        SearchFunctor searchFunctor;
-        searchFunctor.mIdToFind = id;
-        forEach(searchFunctor);
+        SearchVisitor searchVisitor;
+        searchVisitor.mIdToFind = id;
+        forEach(searchVisitor);
 
         mHasState = oldState;
-        return searchFunctor.mFound;
+        return searchVisitor.mFound;
     }
 
     Ptr CellStore::searchViaActorId (int id)

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -770,6 +770,7 @@ namespace MWWorld
                     throw std::runtime_error ("unknown type in cell reference section");
             }
         }
+        updateMergedRefs();
     }
 
     bool operator== (const CellStore& left, const CellStore& right)

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -474,8 +474,6 @@ namespace MWWorld
                     continue;
                 }
 
-                // We don't need to check mMovedToAnotherCell because listRefs isn't used for loaded cells.
-
                 mIds.push_back (Misc::StringUtils::lowerCase (ref.mRefID));
             }
         }
@@ -486,12 +484,6 @@ namespace MWWorld
             const ESM::CellRef &ref = *it;
 
             mIds.push_back(Misc::StringUtils::lowerCase(ref.mRefID));
-        }
-
-        // List runtime moved references
-        for (MovedRefTracker::const_iterator it = mMovedHere.begin(); it != mMovedHere.end(); ++it)
-        {
-            mIds.push_back(Misc::StringUtils::lowerCase(it->first->mRef.getRefId()));
         }
 
         std::sort (mIds.begin(), mIds.end());

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -636,7 +636,15 @@ namespace MWWorld
         writeReferenceCollection<ESM::ObjectState> (writer, mStatics);
         writeReferenceCollection<ESM::ObjectState> (writer, mWeapons);
 
-        // TODO: write moved references
+        for (MovedRefTracker::const_iterator it = mMovedToAnotherCell.begin(); it != mMovedToAnotherCell.end(); ++it)
+        {
+            LiveCellRefBase* base = it->first;
+            ESM::RefNum refNum = base->mRef.getRefNum();
+            ESM::CellId movedTo = it->second->getCell()->getCellId();
+
+            refNum.save(writer, true, "MVRF");
+            movedTo.save(writer);
+        }
     }
 
     void CellStore::readReferences (ESM::ESMReader& reader,
@@ -770,6 +778,18 @@ namespace MWWorld
                     throw std::runtime_error ("unknown type in cell reference section");
             }
         }
+
+        while (reader.isNextSub("MVRF"))
+        {
+            reader.cacheSubName();
+            ESM::RefNum refnum;
+            ESM::CellId movedTo;
+            refnum.load(reader, true, "MVRF");
+            movedTo.load(reader);
+
+            std::cout << "moved to " << movedTo.mWorldspace << " " << movedTo.mIndex.mX << " " << movedTo.mIndex.mY << std::endl;
+        }
+
         updateMergedRefs();
     }
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -213,6 +213,15 @@ namespace MWWorld
 
         // TODO: ensure that the object actually exists in the cell
 
+        // Objects with no refnum can't be handled correctly in the merging process that happens
+        // on a save/load, so do a simple copy & delete for these objects.
+        if (!object.getCellRef().getRefNum().hasContentFile())
+        {
+            MWWorld::Ptr copied = object.getClass().copyToCell(object, *cellToMoveTo);
+            object.getRefData().setCount(0);
+            return copied;
+        }
+
         MovedRefTracker::iterator found = mMovedHere.find(object.getBase());
         if (found != mMovedHere.end())
         {

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -246,6 +246,7 @@ namespace MWWorld
         {
             MWWorld::Ptr copied = object.getClass().copyToCell(object, *cellToMoveTo);
             object.getRefData().setCount(0);
+            object.getRefData().setBaseNode(NULL);
             return copied;
         }
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -379,27 +379,7 @@ namespace MWWorld
 
     int CellStore::count() const
     {
-        return
-            mActivators.mList.size()
-            + mPotions.mList.size()
-            + mAppas.mList.size()
-            + mArmors.mList.size()
-            + mBooks.mList.size()
-            + mClothes.mList.size()
-            + mContainers.mList.size()
-            + mDoors.mList.size()
-            + mIngreds.mList.size()
-            + mCreatureLists.mList.size()
-            + mItemLists.mList.size()
-            + mLights.mList.size()
-            + mLockpicks.mList.size()
-            + mMiscItems.mList.size()
-            + mProbes.mList.size()
-            + mRepairs.mList.size()
-            + mStatics.mList.size()
-            + mWeapons.mList.size()
-            + mCreatures.mList.size()
-            + mNpcs.mList.size();
+        return mMergedRefs.size();
     }
 
     void CellStore::load (const MWWorld::ESMStore &store, std::vector<ESM::ESMReader> &esm)

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -184,6 +184,9 @@ namespace MWWorld
 
     void CellStore::moveFrom(const Ptr &object, CellStore *from)
     {
+        if (mState != State_Loaded)
+            load();
+
         mHasState = true;
         MovedRefTracker::iterator found = mMovedToAnotherCell.find(object.getBase());
         if (found != mMovedToAnotherCell.end())
@@ -196,14 +199,7 @@ namespace MWWorld
         {
             mMovedHere.insert(std::make_pair(object.getBase(), from));
         }
-
-        if (mState == State_Loaded)
-            updateMergedRefs();
-        else if (mState == State_Preloaded)
-        {
-            mIds.push_back(object.getCellRef().getRefId());
-            std::sort(mIds.begin(), mIds.end());
-        }
+        updateMergedRefs();
     }
 
     MWWorld::Ptr CellStore::moveTo(const Ptr &object, CellStore *cellToMoveTo)

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -73,6 +73,7 @@ namespace MWWorld
 
             MWWorld::TimeStamp mLastRespawn;
 
+            // List of refs owned by this cell
             CellRefList<ESM::Activator>         mActivators;
             CellRefList<ESM::Potion>            mPotions;
             CellRefList<ESM::Apparatus>         mAppas;
@@ -179,6 +180,8 @@ namespace MWWorld
                     forEachImp (functor, mNpcs);
             }
 
+            /// \todo add const version of forEach
+
             bool isExterior() const;
 
             Ptr searchInContainer (const std::string& id);
@@ -197,16 +200,6 @@ namespace MWWorld
 
             void respawn ();
             ///< Check mLastRespawn and respawn references if necessary. This is a no-op if the cell is not loaded.
-
-            template <class T>
-            CellRefList<T>& get() {
-                throw std::runtime_error ("Storage for type " + std::string(typeid(T).name())+ " does not exist in cells");
-            }
-
-            template <class T>
-            const CellRefList<T>& getReadOnly() {
-                throw std::runtime_error ("Read Only CellRefList access not available for type " + std::string(typeid(T).name()) );
-            }
 
             bool isPointConnected(const int start, const int end) const;
 
@@ -240,152 +233,6 @@ namespace MWWorld
 
             MWMechanics::PathgridGraph mPathgridGraph;
     };
-
-    template<>
-    inline CellRefList<ESM::Activator>& CellStore::get<ESM::Activator>()
-    {
-        mHasState = true;
-        return mActivators;
-    }
-
-    template<>
-    inline CellRefList<ESM::Potion>& CellStore::get<ESM::Potion>()
-    {
-        mHasState = true;
-        return mPotions;
-    }
-
-    template<>
-    inline CellRefList<ESM::Apparatus>& CellStore::get<ESM::Apparatus>()
-    {
-        mHasState = true;
-        return mAppas;
-    }
-
-    template<>
-    inline CellRefList<ESM::Armor>& CellStore::get<ESM::Armor>()
-    {
-        mHasState = true;
-        return mArmors;
-    }
-
-    template<>
-    inline CellRefList<ESM::Book>& CellStore::get<ESM::Book>()
-    {
-        mHasState = true;
-        return mBooks;
-    }
-
-    template<>
-    inline CellRefList<ESM::Clothing>& CellStore::get<ESM::Clothing>()
-    {
-        mHasState = true;
-        return mClothes;
-    }
-
-    template<>
-    inline CellRefList<ESM::Container>& CellStore::get<ESM::Container>()
-    {
-        mHasState = true;
-        return mContainers;
-    }
-
-    template<>
-    inline CellRefList<ESM::Creature>& CellStore::get<ESM::Creature>()
-    {
-        mHasState = true;
-        return mCreatures;
-    }
-
-    template<>
-    inline CellRefList<ESM::Door>& CellStore::get<ESM::Door>()
-    {
-        mHasState = true;
-        return mDoors;
-    }
-
-    template<>
-    inline CellRefList<ESM::Ingredient>& CellStore::get<ESM::Ingredient>()
-    {
-        mHasState = true;
-        return mIngreds;
-    }
-
-    template<>
-    inline CellRefList<ESM::CreatureLevList>& CellStore::get<ESM::CreatureLevList>()
-    {
-        mHasState = true;
-        return mCreatureLists;
-    }
-
-    template<>
-    inline CellRefList<ESM::ItemLevList>& CellStore::get<ESM::ItemLevList>()
-    {
-        mHasState = true;
-        return mItemLists;
-    }
-
-    template<>
-    inline CellRefList<ESM::Light>& CellStore::get<ESM::Light>()
-    {
-        mHasState = true;
-        return mLights;
-    }
-
-    template<>
-    inline CellRefList<ESM::Lockpick>& CellStore::get<ESM::Lockpick>()
-    {
-        mHasState = true;
-        return mLockpicks;
-    }
-
-    template<>
-    inline CellRefList<ESM::Miscellaneous>& CellStore::get<ESM::Miscellaneous>()
-    {
-        mHasState = true;
-        return mMiscItems;
-    }
-
-    template<>
-    inline CellRefList<ESM::NPC>& CellStore::get<ESM::NPC>()
-    {
-        mHasState = true;
-        return mNpcs;
-    }
-
-    template<>
-    inline CellRefList<ESM::Probe>& CellStore::get<ESM::Probe>()
-    {
-        mHasState = true;
-        return mProbes;
-    }
-
-    template<>
-    inline CellRefList<ESM::Repair>& CellStore::get<ESM::Repair>()
-    {
-        mHasState = true;
-        return mRepairs;
-    }
-
-    template<>
-    inline CellRefList<ESM::Static>& CellStore::get<ESM::Static>()
-    {
-        mHasState = true;
-        return mStatics;
-    }
-
-    template<>
-    inline CellRefList<ESM::Weapon>& CellStore::get<ESM::Weapon>()
-    {
-        mHasState = true;
-        return mWeapons;
-    }
-
-    template<>
-    inline const CellRefList<ESM::Door>& CellStore::getReadOnly<ESM::Door>()
-    {
-        return mDoors;
-    }
 
     bool operator== (const CellStore& left, const CellStore& right);
     bool operator!= (const CellStore& left, const CellStore& right);

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -60,6 +60,9 @@ namespace MWWorld
 
         private:
 
+            const MWWorld::ESMStore& mStore;
+            std::vector<ESM::ESMReader>& mReader;
+
             // Even though fog actually belongs to the player and not cells,
             // it makes sense to store it here since we need it once for each cell.
             // Note this is NULL until the cell is explored to save some memory
@@ -177,7 +180,10 @@ namespace MWWorld
             template <typename T>
             LiveCellRefBase* insert(const LiveCellRef<T>* ref);
 
-            CellStore (const ESM::Cell *cell_);
+            /// @param readerList The readers to use for loading of the cell on-demand.
+            CellStore (const ESM::Cell *cell_,
+                       const MWWorld::ESMStore& store,
+                       std::vector<ESM::ESMReader>& readerList);
 
             const ESM::Cell *getCell() const;
 
@@ -210,10 +216,10 @@ namespace MWWorld
             int count() const;
             ///< Return total number of references, including deleted ones.
 
-            void load (const MWWorld::ESMStore &store, std::vector<ESM::ESMReader> &esm);
+            void load ();
             ///< Load references from content file.
 
-            void preload (const MWWorld::ESMStore &store, std::vector<ESM::ESMReader> &esm);
+            void preload ();
             ///< Build ID list from content file.
 
             /// Call functor (ref) for each reference. functor must return a bool. Returning
@@ -267,11 +273,11 @@ namespace MWWorld
         private:
 
             /// Run through references and store IDs
-            void listRefs(const MWWorld::ESMStore &store, std::vector<ESM::ESMReader> &esm);
+            void listRefs();
 
-            void loadRefs(const MWWorld::ESMStore &store, std::vector<ESM::ESMReader> &esm);
+            void loadRefs();
 
-            void loadRef (ESM::CellRef& ref, bool deleted, const ESMStore& store);
+            void loadRef (ESM::CellRef& ref, bool deleted);
             ///< Make case-adjustments to \a ref and insert it into the respective container.
             ///
             /// Invalid \a ref objects are silently dropped.

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -97,6 +97,9 @@ namespace MWWorld
 
         public:
 
+            /// Make a copy of the given object and insert it into this cell.
+            /// @note If you get a linker error here, this means the given type can not be inserted into a cell.
+            /// The supported types are defined at the bottom of this file.
             template <typename T>
             LiveCellRefBase* insert(const LiveCellRef<T>* ref);
 

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -12,8 +12,6 @@
 #include "livecellref.hpp"
 #include "cellreflist.hpp"
 
-#include <components/esm/cellid.hpp>
-
 #include <components/esm/loadacti.hpp>
 #include <components/esm/loadalch.hpp>
 #include <components/esm/loadappa.hpp>
@@ -42,6 +40,7 @@ namespace ESM
 {
     struct CellState;
     struct FogState;
+    struct CellId;
 }
 
 namespace MWWorld
@@ -263,7 +262,15 @@ namespace MWWorld
 
             void writeReferences (ESM::ESMWriter& writer) const;
 
-            void readReferences (ESM::ESMReader& reader, const std::map<int, int>& contentFileMap);
+            struct GetCellStoreCallback
+            {
+            public:
+                ///@note must return NULL if the cell is not found
+                virtual CellStore* getCellStore(const ESM::CellId& cellId) = 0;
+            };
+
+            /// @param callback to use for retrieving of additional CellStore objects by ID (required for resolving moved references)
+            void readReferences (ESM::ESMReader& reader, const std::map<int, int>& contentFileMap, GetCellStoreCallback* callback);
 
             void respawn ();
             ///< Check mLastRespawn and respawn references if necessary. This is a no-op if the cell is not loaded.

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -12,6 +12,8 @@
 #include "livecellref.hpp"
 #include "cellreflist.hpp"
 
+#include <components/esm/cellid.hpp>
+
 #include <components/esm/loadacti.hpp>
 #include <components/esm/loadalch.hpp>
 #include <components/esm/loadappa.hpp>

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -286,6 +286,18 @@ namespace MWWorld
 
             /// \todo add const version of forEach
 
+
+            // NOTE: does not account for moved references
+            // Should be phased out when we have const version of forEach
+            inline const CellRefList<ESM::Door>& getReadOnlyDoors() const
+            {
+                return mDoors;
+            }
+            inline const CellRefList<ESM::Static>& getReadOnlyStatics() const
+            {
+                return mStatics;
+            }
+
             bool isExterior() const;
 
             Ptr searchInContainer (const std::string& id);

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -97,6 +97,9 @@ namespace MWWorld
 
         public:
 
+            template <typename T>
+            LiveCellRefBase* insert(const LiveCellRef<T>* ref);
+
             CellStore (const ESM::Cell *cell_);
 
             const ESM::Cell *getCell() const;
@@ -233,6 +236,128 @@ namespace MWWorld
 
             MWMechanics::PathgridGraph mPathgridGraph;
     };
+
+
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Activator>(const LiveCellRef<ESM::Activator>* ref)
+    {
+        mHasState = true;
+        return &mActivators.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Potion>(const LiveCellRef<ESM::Potion>* ref)
+    {
+        mHasState = true;
+        return &mPotions.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Apparatus>(const LiveCellRef<ESM::Apparatus>* ref)
+    {
+        mHasState = true;
+        return &mAppas.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Armor>(const LiveCellRef<ESM::Armor>* ref)
+    {
+        mHasState = true;
+        return &mArmors.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Book>(const LiveCellRef<ESM::Book>* ref)
+    {
+        mHasState = true;
+        return &mBooks.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Clothing>(const LiveCellRef<ESM::Clothing>* ref)
+    {
+        mHasState = true;
+        return &mClothes.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Container>(const LiveCellRef<ESM::Container>* ref)
+    {
+        mHasState = true;
+        return &mContainers.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Creature>(const LiveCellRef<ESM::Creature>* ref)
+    {
+        mHasState = true;
+        return &mCreatures.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Door>(const LiveCellRef<ESM::Door>* ref)
+    {
+        mHasState = true;
+        return &mDoors.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Ingredient>(const LiveCellRef<ESM::Ingredient>* ref)
+    {
+        mHasState = true;
+        return &mIngreds.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::CreatureLevList>(const LiveCellRef<ESM::CreatureLevList>* ref)
+    {
+        mHasState = true;
+        return &mCreatureLists.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::ItemLevList>(const LiveCellRef<ESM::ItemLevList>* ref)
+    {
+        mHasState = true;
+        return &mItemLists.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Light>(const LiveCellRef<ESM::Light>* ref)
+    {
+        mHasState = true;
+        return &mLights.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Lockpick>(const LiveCellRef<ESM::Lockpick>* ref)
+    {
+        mHasState = true;
+        return &mLockpicks.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Miscellaneous>(const LiveCellRef<ESM::Miscellaneous>* ref)
+    {
+        mHasState = true;
+        return &mMiscItems.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::NPC>(const LiveCellRef<ESM::NPC>* ref)
+    {
+        mHasState = true;
+        return &mNpcs.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Probe>(const LiveCellRef<ESM::Probe>* ref)
+    {
+        mHasState = true;
+        return &mProbes.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Repair>(const LiveCellRef<ESM::Repair>* ref)
+    {
+        mHasState = true;
+        return &mRepairs.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Static>(const LiveCellRef<ESM::Static>* ref)
+    {
+        mHasState = true;
+        return &mStatics.insert(*ref);
+    }
+    template<>
+    inline LiveCellRefBase* CellStore::insert<ESM::Weapon>(const LiveCellRef<ESM::Weapon>* ref)
+    {
+        mHasState = true;
+        return &mWeapons.insert(*ref);
+    }
 
     bool operator== (const CellStore& left, const CellStore& right);
     bool operator!= (const CellStore& left, const CellStore& right);

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -125,45 +125,45 @@ namespace MWWorld
             }
 
             // helper function for forEachInternal
-            template<class Functor, class List>
-            bool forEachImp (Functor& functor, List& list)
+            template<class Visitor, class List>
+            bool forEachImp (Visitor& visitor, List& list)
             {
                 for (typename List::List::iterator iter (list.mList.begin()); iter!=list.mList.end();
                     ++iter)
                 {
                     if (iter->mData.isDeletedByContentFile())
                         continue;
-                    if (!functor (MWWorld::Ptr(&*iter, this)))
+                    if (!visitor (MWWorld::Ptr(&*iter, this)))
                         return false;
                 }
                 return true;
             }
 
             // listing only objects owned by this cell. Internal use only, you probably want to use forEach() so that moved objects are accounted for.
-            template<class Functor>
-            bool forEachInternal (Functor& functor)
+            template<class Visitor>
+            bool forEachInternal (Visitor& visitor)
             {
                 return
-                    forEachImp (functor, mActivators) &&
-                    forEachImp (functor, mPotions) &&
-                    forEachImp (functor, mAppas) &&
-                    forEachImp (functor, mArmors) &&
-                    forEachImp (functor, mBooks) &&
-                    forEachImp (functor, mClothes) &&
-                    forEachImp (functor, mContainers) &&
-                    forEachImp (functor, mDoors) &&
-                    forEachImp (functor, mIngreds) &&
-                    forEachImp (functor, mItemLists) &&
-                    forEachImp (functor, mLights) &&
-                    forEachImp (functor, mLockpicks) &&
-                    forEachImp (functor, mMiscItems) &&
-                    forEachImp (functor, mProbes) &&
-                    forEachImp (functor, mRepairs) &&
-                    forEachImp (functor, mStatics) &&
-                    forEachImp (functor, mWeapons) &&
-                    forEachImp (functor, mCreatures) &&
-                    forEachImp (functor, mNpcs) &&
-                    forEachImp (functor, mCreatureLists);
+                    forEachImp (visitor, mActivators) &&
+                    forEachImp (visitor, mPotions) &&
+                    forEachImp (visitor, mAppas) &&
+                    forEachImp (visitor, mArmors) &&
+                    forEachImp (visitor, mBooks) &&
+                    forEachImp (visitor, mClothes) &&
+                    forEachImp (visitor, mContainers) &&
+                    forEachImp (visitor, mDoors) &&
+                    forEachImp (visitor, mIngreds) &&
+                    forEachImp (visitor, mItemLists) &&
+                    forEachImp (visitor, mLights) &&
+                    forEachImp (visitor, mLockpicks) &&
+                    forEachImp (visitor, mMiscItems) &&
+                    forEachImp (visitor, mProbes) &&
+                    forEachImp (visitor, mRepairs) &&
+                    forEachImp (visitor, mStatics) &&
+                    forEachImp (visitor, mWeapons) &&
+                    forEachImp (visitor, mCreatures) &&
+                    forEachImp (visitor, mNpcs) &&
+                    forEachImp (visitor, mCreatureLists);
             }
 
         public:
@@ -222,12 +222,12 @@ namespace MWWorld
             void preload ();
             ///< Build ID list from content file.
 
-            /// Call functor (ref) for each reference. functor must return a bool. Returning
+            /// Call visitor (ref) for each reference. visitor must return a bool. Returning
             /// false will abort the iteration.
             /// \attention This function also lists deleted (count 0) objects!
             /// \return Iteration completed?
-            template<class Functor>
-            bool forEach (Functor& functor)
+            template<class Visitor>
+            bool forEach (Visitor& visitor)
             {
                 if (mState != State_Loaded)
                     return false;
@@ -239,7 +239,7 @@ namespace MWWorld
                     if (mMergedRefs[i]->mData.isDeletedByContentFile())
                         continue;
 
-                    if (!functor(MWWorld::Ptr(mMergedRefs[i], this)))
+                    if (!visitor(MWWorld::Ptr(mMergedRefs[i], this)))
                         return false;
                 }
                 return true;

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -95,7 +95,28 @@ namespace MWWorld
             CellRefList<ESM::Static>            mStatics;
             CellRefList<ESM::Weapon>            mWeapons;
 
+            typedef std::map<LiveCellRefBase*, MWWorld::CellStore*> MovedRefTracker;
+            // References owned by a different cell that have been moved here.
+            // <reference, cell the reference originally came from>
+            MovedRefTracker mMovedHere;
+            // References owned by this cell that have been moved to another cell.
+            // <reference, cell the reference was moved to>
+            MovedRefTracker mMovedToAnotherCell;
+
+            // Merged list of ref's currently in this cell - i.e. with added refs from mMovedHere, removed refs from mMovedToAnotherCell
+            std::vector<LiveCellRefBase*> mMergedRefs;
+
+            /// Moves object from the given cell to this cell.
+            void moveFrom(const MWWorld::Ptr& object, MWWorld::CellStore* from);
+
+            /// Repopulate mMergedRefs.
+            void updateMergedRefs();
+
         public:
+
+            /// Moves object from this cell to the given cell.
+            /// @note automatically updates given cell by calling cellToMoveTo->moveFrom(...)
+            void moveTo(const MWWorld::Ptr& object, MWWorld::CellStore* cellToMoveTo);
 
             /// Make a copy of the given object and insert it into this cell.
             /// @note If you get a linker error here, this means the given type can not be inserted into a cell.

--- a/apps/openmw/mwworld/cellvisitors.hpp
+++ b/apps/openmw/mwworld/cellvisitors.hpp
@@ -1,5 +1,5 @@
-#ifndef GAME_MWWORLD_CELLFUNCTORS_H
-#define GAME_MWWORLD_CELLFUNCTORS_H
+#ifndef GAME_MWWORLD_CELLVISITORS_H
+#define GAME_MWWORLD_CELLVISITORS_H
 
 #include <vector>
 #include <string>
@@ -9,7 +9,7 @@
 
 namespace MWWorld
 {
-    struct ListAndResetObjects
+    struct ListAndResetObjectsVisitor
     {
         std::vector<MWWorld::Ptr> mObjects;
 

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -116,6 +116,7 @@ void MWWorld::LocalScripts::add (const std::string& scriptName, const Ptr& ptr)
 
 void MWWorld::LocalScripts::addCell (CellStore *cell)
 {
+    /*
     listCellScripts (*this, cell->get<ESM::Activator>(), cell);
     listCellScripts (*this, cell->get<ESM::Potion>(), cell);
     listCellScripts (*this, cell->get<ESM::Apparatus>(), cell);
@@ -136,6 +137,7 @@ void MWWorld::LocalScripts::addCell (CellStore *cell)
     listCellScripts (*this, cell->get<ESM::Probe>(), cell);
     listCellScripts (*this, cell->get<ESM::Repair>(), cell);
     listCellScripts (*this, cell->get<ESM::Weapon>(), cell);
+    */
 }
 
 void MWWorld::LocalScripts::clear()

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -11,46 +11,54 @@
 
 namespace
 {
-    template<typename T>
-    void listCellScripts (MWWorld::LocalScripts& localScripts,
-        MWWorld::CellRefList<T>& cellRefList,  MWWorld::CellStore *cell)
+
+    struct AddScriptsVisitor
     {
-        for (typename MWWorld::CellRefList<T>::List::iterator iter (
-            cellRefList.mList.begin());
-            iter!=cellRefList.mList.end(); ++iter)
+        AddScriptsVisitor(MWWorld::LocalScripts& scripts)
+            : mScripts(scripts)
         {
-            if (!iter->mBase->mScript.empty() && !iter->mData.isDeleted())
-            {
-                localScripts.add (iter->mBase->mScript, MWWorld::Ptr (&*iter, cell));
-            }
         }
-    }
+        MWWorld::LocalScripts& mScripts;
 
-    // Adds scripts for items in containers (containers/npcs/creatures)
-    template<typename T>
-    void listCellScriptsCont (MWWorld::LocalScripts& localScripts,
-        MWWorld::CellRefList<T>& cellRefList,  MWWorld::CellStore *cell)
-    {
-        for (typename MWWorld::CellRefList<T>::List::iterator iter (
-            cellRefList.mList.begin());
-            iter!=cellRefList.mList.end(); ++iter)
+        bool operator()(const MWWorld::Ptr& ptr)
         {
+            if (ptr.getRefData().isDeleted())
+                return true;
 
-            MWWorld::Ptr containerPtr (&*iter, cell);
+            std::string script = ptr.getClass().getScript(ptr);
 
+            if (!script.empty())
+                mScripts.add(script, ptr);
+
+            return true;
+        }
+    };
+
+    struct AddContainerItemScriptsVisitor
+    {
+        AddContainerItemScriptsVisitor(MWWorld::LocalScripts& scripts)
+            : mScripts(scripts)
+        {
+        }
+        MWWorld::LocalScripts& mScripts;
+
+        bool operator()(const MWWorld::Ptr& containerPtr)
+        {
             MWWorld::ContainerStore& container = containerPtr.getClass().getContainerStore(containerPtr);
-            for(MWWorld::ContainerStoreIterator it3 = container.begin(); it3 != container.end(); ++it3)
+            for(MWWorld::ContainerStoreIterator it = container.begin(); it != container.end(); ++it)
             {
-                std::string script = it3->getClass().getScript(*it3);
+                std::string script = it->getClass().getScript(*it);
                 if(script != "")
                 {
-                    MWWorld::Ptr item = *it3;
-                    item.mCell = cell;
-                    localScripts.add (script, item);
+                    MWWorld::Ptr item = *it;
+                    item.mCell = containerPtr.getCell();
+                    mScripts.add (script, item);
                 }
             }
+            return true;
         }
-    }
+    };
+
 }
 
 MWWorld::LocalScripts::LocalScripts (const MWWorld::ESMStore& store) : mStore (store) {}
@@ -116,28 +124,13 @@ void MWWorld::LocalScripts::add (const std::string& scriptName, const Ptr& ptr)
 
 void MWWorld::LocalScripts::addCell (CellStore *cell)
 {
-    /*
-    listCellScripts (*this, cell->get<ESM::Activator>(), cell);
-    listCellScripts (*this, cell->get<ESM::Potion>(), cell);
-    listCellScripts (*this, cell->get<ESM::Apparatus>(), cell);
-    listCellScripts (*this, cell->get<ESM::Armor>(), cell);
-    listCellScripts (*this, cell->get<ESM::Book>(), cell);
-    listCellScripts (*this, cell->get<ESM::Clothing>(), cell);
-    listCellScripts (*this, cell->get<ESM::Container>(), cell);
-    listCellScriptsCont (*this, cell->get<ESM::Container>(), cell);
-    listCellScripts (*this, cell->get<ESM::Creature>(), cell);
-    listCellScriptsCont (*this, cell->get<ESM::Creature>(), cell);
-    listCellScripts (*this, cell->get<ESM::Door>(), cell);
-    listCellScripts (*this, cell->get<ESM::Ingredient>(), cell);
-    listCellScripts (*this, cell->get<ESM::Light>(), cell);
-    listCellScripts (*this, cell->get<ESM::Lockpick>(), cell);
-    listCellScripts (*this, cell->get<ESM::Miscellaneous>(), cell);
-    listCellScripts (*this, cell->get<ESM::NPC>(), cell);
-    listCellScriptsCont (*this, cell->get<ESM::NPC>(), cell);
-    listCellScripts (*this, cell->get<ESM::Probe>(), cell);
-    listCellScripts (*this, cell->get<ESM::Repair>(), cell);
-    listCellScripts (*this, cell->get<ESM::Weapon>(), cell);
-    */
+    AddScriptsVisitor addScriptsVisitor(*this);
+    cell->forEach(addScriptsVisitor);
+
+    AddContainerItemScriptsVisitor addContainerItemScriptsVisitor(*this);
+    cell->forEachType<ESM::NPC>(addContainerItemScriptsVisitor);
+    cell->forEachType<ESM::Creature>(addContainerItemScriptsVisitor);
+    cell->forEachType<ESM::Container>(addContainerItemScriptsVisitor);
 }
 
 void MWWorld::LocalScripts::clear()

--- a/apps/openmw/mwworld/refdata.cpp
+++ b/apps/openmw/mwworld/refdata.cpp
@@ -182,7 +182,7 @@ namespace MWWorld
         mPosition = pos;
     }
 
-    const ESM::Position& RefData::getPosition()
+    const ESM::Position& RefData::getPosition() const
     {
         return mPosition;
     }

--- a/apps/openmw/mwworld/refdata.hpp
+++ b/apps/openmw/mwworld/refdata.hpp
@@ -103,7 +103,7 @@ namespace MWWorld
             void disable();
 
             void setPosition (const ESM::Position& pos);
-            const ESM::Position& getPosition();
+            const ESM::Position& getPosition() const;
 
             void setCustomData (CustomData *data);
             ///< Set custom data (potentially replacing old custom data). The ownership of \a data is

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1693,6 +1693,7 @@ namespace MWWorld
 
     osg::Vec2f World::getNorthVector (CellStore* cell)
     {
+        /*
         MWWorld::CellRefList<ESM::Static>& statics = cell->get<ESM::Static>();
         MWWorld::LiveCellRef<ESM::Static>* ref = statics.find("northmarker");
         if (!ref)
@@ -1702,10 +1703,13 @@ namespace MWWorld
         osg::Vec3f dir = orient * osg::Vec3f(0,1,0);
         osg::Vec2f d (dir.x(), dir.y());
         return d;
+        */
+        return osg::Vec2f();
     }
 
     void World::getDoorMarkers (CellStore* cell, std::vector<World::DoorMarker>& out)
     {
+        /*
         MWWorld::CellRefList<ESM::Door>& doors = cell->get<ESM::Door>();
         CellRefList<ESM::Door>::List& refList = doors.mList;
         for (CellRefList<ESM::Door>::List::iterator it = refList.begin(); it != refList.end(); ++it)
@@ -1744,6 +1748,7 @@ namespace MWWorld
                 out.push_back(newMarker);
             }
         }
+        */
     }
 
     void World::setWaterHeight(const float height)
@@ -2240,6 +2245,7 @@ namespace MWWorld
 
     void World::getContainersOwnedBy (const MWWorld::Ptr& npc, std::vector<MWWorld::Ptr>& out)
     {
+        /*
         const Scene::CellStoreCollection& collection = mWorldScene->getActiveCells();
         for (Scene::CellStoreCollection::const_iterator cellIt = collection.begin(); cellIt != collection.end(); ++cellIt)
         {
@@ -2254,6 +2260,7 @@ namespace MWWorld
                     out.push_back(ptr);
             }
         }
+        */
     }
 
     struct ListObjectsFunctor
@@ -2316,6 +2323,8 @@ namespace MWWorld
 
     bool World::findInteriorPosition(const std::string &name, ESM::Position &pos)
     {
+        return false;
+        /*
         typedef MWWorld::CellRefList<ESM::Door>::List DoorList;
         typedef MWWorld::CellRefList<ESM::Static>::List StaticList;
 
@@ -2368,6 +2377,7 @@ namespace MWWorld
             pos = statics.begin()->mRef.getPosition();
             return true;
         }
+        */
 
         return false;
     }
@@ -2715,6 +2725,8 @@ namespace MWWorld
 
     bool World::findInteriorPositionInWorldSpace(MWWorld::CellStore* cell, osg::Vec3f& result)
     {
+        return false;
+        /*
         if (cell->isExterior())
             return false;
 
@@ -2732,7 +2744,7 @@ namespace MWWorld
                 MWWorld::CellStore *next = getInterior( *i );
                 if ( !next ) continue;
 
-                const MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnly<ESM::Door>();
+                const MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnlyDoors();
                 const CellRefList<ESM::Door>::List& refList = doors.mList;
 
                 // Check if any door in the cell leads to an exterior directly
@@ -2761,10 +2773,12 @@ namespace MWWorld
 
         // No luck :(
         return false;
+        */
     }
 
     MWWorld::Ptr World::getClosestMarker( const MWWorld::Ptr &ptr, const std::string &id )
     {
+        /*
         if ( ptr.getCell()->isExterior() ) {
             return getClosestMarkerFromExteriorPosition(mPlayer->getLastKnownExteriorPosition(), id);
         }
@@ -2792,7 +2806,7 @@ namespace MWWorld
                     return closestMarker;
                 }
 
-                const MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnly<ESM::Door>();
+                const MWWorld::CellRefList<ESM::Door>& doors = next->getReadOnlyDoors();
                 const CellRefList<ESM::Door>::List& doorList = doors.mList;
 
                 // Check if any door in the cell leads to an exterior directly
@@ -2816,7 +2830,7 @@ namespace MWWorld
                 }
             }
         }
-
+        */
         return MWWorld::Ptr();
     }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1171,7 +1171,6 @@ namespace MWWorld
                     newPtr = currCell->moveTo(ptr, newCell);
 
                     mRendering->updatePtr(ptr, newPtr);
-                    ptr.getRefData().setBaseNode(NULL);
                     MWBase::Environment::get().getSoundManager()->updatePtr (ptr, newPtr);
                     mPhysics->updatePtr(ptr, newPtr);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2341,8 +2341,6 @@ namespace MWWorld
 
     bool World::findInteriorPosition(const std::string &name, ESM::Position &pos)
     {
-        return false;
-        /*
         typedef MWWorld::CellRefList<ESM::Door>::List DoorList;
         typedef MWWorld::CellRefList<ESM::Static>::List StaticList;
 
@@ -2354,7 +2352,8 @@ namespace MWWorld
         if (0 == cellStore) {
             return false;
         }
-        const DoorList &doors = cellStore->get<ESM::Door>().mList;
+
+        const DoorList &doors = cellStore->getReadOnlyDoors().mList;
         for (DoorList::const_iterator it = doors.begin(); it != doors.end(); ++it) {
             if (!it->mRef.getTeleport()) {
                 continue;
@@ -2376,7 +2375,7 @@ namespace MWWorld
             if (0 != source) {
                 // Find door leading to our current teleport door
                 // and use it destination to position inside cell.
-                const DoorList &doors = source->get<ESM::Door>().mList;
+                const DoorList &doors = source->getReadOnlyDoors().mList;
                 for (DoorList::const_iterator jt = doors.begin(); jt != doors.end(); ++jt) {
                     if (it->mRef.getTeleport() &&
                         Misc::StringUtils::ciEqual(name, jt->mRef.getDestCell()))
@@ -2390,12 +2389,11 @@ namespace MWWorld
             }
         }
         // Fall back to the first static location.
-        const StaticList &statics = cellStore->get<ESM::Static>().mList;
+        const StaticList &statics = cellStore->getReadOnlyStatics().mList;
         if ( statics.begin() != statics.end() ) {
             pos = statics.begin()->mRef.getPosition();
             return true;
         }
-        */
 
         return false;
     }
@@ -2743,8 +2741,6 @@ namespace MWWorld
 
     bool World::findInteriorPositionInWorldSpace(MWWorld::CellStore* cell, osg::Vec3f& result)
     {
-        return false;
-        /*
         if (cell->isExterior())
             return false;
 
@@ -2791,7 +2787,6 @@ namespace MWWorld
 
         // No luck :(
         return false;
-        */
     }
 
     MWWorld::Ptr World::getClosestMarker( const MWWorld::Ptr &ptr, const std::string &id )
@@ -2800,7 +2795,6 @@ namespace MWWorld
             return getClosestMarkerFromExteriorPosition(mPlayer->getLastKnownExteriorPosition(), id);
         }
 
-        /*
         // Search for a 'nearest' marker, counting each cell between the starting
         // cell and the exterior as a distance of 1.  If an exterior is found, jump
         // to the nearest exterior marker, without further interior searching.
@@ -2848,7 +2842,6 @@ namespace MWWorld
                 }
             }
         }
-        */
         return MWWorld::Ptr();
     }
 
@@ -2916,7 +2909,7 @@ namespace MWWorld
         Ptr mDetector;
         float mSquaredDist;
         World::DetectionType mType;
-        bool operator() (MWWorld::Ptr ptr)
+        bool operator() (const MWWorld::Ptr& ptr)
         {
             if ((ptr.getRefData().getPosition().asVec3() - mDetector.getRefData().getPosition().asVec3()).length2() >= mSquaredDist)
                 return true;
@@ -2947,7 +2940,7 @@ namespace MWWorld
             return true;
         }
 
-        bool needToAdd (MWWorld::Ptr ptr, MWWorld::Ptr detector)
+        bool needToAdd (const MWWorld::Ptr& ptr, const MWWorld::Ptr& detector)
         {
             if (mType == World::Detect_Creature)
             {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -722,7 +722,7 @@ namespace MWWorld
         for (Scene::CellStoreCollection::const_iterator cellIt = collection.begin(); cellIt != collection.end(); ++cellIt)
         {
             FindContainerFunctor functor(ptr);
-            (*cellIt)->forEachContainer(functor);
+            //(*cellIt)->forEachContainer(functor);
 
             if (!functor.mResult.isEmpty())
                 return functor.mResult;
@@ -1146,7 +1146,7 @@ namespace MWWorld
                 bool newCellActive = mWorldScene->isCellActive(*newCell);
                 if (!currCellActive && newCellActive)
                 {
-                    newPtr = ptr.getClass().copyToCell(ptr, *newCell, pos);
+                    newPtr = currCell->moveTo(ptr, newCell);
                     mWorldScene->addObjectToScene(newPtr);
 
                     std::string script = newPtr.getClass().getScript(newPtr);
@@ -1162,14 +1162,14 @@ namespace MWWorld
                     removeContainerScripts (ptr);
                     haveToMove = false;
 
-                    newPtr = ptr.getClass().copyToCell(ptr, *newCell);
+                    newPtr = currCell->moveTo(ptr, newCell);
                     newPtr.getRefData().setBaseNode(0);
                 }
                 else if (!currCellActive && !newCellActive)
-                    newPtr = ptr.getClass().copyToCell(ptr, *newCell);
+                    newPtr = currCell->moveTo(ptr, newCell);
                 else // both cells active
                 {
-                    newPtr = ptr.getClass().copyToCell(ptr, *newCell, pos);
+                    newPtr = currCell->moveTo(ptr, newCell);
 
                     mRendering->updatePtr(ptr, newPtr);
                     ptr.getRefData().setBaseNode(NULL);
@@ -1189,7 +1189,6 @@ namespace MWWorld
                         addContainerScripts (newPtr, newCell);
                     }
                 }
-                ptr.getRefData().setCount(0);
             }
         }
         if (haveToMove && newPtr.getRefData().getBaseNode())

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -721,7 +721,11 @@ namespace MWWorld
         for (Scene::CellStoreCollection::const_iterator cellIt = collection.begin(); cellIt != collection.end(); ++cellIt)
         {
             FindContainerVisitor visitor(ptr);
-            //(*cellIt)->forEachContainer(visitor);
+            (*cellIt)->forEachType<ESM::Container>(visitor);
+            if (visitor.mResult.isEmpty())
+                (*cellIt)->forEachType<ESM::Creature>(visitor);
+            if (visitor.mResult.isEmpty())
+                (*cellIt)->forEachType<ESM::NPC>(visitor);
 
             if (!visitor.mResult.isEmpty())
                 return visitor.mResult;

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -3,12 +3,12 @@
 #include "esmreader.hpp"
 #include "esmwriter.hpp"
 
-void ESM::RefNum::load (ESMReader& esm, bool wide)
+void ESM::RefNum::load (ESMReader& esm, bool wide, const std::string& tag)
 {
     if (wide)
-        esm.getHNT (*this, "FRMR", 8);
+        esm.getHNT (*this, tag.c_str(), 8);
     else
-        esm.getHNT (mIndex, "FRMR");
+        esm.getHNT (mIndex, tag.c_str());
 }
 
 void ESM::RefNum::save (ESMWriter &esm, bool wide, const std::string& tag) const

--- a/components/esm/cellref.hpp
+++ b/components/esm/cellref.hpp
@@ -16,7 +16,7 @@ namespace ESM
         unsigned int mIndex;
         int mContentFile;
 
-        void load (ESMReader& esm, bool wide = false);
+        void load (ESMReader& esm, bool wide = false, const std::string& tag = "FRMR");
 
         void save (ESMWriter &esm, bool wide = false, const std::string& tag = "FRMR") const;
 


### PR DESCRIPTION
https://bugs.openmw.org/issues/1176

~~Still need to add save game handling, restore some game functionality~~ and do lots more testing. Before I continue I want to ask if I'm on the right track with this. I was inclined not to build merging into the CellRefList because that's also used in ContainerStore. I don't feel that handling merging separately for each reference type is a good idea. We want the system to be easy to maintain and extend after all. Basically the type-specific list access had to be removed, and that's why there's still game code stubbed out that I need to port over to the new forEach() mechanism. Thoughts?