### PR TITLE
Fix Microsoft Visual Studio 2015 warnings

### DIFF
--- a/apps/openmw/mwmechanics/aiactivate.cpp
+++ b/apps/openmw/mwmechanics/aiactivate.cpp
@@ -2,13 +2,12 @@
 
 #include <components/esm/aisequence.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+#include "apps/openmw/mwbase/environment.hpp"
 
-#include "../mwmechanics/creaturestats.hpp"
+#include "apps/openmw/mwworld/class.hpp"
 
-#include "../mwworld/class.hpp"
-
+#include "creaturestats.hpp"
 #include "steering.hpp"
 #include "movement.hpp"
 
@@ -42,10 +41,8 @@ namespace MWMechanics
 
         if(distance(dest, pos.pos[0], pos.pos[1], pos.pos[2]) < 200) { //Stop when you get close
             actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
-            MWWorld::Ptr target = MWBase::Environment::get().getWorld()->getPtr(mObjectId,false);
-
-            MWBase::Environment::get().getWorld()->activate(target, actor);
-
+            MWWorld::Ptr activatetarget = MWBase::Environment::get().getWorld()->getPtr(mObjectId,false);
+            MWBase::Environment::get().getWorld()->activate(activatetarget, actor);
             return true;
         }
         else {

--- a/apps/openmw/mwmechanics/aiactivate.hpp
+++ b/apps/openmw/mwmechanics/aiactivate.hpp
@@ -2,6 +2,7 @@
 #define GAME_MWMECHANICS_AIACTIVATE_H
 
 #include "aipackage.hpp"
+
 #include <string>
 
 #include "pathfinding.hpp"

--- a/apps/openmw/mwmechanics/aiescort.cpp
+++ b/apps/openmw/mwmechanics/aiescort.cpp
@@ -3,15 +3,14 @@
 #include <components/esm/aisequence.hpp>
 #include <components/esm/loadcell.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
-#include "../mwbase/mechanicsmanager.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+#include "apps/openmw/mwbase/environment.hpp"
+#include "apps/openmw/mwbase/mechanicsmanager.hpp"
 
-#include "../mwworld/class.hpp"
-#include "../mwworld/cellstore.hpp"
+#include "apps/openmw/mwworld/class.hpp"
+#include "apps/openmw/mwworld/cellstore.hpp"
 
-#include "../mwmechanics/creaturestats.hpp"
-
+#include "creaturestats.hpp"
 #include "steering.hpp"
 #include "movement.hpp"
 

--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -2,6 +2,7 @@
 #define GAME_MWMECHANICS_AIESCORT_H
 
 #include "aipackage.hpp"
+
 #include <string>
 
 #include "pathfinding.hpp"

--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -3,14 +3,15 @@
 #include <components/esm/aisequence.hpp>
 #include <components/esm/loadcell.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
-#include "../mwbase/mechanicsmanager.hpp"
-#include "../mwworld/class.hpp"
-#include "../mwworld/cellstore.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+#include "apps/openmw/mwbase/environment.hpp"
+#include "apps/openmw/mwbase/mechanicsmanager.hpp"
+
+#include "apps/openmw/mwworld/class.hpp"
+#include "apps/openmw/mwworld/cellstore.hpp"
+
 #include "creaturestats.hpp"
 #include "movement.hpp"
-
 #include "steering.hpp"
 
 namespace MWMechanics

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -2,9 +2,13 @@
 #define GAME_MWMECHANICS_AIFOLLOW_H
 
 #include "aipackage.hpp"
+
 #include <string>
-#include "pathfinding.hpp"
+
 #include <components/esm/defs.hpp>
+
+#include "pathfinding.hpp"
+
 
 namespace ESM
 {

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -6,14 +6,15 @@
 #include <components/esm/loadland.hpp>
 #include <components/esm/loadmgef.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
-#include "../mwworld/class.hpp"
-#include "../mwworld/cellstore.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+#include "apps/openmw/mwbase/environment.hpp"
+
+#include "apps/openmw/mwworld/action.hpp"
+#include "apps/openmw/mwworld/class.hpp"
+#include "apps/openmw/mwworld/cellstore.hpp"
+
 #include "creaturestats.hpp"
 #include "movement.hpp"
-#include "../mwworld/action.hpp"
-
 #include "steering.hpp"
 #include "actorutil.hpp"
 #include "coordinateconverter.hpp"

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -1,9 +1,9 @@
 #ifndef GAME_MWMECHANICS_AIPACKAGE_H
 #define GAME_MWMECHANICS_AIPACKAGE_H
 
-#include "pathfinding.hpp"
 #include <components/esm/defs.hpp>
 
+#include "pathfinding.hpp"
 #include "obstacle.hpp"
 #include "aistate.hpp"
 

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -2,9 +2,13 @@
 
 #include <limits>
 
+#include <components/esm/aisequence.hpp>
+
+#include "apps/openmw/mwbase/environment.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+
 #include "aipackage.hpp"
 #include "aistate.hpp"
-
 #include "aiwander.hpp"
 #include "aiescort.hpp"
 #include "aitravel.hpp"
@@ -13,11 +17,6 @@
 #include "aicombat.hpp"
 #include "aipursue.hpp"
 #include "actorutil.hpp"
-
-#include <components/esm/aisequence.hpp>
-
-#include "../mwbase/environment.hpp"
-#include "../mwbase/world.hpp"
 
 namespace MWMechanics
 {
@@ -92,8 +91,8 @@ std::list<AiPackage*>::const_iterator AiSequence::erase(std::list<AiPackage*>::c
     {
         if (package == it)
         {
-            AiPackage* package = *it;
-            delete package;
+            AiPackage* packagetoerase = *it;
+            delete packagetoerase;
             return mPackages.erase(it);
         }
     }

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -4,7 +4,6 @@
 #include <list>
 
 #include <components/esm/loadnpc.hpp>
-//#include "aistate.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -3,11 +3,11 @@
 #include <components/esm/aisequence.hpp>
 #include <components/esm/loadcell.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+#include "apps/openmw/mwbase/environment.hpp"
 
-#include "../mwworld/class.hpp"
-#include "../mwworld/cellstore.hpp"
+#include "apps/openmw/mwworld/class.hpp"
+#include "apps/openmw/mwworld/cellstore.hpp"
 
 #include "steering.hpp"
 #include "movement.hpp"

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -7,15 +7,15 @@
 
 #include <components/esm/aisequence.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
-#include "../mwbase/mechanicsmanager.hpp"
-#include "../mwbase/dialoguemanager.hpp"
-#include "../mwbase/soundmanager.hpp"
+#include "apps/openmw/mwbase/world.hpp"
+#include "apps/openmw/mwbase/environment.hpp"
+#include "apps/openmw/mwbase/mechanicsmanager.hpp"
+#include "apps/openmw/mwbase/dialoguemanager.hpp"
+#include "apps/openmw/mwbase/soundmanager.hpp"
 
-#include "../mwworld/class.hpp"
-#include "../mwworld/esmstore.hpp"
-#include "../mwworld/cellstore.hpp"
+#include "apps/openmw/mwworld/class.hpp"
+#include "apps/openmw/mwworld/esmstore.hpp"
+#include "apps/openmw/mwworld/cellstore.hpp"
 
 #include "creaturestats.hpp"
 #include "steering.hpp"

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -5,11 +5,10 @@
 
 #include <vector>
 
+#include "apps/openmw/mwworld/timestamp.hpp"
+
 #include "pathfinding.hpp"
 #include "obstacle.hpp"
-
-#include "../mwworld/timestamp.hpp"
-
 #include "aistate.hpp"
 
 namespace ESM


### PR DESCRIPTION
Fixes the following warnings from Microsoft Visual Studio 2015

warning C4464: relative include path contains '..'

\apps\openmw\mwmechanics\aiactivate.cpp(45): warning C4456: declaration of 'target' hides previous local declaration
\apps\openmw\mwmechanics\aiactivate.cpp(30): note: see declaration of 'target'

\apps\openmw\mwmechanics\aisequence.cpp(95): warning C4457: declaration of 'package' hides function parameter
\apps\openmw\mwmechanics\aisequence.cpp(88): note: see declaration of 'package'

Also includes organizing of include statements.