### PR TITLE
Fix potential sound stream leak

### DIFF
--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -915,7 +915,7 @@ void OpenAL_Output::playSound3D(MWBase::SoundPtr sound, Sound_Handle data, float
     sound->mHandle = MAKE_PTRID(source);
 }
 
-void OpenAL_Output::stopSound(MWBase::SoundPtr sound)
+void OpenAL_Output::finishSound(MWBase::SoundPtr sound)
 {
     if(!sound->mHandle) return;
     ALuint source = GET_PTRID(sound->mHandle);
@@ -1012,7 +1012,7 @@ void OpenAL_Output::streamSound3D(DecoderPtr decoder, MWBase::SoundStreamPtr sou
     sound->mHandle = stream;
 }
 
-void OpenAL_Output::stopStream(MWBase::SoundStreamPtr sound)
+void OpenAL_Output::finishStream(MWBase::SoundStreamPtr sound)
 {
     if(!sound->mHandle) return;
     OpenAL_SoundStream *stream = reinterpret_cast<OpenAL_SoundStream*>(sound->mHandle);

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -58,13 +58,13 @@ namespace MWSound
 
         virtual void playSound(MWBase::SoundPtr sound, Sound_Handle data, float offset);
         virtual void playSound3D(MWBase::SoundPtr sound, Sound_Handle data, float offset);
-        virtual void stopSound(MWBase::SoundPtr sound);
+        virtual void finishSound(MWBase::SoundPtr sound);
         virtual bool isSoundPlaying(MWBase::SoundPtr sound);
         virtual void updateSound(MWBase::SoundPtr sound);
 
         virtual void streamSound(DecoderPtr decoder, MWBase::SoundStreamPtr sound);
         virtual void streamSound3D(DecoderPtr decoder, MWBase::SoundStreamPtr sound);
-        virtual void stopStream(MWBase::SoundStreamPtr sound);
+        virtual void finishStream(MWBase::SoundStreamPtr sound);
         virtual double getStreamDelay(MWBase::SoundStreamPtr sound);
         virtual double getStreamOffset(MWBase::SoundStreamPtr sound);
         virtual bool isStreamPlaying(MWBase::SoundStreamPtr sound);

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -37,13 +37,13 @@ namespace MWSound
 
         virtual void playSound(MWBase::SoundPtr sound, Sound_Handle data, float offset) = 0;
         virtual void playSound3D(MWBase::SoundPtr sound, Sound_Handle data, float offset) = 0;
-        virtual void stopSound(MWBase::SoundPtr sound) = 0;
+        virtual void finishSound(MWBase::SoundPtr sound) = 0;
         virtual bool isSoundPlaying(MWBase::SoundPtr sound) = 0;
         virtual void updateSound(MWBase::SoundPtr sound) = 0;
 
         virtual void streamSound(DecoderPtr decoder, MWBase::SoundStreamPtr sound) = 0;
         virtual void streamSound3D(DecoderPtr decoder, MWBase::SoundStreamPtr sound) = 0;
-        virtual void stopStream(MWBase::SoundStreamPtr sound) = 0;
+        virtual void finishStream(MWBase::SoundStreamPtr sound) = 0;
         virtual double getStreamDelay(MWBase::SoundStreamPtr sound) = 0;
         virtual double getStreamOffset(MWBase::SoundStreamPtr sound) = 0;
         virtual bool isStreamPlaying(MWBase::SoundStreamPtr sound) = 0;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -309,7 +309,7 @@ namespace MWSound
     void SoundManager::stopMusic()
     {
         if(mMusic)
-            mOutput->stopStream(mMusic);
+            mOutput->finishStream(mMusic);
         mMusic.reset();
     }
 
@@ -477,7 +477,7 @@ namespace MWSound
         SaySoundMap::iterator snditer = mActiveSaySounds.find(ptr);
         if(snditer != mActiveSaySounds.end())
         {
-            mOutput->stopStream(snditer->second.first);
+            mOutput->finishStream(snditer->second.first);
             mActiveSaySounds.erase(snditer);
         }
         mPendingSaySounds.erase(ptr);
@@ -506,7 +506,7 @@ namespace MWSound
 
     void SoundManager::stopTrack(MWBase::SoundStreamPtr stream)
     {
-        mOutput->stopStream(stream);
+        mOutput->finishStream(stream);
         TrackList::iterator iter = std::lower_bound(mActiveTracks.begin(), mActiveTracks.end(), stream);
         if(iter != mActiveTracks.end() && *iter == stream)
             mActiveTracks.erase(iter);
@@ -624,7 +624,7 @@ namespace MWSound
     void SoundManager::stopSound(MWBase::SoundPtr sound)
     {
         if (sound.get())
-            mOutput->stopSound(sound);
+            mOutput->finishSound(sound);
     }
 
     void SoundManager::stopSound3D(const MWWorld::Ptr &ptr, const std::string& soundId)
@@ -637,7 +637,7 @@ namespace MWSound
             for(;sndidx != snditer->second.end();++sndidx)
             {
                 if(sndidx->second == sfx)
-                    mOutput->stopSound(sndidx->first);
+                    mOutput->finishSound(sndidx->first);
             }
         }
     }
@@ -649,7 +649,7 @@ namespace MWSound
         {
             SoundBufferRefPairList::iterator sndidx = snditer->second.begin();
             for(;sndidx != snditer->second.end();++sndidx)
-                mOutput->stopSound(sndidx->first);
+                mOutput->finishSound(sndidx->first);
         }
     }
 
@@ -664,7 +664,7 @@ namespace MWSound
             {
                 SoundBufferRefPairList::iterator sndidx = snditer->second.begin();
                 for(;sndidx != snditer->second.end();++sndidx)
-                    mOutput->stopSound(sndidx->first);
+                    mOutput->finishSound(sndidx->first);
             }
             ++snditer;
         }
@@ -675,7 +675,7 @@ namespace MWSound
                sayiter->first != MWMechanics::getPlayer() &&
                sayiter->first.getCell() == cell)
             {
-                mOutput->stopStream(sayiter->second.first);
+                mOutput->finishStream(sayiter->second.first);
             }
             ++sayiter;
         }
@@ -691,7 +691,7 @@ namespace MWSound
             for(;sndidx != snditer->second.end();++sndidx)
             {
                 if(sndidx->second == sfx)
-                    mOutput->stopSound(sndidx->first);
+                    mOutput->finishSound(sndidx->first);
             }
         }
     }
@@ -829,7 +829,7 @@ namespace MWSound
             env = Env_Underwater;
         else if(mUnderwaterSound)
         {
-            mOutput->stopSound(mUnderwaterSound);
+            mOutput->finishSound(mUnderwaterSound);
             mUnderwaterSound.reset();
         }
 
@@ -866,13 +866,13 @@ namespace MWSound
                     if(sound->getDistanceCull())
                     {
                         if((mListenerPos - objpos).length2() > 2000*2000)
-                            mOutput->stopSound(sound);
+                            mOutput->finishSound(sound);
                     }
                 }
 
                 if(!mOutput->isSoundPlaying(sound))
                 {
-                    mOutput->stopSound(sound);
+                    mOutput->finishSound(sound);
                     Sound_Buffer *sfx = sndidx->second;
                     if(sfx->mUses-- == 1)
                         mUnusedBuffers.push_front(sfx);
@@ -939,13 +939,13 @@ namespace MWSound
                 if(sound->getDistanceCull())
                 {
                     if((mListenerPos - pos).length2() > 2000*2000)
-                        mOutput->stopStream(sound);
+                        mOutput->finishStream(sound);
                 }
             }
 
             if(!mOutput->isStreamPlaying(sound))
             {
-                mOutput->stopStream(sound);
+                mOutput->finishStream(sound);
                 mActiveSaySounds.erase(sayiter++);
             }
             else
@@ -963,7 +963,7 @@ namespace MWSound
             MWBase::SoundStreamPtr sound = *trkiter;
             if(!mOutput->isStreamPlaying(sound))
             {
-                mOutput->stopStream(sound);
+                mOutput->finishStream(sound);
                 trkiter = mActiveTracks.erase(trkiter);
             }
             else
@@ -1143,7 +1143,7 @@ namespace MWSound
             SoundBufferRefPairList::iterator sndidx = snditer->second.begin();
             for(;sndidx != snditer->second.end();++sndidx)
             {
-                mOutput->stopSound(sndidx->first);
+                mOutput->finishSound(sndidx->first);
                 Sound_Buffer *sfx = sndidx->second;
                 if(sfx->mUses-- == 1)
                     mUnusedBuffers.push_front(sfx);
@@ -1152,11 +1152,11 @@ namespace MWSound
         mActiveSounds.clear();
         SaySoundMap::iterator sayiter = mActiveSaySounds.begin();
         for(;sayiter != mActiveSaySounds.end();++sayiter)
-            mOutput->stopStream(sayiter->second.first);
+            mOutput->finishStream(sayiter->second.first);
         mActiveSaySounds.clear();
         TrackList::iterator trkiter = mActiveTracks.begin();
         for(;trkiter != mActiveTracks.end();++trkiter)
-            mOutput->stopStream(*trkiter);
+            mOutput->finishStream(*trkiter);
         mActiveTracks.clear();
         mPendingSaySounds.clear();
         mUnderwaterSound.reset();


### PR DESCRIPTION
If a say is executed for a given object while it's already saying something, the preexisting ```SoundPtr``` would be overwritten, preventing it from being properly cleaned up when it eventually stops.