### PR TITLE
AI package cleanups

### DIFF
--- a/apps/openmw/mwmechanics/aiescort.cpp
+++ b/apps/openmw/mwmechanics/aiescort.cpp
@@ -16,7 +16,6 @@
 #include "movement.hpp"
 
 /*
-    TODO: Test vanilla behavior on passing x0, y0, and z0 with duration of anything including 0.
     TODO: Different behavior for AIEscort a d x y z and AIEscortCell a c d x y z.
     TODO: Take account for actors being in different cells.
 */
@@ -109,7 +108,7 @@ namespace MWMechanics
         }
         else
         {
-            // Stop moving if the player is to far away
+            // Stop moving if the player is too far away
             MWBase::Environment::get().getMechanicsManager()->playAnimationGroup(actor, "idle3", 0, 1);
             actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
             mMaxDist = 250;

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -10,7 +10,6 @@
 
 #include "../mwworld/timestamp.hpp"
 
-
 #include "aistate.hpp"
 
 namespace ESM
@@ -23,9 +22,7 @@ namespace ESM
 }
 
 namespace MWMechanics
-{    
-    
-    
+{       
     struct AiWanderStorage;
 
     /// \brief Causes the Actor to wander within a specified range
@@ -41,8 +38,6 @@ namespace MWMechanics
             AiWander(int distance, int duration, int timeOfDay, const std::vector<unsigned char>& idle, bool repeat);
 
             AiWander (const ESM::AiSequence::AiWander* wander);
-
-            
 
             virtual AiPackage *clone() const;
 
@@ -72,10 +67,10 @@ namespace MWMechanics
                 Wander_MoveNow,
                 Wander_Walking
             };
+
         private:
             // NOTE: mDistance and mDuration must be set already
             void init();
-            
             void stopWalking(const MWWorld::Ptr& actor, AiWanderStorage& storage);
 
             /// Have the given actor play an idle animation
@@ -107,42 +102,16 @@ namespace MWMechanics
             int mTimeOfDay;
             std::vector<unsigned char> mIdle;
             bool mRepeat;
-            
 
             bool mHasReturnPosition; // NOTE: Could be removed if mReturnPosition was initialized to actor position,
                                     // if we had the actor in the AiWander constructor...
             osg::Vec3f mReturnPosition;
-
             osg::Vec3f mInitialActorPosition;
             bool mStoredInitialActorPosition;
 
-           
-
-            // do we need to calculate allowed nodes based on mDistance
-            bool mPopulateAvailableNodes;
-
-
-            
-
-
-            // allowed pathgrid nodes based on mDistance from the spawn point
-            // in local coordinates of mCell
-            // FIXME: move to AiWanderStorage
-            std::vector<ESM::Pathgrid::Point> mAllowedNodes;
-
             void getAllowedNodes(const MWWorld::Ptr& actor, const ESM::Cell* cell, AiWanderStorage& storage);
-
-            // FIXME: move to AiWanderStorage
-            ESM::Pathgrid::Point mCurrentNode;
-            bool mTrimCurrentNode;
-            void trimAllowedNodes(std::vector<ESM::Pathgrid::Point>& nodes,
-                                  const PathFinder& pathfinder);
-
-
-            // FIXME: move to AiWanderStorage
-//             ObstacleCheck mObstacleCheck;
-            float mDoorCheckDuration;
-            int mStuckCount;
+            
+            void trimAllowedNodes(std::vector<ESM::Pathgrid::Point>& nodes, const PathFinder& pathfinder);
 
             // constants for converting idleSelect values into groupNames
             enum GroupIndex
@@ -154,19 +123,17 @@ namespace MWMechanics
             /// convert point from local (i.e. cell) to world co-ordinates
             void ToWorldCoordinates(ESM::Pathgrid::Point& point, const ESM::Cell * cell);
 
-            void SetCurrentNodeToClosestAllowedNode(osg::Vec3f npcPos);
+            void SetCurrentNodeToClosestAllowedNode(osg::Vec3f npcPos, AiWanderStorage& storage);
 
-            void AddNonPathGridAllowedPoints(osg::Vec3f npcPos, const ESM::Pathgrid * pathGrid, int pointIndex);
+            void AddNonPathGridAllowedPoints(osg::Vec3f npcPos, const ESM::Pathgrid * pathGrid, int pointIndex, AiWanderStorage& storage);
 
-            void AddPointBetweenPathGridPoints(const ESM::Pathgrid::Point& start, const ESM::Pathgrid::Point& end);
+            void AddPointBetweenPathGridPoints(const ESM::Pathgrid::Point& start, const ESM::Pathgrid::Point& end, AiWanderStorage& storage);
 
             /// lookup table for converting idleSelect value to groupName
             static const std::string sIdleSelectToGroupName[GroupIndex_MaxIdle - GroupIndex_MinIdle + 1];
 
             static int OffsetToPreventOvercrowding();
-    };
-    
-    
+    }; 
 }
 
 #endif


### PR DESCRIPTION
Some cleanups to AI package files.

AIEscort:
Removed TODO comment about testing vanilla behavior with destination of 0, 0, 0.
In testing I found that while in the original engine an editor-placed package works OK, using
AIEscort or AIEscortCell through the console with a destination of 0,0,0 causes the NPC to not move. Changing it to e.g. 1,0,0 will make it work. I suppose this was the reason for this TODO, but I don't see it as something that is desirable for us to emulate. Why would we want to prevent AIEscort or AIEscortCell from working with destination 0,0,0? Currently, OpenMW works with these destinations.

AIWander:
I moved variables that were commented with FIXME into AIWander's AIWanderStorage. I've tested and everything seems to be working OK, but as it involved code I was unfamiliar with, it's possible I could have messed something up somewhere. In particular a review of the changes I made to the fastforward function would be appreciated.

I also removed setting the bool mTrimCurrentNode to false in init(), as it is set so in the AIWanderStorage constructor, which I think should be enough.