### PR TITLE
Create record on Return key press (Feature #3250)

### DIFF
--- a/apps/opencs/view/world/genericcreator.cpp
+++ b/apps/opencs/view/world/genericcreator.cpp
@@ -170,6 +170,7 @@ CSVWorld::GenericCreator::GenericCreator (CSMWorld::Data& data, QUndoStack& undo
     connect (mCreate, SIGNAL (clicked (bool)), this, SLOT (create()));
 
     connect (mId, SIGNAL (textChanged (const QString&)), this, SLOT (textChanged (const QString&)));
+    connect (mId, SIGNAL (returnPressed()), this, SLOT (inputReturnPressed()));
 
     connect (&mData, SIGNAL (idListChanged()), this, SLOT (dataIdListChanged()));
 }
@@ -203,6 +204,14 @@ std::string CSVWorld::GenericCreator::getErrors() const
 void CSVWorld::GenericCreator::textChanged (const QString& text)
 {
     update();
+}
+
+void CSVWorld::GenericCreator::inputReturnPressed()
+{
+    if (mCreate->isEnabled())
+    {
+        create();
+    }
 }
 
 void CSVWorld::GenericCreator::create()

--- a/apps/opencs/view/world/genericcreator.hpp
+++ b/apps/opencs/view/world/genericcreator.hpp
@@ -112,6 +112,9 @@ namespace CSVWorld
 
             void textChanged (const QString& text);
 
+            /// \brief Create record if able to after Return key is pressed on input.
+            void inputReturnPressed();
+
             void create();
 
             void scopeChanged (int index);

--- a/apps/opencs/view/world/infocreator.cpp
+++ b/apps/opencs/view/world/infocreator.cpp
@@ -60,6 +60,7 @@ CSVWorld::InfoCreator::InfoCreator (CSMWorld::Data& data, QUndoStack& undoStack,
     setManualEditing (false);
 
     connect (mTopic, SIGNAL (textChanged (const QString&)), this, SLOT (topicChanged()));
+    connect (mTopic, SIGNAL (returnPressed()), this, SLOT (inputReturnPressed()));
 }
 
 void CSVWorld::InfoCreator::cloneMode (const std::string& originId,
@@ -110,7 +111,7 @@ void CSVWorld::InfoCreator::topicChanged()
     update();
 }
 
-CSVWorld::Creator *CSVWorld::InfoCreatorFactory::makeCreator(CSMDoc::Document& document, 
+CSVWorld::Creator *CSVWorld::InfoCreatorFactory::makeCreator(CSMDoc::Document& document,
                                                              const CSMWorld::UniversalId& id) const
 {
     return new InfoCreator(document.getData(),

--- a/apps/opencs/view/world/referencecreator.cpp
+++ b/apps/opencs/view/world/referencecreator.cpp
@@ -87,6 +87,7 @@ CSVWorld::ReferenceCreator::ReferenceCreator (CSMWorld::Data& data, QUndoStack& 
     setManualEditing (false);
 
     connect (mCell, SIGNAL (textChanged (const QString&)), this, SLOT (cellChanged()));
+    connect (mCell, SIGNAL (returnPressed()), this, SLOT (inputReturnPressed()));
 }
 
 void CSVWorld::ReferenceCreator::reset()

--- a/apps/opencs/view/world/startscriptcreator.cpp
+++ b/apps/opencs/view/world/startscriptcreator.cpp
@@ -53,6 +53,7 @@ CSVWorld::StartScriptCreator::StartScriptCreator(
     insertBeforeButtons(mScript, true);
 
     connect(mScript, SIGNAL (textChanged(const QString&)), this, SLOT (scriptChanged()));
+    connect(mScript, SIGNAL (returnPressed()), this, SLOT (inputReturnPressed()));
 }
 
 void CSVWorld::StartScriptCreator::cloneMode(


### PR DESCRIPTION
This allows a record to be created when the user presses the Return key while input has focus. The record is only created if the *Create* button is enabled.

Related issue on bug tracker: [OpenMW-CS: Use "Enter" key instead of clicking "Create" button to confirm ID input in Creator Bar](http://bugs.openmw.org/issues/3250)