### PR TITLE
Improve the MSVC prebuild script to allow compiled binaries to be run directly with no further modification

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -653,6 +653,19 @@ if [ -z $CI ]; then
 		cp "$DLL" $CONFIGURATION/osgPlugins-3.3.8
 	done
 	echo
+	
+	echo "Copying Runtime Resources/Config Files"
+	
+	echo "  gamecontrollerdb.txt"
+	cp $CONFIGURATION/../gamecontrollerdb.txt $CONFIGURATION/gamecontrollerdb.txt
+	echo "  openmw.cfg"
+	cp $CONFIGURATION/../openmw.cfg.install $CONFIGURATION/openmw.cfg
+	echo "  openmw-cs.cfg"
+	cp $CONFIGURATION/../openmw-cs.cfg $CONFIGURATION/openmw-cs.cfg
+	echo "  settings-default.cfg"
+	cp $CONFIGURATION/../settings-default.cfg $CONFIGURATION/settings-default.cfg
+	echo "  resources/"
+	cp -r $CONFIGURATION/../resources $CONFIGURATION/resources
 fi
 
 exit $RET


### PR DESCRIPTION
Before this change, having run the MSVC prebuild script, and built any apps, resource and configuration files would be present in the Build_64 folder, but not the Debug or Release folder, preventing the compiled binaries actually being run.

This change copies these files to the Debug or Release folder (depending on build configuration mode) where they can be accessed by the binaries, allowing them to be run without any manual relocation of files.

This was discussed somewhat with Ace here: https://forum.openmw.org/viewtopic.php?f=8&t=3264&start=10#p36370

Having come across the same problem again, I decided to attempt to resolve it permanently: https://forum.openmw.org/viewtopic.php?f=22&t=3629#p40446

This has been tested by re-running the prebuild script in both debug and release mode, and observing that the correct files (as defined by Ace) appeared in the intended locations, and also that the compiled binaries now ran without error. This *should* be sufficient due to the small scope of changes.