### PR TITLE
Trim unneeded code

### DIFF
--- a/apps/openmw/mwmechanics/aiescort.cpp
+++ b/apps/openmw/mwmechanics/aiescort.cpp
@@ -68,7 +68,6 @@ namespace MWMechanics
             if (mRemainingDuration <= 0)
             {
                 mRemainingDuration = mDuration;
-                mStarted = false; // Reset to false so this package will build path again when repeating
                 return true;
             }
         }
@@ -100,7 +99,6 @@ namespace MWMechanics
             if(pathTo(actor,point,duration)) //Returns true on path complete
             {
                 mRemainingDuration = mDuration;
-                mStarted = false; // Reset to false so this package will build path again when repeating
                 return true;
             }
             mMaxDist = 450;

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -51,7 +51,7 @@ bool MWMechanics::AiPackage::getRepeat() const
     return false;
 }
 
-MWMechanics::AiPackage::AiPackage() : mTimer(0.26f), mStarted(false) { //mTimer starts at .26 to force initial pathbuild
+MWMechanics::AiPackage::AiPackage() : mTimer(0.26f) { //mTimer starts at .26 to force initial pathbuild
 
 }
 
@@ -79,14 +79,8 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, ESM::Pathgrid::Po
     //***********************
     if(mTimer > 0.25)
     {
-        const ESM::Cell *cell = actor.getCell()->getCell();
-        // If repeating an AI package (mStarted has been set to false again), build a new path if needed so package doesn't immediately end
-        if (!mStarted && distance(pos.pos, dest) > 10) {
-            mStarted = true;
-            mPathFinder.buildSyncedPath(pos.pos, dest, actor.getCell(), true); //Rebuild path, in case the target has moved
-            mPrevDest = dest;
-        }
-        else if (doesPathNeedRecalc(dest, cell)) { //Only rebuild path if it's moved
+        const ESM::Cell *cell = actor.getCell()->getCell();       
+        if (doesPathNeedRecalc(dest, cell)) { //Only rebuild path if it's moved
             mPathFinder.buildSyncedPath(pos.pos, dest, actor.getCell(), true); //Rebuild path, in case the target has moved
             mPrevDest = dest;
         }
@@ -146,7 +140,7 @@ void MWMechanics::AiPackage::evadeObstacles(const MWWorld::Ptr& actor, float dur
 
 bool MWMechanics::AiPackage::doesPathNeedRecalc(ESM::Pathgrid::Point dest, const ESM::Cell *cell)
 {
-    return distance(mPrevDest, dest) > 10;
+    return mPathFinder.getPath().empty() || (distance(mPrevDest, dest) > 10);
 }
 
 bool MWMechanics::AiPackage::isTargetMagicallyHidden(const MWWorld::Ptr& target)

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -108,9 +108,6 @@ namespace MWMechanics
 
             float mTimer;
 
-            // Set to true once package starts actually being executed
-            bool mStarted;
-
             ESM::Pathgrid::Point mPrevDest;
 
         private:

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -58,13 +58,9 @@ namespace MWMechanics
         if (!isWithinMaxRange(osg::Vec3f(mX, mY, mZ), pos.asVec3()))
             return false;
 
-        if (!mStarted)
-            mStarted = true;
-
         if (pathTo(actor, ESM::Pathgrid::Point(static_cast<int>(mX), static_cast<int>(mY), static_cast<int>(mZ)), duration))
         {
             actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
-            mStarted = false; // Reset to false so this package will build path again when repeating
             return true;
         }
         return false;


### PR DESCRIPTION
Trim out unneeded variable mStarted and some redundant code.

When escort packages repeat and use aipackage.cpp's `pathTo()` repeat, they need something to get them past the very first call, because their `mPrevDest` is the same as `dest` and their path is empty. Checking for the empty path and using this to start a path recalculation seems to handle this situation. This should also avoid the theoretically possible? situation of `doesPathNeedRecalc()` returning false for a destination of 0,0,0, which is what `mPrevDest` is initialized to.