### PR TITLE
Use the standard cursor if the custom cursor can't be used

### DIFF
--- a/components/sdlutil/sdlcursormanager.cpp
+++ b/components/sdlutil/sdlcursormanager.cpp
@@ -217,14 +217,17 @@ namespace SDLUtil
 
     void SDLCursorManager::_createCursorFromResource(const std::string& name, int rotDegrees, osg::Image* image, Uint8 size_x, Uint8 size_y, Uint8 hotspot_x, Uint8 hotspot_y)
     {
-         #ifdef ANDROID
-         return;
-         #endif
+        osg::ref_ptr<osg::Image> decompressed;
 
         if (mCursorMap.find(name) != mCursorMap.end())
             return;
 
-        osg::ref_ptr<osg::Image> decompressed = decompress(image, static_cast<float>(rotDegrees));
+        try {
+            decompressed = decompress(image, static_cast<float>(rotDegrees));
+        } catch (...) {
+            osg::notify(osg::NOTICE)<<"Using default cursor."<<std::endl;
+            return;
+        }
 
         SDL_Surface* surf = SDLUtil::imageToSurface(decompressed, false);
 


### PR DESCRIPTION
This prevents OpenMW from crashing if OSG was built with OSG_WINDOWING_SYSTEM=None.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>