### PR TITLE
Fix camera input not being reset when focus for widget is lost.

### DIFF
--- a/apps/opencs/view/render/cameracontroller.cpp
+++ b/apps/opencs/view/render/cameracontroller.cpp
@@ -308,6 +308,17 @@ namespace CSVRender
         getCamera()->getViewMatrix().orthoNormal(getCamera()->getViewMatrix());
     }
 
+    void FreeCameraController::resetInput()
+    {
+        mFast = false;
+        mLeft = false;
+        mRight = false;
+        mForward = false;
+        mBackward = false;
+        mRollLeft = false;
+        mRollRight = false;
+    }
+
     void FreeCameraController::yaw(double value)
     {
         getCamera()->getViewMatrix() *= osg::Matrixd::rotate(value, LocalUp);
@@ -533,6 +544,17 @@ namespace CSVRender
 
         // Normalize the matrix to counter drift
         getCamera()->getViewMatrix().orthoNormal(getCamera()->getViewMatrix());
+    }
+
+    void OrbitCameraController::resetInput()
+    {
+        mFast = false;
+        mLeft = false;
+        mRight =false;
+        mUp = false;
+        mDown = false;
+        mRollLeft = false;
+        mRollRight = false;
     }
 
     void OrbitCameraController::onActivate()

--- a/apps/opencs/view/render/cameracontroller.hpp
+++ b/apps/opencs/view/render/cameracontroller.hpp
@@ -51,6 +51,8 @@ namespace CSVRender
 
             virtual void update(double dt) = 0;
 
+            virtual void resetInput() = 0;
+
         protected:
 
             virtual void onActivate(){}
@@ -86,6 +88,8 @@ namespace CSVRender
             bool handleMouseMoveEvent(std::string mode, int x, int y);
 
             void update(double dt);
+
+            void resetInput();
 
         private:
 
@@ -125,6 +129,8 @@ namespace CSVRender
             bool handleMouseMoveEvent(std::string mode, int x, int y);
 
             void update(double dt);
+
+            void resetInput();
 
         private:
 

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -175,6 +175,7 @@ SceneWidget::SceneWidget(boost::shared_ptr<Resource::ResourceSystem> resourceSys
 
     // Recieve mouse move event even if mouse button is not pressed
     setMouseTracking(true);
+    setFocusPolicy(Qt::StrongFocus);
 
     /// \todo make shortcut configurable
     QShortcut *focusToolbar = new QShortcut (Qt::Key_T, this, 0, 0, Qt::WidgetWithChildrenShortcut);
@@ -289,6 +290,11 @@ void SceneWidget::mouseMoveEvent (QMouseEvent *event)
 
     mPrevMouseX = event->x();
     mPrevMouseY = event->y();
+}
+
+void SceneWidget::focusOutEvent (QFocusEvent *event)
+{
+    mCurrentCamControl->resetInput();
 }
 
 void SceneWidget::wheelEvent(QWheelEvent *event)

--- a/apps/opencs/view/render/scenewidget.hpp
+++ b/apps/opencs/view/render/scenewidget.hpp
@@ -96,6 +96,7 @@ namespace CSVRender
             virtual void wheelEvent (QWheelEvent *event);
             virtual void keyPressEvent (QKeyEvent *event);
             virtual void keyReleaseEvent (QKeyEvent *event);
+            virtual void focusOutEvent (QFocusEvent *event);
 
             /// \return Is \a key a button mapping setting? (ignored otherwise)
             virtual bool storeMappingSetting (const CSMPrefs::Setting *setting);

--- a/extern/osgQt/GraphicsWindowQt.cpp
+++ b/extern/osgQt/GraphicsWindowQt.cpp
@@ -245,7 +245,6 @@ bool GraphicsWindowQt::init( QWidget* parent, const QGLWidget* shareWidget, Qt::
     // initialize widget properties
     _widget->setAutoBufferSwap( false );
     _widget->setMouseTracking( true );
-    _widget->setFocusPolicy( Qt::WheelFocus );
     _widget->setGraphicsWindow( this );
     useCursor( _traits->useCursor );
 


### PR DESCRIPTION
Widgets don't receive input events when they have lost focus, which causes a problem with the camera controller. The camera continues moving after a key is released if the widget has lost focus. This commit fixes the issue by resetting the camera input state when the widget focus is lost. The modification to osgQt was necessary because it was intercepting focus events.