### PR TITLE
Fix globals not being initialized with a valid type.

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -66,7 +66,7 @@ opencs_hdrs_noqt (view/doc
 
 
 opencs_units (view/world
-    table tablesubview scriptsubview util regionmapsubview tablebottombox creator genericcreator
+    table tablesubview scriptsubview util regionmapsubview tablebottombox creator genericcreator globalcreator
     cellcreator pathgridcreator referenceablecreator startscriptcreator referencecreator scenesubview
     infocreator scriptedit dialoguesubview previewsubview regionmap dragrecordtable nestedtable
     dialoguespinbox recordbuttonbar tableeditidaction scripterrortable extendedcommandconfigurator

--- a/apps/opencs/view/world/globalcreator.cpp
+++ b/apps/opencs/view/world/globalcreator.cpp
@@ -1,0 +1,26 @@
+#include "globalcreator.hpp"
+
+#include <components/esm/variant.hpp>
+
+#include "../../model/world/data.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/columns.hpp"
+#include "../../model/world/idtable.hpp"
+
+namespace CSVWorld
+{
+    void GlobalCreator::configureCreateCommand (CSMWorld::CreateCommand& command) const
+    {
+        CSMWorld::IdTable* table = static_cast<CSMWorld::IdTable*>(getData().getTableModel(getCollectionId()));
+
+        int index = table->findColumnIndex(CSMWorld::Columns::ColumnId_ValueType);
+        int type = (int)ESM::VT_Float;
+
+        command.addValue(index, type);
+    }
+
+    GlobalCreator::GlobalCreator(CSMWorld::Data& data, QUndoStack& undoStack, const CSMWorld::UniversalId& id)
+        : GenericCreator (data, undoStack, id, true)
+    {
+    }
+}

--- a/apps/opencs/view/world/globalcreator.hpp
+++ b/apps/opencs/view/world/globalcreator.hpp
@@ -1,0 +1,20 @@
+#ifndef CSV_WORLD_GLOBALCREATOR_H
+#define CSV_WORLD_GLOBALCREATOR_H
+
+#include "genericcreator.hpp"
+
+namespace CSVWorld
+{
+    class GlobalCreator : public GenericCreator
+    {
+        public:
+
+            GlobalCreator(CSMWorld::Data& data, QUndoStack& undoStack, const CSMWorld::UniversalId& id);
+
+        protected:
+
+            virtual void configureCreateCommand(CSMWorld::CreateCommand& command) const;
+    };
+}
+
+#endif

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -7,6 +7,7 @@
 #include "scriptsubview.hpp"
 #include "regionmapsubview.hpp"
 #include "genericcreator.hpp"
+#include "globalcreator.hpp"
 #include "cellcreator.hpp"
 #include "referenceablecreator.hpp"
 #include "referencecreator.hpp"
@@ -32,7 +33,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
 
     static const CSMWorld::UniversalId::Type sTableTypes[] =
     {
-        CSMWorld::UniversalId::Type_Globals,
         CSMWorld::UniversalId::Type_Classes,
         CSMWorld::UniversalId::Type_Factions,
         CSMWorld::UniversalId::Type_Races,
@@ -77,6 +77,9 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
 
     manager.add (CSMWorld::UniversalId::Type_Pathgrids,
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<PathgridCreator> >);
+
+    manager.add (CSMWorld::UniversalId::Type_Globals,
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<GlobalCreator> >);
 
     // Subviews for resources tables
     manager.add (CSMWorld::UniversalId::Type_Meshes,


### PR DESCRIPTION
This fixes [bug#3091](https://bugs.openmw.org/issues/3091). Global variables were being created with an invalid type. Seeing how it is only [allowed](https://github.com/OpenMW/openmw/blame/master/apps/opencs/view/doc/viewmanager.cpp#L55) to be a short, int or float type, it does not make sense to create it with a different type.