### PR TITLE
Added 1.5 bonus for ranged weapons when weapons are rated

### DIFF
--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -109,6 +109,10 @@ namespace MWMechanics
             return 0.f;
 
         float rating=0.f;
+        float bonus=0.f;
+
+        if (weapon->mData.mType >= ESM::Weapon::MarksmanBow && weapon->mData.mType <= ESM::Weapon::MarksmanThrown)
+            bonus+=1.5f;
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
         {
@@ -160,7 +164,7 @@ namespace MWMechanics
         if (skill != -1)
             rating *= actor.getClass().getSkill(actor, skill) / 100.f;
 
-        return rating;
+        return rating + bonus;
     }
 
     float rateSpell(const ESM::Spell *spell, const MWWorld::Ptr &actor, const MWWorld::Ptr& enemy)


### PR DESCRIPTION
#3405

Tested Melar baram in vanilla and he indeed uses a range spell which is none damaging and in openmw he is using firefist which is a touch spell and his only damaging spell, to get the behavior as in vanilla the rating of damage vs none damage spells needs rework. 
Did some more research on vanilla for the target weapon bug and distance does not matter when the ai is choosing a weapon. Did get Mulvisie Othril to attack with the blade only if I bumped up the shortblade skill to 79 or equipped it with a glass dagger. Which if vanilla rates weapons as expected damage it should corresponds to roughly a flat bonus of + 1.5 rating if ranged.
If the bonus was applied the ai attacked when shortblade was raised to 77 instead or equipped it with a glass dagger.
The solution does not mirror the exact behavior of vanilla, a more precise bonus or another formula can be applied to fix Mulvisie Othril for different weapons and skills etc but the testing process for vanilla that is known to me is way to slow. That is summoning the npc and giving out stats and weapons.