### PR TITLE
Fix timing of some magicka calculations

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -532,6 +532,9 @@ namespace MWMechanics
             creatureStats.setAttribute(i, stat);
         }
 
+        if (creatureStats.needToRecalcDynamicStats())
+            calculateDynamicStats(ptr);
+
         {
             Spells & spells = creatureStats.getSpells();
             for (Spells::TIterator it = spells.begin(); it != spells.end(); ++it)


### PR DESCRIPTION
A simple change to make intelligence-derived magicka calculations and maximum magicka fortify effects apply immediately when an item is equipped, as other stats do in OpenMW.

Note that the behavior is still a little different from the original game. In the original game when an item with enchantments is equipped, stat modifiers won't apply and the magic visual effect and sound won't play until the stat window is first closed. However, they do apply immediately when an item is unequipped. That means that for unequipping behavior, this fix brings OpenMW in line with the original engine.