### PR TITLE
Update script editor tab width (Bug #3286)

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -136,6 +136,9 @@ void CSMPrefs::State::declare()
     declareBool ("wrap-lines", "Wrap Lines", false).
         setTooltip ("Wrap lines longer than width of script editor.");
     declareBool ("mono-font", "Use monospace font", true);
+    declareInt ("tab-width", "Tab Width", 4).
+        setTooltip ("Number of characters for tab width").
+        setRange (1, 10);
     EnumValue warningsNormal ("Normal", "Report warnings as warning");
     declareEnum ("warnings", "Warning Mode", warningsNormal).
         addValue ("Ignore", "Do not report warning").

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -52,7 +52,7 @@ CSVWorld::ScriptEdit::ScriptEdit(
     mWhiteListQoutes("^[a-z|_]{1}[a-z|0-9|_]{0,}$", Qt::CaseInsensitive)
 {
     wrapLines(false);
-    setTabWidth();
+    setTabWidth(4);
     setUndoRedoEnabled (false); // we use OpenCS-wide undo/redo instead
 
     mAllowedTypes <<CSMWorld::UniversalId::Type_Journal
@@ -194,9 +194,8 @@ bool CSVWorld::ScriptEdit::stringNeedsQuote (const std::string& id) const
     return !(string.contains(mWhiteListQoutes));
 }
 
-void CSVWorld::ScriptEdit::setTabWidth()
+void CSVWorld::ScriptEdit::setTabWidth(const int numCharacters)
 {
-    const int numCharacters = 4;
     QFontMetrics metrics(mMonoFont);
     setTabStopWidth(numCharacters * metrics.width(' '));
 }
@@ -231,6 +230,10 @@ void CSVWorld::ScriptEdit::settingChanged(const CSMPrefs::Setting *setting)
     else if (*setting == "Scripts/wrap-lines")
     {
         wrapLines(setting->isTrue());
+    }
+    else if (*setting == "Scripts/tab-width")
+    {
+        setTabWidth(setting->toInt());
     }
 }
 

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -52,7 +52,7 @@ CSVWorld::ScriptEdit::ScriptEdit(
     mWhiteListQoutes("^[a-z|_]{1}[a-z|0-9|_]{0,}$", Qt::CaseInsensitive)
 {
     wrapLines(false);
-    setTabStopWidth (4);
+    setTabWidth();
     setUndoRedoEnabled (false); // we use OpenCS-wide undo/redo instead
 
     mAllowedTypes <<CSMWorld::UniversalId::Type_Journal
@@ -192,6 +192,13 @@ bool CSVWorld::ScriptEdit::stringNeedsQuote (const std::string& id) const
     const QString string(QString::fromUtf8(id.c_str())); //<regex> is only for c++11, so let's use qregexp for now.
     //I'm not quite sure when do we need to put quotes. To be safe we will use quotes for anything other than…
     return !(string.contains(mWhiteListQoutes));
+}
+
+void CSVWorld::ScriptEdit::setTabWidth()
+{
+    const int numCharacters = 4;
+    QFontMetrics metrics(mMonoFont);
+    setTabStopWidth(numCharacters * metrics.width(' '));
 }
 
 void CSVWorld::ScriptEdit::wrapLines(bool wrap)

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -48,11 +48,12 @@ CSVWorld::ScriptEdit::ScriptEdit(
     mLineNumberArea(0),
     mDefaultFont(font()),
     mMonoFont(QFont("Monospace")),
+    mTabCharCount(4),
     mDocument(document),
     mWhiteListQoutes("^[a-z|_]{1}[a-z|0-9|_]{0,}$", Qt::CaseInsensitive)
 {
     wrapLines(false);
-    setTabWidth(4);
+    setTabWidth();
     setUndoRedoEnabled (false); // we use OpenCS-wide undo/redo instead
 
     mAllowedTypes <<CSMWorld::UniversalId::Type_Journal
@@ -194,10 +195,10 @@ bool CSVWorld::ScriptEdit::stringNeedsQuote (const std::string& id) const
     return !(string.contains(mWhiteListQoutes));
 }
 
-void CSVWorld::ScriptEdit::setTabWidth(const int numCharacters)
+void CSVWorld::ScriptEdit::setTabWidth()
 {
-    QFontMetrics metrics(mMonoFont);
-    setTabStopWidth(numCharacters * metrics.width(' '));
+    // Set tab width to specified number of characters using current font.
+    setTabStopWidth(mTabCharCount * fontMetrics().width(' '));
 }
 
 void CSVWorld::ScriptEdit::wrapLines(bool wrap)
@@ -222,6 +223,7 @@ void CSVWorld::ScriptEdit::settingChanged(const CSMPrefs::Setting *setting)
     else if (*setting == "Scripts/mono-font")
     {
         setFont(setting->isTrue() ? mMonoFont : mDefaultFont);
+        setTabWidth();
     }
     else if (*setting == "Scripts/show-linenum")
     {
@@ -233,7 +235,8 @@ void CSVWorld::ScriptEdit::settingChanged(const CSMPrefs::Setting *setting)
     }
     else if (*setting == "Scripts/tab-width")
     {
-        setTabWidth(setting->toInt());
+        mTabCharCount = setting->toInt();
+        setTabWidth();
     }
 }
 

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -121,14 +121,6 @@ void CSVWorld::ScriptEdit::showLineNum(bool show)
     }
 }
 
-void CSVWorld::ScriptEdit::setMonoFont(bool show)
-{
-    if(show)
-        setFont(mMonoFont);
-    else
-        setFont(mDefaultFont);
-}
-
 bool CSVWorld::ScriptEdit::isChangeLocked() const
 {
     return mChangeLocked!=0;

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -72,7 +72,6 @@ namespace CSVWorld
             void lineNumberAreaPaintEvent(QPaintEvent *event);
             int lineNumberAreaWidth();
             void showLineNum(bool show);
-            void setMonoFont(bool show);
 
         protected:
 

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -53,6 +53,7 @@ namespace CSVWorld
             LineNumberArea *mLineNumberArea;
             QFont mDefaultFont;
             QFont mMonoFont;
+            int mTabCharCount;
 
         protected:
 
@@ -92,8 +93,7 @@ namespace CSVWorld
             bool stringNeedsQuote(const std::string& id) const;
 
             /// \brief Set tab width for script editor.
-            /// \param numCharacters Number of characters for tab width.
-            void setTabWidth(const int numCharacters);
+            void setTabWidth();
 
             /// \brief Turn line wrapping in script editor on or off.
             /// \param wrap Whether or not to wrap lines.

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -91,6 +91,9 @@ namespace CSVWorld
 
             bool stringNeedsQuote(const std::string& id) const;
 
+            /// \brief Set tab width for script editor.
+            void setTabWidth();
+
             /// \brief Turn line wrapping in script editor on or off.
             /// \param wrap Whether or not to wrap lines.
             void wrapLines(bool wrap);

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -92,7 +92,8 @@ namespace CSVWorld
             bool stringNeedsQuote(const std::string& id) const;
 
             /// \brief Set tab width for script editor.
-            void setTabWidth();
+            /// \param numCharacters Number of characters for tab width.
+            void setTabWidth(const int numCharacters);
 
             /// \brief Turn line wrapping in script editor on or off.
             /// \param wrap Whether or not to wrap lines.


### PR DESCRIPTION
This change sets the tab width for the script editor to four spaces based on the monospace font. I attempted to change the tab width whenever the monospace font user setting changed but subsequent calls to `setTabStopWidth()` seemed to have no effect. I'll be away for the next week or so but can play with it more when I'm back if we want this to update with the setting.

Issue on bug tracker: [OpenMW-CS Script editor tab width](http://bugs.openmw.org/issues/3286)