### PR TITLE
Editor: Prevent duplicate pathgrids (Bug #3342)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -102,9 +102,9 @@ Programmers
     Pieter van der Kloet (pvdk)
     pkubik
     Radu-Marius Popovici (rpopovici)
-    rcutmore
     rdimesio
     riothamus
+    Rob Cutmore (rcutmore)
     Robert MacGregor (Ragora)
     Rohit Nirmal
     Roman Melnik (Kromgart)

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -67,7 +67,7 @@ opencs_hdrs_noqt (view/doc
 
 opencs_units (view/world
     table tablesubview scriptsubview util regionmapsubview tablebottombox creator genericcreator
-    cellcreator referenceablecreator startscriptcreator referencecreator scenesubview
+    cellcreator pathgridcreator referenceablecreator startscriptcreator referencecreator scenesubview
     infocreator scriptedit dialoguesubview previewsubview regionmap dragrecordtable nestedtable
     dialoguespinbox recordbuttonbar tableeditidaction scripterrortable extendedcommandconfigurator
     )

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -1139,7 +1139,8 @@ bool CSMWorld::Data::hasId (const std::string& id) const
         getBodyParts().searchId (id)!=-1 ||
         getSoundGens().searchId (id)!=-1 ||
         getMagicEffects().searchId (id)!=-1 ||
-        getReferenceables().searchId (id)!=-1;
+        getReferenceables().searchId (id)!=-1 ||
+        getPathgrids().searchId (id)!=-1;
 }
 
 int CSMWorld::Data::count (RecordBase::State state) const

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -1139,8 +1139,7 @@ bool CSMWorld::Data::hasId (const std::string& id) const
         getBodyParts().searchId (id)!=-1 ||
         getSoundGens().searchId (id)!=-1 ||
         getMagicEffects().searchId (id)!=-1 ||
-        getReferenceables().searchId (id)!=-1 ||
-        getPathgrids().searchId (id)!=-1;
+        getReferenceables().searchId (id)!=-1;
 }
 
 int CSMWorld::Data::count (RecordBase::State state) const

--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -1,0 +1,29 @@
+#include "pathgridcreator.hpp"
+
+#include "../../model/world/data.hpp"
+
+CSVWorld::PathgridCreator::PathgridCreator(
+    CSMWorld::Data& data,
+    QUndoStack& undoStack,
+    const CSMWorld::UniversalId& id,
+    bool relaxedIdRules
+) : GenericCreator(data, undoStack, id, relaxedIdRules)
+{}
+
+std::string CSVWorld::PathgridCreator::getErrors() const
+{
+    std::string pathgridId = getId();
+
+    // Check user input for any errors.
+    std::string errors;
+    if (pathgridId.empty())
+    {
+        errors = "No Pathgrid ID entered";
+    }
+    else if (getData().getPathgrids().searchId(pathgridId) > -1)
+    {
+        errors = "Pathgrid with this ID already exists";
+    }
+
+    return errors;
+}

--- a/apps/opencs/view/world/pathgridcreator.hpp
+++ b/apps/opencs/view/world/pathgridcreator.hpp
@@ -1,0 +1,26 @@
+#ifndef PATHGRIDCREATOR_HPP
+#define PATHGRIDCREATOR_HPP
+
+#include "genericcreator.hpp"
+
+namespace CSVWorld
+{
+    /// \brief Record creator for pathgrids.
+    class PathgridCreator : public GenericCreator
+    {
+        Q_OBJECT
+
+        public:
+
+            PathgridCreator(
+                CSMWorld::Data& data,
+                QUndoStack& undoStack,
+                const CSMWorld::UniversalId& id,
+                bool relaxedIdRules = false);
+
+            /// \return Error description for current user input.
+            virtual std::string getErrors() const;
+    };
+}
+
+#endif // PATHGRIDCREATOR_HPP

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -14,6 +14,7 @@
 #include "scenesubview.hpp"
 #include "dialoguecreator.hpp"
 #include "infocreator.hpp"
+#include "pathgridcreator.hpp"
 #include "previewsubview.hpp"
 
 void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
@@ -42,7 +43,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         CSMWorld::UniversalId::Type_Enchantments,
         CSMWorld::UniversalId::Type_BodyParts,
         CSMWorld::UniversalId::Type_SoundGens,
-        CSMWorld::UniversalId::Type_Pathgrids,
 
         CSMWorld::UniversalId::Type_None // end marker
     };
@@ -74,6 +74,9 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
 
     manager.add (CSMWorld::UniversalId::Type_JournalInfos,
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, InfoCreatorFactory>);
+
+    manager.add (CSMWorld::UniversalId::Type_Pathgrids,
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<PathgridCreator> >);
 
     // Subviews for resources tables
     manager.add (CSMWorld::UniversalId::Type_Meshes,
@@ -125,7 +128,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         CSMWorld::UniversalId::Type_Enchantment,
         CSMWorld::UniversalId::Type_BodyPart,
         CSMWorld::UniversalId::Type_SoundGen,
-        CSMWorld::UniversalId::Type_Pathgrid,
 
         CSMWorld::UniversalId::Type_None // end marker
     };
@@ -167,6 +169,9 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
 
     manager.add (CSMWorld::UniversalId::Type_Journal,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, JournalCreatorFactory> (false));
+
+    manager.add (CSMWorld::UniversalId::Type_Pathgrid,
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<PathgridCreator> > (false));
 
     manager.add (CSMWorld::UniversalId::Type_DebugProfile,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<GenericCreator, CSMWorld::Scope_Project | CSMWorld::Scope_Session> > (false));


### PR DESCRIPTION
This updates *CSMWorld::Data::hasId* to include pathgrids, preventing duplicates from being entered with the editor. Related issue on bug tracker: [Editor: You can create pathgrids with the same ID](http://bugs.openmw.org/issues/3342).

Unrelated to this bug, I noticed pathgrids aren't being included in [CSMWorld::Data::getIds](https://github.com/OpenMW/openmw/blob/24ae9f4ac1cdcd74e702ec8f09ccc45a8542b484/apps/opencs/model/world/data.cpp#L1162). Maybe that method should be updated as well? I haven't had a chance to look into it much yet but it's used in [CSMWorld::ScriptContext::isId](https://github.com/OpenMW/openmw/blob/24ae9f4ac1cdcd74e702ec8f09ccc45a8542b484/apps/opencs/model/world/scriptcontext.cpp#L94) and [CSMWorld::RefIdCollection::getIds](https://github.com/OpenMW/openmw/blob/24ae9f4ac1cdcd74e702ec8f09ccc45a8542b484/apps/opencs/model/world/refidcollection.cpp#L850)