### PR TITLE
Render cell markers (Feature #3043)

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -35,7 +35,7 @@ opencs_hdrs_noqt (model/world
 
 
 opencs_units (model/tools
-    tools reportmodel mergeoperation 
+    tools reportmodel mergeoperation
     )
 
 opencs_units_noqt (model/tools
@@ -90,7 +90,7 @@ opencs_units (view/render
 
 opencs_units_noqt (view/render
     lighting lightingday lightingnight
-    lightingbright object cell terrainstorage tagbase cellarrow
+    lightingbright object cell terrainstorage tagbase cellarrow cellmarker
     )
 
 opencs_hdrs_noqt (view/render
@@ -192,6 +192,7 @@ endif(APPLE)
 target_link_libraries(openmw-cs
     ${OSG_LIBRARIES}
     ${OPENTHREADS_LIBRARIES}
+    ${OSGTEXT_LIBRARIES}
     ${OSGUTIL_LIBRARIES}
     ${OSGVIEWER_LIBRARIES}
     ${OSGGA_LIBRARIES}

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -70,6 +70,8 @@ CSVRender::Cell::Cell (CSMWorld::Data& data, osg::Group* rootNode, const std::st
     mCellNode = new osg::Group;
     rootNode->addChild(mCellNode);
 
+    setCellMarker();
+
     if (!mDeleted)
     {
         CSMWorld::IdTable& references = dynamic_cast<CSMWorld::IdTable&> (
@@ -301,6 +303,11 @@ void CSVRender::Cell::setCellArrows (int mask)
                 mCellArrows[i].reset (0);
         }
     }
+}
+
+void CSVRender::Cell::setCellMarker()
+{
+    mCellMarker.reset(new CellMarker(mCellNode, mCoordinates));
 }
 
 CSMWorld::CellCoordinates CSVRender::Cell::getCoordinates() const

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -307,7 +307,13 @@ void CSVRender::Cell::setCellArrows (int mask)
 
 void CSVRender::Cell::setCellMarker()
 {
-    mCellMarker.reset(new CellMarker(mCellNode, mCoordinates));
+    bool cellExists = false;
+    int cellIndex = mData.getCells().searchId(mId);
+    if (cellIndex > -1)
+    {
+        cellExists = !mData.getCells().getRecord(cellIndex).isDeleted();
+    }
+    mCellMarker.reset(new CellMarker(mCellNode, mCoordinates, cellExists));
 }
 
 CSMWorld::CellCoordinates CSVRender::Cell::getCoordinates() const

--- a/apps/opencs/view/render/cell.hpp
+++ b/apps/opencs/view/render/cell.hpp
@@ -15,6 +15,7 @@
 
 #include "object.hpp"
 #include "cellarrow.hpp"
+#include "cellmarker.hpp"
 
 class QModelIndex;
 
@@ -42,6 +43,7 @@ namespace CSVRender
             std::auto_ptr<Terrain::TerrainGrid> mTerrain;
             CSMWorld::CellCoordinates mCoordinates;
             std::auto_ptr<CellArrow> mCellArrows[4];
+            std::auto_ptr<CellMarker> mCellMarker;
             bool mDeleted;
 
             /// Ignored if cell does not have an object with the given ID.
@@ -104,6 +106,9 @@ namespace CSVRender
             void selectAllWithSameParentId (int elementMask);
 
             void setCellArrows (int mask);
+
+            /// \brief Set marker for this cell.
+            void setCellMarker();
 
             /// Returns 0, 0 in case of an unpaged cell.
             CSMWorld::CellCoordinates getCoordinates() const;

--- a/apps/opencs/view/render/cellmarker.cpp
+++ b/apps/opencs/view/render/cellmarker.cpp
@@ -22,14 +22,27 @@ void CSVRender::CellMarker::buildMarker()
 {
     const int characterSize = 20;
 
-    // Set up marker text containing cell's coordinates.
+    // Set up attributes of marker text.
     osg::ref_ptr<osgText::Text> markerText (new osgText::Text);
-    markerText->setBackdropType(osgText::Text::OUTLINE);
     markerText->setLayout(osgText::Text::LEFT_TO_RIGHT);
     markerText->setCharacterSize(characterSize);
+    markerText->setAlignment(osgText::Text::CENTER_CENTER);
+    markerText->setDrawMode(osgText::Text::TEXT | osgText::Text::FILLEDBOUNDINGBOX);
+
+    // If cell exists then show black bounding box otherwise show red.
+    if (mExists)
+    {
+        markerText->setBoundingBoxColor(osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f));
+    }
+    else
+    {
+        markerText->setBoundingBoxColor(osg::Vec4f(1.0f, 0.0f, 0.0f, 1.0f));
+    }
+
+    // Add text containing cell's coordinates.
     std::string coordinatesText =
-        "#" + boost::lexical_cast<std::string>(mCoordinates.getX()) +
-        " " + boost::lexical_cast<std::string>(mCoordinates.getY());
+        boost::lexical_cast<std::string>(mCoordinates.getX()) + "," +
+        boost::lexical_cast<std::string>(mCoordinates.getY());
     markerText->setText(coordinatesText);
 
     // Add text to marker node.
@@ -51,9 +64,11 @@ void CSVRender::CellMarker::positionMarker()
 
 CSVRender::CellMarker::CellMarker(
     osg::Group *cellNode,
-    const CSMWorld::CellCoordinates& coordinates
+    const CSMWorld::CellCoordinates& coordinates,
+    const bool cellExists
 ) : mCellNode(cellNode),
-    mCoordinates(coordinates)
+    mCoordinates(coordinates),
+    mExists(cellExists)
 {
     // Set up node for cell marker.
     mMarkerNode = new osg::AutoTransform();

--- a/apps/opencs/view/render/cellmarker.cpp
+++ b/apps/opencs/view/render/cellmarker.cpp
@@ -1,0 +1,62 @@
+#include "cellmarker.hpp"
+
+#include <boost/lexical_cast.hpp>
+
+#include <osg/AutoTransform>
+#include <osg/Geode>
+#include <osg/Group>
+#include <osgText/Text>
+
+void CSVRender::CellMarker::buildMarker()
+{
+    const int characterSize = 20;
+
+    // Set up marker text containing cell's coordinates.
+    osg::ref_ptr<osgText::Text> markerText (new osgText::Text);
+    markerText->setBackdropType(osgText::Text::OUTLINE);
+    markerText->setLayout(osgText::Text::LEFT_TO_RIGHT);
+    markerText->setCharacterSize(characterSize);
+    std::string coordinatesText =
+        "#" + boost::lexical_cast<std::string>(mCoordinates.getX()) +
+        " " + boost::lexical_cast<std::string>(mCoordinates.getY());
+    markerText->setText(coordinatesText);
+
+    // Add text to marker node.
+    osg::ref_ptr<osg::Geode> geode (new osg::Geode);
+    geode->addDrawable(markerText);
+    mMarkerNode->addChild(geode);
+}
+
+void CSVRender::CellMarker::positionMarker()
+{
+    const int cellSize = 8192;
+    const int markerHeight = 0;
+
+    // Move marker to center of cell.
+    int x = (mCoordinates.getX() * cellSize) + (cellSize / 2);
+    int y = (mCoordinates.getY() * cellSize) + (cellSize / 2);
+    mMarkerNode->setPosition(osg::Vec3f(x, y, markerHeight));
+}
+
+CSVRender::CellMarker::CellMarker(
+    osg::Group *cellNode,
+    const CSMWorld::CellCoordinates& coordinates
+) : mCellNode(cellNode),
+    mCoordinates(coordinates)
+{
+    // Set up node for cell marker.
+    mMarkerNode = new osg::AutoTransform();
+    mMarkerNode->setAutoRotateMode(osg::AutoTransform::ROTATE_TO_SCREEN);
+    mMarkerNode->setAutoScaleToScreen(true);
+    mMarkerNode->getOrCreateStateSet()->setMode(GL_DEPTH_TEST, osg::StateAttribute::OFF);
+
+    mCellNode->addChild(mMarkerNode);
+
+    buildMarker();
+    positionMarker();
+}
+
+CSVRender::CellMarker::~CellMarker()
+{
+    mCellNode->removeChild(mMarkerNode);
+}

--- a/apps/opencs/view/render/cellmarker.cpp
+++ b/apps/opencs/view/render/cellmarker.cpp
@@ -7,6 +7,17 @@
 #include <osg/Group>
 #include <osgText/Text>
 
+#include "mask.hpp"
+
+CSVRender::CellMarkerTag::CellMarkerTag(CellMarker *marker)
+: TagBase(Mask_CellMarker), mMarker(marker)
+{}
+
+CSVRender::CellMarker *CSVRender::CellMarkerTag::getCellMarker() const
+{
+    return mMarker;
+}
+
 void CSVRender::CellMarker::buildMarker()
 {
     const int characterSize = 20;
@@ -49,6 +60,9 @@ CSVRender::CellMarker::CellMarker(
     mMarkerNode->setAutoRotateMode(osg::AutoTransform::ROTATE_TO_SCREEN);
     mMarkerNode->setAutoScaleToScreen(true);
     mMarkerNode->getOrCreateStateSet()->setMode(GL_DEPTH_TEST, osg::StateAttribute::OFF);
+
+    mMarkerNode->setUserData(new CellMarkerTag(this));
+    mMarkerNode->setNodeMask(Mask_CellMarker);
 
     mCellNode->addChild(mMarkerNode);
 

--- a/apps/opencs/view/render/cellmarker.hpp
+++ b/apps/opencs/view/render/cellmarker.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENCS_VIEW_CELLMARKER_H
 #define OPENCS_VIEW_CELLMARKER_H
 
+#include "tagbase.hpp"
+
 #include <osg/ref_ptr>
 
 #include "../../model/world/cellcoordinates.hpp"
@@ -13,6 +15,21 @@ namespace osg
 
 namespace CSVRender
 {
+    class CellMarker;
+
+    class CellMarkerTag : public TagBase
+    {
+        private:
+
+            CellMarker *mMarker;
+
+        public:
+
+            CellMarkerTag(CellMarker *marker);
+
+            CellMarker *getCellMarker() const;
+    };
+
     /// \brief Marker to display cell coordinates.
     class CellMarker
     {

--- a/apps/opencs/view/render/cellmarker.hpp
+++ b/apps/opencs/view/render/cellmarker.hpp
@@ -38,6 +38,7 @@ namespace CSVRender
             osg::Group* mCellNode;
             osg::ref_ptr<osg::AutoTransform> mMarkerNode;
             CSMWorld::CellCoordinates mCoordinates;
+            bool mExists;
 
             // Not implemented.
             CellMarker(const CellMarker&);
@@ -46,7 +47,7 @@ namespace CSVRender
             /// \brief Build marker containing cell's coordinates.
             void buildMarker();
 
-            /// \brief Position marker above center of cell.
+            /// \brief Position marker at center of cell.
             void positionMarker();
 
         public:
@@ -54,9 +55,11 @@ namespace CSVRender
             /// \brief Constructor.
             /// \param cellNode Cell to create marker for.
             /// \param coordinates Coordinates of cell.
+            /// \param cellExists Whether or not cell exists.
             CellMarker(
                 osg::Group *cellNode,
-                const CSMWorld::CellCoordinates& coordinates);
+                const CSMWorld::CellCoordinates& coordinates,
+                const bool cellExists);
 
             ~CellMarker();
     };

--- a/apps/opencs/view/render/cellmarker.hpp
+++ b/apps/opencs/view/render/cellmarker.hpp
@@ -1,0 +1,48 @@
+#ifndef OPENCS_VIEW_CELLMARKER_H
+#define OPENCS_VIEW_CELLMARKER_H
+
+#include <osg/ref_ptr>
+
+#include "../../model/world/cellcoordinates.hpp"
+
+namespace osg
+{
+    class AutoTransform;
+    class Group;
+}
+
+namespace CSVRender
+{
+    /// \brief Marker to display cell coordinates.
+    class CellMarker
+    {
+        private:
+
+            osg::Group* mCellNode;
+            osg::ref_ptr<osg::AutoTransform> mMarkerNode;
+            CSMWorld::CellCoordinates mCoordinates;
+
+            // Not implemented.
+            CellMarker(const CellMarker&);
+            CellMarker& operator=(const CellMarker&);
+
+            /// \brief Build marker containing cell's coordinates.
+            void buildMarker();
+
+            /// \brief Position marker above center of cell.
+            void positionMarker();
+
+        public:
+
+            /// \brief Constructor.
+            /// \param cellNode Cell to create marker for.
+            /// \param coordinates Coordinates of cell.
+            CellMarker(
+                osg::Group *cellNode,
+                const CSMWorld::CellCoordinates& coordinates);
+
+            ~CellMarker();
+    };
+}
+
+#endif


### PR DESCRIPTION
This adds rendering of cell markers. The markers just display the cell's ID (i.e. "#-1 -1") and use the cell's center as a pivot point. They can be turned on/off using the existing toggle button as well. Let me know if there is missing functionality that needs to be added or if I'm off-track at all.

I was able to find some screenshots of various work in progress versions of the previous markers, but I wasn't sure what the final version looked like. Below are some screenshots for this PR:

![cell-markers-2](https://cloud.githubusercontent.com/assets/873661/12936680/ec2bd308-cf6e-11e5-9772-c182b9766423.png)
![cell-markers](https://cloud.githubusercontent.com/assets/873661/12936581/dff3977a-cf6d-11e5-8e36-ec3615b96878.png)
