### PR TITLE
Link Clang paths

### DIFF
--- a/CI/before_install.linux.sh
+++ b/CI/before_install.linux.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+sudo ln -s /usr/bin/clang-3.6 /usr/local/bin/clang
+sudo ln -s /usr/bin/clang++-3.6 /usr/local/bin/clang++
 
 # build libgtest & libgtest_main
 sudo mkdir /usr/src/gtest/build


### PR DESCRIPTION
For some weeks now, the Clang build has been failing.

I'm not knowledgeable about this, but through trial-and-error and searching online, I seem to have been able to fix the problem by linking the Clang compiler paths.

Description of the problem:
Currently the Clang build will fail when trying to build openmw_test_suite.

The Raw Log shows:

> $ export CXX=clang++

> $ export CC=clang

> $ clang --version

> clang version 3.5.0 (tags/RELEASE_350/final)
> Target: x86_64-unknown-linux-gnu
> Thread model: posix
> travis_fold:start:before_install
> [0Ktravis_time:start:1d712105

> [0K$ ./CI/before_install.${TRAVIS_OS_NAME}.sh
> CMake Error at /usr/share/cmake-3.2/Modules/CMakeDetermineCXXCompiler.cmake:56 (message):
>   Could not find compiler set in environment variable CXX:
> 
>   clang++.
> 
> Call Stack (most recent call first):
>   CMakeLists.txt:42 (project)
> 
> 
> CMake Error: Error required internal CMake variable not set, cmake may be not be built correctly.
> Missing variable is:
> CMAKE_CXX_COMPILER_ENV_VAR
> CMake Error: Error required internal CMake variable not set, cmake may be not be built correctly.
> Missing variable is:
> CMAKE_CXX_COMPILER
> CMake Error: Could not find cmake module file: /usr/src/gtest/build/CMakeFiles/3.2.2/CMakeCXXCompiler.cmake
> CMake Error: Error required internal CMake variable not set, cmake may be not be built correctly.
> Missing variable is:
> CMAKE_C_COMPILER_ENV_VAR
> CMake Error: Error required internal CMake variable not set, cmake may be not be built correctly.
> Missing variable is:
> CMAKE_C_COMPILER
> CMake Error: Could not find cmake module file: /usr/src/gtest/build/CMakeFiles/3.2.2/CMakeCCompiler.cmake
> CMake Error at CMakeLists.txt:42 (project):
>   No CMAKE_CXX_COMPILER could be found.
> 
>   Tell CMake where to find the compiler by setting the CMake cache entry
>   CMAKE_CXX_COMPILER to the full path to the compiler, or to the compiler
>   name if it is in the PATH.
> 
> 
> CMake Error at CMakeLists.txt:42 (project):
>   No CMAKE_C_COMPILER could be found.
> 
>   Tell CMake where to find the compiler by setting the CMake cache entry
>   CMAKE_C_COMPILER to the full path to the compiler, or to the compiler name
>   if it is in the PATH.
> 
> 
> CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
> CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
> -- Configuring incomplete, errors occurred!
> See also "/usr/src/gtest/build/CMakeFiles/CMakeOutput.log".
> make: *** No targets specified and no makefile found.  Stop.

The problem might be related to a change in the Ubuntu version. Previously, when the builds were passing, the version was reported as Ubuntu 14.04.3 LTS. This problem starts appearing at the same time that the logs start showing Ubuntu 14.04.4 LTS, on August 10.

I made this change from referencing this page:
http://blog.conan.io/2016/05/10/Programming-C++-with-the-4-Cs-Clang,-CMake,-CLion-and-Conan.html
from the "Setting up Clang C/C++ compiler" section.

