### PR TITLE
Remove unnecessary destructor

### DIFF
--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -59,8 +59,6 @@ namespace Compiler
        mExprParser (errorHandler, context, locals, literals), mAllowExpression (allowExpression)
     {}
 
-    LineParser::~LineParser() {}
-
     bool LineParser::parseInt (int value, const TokenLoc& loc, Scanner& scanner)
     {
         if (mAllowExpression && mState==BeginState)

--- a/components/compiler/lineparser.hpp
+++ b/components/compiler/lineparser.hpp
@@ -51,9 +51,6 @@ namespace Compiler
                 bool allowExpression = false);
             ///< \param allowExpression Allow lines consisting of a naked expression
             /// (result is send to the messagebox interface)
-            
-            virtual ~LineParser();
-            ///< destructor
 
             virtual bool parseInt (int value, const TokenLoc& loc, Scanner& scanner);
             ///< Handle an int token.


### PR DESCRIPTION
Removes a destructor declaration from my previous PR, 1032, which was unnecessary as pointed out in the comments there.