### PR TITLE
Field of view

### DIFF
--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -638,6 +638,9 @@ MwIniImporter::MwIniImporter()
         "Blood:Texture Name 1",
         "Blood:Texture Name 2",
 
+        // werewolf (Bloodmoon)
+        "General:Werewolf FOV",
+
         0
     };
 

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -256,7 +256,7 @@ namespace MWGui
 
         MyGUI::TextBox* fovText;
         getWidget(fovText, "FovText");
-        fovText->setCaption("Field of View (" + MyGUI::utility::toString(int(Settings::Manager::getInt("field of view", "General"))) + ")");
+        fovText->setCaption("Field of View (" + MyGUI::utility::toString(int(Settings::Manager::getInt("field of view", "Camera"))) + ")");
 
         MyGUI::TextBox* diffText;
         getWidget(diffText, "DifficultyText");

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -61,6 +61,8 @@ private:
     int mPartPriorities[ESM::PRT_Count];
 
     osg::Vec3f mFirstPersonOffset;
+    // Field of view to use when rendering first person meshes
+    float mFirstPersonFieldOfView;
 
     boost::shared_ptr<HeadAnimationTime> mHeadAnimationTime;
     boost::shared_ptr<WeaponAnimationTime> mWeaponAnimationTime;
@@ -102,7 +104,7 @@ public:
      * @param viewMode
      */
     NpcAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group> parentNode, Resource::ResourceSystem* resourceSystem, bool disableListener = false,
-                 bool disableSounds = false, ViewMode viewMode=VM_Normal);
+                 bool disableSounds = false, ViewMode viewMode=VM_Normal, float firstPersonFieldOfView=55.f);
     virtual ~NpcAnimation();
 
     virtual void enableHeadAnimation(bool enable);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -136,6 +136,8 @@ namespace MWRender
         , mUnderwaterFog(0.f)
         , mUnderwaterIndoorFog(fallback->getFallbackFloat("Water_UnderwaterIndoorFog"))
         , mNightEyeFactor(0.f)
+        , mFieldOfViewOverride(0.f)
+        , mFieldOfViewOverridden(false)
     {
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
 
@@ -769,7 +771,10 @@ namespace MWRender
     void RenderingManager::updateProjectionMatrix()
     {
         double aspect = mViewer->getCamera()->getViewport()->aspectRatio();
-        mViewer->getCamera()->setProjectionMatrixAsPerspective(mFieldOfView, aspect, mNearClip, mViewDistance);
+        float fov = mFieldOfView;
+        if (mFieldOfViewOverridden)
+            fov = mFieldOfViewOverride;
+        mViewer->getCamera()->setProjectionMatrixAsPerspective(fov, aspect, mNearClip, mViewDistance);
     }
 
     void RenderingManager::updateTextureFiltering()
@@ -910,6 +915,25 @@ namespace MWRender
     {
         if(mCamera->isVanityOrPreviewModeEnabled())
             mCamera->setCameraDistance(-factor/120.f*10, true, true);
+    }
+
+    void RenderingManager::overrideFieldOfView(float val)
+    {
+        if (mFieldOfViewOverridden != true || mFieldOfViewOverride != val)
+        {
+            mFieldOfViewOverridden = true;
+            mFieldOfViewOverride = val;
+            updateProjectionMatrix();
+        }
+    }
+
+    void RenderingManager::resetFieldOfView()
+    {
+        if (mFieldOfViewOverridden == true)
+        {
+            mFieldOfViewOverridden = false;
+            updateProjectionMatrix();
+        }
     }
 
 }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -207,7 +207,7 @@ namespace MWRender
 
         mNearClip = Settings::Manager::getFloat("near clip", "Camera");
         mViewDistance = Settings::Manager::getFloat("viewing distance", "Camera");
-        mFieldOfView = Settings::Manager::getFloat("field of view", "General");
+        mFieldOfView = Settings::Manager::getFloat("field of view", "Camera");
         updateProjectionMatrix();
         mStateUpdater->setFogEnd(mViewDistance);
 
@@ -813,9 +813,9 @@ namespace MWRender
     {
         for (Settings::CategorySettingVector::const_iterator it = changed.begin(); it != changed.end(); ++it)
         {
-            if (it->first == "General" && it->second == "field of view")
+            if (it->first == "Camera" && it->second == "field of view")
             {
-                mFieldOfView = Settings::Manager::getFloat("field of view", "General");
+                mFieldOfView = Settings::Manager::getFloat("field of view", "Camera");
                 updateProjectionMatrix();
             }
             else if (it->first == "Camera" && it->second == "viewing distance")

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -208,6 +208,7 @@ namespace MWRender
         mNearClip = Settings::Manager::getFloat("near clip", "Camera");
         mViewDistance = Settings::Manager::getFloat("viewing distance", "Camera");
         mFieldOfView = Settings::Manager::getFloat("field of view", "Camera");
+        mFirstPersonFieldOfView = Settings::Manager::getFloat("first person field of view", "Camera");
         updateProjectionMatrix();
         mStateUpdater->setFogEnd(mViewDistance);
 
@@ -729,7 +730,8 @@ namespace MWRender
 
     void RenderingManager::renderPlayer(const MWWorld::Ptr &player)
     {
-        mPlayerAnimation.reset(new NpcAnimation(player, player.getRefData().getBaseNode(), mResourceSystem, 0));
+        mPlayerAnimation.reset(new NpcAnimation(player, player.getRefData().getBaseNode(), mResourceSystem, 0, false, NpcAnimation::VM_Normal,
+                                                mFirstPersonFieldOfView));
 
         mCamera->setAnimation(mPlayerAnimation.get());
         mCamera->attachTo(player);

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -170,6 +170,11 @@ namespace MWRender
         void togglePlayerLooking(bool enable);
         void changeVanityModeScale(float factor);
 
+        /// temporarily override the field of view with given value.
+        void overrideFieldOfView(float val);
+        /// reset a previous overrideFieldOfView() call, i.e. revert to field of view specified in the settings file.
+        void resetFieldOfView();
+
     private:
         void updateProjectionMatrix();
         void updateTextureFiltering();
@@ -208,6 +213,8 @@ namespace MWRender
 
         float mNearClip;
         float mViewDistance;
+        float mFieldOfViewOverride;
+        bool mFieldOfViewOverridden;
         float mFieldOfView;
 
         void operator = (const RenderingManager&);

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -216,6 +216,7 @@ namespace MWRender
         float mFieldOfViewOverride;
         bool mFieldOfViewOverridden;
         float mFieldOfView;
+        float mFirstPersonFieldOfView;
 
         void operator = (const RenderingManager&);
         RenderingManager(const RenderingManager&);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1565,8 +1565,20 @@ namespace MWWorld
             mPlayer->setLastKnownExteriorPosition(pos.asVec3());
         }
 
-        if (player.getClass().getNpcStats(player).isWerewolf())
-            MWBase::Environment::get().getWindowManager()->setWerewolfOverlay(mRendering->getCamera()->isFirstPerson());
+        bool isWerewolf = player.getClass().getNpcStats(player).isWerewolf();
+        bool isFirstPerson = mRendering->getCamera()->isFirstPerson();
+        if (isWerewolf && isFirstPerson)
+        {
+            float werewolfFov = mFallback.getFallbackFloat("General_Werewolf_FOV");
+            if (werewolfFov != 0)
+                mRendering->overrideFieldOfView(werewolfFov);
+            MWBase::Environment::get().getWindowManager()->setWerewolfOverlay(true);
+        }
+        else
+        {
+            mRendering->resetFieldOfView();
+            MWBase::Environment::get().getWindowManager()->setWerewolfOverlay(false);
+        }
 
         // Sink the camera while sneaking
         bool sneaking = player.getClass().getCreatureStats(getPlayerPtr()).getStance(MWMechanics::CreatureStats::Stance_Sneak);

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -280,7 +280,7 @@
                             <Property key="Range" value="10000"/>
                             <Property key="Page" value="300"/>
                             <UserString key="SettingType" value="Slider"/>
-                            <UserString key="SettingCategory" value="General"/>
+                            <UserString key="SettingCategory" value="Camera"/>
                             <UserString key="SettingName" value="field of view"/>
                             <UserString key="SettingValueType" value="Float"/>
                             <UserString key="SettingMin" value="30"/>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -24,7 +24,12 @@ small feature culling = true
 viewing distance = 6666.0
 
 # Camera field of view in degrees (e.g. 30.0 to 110.0).
+# Does not affect the player's hands in the first person camera.
 field of view = 55.0
+
+# Field of view for first person meshes (i.e. the player's hands)
+# Best to leave this at the default since vanilla assets are not complete enough to adapt to high FoV's. Too low FoV would clip the hands off screen.
+first person field of view = 55.0
 
 [Cells]
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -23,6 +23,9 @@ small feature culling = true
 # can dramatically affect performance, see documentation for details.
 viewing distance = 6666.0
 
+# Camera field of view in degrees (e.g. 30.0 to 110.0).
+field of view = 55.0
+
 [Cells]
 
 # Adjacent exterior cells loaded (>0). Caution: this setting can
@@ -98,9 +101,6 @@ show effect duration = false
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).
 anisotropy = 4
-
-# Camera field of view in degrees (e.g. 30.0 to 110.0).
-field of view = 55.0
 
 # File format for screenshots.  (jpg, png, tga, and possibly more).
 screenshot format = png


### PR DESCRIPTION
* Handle Werewolf FOV setting (note: need to re-run mwiniimporter for this to work, since the setting wasn't previously imported)
* Control the FOV for first person meshes separately from the gameworld FOV (https://bugs.openmw.org/issues/3051, https://bugs.openmw.org/issues/858)