### PR TITLE
Add HRTF options and fix an incorrect SoundID

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1103,7 +1103,7 @@ namespace MWClass
             if(world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
                 return "DefaultLandWater";
             if(world->isOnGround(ptr))
-                return "Body Fall Medium";
+                return "DefaultLand";
             return "";
         }
         if(name == "swimleft")

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -19,6 +19,28 @@
 #define ALC_ALL_DEVICES_SPECIFIER 0x1013
 #endif
 
+#ifndef ALC_SOFT_HRTF
+#define ALC_SOFT_HRTF 1
+#define ALC_HRTF_SOFT                            0x1992
+#define ALC_DONT_CARE_SOFT                       0x0002
+#define ALC_HRTF_STATUS_SOFT                     0x1993
+#define ALC_HRTF_DISABLED_SOFT                   0x0000
+#define ALC_HRTF_ENABLED_SOFT                    0x0001
+#define ALC_HRTF_DENIED_SOFT                     0x0002
+#define ALC_HRTF_REQUIRED_SOFT                   0x0003
+#define ALC_HRTF_HEADPHONES_DETECTED_SOFT        0x0004
+#define ALC_HRTF_UNSUPPORTED_FORMAT_SOFT         0x0005
+#define ALC_NUM_HRTF_SPECIFIERS_SOFT             0x1994
+#define ALC_HRTF_SPECIFIER_SOFT                  0x1995
+#define ALC_HRTF_ID_SOFT                         0x1996
+typedef const ALCchar* (ALC_APIENTRY*LPALCGETSTRINGISOFT)(ALCdevice *device, ALCenum paramName, ALCsizei index);
+typedef ALCboolean (ALC_APIENTRY*LPALCRESETDEVICESOFT)(ALCdevice *device, const ALCint *attribs);
+#ifdef AL_ALEXT_PROTOTYPES
+ALC_API const ALCchar* ALC_APIENTRY alcGetStringiSOFT(ALCdevice *device, ALCenum paramName, ALCsizei index);
+ALC_API ALCboolean ALC_APIENTRY alcResetDeviceSOFT(ALCdevice *device, const ALCint *attribs);
+#endif
+#endif
+
 
 #define MAKE_PTRID(id) ((void*)(uintptr_t)id)
 #define GET_PTRID(ptr) ((ALuint)(uintptr_t)ptr)
@@ -568,6 +590,113 @@ void OpenAL_Output::deinit()
     mDevice = 0;
 
     mInitialized = false;
+}
+
+
+std::vector<std::string> OpenAL_Output::enumerateHrtf()
+{
+    if(!mDevice)
+        fail("Device not initialized");
+
+    std::vector<std::string> ret;
+    if(!alcIsExtensionPresent(mDevice, "ALC_SOFT_HRTF"))
+        return ret;
+
+    LPALCGETSTRINGISOFT alcGetStringiSOFT = reinterpret_cast<LPALCGETSTRINGISOFT>(
+        alcGetProcAddress(mDevice, "alcGetStringiSOFT")
+    );
+
+    ALCint num_hrtf;
+    alcGetIntegerv(mDevice, ALC_NUM_HRTF_SPECIFIERS_SOFT, 1, &num_hrtf);
+    ret.reserve(num_hrtf);
+    for(ALCint i = 0;i < num_hrtf;++i)
+    {
+        const ALCchar *entry = alcGetStringiSOFT(mDevice, ALC_HRTF_SPECIFIER_SOFT, i);
+        ret.push_back(entry);
+    }
+
+    return ret;
+}
+
+void OpenAL_Output::enableHrtf(const std::string &hrtfname, bool auto_enable)
+{
+    if(!alcIsExtensionPresent(mDevice, "ALC_SOFT_HRTF"))
+    {
+        std::cerr<< "HRTF extension not present" <<std::endl;
+        return;
+    }
+
+    LPALCGETSTRINGISOFT alcGetStringiSOFT = reinterpret_cast<LPALCGETSTRINGISOFT>(
+        alcGetProcAddress(mDevice, "alcGetStringiSOFT")
+    );
+    LPALCRESETDEVICESOFT alcResetDeviceSOFT = reinterpret_cast<LPALCRESETDEVICESOFT>(
+        alcGetProcAddress(mDevice, "alcResetDeviceSOFT")
+    );
+
+    std::vector<ALCint> attrs;
+    attrs.push_back(ALC_HRTF_SOFT);
+    attrs.push_back(auto_enable ? ALC_DONT_CARE_SOFT : ALC_TRUE);
+    if(!hrtfname.empty())
+    {
+        ALCint index = -1;
+        ALCint num_hrtf;
+        alcGetIntegerv(mDevice, ALC_NUM_HRTF_SPECIFIERS_SOFT, 1, &num_hrtf);
+        for(ALCint i = 0;i < num_hrtf;++i)
+        {
+            const ALCchar *entry = alcGetStringiSOFT(mDevice, ALC_HRTF_SPECIFIER_SOFT, i);
+            if(hrtfname == entry)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if(index < 0)
+            std::cerr<< "Failed to find HRTF name \""<<hrtfname<<"\", using default" <<std::endl;
+        else
+        {
+            attrs.push_back(ALC_HRTF_ID_SOFT);
+            attrs.push_back(index);
+        }
+    }
+    attrs.push_back(0);
+    alcResetDeviceSOFT(mDevice, &attrs[0]);
+
+    ALCint hrtf_state;
+    alcGetIntegerv(mDevice, ALC_HRTF_SOFT, 1, &hrtf_state);
+    if(!hrtf_state)
+        std::cerr<< "Failed to enable HRTF" <<std::endl;
+    else
+    {
+        const ALCchar *hrtf = alcGetString(mDevice, ALC_HRTF_SPECIFIER_SOFT);
+        std::cout<< "Enabled HRTF "<<hrtf <<std::endl;
+    }
+}
+
+void OpenAL_Output::disableHrtf()
+{
+    if(!alcIsExtensionPresent(mDevice, "ALC_SOFT_HRTF"))
+    {
+        std::cerr<< "HRTF extension not present" <<std::endl;
+        return;
+    }
+
+    LPALCRESETDEVICESOFT alcResetDeviceSOFT = reinterpret_cast<LPALCRESETDEVICESOFT>(
+        alcGetProcAddress(mDevice, "alcResetDeviceSOFT")
+    );
+
+    std::vector<ALCint> attrs;
+    attrs.push_back(ALC_HRTF_SOFT);
+    attrs.push_back(ALC_FALSE);
+    attrs.push_back(0);
+    alcResetDeviceSOFT(mDevice, &attrs[0]);
+
+    ALCint hrtf_state;
+    alcGetIntegerv(mDevice, ALC_HRTF_SOFT, 1, &hrtf_state);
+    if(hrtf_state)
+        std::cerr<< "Failed to disable HRTF" <<std::endl;
+    else
+        std::cout<< "Disabled HRTF" <<std::endl;
 }
 
 

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -45,8 +45,12 @@ namespace MWSound
 
     public:
         virtual std::vector<std::string> enumerate();
-        virtual void init(const std::string &devname="");
+        virtual void init(const std::string &devname=std::string());
         virtual void deinit();
+
+        virtual std::vector<std::string> enumerateHrtf();
+        virtual void enableHrtf(const std::string &hrtfname, bool auto_enable);
+        virtual void disableHrtf();
 
         virtual Sound_Handle loadSound(const std::string &fname);
         virtual void unloadSound(Sound_Handle data);

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -24,8 +24,12 @@ namespace MWSound
         SoundManager &mManager;
 
         virtual std::vector<std::string> enumerate() = 0;
-        virtual void init(const std::string &devname="") = 0;
+        virtual void init(const std::string &devname=std::string()) = 0;
         virtual void deinit() = 0;
+
+        virtual std::vector<std::string> enumerateHrtf() = 0;
+        virtual void enableHrtf(const std::string &hrtfname, bool auto_enable) = 0;
+        virtual void disableHrtf() = 0;
 
         virtual Sound_Handle loadSound(const std::string &fname) = 0;
         virtual void unloadSound(Sound_Handle data) = 0;

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -174,6 +174,13 @@ buffer cache min = 14
 # to this much memory until old buffers get purged.
 buffer cache max = 16
 
+# Specifies whether to enable HRTF processing. Valid values are: -1 = auto,
+# 0 = off, 1 = on.
+hrtf enable = -1
+
+# Specifies which HRTF to use when HRTF is used. Blank means use the default.
+hrtf =
+
 [Video]
 
 # Resolution of the OpenMW window or screen.


### PR DESCRIPTION
The HRTF options require the ALC_SOFT_HRTF extension to work (available in OpenAL Soft 1.17.0). I had intended to also add a Sound tab to the launcher where you could select a sound device and HRTF (since they can't be in the in-game options, due to lack of text strings), but I still need a bit of time for figuring out how to make that work and what options to have for it.

The SoundID fix is for https://bugs.openmw.org/issues/3060