### PR TITLE
Add ability to remove multiple rows in subrecords.

### DIFF
--- a/apps/opencs/view/world/nestedtable.cpp
+++ b/apps/opencs/view/world/nestedtable.cpp
@@ -9,6 +9,7 @@
 #include "../../model/world/universalid.hpp"
 #include "../../model/world/commands.hpp"
 #include "../../model/world/commanddispatcher.hpp"
+#include "../../model/world/commandmacro.hpp"
 
 #include "tableeditidaction.hpp"
 #include "util.hpp"
@@ -63,7 +64,7 @@ CSVWorld::NestedTable::NestedTable(CSMDoc::Document& document,
             connect(mAddNewRowAction, SIGNAL(triggered()),
                     this, SLOT(addNewRowActionTriggered()));
 
-            mRemoveRowAction = new QAction (tr ("Remove row"), this);
+            mRemoveRowAction = new QAction (tr ("Remove rows"), this);
 
             connect(mRemoveRowAction, SIGNAL(triggered()),
                     this, SLOT(removeRowActionTriggered()));
@@ -100,10 +101,8 @@ void CSVWorld::NestedTable::contextMenuEvent (QContextMenuEvent *event)
 
     if (mAddNewRowAction && mRemoveRowAction)
     {
-        if (selectionModel()->selectedRows().size() == 1)
-            menu.addAction(mRemoveRowAction);
-
         menu.addAction(mAddNewRowAction);
+        menu.addAction(mRemoveRowAction);
     }
 
     menu.exec (event->globalPos());
@@ -111,10 +110,15 @@ void CSVWorld::NestedTable::contextMenuEvent (QContextMenuEvent *event)
 
 void CSVWorld::NestedTable::removeRowActionTriggered()
 {
-    mDocument.getUndoStack().push(new CSMWorld::DeleteNestedCommand(*(mModel->model()),
-                                                                    mModel->getParentId(),
-                                                                    selectionModel()->selectedRows().begin()->row(),
-                                                                    mModel->getParentColumn()));
+    CSMWorld::CommandMacro macro(mDocument.getUndoStack(),
+        selectionModel()->selectedRows().size() > 1 ? tr("Remove rows") : "");
+
+    // Remove rows in reverse order
+    for (int i = selectionModel()->selectedRows().size() - 1; i >= 0; --i)
+    {
+        macro.push(new CSMWorld::DeleteNestedCommand(*(mModel->model()), mModel->getParentId(),
+            selectionModel()->selectedRows()[i].row(), mModel->getParentColumn()));
+    }
 }
 
 void CSVWorld::NestedTable::addNewRowActionTriggered()


### PR DESCRIPTION
This commit implements [feature#2974](https://bugs.openmw.org/issues/2974), making the deletion of multiple subrecords possible.

On a side note, I noticed a particularly nasty hack for checking if subrecords are fixed tables which currently only works for the classes implemented in refidadapterimp.cpp. It is supposed to disable the creation of the add/remove rows context menu actions for fixed tables.