### PR TITLE
Remove support for OSG 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ if (USE_QT)
     set (OSG_QT osgQt)
 endif()
 
-find_package(OpenSceneGraph 3.2.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle ${OSG_QT} osgUtil osgFX)
+find_package(OpenSceneGraph 3.4.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle ${OSG_QT} osgUtil osgFX)
 
 include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ if (USE_QT)
     set (OSG_QT osgQt)
 endif()
 
-find_package(OpenSceneGraph 3.4.0 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle ${OSG_QT} osgUtil osgFX)
+find_package(OpenSceneGraph 3.3.4 REQUIRED osgDB osgViewer osgText osgGA osgAnimation osgParticle ${OSG_QT} osgUtil osgFX)
 
 include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -10,7 +10,6 @@
 #include <osg/Geode>
 #include <osg/BlendFunc>
 #include <osg/Material>
-#include <osg/Version>
 
 #include <osgParticle/ParticleSystem>
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -201,17 +201,10 @@ namespace
     class RemoveDrawableVisitor : public RemoveVisitor
     {
     public:
-        virtual void apply(osg::Geode &geode)
-        {
-            applyImpl(geode);
-        }
-
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         virtual void apply(osg::Drawable& drw)
         {
             applyImpl(drw);
         }
-#endif
 
         void applyImpl(osg::Node& node)
         {
@@ -239,17 +232,10 @@ namespace
     class RemoveTriBipVisitor : public RemoveVisitor
     {
     public:
-        virtual void apply(osg::Geode &node)
-        {
-            applyImpl(node);
-        }
-
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         virtual void apply(osg::Drawable& drw)
         {
             applyImpl(drw);
         }
-#endif
 
         void applyImpl(osg::Node& node)
         {

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -5,7 +5,6 @@
 #include <osg/Group>
 #include <osg/Geode>
 #include <osg/UserDataContainer>
-#include <osg/Version>
 
 #include <osgParticle/ParticleSystem>
 #include <osgParticle/ParticleProcessor>

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -43,26 +43,11 @@ namespace
             traverse(node);
         }
 
-        virtual void apply(osg::Geode& geode)
-        {
-            std::vector<osgParticle::ParticleSystem*> partsysVector;
-            for (unsigned int i=0; i<geode.getNumDrawables(); ++i)
-            {
-                osg::Drawable* drw = geode.getDrawable(i);
-                if (osgParticle::ParticleSystem* partsys = dynamic_cast<osgParticle::ParticleSystem*>(drw))
-                    partsysVector.push_back(partsys);
-            }
-
-            for (std::vector<osgParticle::ParticleSystem*>::iterator it = partsysVector.begin(); it != partsysVector.end(); ++it)
-                geode.removeDrawable(*it);
-        }
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         virtual void apply(osg::Drawable& drw)
         {
             if (osgParticle::ParticleSystem* partsys = dynamic_cast<osgParticle::ParticleSystem*>(&drw))
                 mToRemove.push_back(partsys);
         }
-#endif
 
         void remove()
         {

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1282,11 +1282,7 @@ public:
                 if (stateset->getAttribute(osg::StateAttribute::MATERIAL))
                 {
                     SceneUtil::CompositeStateSetUpdater* composite = NULL;
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
                     osg::Callback* callback = node.getUpdateCallback();
-#else
-                    osg::NodeCallback* callback = node.getUpdateCallback();
-#endif
                     while (callback)
                     {
                         if ((composite = dynamic_cast<SceneUtil::CompositeStateSetUpdater*>(callback)))

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -11,7 +11,6 @@
 #include <osg/Material>
 #include <osg/TexEnvCombine>
 #include <osg/TexMat>
-#include <osg/Version>
 #include <osg/OcclusionQueryNode>
 #include <osg/ColorMask>
 #include <osg/MatrixTransform>

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -934,13 +934,7 @@ namespace NifOsg
             updater->addParticleSystem(partsys);
             parentNode->addChild(updater);
 
-#if OSG_VERSION_LESS_THAN(3,3,3)
-            osg::ref_ptr<osg::Geode> geode (new osg::Geode);
-            geode->addDrawable(partsys);
-            osg::Node* toAttach = geode.get();
-#else
             osg::Node* toAttach = partsys.get();
-#endif
 
             if (rf == osgParticle::ParticleProcessor::RELATIVE_RF)
                 parentNode->addChild(toAttach);
@@ -1017,11 +1011,6 @@ namespace NifOsg
                 triShapeToGeometry(triShape, geometry, parentNode, composite, boundTextures, animflags);
             }
 
-#if OSG_VERSION_LESS_THAN(3,3,3)
-            osg::ref_ptr<osg::Geode> geode (new osg::Geode);
-            geode->addDrawable(geometry);
-#endif
-
             if (geometry->getDataVariance() == osg::Object::DYNAMIC)
             {
                 // Add a copy, we will alternate between the two copies every other frame using the FrameSwitch
@@ -1029,24 +1018,14 @@ namespace NifOsg
                 geometry->setDataVariance(osg::Object::STATIC);
                 osg::ref_ptr<FrameSwitch> frameswitch = new FrameSwitch;
 
-#if OSG_VERSION_LESS_THAN(3,3,3)
-                osg::ref_ptr<osg::Geode> geode2 = static_cast<osg::Geode*>(osg::clone(geode.get(), osg::CopyOp::DEEP_COPY_NODES|osg::CopyOp::DEEP_COPY_DRAWABLES));
-                frameswitch->addChild(geode);
-                frameswitch->addChild(geode2);
-#else
                 osg::ref_ptr<osg::Geometry> geom2 = static_cast<osg::Geometry*>(osg::clone(geometry.get(), osg::CopyOp::DEEP_COPY_NODES|osg::CopyOp::DEEP_COPY_DRAWABLES));
                 frameswitch->addChild(geometry);
                 frameswitch->addChild(geom2);
-#endif
 
                 parentNode->addChild(frameswitch);
             }
             else
-#if OSG_VERSION_LESS_THAN(3,3,3)
-                parentNode->addChild(geode);
-#else
                 parentNode->addChild(geometry);
-#endif
         }
 
         osg::ref_ptr<osg::Geometry> handleMorphGeometry(const Nif::NiGeomMorpherController* morpher, const Nif::NiTriShape *triShape, osg::Node* parentNode, SceneUtil::CompositeStateSetUpdater* composite, const std::vector<int>& boundTextures, int animflags)
@@ -1151,21 +1130,10 @@ namespace NifOsg
 
             osg::ref_ptr<FrameSwitch> frameswitch = new FrameSwitch;
 
-#if OSG_VERSION_LESS_THAN(3,3,3)
-            osg::ref_ptr<osg::Geode> geode (new osg::Geode);
-            geode->addDrawable(rig);
-
-            osg::Geode* geode2 = static_cast<osg::Geode*>(osg::clone(geode.get(), osg::CopyOp::DEEP_COPY_NODES|
-                                                                     osg::CopyOp::DEEP_COPY_DRAWABLES));
-
-            frameswitch->addChild(geode);
-            frameswitch->addChild(geode2);
-#else
             SceneUtil::RigGeometry* rig2 = static_cast<SceneUtil::RigGeometry*>(osg::clone(rig.get(), osg::CopyOp::DEEP_COPY_NODES|
                                                                                            osg::CopyOp::DEEP_COPY_DRAWABLES));
             frameswitch->addChild(rig);
             frameswitch->addChild(rig2);
-#endif
 
             parentNode->addChild(frameswitch);
         }

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -5,7 +5,6 @@
 #include <osg/Geode>
 #include <osg/Geometry>
 #include <osg/Array>
-#include <osg/Version>
 #include <osg/LOD>
 
 // resource

--- a/components/resource/imagemanager.cpp
+++ b/components/resource/imagemanager.cpp
@@ -62,17 +62,10 @@ namespace Resource
             case(GL_COMPRESSED_RGBA_S3TC_DXT3_EXT):
             case(GL_COMPRESSED_RGBA_S3TC_DXT5_EXT):
             {
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
                 osg::GLExtensions* exts = osg::GLExtensions::Get(0, false);
                 if (exts && !exts->isTextureCompressionS3TCSupported
                         // This one works too. Should it be included in isTextureCompressionS3TCSupported()? Submitted as a patch to OSG.
                         && !osg::isGLExtensionSupported(0, "GL_S3_s3tc"))
-#else
-                osg::Texture::Extensions* exts = osg::Texture::getExtensions(0, false);
-                if (exts && !exts->isTextureCompressionS3TCSupported()
-                        // This one works too. Should it be included in isTextureCompressionS3TCSupported()? Submitted as a patch to OSG.
-                        && !osg::isGLExtensionSupported(0, "GL_S3_s3tc"))
-#endif
                 {
                     std::cerr << "Error loading " << filename << ": no S3TC texture compression support installed" << std::endl;
                     return false;

--- a/components/resource/imagemanager.cpp
+++ b/components/resource/imagemanager.cpp
@@ -2,7 +2,6 @@
 
 #include <osgDB/Registry>
 #include <osg/GLExtensions>
-#include <osg/Version>
 
 #include <components/vfs/manager.hpp>
 

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -4,7 +4,6 @@
 #include <osg/Node>
 #include <osg/Geode>
 #include <osg/UserDataContainer>
-#include <osg/Version>
 
 #include <osgParticle/ParticleSystem>
 #include <osgFX/Effect>
@@ -52,7 +51,6 @@ namespace
                     && partsys->getUserDataContainer()->getDescriptions()[0] == "worldspace");
         }
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         // in OSG 3.3 and up Drawables can be directly in the scene graph without a Geode decorating them.
         void apply(osg::Drawable& drw)
         {
@@ -67,7 +65,6 @@ namespace
                 partsys->setNodeMask(mMask);
             }
         }
-#endif
 
         void transformInitialParticles(osgParticle::ParticleSystem* partsys, osg::Node* node)
         {

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -52,23 +52,6 @@ namespace
                     && partsys->getUserDataContainer()->getDescriptions()[0] == "worldspace");
         }
 
-        void apply(osg::Geode& geode)
-        {
-            for (unsigned int i=0;i<geode.getNumDrawables();++i)
-            {
-                if (osgParticle::ParticleSystem* partsys = dynamic_cast<osgParticle::ParticleSystem*>(geode.getDrawable(i)))
-                {
-                    if (isWorldSpaceParticleSystem(partsys))
-                    {
-                        // HACK: Ignore the InverseWorldMatrix transform the geode is attached to
-                        if (geode.getNumParents() && geode.getParent(0)->getNumParents())
-                            transformInitialParticles(partsys, geode.getParent(0)->getParent(0));
-                    }
-                    geode.setNodeMask(mMask);
-                }
-            }
-        }
-
 #if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         // in OSG 3.3 and up Drawables can be directly in the scene graph without a Geode decorating them.
         void apply(osg::Drawable& drw)

--- a/components/sceneutil/clone.cpp
+++ b/components/sceneutil/clone.cpp
@@ -81,11 +81,6 @@ namespace SceneUtil
 #endif
 
             osg::Drawable* cloned = osg::clone(drawable, copyop);
-#if OSG_VERSION_LESS_THAN(3,3,3)
-            // work around OSG 3.2 not respecting the DEEP_COPY_CALLBACK flag
-            if (cloned->getUpdateCallback())
-                cloned->setUpdateCallback(osg::clone(cloned->getUpdateCallback(), *this));
-#endif
             return cloned;
         }
         if (dynamic_cast<const SceneUtil::RigGeometry*>(drawable))

--- a/components/sceneutil/controller.cpp
+++ b/components/sceneutil/controller.cpp
@@ -65,11 +65,7 @@ namespace SceneUtil
 
     void ControllerVisitor::apply(osg::Node &node)
     {
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         osg::Callback* callback = node.getUpdateCallback();
-#else
-        osg::NodeCallback* callback = node.getUpdateCallback();
-#endif
         while (callback)
         {
             if (Controller* ctrl = dynamic_cast<Controller*>(callback))
@@ -96,11 +92,7 @@ namespace SceneUtil
         {
             osg::Drawable* drw = geode.getDrawable(i);
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
             osg::Callback* callback = drw->getUpdateCallback();
-#else
-            osg::Drawable::UpdateCallback* callback = drw->getUpdateCallback();
-#endif
 
             if (Controller* ctrl = dynamic_cast<Controller*>(callback))
                 visit(geode, *ctrl);

--- a/components/sceneutil/controller.cpp
+++ b/components/sceneutil/controller.cpp
@@ -5,7 +5,6 @@
 #include <osg/Drawable>
 #include <osg/Geode>
 #include <osg/NodeCallback>
-#include <osg/Version>
 
 namespace SceneUtil
 {

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -289,11 +289,9 @@ void RigGeometry::updateBounds(osg::NodeVisitor *nv)
 
     _boundingBox = box;
     _boundingBoxComputed = true;
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
     // in OSG 3.3.3 and up Drawable inherits from Node, so has a bounding sphere as well.
     _boundingSphere = osg::BoundingSphere(_boundingBox);
     _boundingSphereComputed = true;
-#endif
     for (unsigned int i=0; i<getNumParents(); ++i)
         getParent(i)->dirtyBound();
 }

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <cstdlib>
 
-#include <osg/Version>
 #include <osg/MatrixTransform>
 
 #include "skeleton.hpp"

--- a/components/sdlutil/sdlgraphicswindow.cpp
+++ b/components/sdlutil/sdlgraphicswindow.cpp
@@ -112,11 +112,7 @@ void GraphicsWindowSDL2::init()
 
     mValid = true;
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,4)
     getEventQueue()->syncWindowRectangleWithGraphicsContext();
-#else
-    getEventQueue()->syncWindowRectangleWithGraphcisContext();
-#endif
 }
 
 
@@ -133,11 +129,7 @@ bool GraphicsWindowSDL2::realizeImplementation()
 
     SDL_ShowWindow(mWindow);
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,4)
     getEventQueue()->syncWindowRectangleWithGraphicsContext();
-#else
-    getEventQueue()->syncWindowRectangleWithGraphcisContext();
-#endif
 
     mRealized = true;
 

--- a/components/sdlutil/sdlgraphicswindow.cpp
+++ b/components/sdlutil/sdlgraphicswindow.cpp
@@ -2,8 +2,6 @@
 
 #include <SDL_video.h>
 
-#include <osg/Version>
-
 namespace SDLUtil
 {
 

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -193,13 +193,7 @@ osg::ref_ptr<osg::Node> TerrainGrid::buildTerrain (osg::Group* parent, float chu
 
         transform->addChild(effect);
 
-#if OSG_VERSION_GREATER_OR_EQUAL(3,3,3)
         osg::Node* toAttach = geometry.get();
-#else
-        osg::ref_ptr<osg::Geode> geode (new osg::Geode);
-        geode->addDrawable(geometry);
-        osg::Node* toAttach = geode.get();
-#endif
 
         effect->addChild(toAttach);
 

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -19,7 +19,6 @@
 #include <osg/Geometry>
 #include <osg/Geode>
 #include <osg/KdTree>
-#include <osg/Version>
 
 #include <osgFX/Effect>
 


### PR DESCRIPTION
Since commit e8662bea3133ba9dbb09b86c3abb1af39425e90d, we're using OSG functionality that contains an unfixed crash bug in version 3.2. The bug is fixed in version 3.4 (OSG commit 6351e5020371b0b72b300088a5c6772f58379b84)

The crash would happen with a certain type of DDS texture (uncompressed with builtin mipmaps). The vanilla Morrowind game does not include such textures, but openmw-template does and certain mods might contain these also.

See http://forum.openmw.org/viewtopic.php?f=2&t=3351&start=30#p37410

I suspect that http://forum.openmw.org/viewtopic.php?f=2&t=3365&p=37475#p37475 and https://bugs.openmw.org/issues/3204#change-14700 are also the same issue. 