### PR TITLE
Fix for weapon idles

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -500,7 +500,10 @@ void CharacterController::refreshIdleAnims(const WeaponInfo* weap, CharacterStat
                 idle += weap->shortgroup;
                 if(!mAnimation->hasAnimation(idle))
                     idle = "idle";
-                numLoops = 1 + Misc::Rng::rollDice(4);
+
+                // play until the Loop Stop key 2 to 5 times, then play until the Stop key
+                // this replicates original engine behavior for the "Idle1h" 1st-person animation
+                numLoops = 1 + Misc::Rng::rollDice(4); 
             }  
         }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -468,7 +468,8 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
 
 void CharacterController::refreshIdleAnims(const WeaponInfo* weap, CharacterState idle, bool force)
 {
-    if(force || idle != mIdleState)
+    if(force || idle != mIdleState ||
+        ((idle == mIdleState) && !mAnimation->isPlaying(mCurrentIdle) && mAnimQueue.empty()))
     {
         mIdleState = idle;
         size_t numLoops = ~0ul;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -311,12 +311,15 @@ void CharacterController::refreshHitRecoilAnims()
         mAnimation->disable(mCurrentHit);
         mAnimation->play(mCurrentHit, Priority_Knockdown, MWRender::Animation::BlendMask_All, true, 1, "loop stop", "stop", 0.0f, 0);
     }
+    if (mHitState != CharState_None)
+        mIdleState = CharState_None;
 }
 
 void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, bool force)
 {
     if(force || jump != mJumpState)
     {
+        mIdleState = CharState_None;
         bool startAtLoop = (jump == mJumpState);
         mJumpState = jump;
 
@@ -359,6 +362,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
 {
     if(force || movement != mMovementState)
     {
+        mIdleState = CharState_None;
         mMovementState = movement;
 
         std::string movementAnimName;
@@ -1197,6 +1201,7 @@ bool CharacterController::updateWeaponState()
     bool animPlaying;
     if(mAttackingOrSpell)
     {
+        mIdleState = CharState_None;
         if(mUpperBodyState == UpperCharState_WeapEquiped && (mHitState == CharState_None || mHitState == CharState_Block))
         {
             MWBase::Environment::get().getWorld()->breakInvisibility(mPtr);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -471,6 +471,7 @@ void CharacterController::refreshIdleAnims(const WeaponInfo* weap, CharacterStat
     if(force || idle != mIdleState)
     {
         mIdleState = idle;
+        size_t numLoops = ~0ul;
 
         std::string idle;
         MWRender::Animation::AnimPriority idlePriority (Priority_Default);
@@ -494,14 +495,15 @@ void CharacterController::refreshIdleAnims(const WeaponInfo* weap, CharacterStat
                 idle += weap->shortgroup;
                 if(!mAnimation->hasAnimation(idle))
                     idle = "idle";
-            }
+                numLoops = 1 + Misc::Rng::rollDice(4);
+            }  
         }
 
         mAnimation->disable(mCurrentIdle);
         mCurrentIdle = idle;
         if(!mCurrentIdle.empty())
             mAnimation->play(mCurrentIdle, idlePriority, MWRender::Animation::BlendMask_All, false,
-                             1.0f, "start", "stop", 0.0f, ~0ul, true);
+                             1.0f, "start", "stop", 0.0f, numLoops, true);
     }
 }
 


### PR DESCRIPTION
Fix for https://bugs.openmw.org/issues/2288.

Observed original engine behavior is that for the one-handed first-person animation "Idle1h," it plays until the Stop Loop key from 2 to 5 times (loops 1 to 4 times), then plays through to the Stop key. The number of loops seems to be random within this range.

With default animations this is only relevant for Idle1h as far as I know. I did a quick search but didn't find any suitable mod animations for testing, but I manually switched the Idle1h and Idle2c (two-handed swords, axes, etc.) first-person animations keys with a hex editor, and the original engine then did the same behavior for Idle2c, so I suspect this behavior is actually used for a number of idles. For now, I believe this PR applies it for all "armed with object, spell, hand-to-hand" idles.

Changes in this PR:
1. Implemented the above behavior.
2. After implementing 1, I changed refreshIdleAnims() to update if the current idle animation stops due to finishing its loops. Otherwise the animation stops playing at the end of the loops.
3. I noticed that the point in playback of the idle animation was persisting even after moving, jumping, swimming or being hit, which caused a discontinuous look as it jumped back to the mid-animation frame after one of those actions finished. I made the idle always reset back to the first frame if it is interrupted by one of those actions. This matches original engine behavior and resolves the discontinuity  problem.