### PR TITLE
Editor: Fix issue adding start script (Bug #3331)

### DIFF
--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -159,7 +159,11 @@ void CSMWorld::IdTable::addRecordWithData (const std::string& id,
     mIdCollection->appendBlankRecord (id, type);
 
     for (std::map<int, QVariant>::const_iterator iter (data.begin()); iter!=data.end(); ++iter)
-        mIdCollection->setData (index, iter->first, iter->second);
+    {
+        int columnIndex = getModelIndex(id, iter->first).column();
+        if (mIdCollection->getColumn(columnIndex).isEditable())
+            mIdCollection->setData(index, iter->first, iter->second);
+    }
 
     endInsertRows();
 }

--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -160,9 +160,7 @@ void CSMWorld::IdTable::addRecordWithData (const std::string& id,
 
     for (std::map<int, QVariant>::const_iterator iter (data.begin()); iter!=data.end(); ++iter)
     {
-        int columnIndex = getModelIndex(id, iter->first).column();
-        if (mIdCollection->getColumn(columnIndex).isEditable())
-            mIdCollection->setData(index, iter->first, iter->second);
+        mIdCollection->setData(index, iter->first, iter->second);
     }
 
     endInsertRows();

--- a/apps/opencs/view/world/startscriptcreator.cpp
+++ b/apps/opencs/view/world/startscriptcreator.cpp
@@ -24,15 +24,6 @@ CSMWorld::IdTable& CSVWorld::StartScriptCreator::getStartScriptsTable() const
     );
 }
 
-void CSVWorld::StartScriptCreator::configureCreateCommand(CSMWorld::CreateCommand& command) const
-{
-    CSMWorld::IdTable& table = getStartScriptsTable();
-    int column = table.findColumnIndex(CSMWorld::Columns::ColumnId_Id);
-
-    // Set script ID to be added to start scripts table.
-    command.addValue(column, mScript->text());
-}
-
 CSVWorld::StartScriptCreator::StartScriptCreator(
     CSMWorld::Data &data,
     QUndoStack &undoStack,

--- a/apps/opencs/view/world/startscriptcreator.hpp
+++ b/apps/opencs/view/world/startscriptcreator.hpp
@@ -31,10 +31,6 @@ namespace CSVWorld
             /// \return reference to table containing start scripts.
             CSMWorld::IdTable& getStartScriptsTable() const;
 
-            /// \brief Add user input to command for creating start script.
-            /// \param command Creation command to configure.
-            virtual void configureCreateCommand(CSMWorld::CreateCommand& command) const;
-
         public:
 
             StartScriptCreator(


### PR DESCRIPTION
This fixes the issue adding start scripts mentioned here: [OpenMW-CS, Start Scripts table: Adding a script doesn't refresh the list of Start Scripts and allows to add a single script multiple times](http://bugs.openmw.org/issues/3331).

Previously records were added in two steps by adding a blank record and then setting the data in a later step. During that process there was a check to see if the column was editable before setting the data. This just adds the column check to the current process.