### PR TITLE
Make loopgroup loop correct number of times

### DIFF
--- a/apps/openmw/mwscript/animationextensions.cpp
+++ b/apps/openmw/mwscript/animationextensions.cpp
@@ -89,7 +89,7 @@ namespace MWScript
                             throw std::runtime_error ("animation mode out of range");
                     }
 
-                    MWBase::Environment::get().getMechanicsManager()->playAnimationGroup (ptr, group, mode, loops, true);
+                    MWBase::Environment::get().getMechanicsManager()->playAnimationGroup (ptr, group, mode, loops + 1, true);
                }
         };
         


### PR DESCRIPTION
This is mentioned in https://bugs.openmw.org/issues/3385.

This is a change made without much knowledge, because I don't know much about how the animation code works, but it seems to replicate the original engine behavior without a problem so I thought I might as well submit it.

Currently in OpenMW master "loopgroup (animation name) (int)" in the in-game console makes one of the animated banners in towns play once, then loop int - 1 times. "loopgroup idle3 0" and "loopgroup idle3 1" produce the same behavior. (use "togglescripts" first to turn off the script that will override your command otherwise). In the original engine, they will loop (int) times.

I couldn't easily test this change on NPCs in OpenMW. They seem to ignore the loopgroup command unless you toggleAI off first. In that case they will run the animation once then become perfectly still. In the original engine they will play the animation once, then stay looping in it forever, even if you attack them. (Though they will still turn to face you and move their mouth to talk)

I noticed that OpenMW returns an error if you try to run loopgroup with a negative number. In the original engine, it seems to instead start the object looping infinitely (or at least for many times. It never stopped while I was watching.) Seems like maybe something we should replicate for compatibility.