### PR TITLE
RefNum Assignment

### DIFF
--- a/apps/opencs/model/tools/mergestages.cpp
+++ b/apps/opencs/model/tools/mergestages.cpp
@@ -99,6 +99,7 @@ void CSMTools::MergeReferencesStage::perform (int stage, CSMDoc::Messages& messa
 
         ref.mRefNum.mIndex = mIndex[Misc::StringUtils::lowerCase (ref.mCell)]++;
         ref.mRefNum.mContentFile = 0;
+        ref.mNew = false;
 
         CSMWorld::Record<CSMWorld::CellRef> newRecord (
             CSMWorld::RecordBase::State_ModifiedOnly, 0, &ref);

--- a/apps/opencs/model/world/ref.cpp
+++ b/apps/opencs/model/world/ref.cpp
@@ -6,7 +6,7 @@
 
 #include "cellcoordinates.hpp"
 
-CSMWorld::CellRef::CellRef()
+CSMWorld::CellRef::CellRef() : mNew (true)
 {
     mRefNum.mIndex = 0;
     mRefNum.mContentFile = 0;

--- a/apps/opencs/model/world/ref.hpp
+++ b/apps/opencs/model/world/ref.hpp
@@ -13,6 +13,7 @@ namespace CSMWorld
         std::string mId;
         std::string mCell;
         std::string mOriginalCell;
+        bool mNew; // new reference, not counted yet, ref num not assigned yet
 
         CellRef();
 

--- a/apps/opencs/model/world/refcollection.cpp
+++ b/apps/opencs/model/world/refcollection.cpp
@@ -19,6 +19,7 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
     Cell& cell2 = base ? cell.mBase : cell.mModified;
 
     CellRef ref;
+    ref.mNew = false;
     ESM::MovedCellRef mref;
     bool isDeleted = false;
 

--- a/apps/opencs/view/render/instancemode.cpp
+++ b/apps/opencs/view/render/instancemode.cpp
@@ -421,24 +421,7 @@ void CSVRender::InstanceMode::dropEvent (QDropEvent* event)
                      CSMWorld::Columns::ColumnId_ReferenceableId),
                      QString::fromUtf8 (iter->getId().c_str()));
 
-                std::auto_ptr<CSMWorld::ModifyCommand> incrementCommand;
-
-                if (!noCell)
-                {
-                    // increase reference count in cell
-                    QModelIndex countIndex = cellTable.getModelIndex (cellId,
-                        cellTable.findColumnIndex (CSMWorld::Columns::ColumnId_RefNumCounter));
-
-                    int count = cellTable.data (countIndex).toInt();
-
-                    incrementCommand.reset (
-                        new CSMWorld::ModifyCommand (cellTable, countIndex, count+1));
-                }
-
-                CSMWorld::CommandMacro macro (document.getUndoStack());
-                macro.push (createCommand.release());
-                if (incrementCommand.get())
-                    macro.push (incrementCommand.release());
+                document.getUndoStack().push (createCommand.release());
 
                 dropped = true;
             }

--- a/apps/opencs/view/world/referencecreator.cpp
+++ b/apps/opencs/view/world/referencecreator.cpp
@@ -26,51 +26,6 @@ void CSVWorld::ReferenceCreator::configureCreateCommand (CSMWorld::CreateCommand
         findColumnIndex (CSMWorld::Columns::ColumnId_Cell);
 
     command.addValue (cellIdColumn, mCell->text());
-
-    // Set RefNum
-    int refNumColumn = dynamic_cast<CSMWorld::IdTable&> (
-        *getData().getTableModel (CSMWorld::UniversalId::Type_References)).
-        findColumnIndex (CSMWorld::Columns::ColumnId_RefNum);
-
-    command.addValue (refNumColumn, getRefNumCount());
-}
-
-void CSVWorld::ReferenceCreator::pushCommand (std::auto_ptr<CSMWorld::CreateCommand> command,
-    const std::string& id)
-{
-    // get the old count
-    std::string cellId = mCell->text().toUtf8().constData();
-
-    CSMWorld::IdTable& cellTable = dynamic_cast<CSMWorld::IdTable&> (
-        *getData().getTableModel (CSMWorld::UniversalId::Type_Cells));
-
-    int countColumn = cellTable.findColumnIndex (CSMWorld::Columns::ColumnId_RefNumCounter);
-
-    QModelIndex countIndex = cellTable.getModelIndex (cellId, countColumn);
-
-    int count = cellTable.data (countIndex).toInt();
-
-    // command for incrementing counter
-    std::auto_ptr<CSMWorld::ModifyCommand> increment (new CSMWorld::ModifyCommand
-        (cellTable, countIndex, count+1));
-
-    CSMWorld::CommandMacro macro (getUndoStack(), command->text());
-    GenericCreator::pushCommand (command, id);
-    macro.push (increment.release());
-}
-
-int CSVWorld::ReferenceCreator::getRefNumCount() const
-{
-    std::string cellId = mCell->text().toUtf8().constData();
-
-    CSMWorld::IdTable& cellTable = dynamic_cast<CSMWorld::IdTable&> (
-        *getData().getTableModel (CSMWorld::UniversalId::Type_Cells));
-
-    int countColumn = cellTable.findColumnIndex (CSMWorld::Columns::ColumnId_RefNumCounter);
-
-    QModelIndex countIndex = cellTable.getModelIndex (cellId, countColumn);
-
-    return cellTable.data (countIndex).toInt();
 }
 
 CSVWorld::ReferenceCreator::ReferenceCreator (CSMWorld::Data& data, QUndoStack& undoStack,

--- a/apps/opencs/view/world/referencecreator.hpp
+++ b/apps/opencs/view/world/referencecreator.hpp
@@ -29,11 +29,6 @@ namespace CSVWorld
 
             virtual void configureCreateCommand (CSMWorld::CreateCommand& command) const;
 
-            virtual void pushCommand (std::auto_ptr<CSMWorld::CreateCommand> command,
-                const std::string& id);
-
-            int getRefNumCount() const;
-
         public:
 
             ReferenceCreator (CSMWorld::Data& data, QUndoStack& undoStack,
@@ -50,7 +45,7 @@ namespace CSVWorld
 
             /// Focus main input widget
             virtual void focus();
- 
+
         private slots:
 
             void cellChanged();


### PR DESCRIPTION
This PR moved the assignment of RefNums from the instance creation code to the save code.

* Simplifies the code for creating new instances and avoids code duplication
* Avoids creating unneeded move sub records for newly created instances (when moving new instance from one cell to another within the same editing session in which the instance was created)

Possible downside: If an addon is used for playing between two editor saves, the ref nums may not stay consistent (e.g. if some of the new instances are deleted between saves). This can cause problems when saving a game in OpenMW when playing with the addon after the first editor save and then reloading the game with the addon after the 2nd editor save.
IMO this case is insignificant enough that we do not need to consider it, especially since fixing this would be non-trivial.

I think the ref num logic is correct, but considering how fiddly the whole instance business is, I would like a 2nd opinion before this goes into master and therefore into the imminent 0.39.0 release.