### PR TITLE
Do not skip inactive keyframe controllers

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -321,8 +321,8 @@ namespace NifOsg
                     continue;
                 }
 
-                if (!(ctrl->flags & Nif::NiNode::ControllerFlag_Active))
-                    continue;
+                // Vanilla seems to ignore the "active" flag for NiKeyframeController,
+                // so we don't want to skip inactive controllers here.
 
                 const Nif::NiStringExtraData *strdata = static_cast<const Nif::NiStringExtraData*>(extra.getPtr());
                 const Nif::NiKeyframeController *key = static_cast<const Nif::NiKeyframeController*>(ctrl.getPtr());


### PR DESCRIPTION
Bug report: http://bugs.openmw.org/issues/1942

If you deactivate all NiKeyframeControllers in a model, vanilla will continue to play its animations. This fixes the incorrect rotation of Abot's silt striders.