### PR TITLE
Play locked sounds on locked objects instead of actors

### DIFF
--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -190,7 +190,7 @@ namespace MWClass
         }
         else
         {
-            boost::shared_ptr<MWWorld::Action> action(new MWWorld::FailedAction);
+            boost::shared_ptr<MWWorld::Action> action(new MWWorld::FailedAction(std::string(), ptr));
             action->setSound(lockedSound);
             return action;
         }

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -220,7 +220,7 @@ namespace MWClass
         else
         {
             // locked, and we can't open.
-            boost::shared_ptr<MWWorld::Action> action(new MWWorld::FailedAction);
+            boost::shared_ptr<MWWorld::Action> action(new MWWorld::FailedAction(std::string(), ptr));
             action->setSound(lockedSound);
             return action;
         }

--- a/apps/openmw/mwworld/failedaction.cpp
+++ b/apps/openmw/mwworld/failedaction.cpp
@@ -8,8 +8,8 @@
 
 namespace MWWorld
 {
-    FailedAction::FailedAction(const std::string &msg)
-      : Action(false), mMessage(msg)
+    FailedAction::FailedAction(const std::string &msg, const Ptr& target)
+      : Action(false, target), mMessage(msg)
     {   }
 
     void FailedAction::executeImp(const Ptr &actor)

--- a/apps/openmw/mwworld/failedaction.hpp
+++ b/apps/openmw/mwworld/failedaction.hpp
@@ -13,7 +13,7 @@ namespace MWWorld
         virtual void executeImp(const Ptr &actor);
 
     public:
-        FailedAction(const std::string &message = std::string());
+        FailedAction(const std::string &message = std::string(), const Ptr& target = Ptr());
     };
 }
 


### PR DESCRIPTION
Changes the locked sound when trying to open a locked door or container to play on the target object rather than the actor who is using the object. This makes the sounds behave like in the original engine.



