### PR TITLE
Show correct class image in level-up dialog

### DIFF
--- a/apps/essimporter/convertplayer.cpp
+++ b/apps/essimporter/convertplayer.cpp
@@ -17,6 +17,8 @@ namespace ESSImport
             faction.mReputation = it->mReputation;
             out.mObject.mNpcStats.mFactions[Misc::StringUtils::lowerCase(it->mFactionName.toString())] = faction;
         }
+        for (int i=0; i<3; ++i)
+            out.mObject.mNpcStats.mSpecIncreases[i] = pcdt.mPNAM.mSpecIncreases[i];
         for (int i=0; i<8; ++i)
             out.mObject.mNpcStats.mSkillIncrease[i] = pcdt.mPNAM.mSkillIncreases[i];
         for (int i=0; i<27; ++i)

--- a/apps/essimporter/importplayer.hpp
+++ b/apps/essimporter/importplayer.hpp
@@ -67,7 +67,9 @@ struct PCDT
         unsigned int mLevelProgress;
         float mSkillProgress[27]; // skill progress, non-uniform scaled
         unsigned char mSkillIncreases[8]; // number of skill increases for each attribute
-        unsigned char mUnknown3[88];
+        unsigned char mUnknown3[84];
+        unsigned char mSpecIncreases[3]; // number of skill increases for each specialization
+        unsigned char mUnknown4;
     };
 #pragma pack(pop)
 

--- a/apps/openmw/mwgui/levelupdialog.cpp
+++ b/apps/openmw/mwgui/levelupdialog.cpp
@@ -340,7 +340,7 @@ namespace MWGui
                     ret = "pilgrim";
                 break;
             case 3:
-                if (magicFraction == 3 && stealthFraction == 3)
+                if (magicFraction == 3)
                     ret = "bard";
                 break;
             default:

--- a/apps/openmw/mwgui/levelupdialog.cpp
+++ b/apps/openmw/mwgui/levelupdialog.cpp
@@ -156,7 +156,9 @@ namespace MWGui
                 cls = &*it;
         }
 
-        setClassImage(mClassImage, cls->mId);
+        setClassImage(mClassImage, getLevelupClassImage(pcStats.getSkillIncreasesForSpecialization(0),
+                                                        pcStats.getSkillIncreasesForSpecialization(1),
+                                                        pcStats.getSkillIncreasesForSpecialization(2)));
 
         int level = creatureStats.getLevel ()+1;
         mLevelText->setCaptionWithReplacing("#{sLevelUpMenu1} " + MyGUI::utility::toString(level));
@@ -247,5 +249,104 @@ namespace MWGui
                 mSpentAttributes.push_back(attribute);
         }
         assignCoins();
+    }
+
+    std::string LevelupDialog::getLevelupClassImage(const int combatIncreases, const int magicIncreases, const int stealthIncreases)
+    {
+        std::string ret = "acrobat";
+
+        int total = combatIncreases + magicIncreases + stealthIncreases;
+        if (total == 0)
+            return ret;
+
+        int combatFraction = static_cast<int>(static_cast<float>(combatIncreases) / total * 10.f);
+        int magicFraction = static_cast<int>(static_cast<float>(magicIncreases) / total * 10.f);
+        int stealthFraction = static_cast<int>(static_cast<float>(stealthIncreases) / total * 10.f);
+
+        if (combatFraction > 7)
+            ret = "warrior";
+        else if (magicFraction > 7)
+            ret = "mage";
+        else if (stealthFraction > 7)
+            ret = "thief";
+
+        switch (combatFraction)
+        {
+            case 7:
+                ret = "warrior";
+                break;
+            case 6:
+                if (stealthFraction == 1)
+                    ret = "barbarian";
+                else if (stealthFraction == 3)
+                    ret = "crusader";
+                else
+                    ret = "knight";
+                break;
+            case 5:
+                if (stealthFraction == 3)
+                    ret = "scout";
+                else
+                    ret = "archer";
+                break;
+            case 4:
+                ret = "rogue";
+                break;
+            default:
+                break;
+        }
+
+        switch (magicFraction)
+        {
+            case 7:
+                ret = "mage";
+                break;
+            case 6:
+                if (combatFraction == 2)
+                    ret = "sorcerer";
+                else if (combatIncreases == 3)
+                    ret = "healer";
+                else
+                    ret = "battlemage";
+                break;
+            case 5:
+                ret = "witchhunter";
+                break;
+            case 4:
+                ret = "spellsword";
+                // In vanilla there's also code for "nightblade", however it seems to be unreachable.
+                break;
+            default:
+                break;
+        }
+
+        switch (stealthFraction)
+        {
+            case 7:
+                ret = "thief";
+                break;
+            case 6:
+                if (magicFraction == 1)
+                    ret = "agent";
+                else if (magicIncreases == 3)
+                    ret = "assassin";
+                else
+                    ret = "acrobat";
+                break;
+            case 5:
+                if (magicIncreases == 3)
+                    ret = "monk";
+                else
+                    ret = "pilgrim";
+                break;
+            case 3:
+                if (magicFraction == 3 && stealthFraction == 3)
+                    ret = "bard";
+                break;
+            default:
+                break;
+        }
+
+        return ret;
     }
 }

--- a/apps/openmw/mwgui/levelupdialog.hpp
+++ b/apps/openmw/mwgui/levelupdialog.hpp
@@ -39,6 +39,8 @@ namespace MWGui
         void resetCoins();
 
         void setAttributeValues();
+
+        std::string getLevelupClassImage(const int combatIncreases, const int magicIncreases, const int stealthIncreases);
     };
 
 }

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -34,6 +34,7 @@ MWMechanics::NpcStats::NpcStats()
     , mIsWerewolf(false)
 {
     mSkillIncreases.resize (ESM::Attribute::Length, 0);
+    mSpecIncreases.resize(3, 0);
 }
 
 int MWMechanics::NpcStats::getBaseDisposition() const
@@ -255,6 +256,8 @@ void MWMechanics::NpcStats::increaseSkill(int skillIndex, const ESM::Class &clas
         MWBase::Environment::get().getWorld ()->getStore ().get<ESM::Skill>().find(skillIndex);
     mSkillIncreases[skill->mData.mAttribute] += increase;
 
+    mSpecIncreases[skill->mData.mSpecialization] += gmst.find("iLevelupSpecialization")->getInt();
+
     // Play sound & skill progress notification
     /// \todo check if character is the player, if levelling is ever implemented for NPCs
     MWBase::Environment::get().getSoundManager ()->playSound ("skillraise", 1, 1);
@@ -324,6 +327,11 @@ int MWMechanics::NpcStats::getLevelupAttributeMultiplier(int attribute) const
     gmst << "iLevelUp" << std::setfill('0') << std::setw(2) << num << "Mult";
 
     return MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(gmst.str())->getInt();
+}
+
+int MWMechanics::NpcStats::getSkillIncreasesForSpecialization(int spec) const
+{
+    return mSpecIncreases[spec];
 }
 
 void MWMechanics::NpcStats::flagAsUsed (const std::string& id)
@@ -469,6 +477,9 @@ void MWMechanics::NpcStats::writeState (ESM::NpcStats& state) const
     for (int i=0; i<ESM::Attribute::Length; ++i)
         state.mSkillIncrease[i] = mSkillIncreases[i];
 
+    for (int i=0; i<3; ++i)
+        state.mSpecIncreases[i] = mSpecIncreases[i];
+
     std::copy (mUsedIds.begin(), mUsedIds.end(), std::back_inserter (state.mUsedIds));
 
     state.mTimeToStartDrowning = mTimeToStartDrowning;
@@ -507,6 +518,9 @@ void MWMechanics::NpcStats::readState (const ESM::NpcStats& state)
 
     for (int i=0; i<ESM::Attribute::Length; ++i)
         mSkillIncreases[i] = state.mSkillIncrease[i];
+
+    for (int i=0; i<3; ++i)
+        mSpecIncreases[i] = state.mSpecIncreases[i];
 
     for (std::vector<std::string>::const_iterator iter (state.mUsedIds.begin());
         iter!=state.mUsedIds.end(); ++iter)

--- a/apps/openmw/mwmechanics/npcstats.hpp
+++ b/apps/openmw/mwmechanics/npcstats.hpp
@@ -34,7 +34,8 @@ namespace MWMechanics
             std::set<std::string> mExpelled;
             std::map<std::string, int> mFactionReputation;
             int mLevelProgress; // 0-10
-            std::vector<int> mSkillIncreases; // number of skill increases for each attribute
+            std::vector<int> mSkillIncreases; // number of skill increases for each attribute (resets after leveling up)
+            std::vector<int> mSpecIncreases; // number of skill increases for each specialization (accumulates throughout the entire game)
             std::set<std::string> mUsedIds;
             // ---------------------------------------------------------------------------
 
@@ -85,6 +86,8 @@ namespace MWMechanics
             int getLevelProgress() const;
 
             int getLevelupAttributeMultiplier(int attribute) const;
+
+            int getSkillIncreasesForSpecialization(int spec) const;
 
             void levelUp();
 

--- a/components/esm/npcstats.cpp
+++ b/components/esm/npcstats.cpp
@@ -95,6 +95,8 @@ void ESM::NpcStats::load (ESMReader &esm)
 
     esm.getHNT (mSkillIncrease, "INCR");
 
+    esm.getHNOT (mSpecIncreases, "SPEC");
+
     while (esm.isNextSub ("USED"))
         mUsedIds.push_back (esm.getHString());
 
@@ -156,6 +158,8 @@ void ESM::NpcStats::save (ESMWriter &esm) const
 
     esm.writeHNT ("INCR", mSkillIncrease);
 
+    esm.writeHNT ("SPEC", mSpecIncreases);
+
     for (std::vector<std::string>::const_iterator iter (mUsedIds.begin()); iter!=mUsedIds.end();
         ++iter)
         esm.writeHNString ("USED", *iter);
@@ -178,6 +182,8 @@ void ESM::NpcStats::blank()
     mLevelProgress = 0;
     for (int i=0; i<8; ++i)
         mSkillIncrease[i] = 0;
+    for (int i=0; i<3; ++i)
+        mSpecIncreases[i] = 0;
     mTimeToStartDrowning = 20;
     mCrimeId = -1;
 }

--- a/components/esm/npcstats.cpp
+++ b/components/esm/npcstats.cpp
@@ -95,6 +95,8 @@ void ESM::NpcStats::load (ESMReader &esm)
 
     esm.getHNT (mSkillIncrease, "INCR");
 
+    for (int i=0; i<3; ++i)
+        mSpecIncreases[i] = 0;
     esm.getHNOT (mSpecIncreases, "SPEC");
 
     while (esm.isNextSub ("USED"))

--- a/components/esm/npcstats.hpp
+++ b/components/esm/npcstats.hpp
@@ -37,6 +37,7 @@ namespace ESM
         int mWerewolfKills;
         int mLevelProgress;
         int mSkillIncrease[8];
+        int mSpecIncreases[3];
         std::vector<std::string> mUsedIds; // lower case IDs
         float mTimeToStartDrowning;
         int mCrimeId;


### PR DESCRIPTION
Bug report: http://bugs.openmw.org/issues/3443

OpenMW's current behavior of choosing the player's class image in the level-up dialog is wrong.

What image is displayed actually depends on the number of skill increases for each of the three skill specializations (combat, magic & stealth). Unlike the increases that affect attribute multipliers, these numbers do not reset when the player levels up.

I have also updated essimporter to pull these numbers from vanilla savegames.