### PR TITLE
Render water in editor.

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -87,6 +87,7 @@ opencs_units (view/render
     scenewidget worldspacewidget pagedworldspacewidget unpagedworldspacewidget
     previewwidget editmode instancemode instanceselectionmode instancemovemode
     orbitcameramode pathgridmode selectionmode pathgridselectionmode cameracontroller
+    cellwater
     )
 
 opencs_units_noqt (view/render

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -16,6 +16,7 @@
 #include "../../model/world/refcollection.hpp"
 #include "../../model/world/cellcoordinates.hpp"
 
+#include "cellwater.hpp"
 #include "mask.hpp"
 #include "pathgrid.hpp"
 #include "terrainstorage.hpp"
@@ -111,6 +112,7 @@ CSVRender::Cell::Cell (CSMWorld::Data& data, osg::Group* rootNode, const std::st
         }
 
         mPathgrid.reset(new Pathgrid(mData, mCellNode, mId, mCoordinates));
+        mCellWater.reset(new CellWater(mData, mCellNode, mId, mCoordinates));
     }
 }
 

--- a/apps/opencs/view/render/cell.hpp
+++ b/apps/opencs/view/render/cell.hpp
@@ -35,6 +35,7 @@ namespace CSMWorld
 
 namespace CSVRender
 {
+    class CellWater;
     class Pathgrid;
     class TagBase;
 
@@ -49,6 +50,7 @@ namespace CSVRender
             std::auto_ptr<CellArrow> mCellArrows[4];
             std::auto_ptr<CellMarker> mCellMarker;
             std::auto_ptr<CellBorder> mCellBorder;
+            std::auto_ptr<CellWater> mCellWater;
             std::auto_ptr<Pathgrid> mPathgrid;
             bool mDeleted;
             int mSubMode;

--- a/apps/opencs/view/render/cellmarker.cpp
+++ b/apps/opencs/view/render/cellmarker.cpp
@@ -75,7 +75,7 @@ CSVRender::CellMarker::CellMarker(
     mMarkerNode->setAutoRotateMode(osg::AutoTransform::ROTATE_TO_SCREEN);
     mMarkerNode->setAutoScaleToScreen(true);
     mMarkerNode->getOrCreateStateSet()->setMode(GL_DEPTH_TEST, osg::StateAttribute::OFF);
-    mMarkerNode->getOrCreateStateSet()->setRenderBinDetails(2000, "RenderBin");
+    mMarkerNode->getOrCreateStateSet()->setRenderBinDetails(osg::StateSet::TRANSPARENT_BIN + 1, "RenderBin");
 
     mMarkerNode->setUserData(new CellMarkerTag(this));
     mMarkerNode->setNodeMask(Mask_CellMarker);

--- a/apps/opencs/view/render/cellmarker.cpp
+++ b/apps/opencs/view/render/cellmarker.cpp
@@ -75,6 +75,7 @@ CSVRender::CellMarker::CellMarker(
     mMarkerNode->setAutoRotateMode(osg::AutoTransform::ROTATE_TO_SCREEN);
     mMarkerNode->setAutoScaleToScreen(true);
     mMarkerNode->getOrCreateStateSet()->setMode(GL_DEPTH_TEST, osg::StateAttribute::OFF);
+    mMarkerNode->getOrCreateStateSet()->setRenderBinDetails(2000, "RenderBin");
 
     mMarkerNode->setUserData(new CellMarkerTag(this));
     mMarkerNode->setNodeMask(Mask_CellMarker);

--- a/apps/opencs/view/render/cellwater.cpp
+++ b/apps/opencs/view/render/cellwater.cpp
@@ -1,0 +1,191 @@
+#include "cellwater.hpp"
+
+#include <osg/Geode>
+#include <osg/Geometry>
+#include <osg/Group>
+#include <osg/PolygonOffset>
+#include <osg/PositionAttitudeTransform>
+
+#include <components/esm/loadland.hpp>
+#include <components/misc/stringops.hpp>
+
+#include "../../model/world/cell.hpp"
+#include "../../model/world/cellcoordinates.hpp"
+#include "../../model/world/data.hpp"
+
+#include "mask.hpp"
+
+namespace CSVRender
+{
+    const int CellWater::CellSize = ESM::Land::REAL_SIZE;
+
+    CellWater::CellWater(CSMWorld::Data& data, osg::Group* cellNode, const std::string& id,
+        const CSMWorld::CellCoordinates& cellCoords)
+        : mData(data)
+        , mId(id)
+        , mParentNode(cellNode)
+        , mWaterTransform(0)
+        , mWaterNode(0)
+        , mWaterGeometry(0)
+        , mExterior(false)
+        , mHasWater(false)
+        , mWaterHeight(0)
+    {
+        mWaterTransform = new osg::PositionAttitudeTransform();
+        mWaterTransform->setPosition(osg::Vec3f(cellCoords.getX() * CellSize, cellCoords.getY() * CellSize, 0));
+        mWaterTransform->setNodeMask(Mask_Water);
+        mParentNode->addChild(mWaterTransform);
+
+        mWaterNode = new osg::Geode();
+        mWaterTransform->addChild(mWaterNode);
+
+        int cellIndex = mData.getCells().searchId(mId);
+        if (cellIndex > -1)
+        {
+            updateCellData(mData.getCells().getRecord(cellIndex).get());
+        }
+
+        // Keep water existance/height up to date
+        QAbstractItemModel* cells = mData.getTableModel(CSMWorld::UniversalId::Type_Cells);
+        connect(cells, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)),
+            this, SLOT(cellDataChanged(const QModelIndex&, const QModelIndex&)));
+    }
+
+    CellWater::~CellWater()
+    {
+        mParentNode->removeChild(mWaterTransform);
+    }
+
+    void CellWater::updateCellData(const CSMWorld::Cell& cell)
+    {
+        int cellIndex = mData.getCells().searchId(mId);
+        if (cellIndex > -1)
+        {
+            const CSMWorld::Record<CSMWorld::Cell>& cellRecord = mData.getCells().getRecord(cellIndex);
+
+            mDeleted = cellRecord.isDeleted();
+            if (!mDeleted)
+            {
+                mExterior = cellRecord.get().isExterior();
+
+                mHasWater = cellRecord.get().hasWater();
+                mWaterHeight = cellRecord.get().mWater;
+            }
+        }
+        else
+        {
+            mDeleted = true;
+        }
+
+        update();
+    }
+
+    void CellWater::cellDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight)
+    {
+        const CSMWorld::Collection<CSMWorld::Cell>& cells = mData.getCells();
+
+        int rowStart = -1;
+        int rowEnd = -1;
+
+        if (topLeft.parent().isValid())
+        {
+            rowStart = topLeft.parent().row();
+            rowEnd = bottomRight.parent().row();
+        }
+        else
+        {
+            rowStart = topLeft.row();
+            rowEnd = bottomRight.row();
+        }
+
+        for (int row = rowStart; row <= rowEnd; ++row)
+        {
+            const CSMWorld::Cell& cell = cells.getRecord(row).get();
+
+            if (Misc::StringUtils::lowerCase(cell.mId) == mId)
+                updateCellData(cell);
+        }
+    }
+
+    void CellWater::update()
+    {
+        const int InteriorSize = CellSize * 10;
+
+        const size_t NumPoints = 4;
+        const size_t NumIndices = 6;
+
+        const osg::Vec3f ExteriorPoints[] =
+        {
+            osg::Vec3f(0,        0,        mWaterHeight),
+            osg::Vec3f(0,        CellSize, mWaterHeight),
+            osg::Vec3f(CellSize, CellSize, mWaterHeight),
+            osg::Vec3f(CellSize, 0,        mWaterHeight)
+        };
+
+        const osg::Vec3f InteriorPoints[] =
+        {
+            osg::Vec3f(-InteriorSize, -InteriorSize, mWaterHeight),
+            osg::Vec3f(-InteriorSize,  InteriorSize, mWaterHeight),
+            osg::Vec3f( InteriorSize,  InteriorSize, mWaterHeight),
+            osg::Vec3f( InteriorSize, -InteriorSize, mWaterHeight)
+        };
+
+        const unsigned short TriangleStrip[] =
+        {
+            0, 1, 2, 3, 0, 1
+        };
+
+        const osg::Vec4f Color = osg::Vec4f(0.6f, 0.7f, 1.f, 0.5f);
+
+        if (mWaterGeometry)
+        {
+            mWaterNode->removeDrawable(mWaterGeometry);
+            mWaterGeometry = 0;
+        }
+
+        if (mDeleted || !mHasWater)
+            return;
+
+        mWaterGeometry = new osg::Geometry();
+
+        osg::ref_ptr<osg::Vec3Array> vertices = new osg::Vec3Array();
+        osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array();
+        osg::ref_ptr<osg::DrawElementsUShort> indices = new osg::DrawElementsUShort(osg::PrimitiveSet::TRIANGLE_STRIP,
+            NumIndices);
+
+        for (size_t i = 0; i < NumPoints; ++i)
+        {
+            if (mExterior)
+                vertices->push_back(ExteriorPoints[i]);
+            else
+                vertices->push_back(InteriorPoints[i]);
+        }
+
+        colors->push_back(Color);
+
+        for (size_t i = 0; i < NumIndices; ++i)
+        {
+            indices->setElement(i, TriangleStrip[i]);
+        }
+
+        mWaterGeometry->setVertexArray(vertices);
+        mWaterGeometry->setColorArray(colors, osg::Array::BIND_OVERALL);
+        mWaterGeometry->addPrimitiveSet(indices);
+
+        // Transparency
+        mWaterGeometry->getOrCreateStateSet()->setMode(GL_LIGHTING, osg::StateAttribute::OFF);
+        mWaterGeometry->getOrCreateStateSet()->setMode(GL_BLEND, osg::StateAttribute::ON );
+        mWaterGeometry->getOrCreateStateSet()->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+        mWaterGeometry->getOrCreateStateSet()->setRenderBinDetails(1000, "RenderBin");
+
+        // Reduce some z-fighting
+        osg::ref_ptr<osg::PolygonOffset> polygonOffset = new osg::PolygonOffset();
+        polygonOffset->setFactor(0.2f);
+        polygonOffset->setUnits(0.2f);
+
+        mWaterGeometry->getOrCreateStateSet()->setAttributeAndModes(polygonOffset,
+            osg::StateAttribute::OVERRIDE | osg::StateAttribute::ON);
+
+        mWaterNode->addDrawable(mWaterGeometry);
+    }
+}

--- a/apps/opencs/view/render/cellwater.cpp
+++ b/apps/opencs/view/render/cellwater.cpp
@@ -6,7 +6,10 @@
 #include <osg/PositionAttitudeTransform>
 
 #include <components/esm/loadland.hpp>
+#include <components/fallback/fallback.hpp>
 #include <components/misc/stringops.hpp>
+#include <components/resource/imagemanager.hpp>
+#include <components/resource/resourcesystem.hpp>
 #include <components/sceneutil/waterutil.hpp>
 
 #include "../../model/world/cell.hpp"
@@ -154,6 +157,20 @@ namespace CSVRender
 
         mWaterGeometry = SceneUtil::createWaterGeometry(size, segments, textureRepeats);
         mWaterGeometry->setStateSet(SceneUtil::createSimpleWaterStateSet(Alpha, RenderBin));
+
+        // Add water texture
+        std::string textureName = mData.getFallbackMap()->getFallbackString("Water_SurfaceTexture");
+        textureName = "textures/water/" + textureName + "00.dds";
+
+        Resource::ImageManager* imageManager = mData.getResourceSystem()->getImageManager();
+
+        osg::ref_ptr<osg::Texture2D> waterTexture = new osg::Texture2D();
+        waterTexture->setImage(imageManager->getImage(textureName));
+        waterTexture->setWrap(osg::Texture::WRAP_S, osg::Texture::REPEAT);
+        waterTexture->setWrap(osg::Texture::WRAP_T, osg::Texture::REPEAT);
+
+        mWaterGeometry->getStateSet()->setTextureAttributeAndModes(0, waterTexture, osg::StateAttribute::ON);
+
 
         mWaterNode->addDrawable(mWaterGeometry);
     }

--- a/apps/opencs/view/render/cellwater.hpp
+++ b/apps/opencs/view/render/cellwater.hpp
@@ -1,0 +1,69 @@
+#ifndef CSV_RENDER_CELLWATER_H
+#define CSV_RENDER_CELLWATER_H
+
+#include <string>
+
+#include <osg/ref_ptr>
+
+#include <QObject>
+
+namespace osg
+{
+    class Geode;
+    class Geometry;
+    class Group;
+    class PositionAttitudeTransform;
+}
+
+namespace CSMWorld
+{
+    class Cell;
+    class CellCoordinates;
+    class Data;
+}
+
+namespace CSVRender
+{
+    /// For exterior cells, this adds a patch of water to fit the size of the cell. For interior cells with water, this
+    /// adds a large patch of water much larger than the typical size of a cell.
+    class CellWater : public QObject
+    {
+            Q_OBJECT
+
+        public:
+
+            CellWater(CSMWorld::Data& data, osg::Group* cellNode, const std::string& id,
+                const CSMWorld::CellCoordinates& cellCoords);
+
+            ~CellWater();
+
+            void updateCellData(const CSMWorld::Cell& cell);
+
+        private slots:
+
+            void cellDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
+
+        private:
+
+            void update();
+
+            static const int CellSize;
+
+            CSMWorld::Data& mData;
+            std::string mId;
+
+            osg::Group* mParentNode;
+
+            osg::ref_ptr<osg::PositionAttitudeTransform> mWaterTransform;
+            osg::ref_ptr<osg::Geode> mWaterNode;
+            osg::ref_ptr<osg::Geometry> mWaterGeometry;
+
+            bool mDeleted;
+            bool mExterior;
+
+            bool mHasWater;
+            float mWaterHeight;
+    };
+}
+
+#endif

--- a/apps/opencs/view/render/cellwater.hpp
+++ b/apps/opencs/view/render/cellwater.hpp
@@ -20,7 +20,7 @@ namespace osg
 
 namespace CSMWorld
 {
-    class Cell;
+    struct Cell;
     class CellCoordinates;
     class Data;
 }

--- a/apps/opencs/view/render/cellwater.hpp
+++ b/apps/opencs/view/render/cellwater.hpp
@@ -8,6 +8,8 @@
 #include <QObject>
 #include <QModelIndex>
 
+#include "../../model/world/record.hpp"
+
 namespace osg
 {
     class Geode;
@@ -38,7 +40,7 @@ namespace CSVRender
 
             ~CellWater();
 
-            void updateCellData(const CSMWorld::Cell& cell);
+            void updateCellData(const CSMWorld::Record<CSMWorld::Cell>& cellRecord);
 
         private slots:
 
@@ -46,7 +48,7 @@ namespace CSVRender
 
         private:
 
-            void update();
+            void recreate();
 
             static const int CellSize;
 
@@ -61,9 +63,7 @@ namespace CSVRender
 
             bool mDeleted;
             bool mExterior;
-
             bool mHasWater;
-            float mWaterHeight;
     };
 }
 

--- a/apps/opencs/view/render/cellwater.hpp
+++ b/apps/opencs/view/render/cellwater.hpp
@@ -6,6 +6,7 @@
 #include <osg/ref_ptr>
 
 #include <QObject>
+#include <QModelIndex>
 
 namespace osg
 {

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -24,6 +24,8 @@
 #include <components/resource/resourcesystem.hpp>
 #include <components/resource/imagemanager.hpp>
 
+#include <components/sceneutil/waterutil.hpp>
+
 #include <components/nifosg/controller.hpp>
 #include <components/sceneutil/controller.hpp>
 
@@ -39,58 +41,6 @@
 #include "ripplesimulation.hpp"
 #include "renderbin.hpp"
 #include "util.hpp"
-
-namespace
-{
-
-    osg::ref_ptr<osg::Geometry> createWaterGeometry(float size, int segments, float textureRepeats)
-    {
-        osg::ref_ptr<osg::Vec3Array> verts (new osg::Vec3Array);
-        osg::ref_ptr<osg::Vec2Array> texcoords (new osg::Vec2Array);
-
-        // some drivers don't like huge triangles, so we do some subdivisons
-        // a paged solution would be even better
-        const float step = size/segments;
-        const float texCoordStep = textureRepeats / segments;
-        for (int x=0; x<segments; ++x)
-        {
-            for (int y=0; y<segments; ++y)
-            {
-                float x1 = -size/2.f + x*step;
-                float y1 = -size/2.f + y*step;
-                float x2 = x1 + step;
-                float y2 = y1 + step;
-
-                verts->push_back(osg::Vec3f(x1, y2, 0.f));
-                verts->push_back(osg::Vec3f(x1, y1, 0.f));
-                verts->push_back(osg::Vec3f(x2, y1, 0.f));
-                verts->push_back(osg::Vec3f(x2, y2, 0.f));
-
-                float u1 = x*texCoordStep;
-                float v1 = y*texCoordStep;
-                float u2 = u1 + texCoordStep;
-                float v2 = v1 + texCoordStep;
-
-                texcoords->push_back(osg::Vec2f(u1, v2));
-                texcoords->push_back(osg::Vec2f(u1, v1));
-                texcoords->push_back(osg::Vec2f(u2, v1));
-                texcoords->push_back(osg::Vec2f(u2, v2));
-            }
-        }
-
-        osg::ref_ptr<osg::Geometry> waterGeom (new osg::Geometry);
-        waterGeom->setVertexArray(verts);
-        waterGeom->setTexCoordArray(0, texcoords);
-
-        osg::ref_ptr<osg::Vec3Array> normal (new osg::Vec3Array);
-        normal->push_back(osg::Vec3f(0,0,1));
-        waterGeom->setNormalArray(normal, osg::Array::BIND_OVERALL);
-
-        waterGeom->addPrimitiveSet(new osg::DrawArrays(osg::PrimitiveSet::QUADS,0,verts->size()));
-        return waterGeom;
-    }
-
-}
 
 namespace MWRender
 {
@@ -465,7 +415,7 @@ Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem
 {
     mSimulation.reset(new RippleSimulation(parent, resourceSystem, fallback));
 
-    mWaterGeom = createWaterGeometry(CELL_SIZE*150, 40, 900);
+    mWaterGeom = SceneUtil::createWaterGeometry(CELL_SIZE*150, 40, 900);
     mWaterGeom->setDrawCallback(new DepthClampCallback);
     mWaterGeom->setNodeMask(Mask_Water);
 
@@ -527,26 +477,11 @@ void Water::updateWaterMaterial()
 
 void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
 {
-    osg::ref_ptr<osg::StateSet> stateset (new osg::StateSet);
-
-    osg::ref_ptr<osg::Material> material (new osg::Material);
-    material->setEmission(osg::Material::FRONT_AND_BACK, osg::Vec4f(0.f, 0.f, 0.f, 1.f));
-    material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1.f, 1.f, 1.f, alpha));
-    material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1.f, 1.f, 1.f, 1.f));
-    material->setColorMode(osg::Material::OFF);
-    stateset->setAttributeAndModes(material, osg::StateAttribute::ON);
-
-    stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
-    stateset->setMode(GL_CULL_FACE, osg::StateAttribute::OFF);
-
-    osg::ref_ptr<osg::Depth> depth (new osg::Depth);
-    depth->setWriteMask(false);
-    stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
-
-    stateset->setRenderBinDetails(MWRender::RenderBin_Water, "RenderBin");
+    osg::ref_ptr<osg::StateSet> stateset = SceneUtil::createSimpleWaterStateSet(alpha, MWRender::RenderBin_Water);
 
     node->setStateSet(stateset);
 
+    // Add animated textures
     std::vector<osg::ref_ptr<osg::Texture2D> > textures;
     int frameCount = mFallback->getFallbackInt("Water_SurfaceFrameCount");
     std::string texture = mFallback->getFallbackString("Water_SurfaceTexture");

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -50,7 +50,7 @@ add_component_dir (shader
 
 add_component_dir (sceneutil
     clone attach visitor util statesetupdater controller skeleton riggeometry lightcontroller
-    lightmanager lightutil positionattitudetransform workqueue unrefqueue pathgridutil
+    lightmanager lightutil positionattitudetransform workqueue unrefqueue pathgridutil waterutil
     )
 
 add_component_dir (nif

--- a/components/sceneutil/waterutil.cpp
+++ b/components/sceneutil/waterutil.cpp
@@ -1,0 +1,79 @@
+#include "waterutil.hpp"
+
+#include <osg/Depth>
+#include <osg/Geometry>
+#include <osg/Material>
+#include <osg/StateSet>
+
+namespace SceneUtil
+{
+    osg::ref_ptr<osg::Geometry> createWaterGeometry(float size, int segments, float textureRepeats)
+    {
+        osg::ref_ptr<osg::Vec3Array> verts (new osg::Vec3Array);
+        osg::ref_ptr<osg::Vec2Array> texcoords (new osg::Vec2Array);
+
+        // some drivers don't like huge triangles, so we do some subdivisons
+        // a paged solution would be even better
+        const float step = size/segments;
+        const float texCoordStep = textureRepeats / segments;
+        for (int x=0; x<segments; ++x)
+        {
+            for (int y=0; y<segments; ++y)
+            {
+                float x1 = -size/2.f + x*step;
+                float y1 = -size/2.f + y*step;
+                float x2 = x1 + step;
+                float y2 = y1 + step;
+
+                verts->push_back(osg::Vec3f(x1, y2, 0.f));
+                verts->push_back(osg::Vec3f(x1, y1, 0.f));
+                verts->push_back(osg::Vec3f(x2, y1, 0.f));
+                verts->push_back(osg::Vec3f(x2, y2, 0.f));
+
+                float u1 = x*texCoordStep;
+                float v1 = y*texCoordStep;
+                float u2 = u1 + texCoordStep;
+                float v2 = v1 + texCoordStep;
+
+                texcoords->push_back(osg::Vec2f(u1, v2));
+                texcoords->push_back(osg::Vec2f(u1, v1));
+                texcoords->push_back(osg::Vec2f(u2, v1));
+                texcoords->push_back(osg::Vec2f(u2, v2));
+            }
+        }
+
+        osg::ref_ptr<osg::Geometry> waterGeom (new osg::Geometry);
+        waterGeom->setVertexArray(verts);
+        waterGeom->setTexCoordArray(0, texcoords);
+
+        osg::ref_ptr<osg::Vec3Array> normal (new osg::Vec3Array);
+        normal->push_back(osg::Vec3f(0,0,1));
+        waterGeom->setNormalArray(normal, osg::Array::BIND_OVERALL);
+
+        waterGeom->addPrimitiveSet(new osg::DrawArrays(osg::PrimitiveSet::QUADS,0,verts->size()));
+        return waterGeom;
+    }
+
+    osg::ref_ptr<osg::StateSet> createSimpleWaterStateSet(float alpha, int renderBin)
+    {
+        osg::ref_ptr<osg::StateSet> stateset (new osg::StateSet);
+
+        osg::ref_ptr<osg::Material> material (new osg::Material);
+        material->setEmission(osg::Material::FRONT_AND_BACK, osg::Vec4f(0.f, 0.f, 0.f, 1.f));
+        material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1.f, 1.f, 1.f, alpha));
+        material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1.f, 1.f, 1.f, 1.f));
+        material->setColorMode(osg::Material::OFF);
+        stateset->setAttributeAndModes(material, osg::StateAttribute::ON);
+
+        stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
+        stateset->setMode(GL_CULL_FACE, osg::StateAttribute::OFF);
+
+        osg::ref_ptr<osg::Depth> depth (new osg::Depth);
+        depth->setWriteMask(false);
+        stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
+
+        stateset->setRenderBinDetails(renderBin, "RenderBin");
+
+        return stateset;
+    }
+}

--- a/components/sceneutil/waterutil.hpp
+++ b/components/sceneutil/waterutil.hpp
@@ -1,0 +1,19 @@
+#ifndef OPENMW_COMPONENTS_WATERUTIL_H
+#define OPENMW_COMPONENTS_WATERUTIL_H
+
+#include <osg/ref_ptr>
+
+namespace osg
+{
+    class Geometry;
+    class StateSet;
+}
+
+namespace SceneUtil
+{
+    osg::ref_ptr<osg::Geometry> createWaterGeometry(float size, int segments, float textureRepeats);
+
+    osg::ref_ptr<osg::StateSet> createSimpleWaterStateSet(float alpha, int renderBin);
+}
+
+#endif


### PR DESCRIPTION
This implements [feature#1596.](https://bugs.openmw.org/issues/1596)

I wasn't sure what the best way to go about keeping up to date with the cell data. It seemed silly to add yet another slot to the WorldSpaceWidget class that would have to be inherited by both the Paged/Unpaged child classes and passed on to the correct cell. I can change it to do that if desired.

@scrawl 
I was having issues with the lighting flickering when I moved or looked around in certain spots, so I had to disable it. Any idea what could be causing that? Also, should I be using higher numbers for the rendering bins, or will 1000 and 2000 be fine?