### PR TITLE
Bug Fix 3020: Added checks to verifier for container inventories

### DIFF
--- a/apps/opencs/model/tools/referenceablecheck.cpp
+++ b/apps/opencs/model/tools/referenceablecheck.cpp
@@ -399,39 +399,7 @@ void CSMTools::ReferenceableCheckStage::containerCheck(
         messages.push_back (std::make_pair (id, container.mId + " has an empty name"));
     
     //checking contained items
-    const std::vector<ESM::ContItem>& itemList = container.mInventory.mList;
-    for (unsigned i = 0; i < itemList.size(); ++i)
-    {
-        std::string itemName = itemList[i].mItem.toString();
-        CSMWorld::RefIdData::LocalIndex localIndex = mReferencables.searchId(itemName);
-
-        if (localIndex.first == -1)
-            messages.push_back (std::make_pair (id,
-                container.mId + " contains unreferenced item " + itemName));
-        else
-        {
-            switch (localIndex.second)
-            {
-            case CSMWorld::UniversalId::Type_Potion:
-            case CSMWorld::UniversalId::Type_Apparatus:
-            case CSMWorld::UniversalId::Type_Armor:
-            case CSMWorld::UniversalId::Type_Book:
-            case CSMWorld::UniversalId::Type_Clothing:
-            case CSMWorld::UniversalId::Type_Ingredient:
-            case CSMWorld::UniversalId::Type_Light:
-            case CSMWorld::UniversalId::Type_Lockpick:
-            case CSMWorld::UniversalId::Type_Miscellaneous:
-            case CSMWorld::UniversalId::Type_Probe:
-            case CSMWorld::UniversalId::Type_Repair:
-            case CSMWorld::UniversalId::Type_Weapon:
-            case CSMWorld::UniversalId::Type_ItemLevelledList:
-                break;
-            default:
-                messages.push_back (std::make_pair(id,
-                    container.mId + " contains illegal item " + itemName));
-            }
-        }
-    }
+    inventoryListCheck(container.mInventory.mList, messages, id.toString());
 
     // Check that mentioned scripts exist
     scriptCheck<ESM::Container>(container, messages, id.toString());
@@ -506,6 +474,9 @@ void CSMTools::ReferenceableCheckStage::creatureCheck (
     if (creature.mScale == 0)
         messages.push_back (std::make_pair (id, creature.mId + " has zero scale value"));
 
+    // Check inventory
+    inventoryListCheck(creature.mInventory.mList, messages, id.toString());
+ 
     // Check that mentioned scripts exist
     scriptCheck<ESM::Creature>(creature, messages, id.toString());
 }
@@ -777,6 +748,9 @@ void CSMTools::ReferenceableCheckStage::npcCheck (
 
     //TODO: reputation, Disposition, rank, everything else
 
+    // Check inventory
+    inventoryListCheck(npc.mInventory.mList, messages, id.toString());
+ 
     // Check that mentioned scripts exist
     scriptCheck<ESM::NPC>(npc, messages, id.toString());
 }
@@ -926,6 +900,45 @@ void CSMTools::ReferenceableCheckStage::finalCheck (CSMDoc::Messages& messages)
             "There is no player record"));
 }
 
+void CSMTools::ReferenceableCheckStage::inventoryListCheck(
+    const std::vector<ESM::ContItem>& itemList, 
+    CSMDoc::Messages& messages, 
+    const std::string& id)
+{
+    for (size_t i = 0; i < itemList.size(); ++i)
+    {
+        std::string itemName = itemList[i].mItem.toString();
+        CSMWorld::RefIdData::LocalIndex localIndex = mReferencables.searchId(itemName);
+
+        if (localIndex.first == -1)
+            messages.push_back (std::make_pair (id,
+                id + " contains non-existing item (" + itemName + ")"));
+        else
+        {
+            // Needs to accomodate Containers, Creatures, and NPCs
+            switch (localIndex.second)
+            {
+            case CSMWorld::UniversalId::Type_Potion:
+            case CSMWorld::UniversalId::Type_Apparatus:
+            case CSMWorld::UniversalId::Type_Armor:
+            case CSMWorld::UniversalId::Type_Book:
+            case CSMWorld::UniversalId::Type_Clothing:
+            case CSMWorld::UniversalId::Type_Ingredient:
+            case CSMWorld::UniversalId::Type_Light:
+            case CSMWorld::UniversalId::Type_Lockpick:
+            case CSMWorld::UniversalId::Type_Miscellaneous:
+            case CSMWorld::UniversalId::Type_Probe:
+            case CSMWorld::UniversalId::Type_Repair:
+            case CSMWorld::UniversalId::Type_Weapon:
+            case CSMWorld::UniversalId::Type_ItemLevelledList:
+                break;
+            default:
+                messages.push_back (std::make_pair(id,
+                    id + " contains item of invalid type (" + itemName + ")"));
+            }
+        }
+    }
+}
 
 //Templates begins here
 

--- a/apps/opencs/model/tools/referenceablecheck.cpp
+++ b/apps/opencs/model/tools/referenceablecheck.cpp
@@ -397,6 +397,41 @@ void CSMTools::ReferenceableCheckStage::containerCheck(
     //checking for name
     if (container.mName.empty())
         messages.push_back (std::make_pair (id, container.mId + " has an empty name"));
+    
+    //checking contained items
+    const std::vector<ESM::ContItem>& itemList = container.mInventory.mList;
+    for (unsigned i = 0; i < itemList.size(); ++i)
+    {
+        std::string itemName = itemList[i].mItem.toString();
+        CSMWorld::RefIdData::LocalIndex localIndex = mReferencables.searchId(itemName);
+
+        if (localIndex.first == -1)
+            messages.push_back (std::make_pair (id,
+                container.mId + " contains unreferenced item " + itemName));
+        else
+        {
+            switch (localIndex.second)
+            {
+            case CSMWorld::UniversalId::Type_Potion:
+            case CSMWorld::UniversalId::Type_Apparatus:
+            case CSMWorld::UniversalId::Type_Armor:
+            case CSMWorld::UniversalId::Type_Book:
+            case CSMWorld::UniversalId::Type_Clothing:
+            case CSMWorld::UniversalId::Type_Ingredient:
+            case CSMWorld::UniversalId::Type_Light:
+            case CSMWorld::UniversalId::Type_Lockpick:
+            case CSMWorld::UniversalId::Type_Miscellaneous:
+            case CSMWorld::UniversalId::Type_Probe:
+            case CSMWorld::UniversalId::Type_Repair:
+            case CSMWorld::UniversalId::Type_Weapon:
+            case CSMWorld::UniversalId::Type_ItemLevelledList:
+                break;
+            default:
+                messages.push_back (std::make_pair(id,
+                    container.mId + " contains illegal item " + itemName));
+            }
+        }
+    }
 
     // Check that mentioned scripts exist
     scriptCheck<ESM::Container>(container, messages, id.toString());

--- a/apps/opencs/model/tools/referenceablecheck.hpp
+++ b/apps/opencs/model/tools/referenceablecheck.hpp
@@ -47,7 +47,9 @@ namespace CSMTools
             //FINAL CHECK
             void finalCheck (CSMDoc::Messages& messages);
 
-            //TEMPLATE CHECKS
+            //Convenience functions
+            void inventoryListCheck(const std::vector<ESM::ContItem>& itemList, CSMDoc::Messages& messages, const std::string& id);
+
             template<typename ITEM> void inventoryItemCheck(const ITEM& someItem,
                                                             CSMDoc::Messages& messages,
                                                             const std::string& someID,


### PR DESCRIPTION
Added a bit to the containerCheck method so that it also checks the contained items and generates the appropriate error message. I'm not sure what items are allowed in an inventory, so that needs verification. Also, this is my first pull request, so let me know if I did something wrong with git.