### PR TITLE
Valgrind checks

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -107,6 +107,7 @@ namespace MWMechanics
         mActionCooldown(0),
         mStrength(),
         mForceNoShortcut(false),
+        mShortcutFailPos(),
         mLastActorPos(0,0,0),
         mMovement(){}    
 

--- a/components/esm/esmwriter.cpp
+++ b/components/esm/esmwriter.cpp
@@ -9,10 +9,13 @@
 namespace ESM
 {
     ESMWriter::ESMWriter()
-        : mStream(NULL)
-        , mEncoder (0)
-        , mRecordCount (0)
-        , mCounting (true)
+        : mRecords()
+        , mStream(NULL)
+        , mHeaderPos()
+        , mEncoder(NULL)
+        , mRecordCount(0)
+        , mCounting(true)
+        , mHeader()
     {}
 
     unsigned int ESMWriter::getVersion() const


### PR DESCRIPTION
Fix uninitialized values in:
* ESMWriter::save
* MWMechanics::AiCombat

How to reproduce:
```
$ valgrind ./openmw_test_suite  --gtest_filter="StoreTest.*"

==1459== Conditional jump or move depends on uninitialised value(s)
==1459==    at 0x4C2E08E: strnlen (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1459==    by 0x75EC75: ESM::NAME_T<32>::toString() const (in ./openmw_test_suite)
==1459==    by 0x76B3D0: ESM::Header::save(ESM::ESMWriter&) (loadtes3.cpp:76)
==1459==    by 0x734A17: ESM::ESMWriter::save(std::ostream&) (esmwriter.cpp:75)
==1459==    by 0x6F2EC1: boost::shared_ptr<std::istream> getEsmFile<ESM::Apparatus>(ESM::Apparatus, bool) (test_store.cpp:228)
==1459==    by 0x6E89A6: StoreTest_delete_test_Test::TestBody() (test_store.cpp:253)
==1459==    by 0x7275DB: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2090)
==1459==    by 0x7227AB: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2126)
==1459==    by 0x70FB1C: testing::Test::Run() (gtest.cc:2162)
==1459==    by 0x710297: testing::TestInfo::Run() (gtest.cc:2338)
==1459==    by 0x710857: testing::TestCase::Run() (gtest.cc:2445)
==1459==    by 0x7154B1: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4243)
```
```
$ valgrind ./openmw --skip-menu=1

# do nothing

==29349== Conditional jump or move depends on uninitialised value(s)
==29349==    at 0x10C2DA1: MWMechanics::AiCombat::reactionTimeActions(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::AiCombatStorage&, MWWorld::Ptr) (aicombat.cpp:452)
==29349==    by 0x10C1B98: MWMechanics::AiCombat::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) (aicombat.cpp:215)
==29349==    by 0x10AF08A: MWMechanics::AiSequence::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) (aisequence.cpp:232)
==29349==    by 0x10FC7FB: MWMechanics::Actors::update(float, bool) (actors.cpp:1039)
==29349==    by 0x1083EB9: MWMechanics::MechanicsManager::update(float, bool) (mechanicsmanagerimp.cpp:498)
==29349==    by 0x1122225: OMW::Engine::frame(float) (engine.cpp:141)
==29349==    by 0x1127774: OMW::Engine::go() (engine.cpp:687)
==29349==    by 0x11111B4: main (main.cpp:363)
```

```
$ valgrind ./openmw --skip-menu=1

# save game

==14441== Conditional jump or move depends on uninitialised value(s)
==14441==    at 0x11F99D6: ESM::NPC::save(ESM::ESMWriter&, bool) const (loadnpc.cpp:146)
==14441==    by 0xF9C1EA: MWWorld::Store<ESM::NPC>::write(ESM::ESMWriter&, Loading::Listener&) const (store.cpp:323)
==14441==    by 0x1024ACF: MWWorld::ESMStore::write(ESM::ESMWriter&, Loading::Listener&) const (esmstore.cpp:178)
==14441==    by 0xEC7A55: MWWorld::World::write(ESM::ESMWriter&, Loading::Listener&) const (worldimp.cpp:357)
==14441==    by 0x11051A6: MWState::StateManager::saveGame(std::string const&, MWState::Slot const*) (statemanagerimp.cpp:267)
==14441==    by 0xE1011B: MWGui::SaveGameDialog::accept(bool) (savegamedialog.cpp:260)
==14441==    by 0xE102FE: MWGui::SaveGameDialog::onOkButtonClicked(MyGUI::Widget*) (savegamedialog.cpp:277)
==14441==    by 0xE12A1E: MyGUI::delegates::CMethodDelegate1<MWGui::SaveGameDialog, MyGUI::Widget*>::invoke(MyGUI::Widget*) (MyGUI_DelegateImplement.h:89)
==14441==    by 0x8F0AC1B: MyGUI::WidgetInput::_riseMouseButtonClick() (in /usr/lib/libMyGUIEngine.so.3.2.1)
==14441==    by 0x8E2C4FB: MyGUI::InputManager::injectMouseRelease(int, int, MyGUI::MouseButton) (in /usr/lib/libMyGUIEngine.so.3.2.1)
==14441==    by 0xCAA3E1: MWInput::InputManager::mouseReleased(SDL_MouseButtonEvent const&, unsigned char) (inputmanagerimp.cpp:735)
==14441==    by 0x129CEEA: SDLUtil::InputWrapper::capture(bool) (sdlinputwrapper.cpp:86)
```