### PR TITLE
Fix magicka and fatigue calculations from fortifying attributes

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -425,7 +425,9 @@ namespace MWMechanics
 
         DynamicStat<float> magicka = creatureStats.getMagicka();
         float diff = (static_cast<int>(magickaFactor*intelligence)) - magicka.getBase();
-        magicka.modify(diff);
+        float currentToBaseRatio = (magicka.getCurrent() / magicka.getBase());
+        magicka.setModified(magicka.getModified() + diff, 0);
+        magicka.setCurrent(magicka.getBase() * currentToBaseRatio);
         creatureStats.setMagicka(magicka);
     }
 
@@ -553,8 +555,9 @@ namespace MWMechanics
             DynamicStat<float> stat = creatureStats.getDynamic(i);
             stat.setModifier(effects.get(ESM::MagicEffect::FortifyHealth+i).getMagnitude() -
                              effects.get(ESM::MagicEffect::DrainHealth+i).getMagnitude(),
+                             // Magicka can be decreased below zero due to a fortify effect wearing off
                              // Fatigue can be decreased below zero meaning the actor will be knocked out
-                             i == 2);
+                             i == 1 || i == 2);
 
             creatureStats.setDynamic(i, stat);
         }

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -157,7 +157,9 @@ namespace MWMechanics
                 int endurance    = getAttribute(ESM::Attribute::Endurance).getModified();
                 DynamicStat<float> fatigue = getFatigue();
                 float diff = (strength+willpower+agility+endurance) - fatigue.getBase();
-                fatigue.modify(diff);
+                float currentToBaseRatio = (fatigue.getCurrent() / fatigue.getBase());
+                fatigue.setModified(fatigue.getModified() + diff, 0);
+                fatigue.setCurrent(fatigue.getBase() * currentToBaseRatio);
                 setFatigue(fatigue);
             }
         }

--- a/apps/openmw/mwmechanics/stat.cpp
+++ b/apps/openmw/mwmechanics/stat.cpp
@@ -33,18 +33,6 @@ namespace MWMechanics
         mBase = mModified = value;
     }
     template<typename T>
-    void Stat<T>::modify(const T& diff)
-    {
-        mBase += diff;
-        if(mBase >= static_cast<T>(0))
-            mModified += diff;
-        else
-        {
-            mModified += diff - mBase;
-            mBase = static_cast<T>(0);
-        }
-    }
-    template<typename T>
     void Stat<T>::setBase (const T& value)
     {
         T diff = value - mBase;
@@ -137,12 +125,6 @@ namespace MWMechanics
 
         if (mCurrent>getModified())
             mCurrent = getModified();
-    }
-    template<typename T>
-    void DynamicStat<T>::modify (const T& diff, bool allowCurrentDecreaseBelowZero)
-    {
-        mStatic.modify (diff);
-        setCurrent (getCurrent()+diff, allowCurrentDecreaseBelowZero);
     }
     template<typename T>
     void DynamicStat<T>::setCurrent (const T& value, bool allowDecreaseBelowZero)

--- a/apps/openmw/mwmechanics/stat.hpp
+++ b/apps/openmw/mwmechanics/stat.hpp
@@ -32,7 +32,6 @@ namespace MWMechanics
 
             /// Set base and modified to \a value.
             void set (const T& value);
-            void modify(const T& diff);
 
             /// Set base and adjust modified accordingly.
             void setBase (const T& value);
@@ -84,9 +83,6 @@ namespace MWMechanics
 
             /// Set modified value an adjust base accordingly.
             void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max());
-
-            /// Change modified relatively.
-            void modify (const T& diff, bool allowCurrentDecreaseBelowZero=false);
 
             void setCurrent (const T& value, bool allowDecreaseBelowZero = false);
             void setModifier (const T& modifier, bool allowCurrentDecreaseBelowZero=false);


### PR DESCRIPTION
Fix for https://bugs.openmw.org/issues/2604.

This addresses the two issues mentioned in this bug, making magicka retain it's ratio between current magicka and maximum magicka before and after a fortify intelligence effect, and allowing magicka to go into the negatives after a fortify magicka spell has ended.

In game testing of the effects of magicka fortify and drain/damage spells showed that everything seemed to be working right.

This doesn't address the problem of the "fortify magicka" effect working differently from the original game. In the original game fortify magicka does not boost the maximum magicka but can take you over if the fortify is enough to take you over your pre-fortify maximum. Fortify health and fortify endurance are also like this.