### PR TITLE
Fixing font scalability: Player stats window

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -42,7 +42,7 @@ add_openmw_dir (mwgui
     itemmodel containeritemmodel inventoryitemmodel sortfilteritemmodel itemview
     tradeitemmodel companionitemmodel pickpocketitemmodel controllers savegamedialog
     recharge mode videowidget backgroundimage itemwidget screenfader debugwindow spellmodel spellview
-    draganddrop timeadvancer jailscreen
+    draganddrop timeadvancer jailscreen textsizeutil
     )
 
 add_openmw_dir (mwdialogue

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -12,6 +12,7 @@
 #include "../mwworld/esmstore.hpp"
 
 #include "tooltips.hpp"
+#include "textsizeutil.hpp"
 
 namespace
 {
@@ -25,9 +26,6 @@ namespace
 
 namespace MWGui
 {
-
-    const int ReviewDialog::sLineHeight = 18;
-
     ReviewDialog::ReviewDialog()
         : WindowModal("openmw_chargen_review.layout")
     {
@@ -232,8 +230,8 @@ namespace MWGui
         groupWidget->setCaption(label);
         mSkillWidgets.push_back(groupWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        coord1.top += TextSizeUtil::getLineHeight();
+        coord2.top += TextSizeUtil::getLineHeight();
     }
 
     MyGUI::TextBox* ReviewDialog::addValueItem(const std::string& text, const std::string &value, const std::string& state, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2)
@@ -253,8 +251,8 @@ namespace MWGui
         mSkillWidgets.push_back(skillNameWidget);
         mSkillWidgets.push_back(skillValueWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        coord1.top += TextSizeUtil::getLineHeight();
+        coord2.top += TextSizeUtil::getLineHeight();
 
         return skillValueWidget;
     }
@@ -269,8 +267,8 @@ namespace MWGui
 
         mSkillWidgets.push_back(skillNameWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        coord1.top += TextSizeUtil::getLineHeight();
+        coord2.top += TextSizeUtil::getLineHeight();
     }
 
     void ReviewDialog::addSkills(const SkillList &skills, const std::string &titleId, const std::string &titleDefault, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2)

--- a/apps/openmw/mwgui/review.hpp
+++ b/apps/openmw/mwgui/review.hpp
@@ -77,8 +77,6 @@ namespace MWGui
         void addItem(const std::string& text, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2);
         void updateSkillArea();
 
-        static const int sLineHeight;
-
         MyGUI::TextBox *mNameWidget, *mRaceWidget, *mClassWidget, *mBirthSignWidget;
         MyGUI::ScrollView* mSkillView;
 

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -16,11 +16,10 @@
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/actorutil.hpp"
+#include "textsizeutil.hpp"
 
 namespace MWGui
 {
-    const int SpellBuyingWindow::sLineHeight = 18;
-
     SpellBuyingWindow::SpellBuyingWindow() :
         WindowBase("openmw_spell_buying_window.layout")
         , mLastPos(0)
@@ -60,15 +59,15 @@ namespace MWGui
                 0,
                 mCurrentY,
                 200,
-                sLineHeight,
+                TextSizeUtil::getLineHeight(),
                 MyGUI::Align::Default
             );
 
-        mCurrentY += sLineHeight;
+        mCurrentY += TextSizeUtil::getLineHeight();
 
         toAdd->setUserData(price);
         toAdd->setCaptionWithReplacing(spell->mName+"   -   "+MyGUI::utility::toString(price)+"#{sgp}");
-        toAdd->setSize(toAdd->getTextSize().width,sLineHeight);
+        toAdd->setSize(toAdd->getTextSize().width, TextSizeUtil::getLineHeight());
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &SpellBuyingWindow::onMouseWheel);
         toAdd->setUserString("ToolTipType", "Spell");
         toAdd->setUserString("Spell", spellId);

--- a/apps/openmw/mwgui/spellbuyingwindow.hpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.hpp
@@ -42,8 +42,6 @@ namespace MWGui
             void clearSpells();
             int mLastPos,mCurrentY;
 
-            static const int sLineHeight;
-
             void updateLabels();
 
             virtual void onReferenceUnavailable();

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -20,11 +20,10 @@
 
 #include "tooltips.hpp"
 #include <components/settings/settings.hpp>
+#include "textsizeutil.hpp"
 
 namespace MWGui
 {
-    int StatsWindow::sLineHeight = 18;
-
     StatsWindow::StatsWindow (DragAndDrop* drag)
       : WindowPinnableBase("openmw_stats_window.layout")
       , NoDrop(drag, mMainWidget)
@@ -42,9 +41,6 @@ namespace MWGui
       , mSkillWidgets()
       , mChanged(true)
     {
-        MyGUI::FontManager& fontMgr = MyGUI::FontManager::getInstance();
-        sLineHeight = fontMgr.getByName(fontMgr.getDefaultFont())->getDefaultHeight();
-
         setCoord(0,0,498, 342);
 
         const char *names[][2] =
@@ -316,8 +312,8 @@ namespace MWGui
         groupWidget->eventMouseWheel += MyGUI::newDelegate(this, &StatsWindow::onMouseWheel);
         mSkillWidgets.push_back(groupWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        coord1.top += TextSizeUtil::getLineHeight();
+        coord2.top += TextSizeUtil::getLineHeight();
     }
 
     MyGUI::TextBox* StatsWindow::addValueItem(const std::string& text, const std::string &value, const std::string& state, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2)
@@ -341,8 +337,8 @@ namespace MWGui
         mSkillWidgets.push_back(skillNameWidget);
         mSkillWidgets.push_back(skillValueWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        coord1.top += TextSizeUtil::getLineHeight();
+        coord2.top += TextSizeUtil::getLineHeight();
 
         return skillValueWidget;
     }
@@ -361,8 +357,8 @@ namespace MWGui
 
         mSkillWidgets.push_back(skillNameWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        coord1.top += TextSizeUtil::getLineHeight();
+        coord2.top += TextSizeUtil::getLineHeight();
 
         return skillNameWidget;
     }
@@ -448,7 +444,7 @@ namespace MWGui
         }
     }
 
-	void StatsWindow::updateHealthMagickaFatigue(MWBase::World *world)
+    void StatsWindow::updateHealthMagickaFatigue(MWBase::World *world)
     {
         static const char *HealthMagickaFatigueRowWidgets[] = { "Health", "Magicka", "Fatigue", NULL };
         static const char *widgetsToResize[] = { "Health", "Health_str", "HBar", "HBarT", "Magicka", "Magicka_str", "MBar", "MBarT",  "Fatigue", "Fatigue_str", "FBar", "FBarT", NULL };
@@ -459,13 +455,13 @@ namespace MWGui
         for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
         {
             getWidget(pWidget, widgetsToResize[iResize]);
-            resizeWidgetToLineHeight(pWidget);
+            TextSizeUtil::resizeWidgetToLineHeight(pWidget);
         }
 
         for (line = 0; HealthMagickaFatigueRowWidgets[line] != NULL; ++line)
         {
             getWidget(pWidget, HealthMagickaFatigueRowWidgets[line]);
-            moveWidgetToLine(pWidget, line);
+            TextSizeUtil::moveWidgetToLine(pWidget, line, sVerticalPadding);
             borderHeight += pWidget->getCoord().height;
         }
         borderHeight += (2 * sVerticalPadding);
@@ -493,18 +489,18 @@ namespace MWGui
         for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
         {
             getWidget(pWidget, widgetsToResize[iResize]);
-            resizeWidgetToLineHeight(pWidget);
+            TextSizeUtil::resizeWidgetToLineHeight(pWidget);
         }
 
         for (line = 0; LevelRaceClassRowWidgets[line] != NULL; ++line)
         {
             getWidget(pWidget, LevelRaceClassRowWidgets[line]);
-            moveWidgetToLine(pWidget, line);
+            TextSizeUtil::moveWidgetToLine(pWidget, line, sVerticalPadding);
             borderHeight += pWidget->getCoord().height;
         }
 
         borderHeight += (2 * sVerticalPadding);
-		
+
         getWidget(pWidget, "RaceText");
         ToolTips::createRaceToolTip(pWidget, playerRace);
         getWidget(pWidget, "Race_str");
@@ -534,17 +530,18 @@ namespace MWGui
 
         int line = 0, iWidget = 0;
 
-        for (line = 0; AttributeRowWidgets[line] != NULL; ++line)
-        {
-            getWidget(pWidget, AttributeRowWidgets[line]);
-            moveWidgetToLine(pWidget, line);
-        }
-
         for (iWidget = 0; widgetsToResize[iWidget] != NULL; ++iWidget)
         {
             getWidget(pWidget, widgetsToResize[iWidget]);
-            resizeWidgetToLineHeight(pWidget);
+            TextSizeUtil::resizeWidgetToLineHeight(pWidget);
         }
+
+        for (line = 0; AttributeRowWidgets[line] != NULL; ++line)
+        {
+            getWidget(pWidget, AttributeRowWidgets[line]);
+            TextSizeUtil::moveWidgetToLine(pWidget, line, sVerticalPadding);
+        }
+
         const MyGUI::IntCoord &attribCoord = pAttributeWidget->getCoord();
         int top = pHealthMagickaStaminaWidget->getCoord().height + pLevelRaceClassWidget->getCoord().height + (3 * sVerticalMargin);
         int heightDiff = top - attribCoord.top;
@@ -552,24 +549,9 @@ namespace MWGui
         pAttributeWidget->setCoord(attribCoord.left, top, attribCoord.width, attribCoord.height - heightDiff);
     }
 
-    void StatsWindow::resizeWidgetToLineHeight(MyGUI::Widget *widget)
-    {
-        if (widget == NULL) return;
-        const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+    
 
-        widget->setCoord(baseCoordinates.left, baseCoordinates.top, baseCoordinates.width, sLineHeight);
-    }
-
-    void StatsWindow::moveWidgetToLine(MyGUI::Widget *widget, int lineNumber)
-    {
-        if (widget == NULL) return;
-
-        int top = 0;
-        const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
-        top = (lineNumber*sLineHeight) + sVerticalPadding;
-
-        widget->setCoord(baseCoordinates.left, top, baseCoordinates.width, baseCoordinates.height);
-    }
+    
 
     void StatsWindow::updateSkillArea()
     {
@@ -582,8 +564,8 @@ namespace MWGui
         mSkillWidgets.clear();
 
         const int valueSize = 40;
-        MyGUI::IntCoord coord1(10, 0, mSkillView->getWidth() - (10 + valueSize) - 24, sLineHeight);
-        MyGUI::IntCoord coord2(coord1.left + coord1.width, coord1.top, valueSize, sLineHeight);
+        MyGUI::IntCoord coord1(10, 0, mSkillView->getWidth() - (10 + valueSize) - 24, TextSizeUtil::getLineHeight());
+        MyGUI::IntCoord coord2(coord1.left + coord1.width, coord1.top, valueSize, TextSizeUtil::getLineHeight());
 
         if (!mMajorSkills.empty())
             addSkills(mMajorSkills, "sSkillClassMajor", "Major Skills", coord1, coord2);

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -19,11 +19,11 @@
 #include "../mwmechanics/actorutil.hpp"
 
 #include "tooltips.hpp"
+#include <components/settings/settings.hpp>
 
 namespace MWGui
 {
-
-	int StatsWindow::sLineHeight = 18;
+    int StatsWindow::sLineHeight = 18;
 
     StatsWindow::StatsWindow (DragAndDrop* drag)
       : WindowPinnableBase("openmw_stats_window.layout")
@@ -42,8 +42,9 @@ namespace MWGui
       , mSkillWidgets()
       , mChanged(true)
     {
-		MyGUI::FontManager& fontMgr = MyGUI::FontManager::getInstance();
-		sLineHeight = fontMgr.getByName(fontMgr.getDefaultFont())->getDefaultHeight();
+        MyGUI::FontManager& fontMgr = MyGUI::FontManager::getInstance();
+        sLineHeight = fontMgr.getByName(fontMgr.getDefaultFont())->getDefaultHeight();
+
         setCoord(0,0,498, 342);
 
         const char *names[][2] =
@@ -449,125 +450,125 @@ namespace MWGui
 
 	void StatsWindow::updateHealthMagickaFatigue(MWBase::World *world)
     {
-		static const char *HealthMagickaFatigueRowWidgets[] = { "Health", "Magicka", "Fatigue", NULL };
-		static const char *widgetsToResize[] = { "Health", "Health_str", "HBar", "HBarT", "Magicka", "Magicka_str", "MBar", "MBarT",  "Fatigue", "Fatigue_str", "FBar", "FBarT", NULL };
-		MyGUI::Widget *pWidget;
-		int line = 0, iResize = 0;
-		int borderHeight = 0;
+        static const char *HealthMagickaFatigueRowWidgets[] = { "Health", "Magicka", "Fatigue", NULL };
+        static const char *widgetsToResize[] = { "Health", "Health_str", "HBar", "HBarT", "Magicka", "Magicka_str", "MBar", "MBarT",  "Fatigue", "Fatigue_str", "FBar", "FBarT", NULL };
+        MyGUI::Widget *pWidget;
+        int line = 0, iResize = 0;
+        int borderHeight = 0;
 
-		for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
-		{
-			getWidget(pWidget, widgetsToResize[iResize]);
-			resizeWidgetToLineHeight(pWidget);
-		}
+        for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
+        {
+            getWidget(pWidget, widgetsToResize[iResize]);
+            resizeWidgetToLineHeight(pWidget);
+        }
 
-		for (line = 0; HealthMagickaFatigueRowWidgets[line] != NULL; ++line)
-		{
-			getWidget(pWidget, HealthMagickaFatigueRowWidgets[line]);
-			moveWidgetToLine(pWidget, line);
-			borderHeight += pWidget->getCoord().height;
-		}
-		borderHeight += (2 * sVerticalPadding);
+        for (line = 0; HealthMagickaFatigueRowWidgets[line] != NULL; ++line)
+        {
+            getWidget(pWidget, HealthMagickaFatigueRowWidgets[line]);
+            moveWidgetToLine(pWidget, line);
+            borderHeight += pWidget->getCoord().height;
+        }
+        borderHeight += (2 * sVerticalPadding);
 
-		getWidget(pWidget, "HealthMagickaFatigueBorder");
-		const MyGUI::IntCoord &baseCoords = pWidget->getCoord();
-		pWidget->setCoord(baseCoords.left, baseCoords.top, baseCoords.width, borderHeight);
+        getWidget(pWidget, "HealthMagickaFatigueBorder");
+        const MyGUI::IntCoord &baseCoords = pWidget->getCoord();
+        pWidget->setCoord(baseCoords.left, baseCoords.top, baseCoords.width, borderHeight);
     }
 
-	void StatsWindow::updateLevelRaceClass(MWBase::World *world)
+    void StatsWindow::updateLevelRaceClass(MWBase::World *world)
     {
-		static const char *LevelRaceClassRowWidgets[] = { "Level", "Race", "Class", NULL };
-		static const char *widgetsToResize[] = { "Level", "Level_str", "LevelText", "Race", "Race_str", "RaceText", "Class", "Class_str", "ClassText", NULL };
-		const MWWorld::ESMStore &store = world->getStore();
-		const ESM::NPC *player = world->getPlayerPtr().get<ESM::NPC>()->mBase;
-		const ESM::Race* playerRace = store.get<ESM::Race>().find(player->mRace);
-		const ESM::Class *playerClass = store.get<ESM::Class>().find(player->mClass);
-		int borderHeight = 0;
-		int borderTop = 0;
+        static const char *LevelRaceClassRowWidgets[] = { "Level", "Race", "Class", NULL };
+        static const char *widgetsToResize[] = { "Level", "Level_str", "LevelText", "Race", "Race_str", "RaceText", "Class", "Class_str", "ClassText", NULL };
+        const MWWorld::ESMStore &store = world->getStore();
+        const ESM::NPC *player = world->getPlayerPtr().get<ESM::NPC>()->mBase;
+        const ESM::Race* playerRace = store.get<ESM::Race>().find(player->mRace);
+        const ESM::Class *playerClass = store.get<ESM::Class>().find(player->mClass);
+        int borderHeight = 0;
+        int borderTop = 0;
 
-		MyGUI::Widget *pWidget, *pHealthMagickaFatiqueWidget;
+        MyGUI::Widget *pWidget, *pHealthMagickaFatiqueWidget;
 
-		int line = 0, iResize = 0;
+        int line = 0, iResize = 0;
 
-		for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
-		{
-			getWidget(pWidget, widgetsToResize[iResize]);
-			resizeWidgetToLineHeight(pWidget);
-		}
+        for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
+        {
+            getWidget(pWidget, widgetsToResize[iResize]);
+            resizeWidgetToLineHeight(pWidget);
+        }
 
-		for (line = 0; LevelRaceClassRowWidgets[line] != NULL; ++line)
-		{
-			getWidget(pWidget, LevelRaceClassRowWidgets[line]);
-			moveWidgetToLine(pWidget, line);
-			borderHeight += pWidget->getCoord().height;
-		}
+        for (line = 0; LevelRaceClassRowWidgets[line] != NULL; ++line)
+        {
+            getWidget(pWidget, LevelRaceClassRowWidgets[line]);
+            moveWidgetToLine(pWidget, line);
+            borderHeight += pWidget->getCoord().height;
+        }
 
-		borderHeight += (2 * sVerticalPadding);
+        borderHeight += (2 * sVerticalPadding);
 		
-		getWidget(pWidget, "RaceText");
-		ToolTips::createRaceToolTip(pWidget, playerRace);
-		getWidget(pWidget, "Race_str");
-		ToolTips::createRaceToolTip(pWidget, playerRace);
+        getWidget(pWidget, "RaceText");
+        ToolTips::createRaceToolTip(pWidget, playerRace);
+        getWidget(pWidget, "Race_str");
+        ToolTips::createRaceToolTip(pWidget, playerRace);
 
-		getWidget(pWidget, "ClassText");
-		ToolTips::createClassToolTip(pWidget, *playerClass);
-		getWidget(pWidget, "Class_str");
-		ToolTips::createClassToolTip(pWidget, *playerClass);
+        getWidget(pWidget, "ClassText");
+        ToolTips::createClassToolTip(pWidget, *playerClass);
+        getWidget(pWidget, "Class_str");
+        ToolTips::createClassToolTip(pWidget, *playerClass);
 
-		getWidget(pHealthMagickaFatiqueWidget, "HealthMagickaFatigueBorder");
-		getWidget(pWidget, "LevelRaceClassBorder");
-		const MyGUI::IntCoord &oldCoords = pWidget->getCoord();
-		MyGUI::IntCoord borderCoords(oldCoords.left, pHealthMagickaFatiqueWidget->getCoord().height+(2*sVerticalMargin), oldCoords.width, borderHeight);
-		pWidget->setCoord(borderCoords);
-	}
-
-	void StatsWindow::updateAttributes()
-	{
-		static const char *AttributeRowWidgets[] = { "Attrib1Box", "Attrib2Box", "Attrib3Box", "Attrib4Box", "Attrib5Box", "Attrib6Box", "Attrib7Box", "Attrib8Box", NULL };
-		static const char *widgetsToResize[] = { "Attrib1Box", "Attrib1", "AttribVal1", "Attrib2Box", "Attrib2", "AttribVal2", "Attrib3Box", "Attrib3", "AttribVal3", "Attrib4Box", "Attrib4", "AttribVal4", "Attrib5Box", "Attrib5", "AttribVal5", "Attrib6Box", "Attrib6", "AttribVal6", "Attrib7Box", "Attrib7", "AttribVal7", "Attrib8Box", "Attrib8", "AttribVal8", NULL };
-		MyGUI::Widget *pHealthMagickaStaminaWidget, *pLevelRaceClassWidget, *pAttributeWidget, *pWidget;
-
-		getWidget(pHealthMagickaStaminaWidget, "HealthMagickaFatigueBorder");
-		getWidget(pLevelRaceClassWidget, "LevelRaceClassBorder");
-		getWidget(pAttributeWidget, "AttributeBorder");
-
-		int line = 0, iWidget = 0;
-
-		for (line = 0; AttributeRowWidgets[line] != NULL; ++line)
-		{
-			getWidget(pWidget, AttributeRowWidgets[line]);
-			moveWidgetToLine(pWidget, line);
-		}
-
-		for (iWidget = 0; widgetsToResize[iWidget] != NULL; ++iWidget)
-		{
-			getWidget(pWidget, widgetsToResize[iWidget]);
-			resizeWidgetToLineHeight(pWidget);
-		}
-		const MyGUI::IntCoord &attribCoord = pAttributeWidget->getCoord();
-		int top = pHealthMagickaStaminaWidget->getCoord().height + pLevelRaceClassWidget->getCoord().height + (3 * sVerticalMargin);
-		int heightDiff = top - attribCoord.top;
-
-		pAttributeWidget->setCoord(attribCoord.left, top, attribCoord.width, attribCoord.height - heightDiff);
-	}
-
-	void StatsWindow::resizeWidgetToLineHeight(MyGUI::Widget *widget)
-    {
-		if (widget == NULL) return;
-		const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
-
-		widget->setCoord(baseCoordinates.left, baseCoordinates.top, baseCoordinates.width, sLineHeight);
+        getWidget(pHealthMagickaFatiqueWidget, "HealthMagickaFatigueBorder");
+        getWidget(pWidget, "LevelRaceClassBorder");
+        const MyGUI::IntCoord &oldCoords = pWidget->getCoord();
+        MyGUI::IntCoord borderCoords(oldCoords.left, pHealthMagickaFatiqueWidget->getCoord().height+(2*sVerticalMargin), oldCoords.width, borderHeight);
+        pWidget->setCoord(borderCoords);
     }
 
-	void StatsWindow::moveWidgetToLine(MyGUI::Widget *widget, int lineNumber)
+    void StatsWindow::updateAttributes()
     {
-		if (widget == NULL) return;
+        static const char *AttributeRowWidgets[] = { "Attrib1Box", "Attrib2Box", "Attrib3Box", "Attrib4Box", "Attrib5Box", "Attrib6Box", "Attrib7Box", "Attrib8Box", NULL };
+        static const char *widgetsToResize[] = { "Attrib1Box", "Attrib1", "AttribVal1", "Attrib2Box", "Attrib2", "AttribVal2", "Attrib3Box", "Attrib3", "AttribVal3", "Attrib4Box", "Attrib4", "AttribVal4", "Attrib5Box", "Attrib5", "AttribVal5", "Attrib6Box", "Attrib6", "AttribVal6", "Attrib7Box", "Attrib7", "AttribVal7", "Attrib8Box", "Attrib8", "AttribVal8", NULL };
+        MyGUI::Widget *pHealthMagickaStaminaWidget, *pLevelRaceClassWidget, *pAttributeWidget, *pWidget;
 
-		int top = 0;
-		const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
-		top = (lineNumber*sLineHeight) + sVerticalPadding;
+        getWidget(pHealthMagickaStaminaWidget, "HealthMagickaFatigueBorder");
+        getWidget(pLevelRaceClassWidget, "LevelRaceClassBorder");
+        getWidget(pAttributeWidget, "AttributeBorder");
 
-		widget->setCoord(baseCoordinates.left, top, baseCoordinates.width, baseCoordinates.height);
+        int line = 0, iWidget = 0;
+
+        for (line = 0; AttributeRowWidgets[line] != NULL; ++line)
+        {
+            getWidget(pWidget, AttributeRowWidgets[line]);
+            moveWidgetToLine(pWidget, line);
+        }
+
+        for (iWidget = 0; widgetsToResize[iWidget] != NULL; ++iWidget)
+        {
+            getWidget(pWidget, widgetsToResize[iWidget]);
+            resizeWidgetToLineHeight(pWidget);
+        }
+        const MyGUI::IntCoord &attribCoord = pAttributeWidget->getCoord();
+        int top = pHealthMagickaStaminaWidget->getCoord().height + pLevelRaceClassWidget->getCoord().height + (3 * sVerticalMargin);
+        int heightDiff = top - attribCoord.top;
+
+        pAttributeWidget->setCoord(attribCoord.left, top, attribCoord.width, attribCoord.height - heightDiff);
+    }
+
+    void StatsWindow::resizeWidgetToLineHeight(MyGUI::Widget *widget)
+    {
+        if (widget == NULL) return;
+        const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+
+        widget->setCoord(baseCoordinates.left, baseCoordinates.top, baseCoordinates.width, sLineHeight);
+    }
+
+    void StatsWindow::moveWidgetToLine(MyGUI::Widget *widget, int lineNumber)
+    {
+        if (widget == NULL) return;
+
+        int top = 0;
+        const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+        top = (lineNumber*sLineHeight) + sVerticalPadding;
+
+        widget->setCoord(baseCoordinates.left, top, baseCoordinates.width, baseCoordinates.height);
     }
 
     void StatsWindow::updateSkillArea()
@@ -593,12 +594,12 @@ namespace MWGui
         if (!mMiscSkills.empty())
             addSkills(mMiscSkills, "sSkillClassMisc", "Misc Skills", coord1, coord2);
 
-		MWBase::World *world = MWBase::Environment::get().getWorld();
-		const MWWorld::ESMStore &store = world->getStore();
+        MWBase::World *world = MWBase::Environment::get().getWorld();
+        const MWWorld::ESMStore &store = world->getStore();
 
-		StatsWindow::updateLevelRaceClass(world);
-		StatsWindow::updateHealthMagickaFatigue(world);
-		StatsWindow::updateAttributes();
+        StatsWindow::updateLevelRaceClass(world);
+        StatsWindow::updateHealthMagickaFatigue(world);
+        StatsWindow::updateAttributes();
 
         if (!mFactions.empty())
         {

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -5,6 +5,7 @@
 #include <MyGUI_ProgressBar.h>
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_Gui.h>
+#include <MyGUI_FontManager.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -22,7 +23,7 @@
 namespace MWGui
 {
 
-    const int StatsWindow::sLineHeight = 18;
+	int StatsWindow::sLineHeight = 18;
 
     StatsWindow::StatsWindow (DragAndDrop* drag)
       : WindowPinnableBase("openmw_stats_window.layout")
@@ -41,6 +42,8 @@ namespace MWGui
       , mSkillWidgets()
       , mChanged(true)
     {
+		MyGUI::FontManager& fontMgr = MyGUI::FontManager::getInstance();
+		sLineHeight = fontMgr.getByName(fontMgr.getDefaultFont())->getDefaultHeight();
         setCoord(0,0,498, 342);
 
         const char *names[][2] =
@@ -444,6 +447,129 @@ namespace MWGui
         }
     }
 
+	void StatsWindow::updateHealthMagickaFatigue(MWBase::World *world)
+    {
+		static const char *HealthMagickaFatigueRowWidgets[] = { "Health", "Magicka", "Fatigue", NULL };
+		static const char *widgetsToResize[] = { "Health", "Health_str", "HBar", "HBarT", "Magicka", "Magicka_str", "MBar", "MBarT",  "Fatigue", "Fatigue_str", "FBar", "FBarT", NULL };
+		MyGUI::Widget *pWidget;
+		int line = 0, iResize = 0;
+		int borderHeight = 0;
+
+		for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
+		{
+			getWidget(pWidget, widgetsToResize[iResize]);
+			resizeWidgetToLineHeight(pWidget);
+		}
+
+		for (line = 0; HealthMagickaFatigueRowWidgets[line] != NULL; ++line)
+		{
+			getWidget(pWidget, HealthMagickaFatigueRowWidgets[line]);
+			moveWidgetToLine(pWidget, line);
+			borderHeight += pWidget->getCoord().height;
+		}
+		borderHeight += (2 * sVerticalPadding);
+
+		getWidget(pWidget, "HealthMagickaFatigueBorder");
+		const MyGUI::IntCoord &baseCoords = pWidget->getCoord();
+		pWidget->setCoord(baseCoords.left, baseCoords.top, baseCoords.width, borderHeight);
+    }
+
+	void StatsWindow::updateLevelRaceClass(MWBase::World *world)
+    {
+		static const char *LevelRaceClassRowWidgets[] = { "Level", "Race", "Class", NULL };
+		static const char *widgetsToResize[] = { "Level", "Level_str", "LevelText", "Race", "Race_str", "RaceText", "Class", "Class_str", "ClassText", NULL };
+		const MWWorld::ESMStore &store = world->getStore();
+		const ESM::NPC *player = world->getPlayerPtr().get<ESM::NPC>()->mBase;
+		const ESM::Race* playerRace = store.get<ESM::Race>().find(player->mRace);
+		const ESM::Class *playerClass = store.get<ESM::Class>().find(player->mClass);
+		int borderHeight = 0;
+		int borderTop = 0;
+
+		MyGUI::Widget *pWidget, *pHealthMagickaFatiqueWidget;
+
+		int line = 0, iResize = 0;
+
+		for(iResize = 0; widgetsToResize[iResize] != NULL; ++iResize)
+		{
+			getWidget(pWidget, widgetsToResize[iResize]);
+			resizeWidgetToLineHeight(pWidget);
+		}
+
+		for (line = 0; LevelRaceClassRowWidgets[line] != NULL; ++line)
+		{
+			getWidget(pWidget, LevelRaceClassRowWidgets[line]);
+			moveWidgetToLine(pWidget, line);
+			borderHeight += pWidget->getCoord().height;
+		}
+
+		borderHeight += (2 * sVerticalPadding);
+		
+		getWidget(pWidget, "RaceText");
+		ToolTips::createRaceToolTip(pWidget, playerRace);
+		getWidget(pWidget, "Race_str");
+		ToolTips::createRaceToolTip(pWidget, playerRace);
+
+		getWidget(pWidget, "ClassText");
+		ToolTips::createClassToolTip(pWidget, *playerClass);
+		getWidget(pWidget, "Class_str");
+		ToolTips::createClassToolTip(pWidget, *playerClass);
+
+		getWidget(pHealthMagickaFatiqueWidget, "HealthMagickaFatigueBorder");
+		getWidget(pWidget, "LevelRaceClassBorder");
+		const MyGUI::IntCoord &oldCoords = pWidget->getCoord();
+		MyGUI::IntCoord borderCoords(oldCoords.left, pHealthMagickaFatiqueWidget->getCoord().height+(2*sVerticalMargin), oldCoords.width, borderHeight);
+		pWidget->setCoord(borderCoords);
+	}
+
+	void StatsWindow::updateAttributes()
+	{
+		static const char *AttributeRowWidgets[] = { "Attrib1Box", "Attrib2Box", "Attrib3Box", "Attrib4Box", "Attrib5Box", "Attrib6Box", "Attrib7Box", "Attrib8Box", NULL };
+		static const char *widgetsToResize[] = { "Attrib1Box", "Attrib1", "AttribVal1", "Attrib2Box", "Attrib2", "AttribVal2", "Attrib3Box", "Attrib3", "AttribVal3", "Attrib4Box", "Attrib4", "AttribVal4", "Attrib5Box", "Attrib5", "AttribVal5", "Attrib6Box", "Attrib6", "AttribVal6", "Attrib7Box", "Attrib7", "AttribVal7", "Attrib8Box", "Attrib8", "AttribVal8", NULL };
+		MyGUI::Widget *pHealthMagickaStaminaWidget, *pLevelRaceClassWidget, *pAttributeWidget, *pWidget;
+
+		getWidget(pHealthMagickaStaminaWidget, "HealthMagickaFatigueBorder");
+		getWidget(pLevelRaceClassWidget, "LevelRaceClassBorder");
+		getWidget(pAttributeWidget, "AttributeBorder");
+
+		int line = 0, iWidget = 0;
+
+		for (line = 0; AttributeRowWidgets[line] != NULL; ++line)
+		{
+			getWidget(pWidget, AttributeRowWidgets[line]);
+			moveWidgetToLine(pWidget, line);
+		}
+
+		for (iWidget = 0; widgetsToResize[iWidget] != NULL; ++iWidget)
+		{
+			getWidget(pWidget, widgetsToResize[iWidget]);
+			resizeWidgetToLineHeight(pWidget);
+		}
+		const MyGUI::IntCoord &attribCoord = pAttributeWidget->getCoord();
+		int top = pHealthMagickaStaminaWidget->getCoord().height + pLevelRaceClassWidget->getCoord().height + (3 * sVerticalMargin);
+		int heightDiff = top - attribCoord.top;
+
+		pAttributeWidget->setCoord(attribCoord.left, top, attribCoord.width, attribCoord.height - heightDiff);
+	}
+
+	void StatsWindow::resizeWidgetToLineHeight(MyGUI::Widget *widget)
+    {
+		if (widget == NULL) return;
+		const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+
+		widget->setCoord(baseCoordinates.left, baseCoordinates.top, baseCoordinates.width, sLineHeight);
+    }
+
+	void StatsWindow::moveWidgetToLine(MyGUI::Widget *widget, int lineNumber)
+    {
+		if (widget == NULL) return;
+
+		int top = 0;
+		const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+		top = (lineNumber*sLineHeight) + sVerticalPadding;
+
+		widget->setCoord(baseCoordinates.left, top, baseCoordinates.width, baseCoordinates.height);
+    }
+
     void StatsWindow::updateSkillArea()
     {
         mChanged = false;
@@ -455,8 +581,8 @@ namespace MWGui
         mSkillWidgets.clear();
 
         const int valueSize = 40;
-        MyGUI::IntCoord coord1(10, 0, mSkillView->getWidth() - (10 + valueSize) - 24, 18);
-        MyGUI::IntCoord coord2(coord1.left + coord1.width, coord1.top, valueSize, coord1.height);
+        MyGUI::IntCoord coord1(10, 0, mSkillView->getWidth() - (10 + valueSize) - 24, sLineHeight);
+        MyGUI::IntCoord coord2(coord1.left + coord1.width, coord1.top, valueSize, sLineHeight);
 
         if (!mMajorSkills.empty())
             addSkills(mMajorSkills, "sSkillClassMajor", "Major Skills", coord1, coord2);
@@ -467,30 +593,12 @@ namespace MWGui
         if (!mMiscSkills.empty())
             addSkills(mMiscSkills, "sSkillClassMisc", "Misc Skills", coord1, coord2);
 
-        MWBase::World *world = MWBase::Environment::get().getWorld();
-        const MWWorld::ESMStore &store = world->getStore();
-        const ESM::NPC *player =
-            world->getPlayerPtr().get<ESM::NPC>()->mBase;
+		MWBase::World *world = MWBase::Environment::get().getWorld();
+		const MWWorld::ESMStore &store = world->getStore();
 
-        // race tooltip
-        const ESM::Race* playerRace = store.get<ESM::Race>().find(player->mRace);
-
-        MyGUI::Widget* raceWidget;
-        getWidget(raceWidget, "RaceText");
-        ToolTips::createRaceToolTip(raceWidget, playerRace);
-        getWidget(raceWidget, "Race_str");
-        ToolTips::createRaceToolTip(raceWidget, playerRace);
-
-        // class tooltip
-        MyGUI::Widget* classWidget;
-
-        const ESM::Class *playerClass =
-            store.get<ESM::Class>().find(player->mClass);
-
-        getWidget(classWidget, "ClassText");
-        ToolTips::createClassToolTip(classWidget, *playerClass);
-        getWidget(classWidget, "Class_str");
-        ToolTips::createClassToolTip(classWidget, *playerClass);
+		StatsWindow::updateLevelRaceClass(world);
+		StatsWindow::updateHealthMagickaFatigue(world);
+		StatsWindow::updateAttributes();
 
         if (!mFactions.empty())
         {

--- a/apps/openmw/mwgui/statswindow.hpp
+++ b/apps/openmw/mwgui/statswindow.hpp
@@ -6,6 +6,14 @@
 
 #include <components/esm/loadskil.hpp>
 
+namespace MWBase {
+	class World;
+}
+
+namespace MWWorld {
+	class ESMStore;
+}
+
 namespace MWGui
 {
     class WindowManager;
@@ -35,7 +43,14 @@ namespace MWGui
             void configureSkills (const SkillList& major, const SkillList& minor);
             void setReputation (int reputation) { if (reputation != mReputation) mChanged = true; this->mReputation = reputation; }
             void setBounty (int bounty) { if (bounty != mBounty) mChanged = true; this->mBounty = bounty; }
-            void updateSkillArea();
+
+			void updateHealthMagickaFatigue(MWBase::World *world);
+
+			void updateLevelRaceClass(MWBase::World *world);
+			void resizeWidgetToLineHeight(MyGUI::Widget * widget);
+			void moveWidgetToLine(MyGUI::Widget * widget, int lineNumber);
+			void updateAttributes();
+			void updateSkillArea();
 
             virtual void open() { onWindowResize(mMainWidget->castType<MyGUI::Window>()); }
 
@@ -53,7 +68,9 @@ namespace MWGui
             void onWindowResize(MyGUI::Window* window);
             void onMouseWheel(MyGUI::Widget* _sender, int _rel);
 
-            static const int sLineHeight;
+            static int sLineHeight;
+			const static int sVerticalPadding = 4; // distance between the MW_Box border and the child widgets
+			const static int sVerticalMargin = 8; // distance between MW_Box widgets
 
             MyGUI::Widget* mLeftPane;
             MyGUI::Widget* mRightPane;

--- a/apps/openmw/mwgui/statswindow.hpp
+++ b/apps/openmw/mwgui/statswindow.hpp
@@ -45,10 +45,7 @@ namespace MWGui
             void setBounty (int bounty) { if (bounty != mBounty) mChanged = true; this->mBounty = bounty; }
 
             void updateHealthMagickaFatigue(MWBase::World *world);
-
             void updateLevelRaceClass(MWBase::World *world);
-            void resizeWidgetToLineHeight(MyGUI::Widget * widget);
-            void moveWidgetToLine(MyGUI::Widget * widget, int lineNumber);
             void updateAttributes();
             void updateSkillArea();
 
@@ -68,7 +65,6 @@ namespace MWGui
             void onWindowResize(MyGUI::Window* window);
             void onMouseWheel(MyGUI::Widget* _sender, int _rel);
 
-            static int sLineHeight;
             const static int sVerticalPadding = 4; // distance between the MW_Box border and the child widgets
             const static int sVerticalMargin = 8; // distance between MW_Box widgets
 

--- a/apps/openmw/mwgui/statswindow.hpp
+++ b/apps/openmw/mwgui/statswindow.hpp
@@ -7,11 +7,11 @@
 #include <components/esm/loadskil.hpp>
 
 namespace MWBase {
-	class World;
+    class World;
 }
 
 namespace MWWorld {
-	class ESMStore;
+    class ESMStore;
 }
 
 namespace MWGui
@@ -44,13 +44,13 @@ namespace MWGui
             void setReputation (int reputation) { if (reputation != mReputation) mChanged = true; this->mReputation = reputation; }
             void setBounty (int bounty) { if (bounty != mBounty) mChanged = true; this->mBounty = bounty; }
 
-			void updateHealthMagickaFatigue(MWBase::World *world);
+            void updateHealthMagickaFatigue(MWBase::World *world);
 
-			void updateLevelRaceClass(MWBase::World *world);
-			void resizeWidgetToLineHeight(MyGUI::Widget * widget);
-			void moveWidgetToLine(MyGUI::Widget * widget, int lineNumber);
-			void updateAttributes();
-			void updateSkillArea();
+            void updateLevelRaceClass(MWBase::World *world);
+            void resizeWidgetToLineHeight(MyGUI::Widget * widget);
+            void moveWidgetToLine(MyGUI::Widget * widget, int lineNumber);
+            void updateAttributes();
+            void updateSkillArea();
 
             virtual void open() { onWindowResize(mMainWidget->castType<MyGUI::Window>()); }
 
@@ -69,8 +69,8 @@ namespace MWGui
             void onMouseWheel(MyGUI::Widget* _sender, int _rel);
 
             static int sLineHeight;
-			const static int sVerticalPadding = 4; // distance between the MW_Box border and the child widgets
-			const static int sVerticalMargin = 8; // distance between MW_Box widgets
+            const static int sVerticalPadding = 4; // distance between the MW_Box border and the child widgets
+            const static int sVerticalMargin = 8; // distance between MW_Box widgets
 
             MyGUI::Widget* mLeftPane;
             MyGUI::Widget* mRightPane;

--- a/apps/openmw/mwgui/textsizeutil.cpp
+++ b/apps/openmw/mwgui/textsizeutil.cpp
@@ -1,0 +1,54 @@
+#include "textsizeutil.hpp"
+
+#include <MyGUI_Widget.h>
+#include <MyGUI_FontManager.h>
+
+namespace MWGui
+{
+    int TextSizeUtil::sLineHeight = 0;
+
+    int TextSizeUtil::getLineHeight()
+    {
+        if(sLineHeight == 0)
+            sLineHeight = getHeightOfDefaultFont();
+
+        return sLineHeight;
+    }
+
+    void TextSizeUtil::resizeWidgetToLineHeight(MyGUI::Widget *widget)
+    {
+        if (widget == NULL) return;
+        const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+
+        widget->setCoord(baseCoordinates.left, baseCoordinates.top, baseCoordinates.width, getLineHeight());
+    }
+
+    void TextSizeUtil::moveWidgetToLine(MyGUI::Widget *widget, int lineNumber, int padding)
+    {
+        if (widget == NULL) return;
+
+        int top = 0;
+        const MyGUI::IntCoord &baseCoordinates = widget->getCoord();
+        top = (lineNumber*getLineHeight()) + padding;
+
+        widget->setCoord(baseCoordinates.left, top, baseCoordinates.width, baseCoordinates.height);
+    }
+
+    int TextSizeUtil::getHeightOfDefaultFont()
+    {
+        MyGUI::FontManager& fontMgr = MyGUI::FontManager::getInstance();
+        int result = fontMgr.getByName(fontMgr.getDefaultFont())->getDefaultHeight();
+        std::cout << "Using font height: " << result << std::endl;
+        return result;
+    }
+
+    TextSizeUtil::TextSizeUtil()
+    {
+        
+    }
+    TextSizeUtil::~TextSizeUtil()
+    {
+        
+    }
+}
+

--- a/apps/openmw/mwgui/textsizeutil.hpp
+++ b/apps/openmw/mwgui/textsizeutil.hpp
@@ -1,0 +1,24 @@
+#ifndef MWGUI_TEXTSIZEUTIL_H
+#define MWGUI_TEXTSIZEUTIL_H
+#pragma once
+namespace MyGUI {
+    class Widget;
+}
+
+namespace MWGui
+{
+    class TextSizeUtil
+    {
+    public:
+        static int getLineHeight();
+        static void resizeWidgetToLineHeight(MyGUI::Widget * widget);
+        static void moveWidgetToLine(MyGUI::Widget * widget, int lineNumber, int padding);
+    private:
+        static int sLineHeight;
+        static int getHeightOfDefaultFont();
+        TextSizeUtil();
+        ~TextSizeUtil();
+    };
+}
+
+#endif

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -19,11 +19,10 @@
 #include "../mwworld/actionteleport.hpp"
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/cellstore.hpp"
+#include "textsizeutil.hpp"
 
 namespace MWGui
 {
-    const int TravelWindow::sLineHeight = 18;
-
     TravelWindow::TravelWindow() :
         WindowBase("openmw_travel_window.layout")
         , mCurrentY(0)
@@ -76,9 +75,9 @@ namespace MWGui
 
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr,price,true);
 
-        MyGUI::Button* toAdd = mDestinationsView->createWidget<MyGUI::Button>("SandTextButton", 0, mCurrentY, 200, sLineHeight, MyGUI::Align::Default);
+        MyGUI::Button* toAdd = mDestinationsView->createWidget<MyGUI::Button>("SandTextButton", 0, mCurrentY, 200, TextSizeUtil::getLineHeight(), MyGUI::Align::Default);
         toAdd->setEnabled(price<=playerGold);
-        mCurrentY += sLineHeight;
+        mCurrentY += TextSizeUtil::getLineHeight();
         if(interior)
             toAdd->setUserString("interior","y");
         else
@@ -89,7 +88,7 @@ namespace MWGui
         toAdd->setUserString("price",oss.str());
 
         toAdd->setCaptionWithReplacing("#{sCell=" + name + "}   -   " + MyGUI::utility::toString(price)+"#{sgp}");
-        toAdd->setSize(toAdd->getTextSize().width,sLineHeight);
+        toAdd->setSize(toAdd->getTextSize().width, TextSizeUtil::getLineHeight());
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &TravelWindow::onMouseWheel);
         toAdd->setUserString("Destination", name);
         toAdd->setUserData(pos);

--- a/apps/openmw/mwgui/travelwindow.hpp
+++ b/apps/openmw/mwgui/travelwindow.hpp
@@ -43,8 +43,6 @@ namespace MWGui
             void clearDestinations();
             int mCurrentY;
 
-            static const int sLineHeight;
-
             void updateLabels();
 
             virtual void onReferenceUnavailable();

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -499,6 +499,10 @@ namespace MWGui
 
     std::string mVersionDescription;
 
+    // these handle*Tag methods are called inside onRetrieveTag. They return true if they successfully handle the tag.
+    bool handleCellReferenceTag(std::string tag, MyGUI::UString & _result);
+    bool handleScaleTextTag(std::string tag, MyGUI::UString & _result);
+    bool handleSettingsConfigTag(std::string tag, MyGUI::UString & _result);
     /**
      * Called when MyGUI tries to retrieve a tag's value. Tags must be denoted in #{tag} notation and will be replaced upon setting a user visible text/property.
      * Supported syntax:

--- a/files/mygui/openmw_resources.xml
+++ b/files/mygui/openmw_resources.xml
@@ -146,19 +146,4 @@
         </Widget>
     </Resource>
 
-    <!-- Same as MW_Caption, but reserves some free space on the right for the Pin button -
-       i.e. not allowing the caption label to stretch there, but still showing the tiling background. -->
-    <Resource type="ResourceLayout" name="MW_Caption_Pin" version="3.2.0">
-        <Widget type="Widget" skin="" position="0 0 88 20" name="Root">
-            <Widget type="Widget" skin="HB_ALL" position="0 0 30 20" align="Default" name="Left"/>
-            <Widget type="Widget" skin="" position="0 0 69 20" align="Stretch">
-                <Widget type="TextBox" skin="SandText" position="30 0 28 20" align="Left VStretch" name="Client">
-                    <Property key="FontName" value="Default"/>
-                    <Property key="TextAlign" value="Center"/>
-                </Widget>
-            </Widget>
-            <Widget type="Widget" skin="HB_ALL" position="0 0 30 20" align="Right" name="Right"/>
-        </Widget>
-    </Resource>
-
 </MyGUI>

--- a/files/mygui/openmw_stats_window.layout
+++ b/files/mygui/openmw_stats_window.layout
@@ -6,9 +6,9 @@
 
         <Widget type="Widget" skin="" name="LeftPane" position="0 0 220 342">
 
-            <!-- Player health stats -->
-            <Widget type="Widget" skin="MW_Box" position="8 8 212 62" align="Left Top HStretch">
-                <!-- Health -->
+
+            <Widget type="Widget" skin="MW_Box" position="8 8 212 62" name="HealthMagickaFatigueBorder" align="Left Top HStretch">
+                
                 <Widget type="Widget" skin="" position="4 4 204 18" name="Health" align="Left Top HStretch">
                     <Property key="NeedMouse" value="true"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -25,8 +25,6 @@
                         <Property key="NeedMouse" value="false"/>
                     </Widget>
                 </Widget>
-
-                <!-- Magicka -->
                 <Widget type="Widget" skin="" position="4 22 204 18" name="Magicka" align="Left Top HStretch">
                     <Property key="NeedMouse" value="true"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -46,8 +44,6 @@
                         <Property key="NeedMouse" value="false"/>
                     </Widget>
                 </Widget>
-
-                <!-- Fatigue -->
                 <Widget type="Widget" skin="" position="4 40 204 18" name="Fatigue" align="Left Top HStretch">
                     <Property key="NeedMouse" value="true"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -69,14 +65,14 @@
             </Widget>
 
             <!-- Player level, race and class -->
-            <Widget type="Widget" skin="MW_Box" position="8 78 212 62" align="Top HStretch">
-                <Widget type="HBox" position="4 4 204 18" align="Top HStretch">
+			<Widget type="Widget" skin="MW_Box" position="8 78 212 62" name="LevelRaceClassBorder" align="Top HStretch">
+                <Widget type="HBox" position="4 4 204 18" name="Level" align="Top HStretch">
                     <Widget type="AutoSizedTextBox" skin="NormalText" position="0 0 200 18" name="Level_str" align="Left Top">
                         <Property key="Caption" value="#{sLevel}"/>
                         <UserString key="ToolTipType" value="Layout"/>
                         <UserString key="ToolTipLayout" value="LevelToolTip"/>
                     </Widget>
-                    <Widget type="TextBox" skin="SandTextRight" position="200 0 40 18" name="LevelText" align="Right Top">
+                    <Widget type="AutoSizedTextBox" skin="SandTextRight" position="200 0 40 18" name="LevelText" align="Right Top">
                         <Property key="TextAlign" value="Right Top"/>
                         <UserString key="ToolTipType" value="Layout"/>
                         <UserString key="ToolTipLayout" value="LevelToolTip"/>
@@ -84,26 +80,26 @@
                     </Widget>
 
                 </Widget>
-                <Widget type="HBox" position="4 24 204 18" align="Top HStretch">
+                <Widget type="HBox" position="4 24 204 18" name="Race" align="Top HStretch">
                     <Widget type="AutoSizedTextBox" skin="NormalText" position="0 0 95 18" name="Race_str" align="Left Top">
                         <Property key="Caption" value="#{sRace}"/>
                         <UserString key="ToolTipType" value="Layout"/>
                         <UserString key="ToolTipLayout" value="TextWithCenteredCaptionToolTip"/>
                     </Widget>
-                    <Widget type="TextBox" skin="SandTextRight" position="104 0 200 18" name="RaceText" align="Left Top">
+                    <Widget type="AutoSizedTextBox" skin="SandTextRight" position="104 0 200 18" name="RaceText" align="Left Top">
                         <Property key="TextAlign" value="Right Top"/>
                         <UserString key="ToolTipType" value="Layout"/>
                         <UserString key="ToolTipLayout" value="TextWithCenteredCaptionToolTip"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
                 </Widget>
-                <Widget type="HBox" position="4 42 204 18" align="Top HStretch">
+                <Widget type="HBox" position="4 42 204 18" name="Class" align="Top HStretch">
                     <Widget type="AutoSizedTextBox" skin="NormalText" position="0 0 95 18" name="Class_str" align="Left Top">
                         <Property key="Caption" value="#{sClass}"/>
                         <UserString key="ToolTipType" value="Layout"/>
                         <UserString key="ToolTipLayout" value="ClassToolTip"/>
                     </Widget>
-                    <Widget type="TextBox" skin="SandTextRight" position="104 0 200 18" name="ClassText" align="Left Top">
+                    <Widget type="AutoSizedTextBox" skin="SandTextRight" position="104 0 200 18" name="ClassText" align="Left Top">
                         <Property key="TextAlign" value="Right Top"/>
                         <UserString key="ToolTipType" value="Layout"/>
                         <UserString key="ToolTipLayout" value="ClassToolTip"/>
@@ -112,7 +108,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="Widget" skin="MW_Box" position="8 148 212 152" align="Left Top Stretch">
+            <Widget type="Widget" skin="MW_Box" position="8 148 212 152" name="AttributeBorder" align="Left Top Stretch">
             <!-- TODO: this should be a scroll view -->
             <Widget type="Widget" skin="" position="4 4 204 144" align="Left Top Stretch">
                 <Widget type="Button" skin="" position="0 0 204 18" name="Attrib1Box" align="Left Top HStretch">
@@ -227,7 +223,7 @@
                     </Widget>
                 </Widget>
             </Widget>
-            </Widget>
+        </Widget>
 
         </Widget>
 

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -410,11 +410,11 @@
     </Resource>
 
     <Resource type="ResourceSkin" name="HB_ALL" size="260 20">
-        <Child type="Widget" skin="HB_MID" offset="2 2 256 16" align="Top Left HStretch"/>
+        <Child type="Widget" skin="HB_MID" offset="2 2 256 16" align="Top Left Stretch"/>
         <Child type="Widget" skin="HB_TOP" offset="2 0 256 2" align="Top HStretch HStretch"/>
         <Child type="Widget" skin="HB_BOTTOM" offset="2 18 256 2" align="Bottom HStretch"/>
-        <Child type="Widget" skin="HB_LEFT" offset="0 2 2 16" align="Top Left"/>
-        <Child type="Widget" skin="HB_RIGHT" offset="258 2 2 16" align="Top Right"/>
+        <Child type="Widget" skin="HB_LEFT" offset="0 2 2 16" align="Left VStretch"/>
+        <Child type="Widget" skin="HB_RIGHT" offset="258 2 2 16" align="Right VStretch"/>
         <Child type="Widget" skin="HB_TR" offset="258 0 2 2" align="Top Right"/>
         <Child type="Widget" skin="HB_TL" offset="0 0 2 2" align="Top Left"/>
         <Child type="Widget" skin="HB_BR" offset="258 18 2 2" align="Bottom Right"/>
@@ -430,6 +430,21 @@
         <Child type="Widget" skin="HB_ALL" offset="0 0 30 20" align="Default" name="Left"/>
         <Child type="TextBox" skin="SandText" offset="30 0 28 20" align="Left VStretch" name="Client"/>
         <Child type="Widget" skin="HB_ALL" offset="0 0 30 20" align="Right" name="Right"/>
+    </Resource>
+
+    <!-- Same as MW_Caption, but reserves some free space on the right for the Pin button -
+       i.e. not allowing the caption label to stretch there, but still showing the tiling background. -->
+    <Resource type="ResourceLayout" name="MW_Caption_Pin" version="3.2.0">
+        <Widget type="Widget" skin="" position="0 0 88 20" name="Root">
+            <Widget type="Widget" skin="HB_ALL" position="0 0 30 20" align="Left" name="Left"/>
+            <Widget type="Widget" skin="" position="0 0 69 20" align="Stretch">
+                <Widget type="TextBox" skin="SandText" position="30 0 28 20" align="Left VStretch" name="Client">
+                    <Property key="FontName" value="Default"/>
+                    <Property key="TextAlign" value="Center"/>
+                </Widget>
+            </Widget>
+            <Widget type="Widget" skin="HB_ALL" position="0 0 30 20" align="Right" name="Right"/>
+        </Widget>
     </Resource>
 
 <!-- ----------------------------------------------------


### PR DESCRIPTION
I intend to update the rest of the UI in a similar manner, but I wanted to get some feedback on the approach I used before getting too carried away. If the other windows can use the same methods I implemented here, I plan to refactor them into a utility class.

Note that this requires changes to the openmw_stats_window.layout file to function properly. Old versions did not provide names for certain widgets that needed to be touched.

I have tested this in the following ways:

* Using Pelagiad TTF with size=18
* Using Pelagiad TTF with size=36
* Using Pelagiad TTF with size=72
* using Vanilla openmw_font.xml and Vanilla fonts

For screenshots, see my thread on the forums: https://forum.openmw.org/viewtopic.php?f=6&t=3580