### PR TITLE
Rewrite ESM::NAME_T

### DIFF
--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -357,10 +357,10 @@ int load(Arguments& info)
             EsmTool::RecordBase *record = EsmTool::RecordBase::create(n);
             if (record == 0)
             {
-                if (std::find(skipped.begin(), skipped.end(), n.val) == skipped.end())
+                if (std::find(skipped.begin(), skipped.end(), n.intval) == skipped.end())
                 {
                     std::cout << "Skipping " << n.toString() << " records." << std::endl;
-                    skipped.push_back(n.val);
+                    skipped.push_back(n.intval);
                 }
 
                 esm.skipRecord();
@@ -392,7 +392,7 @@ int load(Arguments& info)
                 record->print();
             }
 
-            if (record->getType().val == ESM::REC_CELL && loadCells && interested)
+            if (record->getType().intval == ESM::REC_CELL && loadCells && interested)
             {
                 loadCell(record->cast<ESM::Cell>()->get(), esm, info);
             }
@@ -405,7 +405,7 @@ int load(Arguments& info)
             {
                 delete record;
             }
-            ++info.data.mRecordStats[n.val];
+            ++info.data.mRecordStats[n.intval];
         }
 
     } catch(std::exception &e) {
@@ -448,14 +448,13 @@ int clone(Arguments& info)
 
     std::cout << "Loaded " << recordCount << " records:" << std::endl << std::endl;
 
-    ESM::NAME name;
-
     int i = 0;
     typedef std::map<int, int> Stats;
     Stats &stats = info.data.mRecordStats;
     for (Stats::iterator it = stats.begin(); it != stats.end(); ++it)
     {
-        name.val = it->first;
+        ESM::NAME name;
+        name.intval = it->first;
         int amount = it->second;
         std::cout << std::setw(digitCount) << amount << " " << name.toString() << "  ";
 
@@ -488,12 +487,12 @@ int clone(Arguments& info)
     for (Records::iterator it = records.begin(); it != records.end() && i > 0; ++it)
     {
         EsmTool::RecordBase *record = *it;
-        name.val = record->getType().val;
+        const ESM::NAME& typeName = record->getType();
 
-        esm.startRecord(name.toString(), record->getFlags());
+        esm.startRecord(typeName.toString(), record->getFlags());
 
         record->save(esm);
-        if (name.val == ESM::REC_CELL) {
+        if (typeName.intval == ESM::REC_CELL) {
             ESM::Cell *ptr = &record->cast<ESM::Cell>()->get();
             if (!info.data.mCellRefs[ptr].empty()) {
                 typedef std::deque<std::pair<ESM::CellRef, bool> > RefList;
@@ -505,7 +504,7 @@ int clone(Arguments& info)
             }
         }
 
-        esm.endRecord(name.toString());
+        esm.endRecord(typeName.toString());
 
         saved++;
         int perc = (int)((saved / (float)recordCount)*100);

--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -179,7 +179,7 @@ RecordBase::create(ESM::NAME type)
 {
     RecordBase *record = 0;
 
-    switch (type.val) {
+    switch (type.intval) {
     case ESM::REC_ACTI:
     {
         record = new EsmTool::Record<ESM::Activator>;

--- a/apps/essimporter/importer.cpp
+++ b/apps/essimporter/importer.cpp
@@ -322,14 +322,14 @@ namespace ESSImport
             ESM::NAME n = esm.getRecName();
             esm.getRecHeader();
 
-            std::map<unsigned int, boost::shared_ptr<Converter> >::iterator it = converters.find(n.val);
+            std::map<unsigned int, boost::shared_ptr<Converter> >::iterator it = converters.find(n.intval);
             if (it != converters.end())
             {
                 it->second->read(esm);
             }
             else
             {
-                if (unknownRecords.insert(n.val).second)
+                if (unknownRecords.insert(n.intval).second)
                 {
                     std::ios::fmtflags f(std::cerr.flags());
                     std::cerr << "unknown record " << n.toString() << " (0x" << std::hex << esm.getFileOffset() << ")" << std::endl;

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -942,7 +942,7 @@ bool CSMWorld::Data::continueLoading (CSMDoc::Messages& messages)
 
     bool unhandledRecord = false;
 
-    switch (n.val)
+    switch (n.intval)
     {
         case ESM::REC_GLOB: mGlobals.load (*mReader, mBase); break;
         case ESM::REC_GMST: mGmsts.load (*mReader, mBase); break;

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -1187,7 +1187,7 @@ namespace CSMWorld
 
             std::vector<ESM::ContItem>& list = container.mInventory.mList;
 
-            ESM::ContItem newRow = {0, {""}};
+            ESM::ContItem newRow = ESM::ContItem();
 
             if (position >= (int)list.size())
                 list.push_back(newRow);

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -385,7 +385,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
             ESM::NAME n = reader.getRecName();
             reader.getRecHeader();
 
-            switch (n.val)
+            switch (n.intval)
             {
                 case ESM::REC_SAVE:
                     {
@@ -405,12 +405,12 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
                 case ESM::REC_JOUR_LEGACY:
                 case ESM::REC_QUES:
 
-                    MWBase::Environment::get().getJournal()->readRecord (reader, n.val);
+                    MWBase::Environment::get().getJournal()->readRecord (reader, n.intval);
                     break;
 
                 case ESM::REC_DIAS:
 
-                    MWBase::Environment::get().getDialogueManager()->readRecord (reader, n.val);
+                    MWBase::Environment::get().getDialogueManager()->readRecord (reader, n.intval);
                     break;
 
                 case ESM::REC_ALCH:
@@ -433,7 +433,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
                 case ESM::REC_ENAB:
                 case ESM::REC_LEVC:
                 case ESM::REC_LEVI:
-                    MWBase::Environment::get().getWorld()->readRecord(reader, n.val, contentFileMap);
+                    MWBase::Environment::get().getWorld()->readRecord(reader, n.intval, contentFileMap);
                     break;
 
                 case ESM::REC_CAM_:
@@ -442,7 +442,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
 
                 case ESM::REC_GSCR:
 
-                    MWBase::Environment::get().getScriptManager()->getGlobalScripts().readRecord (reader, n.val);
+                    MWBase::Environment::get().getScriptManager()->getGlobalScripts().readRecord (reader, n.intval);
                     break;
 
                 case ESM::REC_GMAP:
@@ -450,13 +450,13 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
                 case ESM::REC_ASPL:
                 case ESM::REC_MARK:
 
-                    MWBase::Environment::get().getWindowManager()->readRecord(reader, n.val);
+                    MWBase::Environment::get().getWindowManager()->readRecord(reader, n.intval);
                     break;
 
                 case ESM::REC_DCOU:
                 case ESM::REC_STLN:
 
-                    MWBase::Environment::get().getMechanicsManager()->readRecord(reader, n.val);
+                    MWBase::Environment::get().getMechanicsManager()->readRecord(reader, n.intval);
                     break;
 
                 default:

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -74,10 +74,10 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
         esm.getRecHeader();
 
         // Look up the record type.
-        std::map<int, StoreBase *>::iterator it = mStores.find(n.val);
+        std::map<int, StoreBase *>::iterator it = mStores.find(n.intval);
 
         if (it == mStores.end()) {
-            if (n.val == ESM::REC_INFO) {
+            if (n.intval == ESM::REC_INFO) {
                 if (dialogue)
                 {
                     dialogue->readInfo(esm, esm.getIndex() != 0);
@@ -87,12 +87,12 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
                     std::cerr << "error: info record without dialog" << std::endl;
                     esm.skipRecord();
                 }
-            } else if (n.val == ESM::REC_MGEF) {
+            } else if (n.intval == ESM::REC_MGEF) {
                 mMagicEffects.load (esm);
-            } else if (n.val == ESM::REC_SKIL) {
+            } else if (n.intval == ESM::REC_SKIL) {
                 mSkills.load (esm);
             }
-            else if (n.val==ESM::REC_FILT || n.val == ESM::REC_DBGP)
+            else if (n.intval==ESM::REC_FILT || n.intval == ESM::REC_DBGP)
             {
                 // ignore project file only records
                 esm.skipRecord();
@@ -110,7 +110,7 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
                 continue;
             }
 
-            if (n.val==ESM::REC_DIAL) {
+            if (n.intval==ESM::REC_DIAL) {
                 dialogue = const_cast<ESM::Dialogue*>(mDialogs.find(id.mId));
             } else {
                 dialogue = 0;

--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -9,6 +9,8 @@ if (GTEST_FOUND)
         mwworld/test_store.cpp
 
         mwdialogue/test_keywordsearch.cpp
+
+        esm/test_fixed_string.cpp
     )
 
     source_group(apps\\openmw_test_suite FILES openmw_test_suite.cpp ${UNITTEST_SRC_FILES})

--- a/apps/openmw_test_suite/esm/test_fixed_string.cpp
+++ b/apps/openmw_test_suite/esm/test_fixed_string.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include "components/esm/esmcommon.hpp"
+
+TEST(EsmFixedString, operator__eq_ne)
+{
+    {
+        SCOPED_TRACE("asdc == asdc");
+        ESM::NAME name;
+        name.assign("asdc");
+        char s[4] = {'a', 's', 'd', 'c'};
+        std::string ss(s, 4);
+
+        EXPECT_TRUE(name == s);
+        EXPECT_TRUE(name == ss.c_str());
+        EXPECT_TRUE(name == ss);
+    }
+    {
+        SCOPED_TRACE("asdc == asdcx");
+        ESM::NAME name;
+        name.assign("asdc");
+        char s[5] = {'a', 's', 'd', 'c', 'x'};
+        std::string ss(s, 5);
+
+        EXPECT_TRUE(name != s);
+        EXPECT_TRUE(name != ss.c_str());
+        EXPECT_TRUE(name != ss);
+    }
+    {
+        SCOPED_TRACE("asdc == asdc[NULL]");
+        ESM::NAME name;
+        name.assign("asdc");
+        char s[5] = {'a', 's', 'd', 'c', '\0'};
+        std::string ss(s, 5);
+
+        EXPECT_TRUE(name == s);
+        EXPECT_TRUE(name == ss.c_str());
+        EXPECT_TRUE(name == ss);
+    }
+}
+
+TEST(EsmFixedString, empty_strings)
+{
+    {
+        SCOPED_TRACE("4 bytes");
+        ESM::NAME empty = ESM::NAME();
+        EXPECT_TRUE(empty == "");
+        EXPECT_TRUE(empty == static_cast<uint32_t>(0));
+        EXPECT_TRUE(empty != "some string");
+        EXPECT_TRUE(empty != static_cast<uint32_t>(42));
+    }
+    {
+        SCOPED_TRACE("32 bytes");
+        ESM::NAME32 empty = ESM::NAME32();
+        EXPECT_TRUE(empty == "");
+        EXPECT_TRUE(empty != "some string");
+    }
+}
+
+TEST(EsmFixedString, struct_size)
+{
+    ASSERT_EQ(4, sizeof(ESM::NAME));
+    ASSERT_EQ(32, sizeof(ESM::NAME32));
+    ASSERT_EQ(64, sizeof(ESM::NAME64));
+    ASSERT_EQ(256, sizeof(ESM::NAME256));
+}
+
+TEST(EsmFixedString, DISABLED_is_pod)
+{
+    /* TODO: enable in C++11
+     * ASSERT_TRUE(std::is_pod<ESM::NAME>::value);
+     * ASSERT_TRUE(std::is_pod<ESM::NAME32>::value);
+     * ASSERT_TRUE(std::is_pod<ESM::NAME64>::value);
+     * ASSERT_TRUE(std::is_pod<ESM::NAME256>::value);
+     */
+}

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -62,7 +62,7 @@ void ESM::CellRef::loadData(ESMReader &esm, bool &isDeleted)
     while (!isLoaded && esm.hasMoreSubs())
     {
         esm.getSubName();
-        switch (esm.retSubName().val)
+        switch (esm.retSubName().intval)
         {
             case ESM::FourCC<'U','N','A','M'>::value:
                 esm.getHT(mReferenceBlocked);

--- a/components/esm/debugprofile.cpp
+++ b/components/esm/debugprofile.cpp
@@ -13,7 +13,7 @@ void ESM::DebugProfile::load (ESMReader& esm, bool &isDeleted)
     while (esm.hasMoreSubs())
     {
         esm.getSubName();
-        switch (esm.retSubName().val)
+        switch (esm.retSubName().intval)
         {
             case ESM::SREC_NAME:
                 mId = esm.getHString();

--- a/components/esm/esmcommon.hpp
+++ b/components/esm/esmcommon.hpp
@@ -15,43 +15,98 @@ enum Version
     VER_13 = 0x3fa66666
   };
 
-/* A structure used for holding fixed-length strings. In the case of
-   LEN=4, it can be more efficient to match the string as a 32 bit
-   number, therefore the struct is implemented as a union with an int.
- */
-template <int LEN>
-union NAME_T
+
+// CRTP for FIXED_STRING class, a structure used for holding fixed-length strings
+template< template<size_t> class DERIVED, size_t SIZE>
+class FIXED_STRING_BASE
 {
-    char name[LEN];
-    uint32_t val;
+    /* The following methods must be implemented in derived classes:
+     *   char const* ro_data() const; // return pointer to ro buffer
+     *   char*       rw_data();       // return pointer to rw buffer
+     */
+public:
+    enum { size = SIZE };
 
-  bool operator==(const char *str) const
-  {
-    for(int i=0; i<LEN; i++)
-      if(name[i] != str[i]) return false;
-      else if(name[i] == 0) return true;
-    return str[LEN] == 0;
-  }
-  bool operator!=(const char *str) const { return !((*this)==str); }
+    template<size_t OTHER_SIZE>
+    bool operator==(char const (&str)[OTHER_SIZE]) const
+    {
+        size_t other_len = strnlen(str, OTHER_SIZE);
+        if (other_len != this->length())
+            return false;
+        return std::strncmp(self()->ro_data(), str, size) == 0;
+    }
+    bool operator==(const char* const str) const
+    {
+        char const* const data = self()->ro_data();
+        for(size_t i = 0; i < size; ++i)
+        {
+            if(data[i] != str[i]) return false;
+            else if(data[i] == '\0') return true;
+        }
+        return str[size] == '\0';
+    }
+    bool operator!=(const char* const str) const { return !( (*this) == str ); }
 
-  bool operator==(const std::string &str) const
-  {
-    return (*this) == str.c_str();
-  }
-  bool operator!=(const std::string &str) const { return !((*this)==str); }
+    bool operator==(const std::string& str) const
+    {
+        return (*this) == str.c_str();
+    }
+    bool operator!=(const std::string& str) const { return !( (*this) == str ); }
 
-  bool operator==(uint32_t v) const { return v == val; }
-  bool operator!=(uint32_t v) const { return v != val; }
+    size_t data_size() const { return size; }
+    size_t length() const { return strnlen(self()->ro_data(), size); }
+    std::string toString() const { return std::string(self()->ro_data(), this->length()); }
 
-  std::string toString() const { return std::string(name, strnlen(name, LEN)); }
+    void assign(const std::string& value) { std::strncpy(self()->rw_data(), value.c_str(), size); }
+    void clear() { this->assign(""); }
+private:
+    DERIVED<size> const* self() const
+    {
+        return static_cast<DERIVED<size> const*>(this);
+    }
 
-  void assign (const std::string& value) { std::strncpy (name, value.c_str(), LEN); }
+    // write the non-const version in terms of the const version
+    // Effective C++ 3rd ed., Item 3 (p. 24-25)
+    DERIVED<size>* self()
+    {
+        return const_cast<DERIVED<size>*>(static_cast<FIXED_STRING_BASE const*>(this)->self());
+    }
 };
 
-typedef NAME_T<4> NAME;
-typedef NAME_T<32> NAME32;
-typedef NAME_T<64> NAME64;
-typedef NAME_T<256> NAME256;
+// Generic implementation
+template <size_t SIZE>
+struct FIXED_STRING : public FIXED_STRING_BASE<FIXED_STRING, SIZE>
+{
+    char data[SIZE];
+
+    char const* ro_data() const { return data; }
+    char*       rw_data() { return data; }
+};
+
+// In the case of SIZE=4, it can be more efficient to match the string
+// as a 32 bit number, therefore the struct is implemented as a union with an int.
+template <>
+struct FIXED_STRING<4> : public FIXED_STRING_BASE<FIXED_STRING, 4>
+{
+    union {
+        char data[4];
+        uint32_t intval;
+    };
+
+    using FIXED_STRING_BASE::operator==;
+    using FIXED_STRING_BASE::operator!=;
+
+    bool operator==(uint32_t v) const { return v == intval; }
+    bool operator!=(uint32_t v) const { return v != intval; }
+
+    char const* ro_data() const { return data; }
+    char*       rw_data() { return data; }
+};
+
+typedef FIXED_STRING<4> NAME;
+typedef FIXED_STRING<32> NAME32;
+typedef FIXED_STRING<64> NAME64;
+typedef FIXED_STRING<256> NAME256;
 
 /* This struct defines a file 'context' which can be saved and later
    restored by an ESMReader instance. It will save the position within

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -55,8 +55,8 @@ void ESMReader::close()
     mCtx.leftRec = 0;
     mCtx.leftSub = 0;
     mCtx.subCached = false;
-    mCtx.recName.val = 0;
-    mCtx.subName.val = 0;
+    mCtx.recName.clear();
+    mCtx.subName.clear();
 }
 
 void ESMReader::openRaw(Files::IStreamPtr _esm, const std::string& name)
@@ -204,16 +204,18 @@ void ESMReader::getSubName()
     }
 
     // reading the subrecord data anyway.
-    getExact(mCtx.subName.name, 4);
-    mCtx.leftRec -= 4;
+    const size_t subNameSize = mCtx.subName.data_size();
+    getExact(mCtx.subName.rw_data(), subNameSize);
+    mCtx.leftRec -= subNameSize;
 }
 
 bool ESMReader::isEmptyOrGetName()
 {
     if (mCtx.leftRec)
     {
-        getExact(mCtx.subName.name, 4);
-        mCtx.leftRec -= 4;
+        const size_t subNameSize = mCtx.subName.data_size();
+        getExact(mCtx.subName.rw_data(), subNameSize);
+        mCtx.leftRec -= subNameSize;
         return false;
     }
     return true;
@@ -267,7 +269,7 @@ NAME ESMReader::getRecName()
     if (!hasMoreRecs())
         fail("No more records, getRecName() failed");
     getName(mCtx.recName);
-    mCtx.leftFile -= 4;
+    mCtx.leftFile -= mCtx.recName.data_size();
 
     // Make sure we don't carry over any old cached subrecord
     // names. This can happen in some cases when we skip parts of a

--- a/components/esm/filter.cpp
+++ b/components/esm/filter.cpp
@@ -13,7 +13,7 @@ void ESM::Filter::load (ESMReader& esm, bool &isDeleted)
     while (esm.hasMoreSubs())
     {
         esm.getSubName();
-        uint32_t name = esm.retSubName().val;
+        uint32_t name = esm.retSubName().intval;
         switch (name)
         {
             case ESM::SREC_NAME:

--- a/components/esm/loadacti.cpp
+++ b/components/esm/loadacti.cpp
@@ -16,7 +16,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadalch.cpp
+++ b/components/esm/loadalch.cpp
@@ -19,7 +19,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadappa.cpp
+++ b/components/esm/loadappa.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadarmo.cpp
+++ b/components/esm/loadarmo.cpp
@@ -49,7 +49,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadbody.cpp
+++ b/components/esm/loadbody.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadbook.cpp
+++ b/components/esm/loadbook.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadbsgn.cpp
+++ b/components/esm/loadbsgn.cpp
@@ -18,7 +18,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadcell.cpp
+++ b/components/esm/loadcell.cpp
@@ -69,7 +69,7 @@ namespace ESM
         while (!isLoaded && esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mName = esm.getHString();
@@ -114,7 +114,7 @@ namespace ESM
         while (!isLoaded && esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'I','N','T','V'>::value:
                     int waterl;

--- a/components/esm/loadclas.cpp
+++ b/components/esm/loadclas.cpp
@@ -47,7 +47,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadclot.cpp
+++ b/components/esm/loadclot.cpp
@@ -19,7 +19,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadcont.cpp
+++ b/components/esm/loadcont.cpp
@@ -36,7 +36,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadcrea.cpp
+++ b/components/esm/loadcrea.cpp
@@ -30,7 +30,7 @@ namespace ESM {
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loaddial.cpp
+++ b/components/esm/loaddial.cpp
@@ -28,7 +28,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'D','A','T','A'>::value:
                 {

--- a/components/esm/loaddoor.cpp
+++ b/components/esm/loaddoor.cpp
@@ -16,7 +16,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadench.cpp
+++ b/components/esm/loadench.cpp
@@ -18,7 +18,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadfact.cpp
+++ b/components/esm/loadfact.cpp
@@ -40,7 +40,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadinfo.cpp
+++ b/components/esm/loadinfo.cpp
@@ -35,7 +35,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'D','A','T','A'>::value:
                     esm.getHT(mData, 12);

--- a/components/esm/loadingr.cpp
+++ b/components/esm/loadingr.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -94,7 +94,7 @@ namespace ESM
         while (!isLoaded && esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'I','N','T','V'>::value:
                     esm.getSubHeaderIs(8);
@@ -125,7 +125,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'V','N','M','L'>::value:
                     esm.skipHSub();

--- a/components/esm/loadlevlist.cpp
+++ b/components/esm/loadlevlist.cpp
@@ -15,7 +15,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadligh.cpp
+++ b/components/esm/loadligh.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadlock.cpp
+++ b/components/esm/loadlock.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadltex.cpp
+++ b/components/esm/loadltex.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadmgef.cpp
+++ b/components/esm/loadmgef.cpp
@@ -211,7 +211,7 @@ void MagicEffect::load(ESMReader &esm, bool &isDeleted)
     while (esm.hasMoreSubs())
     {
         esm.getSubName();
-        switch (esm.retSubName().val)
+        switch (esm.retSubName().intval)
         {
             case ESM::FourCC<'I','T','E','X'>::value:
                 mIcon = esm.getHString();

--- a/components/esm/loadmisc.cpp
+++ b/components/esm/loadmisc.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadnpc.cpp
+++ b/components/esm/loadnpc.cpp
@@ -26,7 +26,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadpgrd.cpp
+++ b/components/esm/loadpgrd.cpp
@@ -46,7 +46,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mCell = esm.getHString();

--- a/components/esm/loadprob.cpp
+++ b/components/esm/loadprob.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadrace.cpp
+++ b/components/esm/loadrace.cpp
@@ -29,7 +29,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadregn.cpp
+++ b/components/esm/loadregn.cpp
@@ -16,7 +16,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();
@@ -61,10 +61,12 @@ namespace ESM
                     esm.getHT(mMapColor);
                     break;
                 case ESM::FourCC<'S','N','A','M'>::value:
+                {
                     SoundRef sr;
                     esm.getHT(sr, 33);
                     mSoundList.push_back(sr);
                     break;
+                }
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;

--- a/components/esm/loadrepa.cpp
+++ b/components/esm/loadrepa.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadscpt.cpp
+++ b/components/esm/loadscpt.cpp
@@ -67,15 +67,17 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'S','C','H','D'>::value:
+                {
                     SCHD data;
                     esm.getHT(data, 52);
                     mData = data.mData;
                     mId = data.mName.toString();
                     hasHeader = true;
                     break;
+                }
                 case ESM::FourCC<'S','C','V','R'>::value:
                     // list of local variables
                     loadSCVR(esm);
@@ -113,7 +115,7 @@ namespace ESM
         memset(&data, 0, sizeof(data));
 
         data.mData = mData;
-        memcpy(data.mName.name, mId.c_str(), mId.size());
+        data.mName.assign(mId);
 
         esm.writeHNT("SCHD", data, 52);
 

--- a/components/esm/loadskil.cpp
+++ b/components/esm/loadskil.cpp
@@ -138,7 +138,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::FourCC<'I','N','D','X'>::value:
                     esm.getHT(mIndex);

--- a/components/esm/loadsndg.cpp
+++ b/components/esm/loadsndg.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadsoun.cpp
+++ b/components/esm/loadsoun.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadspel.cpp
+++ b/components/esm/loadspel.cpp
@@ -19,7 +19,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadsscr.cpp
+++ b/components/esm/loadsscr.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadstat.cpp
+++ b/components/esm/loadstat.cpp
@@ -16,7 +16,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/loadtes3.cpp
+++ b/components/esm/loadtes3.cpp
@@ -9,8 +9,8 @@ void ESM::Header::blank()
 {
     mData.version = ESM::VER_13;
     mData.type = 0;
-    mData.author.assign ("");
-    mData.desc.assign ("");
+    mData.author.clear();
+    mData.desc.clear();
     mData.records = 0;
     mFormat = CurrentFormat;
     mMaster.clear();
@@ -32,8 +32,8 @@ void ESM::Header::load (ESMReader &esm)
       esm.getSubHeader();
       esm.getT(mData.version);
       esm.getT(mData.type);
-      mData.author.assign(esm.getString(sizeof(mData.author.name)));
-      mData.desc.assign(esm.getString(sizeof(mData.desc.name)));
+      mData.author.assign( esm.getString(mData.author.data_size()) );
+      mData.desc.assign( esm.getString(mData.desc.data_size()) );
       esm.getT(mData.records);
     }
 
@@ -73,8 +73,8 @@ void ESM::Header::save (ESMWriter &esm)
     esm.startSubRecord("HEDR");
     esm.writeT(mData.version);
     esm.writeT(mData.type);
-    esm.writeFixedSizeString(mData.author.toString(), 32);
-    esm.writeFixedSizeString(mData.desc.toString(), 256);
+    esm.writeFixedSizeString(mData.author.toString(), mData.author.data_size());
+    esm.writeFixedSizeString(mData.desc.toString(), mData.desc.data_size());
     esm.writeT(mData.records);
     esm.endRecord("HEDR");
 

--- a/components/esm/loadweap.cpp
+++ b/components/esm/loadweap.cpp
@@ -17,7 +17,7 @@ namespace ESM
         while (esm.hasMoreSubs())
         {
             esm.getSubName();
-            switch (esm.retSubName().val)
+            switch (esm.retSubName().intval)
             {
                 case ESM::SREC_NAME:
                     mId = esm.getHString();

--- a/components/esm/transport.cpp
+++ b/components/esm/transport.cpp
@@ -8,13 +8,13 @@ namespace ESM
 
     void Transport::add(ESMReader &esm)
     {
-        if (esm.retSubName().val == ESM::FourCC<'D','O','D','T'>::value)
+        if (esm.retSubName().intval == ESM::FourCC<'D','O','D','T'>::value)
         {
             Dest dodt;
             esm.getHExact(&dodt.mPos, 24);
             mList.push_back(dodt);
         }
-        else if (esm.retSubName().val == ESM::FourCC<'D','N','A','M'>::value)
+        else if (esm.retSubName().intval == ESM::FourCC<'D','N','A','M'>::value)
         {
             mList.back().mCellName = esm.getHString();
         }


### PR DESCRIPTION
I wrote some unit tests.

Before refactoring:
```
Note: Google Test filter = EsmFixedString.*
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from EsmFixedString
[ RUN      ] EsmFixedString.operator__eq_ne
==21569== Conditional jump or move depends on uninitialised value(s)
==21569==    at 0x70D47C: EsmFixedString_operator__eq_ne_Test::TestBody() (test_fixed_string.cpp:13)
==21569==    by 0x72C763: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2090)
==21569==    by 0x727A7D: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2126)
==21569==    by 0x714F2E: testing::Test::Run() (gtest.cc:2162)
==21569==    by 0x7156A9: testing::TestInfo::Run() (gtest.cc:2338)
==21569==    by 0x715C69: testing::TestCase::Run() (gtest.cc:2445)
==21569==    by 0x71A8C3: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4243)
==21569==    by 0x72DC52: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2090)
==21569==    by 0x7288D5: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2126)
==21569==    by 0x7196C0: testing::UnitTest::Run() (gtest.cc:3880)
==21569==    by 0x60F87B: main (openmw_test_suite.cpp:5)
==21569== 
/home/humbug/openmw/apps/openmw_test_suite/esm/test_fixed_string.cpp:13: Failure
Value of: name == s
  Actual: false
Expected: true
Google Test trace:
/home/humbug/openmw/apps/openmw_test_suite/esm/test_fixed_string.cpp:7: asdc == asdc
[  FAILED  ] EsmFixedString.operator__eq_ne (77 ms)
[ RUN      ] EsmFixedString.empty_strings
[       OK ] EsmFixedString.empty_strings (7 ms)
[ RUN      ] EsmFixedString.struct_size
[       OK ] EsmFixedString.struct_size (4 ms)
[----------] 3 tests from EsmFixedString (105 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (155 ms total)
[  PASSED  ] 2 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] EsmFixedString.operator__eq_ne
```
After:
```
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from EsmFixedString
[ RUN      ] EsmFixedString.operator__eq_ne
[       OK ] EsmFixedString.operator__eq_ne (50 ms)
[ RUN      ] EsmFixedString.empty_strings
[       OK ] EsmFixedString.empty_strings (10 ms)
[ RUN      ] EsmFixedString.struct_size
[       OK ] EsmFixedString.struct_size (4 ms)
[----------] 3 tests from EsmFixedString (80 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (127 ms total)
[  PASSED  ] 3 tests.
```