### PR TITLE
Don't allow casting Water Walking in deep water

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -385,6 +385,7 @@ namespace MWBase
             ///Is the head of the creature underwater?
             virtual bool isSubmerged(const MWWorld::ConstPtr &object) const = 0;
             virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const = 0;
+            virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const = 0;
             virtual bool isOnGround(const MWWorld::Ptr &ptr) const = 0;
 
             virtual osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const = 0;

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -393,7 +393,7 @@ namespace MWMechanics
 
                 if (!world->isWaterWalkingCastableOnTarget(target))
                 {
-                    if (castByPlayer)
+                    if (castByPlayer && caster == target)
                         MWBase::Environment::get().getWindowManager()->messageBox ("#{sMagicInvalidEffect}");
                     continue;
                 }

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -383,6 +383,21 @@ namespace MWMechanics
             }
             else
                 canCastAnEffect = true;
+          
+            if (magicEffect->mIndex == ESM::MagicEffect::WaterWalking)
+            {
+                if (target.getClass().isPureWaterCreature(target))
+                    continue;
+
+                MWBase::World *world = MWBase::Environment::get().getWorld();
+
+                if (!world->isWaterWalkingCastableOnTarget(target))
+                {
+                    if (caster == getPlayer())
+                        MWBase::Environment::get().getWindowManager()->messageBox ("#{sMagicInvalidEffect}");
+                    continue;
+                }
+            }
 
             if (!checkEffectTarget(effectIt->mEffectID, target, castByPlayer))
                 continue;

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -292,7 +292,7 @@ namespace MWMechanics
                 }
                 break;
             case ESM::MagicEffect::WaterWalking:
-                if (target.getClass().isPureWaterCreature(target))
+                if (target.getClass().isPureWaterCreature(target) && MWBase::Environment::get().getWorld()->isSwimming(target))
                     return false;
 
                 MWBase::World *world = MWBase::Environment::get().getWorld();

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -393,7 +393,7 @@ namespace MWMechanics
 
                 if (!world->isWaterWalkingCastableOnTarget(target))
                 {
-                    if (caster == getPlayer())
+                    if (castByPlayer)
                         MWBase::Environment::get().getWindowManager()->messageBox ("#{sMagicInvalidEffect}");
                     continue;
                 }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2077,6 +2077,19 @@ namespace MWWorld
         return pos.z() < cell->getWaterLevel();
     }
 
+    bool World::isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const
+    {
+        const MWWorld::CellStore* cell = target.getCell();
+        if (!cell->getCell()->hasWater())
+            return true;
+
+        // Based on observations from the original engine, the depth
+        // limit at which water walking can still be cast on a target
+        // in water appears to be the same as what the highest swimmable
+        // z position would be with SwimHeightScale + 1.
+        return !isUnderwater(target, mSwimHeightScale + 1);
+    }
+
     bool World::isOnGround(const MWWorld::Ptr &ptr) const
     {
         return mPhysics->isOnGround(ptr);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -481,6 +481,7 @@ namespace MWWorld
             virtual bool isSwimming(const MWWorld::ConstPtr &object) const;
             virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const;
             virtual bool isWading(const MWWorld::ConstPtr &object) const;
+            virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const;
             virtual bool isOnGround(const MWWorld::Ptr &ptr) const;
 
             virtual osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const;


### PR DESCRIPTION
For https://bugs.openmw.org/issues/3516. Somewhat related to https://bugs.openmw.org/issues/1138. This is a precursor to work on 1138, but does nothing about moving the player out of the water.

After a whole lot of testing I implemented the following behavior from the original engine:

- You will receive a "You cannot cast this effect right now." message if you try to cast water walking on yourself when your character is too deep in water. Generally, you seem to get this message if the z-position in water is below what would be the highest swimmable z-position if the fSwimHeightScale was 1 higher. Compare these results from the original engine, with z as reported with the "tdt" command in first-person. There were a couple oddities, possibly bugs in the original engine.

Value 0.9 (default) for fSwimHeightScale:
Dark Elf male can swim up to z of 6, can cast Water Walking down to z of -128.
High Elf male can swim up to z of 6, can cast Water Walking down to z of -141.
Wood Elf male can swim up to z of 5, can cast Water Walking down to z of -115.

Value 1.9 for fSwimHeightScale:
Dark Elf male can swim up to z of -127.
High Elf male can swim up to z of -140.
Wood Elf male can swim up to z of -114.

Value 1 for fSwimHeightScale:
Dark Elf male can swim up to z of -8, can cast Water Walking down to z of -141.
High Elf male can swim up to z of -8, can cast Water Walking down to z of -141. (no idea why)
Wood Elf male can swim up to z of -7, can cast Water Walking down to z of -126.

Value 2 for fSwimHeightScale:
Dark Elf male can swim up to z of -141, can cast Water Walking down to z of -273.
High Elf male can swim up to z of -155, can cast Water Walking down to z of -302.
Wood Elf male can swim up to z of -126, can cast Water Walking down to z of -260. (seems too low?)

Value 3 for fSwimHeightScale:
Dark Elf male can swim up to z of -274.
High Elf male can swim up to z of -301.
Wood Elf male can swim up to z of -246.

- The behavior in above, or something similar to it, also applies when you cast water walking on an NPC, in that it won't work if they are too deep in the water. You get no message, however. I decided to allow the message to show for OpenMW, since it seems like you should get the same feedback here as when you cast on yourself.

- When the message appears, you still lose the magicka, have no spell fail sound, and gain points in the magic skill.

- You can't cast water walking on water creatures (or slaughterfish, at least). 

- Even if you get the message that you cannot cast the effect right now, any other effects in the spell will cast as usual.