### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ endif (APPLE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 
+if (ANDROID)
+    set(CMAKE_FIND_ROOT_PATH ${OPENMW_DEPENDENCIES_DIR} "${CMAKE_FIND_ROOT_PATH}")
+    set (OSG_PLUGINS_DIR CACHE STRING "")
+endif()
+
 # Version
 message(STATUS "Configuring OpenMW...")
 
@@ -157,7 +162,6 @@ if (WIN32)
 endif()
 
 if (ANDROID)
-    set(CMAKE_FIND_ROOT_PATH ${OPENMW_DEPENDENCIES_DIR} "${CMAKE_FIND_ROOT_PATH}")
     set(OPENGL_ES TRUE CACHE BOOL "enable opengl es support for android" FORCE)
 endif (ANDROID)
 

--- a/cmake/FindMyGUI.cmake
+++ b/cmake/FindMyGUI.cmake
@@ -71,7 +71,7 @@ ELSE (WIN32) #Unix
     FIND_PACKAGE(PkgConfig)
     IF(MYGUI_STATIC)
         # don't use pkgconfig on OS X, find freetype & append it's libs to resulting MYGUI_LIBRARIES
-        IF (NOT APPLE)
+        IF (NOT APPLE AND NOT ANDROID)
             PKG_SEARCH_MODULE(MYGUI MYGUIStatic MyGUIStatic)
             IF (MYGUI_INCLUDE_DIRS)
                 SET(MYGUI_INCLUDE_DIRS ${MYGUI_INCLUDE_DIRS})
@@ -84,15 +84,15 @@ ELSE (WIN32) #Unix
                 STRING(REGEX REPLACE "(.*)/.*" "\\1" MYGUI_LIB_DIR "${MYGUI_LIB_DIR}")
                 STRING(REGEX REPLACE ".*/" "" MYGUI_LIBRARIES "${MYGUI_LIBRARIES}")
             ENDIF (MYGUI_INCLUDE_DIRS)
-        ELSE (NOT APPLE)
+        ELSE (NOT APPLE AND NOT ANDROID)
             SET(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${MYGUI_DEPENDENCIES_DIR})
-            FIND_PACKAGE(freetype)
+            FIND_PACKAGE(Freetype REQUIRED)
             FIND_PATH(MYGUI_INCLUDE_DIRS MyGUI.h PATHS /usr/local/include /usr/include PATH_SUFFIXES MyGUI MYGUI)
-            FIND_LIBRARY(MYGUI_LIBRARIES MyGUIEngineStatic PATHS /usr/lib /usr/local/lib)
+            FIND_LIBRARY(MYGUI_LIBRARIES MyGUIEngineStatic PATHS /usr/lib /usr/local/lib ${OPENMW_DEPENDENCIES_DIR})
             SET(MYGUI_LIB_DIR ${MYGUI_LIBRARIES})
             STRING(REGEX REPLACE "(.*)/.*" "\\1" MYGUI_LIB_DIR "${MYGUI_LIB_DIR}")
             STRING(REGEX REPLACE ".*/" "" MYGUI_LIBRARIES "${MYGUI_LIBRARIES}")
-        ENDIF (NOT APPLE)
+        ENDIF (NOT APPLE AND NOT ANDROID)
     ELSE(MYGUI_STATIC)
         PKG_SEARCH_MODULE(MYGUI MYGUI MyGUI)
         IF (MYGUI_INCLUDE_DIRS)
@@ -108,6 +108,7 @@ ELSE (WIN32) #Unix
         ENDIF (MYGUI_INCLUDE_DIRS)
     ENDIF(MYGUI_STATIC)
 ENDIF (WIN32)
+
 
 #Do some preparation
 IF (NOT WIN32) # This does not work on Windows for paths with spaces in them


### PR DESCRIPTION
So 
1) Pkgconfig not work when building for Android platform .
2) my final cmake command looks like it :

cmake /home/sandstranger/Android/openmw -DCMAKE_TOOLCHAIN_FILE=/home/sandstranger/Android/android-cmake-master/android.toolchain.cmake -DANDROID_TOOLCHAIN_NAME=aarch64-linux-android-4.9 -DANDROID_NATIVE_API_LEVEL=android-21 -DANDROID_NDK=/home/sandstranger/Android/crystax-ndk-10.1.0/ -DANDROID_ABI=arm64-v8a -DOPENMW_DEPENDENCIES_DIR=/home/sandstranger/Android/AndroidDependenciesARMV8 -DOSG_PLUGINS_DIR=/home/sandstranger/Android/AndroidDependenciesARMV8/lib/osgPlugins-3.5.1 -G"Eclipse CDT4 - Unix Makefiles" -DBUILD_BSATOOL=OFF -DBUILD_ESMTOOL=OFF -DBUILD_LAUNCHER=OFF -DBUILD_MWINIIMPORTER=OFF -DBUILD_ESSIMPORTER=OFF -DBUILD_OPENCS=OFF -DBUILD_WIZARD=OFF -DBUILD_MYGUI_PLUGIN=OFF -DMYGUI_STATIC=ON -DBOOST_STATIC=ON

