### PR TITLE
Fix camera distance not getting reset to max value (Fixes #3473)

### DIFF
--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -54,7 +54,6 @@ namespace MWRender
       mIsNearest(false),
       mHeight(124.f),
       mMaxCameraDistance(192.f),
-      mDistanceAdjusted(false),
       mVanityToggleQueued(false),
       mVanityToggleQueuedValue(false),
       mViewModeToggleQueued(false),
@@ -342,21 +341,16 @@ namespace MWRender
             } else if (!mFirstPersonView) {
                 mMaxCameraDistance = mCameraDistance;
             }
-        } else {
-            mDistanceAdjusted = true;
         }
     }
 
     void Camera::setCameraDistance()
     {
-        if (mDistanceAdjusted) {
-            if (mVanity.enabled || mPreviewMode) {
-                mCameraDistance = mPreviewCam.offset;
-            } else if (!mFirstPersonView) {
-                mCameraDistance = mMaxCameraDistance;
-            }
+        if (mVanity.enabled || mPreviewMode) {
+            mCameraDistance = mPreviewCam.offset;
+        } else if (!mFirstPersonView) {
+            mCameraDistance = mMaxCameraDistance;
         }
-        mDistanceAdjusted = false;
     }
 
     void Camera::setAnimation(NpcAnimation *anim)

--- a/apps/openmw/mwrender/camera.hpp
+++ b/apps/openmw/mwrender/camera.hpp
@@ -49,8 +49,6 @@ namespace MWRender
         float mHeight, mMaxCameraDistance;
         CamData mMainCam, mPreviewCam;
 
-        bool mDistanceAdjusted;
-
         bool mVanityToggleQueued;
         bool mVanityToggleQueuedValue;
         bool mViewModeToggleQueued;


### PR DESCRIPTION
Bug: https://bugs.openmw.org/issues/3473

The bug is caused by `mDistanceAdjusted` preventing camera distance from resetting to the maximum value when you switch to first person while the camera is hugging a wall. I don't see the purpose of this member - it seems useless and buggy, so I decided to get rid of it.