### PR TITLE
disable occlusion query for gles1

### DIFF
--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -476,7 +476,7 @@ public:
                                                                         osg::Texture::CLAMP);
 
         mGeode->getOrCreateStateSet()->setTextureAttributeAndModes(0, sunTex, osg::StateAttribute::ON);
-
+#ifndef OPENGL_ES
         osg::ref_ptr<osg::Group> queryNode (new osg::Group);
         // Need to render after the world geometry so we can correctly test for occlusions
         queryNode->getOrCreateStateSet()->setRenderBinDetails(RenderBin_OcclusionQuery, "RenderBin");
@@ -495,13 +495,16 @@ public:
 
         createSunFlash(textureManager);
         createSunGlare();
+#endif
     }
 
     ~Sun()
     {
         mTransform->removeUpdateCallback(mUpdater);
+#ifndef OPENGL_ES
         destroySunFlash();
         destroySunGlare();
+#endif
     }
 
     void setColor(const osg::Vec4f& color)


### PR DESCRIPTION
gles1 not support occlusion query , only gles 3.0 support it . 
If build game with occlusion query for gles1, game will crash on external locations