### PR TITLE
Various reference handling fixes

### DIFF
--- a/apps/openmw/mwworld/cellreflist.hpp
+++ b/apps/openmw/mwworld/cellreflist.hpp
@@ -29,6 +29,18 @@ namespace MWWorld
             mList.push_back(item);
             return mList.back();
         }
+
+        /// Remove all references with the given refNum from this list.
+        void remove (const ESM::RefNum &refNum)
+        {
+            for (typename List::iterator it = mList.begin(); it != mList.end();)
+            {
+                if (*it == refNum)
+                    mList.erase(it++);
+                else
+                    ++it;
+            }
+        }
     };
 }
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -516,6 +516,8 @@ namespace MWWorld
         if (mCell->mContextList.empty())
             return; // this is a dynamically generated cell -> skipping.
 
+        std::map<ESM::RefNum, std::string> refNumToID; // used to detect refID modifications
+
         // Load references from all plugins that do something with this cell.
         for (size_t i = 0; i < mCell->mContextList.size(); i++)
         {
@@ -539,7 +541,7 @@ namespace MWWorld
                         continue;
                     }
 
-                    loadRef (ref, deleted);
+                    loadRef (ref, deleted, refNumToID);
                 }
             }
             catch (std::exception& e)
@@ -554,7 +556,7 @@ namespace MWWorld
             ESM::CellRef &ref = const_cast<ESM::CellRef&>(it->first);
             bool deleted = it->second;
 
-            loadRef (ref, deleted);
+            loadRef (ref, deleted, refNumToID);
         }
 
         updateMergedRefs();
@@ -585,11 +587,46 @@ namespace MWWorld
         return Ptr();
     }
 
-    void CellStore::loadRef (ESM::CellRef& ref, bool deleted)
+    void CellStore::loadRef (ESM::CellRef& ref, bool deleted, std::map<ESM::RefNum, std::string>& refNumToID)
     {
         Misc::StringUtils::lowerCaseInPlace (ref.mRefID);
 
         const MWWorld::ESMStore& store = mStore;
+
+        std::map<ESM::RefNum, std::string>::iterator it = refNumToID.find(ref.mRefNum);
+        if (it != refNumToID.end())
+        {
+            if (it->second != ref.mRefID)
+            {
+                // refID was modified, make sure we don't end up with duplicated refs
+                switch (store.find(it->second))
+                {
+                    case ESM::REC_ACTI: mActivators.remove(ref.mRefNum); break;
+                    case ESM::REC_ALCH: mPotions.remove(ref.mRefNum); break;
+                    case ESM::REC_APPA: mAppas.remove(ref.mRefNum); break;
+                    case ESM::REC_ARMO: mArmors.remove(ref.mRefNum); break;
+                    case ESM::REC_BOOK: mBooks.remove(ref.mRefNum); break;
+                    case ESM::REC_CLOT: mClothes.remove(ref.mRefNum); break;
+                    case ESM::REC_CONT: mContainers.remove(ref.mRefNum); break;
+                    case ESM::REC_CREA: mCreatures.remove(ref.mRefNum); break;
+                    case ESM::REC_DOOR: mDoors.remove(ref.mRefNum); break;
+                    case ESM::REC_INGR: mIngreds.remove(ref.mRefNum); break;
+                    case ESM::REC_LEVC: mCreatureLists.remove(ref.mRefNum); break;
+                    case ESM::REC_LEVI: mItemLists.remove(ref.mRefNum); break;
+                    case ESM::REC_LIGH: mLights.remove(ref.mRefNum); break;
+                    case ESM::REC_LOCK: mLockpicks.remove(ref.mRefNum); break;
+                    case ESM::REC_MISC: mMiscItems.remove(ref.mRefNum); break;
+                    case ESM::REC_NPC_: mNpcs.remove(ref.mRefNum); break;
+                    case ESM::REC_PROB: mProbes.remove(ref.mRefNum); break;
+                    case ESM::REC_REPA: mRepairs.remove(ref.mRefNum); break;
+                    case ESM::REC_STAT: mStatics.remove(ref.mRefNum); break;
+                    case ESM::REC_WEAP: mWeapons.remove(ref.mRefNum); break;
+                    case ESM::REC_BODY: mBodyParts.remove(ref.mRefNum); break;
+                    default:
+                        break;
+                }
+            }
+        }
 
         switch (store.find (ref.mRefID))
         {
@@ -615,12 +652,15 @@ namespace MWWorld
             case ESM::REC_WEAP: mWeapons.load(ref, deleted, store); break;
             case ESM::REC_BODY: mBodyParts.load(ref, deleted, store); break;
 
-            case 0: std::cerr << "Cell reference '" + ref.mRefID + "' not found!\n"; break;
+            case 0: std::cerr << "Cell reference '" + ref.mRefID + "' not found!\n"; return;
 
             default:
                 std::cerr
                     << "WARNING: Ignoring reference '" << ref.mRefID << "' of unhandled type\n";
+                return;
         }
+
+        refNumToID[ref.mRefNum] = ref.mRefID;
     }
 
     void CellStore::loadState (const ESM::CellState& state)

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -497,9 +497,11 @@ namespace MWWorld
         // List moved references, from separately tracked list.
         for (ESM::CellRefTracker::const_iterator it = mCell->mLeasedRefs.begin(); it != mCell->mLeasedRefs.end(); ++it)
         {
-            const ESM::CellRef &ref = *it;
+            const ESM::CellRef &ref = it->first;
+            bool deleted = it->second;
 
-            mIds.push_back(Misc::StringUtils::lowerCase(ref.mRefID));
+            if (!deleted)
+                mIds.push_back(Misc::StringUtils::lowerCase(ref.mRefID));
         }
 
         std::sort (mIds.begin(), mIds.end());
@@ -549,9 +551,10 @@ namespace MWWorld
         // Load moved references, from separately tracked list.
         for (ESM::CellRefTracker::const_iterator it = mCell->mLeasedRefs.begin(); it != mCell->mLeasedRefs.end(); ++it)
         {
-            ESM::CellRef &ref = const_cast<ESM::CellRef&>(*it);
+            ESM::CellRef &ref = const_cast<ESM::CellRef&>(it->first);
+            bool deleted = it->second;
 
-            loadRef (ref, false);
+            loadRef (ref, deleted);
         }
 
         updateMergedRefs();

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -385,7 +385,7 @@ namespace MWWorld
 
             void loadRefs();
 
-            void loadRef (ESM::CellRef& ref, bool deleted);
+            void loadRef (ESM::CellRef& ref, bool deleted, std::map<ESM::RefNum, std::string>& refNumToID);
             ///< Make case-adjustments to \a ref and insert it into the respective container.
             ///
             /// Invalid \a ref objects are silently dropped.

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -675,14 +675,17 @@ namespace MWWorld
                 for (ESM::MovedCellRefTracker::const_iterator it = cell.mMovedRefs.begin(); it != cell.mMovedRefs.end(); ++it) {
                     // remove reference from current leased ref tracker and add it to new cell
                     ESM::MovedCellRefTracker::iterator itold = std::find(oldcell->mMovedRefs.begin(), oldcell->mMovedRefs.end(), it->mRefNum);
-                    if (itold != oldcell->mMovedRefs.end()) {
-                        ESM::MovedCellRef target0 = *itold;
-                        ESM::Cell *wipecell = const_cast<ESM::Cell*>(search(target0.mTarget[0], target0.mTarget[1]));
-                        ESM::CellRefTracker::iterator it_lease = std::find_if(wipecell->mLeasedRefs.begin(), wipecell->mLeasedRefs.end(), ESM::CellRefTrackerPredicate(it->mRefNum));
-                        if (it_lease != wipecell->mLeasedRefs.end())
-                            wipecell->mLeasedRefs.erase(it_lease);
-                        else
-                            std::cerr << "can't find " << it->mRefNum.mIndex << " " << it->mRefNum.mContentFile  << " in leasedRefs " << std::endl;
+                    if (itold != oldcell->mMovedRefs.end())
+                    {
+                        if (it->mTarget[0] != itold->mTarget[0] || it->mTarget[1] != itold->mTarget[1])
+                        {
+                            ESM::Cell *wipecell = const_cast<ESM::Cell*>(search(itold->mTarget[0], itold->mTarget[1]));
+                            ESM::CellRefTracker::iterator it_lease = std::find_if(wipecell->mLeasedRefs.begin(), wipecell->mLeasedRefs.end(), ESM::CellRefTrackerPredicate(it->mRefNum));
+                            if (it_lease != wipecell->mLeasedRefs.end())
+                                wipecell->mLeasedRefs.erase(it_lease);
+                            else
+                                std::cerr << "can't find " << it->mRefNum.mIndex << " " << it->mRefNum.mContentFile  << " in leasedRefs " << std::endl;
+                        }
                         *itold = *it;
                     }
                     else

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -513,19 +513,16 @@ namespace MWWorld
             bool deleted = false;
             cell->getNextRef(esm, ref, deleted);
 
-            if (!deleted)
-            {
-                // Add data required to make reference appear in the correct cell.
-                // We should not need to test for duplicates, as this part of the code is pre-cell merge.
-                cell->mMovedRefs.push_back(cMRef);
+            // Add data required to make reference appear in the correct cell.
+            // We should not need to test for duplicates, as this part of the code is pre-cell merge.
+            cell->mMovedRefs.push_back(cMRef);
 
-                // But there may be duplicates here!
-                ESM::CellRefTracker::iterator iter = std::find(cellAlt->mLeasedRefs.begin(), cellAlt->mLeasedRefs.end(), ref.mRefNum);
-                if (iter == cellAlt->mLeasedRefs.end())
-                  cellAlt->mLeasedRefs.push_back(ref);
-                else
-                  *iter = ref;
-            }
+            // But there may be duplicates here!
+            ESM::CellRefTracker::iterator iter = std::find_if(cellAlt->mLeasedRefs.begin(), cellAlt->mLeasedRefs.end(), ESM::CellRefTrackerPredicate(ref.mRefNum));
+            if (iter == cellAlt->mLeasedRefs.end())
+                cellAlt->mLeasedRefs.push_back(std::make_pair(ref, deleted));
+            else
+                *iter = std::make_pair(ref, deleted);
         }
     }
     const ESM::Cell *Store<ESM::Cell>::search(const std::string &id) const
@@ -681,7 +678,7 @@ namespace MWWorld
                     if (itold != oldcell->mMovedRefs.end()) {
                         ESM::MovedCellRef target0 = *itold;
                         ESM::Cell *wipecell = const_cast<ESM::Cell*>(search(target0.mTarget[0], target0.mTarget[1]));
-                        ESM::CellRefTracker::iterator it_lease = std::find(wipecell->mLeasedRefs.begin(), wipecell->mLeasedRefs.end(), it->mRefNum);
+                        ESM::CellRefTracker::iterator it_lease = std::find_if(wipecell->mLeasedRefs.begin(), wipecell->mLeasedRefs.end(), ESM::CellRefTrackerPredicate(it->mRefNum));
                         if (it_lease != wipecell->mLeasedRefs.end())
                             wipecell->mLeasedRefs.erase(it_lease);
                         else

--- a/components/esm/loadcell.hpp
+++ b/components/esm/loadcell.hpp
@@ -43,7 +43,15 @@ bool operator==(const MovedCellRef& ref, const RefNum& refNum);
 bool operator==(const CellRef& ref, const RefNum& refNum);
 
 typedef std::list<MovedCellRef> MovedCellRefTracker;
-typedef std::list<CellRef> CellRefTracker;
+typedef std::list<std::pair<CellRef, bool> > CellRefTracker;
+
+struct CellRefTrackerPredicate
+{
+    RefNum mRefNum;
+
+    CellRefTrackerPredicate(const RefNum& refNum) : mRefNum(refNum) {}
+    bool operator() (const std::pair<CellRef, bool>& refdelPair) { return refdelPair.first == mRefNum; }
+};
 
 /* Cells hold data about objects, creatures, statics (rocks, walls,
    buildings) and landscape (for exterior cells). Cells frequently


### PR DESCRIPTION
Fixes bug: https://bugs.openmw.org/issues/3471

Most of the remnant references mentioned in the bug report are moved references that another plugin is deleting - as suspected. The rest are regular references that had their refID changed to an object of a different category (e.g. from a static to an activator), and then deleted afterwards by another plugin. Vanilla MW seems to support refID changes, however the TES CS does not seem to provide a way to achieve that.