### PR TITLE
Allow +/- buttons in trade window to decrease offer to 0

### DIFF
--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -476,15 +476,15 @@ namespace MWGui
         // prevent overflows, and prevent entering INT_MIN since abs(INT_MIN) is undefined
         if (mCurrentBalance == INT_MAX || mCurrentBalance == INT_MIN+1)
             return;
-        if(mCurrentBalance<=-1) mCurrentBalance -= 1;
-        if(mCurrentBalance>=1) mCurrentBalance += 1;
+        if (mCurrentBalance < 0) mCurrentBalance -= 1;
+        else mCurrentBalance += 1;
         updateLabels();
     }
 
     void TradeWindow::onDecreaseButtonTriggered()
     {
-        if(mCurrentBalance<-1) mCurrentBalance += 1;
-        if(mCurrentBalance>1) mCurrentBalance -= 1;
+        if (mCurrentBalance < 0) mCurrentBalance += 1;
+        else mCurrentBalance -= 1;
         updateLabels();
     }
 
@@ -495,13 +495,13 @@ namespace MWGui
 
         mPlayerGold->setCaptionWithReplacing("#{sYourGold} " + MyGUI::utility::toString(playerGold));
 
-        if (mCurrentBalance > 0)
+        if (mCurrentBalance < 0)
         {
-            mTotalBalanceLabel->setCaptionWithReplacing("#{sTotalSold}");
+            mTotalBalanceLabel->setCaptionWithReplacing("#{sTotalCost}");
         }
         else
         {
-            mTotalBalanceLabel->setCaptionWithReplacing("#{sTotalCost}");
+            mTotalBalanceLabel->setCaptionWithReplacing("#{sTotalSold}");
         }
 
         mTotalBalance->setValue(std::abs(mCurrentBalance));


### PR DESCRIPTION
These changes allow the increase/decrease buttons to go to 0, which is more consistent with the original game's behavior.

And @scrawl you can put my nickname and full name in AUTHORS.md. ;)