### PR TITLE
disable end enable moons on gles1

### DIFF
--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1632,7 +1632,24 @@ void SkyManager::sunDisable()
 
     mSun->setVisible(false);
 }
+#ifdef OPENGL_ES
+void SkyManager::moonsEnable()
+{
+    if (!mCreated) return;
 
+    mSecunda->setVisible(true);
+    mMasser->setVisible(true);
+}
+
+void SkyManager::moonsDisable()
+{
+    if (!mCreated) return;
+
+    mSecunda->setVisible(false);
+    mMasser->setVisible(false);
+}
+
+#endif
 void SkyManager::setStormDirection(const osg::Vec3f &direction)
 {
     mStormDirection = direction;

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -136,6 +136,12 @@ namespace MWRender
 
         void sunDisable();
 
+#ifdef OPENGL_ES
+        void moonsEnable();
+
+        void moonsDisable();
+#endif
+
         void setRainSpeed(float speed);
 
         void setStormDirection(const osg::Vec3f& direction);

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -669,9 +669,19 @@ void WeatherManager::update(float duration, bool paused)
 
     // disable sun during night
     if (time.getHour() >= mTimeSettings.mNightStart || time.getHour() <= mSunriseTime)
+    {
         mRendering.getSkyManager()->sunDisable();
+#ifdef OPENGL_ES
+        mRendering.getSkyManager()->moonsEnable();
+#endif
+    }
     else
+    {
         mRendering.getSkyManager()->sunEnable();
+#ifdef OPENGL_ES
+        mRendering.getSkyManager()->moonsDisable();
+#endif
+    }
 
     // Update the sun direction.  Run it east to west at a fixed angle from overhead.
     // The sun's speed at day and night may differ, since mSunriseTime and mNightStart


### PR DESCRIPTION
I found only this way to enable and disable moons on gles1 . It works very bad of course , because moons instantly disappears from sky