### PR TITLE
Use correct direction multipliers during awareness check

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1435,7 +1435,7 @@ namespace MWMechanics
             osg::Vec3f observerDir = (observer.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0));
 
             float angleRadians = std::acos(observerDir * vec / (observerDir.length() * vec.length()));
-            if (angleRadians < osg::DegreesToRadians(90.f))
+            if (angleRadians > osg::DegreesToRadians(90.f))
                 y = obsTerm * observerStats.getFatigueTerm() * fSneakNoViewMult;
             else
                 y = obsTerm * observerStats.getFatigueTerm() * fSneakViewMult;


### PR DESCRIPTION
A sneaking player is more likely to be noticed when behind an NPC, than when in front. This is the opposite of vanilla behavior. It happens in both 0.37 and in the master branch.