### PR TITLE
Fix incorrect purging of constant-effect invisibility

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -722,7 +722,11 @@ void MWWorld::InventoryStore::rechargeItems(float duration)
 
 void MWWorld::InventoryStore::purgeEffect(short effectId)
 {
-    mMagicEffects.remove(MWMechanics::EffectKey(effectId));
+    for (TSlots::const_iterator it = mSlots.begin(); it != mSlots.end(); ++it)
+    {
+        if (*it != end())
+            purgeEffect(effectId, (*it)->getCellRef().getRefId());
+    }
 }
 
 void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sourceId)


### PR DESCRIPTION
Bug report: https://bugs.openmw.org/issues/3448

This PR fixes bugs that occur after breaking constant-effect invisibility:
 - effect icon not disappearing
 - effect reapplied after saving and reloading the game
 - effect reapplied after (un)equpping an item other than the one that gave the player invisibility

I'm not really sure whether https://github.com/OpenMW/openmw/blob/528de956da1508a51e0e9ec8af8dda9b9b3937f3/apps/openmw/mwmechanics/actors.cpp#L518 is affected by this change, though.