### PR TITLE
Improve format specifiers for message boxes

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -85,7 +85,7 @@ add_component_dir (esmterrain
     )
 
 add_component_dir (misc
-    utf8stream stringops resourcehelpers rng
+    utf8stream stringops resourcehelpers rng messageformatparser
     )
 
 IF(NOT WIN32 AND NOT APPLE)

--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -140,30 +140,9 @@ namespace Compiler
 
         if (mState==MessageState || mState==MessageCommaState)
         {
-            std::string arguments;
-
-            for (std::size_t i=0; i<name.size(); ++i)
-            {
-                if (name[i]=='%')
-                {
-                    ++i;
-                    if (i<name.size())
-                    {
-                        if (name[i]=='G' || name[i]=='g')
-                        {
-                            arguments += "l";
-                        }
-                        else if (name[i]=='S' || name[i]=='s')
-                        {
-                            arguments += 'S';
-                        }
-                        else if (name[i]=='.' || name[i]=='f')
-                        {
-                            arguments += 'f';
-                        }
-                    }
-                }
-            }
+            GetArgumentsFromMessageFormat processor;
+            processor.process(name);
+            std::string arguments = processor.getArguments();
 
             if (!arguments.empty())
             {
@@ -577,4 +556,23 @@ namespace Compiler
         mName.clear();
         mExplicit.clear();
     }
+
+    void GetArgumentsFromMessageFormat::visitedPlaceholder(Placeholder placeholder, char /*padding*/, int /*width*/, int /*precision*/)
+    {
+        switch (placeholder)
+        {
+            case StringPlaceholder:
+                mArguments += 'S';
+                break;
+            case IntegerPlaceholder:
+                mArguments += 'l';
+                break;
+            case FloatPlaceholder:
+                mArguments += 'f';
+                break;
+            default:
+                break;
+        }
+    }
+
 }

--- a/components/compiler/lineparser.hpp
+++ b/components/compiler/lineparser.hpp
@@ -2,8 +2,10 @@
 #define COMPILER_LINEPARSER_H_INCLUDED
 
 #include <vector>
+#include <string>
 
 #include <components/interpreter/types.hpp>
+#include <components/misc/messageformatparser.hpp>
 
 #include "parser.hpp"
 #include "exprparser.hpp"
@@ -73,6 +75,24 @@ namespace Compiler
 
             void reset();
             ///< Reset parser to clean state.
+    };
+
+    class GetArgumentsFromMessageFormat : public ::Misc::MessageFormatParser
+    {
+        private:
+            std::string mArguments;
+
+        protected:
+            virtual void visitedPlaceholder(Placeholder placeholder, char padding, int width, int precision);
+            virtual void visitedCharacter(char c) {}
+
+        public:
+            virtual void process(const std::string& message)
+            {
+                mArguments.clear();
+                ::Misc::MessageFormatParser::process(message);
+            }
+            std::string getArguments() const { return mArguments; }
     };
 }
 

--- a/components/misc/messageformatparser.cpp
+++ b/components/misc/messageformatparser.cpp
@@ -1,0 +1,68 @@
+#include "messageformatparser.hpp"
+
+namespace Misc
+{
+    void MessageFormatParser::process(const std::string& m)
+    {
+        for (unsigned int i = 0; i < m.size(); ++i)
+        {
+            if (m[i] == '%')
+            {
+                if (++i < m.size())
+                {
+                    if (m[i] == '%')
+                        visitedCharacter('%');
+                    else
+                    {
+                        char pad = ' ';
+                        if (m[i] == '0' || m[i] == ' ')
+                        {
+                            pad = m[i];
+                            ++i;
+                        }
+
+                        int width = 0;
+                        bool widthSet = false;
+                        while (i < m.size() && m[i] >= '0' && m[i] <= '9')
+                        {
+                            width = width * 10 + (m[i] - '0');
+                            widthSet = true;
+                            ++i;
+                        }
+
+                        if (i < m.size())
+                        {
+                            int precision = 0;
+                            bool precisionSet = false;
+                            if (m[i] == '.')
+                            {
+                                while (++i < m.size() && m[i] >= '0' && m[i] <= '9')
+                                {
+                                    precision = precision * 10 + (m[i] - '0');
+                                    precisionSet = true;
+                                }
+                            }
+
+                            if (i < m.size())
+                            {
+                                width = (widthSet) ? width : -1;
+                                precision = (precisionSet) ? precision : -1;
+
+                                if (m[i] == 'S' || m[i] == 's')
+                                    visitedPlaceholder(StringPlaceholder, pad, width, precision);
+                                else if (m[i] == 'g' || m[i] == 'G')
+                                    visitedPlaceholder(IntegerPlaceholder, pad, width, precision);
+                                else if (m[i] == 'f' || m[i] == 'F')
+                                    visitedPlaceholder(FloatPlaceholder, pad, width, precision);
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                visitedCharacter(m[i]);
+            }
+        }
+    }
+}

--- a/components/misc/messageformatparser.hpp
+++ b/components/misc/messageformatparser.hpp
@@ -1,0 +1,26 @@
+#ifndef OPENMW_COMPONENTS_MISC_MESSAGEFORMATPARSER_H
+#define OPENMW_COMPONENTS_MISC_MESSAGEFORMATPARSER_H
+
+#include <string>
+
+namespace Misc
+{
+    class MessageFormatParser
+    {
+        protected:
+            enum Placeholder
+            {
+                StringPlaceholder,
+                IntegerPlaceholder,
+                FloatPlaceholder
+            };
+
+            virtual void visitedPlaceholder(Placeholder placeholder, char padding, int width, int precision) = 0;
+            virtual void visitedCharacter(char c) = 0;
+
+        public:
+            virtual void process(const std::string& message);
+    };
+}
+
+#endif


### PR DESCRIPTION
Add basic support for fill characters, width and precision, e.g. "%02g" or "%.2f". Also, the format parsing code is now shared between the compiler and the interpreter.

This fixes message box issues in Abot's Silt Striders mod:
![msgbox](https://cloud.githubusercontent.com/assets/7346770/16705302/5d07d2b6-4585-11e6-8573-a44aa8f1577e.png)
