### PR TITLE
Fix doubled particle spawn range

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -918,9 +918,9 @@ namespace NifOsg
             emitter->setShooter(shooter);
 
             osgParticle::BoxPlacer* placer = new osgParticle::BoxPlacer;
-            placer->setXRange(-partctrl->offsetRandom.x(), partctrl->offsetRandom.x());
-            placer->setYRange(-partctrl->offsetRandom.y(), partctrl->offsetRandom.y());
-            placer->setZRange(-partctrl->offsetRandom.z(), partctrl->offsetRandom.z());
+            placer->setXRange(-partctrl->offsetRandom.x() / 2.f, partctrl->offsetRandom.x() / 2.f);
+            placer->setYRange(-partctrl->offsetRandom.y() / 2.f, partctrl->offsetRandom.y() / 2.f);
+            placer->setZRange(-partctrl->offsetRandom.z() / 2.f, partctrl->offsetRandom.z() / 2.f);
 
             emitter->setPlacer(placer);
             return emitter;


### PR DESCRIPTION
Bug report: https://bugs.openmw.org/issues/3408

Another example: in meshes/e/magic_cast_restore.nif, the sparks should only spawn within the tube, but they extend further beyond it.