### PR TITLE
Fix CellRefs being teleported from interior to exterior cells.

### DIFF
--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -37,11 +37,16 @@ std::string CSMWorld::CellCoordinates::getId (const std::string& worldspace) con
     return stream.str();
 }
 
+bool CSMWorld::CellCoordinates::isExteriorCell (const std::string& id)
+{
+    return (!id.empty() && id[0]=='#');
+}
+
 std::pair<CSMWorld::CellCoordinates, bool> CSMWorld::CellCoordinates::fromId (
     const std::string& id)
 {
     // no worldspace for now, needs to be changed for 1.1
-    if (!id.empty() && id[0]=='#')
+    if (isExteriorCell(id))
     {
         int x, y;
         char ignore;

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -32,12 +32,14 @@ namespace CSMWorld
             std::string getId (const std::string& worldspace) const;
             ///< Return the ID for the cell at these coordinates.
 
+            static bool isExteriorCell (const std::string& id);
+
             /// \return first: CellCoordinates (or 0, 0 if cell does not have coordinates),
             /// second: is cell paged?
             ///
             /// \note The worldspace part of \a id is ignored
             static std::pair<CellCoordinates, bool> fromId (const std::string& id);
-            
+
             /// \return cell coordinates such that given world coordinates are in it.
             static std::pair<int, int> coordinatesToCellIndex (float x, float y);
     };

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -644,13 +644,16 @@ void CSVRender::Object::apply (CSMWorld::CommandMacro& commands)
         int column = collection.findColumnIndex (static_cast<CSMWorld::Columns::ColumnId> (
             CSMWorld::Columns::ColumnId_Cell));
 
-        std::pair<int, int> cellIndex = collection.getRecord (recordIndex).get().getCellIndex();
+        if (CSMWorld::CellCoordinates::isExteriorCell(collection.getRecord (recordIndex).get().mCell))
+        {
+            std::pair<int, int> cellIndex = collection.getRecord (recordIndex).get().getCellIndex();
 
-        /// \todo figure out worldspace (not important until multiple worldspaces are supported)
-        std::string cellId = CSMWorld::CellCoordinates (cellIndex).getId ("");
+            /// \todo figure out worldspace (not important until multiple worldspaces are supported)
+            std::string cellId = CSMWorld::CellCoordinates (cellIndex).getId ("");
 
-        commands.push (new CSMWorld::ModifyCommand (*model,
-            model->index (recordIndex, column), QString::fromUtf8 (cellId.c_str())));
+            commands.push (new CSMWorld::ModifyCommand (*model,
+                model->index (recordIndex, column), QString::fromUtf8 (cellId.c_str())));
+        }
     }
 
     if (mOverrideFlags & Override_Rotation)


### PR DESCRIPTION
I just added a check to make sure the CellRef is located in an exterior cell before changing the cell it is associated with.