### PR TITLE
Unity build fix

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -42,6 +42,7 @@
 #include "camera.hpp"
 #include "water.hpp"
 #include "terrainstorage.hpp"
+#include "util.hpp"
 
 namespace MWRender
 {
@@ -502,15 +503,6 @@ namespace MWRender
         mutable OpenThreads::Condition mCondition;
         mutable OpenThreads::Mutex mMutex;
         mutable bool mDone;
-    };
-
-
-    class NoTraverseCallback : public osg::NodeCallback
-    {
-    public:
-        virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
-        {
-        }
     };
 
     void RenderingManager::screenshot(osg::Image *image, int w, int h)

--- a/apps/openmw/mwrender/util.hpp
+++ b/apps/openmw/mwrender/util.hpp
@@ -1,7 +1,7 @@
 #ifndef OPENMW_MWRENDER_UTIL_H
 #define OPENMW_MWRENDER_UTIL_H
 
-#include <osg/Callback>
+#include <osg/NodeCallback>
 #include <osg/ref_ptr>
 #include <string>
 

--- a/apps/openmw/mwrender/util.hpp
+++ b/apps/openmw/mwrender/util.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENMW_MWRENDER_UTIL_H
 #define OPENMW_MWRENDER_UTIL_H
 
+#include <osg/Callback>
 #include <osg/ref_ptr>
 #include <string>
 

--- a/apps/openmw/mwrender/util.hpp
+++ b/apps/openmw/mwrender/util.hpp
@@ -16,9 +16,17 @@ namespace Resource
 
 namespace MWRender
 {
-
     void overrideTexture(const std::string& texture, Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Node> node);
 
+    // Node callback to entirely skip the traversal.
+    class NoTraverseCallback : public osg::NodeCallback
+    {
+    public:
+        virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
+        {
+            // no traverse()
+        }
+    };
 }
 
 #endif

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -210,16 +210,6 @@ private:
     osg::Plane mPlane;
 };
 
-// Node callback to entirely skip the traversal.
-class NoTraverseCallback : public osg::NodeCallback
-{
-public:
-    virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
-    {
-        // no traverse()
-    }
-};
-
 /// Moves water mesh away from the camera slightly if the camera gets too close on the Z axis.
 /// The offset works around graphics artifacts that occured with the GL_DEPTH_CLAMP when the camera gets extremely close to the mesh (seen on NVIDIA at least).
 /// Must be added as a Cull callback.

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -41,6 +41,7 @@
 #include "vismask.hpp"
 #include "ripplesimulation.hpp"
 #include "renderbin.hpp"
+#include "util.hpp"
 
 namespace
 {


### PR DESCRIPTION
Moves NoTraverseCallback to mwrender/util.hpp to get rid of the multi-definition.