### PR TITLE
Trap and lock fixes

### DIFF
--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -137,7 +137,8 @@ namespace MWClass
         MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
         MWWorld::InventoryStore& invStore = player.getClass().getInventoryStore(player);
 
-        bool needKey = ptr.getCellRef().getLockLevel() > 0;
+        bool isLocked = ptr.getCellRef().getLockLevel() > 0;
+        bool isTrapped = !ptr.getCellRef().getTrap().empty();
         bool hasKey = false;
         std::string keyName;
 
@@ -155,24 +156,26 @@ namespace MWClass
             }
         }
 
-        if (needKey && hasKey)
+        if ((isLocked || isTrapped) && hasKey)
         {
             MWBase::Environment::get().getWindowManager ()->messageBox (keyName + " #{sKeyUsed}");
-            unlock(ptr);
+            if(isLocked)
+                unlock(ptr);
             // using a key disarms the trap
-            if(!ptr.getCellRef().getTrap().empty())
+            if(isTrapped)
             {
                 ptr.getCellRef().setTrap("");
                 MWBase::Environment::get().getSoundManager()->playSound3D(ptr,
                     "Disarm Trap", 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx,
                     MWBase::SoundManager::Play_Normal);
+                isTrapped = false;
             }
         }
 
 
-        if (!needKey || hasKey)
+        if (!isLocked || hasKey)
         {
-            if(ptr.getCellRef().getTrap().empty())
+            if(!isTrapped)
             {
                 boost::shared_ptr<MWWorld::Action> action (new MWWorld::ActionOpen(ptr));
                 return action;

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -173,7 +173,7 @@ namespace MWClass
             else
             {
                 // Activate trap
-                boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionTrap(actor, ptr.getCellRef().getTrap(), ptr));
+                boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionTrap(ptr.getCellRef().getTrap(), ptr));
                 action->setSound(trapActivationSound);
                 return action;
             }

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -7,6 +7,7 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/failedaction.hpp"
@@ -159,7 +160,13 @@ namespace MWClass
             MWBase::Environment::get().getWindowManager ()->messageBox (keyName + " #{sKeyUsed}");
             unlock(ptr);
             // using a key disarms the trap
-            ptr.getCellRef().setTrap("");
+            if(!ptr.getCellRef().getTrap().empty())
+            {
+                ptr.getCellRef().setTrap("");
+                MWBase::Environment::get().getSoundManager()->playSound3D(ptr,
+                    "Disarm Trap", 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx,
+                    MWBase::SoundManager::Play_Normal);
+            }
         }
 
 

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -139,7 +139,7 @@ namespace MWClass
             if(!ptr.getCellRef().getTrap().empty())
             {
                 // Trap activation
-                boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionTrap(actor, ptr.getCellRef().getTrap(), ptr));
+                boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionTrap(ptr.getCellRef().getTrap(), ptr));
                 action->setSound(trapActivationSound);
                 return action;
             }

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -131,7 +131,13 @@ namespace MWClass
                 MWBase::Environment::get().getWindowManager()->messageBox(keyName + " #{sKeyUsed}");
             unlock(ptr); //Call the function here. because that makes sense.
             // using a key disarms the trap
-            ptr.getCellRef().setTrap("");
+            if(!ptr.getCellRef().getTrap().empty())
+            {
+                ptr.getCellRef().setTrap("");
+                MWBase::Environment::get().getSoundManager()->playSound3D(ptr,
+                    "Disarm Trap", 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx,
+                    MWBase::SoundManager::Play_Normal);
+            }
         }
 
         if (!needKey || hasKey)

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1305,7 +1305,9 @@ bool CharacterController::updateWeaponState()
                 if(!resultMessage.empty())
                     MWBase::Environment::get().getWindowManager()->messageBox(resultMessage);
                 if(!resultSound.empty())
-                    MWBase::Environment::get().getSoundManager()->playSound(resultSound, 1.0f, 1.0f);
+                    MWBase::Environment::get().getSoundManager()->playSound3D(target,
+                    resultSound, 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx,
+                    MWBase::SoundManager::Play_Normal);
             }
             else if (ammunition)
             {

--- a/apps/openmw/mwworld/actiontrap.hpp
+++ b/apps/openmw/mwworld/actiontrap.hpp
@@ -18,10 +18,9 @@ namespace MWWorld
         public:
 
             /// @param spellId
-            /// @param actor Actor that activated the trap
             /// @param trapSource
-            ActionTrap (const Ptr& actor, const std::string& spellId, const Ptr& trapSource)
-                : Action(false, actor), mSpellId(spellId), mTrapSource(trapSource) {}
+            ActionTrap (const std::string& spellId, const Ptr& trapSource)
+                : Action(false, trapSource), mSpellId(spellId), mTrapSource(trapSource) {}
     };
 }
 


### PR DESCRIPTION
Some fixes to make OpenMW behavior the same as original engine behavior.

1. The trap activation sound was playing on the actor, not the trap. Fixed this and removed resulting unused parameter in `actiontrap.`
2. Doors and containers that are disarmed with a key now play the disarm trap sound.
3. Lockpick and probe sounds are now 3d and play on the picked/probed object.
4. Keys can be used to disarm trapped objects of lock level 0 now. This produces a message "-- key used to open lock" which is a little odd maybe but the same message as the original game. I at first was doing an implementation that disarmed the trap without any message, but I thought that for gameplay purposes it is good to know what key was used, so I copied the original engine behavior. 