### PR TITLE
Adjust trade window to allow 0 gold bartering

### DIFF
--- a/apps/openmw/mwgui/tradewindow.hpp
+++ b/apps/openmw/mwgui/tradewindow.hpp
@@ -65,8 +65,10 @@ namespace MWGui
 
             int mItemToSell;
 
-            int mCurrentBalance;
-            int mCurrentMerchantOffer;
+            bool mIsPlayerSelling;
+            bool mIsMerchantBuying;
+            int mPlayerOffer;
+            int mMerchantOffer;
 
             void sellToNpc(const MWWorld::Ptr& item, int count, bool boughtItem); ///< only used for adjusting the gold balance
             void buyFromNpc(const MWWorld::Ptr& item, int count, bool soldItem); ///< only used for adjusting the gold balance


### PR DESCRIPTION
These edits to the TradeWindow class should allow the player to decrease "Total Cost/Sold" to 0. Basically, each offer is now represented by a magnitude and a boolean indicating buy or sell.

Also, whenever an item is transferred, the player's offer is now reset to the merchant's offer instead of offset, which is consistent with the original game.

This change is minor and probably not critical to the current roadmap, but for that reason I figure it's also a good way for me to test the waters and get into the right workflow with you guys.

I tested these changes in game and encountered no problems.