### PR TITLE
Fix for bug #2952: Enchantment Merchant Items reshuffled EVERY time 'barter' is clicked

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,6 +74,7 @@ Programmers
     Marco Melletti (mellotanica)
     Marco Schulze
     Mateusz Kołaczek (PL_kolek)
+    Mateusz Malisz (malice)
     megaton
     Michael Hogan (Xethik)
     Michael Mc Donnell

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -449,7 +449,7 @@ void MWWorld::ContainerStore::addInitialItem (const std::string& id, const std::
                 //Update spawned count
                 itemInMap->second += std::abs(count);
             }
-            count  = std::abs(count);
+            count = std::abs(count);
 
             ref.getPtr().getCellRef().setOwner(owner);
             addImp (ref.getPtr(), count);

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -477,14 +477,14 @@ void MWWorld::ContainerStore::restock (const ESM::InventoryList& items, const MW
         //If something was not sold
         if(itemCount >= spawnedCount)
         {
-            const std::string& ancestor = it->second.second;
+            const std::string& parent = it->second.second;
             // Security check for old saves:
-            //If item is imported from old save(doesn't have an ancestor) and wasn't sold
-            if(ancestor == "")
+            //If item is imported from old save(doesn't have an parent) and wasn't sold
+            if(parent == "")
             {
                 //Remove it, from shop,
                 remove(it->first, itemCount, ptr);//ptr is the NPC
-                //And remove it from map, so that when we restock, the new item will have proper ancestor.
+                //And remove it from map, so that when we restock, the new item will have proper parent.
                 mLevelledItemMap.erase(it);
                 continue;
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -3,6 +3,7 @@
 
 #include <iterator>
 #include <map>
+#include <utility>
 
 #include <components/esm/loadalch.hpp>
 #include <components/esm/loadappa.hpp>
@@ -68,9 +69,9 @@ namespace MWWorld
             MWWorld::CellRefList<ESM::Repair>            repairs;
             MWWorld::CellRefList<ESM::Weapon>            weapons;
 
-            std::map<std::string, int> mLevelledItemMap;
-            ///< Stores result of levelled item spawns. <refId, count>
-            /// This is used to remove the spawned item(s) if the levelled item is restocked.
+            std::map<std::string, std::pair<int, std::string> > mLevelledItemMap;
+            ///< Stores result of levelled item spawns. <refId, pair(count, spawningGroup)>
+            /// This is used to restock levelled items(s) if the old item was sold.
 
             mutable float mCachedWeight;
             mutable bool mWeightUpToDate;

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -69,8 +69,8 @@ namespace MWWorld
             MWWorld::CellRefList<ESM::Repair>            repairs;
             MWWorld::CellRefList<ESM::Weapon>            weapons;
 
-            std::map<std::string, std::pair<int, std::string> > mLevelledItemMap;
-            ///< Stores result of levelled item spawns. <refId, pair(count, spawningGroup)>
+            std::map<std::pair<std::string, std::string>, int> mLevelledItemMap;
+            ///< Stores result of levelled item spawns. <(refId, spawningGroup), count>
             /// This is used to restock levelled items(s) if the old item was sold.
 
             mutable float mCachedWeight;

--- a/components/esm/inventorystate.cpp
+++ b/components/esm/inventorystate.cpp
@@ -44,7 +44,7 @@ void ESM::InventoryState::load (ESMReader &esm)
         if(esm.isNextSub("LGRP"))
             //Newest saves contain parent group
             parentGroup = esm.getHString();
-        mLevelledItemMap[id] = std::make_pair(count, parentGroup);
+        mLevelledItemMap[std::make_pair(id, parentGroup)] = count;
     }
 
     while (esm.isNextSub("MAGI"))
@@ -86,11 +86,11 @@ void ESM::InventoryState::save (ESMWriter &esm) const
         iter->save (esm, true);
     }
 
-    for (std::map<std::string, std::pair<int, std::string> >::const_iterator it = mLevelledItemMap.begin(); it != mLevelledItemMap.end(); ++it)
+    for (std::map<std::pair<std::string, std::string>, int>::const_iterator it = mLevelledItemMap.begin(); it != mLevelledItemMap.end(); ++it)
     {
-        esm.writeHNString ("LEVM", it->first);
-        esm.writeHNT ("COUN", it->second.first);
-        esm.writeHNString("LGRP", it->second.second);
+        esm.writeHNString ("LEVM", it->first.first);
+        esm.writeHNT ("COUN", it->second);
+        esm.writeHNString("LGRP", it->first.second);
     }
 
     for (TEffectMagnitudes::const_iterator it = mPermanentMagicEffectMagnitudes.begin(); it != mPermanentMagicEffectMagnitudes.end(); ++it)

--- a/components/esm/inventorystate.cpp
+++ b/components/esm/inventorystate.cpp
@@ -31,17 +31,20 @@ void ESM::InventoryState::load (ESMReader &esm)
 
         ++index;
     }
-
+    //Next item is Levelled item
     while (esm.isNextSub("LEVM"))
     {
+        //Get its name
         std::string id = esm.getHString();
         int count;
-        std::string parentList;
-        //TODO: How should I handle old saves?
-        if(esm.isNextSub("LLST"))
-            std::string parentList = esm.getHString();
+        std::string parentGroup = "";
+        //Then get its count
         esm.getHNT (count, "COUN");
-        mLevelledItemMap[id] = count;
+        //Old save formats don't have information about parent group; check for that
+        if(esm.isNextSub("LGRP"))
+            //Newest saves contain parent group
+            parentGroup = esm.getHString();
+        mLevelledItemMap[id] = std::make_pair(count, parentGroup);
     }
 
     while (esm.isNextSub("MAGI"))
@@ -87,7 +90,7 @@ void ESM::InventoryState::save (ESMWriter &esm) const
     {
         esm.writeHNString ("LEVM", it->first);
         esm.writeHNT ("COUN", it->second.first);
-        esm.writeHNString("LLST", it->second.second)
+        esm.writeHNString("LGRP", it->second.second);
     }
 
     for (TEffectMagnitudes::const_iterator it = mPermanentMagicEffectMagnitudes.begin(); it != mPermanentMagicEffectMagnitudes.end(); ++it)

--- a/components/esm/inventorystate.cpp
+++ b/components/esm/inventorystate.cpp
@@ -36,6 +36,10 @@ void ESM::InventoryState::load (ESMReader &esm)
     {
         std::string id = esm.getHString();
         int count;
+        std::string parentList;
+        //TODO: How should I handle old saves?
+        if(esm.isNextSub("LLST"))
+            std::string parentList = esm.getHString();
         esm.getHNT (count, "COUN");
         mLevelledItemMap[id] = count;
     }
@@ -79,10 +83,11 @@ void ESM::InventoryState::save (ESMWriter &esm) const
         iter->save (esm, true);
     }
 
-    for (std::map<std::string, int>::const_iterator it = mLevelledItemMap.begin(); it != mLevelledItemMap.end(); ++it)
+    for (std::map<std::string, std::pair<int, std::string> >::const_iterator it = mLevelledItemMap.begin(); it != mLevelledItemMap.end(); ++it)
     {
         esm.writeHNString ("LEVM", it->first);
-        esm.writeHNT ("COUN", it->second);
+        esm.writeHNT ("COUN", it->second.first);
+        esm.writeHNString("LLST", it->second.second)
     }
 
     for (TEffectMagnitudes::const_iterator it = mPermanentMagicEffectMagnitudes.begin(); it != mPermanentMagicEffectMagnitudes.end(); ++it)

--- a/components/esm/inventorystate.hpp
+++ b/components/esm/inventorystate.hpp
@@ -20,7 +20,7 @@ namespace ESM
         // <Index in mItems, equipment slot>
         std::map<int, int> mEquipmentSlots;
 
-        std::map<std::string, std::pair<int, std::string> > mLevelledItemMap;
+        std::map<std::pair<std::string, std::string>, int> mLevelledItemMap;
 
         typedef std::map<std::string, std::vector<std::pair<float, float> > > TEffectMagnitudes;
         TEffectMagnitudes mPermanentMagicEffectMagnitudes;

--- a/components/esm/inventorystate.hpp
+++ b/components/esm/inventorystate.hpp
@@ -20,7 +20,7 @@ namespace ESM
         // <Index in mItems, equipment slot>
         std::map<int, int> mEquipmentSlots;
 
-        std::map<std::string, int> mLevelledItemMap;
+        std::map<std::string, std::pair<int, std::string> > mLevelledItemMap;
 
         typedef std::map<std::string, std::vector<std::pair<float, float> > > TEffectMagnitudes;
         TEffectMagnitudes mPermanentMagicEffectMagnitudes;


### PR DESCRIPTION
Sorry that it took so long, but I'm busy lately.

[Bugtracker link](http://bugs.openmw.org/issues/2952)

Basically I did what you guys asked - now we remember the parent group. We save it in the save file, and later recover it. If there's no group, we add empty group, and later remove the item(so the bug happens only once for older saves).

As for algorithm, it's pretty easy, I guess. We keep list of items that were **not** sold, and later we restock with basicRestockValue - notSoldItems. We keep this negative, because levelled group items have negative count. I tested saving/loading as well as restocking(on Galbedir) and it seems to work for me.