### PR TITLE
Correct telekinesis glow length

### DIFF
--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -124,7 +124,7 @@ namespace MWClass
             int index = ESM::MagicEffect::effectStringToId("sEffectTelekinesis");
             const ESM::MagicEffect *effect = store.get<ESM::MagicEffect>().find(index);
 
-            animation->addSpellCastGlow(effect); // TODO: Telekinesis glow should only be as long as the door animation
+            animation->addSpellCastGlow(effect, 1); // 1 second glow to match the time taken for a door opening or closing
         }
 
         // make key id lowercase

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1187,7 +1187,7 @@ namespace MWRender
         int mLowestUnusedTexUnit;
     };
 
-    void Animation::addSpellCastGlow(const ESM::MagicEffect *effect)
+    void Animation::addSpellCastGlow(const ESM::MagicEffect *effect, float glowDuration)
     {
         osg::Vec4f glowColor(1,1,1,1);
         glowColor.x() = effect->mData.mRed / 255.f;
@@ -1202,10 +1202,10 @@ namespace MWRender
             if (mGlowUpdater && mGlowUpdater->isPermanentGlowUpdater())
             {
                 mGlowUpdater->setColor(glowColor);
-                mGlowUpdater->setDuration(1.5); // Glow length measured from original engine as about 1.5 seconds
+                mGlowUpdater->setDuration(glowDuration);
             }
             else
-                addGlow(mObjectRoot, glowColor, 1.5);
+                addGlow(mObjectRoot, glowColor, glowDuration);
         }
     }
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -360,7 +360,9 @@ public:
     void removeEffect (int effectId);
     void getLoopingEffects (std::vector<int>& out) const;
 
-    void addSpellCastGlow(const ESM::MagicEffect *effect);
+    // Add a spell casting glow to an object. From measuring video taken from the original engine,
+    // the glow seems to be about 1.5 seconds except for telekinesis, which is 1 second.
+    void addSpellCastGlow(const ESM::MagicEffect *effect, float glowDuration = 1.5);
 
     virtual void updatePtr(const MWWorld::Ptr &ptr);
 


### PR DESCRIPTION
Added a glowDuration parameter to addSpellGlow().

Based on taking video from the original engine and measuring the time in a video editor, the glow from using telekinesis on doors should be about 1 second, which matches with another comment in the source that doors rotate at 90 degrees per second.

Open and Lock spells measure at about 1.5 seconds, the same as when an object casts a spell, so the default glowDuration for addSpellGlow() is 1.5 seconds.