### PR TITLE
Improve duration calculations in Wander AI

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -103,6 +103,7 @@ namespace MWMechanics
 
             int mDistance; // how far the actor can wander from the spawn point
             int mDuration;
+            float mRemainingDuration;
             int mTimeOfDay;
             std::vector<unsigned char> mIdle;
             bool mRepeat;
@@ -123,7 +124,6 @@ namespace MWMechanics
 
             
 
-            MWWorld::TimeStamp mStartTime;
 
             // allowed pathgrid nodes based on mDistance from the spawn point
             // in local coordinates of mCell

--- a/components/esm/aisequence.cpp
+++ b/components/esm/aisequence.cpp
@@ -15,7 +15,7 @@ namespace AiSequence
     void AiWander::load(ESMReader &esm)
     {
         esm.getHNT (mData, "DATA");
-        esm.getHNT(mStartTime, "STAR");
+        esm.getHNT(mDurationData, "STAR");
         mStoredInitialActorPosition = false;
         if (esm.isNextSub("POS_"))
         {
@@ -27,7 +27,7 @@ namespace AiSequence
     void AiWander::save(ESMWriter &esm) const
     {
         esm.writeHNT ("DATA", mData);
-        esm.writeHNT ("STAR", mStartTime);
+        esm.writeHNT ("STAR", mDurationData);
         if (mStoredInitialActorPosition)
             esm.writeHNT ("POS_", mInitialActorPosition);
     }

--- a/components/esm/aisequence.hpp
+++ b/components/esm/aisequence.hpp
@@ -46,6 +46,11 @@ namespace ESM
         unsigned char mIdle[8];
         unsigned char mShouldRepeat;
     };
+    struct AiWanderDuration
+    {
+        float mRemainingDuration;
+        int unused;
+    };
     struct AiTravelData
     {
         float   mX, mY, mZ;
@@ -61,7 +66,7 @@ namespace ESM
     struct AiWander : AiPackage
     {
         AiWanderData mData;
-        ESM::TimeStamp mStartTime;
+        AiWanderDuration mDurationData; // was ESM::TimeStamp mStartTime;
 
         bool mStoredInitialActorPosition;
         ESM::Vector3 mInitialActorPosition;


### PR DESCRIPTION
Fixes: https://bugs.openmw.org/issues/3412

Summary of the changes made:
Wander AI now runs on a counter, matching observed behavior in the original game more closely. The checks for the end of duration are now unrelated to the current timestamp.

The remaining duration on the counter is saved and retrieved on loading, which fixes bug#3412. This is an enhancement over the original game.

This implementation introduces a new float mRemainingDuration and repurposes mStartTime as a way to store the remaining duration.

Existing save games will have a wrong duration for one run through all the Wander packages in the save file (since mStartTime did not mean what it does now) but the duration should be corrected when the packages finish or for any that were not yet in the save game.

Tested with NPCs, both editor-placed packages and console-issued AIWander commands.