### PR TITLE
Landing audio candidate fix

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -356,7 +356,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
             mCurrentJump.clear();
             if (mAnimation->hasAnimation("jump"))
                 mAnimation->play(jumpAnimName, Priority_Jump, jumpmask, true,
-                             1.0f, "loop stop", "stop", 0.0f, 0);
+                             1.0f, "loop stop", "stop", 0.3f, 0);
         }
     }
 


### PR DESCRIPTION
Bug #2256

Slightly modified the starting point of the landing animation preventing the user from cutting it off with a consecutive jump. After this change I'm no longer able to time consecutive jumps which cut off the audio.

To my knowledge there's a small gap of time between the landing animation starting and the landing audio actually being played. By setting the starting point of the animation further in I was able to eliminate the window with which the player could jump again after landing and cut off the audio.

I'm new to the project and unsure if this would be considered a fix. Admittedly it seems like putting a band-aid on the issue instead of fixing the root cause but I'm assuming the animation data is drawn from the original game files and we don't want to tamper with that instead.
