### PR TITLE
Accurately pick the cell ref.

### DIFF
--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -178,8 +178,12 @@ namespace MWWorld
 
         if (const X *ptr = store.search (ref.mRefID))
         {
-            typename std::list<LiveRef>::iterator iter =
-                std::find(mList.begin(), mList.end(), ref.mRefNum);
+            typename std::list<LiveRef>::iterator iter;
+            for (iter = mList.begin(); iter != mList.end(); ++iter)
+            {
+                if (iter->mRef.getRefNum().mIndex == ref.mRefNum.mIndex)
+                    break;
+            }
 
             LiveRef liveCellRef (ref, ptr);
 


### PR DESCRIPTION
This fixes [bug#3427](https://bugs.openmw.org/issues/3427), though I'm not 100% sure if this is the right fix. I think that [RefNum.mContentFile](https://github.com/OpenMW/openmw/blob/master/components/esm/cellref.hpp#L17) refers to the content file it was loaded from, and not the content file it overrides. Anyone know off the top of their head?