### PR TITLE
Permanent barter disposition

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -21,6 +21,8 @@
 #include <components/interpreter/interpreter.hpp>
 #include <components/interpreter/defines.hpp>
 
+#include <components/settings/settings.hpp>
+
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/journal.hpp"
@@ -584,6 +586,9 @@ namespace MWDialogue
     void DialogueManager::applyDispositionChange(int delta)
     {
         mTemporaryDispositionChange += delta;
+        if(Settings::Manager::getBool("permanent barter disposition", "Game")){
+            mPermanentDispositionChange += delta;
+        }
     }
 
     bool DialogueManager::checkServiceRefused()

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -145,6 +145,9 @@ difficulty = 0
 # Show duration of magic effect and lights in the spells window.
 show effect duration = false
 
+# Makes disposition changes through bartering permanent.
+permanent barter disposition = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
This adds a setting to allow temporary disposition changes to apply to an npc's permanent disposition similar to the option in MCP. The goal is to help remove the aspect of bartering where the user will always choose an improbably good deal and offer until it's accepted for maximum profit and experience. This is not a fix-all and works best balancing mods(like mods that raise merchant speechcraft skill, make speechcraft harder to raise, set iBarterSuccessDisposition to 0, etc).
