### PR TITLE
Add script editor line wrapping (Feature #2926)

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -133,6 +133,8 @@ void CSMPrefs::State::declare()
     declareBool ("show-linenum", "Show Line Numbers", true).
         setTooltip ("Show line numbers to the left of the script editor window."
         "The current row and column numbers of the text cursor are shown at the bottom.");
+    declareBool ("wrap-lines", "Wrap Lines", false).
+        setTooltip ("Wrap lines longer than width of script editor.");
     declareBool ("mono-font", "Use monospace font", true);
     EnumValue warningsNormal ("Normal", "Report warnings as warning");
     declareEnum ("warnings", "Warning Mode", warningsNormal).

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -38,20 +38,20 @@ bool CSVWorld::ScriptEdit::event (QEvent *event)
     return QPlainTextEdit::event (event);
 }
 
-CSVWorld::ScriptEdit::ScriptEdit (const CSMDoc::Document& document, ScriptHighlighter::Mode mode,
-    QWidget* parent)
-    : QPlainTextEdit (parent),
-    mChangeLocked (0),
+CSVWorld::ScriptEdit::ScriptEdit(
+    const CSMDoc::Document& document,
+    ScriptHighlighter::Mode mode,
+    QWidget* parent
+) : QPlainTextEdit(parent),
+    mChangeLocked(0),
     mShowLineNum(false),
     mLineNumberArea(0),
     mDefaultFont(font()),
     mMonoFont(QFont("Monospace")),
-    mDocument (document),
+    mDocument(document),
     mWhiteListQoutes("^[a-z|_]{1}[a-z|0-9|_]{0,}$", Qt::CaseInsensitive)
-
 {
-//    setAcceptRichText (false);
-    setLineWrapMode (QPlainTextEdit::NoWrap);
+    wrapLines(false);
     setTabStopWidth (4);
     setUndoRedoEnabled (false); // we use OpenCS-wide undo/redo instead
 
@@ -194,14 +194,37 @@ bool CSVWorld::ScriptEdit::stringNeedsQuote (const std::string& id) const
     return !(string.contains(mWhiteListQoutes));
 }
 
-void CSVWorld::ScriptEdit::settingChanged (const CSMPrefs::Setting *setting)
+void CSVWorld::ScriptEdit::wrapLines(bool wrap)
 {
-    if (mHighlighter->settingChanged (setting))
+    if (wrap)
+    {
+        setLineWrapMode(QPlainTextEdit::WidgetWidth);
+    }
+    else
+    {
+        setLineWrapMode(QPlainTextEdit::NoWrap);
+    }
+}
+
+void CSVWorld::ScriptEdit::settingChanged(const CSMPrefs::Setting *setting)
+{
+    // Determine which setting was changed.
+    if (mHighlighter->settingChanged(setting))
+    {
         updateHighlighting();
-    else if (*setting=="Scripts/mono-font")
-        setFont (setting->isTrue() ? mMonoFont : mDefaultFont);
-    else if (*setting=="Scripts/show-linenum")
-        showLineNum (setting->isTrue());
+    }
+    else if (*setting == "Scripts/mono-font")
+    {
+        setFont(setting->isTrue() ? mMonoFont : mDefaultFont);
+    }
+    else if (*setting == "Scripts/show-linenum")
+    {
+        showLineNum(setting->isTrue());
+    }
+    else if (*setting == "Scripts/wrap-lines")
+    {
+        wrapLines(setting->isTrue());
+    }
 }
 
 void CSVWorld::ScriptEdit::idListChanged()

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -22,6 +22,7 @@ namespace CSVWorld
 {
     class LineNumberArea;
 
+    /// \brief Editor for scripts.
     class ScriptEdit : public QPlainTextEdit
     {
             Q_OBJECT
@@ -77,6 +78,7 @@ namespace CSVWorld
             virtual void resizeEvent(QResizeEvent *e);
 
         private:
+
             QVector<CSMWorld::UniversalId::Type> mAllowedTypes;
             const CSMDoc::Document& mDocument;
             const QRegExp mWhiteListQoutes;
@@ -89,9 +91,15 @@ namespace CSVWorld
 
             bool stringNeedsQuote(const std::string& id) const;
 
+            /// \brief Turn line wrapping in script editor on or off.
+            /// \param wrap Whether or not to wrap lines.
+            void wrapLines(bool wrap);
+
         private slots:
 
-            void settingChanged (const CSMPrefs::Setting *setting);
+            /// \brief Update editor when related setting is changed.
+            /// \param setting Setting that was changed.
+            void settingChanged(const CSMPrefs::Setting *setting);
 
             void idListChanged();
 


### PR DESCRIPTION
This adds the option to turn line wrapping on or off for the script editor in the settings window as requested in [#2926](https://bugs.openmw.org/issues/2926). I kept no line wrapping as the default.