### PR TITLE
Warn about ignored script arguments

### DIFF
--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -804,6 +804,8 @@ namespace Compiler
                     if (optional)
                         ++optionalCount;
                 }
+                else
+                    getErrorHandler().warning("Ignoring extra argument", mTokenLoc);
             }
             else if (*iter=='X')
             {
@@ -815,6 +817,8 @@ namespace Compiler
 
                 if (parser.isEmpty())
                     break;
+                else
+                    getErrorHandler().warning("Ignoring extra argument", mTokenLoc);
             }
             else if (*iter=='z')
             {
@@ -825,6 +829,8 @@ namespace Compiler
 
                 if (discardParser.isEmpty())
                     break;
+                else
+                    getErrorHandler().warning("Ignoring extra argument", mTokenLoc);
             }
             else if (*iter=='j')
             {

--- a/components/compiler/extensions.hpp
+++ b/components/compiler/extensions.hpp
@@ -20,9 +20,9 @@ namespace Compiler
         l - Integer <BR>
         s - Short <BR>
         S - String, case preserved <BR>
-        x - Optional, ignored string argument
-        X - Optional, ignored numeric expression
-        z - Optional, ignored string or numeric argument
+        x - Optional, ignored string argument. Emits a parser warning when this argument is supplied. <BR>
+        X - Optional, ignored numeric expression. Emits a parser warning when this argument is supplied. <BR>
+        z - Optional, ignored string or numeric argument. Emits a parser warning when this argument is supplied. <BR>
         j - A piece of junk (either . or a specific keyword)
     **/
     typedef std::string ScriptArgs;

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -341,9 +341,9 @@ namespace Compiler
             extensions.registerInstruction ("say", "SS", opcodeSay, opcodeSayExplicit);
             extensions.registerFunction ("saydone", 'l', "", opcodeSayDone, opcodeSayDoneExplicit);
             extensions.registerInstruction ("streammusic", "S", opcodeStreamMusic);
-            extensions.registerInstruction ("playsound", "c", opcodePlaySound);
+            extensions.registerInstruction ("playsound", "cXX", opcodePlaySound);
             extensions.registerInstruction ("playsoundvp", "cff", opcodePlaySoundVP);
-            extensions.registerInstruction ("playsound3d", "c", opcodePlaySound3D,
+            extensions.registerInstruction ("playsound3d", "cXX", opcodePlaySound3D,
                 opcodePlaySound3DExplicit);
             extensions.registerInstruction ("playsound3dvp", "cff", opcodePlaySound3DVP,
                 opcodePlaySound3DVPExplicit);


### PR DESCRIPTION
Example:

<pre>
; correct would be player->activate, the extra "player" is ignored
player->activate "player"
</pre>

<pre>
column 0 (): warning: Ignoring extra argument
</pre>

Not sure how to get the column numbers correct, but I guess that's not so important.