### PR TITLE
Add virtual destructors

### DIFF
--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -59,6 +59,8 @@ namespace Compiler
        mExprParser (errorHandler, context, locals, literals), mAllowExpression (allowExpression)
     {}
 
+    LineParser::~LineParser() {}
+
     bool LineParser::parseInt (int value, const TokenLoc& loc, Scanner& scanner)
     {
         if (mAllowExpression && mState==BeginState)

--- a/components/compiler/lineparser.hpp
+++ b/components/compiler/lineparser.hpp
@@ -51,6 +51,9 @@ namespace Compiler
                 bool allowExpression = false);
             ///< \param allowExpression Allow lines consisting of a naked expression
             /// (result is send to the messagebox interface)
+            
+            virtual ~LineParser();
+            ///< destructor
 
             virtual bool parseInt (int value, const TokenLoc& loc, Scanner& scanner);
             ///< Handle an int token.

--- a/components/misc/messageformatparser.cpp
+++ b/components/misc/messageformatparser.cpp
@@ -2,6 +2,8 @@
 
 namespace Misc
 {
+    MessageFormatParser::~MessageFormatParser() {}
+
     void MessageFormatParser::process(const std::string& m)
     {
         for (unsigned int i = 0; i < m.size(); ++i)

--- a/components/misc/messageformatparser.hpp
+++ b/components/misc/messageformatparser.hpp
@@ -19,6 +19,8 @@ namespace Misc
             virtual void visitedCharacter(char c) = 0;
 
         public:
+            virtual ~MessageFormatParser();
+
             virtual void process(const std::string& message);
     };
 }


### PR DESCRIPTION
Addresses the following warnings from MSVC/AppVeyor.

\components\compiler\lineparser.hpp(96): warning C4265: 'Compiler::GetArgumentsFromMessageFormat': class has virtual functions, but destructor is not virtual
           instances of this class may not be destructed correctly

\components\interpreter\miscopcodes.hpp(91): warning C4265: 'Interpreter::RuntimeMessageFormatter': class has virtual functions, but destructor is not virtual
           instances of this class may not be destructed correctly