### PR TITLE
Fix return values for AITravel

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -47,7 +47,7 @@ bool MWMechanics::AiPackage::shouldCancelPreviousAi() const
 
 bool MWMechanics::AiPackage::getRepeat() const
 {
-    return true;
+    return false;
 }
 
 MWMechanics::AiPackage::AiPackage() : mTimer(0.26f), mStarted(false) { //mTimer starts at .26 to force initial pathbuild

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -87,8 +87,7 @@ namespace MWMechanics
             /// Upon adding this Ai package, should the Ai Sequence attempt to cancel previous Ai packages (default true)?
             virtual bool shouldCancelPreviousAi() const;
 
-            /// Return true if this package should repeat. Can only be false for AIWander, if AIWander is assigned
-            /// assigned through the console or script.
+            /// Return true if this package should repeat. Currently only used for Wander packages.
             virtual bool getRepeat() const;
 
             bool isTargetMagicallyHidden(const MWWorld::Ptr& target);

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -40,6 +40,9 @@ namespace MWMechanics
             ///Finished with top AIPackage, set for one frame
             bool mDone;
 
+            ///Does this AI sequence repeat (repeating of Wander packages handled separately)
+            bool mRepeat;
+
             ///Copy AiSequence
             void copy (const AiSequence& sequence);
 


### PR DESCRIPTION
Bug report
https://bugs.openmw.org/issues/3411

Summary
Changes Travel, Escort, Follow and Activate packages to not repeat if they are issued in-game (console or script.)

Reasons
To fix return values for in-game issued AI packages, matching original game behavior..

Testing
Tested editor-placed and console-given AI packages in-game.


