### PR TITLE
Fix content file number issues.

### DIFF
--- a/apps/opencs/model/doc/savingstages.cpp
+++ b/apps/opencs/model/doc/savingstages.cpp
@@ -321,6 +321,10 @@ void CSMDoc::WriteCellCollectionStage::perform (int stage, Messages& messages)
                 {
                     CSMWorld::CellRef refRecord = ref.get();
 
+                    // Correct content file number to be relative to plugin
+                    refRecord.mRefNum.mContentFile = mDocument.getData().getPluginContentFile(
+                        refRecord.mRefNum.mContentFile);
+
                     // recalculate the ref's cell location
                     std::ostringstream stream;
                     if (!interior)

--- a/apps/opencs/model/doc/savingstages.cpp
+++ b/apps/opencs/model/doc/savingstages.cpp
@@ -321,9 +321,9 @@ void CSMDoc::WriteCellCollectionStage::perform (int stage, Messages& messages)
                 {
                     CSMWorld::CellRef refRecord = ref.get();
 
-                    // Correct content file number to be relative to plugin
-                    refRecord.mRefNum.mContentFile = mDocument.getData().getPluginContentFile(
-                        refRecord.mRefNum.mContentFile);
+                    // Check for uninitialized content file
+                    if (!refRecord.mRefNum.hasContentFile())
+                        refRecord.mRefNum.mContentFile = 0;
 
                     // recalculate the ref's cell location
                     std::ostringstream stream;

--- a/apps/opencs/model/world/data.hpp
+++ b/apps/opencs/model/world/data.hpp
@@ -123,6 +123,10 @@ namespace CSMWorld
 
             std::vector<boost::shared_ptr<ESM::ESMReader> > mReaders;
 
+            std::map<std::string, int> mContentFileNames;
+            // current index, plugin index
+            std::map<int, int> mReverseContentFiles;
+
             // not implemented
             Data (const Data&);
             Data& operator= (const Data&);
@@ -297,6 +301,9 @@ namespace CSMWorld
 
             int count (RecordBase::State state) const;
             ///< Return number of top-level records with the given \a state.
+
+            /// Returns the content file number relative to the plugin being edited, 0 by default
+            int getPluginContentFile(int currentContentFile);
 
         signals:
 

--- a/apps/opencs/model/world/data.hpp
+++ b/apps/opencs/model/world/data.hpp
@@ -124,8 +124,6 @@ namespace CSMWorld
             std::vector<boost::shared_ptr<ESM::ESMReader> > mReaders;
 
             std::map<std::string, int> mContentFileNames;
-            // current index, plugin index
-            std::map<int, int> mReverseContentFiles;
 
             // not implemented
             Data (const Data&);
@@ -301,9 +299,6 @@ namespace CSMWorld
 
             int count (RecordBase::State state) const;
             ///< Return number of top-level records with the given \a state.
-
-            /// Returns the content file number relative to the plugin being edited, 0 by default
-            int getPluginContentFile(int currentContentFile);
 
         signals:
 


### PR DESCRIPTION
Some preliminary testing would suggest I've found the two larger issues:
- The RefNum.mContentFile field needed to be saved relative to the plugin
- The MasterData.index field wasn't being initialized

Admittedly the second fix is more of a hack by using a const_cast to modify the field. However, that is the same fix employed by the openmw engine in [esmstore.cpp](https://github.com/OpenMW/openmw/blob/master/apps/openmw/mwworld/esmstore.cpp#L49). To me, that would suggest that some of the loading code needs to be redesigned at some point.

