### PR TITLE
AI package fixes

### DIFF
--- a/apps/openmw/mwmechanics/aiescort.cpp
+++ b/apps/openmw/mwmechanics/aiescort.cpp
@@ -72,7 +72,11 @@ namespace MWMechanics
         {
             mRemainingDuration -= duration;
             if (duration <= 0)
+            {
+                // Reset mStarted to false so that package can be repeated again
+                mStarted = false;
                 return true;
+            }
         }
 
         if (!mCellId.empty() && mCellId != actor.getCell()->getCell()->getCellId().mWorldspace)
@@ -100,7 +104,11 @@ namespace MWMechanics
             point.mConnectionNum = 0;
             point.mUnknown = 0;
             if(pathTo(actor,point,duration)) //Returns true on path complete
+            {
+                // Reset mStarted to false so that package can be repeated again
+                mStarted = false;
                 return true;
+            }
             mMaxDist = 450;
         }
         else

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -45,7 +45,12 @@ bool MWMechanics::AiPackage::shouldCancelPreviousAi() const
     return true;
 }
 
-MWMechanics::AiPackage::AiPackage() : mTimer(0.26f) { //mTimer starts at .26 to force initial pathbuild
+bool MWMechanics::AiPackage::getRepeat() const
+{
+    return true;
+}
+
+MWMechanics::AiPackage::AiPackage() : mTimer(0.26f), mStarted(false) { //mTimer starts at .26 to force initial pathbuild
 
 }
 
@@ -74,7 +79,13 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, ESM::Pathgrid::Po
     if(mTimer > 0.25)
     {
         const ESM::Cell *cell = actor.getCell()->getCell();
-        if (doesPathNeedRecalc(dest, cell)) { //Only rebuild path if it's moved
+        // If repeating an AI package (mStarted has been set to false again), build a new path if needed so package doesn't immediately end
+        if (!mStarted && distance(pos.pos, dest) > 10) {
+            mStarted = true;
+            mPathFinder.buildSyncedPath(pos.pos, dest, actor.getCell(), true); //Rebuild path, in case the target has moved
+            mPrevDest = dest;
+        }
+        else if (doesPathNeedRecalc(dest, cell)) { //Only rebuild path if it's moved
             mPathFinder.buildSyncedPath(pos.pos, dest, actor.getCell(), true); //Rebuild path, in case the target has moved
             mPrevDest = dest;
         }
@@ -94,7 +105,11 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, ESM::Pathgrid::Po
     /// Checks if you aren't moving; attempts to unstick you
     //************************
     if(mPathFinder.checkPathCompleted(pos.pos[0],pos.pos[1])) //Path finished?
+    {
+        // Reset mTimer so that path will be built right away when a package is repeated
+        mTimer = 0.26f;
         return true;
+    }
     else
     {
         evadeObstacles(actor, duration, pos);

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -87,6 +87,10 @@ namespace MWMechanics
             /// Upon adding this Ai package, should the Ai Sequence attempt to cancel previous Ai packages (default true)?
             virtual bool shouldCancelPreviousAi() const;
 
+            /// Return true if this package should repeat. Can only be false for AIWander, if AIWander is assigned
+            /// assigned through the console or script.
+            virtual bool getRepeat() const;
+
             bool isTargetMagicallyHidden(const MWWorld::Ptr& target);
 
         protected:
@@ -103,6 +107,9 @@ namespace MWMechanics
             ObstacleCheck mObstacleCheck;
 
             float mTimer;
+
+            // Set to true once package starts actually being executed
+            bool mStarted;
 
             ESM::Pathgrid::Point mPrevDest;
 

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -230,6 +230,11 @@ void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& charac
 
         if (package->execute (actor,characterController,state,duration))
         {
+            // Put repeating noncombat AI packages on the end of the stack so they can be used again
+            if (isActualAiPackage(packageTypeId) && package->getRepeat())
+            {
+                mPackages.push_back(package->clone());
+            }
             // To account for the rare case where AiPackage::execute() queued another AI package
             // (e.g. AiPursue executing a dialogue script that uses startCombat)
             std::list<MWMechanics::AiPackage*>::iterator toRemove =

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -58,9 +58,13 @@ namespace MWMechanics
         if (!isWithinMaxRange(osg::Vec3f(mX, mY, mZ), pos.asVec3()))
             return false;
 
+        if (!mStarted)
+            mStarted = true;
+
         if (pathTo(actor, ESM::Pathgrid::Point(static_cast<int>(mX), static_cast<int>(mY), static_cast<int>(mZ)), duration))
         {
             actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
+            mStarted = false;
             return true;
         }
         return false;

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -123,8 +123,6 @@ namespace MWMechanics
         if(mDuration == 0)
             mTimeOfDay = 0;
 
-        mStartTime = MWBase::Environment::get().getWorld()->getTimeStamp();
-
         mPopulateAvailableNodes = true;
 
     }
@@ -202,6 +200,13 @@ namespace MWMechanics
             mPopulateAvailableNodes = true;
         }
 
+        if (!mStarted)
+        {
+            // Set mStartTime once this package starts being executed
+            mStartTime = MWBase::Environment::get().getWorld()->getTimeStamp();
+            mStarted = true;
+        }
+
         cStats.setDrawState(DrawState_Nothing);
         cStats.setMovementFlag(CreatureStats::Flag_Run, false);
 
@@ -230,6 +235,8 @@ namespace MWMechanics
 
         if (isPackageCompleted(actor, storage))
         {
+            // Reset mStarted so that package will get a new mStarttime when it repeats
+            mStarted = false;
             return true;
         }
 
@@ -301,6 +308,11 @@ namespace MWMechanics
         return false; // AiWander package not yet completed
     }
 
+    bool AiWander::getRepeat() const
+    { 
+         return mRepeat; 
+    }
+
     bool AiWander::isPackageCompleted(const MWWorld::Ptr& actor, AiWanderStorage& storage)
     {
         if (mDuration)
@@ -310,15 +322,8 @@ namespace MWMechanics
             if ((currentTime.getHour() >= mStartTime.getHour() + mDuration) ||
                 (int(currentTime.getHour()) == 0 && currentTime.getDay() != mStartTime.getDay()))
             {
-                if (!mRepeat)
-                {
                     stopWalking(actor, storage);
                     return true;
-                }
-                else
-                {
-                    mStartTime = currentTime;
-                }
             }
         }
         // if get here, not yet completed
@@ -501,8 +506,7 @@ namespace MWMechanics
                 }
             }
         }
-        // Recreate vanilla (broken?) behavior of resetting start time of AIWander:
-        mStartTime = MWBase::Environment::get().getWorld()->getTimeStamp();
+
         storage.setState(Wander_IdleNow);
     }
 

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -58,6 +58,8 @@ namespace MWMechanics
 
             virtual void fastForward(const MWWorld::Ptr& actor, AiState& state);
             
+            bool getRepeat() const;
+            
             enum GreetingState {
                 Greet_None,
                 Greet_InProgress,


### PR DESCRIPTION
Fixes for bug 3349.
https://bugs.openmw.org/issues/3349

Summary of the changes made

- Noncombat AI packages will be cycled instead of only run through once. The only exception is AIWander if passed with a "no repeat" flag through script or console.
- AIWander and AIFollow packages will end when their specified duration is up, instead of continuing forever.

Reasoning / motivation behind the change

Recreates AI cycling behavior from the original game. 

What testing you have carried out to verify the change

Tested in various situations in game. Patrolling NPCs at Dren Plantation, guard who escorts player in opening, AI commands given through console, and testaipackage.esp (in linked bug report.)