### PR TITLE
Remove unused forward declarations in filedialog.hpp

### DIFF
--- a/apps/opencs/view/doc/filedialog.hpp
+++ b/apps/opencs/view/doc/filedialog.hpp
@@ -14,9 +14,6 @@ Q_DECLARE_METATYPE (boost::filesystem::path)
 
 #include "ui_filedialog.h"
 
-class DataFilesModel;
-class PluginsProxyModel;
-
 namespace ContentSelectorView
 {
     class ContentSelector;


### PR DESCRIPTION
This removes a couple forward declarations that aren't needed any longer.