### PR TITLE
Slowfall now stops momentum when jumping

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -448,6 +448,10 @@ namespace MWPhysics
                 inertia.z() += time * -627.2f;
                 if (inertia.z() < 0)
                     inertia.z() *= slowFall;
+                if (slowFall < 1.f) {
+                    inertia.x() = 0;
+                    inertia.y() = 0;
+                }
                 physicActor->setInertialForce(inertia);
             }
             physicActor->setOnGround(isOnGround);


### PR DESCRIPTION
Bug #3071

First off i don't want to be a nuisance with old or meaningless bugs just want to get familiarized with the code base.
Now slowfall mirrors the momentum behavior in vanilla don't know if it makes more or less sense lore wise.
