### PR TITLE
Make zero-weight boots play light boot footsteps

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1161,6 +1161,7 @@ namespace MWClass
 
                 switch(boots->getClass().getEquipmentSkill(*boots))
                 {
+                    case ESM::Skill::Unarmored:
                     case ESM::Skill::LightArmor:
                         return (name == "left") ? "FootLightLeft" : "FootLightRight";
                     case ESM::Skill::MediumArmor:


### PR DESCRIPTION
For https://bugs.openmw.org/issues/3496.

You can read my reasoning for the change there. I created a report so that it will be easier to see this and include in the version changes, since I noticed that people seem to use the bug and feature reports for that.

Some related testing results from the original engine:

1. In the original game, and in OpenMW, bound equipment uses the unarmored skill.
2. In the TES Construction Set, the Bound Boots are categorized "Light."
3. In the original game, when you are hit on a body part that is equipped with bound equipment, your light armor skill rises.
4. Any zero-weight boots, not just Bound Boots, are considered Light Armor in the Construction Set (and probably in-game, didn't check that) and play the light boot footstep.

3 seems like incorrect behavior to me. Looks like probably somewhere there is logic that armor must at least be classified as "light," but there is also something making bound items use unarmored skill. Because of the unarmored skill use, OpenMW played no footstep sound.