### PR TITLE
Make non-actors play spell cast visuals and sounds

### DIFF
--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -122,14 +122,10 @@ namespace MWClass
 
             const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
             const ESM::MagicEffect *effect;
-            effect = store.get<ESM::MagicEffect>().find(59);
+            int index = effect->effectStringToId("sEffectTelekinesis");
+            effect = store.get<ESM::MagicEffect>().find(index);
 
-            osg::Vec4f glowcolor(1,1,1,1);
-            glowcolor.x() = effect->mData.mRed / 255.f;
-            glowcolor.y() = effect->mData.mGreen / 255.f;
-            glowcolor.z() = effect->mData.mBlue / 255.f;
-
-            animation->addSpellCastGlow(glowcolor); // TODO: Telekinesis glow should only be as long as the door animation
+            animation->addSpellCastGlow(effect); // TODO: Telekinesis glow should only be as long as the door animation
         }
 
         // make key id lowercase

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -25,6 +25,7 @@
 
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
+#include "../mwrender/animation.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
 
@@ -111,6 +112,24 @@ namespace MWClass
         bool isTrapped = !ptr.getCellRef().getTrap().empty();
         bool hasKey = false;
         std::string keyName;
+
+        if (actor == MWBase::Environment::get().getWorld()->getPlayerPtr() &&  // assuming player is using telekinesis
+            MWBase::Environment::get().getWorld()->getDistanceToFacedObject() > 
+            MWBase::Environment::get().getWorld()->getMaxActivationDistance())
+        {
+            MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(ptr);
+
+            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
+            const ESM::MagicEffect *effect;
+            effect = store.get<ESM::MagicEffect>().find(59);
+
+            osg::Vec4f glowcolor(1,1,1,1);
+            glowcolor.x() = effect->mData.mRed / 255.f;
+            glowcolor.y() = effect->mData.mGreen / 255.f;
+            glowcolor.z() = effect->mData.mBlue / 255.f;
+
+            animation->addSpellCastGlow(glowcolor); // TODO: Telekinesis glow should only be as long as the door animation
+        }
 
         // make key id lowercase
         std::string keyId = ptr.getCellRef().getKey();

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -113,7 +113,8 @@ namespace MWClass
         bool hasKey = false;
         std::string keyName;
 
-        if (actor == MWBase::Environment::get().getWorld()->getPlayerPtr() &&  // assuming player is using telekinesis
+        // make door glow if player activates it with telekinesis
+        if (actor == MWBase::Environment::get().getWorld()->getPlayerPtr() &&
             MWBase::Environment::get().getWorld()->getDistanceToFacedObject() > 
             MWBase::Environment::get().getWorld()->getMaxActivationDistance())
         {

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -120,10 +120,9 @@ namespace MWClass
         {
             MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(ptr);
 
-            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
-            const ESM::MagicEffect *effect;
-            int index = effect->effectStringToId("sEffectTelekinesis");
-            effect = store.get<ESM::MagicEffect>().find(index);
+            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();            
+            int index = ESM::MagicEffect::effectStringToId("sEffectTelekinesis");
+            const ESM::MagicEffect *effect = store.get<ESM::MagicEffect>().find(index);
 
             animation->addSpellCastGlow(effect); // TODO: Telekinesis glow should only be as long as the door animation
         }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1531,11 +1531,10 @@ void CharacterController::update(float duration)
     osg::Vec3f movement(0.f, 0.f, 0.f);
     float speed = 0.f;
 
+    updateMagicEffects();
+
     if(!cls.isActor())
     {
-        updateMagicEffects();
-        MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(mPtr);
-        animation->updateSpellGlow(duration);
         if(mAnimQueue.size() > 1)
         {
             if(mAnimation->isPlaying(mAnimQueue.front().mGroup) == false)

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1531,10 +1531,11 @@ void CharacterController::update(float duration)
     osg::Vec3f movement(0.f, 0.f, 0.f);
     float speed = 0.f;
 
-    updateMagicEffects();
-
     if(!cls.isActor())
     {
+        updateMagicEffects();
+        MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(mPtr);
+        animation->updateSpellGlow(duration);
         if(mAnimQueue.size() > 1)
         {
             if(mAnimation->isPlaying(mAnimQueue.front().mGroup) == false)

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -214,8 +214,6 @@ class CharacterController : public MWRender::Animation::TextKeyListener
 
     void updateHeadTracking(float duration);
 
-    void castSpell(const std::string& spellid);
-
     void updateMagicEffects();
 
     void playDeath(float startpoint, CharacterState death);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -943,6 +943,8 @@ namespace MWMechanics
         const ESM::MagicEffect *effect;
         effect = store.get<ESM::MagicEffect>().find(effectentry.mEffectID);
 
+        MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
+
         if (mCaster.getClass().isActor()) // TODO: Non-actors (except for large statics?) should also create a visual casting effect
         {
             const ESM::Static* castStatic;
@@ -951,8 +953,17 @@ namespace MWMechanics
             else
                 castStatic = store.get<ESM::Static>().find ("VFX_DefaultCast");
 
-            MWBase::Environment::get().getWorld()->getAnimation(mCaster)->addEffect(
-                                "meshes\\" + castStatic->mModel, effect->mIndex);
+            animation->addEffect("meshes\\" + castStatic->mModel, effect->mIndex);
+        }
+
+        if (!mCaster.getClass().isActor())
+        {
+            osg::Vec4f glowcolor(1,1,1,1);
+            glowcolor.x() = effect->mData.mRed / 255.f;
+            glowcolor.y() = effect->mData.mGreen / 255.f;
+            glowcolor.z() = effect->mData.mBlue / 255.f;
+
+            animation->addSpellCastGlow(glowcolor);
         }
 
         static const std::string schools[] = {

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -837,7 +837,7 @@ namespace MWMechanics
             mCaster.getClass().skillUsageSucceeded(mCaster,
                 spellSchoolToSkill(school), 0);
     
-        // A non-actor doesn't have casting animation so it plays its spell casting effects here
+        // A non-actor doesn't play its effects from a character controller, so play spell casting effects here
         if (!mCaster.getClass().isActor())
             playSpellCastingEffects(mId);
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -584,6 +584,12 @@ namespace MWMechanics
             }
             else if (effectId == ESM::MagicEffect::Open)
             {
+                const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
+                const ESM::MagicEffect *magiceffect;
+                magiceffect = store.get<ESM::MagicEffect>().find(effectId);
+                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
+                animation->addSpellCastGlow(magiceffect);
+
                 if (target.getCellRef().getLockLevel() <= magnitude)
                 {
                     if (target.getCellRef().getLockLevel() > 0)
@@ -837,7 +843,7 @@ namespace MWMechanics
             mCaster.getClass().skillUsageSucceeded(mCaster,
                 spellSchoolToSkill(school), 0);
     
-        // A non-actor doesn't play its effects from a character controller, so play spell casting effects here
+        // A non-actor doesn't play its spell cast effects from a character controller, so play them here
         if (!mCaster.getClass().isActor())
             playSpellCastingEffects(mId);
 
@@ -945,7 +951,7 @@ namespace MWMechanics
 
         MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
 
-        if (mCaster.getClass().isActor()) // TODO: Non-actors (except for large statics?) should also create a visual casting effect
+        if (mCaster.getClass().isActor()) // TODO: Non-actors (except for large statics?) should also create a spell cast vfx
         {
             const ESM::Static* castStatic;
             if (!effect->mCasting.empty())
@@ -957,14 +963,7 @@ namespace MWMechanics
         }
 
         if (!mCaster.getClass().isActor())
-        {
-            osg::Vec4f glowcolor(1,1,1,1);
-            glowcolor.x() = effect->mData.mRed / 255.f;
-            glowcolor.y() = effect->mData.mGreen / 255.f;
-            glowcolor.z() = effect->mData.mBlue / 255.f;
-
-            animation->addSpellCastGlow(glowcolor);
-        }
+            animation->addSpellCastGlow(effect);
 
         static const std::string schools[] = {
             "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -571,14 +571,13 @@ namespace MWMechanics
     {
         short effectId = effect.mId;
         if (target.getClass().canLock(target))
-        {
-            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
-            const ESM::MagicEffect *magiceffect;
-            magiceffect = store.get<ESM::MagicEffect>().find(effectId);
-            MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
-            animation->addSpellCastGlow(magiceffect);
+        {      
             if (effectId == ESM::MagicEffect::Lock)
             {
+                const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
+                const ESM::MagicEffect *magiceffect = store.get<ESM::MagicEffect>().find(effectId);
+                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);     
+                animation->addSpellCastGlow(magiceffect);
                 if (target.getCellRef().getLockLevel() < magnitude) //If the door is not already locked to a higher value, lock it to spell magnitude
                 {
                     if (caster == getPlayer())
@@ -589,6 +588,10 @@ namespace MWMechanics
             }
             else if (effectId == ESM::MagicEffect::Open)
             {
+                const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
+                const ESM::MagicEffect *magiceffect = store.get<ESM::MagicEffect>().find(effectId);
+                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);     
+                animation->addSpellCastGlow(magiceffect);
                 if (target.getCellRef().getLockLevel() <= magnitude)
                 {
                     if (target.getCellRef().getLockLevel() > 0)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -572,6 +572,11 @@ namespace MWMechanics
         short effectId = effect.mId;
         if (target.getClass().canLock(target))
         {
+            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
+            const ESM::MagicEffect *magiceffect;
+            magiceffect = store.get<ESM::MagicEffect>().find(effectId);
+            MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
+            animation->addSpellCastGlow(magiceffect);
             if (effectId == ESM::MagicEffect::Lock)
             {
                 if (target.getCellRef().getLockLevel() < magnitude) //If the door is not already locked to a higher value, lock it to spell magnitude
@@ -584,12 +589,6 @@ namespace MWMechanics
             }
             else if (effectId == ESM::MagicEffect::Open)
             {
-                const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
-                const ESM::MagicEffect *magiceffect;
-                magiceffect = store.get<ESM::MagicEffect>().find(effectId);
-                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
-                animation->addSpellCastGlow(magiceffect);
-
                 if (target.getCellRef().getLockLevel() <= magnitude)
                 {
                     if (target.getCellRef().getLockLevel() > 0)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -571,7 +571,7 @@ namespace MWMechanics
     {
         short effectId = effect.mId;
         if (target.getClass().canLock(target))
-        {      
+        {
             if (effectId == ESM::MagicEffect::Lock)
             {
                 const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -92,6 +92,8 @@ namespace MWMechanics
         /// @note Auto detects if spell, ingredient or potion
         bool cast (const std::string& id);
 
+        void playSpellCastingEffects(const std::string &spellid);
+
         /// @note \a target can be any type of object, not just actors.
         /// @note \a caster can be any type of object, or even an empty object.
         void inflict (const MWWorld::Ptr& target, const MWWorld::Ptr& caster,

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -269,10 +269,7 @@ namespace MWRender
         virtual void setDefaults(osg::StateSet *stateset)
         {
             if (mDone)
-            {
-                stateset->removeTextureAttribute(mTexUnit, osg::StateAttribute::TEXTURE);
-                stateset->removeTextureAttribute(mTexUnit, osg::StateAttribute::TEXGEN);
-            }
+                removeTexture(stateset);
             else
             {
                 stateset->setTextureMode(mTexUnit, GL_TEXTURE_2D, osg::StateAttribute::ON);
@@ -291,6 +288,19 @@ namespace MWRender
                 stateset->setTextureAttributeAndModes(mTexUnit, texEnv, osg::StateAttribute::ON);
                 stateset->addUniform(new osg::Uniform("envMapColor", mColor));
             }
+        }
+
+        void removeTexture(osg::StateSet* stateset)
+        {
+            stateset->removeTextureAttribute(mTexUnit, osg::StateAttribute::TEXTURE);
+            stateset->removeTextureAttribute(mTexUnit, osg::StateAttribute::TEXGEN);
+            stateset->removeTextureAttribute(mTexUnit, osg::StateAttribute::TEXENV);
+            stateset->removeTextureMode(mTexUnit, GL_TEXTURE_2D);
+            stateset->removeUniform("envMapColor");
+
+            osg::StateSet::TextureAttributeList& list = stateset->getTextureAttributeList();
+            while (list.size() && list.rbegin()->empty())
+                list.pop_back();
         }
 
         virtual void apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
@@ -315,7 +325,7 @@ namespace MWRender
             {
                 if (mOriginalDuration >= 0) // if this glowupdater was a temporary glow since its creation
                 {
-                    stateset->removeTextureAttribute(mTexUnit, osg::StateAttribute::TEXTURE);
+                    removeTexture(stateset);
                     this->reset();
                     mDone = true;
                     mResourceSystem->getSceneManager()->recreateShaders(mNode);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -251,7 +251,7 @@ namespace MWRender
     {
     public:
         GlowUpdater(int texUnit, osg::Vec4f color, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures,
-            osg::ref_ptr<osg::Node> node, float duration, Resource::ResourceSystem* resourcesystem)
+            osg::Node* node, float duration, Resource::ResourceSystem* resourcesystem)
             : mTexUnit(texUnit)
             , mColor(color)
             , mOriginalColor(color)
@@ -367,7 +367,7 @@ namespace MWRender
         osg::Vec4f mColor;
         osg::Vec4f mOriginalColor; // for restoring the color of a permanent glow after a temporary glow on the object finishes
         std::vector<osg::ref_ptr<osg::Texture2D> > mTextures;
-        osg::ref_ptr<osg::Node> mNode;
+        osg::Node* mNode;
         float mDuration;
         float mOriginalDuration; // for recording that this is originally a permanent glow if it is changed to a temporary one
         float mStartingTime;
@@ -1200,7 +1200,7 @@ namespace MWRender
         glowColor.z() = effect->mData.mBlue / 255.f;
 
         if (!mGlowUpdater) // If there is no glow on object
-            addGlow(mObjectRoot, glowColor, 1.5); // Glow length measured from in-game as about 1.5 seconds
+            addGlow(mObjectRoot, glowColor, 1.5); // Glow length measured from original engine as about 1.5 seconds
 
         else if (mGlowUpdater->isDone() || (mGlowUpdater->isPermanentGlowUpdater() == true))
             addGlow(mObjectRoot, glowColor, 1.5);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -183,11 +183,6 @@ namespace
             return mDone;
         }
 
-        int getTexUnit()
-        {
-            return mTexUnit;
-        }
-
         void setWatchedSpellGlow(osg::ref_ptr<GlowUpdater> watched)
         {
             mWatchedSpellGlow = watched;
@@ -1190,7 +1185,7 @@ namespace MWRender
 
     void Animation::addSpellCastGlow(const ESM::MagicEffect *effect){
 
-        osg::Vec4f glowColor = {1,1,1,1};
+        osg::Vec4f glowColor(1,1,1,1);
         glowColor.x() = effect->mData.mRed / 255.f;
         glowColor.y() = effect->mData.mGreen / 255.f;
         glowColor.z() = effect->mData.mBlue / 255.f;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -159,9 +159,9 @@ namespace
                 else
                     writableStateSet = osg::clone(mNode->getStateSet(), osg::CopyOp::SHALLOW_COPY);
                 
-                for (size_t index = 0; index < mTextures.size(); index++)
+                for (size_t i = 0; i < mTextures.size(); i++)
                 {
-                    writableStateSet->removeTextureAttribute(mTexUnit, mTextures[index]);
+                    writableStateSet->removeTextureAttribute(mTexUnit, mTextures[i]);
                 }
 
                 writableStateSet->removeUniform(mUniform); // remove the uniform given to the temporary glow in addglow()
@@ -1194,7 +1194,13 @@ namespace MWRender
         int mLowestUnusedTexUnit;
     };
 
-    void Animation::addSpellCastGlow(osg::Vec4f glowColor){
+    void Animation::addSpellCastGlow(const ESM::MagicEffect *effect){
+
+        osg::Vec4f glowColor = {1,1,1,1};
+        glowColor.x() = effect->mData.mRed / 255.f;
+        glowColor.y() = effect->mData.mGreen / 255.f;
+        glowColor.z() = effect->mData.mBlue / 255.f;
+
         if (!mObjectRoot->getUpdateCallback()) // If there is no glow on object
             addGlow(mObjectRoot, glowColor, 1.5); // Glow length measured from in-game as about 1.5 seconds
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -5,6 +5,11 @@
 
 #include <components/sceneutil/controller.hpp>
 
+namespace
+{
+    class GlowUpdater;
+}
+
 namespace ESM
 {
     struct Light;
@@ -263,6 +268,10 @@ protected:
     osg::ref_ptr<SceneUtil::LightSource> mGlowLight;
 
     float mAlpha;
+    float mSpellGlowDuration;
+
+    osg::ref_ptr<GlowUpdater> mGlowUpdater;
+    osg::Uniform* mUniform;
 
     const NodeMap& getNodeMap() const;
 
@@ -317,7 +326,7 @@ protected:
 
     osg::Vec4f getEnchantmentColor(const MWWorld::ConstPtr& item) const;
 
-    void addGlow(osg::ref_ptr<osg::Node> node, osg::Vec4f glowColor);
+    void addGlow(osg::ref_ptr<osg::Node> node, osg::Vec4f glowColor, bool hasDuration = false);
 
     /// Set the render bin for this animation's object root. May be customized by subclasses.
     virtual void setRenderBin();
@@ -350,6 +359,10 @@ public:
     void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", std::string texture = "");
     void removeEffect (int effectId);
     void getLoopingEffects (std::vector<int>& out) const;
+
+    void addSpellCastGlow(osg::Vec4f glowColor);
+    void updateSpellGlow(float duration);
+    void removeSpellGlow();
 
     virtual void updatePtr(const MWWorld::Ptr &ptr);
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -270,8 +270,7 @@ protected:
     float mAlpha;
     float mSpellGlowDuration;
 
-    osg::ref_ptr<GlowUpdater> mGlowUpdater;
-    osg::Uniform* mUniform;
+    osg::ref_ptr<GlowUpdater> mSpellGlowUpdater;
 
     const NodeMap& getNodeMap() const;
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -33,6 +33,7 @@ namespace MWRender
 
 class ResetAccumRootCallback;
 class RotateController;
+class GlowUpdater;
 
 class EffectAnimationTime : public SceneUtil::ControllerSource
 {
@@ -262,6 +263,7 @@ protected:
     float mHeadPitchRadians;
 
     osg::ref_ptr<SceneUtil::LightSource> mGlowLight;
+    osg::ref_ptr<GlowUpdater> mGlowUpdater;
 
     float mAlpha;
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -5,11 +5,6 @@
 
 #include <components/sceneutil/controller.hpp>
 
-namespace
-{
-    class GlowUpdater;
-}
-
 namespace ESM
 {
     struct Light;
@@ -268,9 +263,6 @@ protected:
     osg::ref_ptr<SceneUtil::LightSource> mGlowLight;
 
     float mAlpha;
-    float mSpellGlowDuration;
-
-    osg::ref_ptr<GlowUpdater> mSpellGlowUpdater;
 
     const NodeMap& getNodeMap() const;
 
@@ -325,7 +317,7 @@ protected:
 
     osg::Vec4f getEnchantmentColor(const MWWorld::ConstPtr& item) const;
 
-    void addGlow(osg::ref_ptr<osg::Node> node, osg::Vec4f glowColor, bool hasDuration = false);
+    void addGlow(osg::ref_ptr<osg::Node> node, osg::Vec4f glowColor, float glowDuration = -1);
 
     /// Set the render bin for this animation's object root. May be customized by subclasses.
     virtual void setRenderBin();
@@ -360,8 +352,6 @@ public:
     void getLoopingEffects (std::vector<int>& out) const;
 
     void addSpellCastGlow(osg::Vec4f glowColor);
-    void updateSpellGlow(float duration);
-    void removeSpellGlow();
 
     virtual void updatePtr(const MWWorld::Ptr &ptr);
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -8,6 +8,7 @@
 namespace ESM
 {
     struct Light;
+    struct MagicEffect;
 }
 
 namespace Resource
@@ -351,7 +352,7 @@ public:
     void removeEffect (int effectId);
     void getLoopingEffects (std::vector<int>& out) const;
 
-    void addSpellCastGlow(osg::Vec4f glowColor);
+    void addSpellCastGlow(const ESM::MagicEffect *effect);
 
     virtual void updatePtr(const MWWorld::Ptr &ptr);
 


### PR DESCRIPTION
These changes make trapped objects, or any non-actor object given a "cast" command through the console or script, play their casting sound effect and visual casting effect like the original game  (except for the glow).

There are still problems that this PR does not address.

- The visual effect is located differently from the original game. From observation, I think the original game's effect may be created at the same point used for an object's "position," while in OpenMW it is created higher up than that.

- There is no glow effect like there is in the original game. I started looking at trying to adapt the "getEnchantmentColor" and "addGlow" functions in animation.cpp for this, but it's uncertain ground for me, and I'm not sure how to proceed there.

In the original game statics seem to only get the glow when they cast a spell, not the other visual effect, so I disabled the non-glow effect for them.
 
- Maybe not strictly related, but the "cast" command should make an NPC play their spellcasting animation and aim at the target, which currently it doesn't.