### PR TITLE
Find ffmpeg

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -405,22 +405,7 @@ printf "FFmpeg 2.5.2... "
 		rm -rf ffmpeg-2.5.2-win$BITS-dev
 	fi
 
-	FFMPEG_SDK="`real_pwd`/FFmpeg"
-	add_cmake_opts -DAVCODEC_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DAVCODEC_LIBRARIES="$FFMPEG_SDK/lib/avcodec.lib" \
-		-DAVDEVICE_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DAVDEVICE_LIBRARIES="$FFMPEG_SDK/lib/avdevice.lib" \
-		-DAVFORMAT_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DAVFORMAT_LIBRARIES="$FFMPEG_SDK/lib/avformat.lib" \
-		-DAVUTIL_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DAVUTIL_LIBRARIES="$FFMPEG_SDK/lib/avutil.lib" \
-		-DPOSTPROC_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DPOSTPROC_LIBRARIES="$FFMPEG_SDK/lib/postproc.lib" \
-		-DSWRESAMPLE_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DSWRESAMPLE_LIBRARIES="$FFMPEG_SDK/lib/swresample.lib" \
-		-DSWSCALE_INCLUDE_DIRS="$FFMPEG_SDK/include" \
-		-DSWSCALE_LIBRARIES="$FFMPEG_SDK/lib/swscale.lib"
-
+	export FFMPEG_SDK="`real_pwd`/FFmpeg"
 	add_runtime_dlls `pwd`/FFmpeg/bin/{avcodec-56,avformat-56,avutil-54,swresample-1,swscale-3}.dll
 
 	if [ $BITS -eq 32 ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,15 +149,7 @@ else()
 endif()
 
 # Sound setup
-unset(FFMPEG_LIBRARIES CACHE)
-
-find_package(FFmpeg REQUIRED)
-
-set (FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} ${SWSCALE_LIBRARY} ${SWRESAMPLE_LIBRARIES})
-
-if ( NOT AVCODEC_FOUND OR NOT AVFORMAT_FOUND OR NOT AVUTIL_FOUND OR NOT SWSCALE_FOUND OR NOT SWRESAMPLE_FOUND)
-    message(FATAL_ERROR "FFmpeg component required, but not found!")
-endif()
+find_package(FFmpeg REQUIRED COMPONENTS AVCODEC AVFORMAT AVUTIL SWSCALE SWRESAMPLE)
 # Required for building the FFmpeg headers
 add_definitions(-D__STDC_CONSTANT_MACROS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,11 +141,11 @@ if (USE_QT)
 endif()
 
 if (USE_QT AND DESIRED_QT_VERSION MATCHES 5)
-	# 2.8.11+ is required to make Qt5 happy and allow linking QtMain on Windows.
-	cmake_minimum_required(VERSION 2.8.11)
+    # 2.8.11+ is required to make Qt5 happy and allow linking QtMain on Windows.
+    cmake_minimum_required(VERSION 2.8.11)
 else()
-	# We probably support older versions than this.
-	cmake_minimum_required(VERSION 2.6)
+    # We probably support older versions than this.
+    cmake_minimum_required(VERSION 2.6)
 endif()
 
 # Sound setup
@@ -246,12 +246,6 @@ if(OSG_STATIC)
       set(OPENSCENEGRAPH_LIBRARIES ${OPENSCENEGRAPH_LIBRARIES} ${${PLUGIN_NAME}_LIBRARY})
    endmacro()
 
-   macro(use_static_osg_plugin_dep DEPENDENCY)
-      find_package(${DEPENDENCY} REQUIRED)
-
-      set(OPENSCENEGRAPH_LIBRARIES ${OPENSCENEGRAPH_LIBRARIES} ${${DEPENDENCY}_LIBRARIES})
-   endmacro()
-
    add_definitions(-DOSG_LIBRARY_STATIC)
 
    set(PLUGIN_LIST
@@ -272,6 +266,11 @@ if(OSG_STATIC)
        JPEG # needed by osgdb_jpeg
        )
 
+   macro(use_static_osg_plugin_dep DEPENDENCY)
+      find_package(${DEPENDENCY} REQUIRED)
+
+      set(OPENSCENEGRAPH_LIBRARIES ${OPENSCENEGRAPH_LIBRARIES} ${${DEPENDENCY}_LIBRARIES})
+   endmacro()
    foreach(DEPENDENCY ${PLUGIN_DEPS_LIST})
       use_static_osg_plugin_dep(${DEPENDENCY})
    endforeach()
@@ -376,18 +375,14 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wundef -Wno-unused-parameter -std=c++98 -pedantic -Wno-long-long")
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT APPLE)
-        execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE CLANG_VERSION)
-        string(REGEX REPLACE ".*version ([0-9\\.]*).*" "\\1" CLANG_VERSION ${CLANG_VERSION})
-        if ("${CLANG_VERSION}" VERSION_GREATER 3.6 OR "${CLANG_VERSION}" VERSION_EQUAL 3.6)
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.6 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 3.6)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-potentially-evaluated-expression")
-        endif ("${CLANG_VERSION}" VERSION_GREATER 3.6 OR "${CLANG_VERSION}" VERSION_EQUAL 3.6)
-    endif(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT APPLE)
+        endif ()
+    endif()
 
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                OUTPUT_VARIABLE GCC_VERSION)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL GNU AND "${GCC_VERSION}" VERSION_GREATER 4.6 OR "${GCC_VERSION}" VERSION_EQUAL 4.6)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.6 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.6)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-parameter")
-    endif(CMAKE_CXX_COMPILER_ID STREQUAL GNU AND "${GCC_VERSION}" VERSION_GREATER 4.6 OR "${GCC_VERSION}" VERSION_EQUAL 4.6)
+    endif()
 elseif (MSVC)
     # Enable link-time code generation globally for all linking
     if (OPENMW_LTO_BUILD)

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -115,7 +115,7 @@ endif ()
 # Sound stuff - here so CMake doesn't stupidly recompile EVERYTHING
 # when we change the backend.
 include_directories(
-    ${FFMPEG_INCLUDE_DIRS}
+    ${FFmpeg_INCLUDE_DIRS}
 )
 
 target_link_libraries(openmw
@@ -131,7 +131,7 @@ target_link_libraries(openmw
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${OPENAL_LIBRARY}
-    ${FFMPEG_LIBRARIES}
+    ${FFmpeg_LIBRARIES}
     ${BULLET_LIBRARIES}
     ${MYGUI_LIBRARIES}
     ${SDL2_LIBRARY}
@@ -183,7 +183,7 @@ if(APPLE)
     find_library(IOKIT_FRAMEWORK IOKit)
     target_link_libraries(openmw ${COCOA_FRAMEWORK} ${IOKIT_FRAMEWORK})
 
-    if (FFMPEG_FOUND)
+    if (FFmpeg_FOUND)
         find_library(COREVIDEO_FRAMEWORK CoreVideo)
         find_library(VDA_FRAMEWORK VideoDecodeAcceleration)
         target_link_libraries(openmw ${COREVIDEO_FRAMEWORK} ${VDA_FRAMEWORK})

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -1,11 +1,14 @@
 # vim: ts=2 sw=2
-# - Try to find the required ffmpeg components(default: AVFORMAT, AVUTIL, AVCODEC)
+# - Try to find the required ffmpeg components
+#
+# This module accepts the following env variable
+#  FFMPEG_SDK - Can be set to custom install path
 #
 # Once done this will define
-#  FFMPEG_FOUND         - System has the all required components.
-#  FFMPEG_INCLUDE_DIRS  - Include directory necessary for using the required components headers.
-#  FFMPEG_LIBRARIES     - Link these to use the required ffmpeg components.
-#  FFMPEG_DEFINITIONS   - Compiler switches required for using the required ffmpeg components.
+#  FFmpeg_FOUND         - System has the all required components.
+#  FFmpeg_INCLUDE_DIRS  - Include directory necessary for using the required components headers.
+#  FFmpeg_LIBRARIES     - Link these to use the required ffmpeg components.
+#  FFmpeg_DEFINITIONS   - Compiler switches required for using the required ffmpeg components.
 #
 # For each of the components it will additionaly set.
 #   - AVCODEC
@@ -16,144 +19,95 @@
 #   - SWSCALE
 #   - SWRESAMPLE
 # the following variables will be defined
-#  <component>_FOUND        - System has <component>
-#  <component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
-#  <component>_LIBRARIES    - Link these to use <component>
-#  <component>_DEFINITIONS  - Compiler switches required for using <component>
-#  <component>_VERSION      - The components version
+#  FFmpeg_<component>_FOUND        - System has <component>
+#  FFmpeg_<component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
+#  FFmpeg_<component>_LIBRARIES    - Link these to use <component>
+#  FFmpeg_<component>_DEFINITIONS  - Compiler switches required for using <component>
+#  FFmpeg_<component>_VERSION      - The components version
 #
 # Copyright (c) 2006, Matthias Kretz, <kretz@kde.org>
 # Copyright (c) 2008, Alexander Neundorf, <neundorf@kde.org>
 # Copyright (c) 2011, Michael Jansen, <kde@michael-jansen.biz>
+# Copyright (c) 2016, Roman Proskuryakov, <humbug@deeptown.org>
 #
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
+include(LibFindMacros)
 include(FindPackageHandleStandardArgs)
 
-# The default components were taken from a survey over other FindFFMPEG.cmake files
-if (NOT FFmpeg_FIND_COMPONENTS)
-  set(FFmpeg_FIND_COMPONENTS AVCODEC AVFORMAT AVUTIL SWSCALE)
-endif ()
-
-#
-### Macro: set_component_found
-#
-# Marks the given component as found if both *_LIBRARIES AND *_INCLUDE_DIRS is present.
-#
-macro(set_component_found _component )
-  if (${_component}_LIBRARIES AND ${_component}_INCLUDE_DIRS)
-    # message(STATUS "  - ${_component} found.")
-    set(${_component}_FOUND TRUE)
-  else ()
-    # message(STATUS "  - ${_component} not found.")
-  endif ()
-endmacro()
-
-#
-### Macro: find_component
-#
-# Checks for the given component by invoking pkgconfig and then looking up the libraries and
-# include directories.
-#
-macro(find_component _component _pkgconfig _library _header)
-
-  if (NOT WIN32)
-     # use pkg-config to get the directories and then use these values
-     # in the FIND_PATH() and FIND_LIBRARY() calls
-     find_package(PkgConfig)
-     if (PKG_CONFIG_FOUND)
-       pkg_check_modules(PC_${_component} ${_pkgconfig})
-     endif ()
-  endif (NOT WIN32)
-
-  find_path(${_component}_INCLUDE_DIRS ${_header}
-    HINTS
-      ${FFMPEGSDK_INC}
-      ${PC_LIB${_component}_INCLUDEDIR}
-      ${PC_LIB${_component}_INCLUDE_DIRS}
-    PATH_SUFFIXES
-      ffmpeg
-  )
-
-  find_library(${_component}_LIBRARIES NAMES ${_library}
-      HINTS
-      ${FFMPEGSDK_LIB}
-      ${PC_LIB${_component}_LIBDIR}
-      ${PC_LIB${_component}_LIBRARY_DIRS}
-  )
-
-  set(${_component}_DEFINITIONS  ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")
-  set(${_component}_VERSION      ${PC_${_component}_VERSION}      CACHE STRING "The ${_component} version number.")
-
-  set_component_found(${_component})
-
-  mark_as_advanced(
-    ${_component}_INCLUDE_DIRS
-    ${_component}_LIBRARIES
-    ${_component}_DEFINITIONS
-    ${_component}_VERSION)
-
+# Macro: _internal_find_component
+# Checks for the given component by invoking pkgconfig etc.
+macro(_internal_find_component _component _pkgconfig _library _header)
+    set(_package_component FFmpeg_${_component})
+    libfind_pkg_detect(${_package_component} ${_pkgconfig}
+        FIND_PATH ${_header}
+            HINTS $ENV{FFMPEG_SDK}/include
+            PATH_SUFFIXES ffmpeg
+        FIND_LIBRARY ${_library}
+            HINTS $ENV{FFMPEG_SDK}/lib
+    )
+    set(${_package_component}_DEFINITIONS  ${${_package_component}_PKGCONF_CFLAGS_OTHER})
+    set(${_package_component}_VERSION      ${${_package_component}_PKGCONF_VERSION})
+    libfind_process(${_package_component})
 endmacro()
 
 
-# Check for cached results. If there are skip the costly part.
-if (NOT FFMPEG_LIBRARIES)
+# setter for 'hashmap'
+macro(hashmap_set _table _key) # ARGN
+    set(${_table}_${_key} ${ARGN})
+endmacro()
 
-  set (FFMPEGSDK $ENV{FFMPEG_HOME})
-  if (FFMPEGSDK)
-    set (FFMPEGSDK_INC "${FFMPEGSDK}/include")
-    set (FFMPEGSDK_LIB "${FFMPEGSDK}/lib")
-  endif ()
+# check for key in 'hashmap'
+macro(hashmap_exists _table _key _out_var)
+    if (DEFINED ${_table}_${_key})
+        set(${_out_var} TRUE)
+    else()
+        set(${_out_var} FALSE)
+    endif()
+endmacro()
 
-  # Check for all possible component.
-  find_component(AVCODEC  libavcodec  avcodec  libavcodec/avcodec.h)
-  find_component(AVFORMAT libavformat avformat libavformat/avformat.h)
-  find_component(AVDEVICE libavdevice avdevice libavdevice/avdevice.h)
-  find_component(AVUTIL   libavutil   avutil   libavutil/avutil.h)
-  find_component(SWSCALE  libswscale  swscale  libswscale/swscale.h)
-  find_component(POSTPROC libpostproc postproc libpostproc/postprocess.h)
-  find_component(SWRESAMPLE  libswresample  swresample  libswresample/swresample.h)
-  find_component(AVRESAMPLE  libavresample  avresample  libavresample/avresample.h)
+# getter for 'hashmap'
+macro(hashmap_get _table _key _out_var)
+    set(${_out_var} ${${_table}_${_key}})
+endmacro()
 
-  # Check if the required components were found and add their stuff to the FFMPEG_* vars.
-  foreach (_component ${FFmpeg_FIND_COMPONENTS})
-    if (${_component}_FOUND)
-      # message(STATUS "Required component ${_component} present.")
-      set(FFMPEG_LIBRARIES   ${FFMPEG_LIBRARIES}   ${${_component}_LIBRARIES})
-      set(FFMPEG_DEFINITIONS ${FFMPEG_DEFINITIONS} ${${_component}_DEFINITIONS})
-      list(APPEND FFMPEG_INCLUDE_DIRS ${${_component}_INCLUDE_DIRS})
-    else ()
-      # message(STATUS "Required component ${_component} missing.")
-    endif ()
-  endforeach ()
 
-  # Build the include path with duplicates removed.
-  if (FFMPEG_INCLUDE_DIRS)
-    list(REMOVE_DUPLICATES FFMPEG_INCLUDE_DIRS)
-  endif ()
+# fill 'hashmap' named find_args
+hashmap_set(find_args AVCODEC  libavcodec  avcodec  libavcodec/avcodec.h)
+hashmap_set(find_args AVFORMAT libavformat avformat libavformat/avformat.h)
+hashmap_set(find_args AVDEVICE libavdevice avdevice libavdevice/avdevice.h)
+hashmap_set(find_args AVUTIL   libavutil   avutil   libavutil/avutil.h)
+hashmap_set(find_args SWSCALE  libswscale  swscale  libswscale/swscale.h)
+hashmap_set(find_args POSTPROC libpostproc postproc libpostproc/postprocess.h)
+hashmap_set(find_args SWRESAMPLE  libswresample  swresample  libswresample/swresample.h)
+hashmap_set(find_args AVRESAMPLE  libavresample  avresample  libavresample/avresample.h)
 
-  # cache the vars.
-  set(FFMPEG_INCLUDE_DIRS ${FFMPEG_INCLUDE_DIRS} CACHE STRING "The FFmpeg include directories." FORCE)
-  set(FFMPEG_LIBRARIES    ${FFMPEG_LIBRARIES}    CACHE STRING "The FFmpeg libraries." FORCE)
-  set(FFMPEG_DEFINITIONS  ${FFMPEG_DEFINITIONS}  CACHE STRING "The FFmpeg cflags." FORCE)
-
-  mark_as_advanced(FFMPEG_INCLUDE_DIRS
-                   FFMPEG_LIBRARIES
-                   FFMPEG_DEFINITIONS)
-
-endif ()
-
-# Now set the noncached _FOUND vars for the components.
-foreach (_component AVCODEC AVDEVICE AVFORMAT AVUTIL POSTPROCESS SWSCALE SWRESAMPLE AVRESAMPLE)
-  set_component_found(${_component})
-endforeach ()
-
-# Compile the list of required vars
-set(_FFmpeg_REQUIRED_VARS FFMPEG_LIBRARIES FFMPEG_INCLUDE_DIRS)
+# Check if the required components were found and add their stuff to the FFmpeg_* vars.
 foreach (_component ${FFmpeg_FIND_COMPONENTS})
-  list(APPEND _FFmpeg_REQUIRED_VARS ${_component}_LIBRARIES ${_component}_INCLUDE_DIRS)
+    hashmap_exists(find_args ${_component} _known_component)
+    if (NOT _known_component)
+        message(FATAL_ERROR "Unknown component '${_component}'")
+    endif()
+    hashmap_get(find_args ${_component} _component_find_args)
+    _internal_find_component(${_component} ${_component_find_args})
+    set(_package_component FFmpeg_${_component})
+    if (${_package_component}_FOUND)
+        list(APPEND FFmpeg_LIBRARIES ${${_package_component}_LIBRARIES})
+        list(APPEND FFmpeg_INCLUDE_DIRS ${${_package_component}_INCLUDE_DIRS})
+        list(APPEND FFmpeg_DEFINITIONS ${${_package_component}_DEFINITIONS})
+    endif ()
 endforeach ()
 
-# Give a nice error message if some of the required vars are missing.
-find_package_handle_standard_args(FFmpeg DEFAULT_MSG ${_FFmpeg_REQUIRED_VARS})
+# Build the include path with duplicates removed.
+if (FFmpeg_INCLUDE_DIRS)
+    list(REMOVE_DUPLICATES FFmpeg_INCLUDE_DIRS)
+endif()
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(FFmpeg
+    FOUND_VAR FFmpeg_FOUND
+    HANDLE_COMPONENTS
+    REQUIRED_VARS
+        FFmpeg_LIBRARIES
+        FFmpeg_INCLUDE_DIRS
+)

--- a/cmake/LibFindMacros.cmake
+++ b/cmake/LibFindMacros.cmake
@@ -1,0 +1,266 @@
+# Version 2.2
+# Public Domain, originally written by Lasse Kärkkäinen <tronic>
+# Maintained at https://github.com/Tronic/cmake-modules
+# Please send your improvements as pull requests on Github.
+
+# Find another package and make it a dependency of the current package.
+# This also automatically forwards the "REQUIRED" argument.
+# Usage: libfind_package(<prefix> <another package> [extra args to find_package])
+macro (libfind_package PREFIX PKG)
+  set(${PREFIX}_args ${PKG} ${ARGN})
+  if (${PREFIX}_FIND_REQUIRED)
+    set(${PREFIX}_args ${${PREFIX}_args} REQUIRED)
+  endif()
+  find_package(${${PREFIX}_args})
+  set(${PREFIX}_DEPENDENCIES ${${PREFIX}_DEPENDENCIES};${PKG})
+  unset(${PREFIX}_args)
+endmacro()
+
+# A simple wrapper to make pkg-config searches a bit easier.
+# Works the same as CMake's internal pkg_check_modules but is always quiet.
+macro (libfind_pkg_check_modules)
+  find_package(PkgConfig QUIET)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(${ARGN} QUIET)
+  endif()
+endmacro()
+
+# Avoid useless copy&pasta by doing what most simple libraries do anyway:
+# pkg-config, find headers, find library.
+# Usage: libfind_pkg_detect(<prefix> <pkg-config args> FIND_PATH <name> [other args] FIND_LIBRARY <name> [other args])
+# E.g. libfind_pkg_detect(SDL2 sdl2 FIND_PATH SDL.h PATH_SUFFIXES SDL2 FIND_LIBRARY SDL2)
+function (libfind_pkg_detect PREFIX)
+  # Parse arguments
+  set(argname pkgargs)
+  foreach (i ${ARGN})
+    if ("${i}" STREQUAL "FIND_PATH")
+      set(argname pathargs)
+    elseif ("${i}" STREQUAL "FIND_LIBRARY")
+      set(argname libraryargs)
+    else()
+      set(${argname} ${${argname}} ${i})
+    endif()
+  endforeach()
+  if (NOT pkgargs)
+    message(FATAL_ERROR "libfind_pkg_detect requires at least a pkg_config package name to be passed.")
+  endif()
+  # Find library
+  libfind_pkg_check_modules(${PREFIX}_PKGCONF ${pkgargs})
+  if (pathargs)
+    find_path(${PREFIX}_INCLUDE_DIR NAMES ${pathargs} HINTS ${${PREFIX}_PKGCONF_INCLUDE_DIRS})
+  endif()
+  if (libraryargs)
+    find_library(${PREFIX}_LIBRARY NAMES ${libraryargs} HINTS ${${PREFIX}_PKGCONF_LIBRARY_DIRS})
+  endif()
+endfunction()
+
+# Extracts a version #define from a version.h file, output stored to <PREFIX>_VERSION.
+# Usage: libfind_version_header(Foobar foobar/version.h FOOBAR_VERSION_STR)
+# Fourth argument "QUIET" may be used for silently testing different define names.
+# This function does nothing if the version variable is already defined.
+function (libfind_version_header PREFIX VERSION_H DEFINE_NAME)
+  # Skip processing if we already have a version or if the include dir was not found
+  if (${PREFIX}_VERSION OR NOT ${PREFIX}_INCLUDE_DIR)
+    return()
+  endif()
+  set(quiet ${${PREFIX}_FIND_QUIETLY})
+  # Process optional arguments
+  foreach(arg ${ARGN})
+    if (arg STREQUAL "QUIET")
+      set(quiet TRUE)
+    else()
+      message(AUTHOR_WARNING "Unknown argument ${arg} to libfind_version_header ignored.")
+    endif()
+  endforeach()
+  # Read the header and parse for version number
+  set(filename "${${PREFIX}_INCLUDE_DIR}/${VERSION_H}")
+  if (NOT EXISTS ${filename})
+    if (NOT quiet)
+      message(AUTHOR_WARNING "Unable to find ${${PREFIX}_INCLUDE_DIR}/${VERSION_H}")
+    endif()
+    return()
+  endif()
+  file(READ "${filename}" header)
+  string(REGEX MATCH ".*#[ \t]*define[ \t]+${DEFINE_NAME}[ \t]+((\"([^\n]*)\")|([^\n]*))" match "${header}")
+  # No regex match?
+  if (match STREQUAL header)
+    if (NOT quiet)
+      message(AUTHOR_WARNING "Unable to find \#define ${DEFINE_NAME} \"<version>\" from ${${PREFIX}_INCLUDE_DIR}/${VERSION_H}")
+    endif()
+    return()
+  endif()
+  # Export the version string
+  set(${PREFIX}_VERSION "${CMAKE_MATCH_3}${CMAKE_MATCH_4}" PARENT_SCOPE)
+endfunction()
+
+# Do the final processing once the paths have been detected.
+# If include dirs are needed, ${PREFIX}_PROCESS_INCLUDES should be set to contain
+# all the variables, each of which contain one include directory.
+# Ditto for ${PREFIX}_PROCESS_LIBS and library files.
+# Will set ${PREFIX}_FOUND, ${PREFIX}_INCLUDE_DIRS and ${PREFIX}_LIBRARIES.
+# Also handles errors in case library detection was required, etc.
+function (libfind_process PREFIX)
+  # Skip processing if already processed during this configuration run
+  if (${PREFIX}_FOUND)
+    return()
+  endif()
+
+  set(found TRUE)  # Start with the assumption that the package was found
+
+  # Did we find any files? Did we miss includes? These are for formatting better error messages.
+  set(some_files FALSE)
+  set(missing_headers FALSE)
+
+  # Shorthands for some variables that we need often
+  set(quiet ${${PREFIX}_FIND_QUIETLY})
+  set(required ${${PREFIX}_FIND_REQUIRED})
+  set(exactver ${${PREFIX}_FIND_VERSION_EXACT})
+  set(findver "${${PREFIX}_FIND_VERSION}")
+  set(version "${${PREFIX}_VERSION}")
+
+  # Lists of config option names (all, includes, libs)
+  unset(configopts)
+  set(includeopts ${${PREFIX}_PROCESS_INCLUDES})
+  set(libraryopts ${${PREFIX}_PROCESS_LIBS})
+
+  # Process deps to add to
+  foreach (i ${PREFIX} ${${PREFIX}_DEPENDENCIES})
+    if (DEFINED ${i}_INCLUDE_OPTS OR DEFINED ${i}_LIBRARY_OPTS)
+      # The package seems to export option lists that we can use, woohoo!
+      list(APPEND includeopts ${${i}_INCLUDE_OPTS})
+      list(APPEND libraryopts ${${i}_LIBRARY_OPTS})
+    else()
+      # If plural forms don't exist or they equal singular forms
+      if ((NOT DEFINED ${i}_INCLUDE_DIRS AND NOT DEFINED ${i}_LIBRARIES) OR
+          ({i}_INCLUDE_DIR STREQUAL ${i}_INCLUDE_DIRS AND ${i}_LIBRARY STREQUAL ${i}_LIBRARIES))
+        # Singular forms can be used
+        if (DEFINED ${i}_INCLUDE_DIR)
+          list(APPEND includeopts ${i}_INCLUDE_DIR)
+        endif()
+        if (DEFINED ${i}_LIBRARY)
+          list(APPEND libraryopts ${i}_LIBRARY)
+        endif()
+      else()
+        # Oh no, we don't know the option names
+        message(FATAL_ERROR "We couldn't determine config variable names for ${i} includes and libs. Aieeh!")
+      endif()
+    endif()
+  endforeach()
+
+  if (includeopts)
+    list(REMOVE_DUPLICATES includeopts)
+  endif()
+
+  if (libraryopts)
+    list(REMOVE_DUPLICATES libraryopts)
+  endif()
+
+  string(REGEX REPLACE ".*[ ;]([^ ;]*(_INCLUDE_DIRS|_LIBRARIES))" "\\1" tmp "${includeopts} ${libraryopts}")
+  if (NOT tmp STREQUAL "${includeopts} ${libraryopts}")
+    message(AUTHOR_WARNING "Plural form ${tmp} found in config options of ${PREFIX}. This works as before but is now deprecated. Please only use singular forms INCLUDE_DIR and LIBRARY, and update your find scripts for LibFindMacros > 2.0 automatic dependency system (most often you can simply remove the PROCESS variables entirely).")
+  endif()
+
+  # Include/library names separated by spaces (notice: not CMake lists)
+  unset(includes)
+  unset(libs)
+
+  # Process all includes and set found false if any are missing
+  foreach (i ${includeopts})
+    list(APPEND configopts ${i})
+    if (NOT "${${i}}" STREQUAL "${i}-NOTFOUND")
+      list(APPEND includes "${${i}}")
+    else()
+      set(found FALSE)
+      set(missing_headers TRUE)
+    endif()
+  endforeach()
+
+  # Process all libraries and set found false if any are missing
+  foreach (i ${libraryopts})
+    list(APPEND configopts ${i})
+    if (NOT "${${i}}" STREQUAL "${i}-NOTFOUND")
+      list(APPEND libs "${${i}}")
+    else()
+      set (found FALSE)
+    endif()
+  endforeach()
+
+  # Version checks
+  if (found AND findver)
+    if (NOT version)
+      message(WARNING "The find module for ${PREFIX} does not provide version information, so we'll just assume that it is OK. Please fix the module or remove package version requirements to get rid of this warning.")
+    elseif (version VERSION_LESS findver OR (exactver AND NOT version VERSION_EQUAL findver))
+      set(found FALSE)
+      set(version_unsuitable TRUE)
+    endif()
+  endif()
+
+  # If all-OK, hide all config options, export variables, print status and exit
+  if (found)
+    foreach (i ${configopts})
+      mark_as_advanced(${i})
+    endforeach()
+    if (NOT quiet)
+      message(STATUS "Found ${PREFIX} ${${PREFIX}_VERSION}")
+      if (LIBFIND_DEBUG)
+        message(STATUS "  ${PREFIX}_DEPENDENCIES=${${PREFIX}_DEPENDENCIES}")
+        message(STATUS "  ${PREFIX}_INCLUDE_OPTS=${includeopts}")
+        message(STATUS "  ${PREFIX}_INCLUDE_DIRS=${includes}")
+        message(STATUS "  ${PREFIX}_LIBRARY_OPTS=${libraryopts}")
+        message(STATUS "  ${PREFIX}_LIBRARIES=${libs}")
+      endif()
+      set (${PREFIX}_INCLUDE_OPTS ${includeopts} PARENT_SCOPE)
+      set (${PREFIX}_LIBRARY_OPTS ${libraryopts} PARENT_SCOPE)
+      set (${PREFIX}_INCLUDE_DIRS ${includes} PARENT_SCOPE)
+      set (${PREFIX}_LIBRARIES ${libs} PARENT_SCOPE)
+      set (${PREFIX}_FOUND TRUE PARENT_SCOPE)
+    endif()
+    return()
+  endif()
+
+  # Format messages for debug info and the type of error
+  set(vars "Relevant CMake configuration variables:\n")
+  foreach (i ${configopts})
+    mark_as_advanced(CLEAR ${i})
+    set(val ${${i}})
+    if ("${val}" STREQUAL "${i}-NOTFOUND")
+      set (val "<not found>")
+    elseif (val AND NOT EXISTS ${val})
+      set (val "${val}  (does not exist)")
+    else()
+      set(some_files TRUE)
+    endif()
+    set(vars "${vars}  ${i}=${val}\n")
+  endforeach()
+  set(vars "${vars}You may use CMake GUI, cmake -D or ccmake to modify the values. Delete CMakeCache.txt to discard all values and force full re-detection if necessary.\n")
+  if (version_unsuitable)
+    set(msg "${PREFIX} ${${PREFIX}_VERSION} was found but")
+    if (exactver)
+      set(msg "${msg} only version ${findver} is acceptable.")
+    else()
+      set(msg "${msg} version ${findver} is the minimum requirement.")
+    endif()
+  else()
+    if (missing_headers)
+      set(msg "We could not find development headers for ${PREFIX}. Do you have the necessary dev package installed?")
+    elseif (some_files)
+      set(msg "We only found some files of ${PREFIX}, not all of them. Perhaps your installation is incomplete or maybe we just didn't look in the right place?")
+      if(findver)
+        set(msg "${msg} This could also be caused by incompatible version (if it helps, at least ${PREFIX} ${findver} should work).")
+      endif()
+    else()
+      set(msg "We were unable to find package ${PREFIX}.")
+    endif()
+  endif()
+
+  # Fatal error out if REQUIRED
+  if (required)
+    set(msg "REQUIRED PACKAGE NOT FOUND\n${msg} This package is REQUIRED and you need to install it or adjust CMake configuration in order to continue building ${CMAKE_PROJECT_NAME}.")
+    message(FATAL_ERROR "${msg}\n${vars}")
+  endif()
+  # Otherwise just print a nasty warning
+  if (NOT quiet)
+    message(WARNING "WARNING: MISSING PACKAGE\n${msg} This package is NOT REQUIRED and you may ignore this warning but by doing so you may miss some functionality of ${CMAKE_PROJECT_NAME}. \n${vars}")
+  endif()
+endfunction()
+

--- a/cmake/PreprocessorUtils.cmake
+++ b/cmake/PreprocessorUtils.cmake
@@ -36,9 +36,9 @@ endmacro()
 macro(replace_preprocessor_entry VARIABLE KEYWORD NEW_VALUE)
   string(REGEX REPLACE 
     "(// *)?# *define +${KEYWORD} +[^ \n]*"
-	"#define ${KEYWORD} ${NEW_VALUE}"
-	${VARIABLE}_TEMP
-	${${VARIABLE}}
+        "#define ${KEYWORD} ${NEW_VALUE}"
+        ${VARIABLE}_TEMP
+        ${${VARIABLE}}
   )
   set(${VARIABLE} ${${VARIABLE}_TEMP})  
 endmacro()
@@ -51,10 +51,35 @@ macro(set_preprocessor_entry VARIABLE KEYWORD ENABLE)
   endif ()
   string(REGEX REPLACE 
     "(// *)?# *define +${KEYWORD} *\n"
-	${TMP_REPLACE_STR}
-	${VARIABLE}_TEMP
-	${${VARIABLE}}
+        ${TMP_REPLACE_STR}
+        ${VARIABLE}_TEMP
+        ${${VARIABLE}}
   )
   set(${VARIABLE} ${${VARIABLE}_TEMP})  
 endmacro()
-  
+
+
+# get_version_from_n_defines(result_version_name header_path [list of defines...])
+#
+# get_version_from_n_defines(MyPackage_VERSION /Header/Path/HeaderName.h
+#     MYPACKAGE_VERSION_MAJOR
+#     MYPACKAGE_VERSION_MINOR
+# )
+# Function call will get the values of defines MYPACKAGE_VERSION_MAJOR & MYPACKAGE_VERSION_MINOR
+#  from header and set "${MYPACKAGE_VERSION_MAJOR}.${MYPACKAGE_VERSION_MINOR}" into MyPackage_VERSION
+#
+
+function(get_version_from_n_defines OUT_VAR HEADER_PATH)
+    if (NOT EXISTS ${HEADER_PATH})
+        message(FATAL_ERROR "Unable to find '${HEADER_PATH}'")
+        return()
+    endif ()
+    file(READ ${HEADER_PATH} _CONTENT)
+    unset(_DEFINES_LIST)
+    foreach (_DEFINE_NAME ${ARGN})
+        get_preprocessor_entry(_CONTENT ${_DEFINE_NAME} _DEFINE_VALUE)
+        list(APPEND _DEFINES_LIST ${_DEFINE_VALUE})
+    endforeach()
+    string(REPLACE ";" "." _VERSION "${_DEFINES_LIST}")
+    set(${OUT_VAR} "${_VERSION}" PARENT_SCOPE)
+endfunction()

--- a/extern/osg-ffmpeg-videoplayer/CMakeLists.txt
+++ b/extern/osg-ffmpeg-videoplayer/CMakeLists.txt
@@ -10,8 +10,8 @@ set(OSG_FFMPEG_VIDEOPLAYER_SOURCE_FILES
     audiofactory.hpp
 )
 
-include_directories(${FFMPEG_INCLUDE_DIRS})
+include_directories(${FFmpeg_INCLUDE_DIRS})
 add_library(${OSG_FFMPEG_VIDEOPLAYER_LIBRARY} STATIC ${OSG_FFMPEG_VIDEOPLAYER_SOURCE_FILES})
-target_link_libraries(${OSG_FFMPEG_VIDEOPLAYER_LIBRARY} ${FFMPEG_LIBRARIES} ${Boost_THREAD_LIBRARY})
+target_link_libraries(${OSG_FFMPEG_VIDEOPLAYER_LIBRARY} ${FFmpeg_LIBRARIES} ${Boost_THREAD_LIBRARY})
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
`FindFFmpeg.cmake` set FFMPEG_* variables, which is incorrect acording to CMake docs. I fixed that. As a byproduct I fixed handling of components, e.g.
```
find_package(FFmpeg REQUIRED COMPONENTS AVUTIL) # only avutil will be searched + it fail if there is no avutil
```

Output from normal build:
```
-- Found FFmpeg_AVCODEC 56.60.100

-- Found FFmpeg_AVFORMAT 56.40.101

-- Found FFmpeg_AVUTIL 54.31.100

-- Found FFmpeg_SWSCALE 3.1.101

-- Found FFmpeg_SWRESAMPLE 1.2.101

-- Found FFmpeg: /tmp/openmw-deps/openmw-deps/lib/libavcodec.a;/tmp/openmw-deps/openmw-deps/lib/libavformat.a;/tmp/openmw-deps/openmw-deps/lib/libavutil.a;/tmp/openmw-deps/openmw-deps/lib/libswscale.a;/tmp/openmw-deps/openmw-deps/lib/libswresample.a  found components:  AVCODEC AVFORMAT AVUTIL SWSCALE SWRESAMPLE 
```

