### PR TITLE
Implement effect removal for abilities (Fixes #3455)

### DIFF
--- a/apps/essimporter/converter.hpp
+++ b/apps/essimporter/converter.hpp
@@ -121,7 +121,7 @@ public:
         {
             mContext->mPlayer.mObject.mCreatureStats.mLevel = npc.mNpdt52.mLevel;
             mContext->mPlayerBase = npc;
-            std::map<int, float> empty;
+            ESM::SpellState::SpellParams empty;
             // FIXME: player start spells and birthsign spells aren't listed here,
             // need to fix openmw to account for this
             for (std::vector<std::string>::const_iterator it = npc.mSpells.mList.begin(); it != npc.mSpells.mList.end(); ++it)

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -513,6 +513,7 @@ namespace MWMechanics
                     CastSpell cast(ptr, ptr);
                     if (cast.applyInstantEffect(ptr, ptr, it->first, it->second.getMagnitude()))
                     {
+                        creatureStats.getSpells().purgeEffect(it->first.mId);
                         creatureStats.getActiveSpells().purgeEffect(it->first.mId);
                         if (ptr.getClass().hasInventoryStore(ptr))
                             ptr.getClass().getInventoryStore(ptr).purgeEffect(it->first.mId);

--- a/apps/openmw/mwmechanics/spells.hpp
+++ b/apps/openmw/mwmechanics/spells.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <string>
+#include <set>
 
 #include <components/misc/stringops.hpp>
 
@@ -32,8 +33,12 @@ namespace MWMechanics
         public:
 
             typedef const ESM::Spell* SpellKey;
+            struct SpellParams {
+                std::map<int, float> mEffectRands; // <effect index, normalised random magnitude>
+                std::set<int> mPurgedEffects; // indices of purged effects
+            };
 
-            typedef std::map<SpellKey, std::map<int, float> > TContainer; // ID, <effect index, normalised random magnitude>
+            typedef std::map<SpellKey, SpellParams> TContainer;
             typedef TContainer::const_iterator TIterator;
 
             struct CorprusStats
@@ -66,6 +71,9 @@ namespace MWMechanics
             void worsenCorprus(const ESM::Spell* spell);
             static bool hasCorprusEffect(const ESM::Spell *spell);
             const std::map<SpellKey, CorprusStats> & getCorprusSpells() const;
+
+            void purgeEffect(int effectId);
+            void purgeEffect(int effectId, const std::string & sourceId);
 
             bool canUsePower (const ESM::Spell* spell) const;
             void usePower (const ESM::Spell* spell);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2687,6 +2687,7 @@ namespace MWWorld
 
     void World::breakInvisibility(const Ptr &actor)
     {
+        actor.getClass().getCreatureStats(actor).getSpells().purgeEffect(ESM::MagicEffect::Invisibility);
         actor.getClass().getCreatureStats(actor).getActiveSpells().purgeEffect(ESM::MagicEffect::Invisibility);
         if (actor.getClass().hasInventoryStore(actor))
             actor.getClass().getInventoryStore(actor).purgeEffect(ESM::MagicEffect::Invisibility);

--- a/components/esm/spellstate.cpp
+++ b/components/esm/spellstate.cpp
@@ -12,7 +12,7 @@ namespace ESM
         {
             std::string id = esm.getHString();
 
-            std::map<int, float> random;
+            SpellParams state;
             while (esm.isNextSub("INDX"))
             {
                 int index;
@@ -21,10 +21,16 @@ namespace ESM
                 float magnitude;
                 esm.getHNT(magnitude, "RAND");
 
-                random[index] = magnitude;
+                state.mEffectRands[index] = magnitude;
             }
 
-            mSpells[id] = random;
+            while (esm.isNextSub("PURG")) {
+                int index;
+                esm.getHT(index);
+                state.mPurgedEffects.insert(index);
+            }
+
+            mSpells[id] = state;
         }
 
         while (esm.isNextSub("PERM"))
@@ -73,12 +79,16 @@ namespace ESM
         {
             esm.writeHNString("SPEL", it->first);
 
-            const std::map<int, float>& random = it->second;
+            const std::map<int, float>& random = it->second.mEffectRands;
             for (std::map<int, float>::const_iterator rIt = random.begin(); rIt != random.end(); ++rIt)
             {
                 esm.writeHNT("INDX", rIt->first);
                 esm.writeHNT("RAND", rIt->second);
             }
+
+            const std::set<int>& purges = it->second.mPurgedEffects;
+            for (std::set<int>::const_iterator pIt = purges.begin(); pIt != purges.end(); ++pIt)
+                esm.writeHNT("PURG", *pIt);
         }
 
         for (std::map<std::string, std::vector<PermanentSpellEffectInfo> >::const_iterator it = mPermanentSpellEffects.begin(); it != mPermanentSpellEffects.end(); ++it)

--- a/components/esm/spellstate.hpp
+++ b/components/esm/spellstate.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <set>
 
 #include "defs.hpp"
 
@@ -28,7 +29,11 @@ namespace ESM
             float mMagnitude;
         };
 
-        typedef std::map<std::string, std::map<int, float> > TContainer;
+        struct SpellParams {
+            std::map<int, float> mEffectRands;
+            std::set<int> mPurgedEffects;
+        };
+        typedef std::map<std::string, SpellParams> TContainer;
         TContainer mSpells;
 
         std::map<std::string, std::vector<PermanentSpellEffectInfo> > mPermanentSpellEffects;


### PR DESCRIPTION
Bug report: https://bugs.openmw.org/issues/3455

Instant effects originating from abilities/diseases/curses will now only be applied once instead of every frame. Tested with [Bruno's Box Home 3.0](http://mw.modhistory.com/download-44-15336), which utilizes abilities with Mark and Recall effects.

Save game backwards compatibility should remain unaffected.