### PR TITLE
Fix pointer being deleted twice.

### DIFF
--- a/apps/opencs/view/render/orbitcameramode.cpp
+++ b/apps/opencs/view/render/orbitcameramode.cpp
@@ -15,9 +15,9 @@ namespace CSVRender
         , mWorldspaceWidget(worldspaceWidget)
         , mCenterOnSelection(0)
     {
-        mCenterShortcut.reset(new CSMPrefs::Shortcut("orbit-center-selection", worldspaceWidget));
+        mCenterShortcut = new CSMPrefs::Shortcut("orbit-center-selection", worldspaceWidget);
         mCenterShortcut->enable(false);
-        connect(mCenterShortcut.get(), SIGNAL(activated()), this, SLOT(centerSelection()));
+        connect(mCenterShortcut, SIGNAL(activated()), this, SLOT(centerSelection()));
     }
 
     OrbitCameraMode::~OrbitCameraMode()

--- a/apps/opencs/view/render/orbitcameramode.hpp
+++ b/apps/opencs/view/render/orbitcameramode.hpp
@@ -32,7 +32,7 @@ namespace CSVRender
 
             WorldspaceWidget* mWorldspaceWidget;
             QAction* mCenterOnSelection;
-            std::auto_ptr<CSMPrefs::Shortcut> mCenterShortcut;
+            CSMPrefs::Shortcut* mCenterShortcut;
 
         private slots:
 


### PR DESCRIPTION
This fixes [bug#3483.](https://bugs.openmw.org/issues/3483) It was caused by both Qt's memory management and an std::auto_ptr keeping track of the same pointer. I missed it after one of my redesigns.