### PR TITLE
Fix editor tab order when adding record

### DIFF
--- a/apps/opencs/view/world/genericcreator.cpp
+++ b/apps/opencs/view/world/genericcreator.cpp
@@ -40,6 +40,10 @@ void CSVWorld::GenericCreator::insertAtBeginning (QWidget *widget, bool stretche
 void CSVWorld::GenericCreator::insertBeforeButtons (QWidget *widget, bool stretched)
 {
     mLayout->insertWidget (mLayout->count()-2, widget, stretched ? 1 : 0);
+
+    // Reset tab order relative to buttons.
+    setTabOrder(widget, mCreate);
+    setTabOrder(mCreate, mCancel);
 }
 
 std::string CSVWorld::GenericCreator::getId() const
@@ -161,12 +165,12 @@ CSVWorld::GenericCreator::GenericCreator (CSMWorld::Data& data, QUndoStack& undo
     mCreate = new QPushButton ("Create");
     mLayout->addWidget (mCreate);
 
-    QPushButton *cancelButton = new QPushButton ("Cancel");
-    mLayout->addWidget (cancelButton);
+    mCancel = new QPushButton("Cancel");
+    mLayout->addWidget(mCancel);
 
     setLayout (mLayout);
 
-    connect (cancelButton, SIGNAL (clicked (bool)), this, SIGNAL (done()));
+    connect (mCancel, SIGNAL (clicked (bool)), this, SIGNAL (done()));
     connect (mCreate, SIGNAL (clicked (bool)), this, SLOT (create()));
 
     connect (mId, SIGNAL (textChanged (const QString&)), this, SLOT (textChanged (const QString&)));

--- a/apps/opencs/view/world/genericcreator.hpp
+++ b/apps/opencs/view/world/genericcreator.hpp
@@ -33,6 +33,7 @@ namespace CSVWorld
             QUndoStack& mUndoStack;
             CSMWorld::UniversalId mListId;
             QPushButton *mCreate;
+            QPushButton *mCancel;
             QLineEdit *mId;
             std::string mErrors;
             QHBoxLayout *mLayout;
@@ -56,6 +57,9 @@ namespace CSVWorld
 
             void insertAtBeginning (QWidget *widget, bool stretched);
 
+            /// \brief Insert given widget before Create and Cancel buttons.
+            /// \param widget Widget to add to layout.
+            /// \param stretched Whether widget should be streched or not.
             void insertBeforeButtons (QWidget *widget, bool stretched);
 
             virtual std::string getId() const;


### PR DESCRIPTION
This improves the tab ordering when adding a record to certain tables (those using a creator subclass where the *mId* line edit isn't used). Previously the input's tab order would come after the *Create* and *Cancel* buttons. An example is adding a cell under *World* -> *Instances*.