### PR TITLE
Fix QTimer not being stopped in right thread

### DIFF
--- a/apps/opencs/model/doc/documentmanager.cpp
+++ b/apps/opencs/model/doc/documentmanager.cpp
@@ -41,6 +41,7 @@ CSMDoc::DocumentManager::DocumentManager (const Files::ConfigurationManager& con
 CSMDoc::DocumentManager::~DocumentManager()
 {
     mLoaderThread.quit();
+    mLoader.stop();
     mLoader.hasThingsToDo().wakeAll();
     mLoaderThread.wait();
 

--- a/apps/opencs/model/doc/loader.cpp
+++ b/apps/opencs/model/doc/loader.cpp
@@ -1,6 +1,6 @@
 #include "loader.hpp"
 
-#include <QTimer>
+#include <iostream>
 
 #include "../tools/reportmodel.hpp"
 
@@ -11,16 +11,22 @@ CSMDoc::Loader::Stage::Stage() : mFile (0), mRecordsLoaded (0), mRecordsLeft (fa
 
 
 CSMDoc::Loader::Loader()
+    : mShouldStop(false)
 {
-    QTimer *timer = new QTimer (this);
+    mTimer = new QTimer (this);
 
-    connect (timer, SIGNAL (timeout()), this, SLOT (load()));
-    timer->start();
+    connect (mTimer, SIGNAL (timeout()), this, SLOT (load()));
+    mTimer->start();
 }
 
 QWaitCondition& CSMDoc::Loader::hasThingsToDo()
 {
     return mThingsToDo;
+}
+
+void CSMDoc::Loader::stop()
+{
+    mShouldStop = true;
 }
 
 void CSMDoc::Loader::load()
@@ -30,6 +36,10 @@ void CSMDoc::Loader::load()
         mMutex.lock();
         mThingsToDo.wait (&mMutex);
         mMutex.unlock();
+
+        if (mShouldStop)
+            mTimer->stop();
+
         return;
     }
 

--- a/apps/opencs/model/doc/loader.hpp
+++ b/apps/opencs/model/doc/loader.hpp
@@ -5,6 +5,7 @@
 
 #include <QObject>
 #include <QMutex>
+#include <QTimer>
 #include <QWaitCondition>
 
 namespace CSMDoc
@@ -28,11 +29,16 @@ namespace CSMDoc
             QWaitCondition mThingsToDo;
             std::vector<std::pair<Document *, Stage> > mDocuments;
 
+            QTimer* mTimer;
+            bool mShouldStop;
+
         public:
 
             Loader();
 
             QWaitCondition& hasThingsToDo();
+
+            void stop();
 
         private slots:
 


### PR DESCRIPTION
QTimers apparently cannot be stopped from other threads.
This gets rid of the following complaint:
> QObject::killTimer: Timers cannot be stopped from another thread
> QObject::~QObject: Timers cannot be stopped from another thread