### PR TITLE
Fix build error with OSG >=3.3.3 <3.4.0

### DIFF
--- a/components/resource/objectcache.cpp
+++ b/components/resource/objectcache.cpp
@@ -13,7 +13,7 @@
 
 #include <osg/Version>
 
-#if OSG_VERSION_LESS_THAN(3,4,0)
+#if OSG_VERSION_LESS_THAN(3,3,3)
 
 #include "objectcache.hpp"
 

--- a/components/resource/objectcache.hpp
+++ b/components/resource/objectcache.hpp
@@ -19,7 +19,7 @@
 
 #include <osg/Version>
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3,4,0)
+#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
 #include <osgDB/ObjectCache>
 #else
 


### PR DESCRIPTION
osgDB::ObjectCache was added in 3.3.3, not 3.4.0
So builds fail on versions inbetween them.