### PR TITLE
Physics

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -270,7 +270,7 @@ namespace MWBase
             virtual MWWorld::Ptr moveObject (const MWWorld::Ptr& ptr, float x, float y, float z) = 0;
             ///< @return an updated Ptr in case the Ptr's cell changes
 
-            virtual MWWorld::Ptr moveObject(const MWWorld::Ptr &ptr, MWWorld::CellStore* newCell, float x, float y, float z) = 0;
+            virtual MWWorld::Ptr moveObject(const MWWorld::Ptr &ptr, MWWorld::CellStore* newCell, float x, float y, float z, bool movePhysics=true) = 0;
             ///< @return an updated Ptr
 
             virtual void scaleObject (const MWWorld::Ptr& ptr, float scale) = 0;

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -45,8 +45,7 @@ Actor::Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<const Resource::BulletShape> 
 
     updateRotation();
     updateScale();
-    // already called by updateScale()
-    //updatePosition();
+    updatePosition();
 
     updateCollisionMask();
 }
@@ -86,17 +85,42 @@ void Actor::updatePosition()
 {
     osg::Vec3f position = mPtr.getRefData().getPosition().asVec3();
 
+    mPosition = position;
+    mPreviousPosition = position;
+
+    updateCollisionObjectPosition();
+}
+
+void Actor::updateCollisionObjectPosition()
+{
     btTransform tr = mCollisionObject->getWorldTransform();
     osg::Vec3f scaledTranslation = mRotation * osg::componentMultiply(mMeshTranslation, mScale);
-    osg::Vec3f newPosition = scaledTranslation + position;
-
+    osg::Vec3f newPosition = scaledTranslation + mPosition;
     tr.setOrigin(toBullet(newPosition));
     mCollisionObject->setWorldTransform(tr);
 }
 
-osg::Vec3f Actor::getPosition() const
+osg::Vec3f Actor::getCollisionObjectPosition() const
 {
     return toOsg(mCollisionObject->getWorldTransform().getOrigin());
+}
+
+void Actor::setPosition(const osg::Vec3f &position)
+{
+    mPreviousPosition = mPosition;
+
+    mPosition = position;
+    updateCollisionObjectPosition();
+}
+
+osg::Vec3f Actor::getPosition() const
+{
+    return mPosition;
+}
+
+osg::Vec3f Actor::getPreviousPosition() const
+{
+    return mPreviousPosition;
 }
 
 void Actor::updateRotation ()
@@ -106,7 +130,7 @@ void Actor::updateRotation ()
     tr.setRotation(toBullet(mRotation));
     mCollisionObject->setWorldTransform(tr);
 
-    updatePosition();
+    updateCollisionObjectPosition();
 }
 
 void Actor::updateScale()
@@ -122,7 +146,7 @@ void Actor::updateScale()
     mPtr.getClass().adjustScale(mPtr, scaleVec, true);
     mRenderingScale = scaleVec;
 
-    updatePosition();
+    updateCollisionObjectPosition();
 }
 
 osg::Vec3f Actor::getHalfExtents() const

--- a/apps/openmw/mwphysics/actor.hpp
+++ b/apps/openmw/mwphysics/actor.hpp
@@ -68,7 +68,14 @@ namespace MWPhysics
 
         void updateScale();
         void updateRotation();
+
+        /**
+         * Set mPosition and mPreviousPosition to the position in the Ptr's RefData. This should be used
+         * when an object is "instantly" moved/teleported as opposed to being moved by the physics simulation.
+         */
         void updatePosition();
+
+        void updateCollisionObjectPosition();
 
         /**
          * Returns the half extents of the collision body (scaled according to collision scale)
@@ -79,7 +86,16 @@ namespace MWPhysics
          * Returns the position of the collision body
          * @note The collision shape's origin is in its center, so the position returned can be described as center of the actor collision box in world space.
          */
+        osg::Vec3f getCollisionObjectPosition() const;
+
+        /**
+          * Store the current position into mPreviousPosition, then move to this position.
+          */
+        void setPosition(const osg::Vec3f& position);
+
         osg::Vec3f getPosition() const;
+
+        osg::Vec3f getPreviousPosition() const;
 
         /**
          * Returns the half extents of the collision body (scaled according to rendering scale)
@@ -138,6 +154,7 @@ namespace MWPhysics
         osg::Vec3f mScale;
         osg::Vec3f mRenderingScale;
         osg::Vec3f mPosition;
+        osg::Vec3f mPreviousPosition;
 
         osg::Vec3f mForce;
         bool mOnGround;

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1295,7 +1295,11 @@ namespace MWPhysics
 
         mTimeAccum += dt;
         const float physicsDt = 1.f/60.0f;
+
+        const int maxAllowedSteps = 20;
         int numSteps = mTimeAccum / (physicsDt);
+        numSteps = std::min(numSteps, maxAllowedSteps);
+
         mTimeAccum -= numSteps * physicsDt;
 
         if (numSteps)

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -129,7 +129,7 @@ namespace MWPhysics
 
             /// Get the position of the collision shape for the actor. Use together with getHalfExtents() to get the collision bounds in world space.
             /// @note The collision shape's origin is in its center, so the position returned can be described as center of the actor collision box in world space.
-            osg::Vec3f getPosition(const MWWorld::ConstPtr& actor) const;
+            osg::Vec3f getCollisionObjectPosition(const MWWorld::ConstPtr& actor) const;
 
             /// Queues velocity movement for a Ptr. If a Ptr is already queued, its velocity will
             /// be overwritten. Valid until the next call to applyQueuedMovement.

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -117,7 +117,7 @@ namespace MWWorld
                                             const ESM::EffectList &effects, const Ptr &caster, const std::string &sourceName,
                                             const osg::Vec3f& fallbackDirection)
     {
-        osg::Vec3f pos = mPhysics->getPosition(caster) + osg::Vec3f(0,0,mPhysics->getHalfExtents(caster).z() * 0.5); // Spawn at 0.75 * ActorHeight
+        osg::Vec3f pos = mPhysics->getCollisionObjectPosition(caster) + osg::Vec3f(0,0,mPhysics->getHalfExtents(caster).z() * 0.5); // Spawn at 0.75 * ActorHeight
 
         if (MWBase::Environment::get().getWorld()->isUnderwater(caster.getCell(), pos)) // Underwater casting not possible
             return;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1113,7 +1113,7 @@ namespace MWWorld
         }
     }
 
-    MWWorld::Ptr World::moveObject(const Ptr &ptr, CellStore* newCell, float x, float y, float z)
+    MWWorld::Ptr World::moveObject(const Ptr &ptr, CellStore* newCell, float x, float y, float z, bool movePhysics)
     {
         ESM::Position pos = ptr.getRefData().getPosition();
 
@@ -1201,7 +1201,8 @@ namespace MWWorld
         if (haveToMove && newPtr.getRefData().getBaseNode())
         {
             mRendering->moveObject(newPtr, vec);
-            mPhysics->updatePosition(newPtr);
+            if (movePhysics)
+                mPhysics->updatePosition(newPtr);
         }
         if (isPlayer)
         {
@@ -1210,7 +1211,7 @@ namespace MWWorld
         return newPtr;
     }
 
-    MWWorld::Ptr World::moveObjectImp(const Ptr& ptr, float x, float y, float z)
+    MWWorld::Ptr World::moveObjectImp(const Ptr& ptr, float x, float y, float z, bool movePhysics)
     {
         CellStore *cell = ptr.getCell();
 
@@ -1221,7 +1222,7 @@ namespace MWWorld
             cell = getExterior(cellX, cellY);
         }
 
-        return moveObject(ptr, cell, x, y, z);
+        return moveObject(ptr, cell, x, y, z, movePhysics);
     }
 
     MWWorld::Ptr World::moveObject (const Ptr& ptr, float x, float y, float z)
@@ -1373,10 +1374,10 @@ namespace MWWorld
                 player = iter;
                 continue;
             }
-            moveObjectImp(iter->first, iter->second.x(), iter->second.y(), iter->second.z());
+            moveObjectImp(iter->first, iter->second.x(), iter->second.y(), iter->second.z(), false);
         }
         if(player != results.end())
-            moveObjectImp(player->first, player->second.x(), player->second.y(), player->second.z());
+            moveObjectImp(player->first, player->second.x(), player->second.y(), player->second.z(), false);
 
         mPhysics->debugDraw();
     }
@@ -3206,7 +3207,7 @@ namespace MWWorld
     osg::Vec3f World::aimToTarget(const ConstPtr &actor, const MWWorld::ConstPtr& target)
     {
         osg::Vec3f weaponPos = getActorHeadTransform(actor).getTrans();
-        osg::Vec3f targetPos = mPhysics->getPosition(target);
+        osg::Vec3f targetPos = mPhysics->getCollisionObjectPosition(target);
         return (targetPos - weaponPos);
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -119,7 +119,7 @@ namespace MWWorld
 
             void rotateObjectImp (const Ptr& ptr, const osg::Vec3f& rot, bool adjust);
 
-            Ptr moveObjectImp (const Ptr& ptr, float x, float y, float z);
+            Ptr moveObjectImp (const Ptr& ptr, float x, float y, float z, bool movePhysics=true);
             ///< @return an updated Ptr in case the Ptr's cell changes
 
             Ptr copyObjectToCell(const ConstPtr &ptr, CellStore* cell, ESM::Position pos, int count, bool adjustPos);
@@ -355,7 +355,7 @@ namespace MWWorld
             virtual MWWorld::Ptr moveObject (const Ptr& ptr, float x, float y, float z);
             ///< @return an updated Ptr in case the Ptr's cell changes
 
-            virtual MWWorld::Ptr moveObject (const Ptr& ptr, CellStore* newCell, float x, float y, float z);
+            virtual MWWorld::Ptr moveObject (const Ptr& ptr, CellStore* newCell, float x, float y, float z, bool movePhysics=true);
             ///< @return an updated Ptr
 
             virtual void scaleObject (const Ptr& ptr, float scale);


### PR DESCRIPTION
- Decouples physics framerate from the rendering framerate to always run at 60 fps. This makes the simulation behave more predictably and should reduce the risk of "phasing" through collision objects that could previously happen with low frame rates. See various reported bugs at https://bugs.openmw.org/issues/1587
- Perform interpolation in between physics frames. This reduces the 'shaking' effects that can occur due to the camera rotation updating at a different rate than the (physics controlled) camera position. ( https://bugs.openmw.org/issues/2737 )