### PR TITLE
Fix incorrect handling of baseDisposition >= 100 in testDisposition()

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -97,7 +97,7 @@ namespace MWBase
             virtual int getBarterOffer(const MWWorld::Ptr& ptr,int basePrice, bool buying) = 0;
             ///< This is used by every service to determine the price of objects given the trading skills of the player and NPC.
 
-            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr) = 0;
+            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr, bool bounded = true) = 0;
             ///< Calculate the diposition of an NPC toward the player.
 
             virtual int countDeaths (const std::string& id) const = 0;

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -97,7 +97,7 @@ namespace MWBase
             virtual int getBarterOffer(const MWWorld::Ptr& ptr,int basePrice, bool buying) = 0;
             ///< This is used by every service to determine the price of objects given the trading skills of the player and NPC.
 
-            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr) = 0;
+            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr, bool addTemporaryDispositionChange = false) = 0;
             ///< Calculate the diposition of an NPC toward the player.
 
             virtual int countDeaths (const std::string& id) const = 0;

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -97,7 +97,7 @@ namespace MWBase
             virtual int getBarterOffer(const MWWorld::Ptr& ptr,int basePrice, bool buying) = 0;
             ///< This is used by every service to determine the price of objects given the trading skills of the player and NPC.
 
-            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr, bool bounded = true) = 0;
+            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr) = 0;
             ///< Calculate the diposition of an NPC toward the player.
 
             virtual int countDeaths (const std::string& id) const = 0;

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -145,7 +145,7 @@ bool MWDialogue::Filter::testDisposition (const ESM::DialInfo& info, bool invert
     if (isCreature)
         return true;
 
-    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor)
+    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, false)
             + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange();
     // For service refusal, the disposition check is inverted. However, a value of 0 still means "always succeed".
     return invert ? (info.mData.mDisposition == 0 || actorDisposition < info.mData.mDisposition)

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -145,8 +145,7 @@ bool MWDialogue::Filter::testDisposition (const ESM::DialInfo& info, bool invert
     if (isCreature)
         return true;
 
-    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor)
-            + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange();
+    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, true);
     // For service refusal, the disposition check is inverted. However, a value of 0 still means "always succeed".
     return invert ? (info.mData.mDisposition == 0 || actorDisposition < info.mData.mDisposition)
                   : (actorDisposition >= info.mData.mDisposition);

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -145,7 +145,7 @@ bool MWDialogue::Filter::testDisposition (const ESM::DialInfo& info, bool invert
     if (isCreature)
         return true;
 
-    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, false)
+    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor)
             + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange();
     // For service refusal, the disposition check is inverted. However, a value of 0 still means "always succeed".
     return invert ? (info.mData.mDisposition == 0 || actorDisposition < info.mData.mDisposition)

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -640,8 +640,7 @@ namespace MWGui
         if(mMainWidget->getVisible() && mEnabled && mPtr.getTypeName() == typeid(ESM::NPC).name())
         {
             int disp = std::max(0, std::min(100,
-                MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr)
-                    + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange()));
+                MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr, true)));
             mDispositionBar->setProgressRange(100);
             mDispositionBar->setProgressPosition(disp);
             mDispositionText->setCaption(MyGUI::utility::toString(disp)+std::string("/100"));

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -346,8 +346,7 @@ namespace MWGui
             else
                 d = int(100 * (b - a) / a);
 
-            int clampedDisposition = std::max(0, std::min(MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr)
-                + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange(),100));
+            int clampedDisposition = std::max(0, std::min(MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr, true),100));
 
             const MWMechanics::CreatureStats &sellerStats = mPtr.getClass().getCreatureStats(mPtr);
             const MWMechanics::CreatureStats &playerStats = player.getClass().getCreatureStats(player);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -581,7 +581,7 @@ namespace MWMechanics
         mUpdatePlayer = true;
     }
 
-    int MechanicsManager::getDerivedDisposition(const MWWorld::Ptr& ptr)
+    int MechanicsManager::getDerivedDisposition(const MWWorld::Ptr& ptr, bool bounded /* = true */)
     {
         const MWMechanics::NpcStats& npcSkill = ptr.getClass().getNpcStats(ptr);
         float x = static_cast<float>(npcSkill.getBaseDisposition());
@@ -653,7 +653,7 @@ namespace MWMechanics
 
         x += ptr.getClass().getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::Charm).getMagnitude();
 
-        int effective_disposition = std::max(0,std::min(int(x),100));//, normally clamped to [0..100] when used
+        int effective_disposition = std::max(0,std::min(int(x), (bounded ? 100 : std::numeric_limits<int>::max()) )); // clamped to [0..100] unless !bounded
         return effective_disposition;
     }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -581,7 +581,7 @@ namespace MWMechanics
         mUpdatePlayer = true;
     }
 
-    int MechanicsManager::getDerivedDisposition(const MWWorld::Ptr& ptr, bool bounded /* = true */)
+    int MechanicsManager::getDerivedDisposition(const MWWorld::Ptr& ptr)
     {
         const MWMechanics::NpcStats& npcSkill = ptr.getClass().getNpcStats(ptr);
         float x = static_cast<float>(npcSkill.getBaseDisposition());
@@ -653,7 +653,7 @@ namespace MWMechanics
 
         x += ptr.getClass().getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::Charm).getMagnitude();
 
-        int effective_disposition = std::max(0,std::min(int(x), (bounded ? 100 : std::numeric_limits<int>::max()) )); // clamped to [0..100] unless !bounded
+        int effective_disposition = std::max(0,std::min(int(x),100));//, normally clamped to [0..100] when used
         return effective_disposition;
     }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -581,7 +581,7 @@ namespace MWMechanics
         mUpdatePlayer = true;
     }
 
-    int MechanicsManager::getDerivedDisposition(const MWWorld::Ptr& ptr)
+    int MechanicsManager::getDerivedDisposition(const MWWorld::Ptr& ptr, bool addTemporaryDispositionChange/* = false */)
     {
         const MWMechanics::NpcStats& npcSkill = ptr.getClass().getNpcStats(ptr);
         float x = static_cast<float>(npcSkill.getBaseDisposition());
@@ -653,6 +653,9 @@ namespace MWMechanics
 
         x += ptr.getClass().getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::Charm).getMagnitude();
 
+        if(addTemporaryDispositionChange)
+          x += MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange();
+
         int effective_disposition = std::max(0,std::min(int(x),100));//, normally clamped to [0..100] when used
         return effective_disposition;
     }
@@ -667,10 +670,9 @@ namespace MWMechanics
         MWWorld::Ptr playerPtr = getPlayer();
         const MWMechanics::NpcStats &playerStats = playerPtr.getClass().getNpcStats(playerPtr);
 
-        // I suppose the temporary disposition change _has_ to be considered here,
+        // I suppose the temporary disposition change (second param to getDerivedDisposition()) _has_ to be considered here,
         // otherwise one would get different prices when exiting and re-entering the dialogue window...
-        int clampedDisposition = std::max(0, std::min(getDerivedDisposition(ptr)
-            + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange(),100));
+        int clampedDisposition = std::max(0, std::min(getDerivedDisposition(ptr, true),100));
         float a = static_cast<float>(std::min(playerStats.getSkill(ESM::Skill::Mercantile).getModified(), 100));
         float b = std::min(0.1f * playerStats.getAttribute(ESM::Attribute::Luck).getModified(), 10.f);
         float c = std::min(0.2f * playerStats.getAttribute(ESM::Attribute::Personality).getModified(), 10.f);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -92,7 +92,7 @@ namespace MWMechanics
             virtual int getBarterOffer(const MWWorld::Ptr& ptr,int basePrice, bool buying);
             ///< This is used by every service to determine the price of objects given the trading skills of the player and NPC.
 
-            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr);
+            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr, bool addTemporaryDispositionChange = false);
             ///< Calculate the diposition of an NPC toward the player.
 
             virtual int countDeaths (const std::string& id) const;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -92,7 +92,7 @@ namespace MWMechanics
             virtual int getBarterOffer(const MWWorld::Ptr& ptr,int basePrice, bool buying);
             ///< This is used by every service to determine the price of objects given the trading skills of the player and NPC.
 
-            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr, bool bounded = true);
+            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr);
             ///< Calculate the diposition of an NPC toward the player.
 
             virtual int countDeaths (const std::string& id) const;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -92,7 +92,7 @@ namespace MWMechanics
             virtual int getBarterOffer(const MWWorld::Ptr& ptr,int basePrice, bool buying);
             ///< This is used by every service to determine the price of objects given the trading skills of the player and NPC.
 
-            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr);
+            virtual int getDerivedDisposition(const MWWorld::Ptr& ptr, bool bounded = true);
             ///< Calculate the diposition of an NPC toward the player.
 
             virtual int countDeaths (const std::string& id) const;


### PR DESCRIPTION
`MechanicsManager::getDerivedDisposition()` currently bounds its result to 0..100 (after applying faction modifications etc to the actor's `baseDisposition`).
`MWDialogue::Filter::testDisposition()`, which is used to filter candidate topics by disposition checks, uses this bounded value and applies the current `mTemporaryDispositionChange` of this dialogue (retrieved via `MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange()`) to it.

If `baseDisposition` is >= 100, `MechanicsManager::getDerivedDisposition()` will usually return 100. If there is a topic that tests for a disposition, e.g. 70, and `mTemporaryDispositionChange` is < -30 (through failed Persuasion, for instance), the test will always fail, no matter how high `baseDisposition` is. See http://bugs.openmw.org/issues/3233 for a reproducer that calls `ModDisposition 20` every time a certain topic is clicked, enabling the user to increase their `baseDisposition` indefinitely.

This PR adds an optional parameter `bounded` to `MechanicsManager::getDerivedDisposition()`, set to `true` by default. If it is set to `false` (which is only the case in `MWDialogue::Filter::testDisposition()` as of now), it no longer bounds its return value to 0..100, but 0..`std::numeric_limits<int>::max()`.

I tested it for about two hours during normal play with a little regression test that I hope is correct; no errors were reported.
> int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, false) + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange();
>
> // XXX Remove this - regression test
> int derivedDispositionOld = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, true);
> int actorDispositionOld = derivedDispositionOld + MWBase::Environment::get().getDialogueManager()->getTemporaryDispositionChange();
> if( (actorDisposition != actorDispositionOld) && (derivedDispositionOld != 100))
> {
>     std::cerr << "Possible REGRESSION: New disposition " << actorDisposition << " != " << actorDispositionOld << " (old) and derivedDispositionOld = " << derivedDispositionOld << std::endl;
> }
> // XXX End regression test