### PR TITLE
Duration fixes for Follow and Escort

### DIFF
--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -42,6 +42,8 @@ namespace MWMechanics
 
             void writeState(ESM::AiSequence::AiSequence &sequence) const;
 
+            void fastForward(const MWWorld::Ptr& actor, AiState& state);
+
         private:
             std::string mActorId;
             std::string mCellId;
@@ -49,7 +51,8 @@ namespace MWMechanics
             float mY;
             float mZ;
             float mMaxDist;
-            float mRemainingDuration; // In seconds
+            float mDuration; // In hours
+            float mRemainingDuration; // In hours
 
             int mCellX;
             int mCellY;

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -50,12 +50,15 @@ namespace MWMechanics
 
             int getFollowIndex() const;
 
+            void fastForward(const MWWorld::Ptr& actor, AiState& state);
+
         private:
             /// This will make the actor always follow.
             /** Thus ignoring mDuration and mX,mY,mZ (used for summoned creatures). **/
             bool mAlwaysFollow;
             bool mCommanded;
-            float mRemainingDuration; // Seconds
+            float mDuration; // Hours
+            float mRemainingDuration; // Hours
             float mX;
             float mY;
             float mZ;

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -64,7 +64,7 @@ namespace MWMechanics
         if (pathTo(actor, ESM::Pathgrid::Point(static_cast<int>(mX), static_cast<int>(mY), static_cast<int>(mZ)), duration))
         {
             actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
-            mStarted = false;
+            mStarted = false; // Reset to false so this package will build path again when repeating
             return true;
         }
         return false;

--- a/components/esm/aisequence.cpp
+++ b/components/esm/aisequence.cpp
@@ -15,7 +15,7 @@ namespace AiSequence
     void AiWander::load(ESMReader &esm)
     {
         esm.getHNT (mData, "DATA");
-        esm.getHNT(mDurationData, "STAR");
+        esm.getHNT(mDurationData, "STAR"); // was mStartTime
         mStoredInitialActorPosition = false;
         if (esm.isNextSub("POS_"))
         {

--- a/components/esm/aisequence.hpp
+++ b/components/esm/aisequence.hpp
@@ -66,7 +66,7 @@ namespace ESM
     struct AiWander : AiPackage
     {
         AiWanderData mData;
-        AiWanderDuration mDurationData; // was ESM::TimeStamp mStartTime;
+        AiWanderDuration mDurationData; // was ESM::TimeStamp mStartTime
 
         bool mStoredInitialActorPosition;
         ESM::Vector3 mInitialActorPosition;


### PR DESCRIPTION
Fixes for bug https://bugs.openmw.org/issues/3432

Summary of the changes made:
- Follow and Escort changed to run on hours, not seconds
- End of remaining duration check fixed (was checking against wrong value)
- Fast-forwarding (resting) now affects remaining duration
- Remaining duration reset after package ends so the package can repeat
- Removed code that sets Escort to infinite duration if it has a destination specified (it was commented that this is in the Construction Set help file, but this behavior does not match what actually happens in the original engine and would be inconsistent with follow packages)

Note that in order to store the starting duration of a follow package, I needed an extra variable. I used the mAlwaysFollow boolean's spot in the save file for this. Saves are compatible as far as I could see. I tested with saving/loading with NPCs, positive and negative mRemainingDurations, and summons (which use the mAlwaysFollow boolean).

There was no variable I could use like this for Escort, so the escort package will just use the mRemainingDuration variable to judge whether or not the package had a duration. If the mRemainingDuration variable is anything but 0 the duration will be set to 1. This only affects repeating editor-placed escort packages.

Really what should happen, I think, is that editor-placed AI packages should read any unchanging data, such as mDuration (not mRemainingDuration) from the .esm/.esp or equivalent file. This seems to be what happens in the original game (the original game doesn't save remaining duration, either) and would fix another problem: currently if you introduce a mod that changes the AI packages of an NPC that has already been saved in the game file, the AI will not change in OpenMW because the AI packages are loaded from the save file. In the original game the new AI packages from the .esp will be loaded.
