### PR TITLE
Make setup method of MainDialog class private

### DIFF
--- a/apps/launcher/maindialog.hpp
+++ b/apps/launcher/maindialog.hpp
@@ -50,7 +50,6 @@ namespace Launcher
         explicit MainDialog(QWidget *parent = 0);
         ~MainDialog();
 
-        bool setup();
         FirstRunDialogResult showFirstRunDialog();
 
         bool reloadSettings();
@@ -65,6 +64,8 @@ namespace Launcher
         void wizardFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
     private:
+        bool setup();
+
         void createIcons();
         void createPages();
 


### PR DESCRIPTION
This makes the setup() method private for the launcher's MainDialog class as suggested in #873. I can't tell if there is an ordering scheme in maindialog.cpp so I didn't make any changes there.