### PR TITLE
Fix third-person activation range

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1737,7 +1737,7 @@ namespace MWWorld
 
         facedObject = rayToObject.mHitObject;
         if (rayToObject.mHit)
-            mDistanceToFacedObject = rayToObject.mRatio * maxDistance;
+            mDistanceToFacedObject = (rayToObject.mRatio * maxDistance) - mRendering->getCameraDistance();
         else
             mDistanceToFacedObject = -1;
         return facedObject;


### PR DESCRIPTION
Fix a mistake in my previous PR on telekinesis that caused third-person activation range to be miscalculated. The camera distance of third person was being erroneously added to the distance to the faced object.