### PR TITLE
Fix update of fatigue display

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -423,12 +423,25 @@ namespace MWMechanics
         double magickaFactor = base +
             creatureStats.getMagicEffects().get (EffectKey (ESM::MagicEffect::FortifyMaximumMagicka)).getMagnitude() * 0.1;
 
-        DynamicStat<float> magicka = creatureStats.getMagicka();
-        float diff = (static_cast<int>(magickaFactor*intelligence)) - magicka.getBase();
-        float currentToBaseRatio = (magicka.getCurrent() / magicka.getBase());
-        magicka.setModified(magicka.getModified() + diff, 0);
-        magicka.setCurrent(magicka.getBase() * currentToBaseRatio);
-        creatureStats.setMagicka(magicka);
+        DynamicStat<float> stat = creatureStats.getMagicka();
+        float diff = (static_cast<int>(magickaFactor*intelligence)) - stat.getBase();
+
+        float currentToBaseRatio = (stat.getCurrent() / stat.getBase());
+        stat.setModified(stat.getModified() + diff, 0);
+        stat.setCurrent(stat.getBase() * currentToBaseRatio);
+        creatureStats.setMagicka(stat);
+
+        int strength = creatureStats.getAttribute(ESM::Attribute::Strength).getModified();
+        int willpower = creatureStats.getAttribute(ESM::Attribute::Willpower).getModified();
+        int agility = creatureStats.getAttribute(ESM::Attribute::Agility).getModified();
+        int endurance = creatureStats.getAttribute(ESM::Attribute::Endurance).getModified();
+        stat = creatureStats.getFatigue();
+        diff = (strength+willpower+agility+endurance) - stat.getBase();
+
+        currentToBaseRatio = (stat.getCurrent() / stat.getBase());
+        stat.setModified(stat.getModified() + diff, 0);
+        stat.setCurrent(stat.getBase() * currentToBaseRatio);
+        creatureStats.setFatigue(stat);
     }
 
     void Actors::restoreDynamicStats (const MWWorld::Ptr& ptr, bool sleep)

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -54,6 +54,7 @@ namespace MWMechanics
         std::string mLastHitAttemptObject; // The last object to attempt to hit this actor
 
         bool mRecalcMagicka;
+        bool mRecalcFatigue;
 
         // For merchants: the last time items were restocked and gold pool refilled.
         MWWorld::TimeStamp mLastRestock;


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3449

The fatigue display was updated before `void MechanicsManager::update` in mechanicsmanagerimp.cpp could update the stat window. Now fatigue's update works in the same way as magicka's update.