### PR TITLE
Refactor local script iteration (Bug #2806)

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -69,11 +69,9 @@ void OMW::Engine::executeLocalScripts()
     MWWorld::LocalScripts& localScripts = mEnvironment.getWorld()->getLocalScripts();
 
     localScripts.startIteration();
-
-    while (!localScripts.isFinished())
+    std::pair<std::string, MWWorld::Ptr> script;
+    while (localScripts.getNext(script))
     {
-        std::pair<std::string, MWWorld::Ptr> script = localScripts.getNext();
-
         MWScript::InterpreterContext interpreterContext (
             &script.second.getRefData().getLocals(), script.second);
         mEnvironment.getScriptManager()->run (script.first, interpreterContext);

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -110,6 +110,14 @@ void MWWorld::LocalScripts::add (const std::string& scriptName, const Ptr& ptr)
         {
             ptr.getRefData().setLocals (*script);
 
+            for (std::list<std::pair<std::string, Ptr> >::iterator iter = mScripts.begin(); iter!=mScripts.end(); ++iter)
+                if (iter->second==ptr)
+                {
+                    std::cout << "warning, tried to add local script twice for " << ptr.getCellRef().getRefId() << std::endl;
+                    remove(ptr);
+                    break;
+                }
+
             mScripts.push_back (std::make_pair (scriptName, ptr));
         }
         catch (const std::exception& exception)

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -76,30 +76,18 @@ void MWWorld::LocalScripts::startIteration()
     mIter = mScripts.begin();
 }
 
-bool MWWorld::LocalScripts::isFinished() const
+bool MWWorld::LocalScripts::getNext(std::pair<std::string, Ptr>& script)
 {
-    if (mIter==mScripts.end())
-        return true;
-
-    if (!mIgnore.isEmpty() && mIter->second==mIgnore)
+    while (mIter!=mScripts.end())
     {
-        std::list<std::pair<std::string, Ptr> >::iterator iter = mIter;
-        return ++iter==mScripts.end();
+        std::list<std::pair<std::string, Ptr> >::iterator iter = mIter++;
+        if (mIgnore.isEmpty() || iter->second!=mIgnore)
+        {
+            script = *iter;
+            return true;
+        }
     }
-
     return false;
-}
-
-std::pair<std::string, MWWorld::Ptr> MWWorld::LocalScripts::getNext()
-{
-    assert (!isFinished());
-
-    std::list<std::pair<std::string, Ptr> >::iterator iter = mIter++;
-
-    if (mIgnore.isEmpty() || iter->second!=mIgnore)
-        return *iter;
-
-    return getNext();
 }
 
 void MWWorld::LocalScripts::add (const std::string& scriptName, const Ptr& ptr)

--- a/apps/openmw/mwworld/localscripts.hpp
+++ b/apps/openmw/mwworld/localscripts.hpp
@@ -31,11 +31,9 @@ namespace MWWorld
             void startIteration();
             ///< Set the iterator to the begin of the script list.
 
-            bool isFinished() const;
-            ///< Is iteration finished?
-
-            std::pair<std::string, Ptr> getNext();
-            ///< Get next local script (must not be called if isFinished())
+            bool getNext(std::pair<std::string, Ptr>& script);
+            ///< Get next local script
+            /// @return Did we get a script?
 
             void add (const std::string& scriptName, const Ptr& ptr);
             ///< Add script to collection of active local scripts.


### PR DESCRIPTION
This should be much safer. Don't use recursion. Don't fail if mIgnore happens to be in the list twice. Don't rely on preconditions / assertions.

Still not sure about the exact cause of bug 2806, but I presume it had to do with a Ptr being in the list twice for some reason. I've added a warning message so we can catch that the next time it happens.