### PR TITLE
Improvements for playgroup and loopgroup

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1533,8 +1533,8 @@ void CharacterController::update(float duration)
 
     updateMagicEffects();
 
-    if(mAnimQueue.size() > 1 && (mAnimation->getLoopingEnabled(mAnimQueue.front().mGroup) == true))
-        mAnimation->setLoopingEnabled(mAnimQueue.front().mGroup, false);
+    if(!mAnimQueue.empty())
+        mAnimation->setLoopingEnabled(mAnimQueue.front().mGroup, mAnimQueue.size() <= 1);
 
     if(!cls.isActor())
     {

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1539,6 +1539,9 @@ void CharacterController::updateAnimQueue()
                              1.0f, "start", "stop", 0.0f, mAnimQueue.front().mLoopCount, loopfallback);
         }
     }
+
+    if(!mAnimQueue.empty())
+        mAnimation->setLoopingEnabled(mAnimQueue.front().mGroup, mAnimQueue.size() <= 1);
 }
 
 void CharacterController::update(float duration)
@@ -1549,9 +1552,6 @@ void CharacterController::update(float duration)
     float speed = 0.f;
 
     updateMagicEffects();
-
-    if(!mAnimQueue.empty())
-        mAnimation->setLoopingEnabled(mAnimQueue.front().mGroup, mAnimQueue.size() <= 1);
 
     if(!cls.isActor())
         updateAnimQueue();

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2009,6 +2009,9 @@ bool CharacterController::playGroup(const std::string &groupname, int mode, int 
     }
     else
     {
+        if (!mAnimQueue.empty() && mAnimQueue.front().mGroup == groupname && isAnimPlaying(mAnimQueue.front().mGroup))
+            return true;
+
         count = std::max(count, 1);
 
         AnimationQueueEntry entry;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1989,9 +1989,10 @@ void CharacterController::unpersistAnimationState()
         mCurrentIdle.clear();
         mIdleState = CharState_SpecialIdle;
 
+        bool loopfallback = (mAnimQueue.front().mGroup.compare(0,4,"idle") == 0);
         mAnimation->play(anim.mGroup,
                          Priority_Default, MWRender::Animation::BlendMask_All, false, 1.0f,
-                         "start", "stop", complete, anim.mLoopCount);
+                         "start", "stop", complete, anim.mLoopCount, loopfallback);
     }
 }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1524,6 +1524,23 @@ bool CharacterController::updateWeaponState()
     return forcestateupdate;
 }
 
+void CharacterController::updateAnimQueue()
+{
+    if(mAnimQueue.size() > 1)
+    {
+        if(mAnimation->isPlaying(mAnimQueue.front().mGroup) == false)
+        {
+            mAnimation->disable(mAnimQueue.front().mGroup);
+            mAnimQueue.pop_front();
+
+            bool loopfallback = (mAnimQueue.front().mGroup.compare(0,4,"idle") == 0);
+            mAnimation->play(mAnimQueue.front().mGroup, Priority_Default,
+                             MWRender::Animation::BlendMask_All, false,
+                             1.0f, "start", "stop", 0.0f, mAnimQueue.front().mLoopCount, loopfallback);
+        }
+    }
+}
+
 void CharacterController::update(float duration)
 {
     MWBase::World *world = MWBase::Environment::get().getWorld();
@@ -1537,21 +1554,7 @@ void CharacterController::update(float duration)
         mAnimation->setLoopingEnabled(mAnimQueue.front().mGroup, mAnimQueue.size() <= 1);
 
     if(!cls.isActor())
-    {
-        if(mAnimQueue.size() > 1)
-        {
-            if(mAnimation->isPlaying(mAnimQueue.front().mGroup) == false)
-            {
-                mAnimation->disable(mAnimQueue.front().mGroup);
-                mAnimQueue.pop_front();
-
-                bool loopfallback = (mAnimQueue.front().mGroup.compare(0,4,"idle") == 0);
-                mAnimation->play(mAnimQueue.front().mGroup, Priority_Default,
-                                 MWRender::Animation::BlendMask_All, false,
-                                 1.0f, "start", "stop", 0.0f, mAnimQueue.front().mLoopCount, loopfallback);
-            }
-        }
-    }
+        updateAnimQueue();
     else if(!cls.getCreatureStats(mPtr).isDead())
     {
         bool onground = world->isOnGround(mPtr);
@@ -1819,19 +1822,8 @@ void CharacterController::update(float duration)
         {
             idlestate = (inwater ? CharState_IdleSwim : (sneak && !inJump ? CharState_IdleSneak : CharState_Idle));
         }
-        else if(mAnimQueue.size() > 1)
-        {
-            if(mAnimation->isPlaying(mAnimQueue.front().mGroup) == false)
-            {
-                mAnimation->disable(mAnimQueue.front().mGroup);
-                mAnimQueue.pop_front();
-
-                bool loopfallback = (mAnimQueue.front().mGroup.compare(0,4,"idle") == 0);
-                mAnimation->play(mAnimQueue.front().mGroup, Priority_Default,
-                                 MWRender::Animation::BlendMask_All, false,
-                                 1.0f, "start", "stop", 0.0f, mAnimQueue.front().mLoopCount, loopfallback);
-            }
-        }
+        else
+            updateAnimQueue();
 
         if (!mSkipAnim)
         {

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -212,6 +212,8 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     bool updateCreatureState();
     void updateIdleStormState(bool inwater);
 
+    void updateAnimQueue();
+
     void updateHeadTracking(float duration);
 
     void updateMagicEffects();

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1023,7 +1023,7 @@ namespace MWRender
             {
                 float targetTime;
 
-                if (state.getTime() < state.mLoopStopTime || state.mLoopCount == 0)
+                if (!state.shouldLoop())
                 {
                     targetTime = state.getTime() + timepassed;
                     if(textkey == textkeys.end() || textkey->first > targetTime)
@@ -1048,27 +1048,21 @@ namespace MWRender
                         ++textkey;
                     }
                 }
-
-                if(state.getTime() >= state.mLoopStopTime)
+                if(state.shouldLoop())
                 {
-                    if (!state.mLoopingEnabled)
-                        state.mLoopCount = 0;
-                    else if (state.mLoopCount > 0)
+                    state.mLoopCount--;
+                    state.setTime(state.mLoopStartTime);
+                    state.mPlaying = true;
+
+                    textkey = textkeys.lower_bound(state.getTime());
+                    while(textkey != textkeys.end() && textkey->first <= state.getTime())
                     {
-                        state.mLoopCount--;
-                        state.setTime(state.mLoopStartTime);
-                        state.mPlaying = true;
-
-                        textkey = textkeys.lower_bound(state.getTime());
-                        while(textkey != textkeys.end() && textkey->first <= state.getTime())
-                        {
-                            handleTextKey(state, stateiter->first, textkey, textkeys);
-                            ++textkey;
-                        }
-
-                        if(state.getTime() >= state.mLoopStopTime)
-                            break;
+                        handleTextKey(state, stateiter->first, textkey, textkeys);
+                        ++textkey;
                     }
+
+                    if(state.getTime() >= state.mLoopStopTime)
+                        break;
                 } 
 
                 if(timepassed <= 0.0f)

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1106,14 +1106,6 @@ namespace MWRender
             state->second.mLoopingEnabled = enabled;
     }
 
-    bool Animation::getLoopingEnabled(const std::string &groupname) const
-    {
-        AnimStateMap::const_iterator state(mStates.find(groupname));
-        if(state != mStates.end())
-            return state->second.mLoopingEnabled;
-        return false;
-    }
-
     void Animation::setObjectRoot(const std::string &model, bool forceskeleton, bool baseonly, bool isCreature)
     {
         osg::ref_ptr<osg::StateSet> previousStateset;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -873,16 +873,6 @@ namespace MWRender
         addControllers();
     }
 
-    void Animation::stopLooping(const std::string& groupname)
-    {
-        AnimStateMap::iterator stateiter = mStates.find(groupname);
-        if(stateiter != mStates.end())
-        {
-            stateiter->second.mLoopCount = 0;
-            return;
-        }
-    }
-
     void Animation::adjustSpeedMult(const std::string &groupname, float speedmult)
     {
         AnimStateMap::iterator state(mStates.find(groupname));

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1023,49 +1023,53 @@ namespace MWRender
             {
                 float targetTime;
 
-                if(state.getTime() >= state.mLoopStopTime && state.mLoopCount > 0)
-                    goto handle_loop;
-
-                targetTime = state.getTime() + timepassed;
-                if(textkey == textkeys.end() || textkey->first > targetTime)
+                if (state.getTime() < state.mLoopStopTime || state.mLoopCount == 0)
                 {
-                    if(mAccumCtrl && state.mTime == mAnimationTimePtr[0]->getTimePtr())
-                        updatePosition(state.getTime(), targetTime, movement);
-                    state.setTime(std::min(targetTime, state.mStopTime));
-                }
-                else
-                {
-                    if(mAccumCtrl && state.mTime == mAnimationTimePtr[0]->getTimePtr())
-                        updatePosition(state.getTime(), textkey->first, movement);
-                    state.setTime(textkey->first);
-                }
+                    targetTime = state.getTime() + timepassed;
+                    if(textkey == textkeys.end() || textkey->first > targetTime)
+                    {
+                        if(mAccumCtrl && state.mTime == mAnimationTimePtr[0]->getTimePtr())
+                            updatePosition(state.getTime(), targetTime, movement);
+                        state.setTime(std::min(targetTime, state.mStopTime));
+                    }
+                    else
+                    {
+                        if(mAccumCtrl && state.mTime == mAnimationTimePtr[0]->getTimePtr())
+                            updatePosition(state.getTime(), textkey->first, movement);
+                        state.setTime(textkey->first);
+                    }
 
-                state.mPlaying = (state.getTime() < state.mStopTime);
-                timepassed = targetTime - state.getTime();
+                    state.mPlaying = (state.getTime() < state.mStopTime);
+                    timepassed = targetTime - state.getTime();
 
-                while(textkey != textkeys.end() && textkey->first <= state.getTime())
-                {
-                    handleTextKey(state, stateiter->first, textkey, textkeys);
-                    ++textkey;
-                }
-
-                if(state.getTime() >= state.mLoopStopTime && state.mLoopCount > 0)
-                {
-                handle_loop:
-                    state.mLoopCount--;
-                    state.setTime(state.mLoopStartTime);
-                    state.mPlaying = true;
-
-                    textkey = textkeys.lower_bound(state.getTime());
                     while(textkey != textkeys.end() && textkey->first <= state.getTime())
                     {
                         handleTextKey(state, stateiter->first, textkey, textkeys);
                         ++textkey;
                     }
-
-                    if(state.getTime() >= state.mLoopStopTime)
-                        break;
                 }
+
+                if(state.getTime() >= state.mLoopStopTime)
+                {
+                    if (!state.mLoopingEnabled)
+                        state.mLoopCount = 0;
+                    else if (state.mLoopCount > 0)
+                    {
+                        state.mLoopCount--;
+                        state.setTime(state.mLoopStartTime);
+                        state.mPlaying = true;
+
+                        textkey = textkeys.lower_bound(state.getTime());
+                        while(textkey != textkeys.end() && textkey->first <= state.getTime())
+                        {
+                            handleTextKey(state, stateiter->first, textkey, textkeys);
+                            ++textkey;
+                        }
+
+                        if(state.getTime() >= state.mLoopStopTime)
+                            break;
+                    }
+                } 
 
                 if(timepassed <= 0.0f)
                     break;
@@ -1093,6 +1097,21 @@ namespace MWRender
         }
 
         return movement;
+    }
+
+    void Animation::setLoopingEnabled(const std::string &groupname, bool enabled)
+    {
+        AnimStateMap::iterator state(mStates.find(groupname));
+        if(state != mStates.end())
+            state->second.mLoopingEnabled = enabled;
+    }
+
+    bool Animation::getLoopingEnabled(const std::string &groupname) const
+    {
+        AnimStateMap::const_iterator state(mStates.find(groupname));
+        if(state != mStates.end())
+            return state->second.mLoopingEnabled;
+        return false;
     }
 
     void Animation::setObjectRoot(const std::string &model, bool forceskeleton, bool baseonly, bool isCreature)

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -395,10 +395,6 @@ public:
               float speedmult, const std::string &start, const std::string &stop,
               float startpoint, size_t loops, bool loopfallback=false);
 
-    /** If the given animation group is currently playing, set its remaining loop count to '0'.
-     */
-    void stopLooping(const std::string& groupName);
-
     /** Adjust the speed multiplier of an already playing animation.
      */
     void adjustSpeedMult (const std::string& groupname, float speedmult);

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -205,6 +205,11 @@ protected:
         {
             *mTime = time;
         }
+
+        bool shouldLoop() const
+        {
+            return getTime() >= mLoopStopTime && mLoopingEnabled && mLoopCount > 0;
+        }
     };
     typedef std::map<std::string,AnimState> AnimStateMap;
     AnimStateMap mStates;

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -435,8 +435,6 @@ public:
 
     void setLoopingEnabled(const std::string &groupname, bool enabled);
 
-    bool getLoopingEnabled(const std::string &groupname) const;
-
     /// This is typically called as part of runAnimation, but may be called manually if needed.
     void updateEffects(float duration);
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -183,6 +183,7 @@ protected:
         float mSpeedMult;
 
         bool mPlaying;
+        bool mLoopingEnabled;
         size_t mLoopCount;
 
         AnimPriority mPriority;
@@ -190,8 +191,8 @@ protected:
         bool mAutoDisable;
 
         AnimState() : mStartTime(0.0f), mLoopStartTime(0.0f), mLoopStopTime(0.0f), mStopTime(0.0f),
-                      mTime(new float), mSpeedMult(1.0f), mPlaying(false), mLoopCount(0),
-                      mPriority(0), mBlendMask(0), mAutoDisable(true)
+                      mTime(new float), mSpeedMult(1.0f), mPlaying(false), mLoopingEnabled(true),
+                      mLoopCount(0), mPriority(0), mBlendMask(0), mAutoDisable(true)
         {
         }
         ~AnimState();
@@ -431,6 +432,10 @@ public:
     float getVelocity(const std::string &groupname) const;
 
     virtual osg::Vec3f runAnimation(float duration);
+
+    void setLoopingEnabled(const std::string &groupname, bool enabled);
+
+    bool getLoopingEnabled(const std::string &groupname) const;
 
     /// This is typically called as part of runAnimation, but may be called manually if needed.
     void updateEffects(float duration);


### PR DESCRIPTION
This fixes https://bugs.openmw.org/issues/3385.

Currently, in OpenMW banners never loop their animation in stormy weather. They are animated by the script OutsideBanner, which during stormy weather is constantly (every frame?) calling either loopgroup idle3 5 or playgroup idle. Everytime one of these is called, currently OpenMW sets the currently playing animation's loop count to 0, so a loop never occurs. This PR fixes this.

The following behavior is not in OpenMW master but was observed in the original engine and emulated in this PR:

-- When the same looped animation (an animation with a "Loop Start" key) is called as is already playing, all animations except for the already playing one are removed from the queue, even the newly called animation.

Ex.
`loopgroup idle3 5` (5 loops)
After playing through one loop and having 4 left
`playgroup idle` (still on loop 4, "idle" put in animation queue)
`loopgroup idle3 2` (still on loop 4. "idle" is removed from the animation queue, and no new "idle3" is added to the queue. The original loopcount of 4 continues to be used, not 2)

-- When an animation differing from the currently playing one is put in the queue, the currently playing animation's loops remain salvageable by running the animation again as long as the Loop Stop key has not been passed. Once it has been passed, trying to run the animation again will instead queue a new one.

