### PR TITLE
Fix assertion failure with NiTextureEffect missing source texture

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -481,6 +481,12 @@ namespace NifOsg
                 return;
             }
 
+            if (textureEffect->texture.empty())
+            {
+                std::cerr << "NiTextureEffect missing source texture in " << mFilename << std::endl;
+                return;
+            }
+
             osg::ref_ptr<osg::TexGen> texGen (new osg::TexGen);
             switch (textureEffect->coordGenType)
             {


### PR DESCRIPTION
    /components/nif/recordptr.hpp:54: const X* Nif::RecordPtrT<X>::getPtr() const [with X = Nif::NiSourceTexture]: Assertion `ptr != __null' failed.

Observed with Morrowind Rebirth 3.7.

Mod: http://www.nexusmods.com/morrowind/mods/37795/
Affected model: meshes/f/flora_bush_01.nif