### PR TITLE
OpenMW-CS: Camera resets every time cell->view is pressed

### DIFF
--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -37,10 +37,9 @@ namespace CSMWorld
             ///
             /// \note The worldspace part of \a id is ignored
             static std::pair<CellCoordinates, bool> fromId (const std::string& id);
-
+            
             /// \return cell coordinates such that given world coordinates are in it.
             static std::pair<int, int> coordinatesToCellIndex (float x, float y);
-            
     };
 
     bool operator== (const CellCoordinates& left, const CellCoordinates& right);

--- a/apps/opencs/view/render/pagedworldspacewidget.hpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.hpp
@@ -84,7 +84,7 @@ namespace CSVRender
             /// hint system.
 
             virtual ~PagedWorldspaceWidget();
-
+            
             /// Decodes the the hint string to set of cell that are rendered.
             void useViewHint (const std::string& hint);
 

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -32,7 +32,7 @@ RenderWidget::RenderWidget(QWidget *parent, Qt::WindowFlags f)
     : QWidget(parent, f)
     , mRootNode(0)
 {
-    
+
     osgViewer::CompositeViewer& viewer = CompositeViewer::get();
 
     osg::DisplaySettings* ds = osg::DisplaySettings::instance().get();

--- a/apps/opencs/view/render/scenewidget.hpp
+++ b/apps/opencs/view/render/scenewidget.hpp
@@ -7,14 +7,15 @@
 #include <QWidget>
 #include <QTimer>
 
+#include <osgViewer/View>
+#include <osgViewer/CompositeViewer>
+
 #include <boost/shared_ptr.hpp>
 
 #include "lightingday.hpp"
 #include "lightingnight.hpp"
 #include "lightingbright.hpp"
 
-#include <osgViewer/View>
-#include <osgViewer/CompositeViewer>
 
 namespace Resource
 {
@@ -53,6 +54,7 @@ namespace CSVRender
             RenderWidget(QWidget* parent = 0, Qt::WindowFlags f = 0);
             virtual ~RenderWidget();
 
+            /// Initiates a request to redraw the view
             void flagAsModified();
 
             void setVisibilityMask(int mask);
@@ -62,13 +64,16 @@ namespace CSVRender
         protected:
 
             osg::ref_ptr<osgViewer::View> mView;
-
-            osg::Group* mRootNode;
+            osg::ref_ptr<osg::Group> mRootNode;
 
             QTimer mTimer;
+
+        protected slots:
+
+            void toggleRenderStats();
     };
 
-    // Extension of RenderWidget to support lighting mode selection & toolbar
+    /// Extension of RenderWidget to support lighting mode selection & toolbar
     class SceneWidget : public RenderWidget
     {
             Q_OBJECT
@@ -90,18 +95,8 @@ namespace CSVRender
 
             void setAmbient(const osg::Vec4f& ambient);
 
-            virtual void mousePressEvent (QMouseEvent *event);
-            virtual void mouseReleaseEvent (QMouseEvent *event);
             virtual void mouseMoveEvent (QMouseEvent *event);
             virtual void wheelEvent (QWheelEvent *event);
-            virtual void keyPressEvent (QKeyEvent *event);
-            virtual void keyReleaseEvent (QKeyEvent *event);
-            virtual void focusOutEvent (QFocusEvent *event);
-
-            /// \return Is \a key a button mapping setting? (ignored otherwise)
-            virtual bool storeMappingSetting (const CSMPrefs::Setting *setting);
-
-            std::string mapButton (QMouseEvent *event);
 
             boost::shared_ptr<Resource::ResourceSystem> mResourceSystem;
 
@@ -114,17 +109,15 @@ namespace CSVRender
             LightingBright mLightingBright;
 
             int mPrevMouseX, mPrevMouseY;
-            std::string mMouseMode;
-            std::auto_ptr<FreeCameraController> mFreeCamControl;
-            std::auto_ptr<OrbitCameraController> mOrbitCamControl;
-            CameraController* mCurrentCamControl;
+            
             /// Tells update that camera isn't set
             bool mCamPositionSet;
 
-            std::map<std::pair<Qt::MouseButton, bool>, std::string> mButtonMapping;
+            FreeCameraController* mFreeCamControl;
+            OrbitCameraController* mOrbitCamControl;
+            CameraController* mCurrentCamControl;
 
         public slots:
-            /// \note Remember set the camera before running
             void update(double dt);
 
         protected slots:


### PR DESCRIPTION
Camera didn't reset when right clicking cell and pressing view if world renderer was open.

PS: Shouldn't "const int cellSize = 8192" be some where it can be accessed easily rather than be local variable.