### PR TITLE
Cleanup of #include statements

### DIFF
--- a/apps/openmw/mwmechanics/activespells.cpp
+++ b/apps/openmw/mwmechanics/activespells.cpp
@@ -1,7 +1,6 @@
 #include "activespells.hpp"
 
 #include <components/misc/rng.hpp>
-
 #include <components/misc/stringops.hpp>
 
 #include <components/esm/loadmgef.hpp>

--- a/apps/openmw/mwmechanics/activespells.hpp
+++ b/apps/openmw/mwmechanics/activespells.hpp
@@ -5,12 +5,12 @@
 #include <vector>
 #include <string>
 
+#include <components/esm/defs.hpp>
+#include <components/esm/activespells.hpp>
+
 #include "../mwworld/timestamp.hpp"
 
 #include "magiceffects.hpp"
-
-#include <components/esm/defs.hpp>
-#include <components/esm/activespells.hpp>
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -6,6 +6,7 @@
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/loadnpc.hpp>
+
 #include <components/sceneutil/positionattitudetransform.hpp>
 
 #include "../mwworld/esmstore.hpp"
@@ -22,8 +23,7 @@
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/statemanager.hpp"
 
-#include "../mwmechanics/spellcasting.hpp"
-
+#include "spellcasting.hpp"
 #include "npcstats.hpp"
 #include "creaturestats.hpp"
 #include "movement.hpp"

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -7,8 +7,9 @@
 #include <map>
 #include <list>
 
-#include "movement.hpp"
 #include "../mwbase/world.hpp"
+
+#include "movement.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwmechanics/aiactivate.cpp
+++ b/apps/openmw/mwmechanics/aiactivate.cpp
@@ -5,10 +5,9 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 
-#include "../mwmechanics/creaturestats.hpp"
-
 #include "../mwworld/class.hpp"
 
+#include "creaturestats.hpp"
 #include "steering.hpp"
 #include "movement.hpp"
 

--- a/apps/openmw/mwmechanics/aiactivate.hpp
+++ b/apps/openmw/mwmechanics/aiactivate.hpp
@@ -2,6 +2,7 @@
 #define GAME_MWMECHANICS_AIACTIVATE_H
 
 #include "aipackage.hpp"
+
 #include <string>
 
 #include "pathfinding.hpp"

--- a/apps/openmw/mwmechanics/aiavoiddoor.cpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.cpp
@@ -3,12 +3,12 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+
 #include "../mwworld/class.hpp"
+
 #include "creaturestats.hpp"
 #include "movement.hpp"
 #include "actorutil.hpp"
-
-
 #include "steering.hpp"
 
 MWMechanics::AiAvoidDoor::AiAvoidDoor(const MWWorld::ConstPtr& doorPtr)

--- a/apps/openmw/mwmechanics/aiavoiddoor.hpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.hpp
@@ -2,10 +2,14 @@
 #define GAME_MWMECHANICS_AIAVOIDDOOR_H
 
 #include "aipackage.hpp"
+
 #include <string>
-#include "pathfinding.hpp"
+
 #include <components/esm/defs.hpp>
+
 #include "../mwworld/class.hpp"
+
+#include "pathfinding.hpp"
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -16,7 +16,6 @@
 #include "steering.hpp"
 #include "movement.hpp"
 #include "character.hpp"
-
 #include "aicombataction.hpp"
 #include "combat.hpp"
 

--- a/apps/openmw/mwmechanics/aicombat.hpp
+++ b/apps/openmw/mwmechanics/aicombat.hpp
@@ -3,16 +3,15 @@
 
 #include "aipackage.hpp"
 
-#include "pathfinding.hpp"
-
-#include "movement.hpp"
-#include "obstacle.hpp"
+#include <boost/shared_ptr.hpp>
 
 #include "../mwworld/cellstore.hpp" // for Doors
 
 #include "../mwbase/world.hpp"
 
-#include <boost/shared_ptr.hpp>
+#include "pathfinding.hpp"
+#include "movement.hpp"
+#include "obstacle.hpp"
 
 namespace ESM
 {

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -1,5 +1,8 @@
 #include "aicombataction.hpp"
 
+#include <components/esm/loadench.hpp>
+#include <components/esm/loadmgef.hpp>
+
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 
@@ -8,11 +11,8 @@
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/actionequip.hpp"
 
-#include "../mwmechanics/npcstats.hpp"
-#include "../mwmechanics/spellcasting.hpp"
-
-#include <components/esm/loadench.hpp>
-#include <components/esm/loadmgef.hpp>
+#include "npcstats.hpp"
+#include "spellcasting.hpp"
 
 namespace
 {

--- a/apps/openmw/mwmechanics/aicombataction.hpp
+++ b/apps/openmw/mwmechanics/aicombataction.hpp
@@ -3,10 +3,10 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include <components/esm/loadspel.hpp>
+
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/containerstore.hpp"
-
-#include <components/esm/loadspel.hpp>
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/aiescort.cpp
+++ b/apps/openmw/mwmechanics/aiescort.cpp
@@ -10,8 +10,7 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
 
-#include "../mwmechanics/creaturestats.hpp"
-
+#include "creaturestats.hpp"
 #include "steering.hpp"
 #include "movement.hpp"
 

--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -2,6 +2,7 @@
 #define GAME_MWMECHANICS_AIESCORT_H
 
 #include "aipackage.hpp"
+
 #include <string>
 
 #include "pathfinding.hpp"

--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -6,11 +6,12 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
+
 #include "creaturestats.hpp"
 #include "movement.hpp"
-
 #include "steering.hpp"
 
 namespace MWMechanics

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -2,9 +2,12 @@
 #define GAME_MWMECHANICS_AIFOLLOW_H
 
 #include "aipackage.hpp"
+
 #include <string>
-#include "pathfinding.hpp"
+
 #include <components/esm/defs.hpp>
+
+#include "pathfinding.hpp"
 
 namespace ESM
 {

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -8,12 +8,13 @@
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
+
+#include "../mwworld/action.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
+
 #include "creaturestats.hpp"
 #include "movement.hpp"
-#include "../mwworld/action.hpp"
-
 #include "steering.hpp"
 #include "actorutil.hpp"
 #include "coordinateconverter.hpp"

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -1,9 +1,9 @@
 #ifndef GAME_MWMECHANICS_AIPACKAGE_H
 #define GAME_MWMECHANICS_AIPACKAGE_H
 
-#include "pathfinding.hpp"
 #include <components/esm/defs.hpp>
 
+#include "pathfinding.hpp"
 #include "obstacle.hpp"
 #include "aistate.hpp"
 

--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -8,8 +8,6 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/action.hpp"
 
-#include "../mwmechanics/creaturestats.hpp"
-
 #include "movement.hpp"
 #include "creaturestats.hpp"
 

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -2,9 +2,13 @@
 
 #include <limits>
 
+#include <components/esm/aisequence.hpp>
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
+
 #include "aipackage.hpp"
 #include "aistate.hpp"
-
 #include "aiwander.hpp"
 #include "aiescort.hpp"
 #include "aitravel.hpp"
@@ -13,11 +17,6 @@
 #include "aicombat.hpp"
 #include "aipursue.hpp"
 #include "actorutil.hpp"
-
-#include <components/esm/aisequence.hpp>
-
-#include "../mwbase/environment.hpp"
-#include "../mwbase/world.hpp"
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -4,7 +4,6 @@
 #include <list>
 
 #include <components/esm/loadnpc.hpp>
-//#include "aistate.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -5,11 +5,10 @@
 
 #include <vector>
 
-#include "pathfinding.hpp"
-#include "obstacle.hpp"
-
 #include "../mwworld/timestamp.hpp"
 
+#include "pathfinding.hpp"
+#include "obstacle.hpp"
 #include "aistate.hpp"
 
 namespace ESM

--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -15,7 +15,6 @@
 #include <components/esm/loadgmst.hpp>
 #include <components/esm/loadmgef.hpp>
 
-
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -21,13 +21,6 @@
 
 #include <iostream>
 
-
-#include "movement.hpp"
-#include "npcstats.hpp"
-#include "creaturestats.hpp"
-#include "security.hpp"
-#include "actorutil.hpp"
-
 #include <components/misc/rng.hpp>
 
 #include <components/settings/settings.hpp>
@@ -45,6 +38,12 @@
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/player.hpp"
+
+#include "movement.hpp"
+#include "npcstats.hpp"
+#include "creaturestats.hpp"
+#include "security.hpp"
+#include "actorutil.hpp"
 
 namespace
 {

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -8,17 +8,16 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/soundmanager.hpp"
-
-#include "../mwmechanics/npcstats.hpp"
-#include "../mwmechanics/movement.hpp"
-#include "../mwmechanics/spellcasting.hpp"
-#include "../mwmechanics/difficultyscaling.hpp"
+#include "../mwbase/windowmanager.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/esmstore.hpp"
 
-#include "../mwbase/windowmanager.hpp"
+#include "npcstats.hpp"
+#include "movement.hpp"
+#include "spellcasting.hpp"
+#include "difficultyscaling.hpp"
 #include "actorutil.hpp"
 
 namespace

--- a/apps/openmw/mwmechanics/difficultyscaling.cpp
+++ b/apps/openmw/mwmechanics/difficultyscaling.cpp
@@ -1,10 +1,10 @@
 #include "difficultyscaling.hpp"
 
+#include <components/settings/settings.hpp>
+
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwworld/esmstore.hpp"
-
-#include <components/settings/settings.hpp>
 
 #include "actorutil.hpp"
 

--- a/apps/openmw/mwmechanics/disease.hpp
+++ b/apps/openmw/mwmechanics/disease.hpp
@@ -6,13 +6,14 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
+
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
+
 #include "spells.hpp"
 #include "creaturestats.hpp"
 #include "actorutil.hpp"
-
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -6,6 +6,7 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/esmstore.hpp"
+
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "creaturestats.hpp"

--- a/apps/openmw/mwmechanics/enchanting.hpp
+++ b/apps/openmw/mwmechanics/enchanting.hpp
@@ -1,10 +1,15 @@
 #ifndef GAME_MWMECHANICS_ENCHANTING_H
 #define GAME_MWMECHANICS_ENCHANTING_H
+
 #include <string>
-#include "../mwworld/ptr.hpp"
+
 #include <components/esm/effectlist.hpp>
+
+#include "../mwworld/ptr.hpp"
+
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
+
 namespace MWMechanics
 {
     class Enchanting

--- a/apps/openmw/mwmechanics/levelledlist.hpp
+++ b/apps/openmw/mwmechanics/levelledlist.hpp
@@ -1,16 +1,18 @@
 #ifndef OPENMW_MECHANICS_LEVELLEDLIST_H
 #define OPENMW_MECHANICS_LEVELLEDLIST_H
 
-#include <components/misc/rng.hpp>
-
 #include <iostream>
+
+#include <components/misc/rng.hpp>
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/manualref.hpp"
 #include "../mwworld/class.hpp"
+
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
+
 #include "creaturestats.hpp"
 #include "actorutil.hpp"
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -11,18 +11,16 @@
 
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/inventorystore.hpp"
+#include "../mwworld/class.hpp"
+#include "../mwworld/player.hpp"
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 
-#include "../mwworld/class.hpp"
-#include "../mwworld/player.hpp"
-
-#include "../mwmechanics/aicombat.hpp"
-#include "../mwmechanics/aipursue.hpp"
-
+#include "aicombat.hpp"
+#include "aipursue.hpp"
 #include "spellcasting.hpp"
 #include "autocalcspell.hpp"
 #include "npcstats.hpp"

--- a/apps/openmw/mwmechanics/objects.cpp
+++ b/apps/openmw/mwmechanics/objects.cpp
@@ -2,10 +2,10 @@
 
 #include <iostream>
 
-#include "movement.hpp"
-
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
+
+#include "movement.hpp"
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -1,4 +1,5 @@
 #include "pathfinding.hpp"
+
 #include <limits>
 
 #include "../mwbase/world.hpp"
@@ -6,6 +7,7 @@
 
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/cellstore.hpp"
+
 #include "coordinateconverter.hpp"
 
 namespace

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -1,10 +1,11 @@
 #ifndef GAME_MWMECHANICS_PATHFINDING_H
 #define GAME_MWMECHANICS_PATHFINDING_H
 
-#include <components/esm/defs.hpp>
-#include <components/esm/loadpgrd.hpp>
 #include <list>
 #include <cassert>
+
+#include <components/esm/defs.hpp>
+#include <components/esm/loadpgrd.hpp>
 
 namespace MWWorld
 {

--- a/apps/openmw/mwmechanics/pathgrid.hpp
+++ b/apps/openmw/mwmechanics/pathgrid.hpp
@@ -1,8 +1,9 @@
 #ifndef GAME_MWMECHANICS_PATHGRID_H
 #define GAME_MWMECHANICS_PATHGRID_H
 
-#include <components/esm/loadpgrd.hpp>
 #include <list>
+
+#include <components/esm/loadpgrd.hpp>
 
 namespace ESM
 {

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -19,7 +19,6 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/esmstore.hpp"
-
 #include "../mwworld/inventorystore.hpp"
 
 #include "../mwrender/animation.hpp"

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -1,9 +1,9 @@
 #ifndef MWMECHANICS_SPELLSUCCESS_H
 #define MWMECHANICS_SPELLSUCCESS_H
 
-#include "../mwworld/ptr.hpp"
-
 #include <components/esm/loadskil.hpp>
+
+#include "../mwworld/ptr.hpp"
 
 namespace ESM
 {

--- a/apps/openmw/mwmechanics/summoning.cpp
+++ b/apps/openmw/mwmechanics/summoning.cpp
@@ -6,8 +6,6 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
-#include "../mwmechanics/spellcasting.hpp"
-
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/manualref.hpp"
@@ -15,9 +13,9 @@
 
 #include "../mwrender/animation.hpp"
 
+#include "spellcasting.hpp"
 #include "creaturestats.hpp"
 #include "aifollow.hpp"
-
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/summoning.hpp
+++ b/apps/openmw/mwmechanics/summoning.hpp
@@ -3,8 +3,9 @@
 
 #include <set>
 
-#include "magiceffects.hpp"
 #include "../mwworld/ptr.hpp"
+
+#include "magiceffects.hpp"
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/trading.cpp
+++ b/apps/openmw/mwmechanics/trading.cpp
@@ -6,10 +6,10 @@
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 
-#include "../mwmechanics/creaturestats.hpp"
-
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
+
+#include "creaturestats.hpp"
 
 namespace MWMechanics
 {


### PR DESCRIPTION
A general cleanup of #include statements for all files in mwmechanics.

Based on what seemed to be the general organization already in the files, I went by the following organization:

- include parent class file (if this is .hpp file) or header file for this file (if this is .cpp file)
- include standard C++ header files
- include /component/ header files*
- include header files from inside apps/openmw/ but outside mwmechanics*
- include header files from mwmechanics, without path attached

*grouped by path. 

One empty line separates each section.