### PR TITLE
Remove container scripts before deleting container

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -549,6 +549,8 @@ namespace MWBase
 
             /// Return the distance between actor's weapon and target's collision box.
             virtual float getHitDistance(const MWWorld::Ptr& actor, const MWWorld::Ptr& target) = 0;
+
+            virtual void removeContainerScripts(const MWWorld::Ptr& reference) = 0;
     };
 }
 

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -77,6 +77,7 @@ namespace MWClass
             ptr.get<ESM::Container>();
         if (ref->mBase->mFlags & ESM::Container::Respawn)
         {
+            MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
             ptr.getRefData().setCustomData(NULL);
         }
     }

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -762,6 +762,7 @@ namespace MWClass
                 // Reset to original position
                 ptr.getRefData().setPosition(ptr.getCellRef().getPosition());
 
+                MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
                 ptr.getRefData().setCustomData(NULL);
             }
         }

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1224,6 +1224,7 @@ namespace MWClass
                 // Reset to original position
                 ptr.getRefData().setPosition(ptr.getCellRef().getPosition());
 
+                MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
                 ptr.getRefData().setCustomData(NULL);
             }
         }

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -1127,6 +1127,7 @@ namespace MWScript
                     {
                         MWBase::Environment::get().getWorld()->undeleteObject(ptr);
                         // resets runtime state such as inventory, stats and AI. does not reset position in the world
+                        MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
                         ptr.getRefData().setCustomData(NULL);
                     }
                 }

--- a/apps/openmw/mwworld/localscripts.hpp
+++ b/apps/openmw/mwworld/localscripts.hpp
@@ -52,7 +52,7 @@ namespace MWWorld
             void remove (RefData *ref);
 
             void remove (const Ptr& ptr);
-            ///< Remove script for given reference (ignored if reference does not have a scirpt listed).
+            ///< Remove script for given reference (ignored if reference does not have a script listed).
     };
 }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -129,8 +129,9 @@ namespace MWWorld
             void updateWindowManager ();
             void updatePlayer(bool paused);
             MWWorld::Ptr getFacedObject(float maxDistance, bool ignorePlayer=true);
-
+    public: // FIXME
             void removeContainerScripts(const Ptr& reference);
+    private:
             void addContainerScripts(const Ptr& reference, CellStore* cell);
             void PCDropped (const Ptr& item);
 


### PR DESCRIPTION
Fixes a crash encountered in the Morrowind Crafting mod when entering balmora.

It seems we have a design issue here (ideally whoever adds the script should be responsible for removing it), but this is the simplest fix I could find.