### PR TITLE
use tga textures instead dds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,12 @@ endif (ANDROID)
 
 option(OPENGL_ES "enable opengl es support" FALSE )
 
+option(USE_TGA "enable tga texture support instead dds" FALSE )
+
+if (USE_TGA)
+    add_definitions(-DUSE_TGA)
+endif(USE_TGA)
+
 if (OPENGL_ES)
     add_definitions(-DOPENGL_ES)
 endif(OPENGL_ES)

--- a/components/misc/resourcehelpers.cpp
+++ b/components/misc/resourcehelpers.cpp
@@ -34,7 +34,11 @@ bool Misc::ResourceHelpers::changeExtensionToDds(std::string &path)
     std::string::size_type pos = path.rfind('.');
     if(pos != std::string::npos && path.compare(pos, path.length() - pos, ".dds") != 0)
     {
+#ifdef USE_TGA
+        path.replace(pos, path.length(), ".tga");
+#else
         path.replace(pos, path.length(), ".dds");
+#endif
         return true;
     }
     return false;

--- a/components/resource/texturemanager.cpp
+++ b/components/resource/texturemanager.cpp
@@ -164,21 +164,15 @@ namespace Resource
             }
 
             osg::ref_ptr<osgDB::Options> opts (new osgDB::Options);
+#ifndef USE_TGA 
             opts->setOptionString("dds_dxt1_detect_rgba"); // tx_creature_werewolf.dds isn't loading in the correct format without this option
+#endif
             size_t extPos = normalized.find_last_of('.');
             std::string ext;
             if (extPos != std::string::npos && extPos+1 < normalized.size())
                 ext = normalized.substr(extPos+1);
 
-#ifdef USE_TGA
-            osgDB::ReaderWriter* reader =NULL;
-            if (ends_with(ext,"dds"))
-              reader = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
-            else
-              reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
-#else
             osgDB::ReaderWriter* reader =osgDB::Registry::instance()->getReaderWriterForExtension(ext);
-#endif 
 
             if (!reader)
             {
@@ -204,14 +198,6 @@ namespace Resource
         }
     }
 
-#ifdef USE_TGA
-    inline bool TextureManager::ends_with(std::string const & value, std::string const & ending)
-    {
-        if (ending.size() > value.size()) return false;
-        return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-    }
-#endif
-
     osg::ref_ptr<osg::Texture2D> TextureManager::getTexture2D(const std::string &filename, osg::Texture::WrapMode wrapS, osg::Texture::WrapMode wrapT)
     {
         std::string normalized = filename;
@@ -236,20 +222,16 @@ namespace Resource
             }
 
             osg::ref_ptr<osgDB::Options> opts (new osgDB::Options);
+#ifndef USE_TGA
             opts->setOptionString("dds_dxt1_detect_rgba"); // tx_creature_werewolf.dds isn't loading in the correct format without this option
-            size_t extPos = normalized.find_last_of('.');
+#endif 
+           size_t extPos = normalized.find_last_of('.');
             std::string ext;
             if (extPos != std::string::npos && extPos+1 < normalized.size())
                 ext = normalized.substr(extPos+1);
-#ifdef USE_TGA
-            osgDB::ReaderWriter* reader =NULL;
-            if (ends_with(ext,"dds"))
-              reader = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
-            else
-              reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
-#else
+
             osgDB::ReaderWriter* reader =osgDB::Registry::instance()->getReaderWriterForExtension(ext);
-#endif
+
             if (!reader)
             {
                 std::cerr << "Error loading " << filename << ": no readerwriter for '" << ext << "' found" << std::endl;

--- a/components/resource/texturemanager.cpp
+++ b/components/resource/texturemanager.cpp
@@ -169,7 +169,17 @@ namespace Resource
             std::string ext;
             if (extPos != std::string::npos && extPos+1 < normalized.size())
                 ext = normalized.substr(extPos+1);
-            osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+
+#ifdef USE_TGA
+            osgDB::ReaderWriter* reader =NULL;
+            if (ends_with(ext,"dds"))
+              reader = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
+            else
+              reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+#else
+            osgDB::ReaderWriter* reader =osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+#endif 
+
             if (!reader)
             {
                 std::cerr << "Error loading " << filename << ": no readerwriter for '" << ext << "' found" << std::endl;
@@ -193,6 +203,14 @@ namespace Resource
             return image;
         }
     }
+
+#ifdef USE_TGA
+    inline bool TextureManager::ends_with(std::string const & value, std::string const & ending)
+    {
+        if (ending.size() > value.size()) return false;
+        return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+    }
+#endif
 
     osg::ref_ptr<osg::Texture2D> TextureManager::getTexture2D(const std::string &filename, osg::Texture::WrapMode wrapS, osg::Texture::WrapMode wrapT)
     {
@@ -223,7 +241,15 @@ namespace Resource
             std::string ext;
             if (extPos != std::string::npos && extPos+1 < normalized.size())
                 ext = normalized.substr(extPos+1);
-            osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+#ifdef USE_TGA
+            osgDB::ReaderWriter* reader =NULL;
+            if (ends_with(ext,"dds"))
+              reader = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
+            else
+              reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+#else
+            osgDB::ReaderWriter* reader =osgDB::Registry::instance()->getReaderWriterForExtension(ext);
+#endif
             if (!reader)
             {
                 std::cerr << "Error loading " << filename << ": no readerwriter for '" << ext << "' found" << std::endl;
@@ -246,11 +272,14 @@ namespace Resource
             // We need to flip images, because the Morrowind texture coordinates use the DirectX convention (top-left image origin),
             // but OpenGL uses bottom left as the image origin.
             // For some reason this doesn't concern DDS textures, which are already flipped when loaded.
-            if (ext != "dds")
+#ifdef USE_TGA 
+           image->flipVertical();
+#else
+           if (ext != "dds")
             {
                 image->flipVertical();
             }
-
+#endif
             osg::ref_ptr<osg::Texture2D> texture(new osg::Texture2D);
             texture->setImage(image);
             texture->setWrap(osg::Texture::WRAP_S, wrapS);

--- a/components/resource/texturemanager.hpp
+++ b/components/resource/texturemanager.hpp
@@ -55,9 +55,6 @@ namespace Resource
 
         osg::ref_ptr<osg::Texture2D> mWarningTexture;
 
-#ifdef USE_TGA
-        inline bool ends_with(std::string const & value, std::string const & ending);
-#endif
         bool mUnRefImageDataAfterApply;
 
         TextureManager(const TextureManager&);

--- a/components/resource/texturemanager.hpp
+++ b/components/resource/texturemanager.hpp
@@ -55,6 +55,9 @@ namespace Resource
 
         osg::ref_ptr<osg::Texture2D> mWarningTexture;
 
+#ifdef USE_TGA
+        inline bool ends_with(std::string const & value, std::string const & ending);
+#endif
         bool mUnRefImageDataAfterApply;
 
         TextureManager(const TextureManager&);


### PR DESCRIPTION
Itn this PR I add tga texture support , because there is issues in osg dds loader in gles1 render . Unpacked dds textures not shows . So now I convert all textures to tga and store it with .dds name .
