### PR TITLE
Unlinking qt too

### DIFF
--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -6,4 +6,5 @@ export CC=clang
 brew tap openmw/openmw
 brew update
 brew unlink boost
+brew unlink qt
 brew install openmw-mygui openmw-bullet openmw-sdl2 openmw-ffmpeg openmw/openmw/qt unshield


### PR DESCRIPTION
There is another version of qt in homebrew, so if boost is unlinked, then qt should also be unlinked. I don't know everything about this project, so there might be a reason for why qt is not also unlinked?