### PR TITLE
Fix tooltip issue

### DIFF
--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -173,6 +173,9 @@ SceneWidget::SceneWidget(boost::shared_ptr<Resource::ResourceSystem> resourceSys
 
     mResourceSystem->getSceneManager()->setParticleSystemMask(Mask_ParticleSystem);
 
+    // Recieve mouse move event even if mouse button is not pressed
+    setMouseTracking(true);
+
     /// \todo make shortcut configurable
     QShortcut *focusToolbar = new QShortcut (Qt::Key_T, this, 0, 0, Qt::WidgetWithChildrenShortcut);
     connect (focusToolbar, SIGNAL (activated()), this, SIGNAL (focusToolbarRequest()));

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -646,7 +646,10 @@ void CSVRender::WorldspaceWidget::mouseMoveEvent (QMouseEvent *event)
             mToolTipPos = event->globalPos();
 
             if (mShowToolTips)
+            {
+                QToolTip::hideText();
                 mToolTipDelayTimer.start (mToolTipDelay);
+            }
         }
 
         SceneWidget::mouseMoveEvent(event);


### PR DESCRIPTION
This fixes [bug#3332](https://bugs.openmw.org/issues/3332). By default, Qt doesn't pass mouse movement when no mouse button is pressed. I also added some code to hide the tooltip when the mouse is moved.