### PR TITLE
Fix uninitialized escape_hash_filter

### DIFF
--- a/components/files/escape.cpp
+++ b/components/files/escape.cpp
@@ -9,7 +9,7 @@ namespace Files
     const int escape_hash_filter::sEscapeIdentifier = 'a';
     const int escape_hash_filter::sHashIdentifier = 'h';
 
-    escape_hash_filter::escape_hash_filter() : mNext(), mSeenNonWhitespace(false), mFinishLine(false)
+    escape_hash_filter::escape_hash_filter() : mNext(), mPrevious(), mSeenNonWhitespace(false), mFinishLine(false)
     {
     }
 


### PR DESCRIPTION
Before:
```
==6866== Conditional jump or move depends on uninitialised value(s)
==6866==    at 0xBBB7BD: int Files::escape_hash_filter::get<boost::iostreams::detail::linked_streambuf<char, std::char_traits<char> > >(boost::iostreams::detail::linked_streambuf<char, std::char_traits<char> >&) (escape.hpp:81)
==6866==    by 0xBBBB65: read<Files::escape_hash_filter, boost::iostreams::detail::linked_streambuf<char, std::char_traits<char> > > (read.hpp:228)
==6866==    by 0xBBBB65: read<Files::escape_hash_filter, boost::iostreams::detail::linked_streambuf<char, std::char_traits<char> > > (read.hpp:57)
==6866==    by 0xBBBB65: read<Files::escape_hash_filter, boost::iostreams::detail::linked_streambuf<char, std::char_traits<char> > > (concept_adapter.hpp:256)
==6866==    by 0xBBBB65: read<boost::iostreams::detail::linked_streambuf<char, std::char_traits<char> > > (concept_adapter.hpp:78)
==6866==    by 0xBBBB65: boost::iostreams::detail::indirect_streambuf<Files::escape_hash_filter, std::char_traits<char>, std::allocator<char>, boost::iostreams::input>::underflow() (indirect_streambuf.hpp:258)
==6866==    by 0xA51EB79: std::basic_istream<char, std::char_traits<char> >& std::getline<char, std::char_traits<char>, std::allocator<char> >(std::basic_istream<char, std::char_traits<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==6866==    by 0x68310AF: boost::program_options::detail::basic_config_file_iterator<char>::getline(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (in /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.58.0)
==6866==    by 0x682123F: boost::program_options::detail::common_config_file_iterator::get() (in /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.58.0)
==6866==    by 0x6832565: boost::program_options::detail::basic_config_file_iterator<char>::basic_config_file_iterator(std::istream&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool) (in /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.58.0)
==6866==    by 0x6837DFD: boost::program_options::basic_parsed_options<char> boost::program_options::parse_config_file<char>(std::basic_istream<char, std::char_traits<char> >&, boost::program_options::options_description const&, bool) (in /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.58.0)
==6866==    by 0xBB7BF0: Files::ConfigurationManager::loadConfig(boost::filesystem::path const&, boost::program_options::variables_map&, boost::program_options::options_description&) (configurationmanager.cpp:153)
==6866==    by 0xBB835D: Files::ConfigurationManager::readConfiguration(boost::program_options::variables_map&, boost::program_options::options_description&, bool) (configurationmanager.cpp:63)
==6866==    by 0xA99D56: parseOptions(int, char**, OMW::Engine&, Files::ConfigurationManager&) (main.cpp:182)
==6866==    by 0x639C67: main (main.cpp:362)
==6866== 
```