### PR TITLE
mwrender: Add missing includes

### DIFF
--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <stdint.h>
 
+#include <osg/Fog>
 #include <osg/LightModel>
 #include <osg/Texture2D>
 #include <osg/ComputeBoundsVisitor>

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include <osg/ClipPlane>
+#include <osg/Fog>
 #include <osg/Transform>
 #include <osg/Geode>
 #include <osg/Depth>

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 
+#include <osg/Fog>
 #include <osg/Depth>
 #include <osg/Group>
 #include <osg/Geode>


### PR DESCRIPTION
Those missing includes were causing the build to fail when compiled with
USE_GLES set (the build still fails, but with an error unrelated to this fix).

Signed-off-by: Paul Cercueil <paul@crapouillou.net>