### PR TITLE
Changes to multi-effect spells

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -486,7 +486,7 @@ namespace MWBase
 
             virtual void castSpell (const MWWorld::Ptr& actor) = 0;
 
-            virtual void launchMagicBolt (const std::vector<std::string>& models, const std::vector<std::string>& sounds, const std::string& spellId,
+            virtual void launchMagicBolt (const std::vector<std::string>& projectileIDs, const std::vector<std::string>& sounds, const std::string& spellId,
                                           float speed, bool stack, const ESM::EffectList& effects,
                                            const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection) = 0;
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -486,9 +486,8 @@ namespace MWBase
 
             virtual void castSpell (const MWWorld::Ptr& actor) = 0;
 
-            virtual void launchMagicBolt (const std::vector<std::string>& projectileIDs, const std::vector<std::string>& sounds, const std::string& spellId,
-                                          float speed, bool stack, const ESM::EffectList& effects,
-                                           const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection) = 0;
+            virtual void launchMagicBolt (const std::string& spellId, bool stack, const ESM::EffectList& effects,
+                                          const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection) = 0;
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
                                            const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength) = 0;
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -486,7 +486,7 @@ namespace MWBase
 
             virtual void castSpell (const MWWorld::Ptr& actor) = 0;
 
-            virtual void launchMagicBolt (const std::string& model, const std::string& sound, const std::string& spellId,
+            virtual void launchMagicBolt (const std::vector<std::string>& models, const std::vector<std::string>& sounds, const std::string& spellId,
                                           float speed, bool stack, const ESM::EffectList& effects,
                                            const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection) = 0;
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1236,10 +1236,10 @@ bool CharacterController::updateWeaponState()
                     cast.playSpellCastingEffects(spellid);
 
                     const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);
-                    const ESM::ENAMstruct &effectentry = spell->mEffects.mList.at(0);
+                    const ESM::ENAMstruct &lasteffect = spell->mEffects.mList.at(spell->mEffects.mList.size() - 1);
 
                     const ESM::MagicEffect *effect;
-                    effect = store.get<ESM::MagicEffect>().find(effectentry.mEffectID);
+                    effect = store.get<ESM::MagicEffect>().find(lasteffect.mEffectID);
 
                     const ESM::Static* castStatic = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>().find ("VFX_Hands");
                     if (mAnimation->getNode("Bip01 L Hand"))
@@ -1248,7 +1248,7 @@ bool CharacterController::updateWeaponState()
                     if (mAnimation->getNode("Bip01 R Hand"))
                         mAnimation->addEffect("meshes\\" + castStatic->mModel, -1, false, "Bip01 R Hand", effect->mParticle);
 
-                    switch(effectentry.mRange)
+                    switch(lasteffect.mRange)
                     {
                         case 0: mAttackType = "self"; break;
                         case 1: mAttackType = "touch"; break;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1236,19 +1236,27 @@ bool CharacterController::updateWeaponState()
                     cast.playSpellCastingEffects(spellid);
 
                     const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);
-                    const ESM::ENAMstruct &lasteffect = spell->mEffects.mList.at(spell->mEffects.mList.size() - 1);
+                    
+                    const ESM::ENAMstruct &lastEffect = spell->mEffects.mList.at(spell->mEffects.mList.size() - 1);
 
                     const ESM::MagicEffect *effect;
-                    effect = store.get<ESM::MagicEffect>().find(lasteffect.mEffectID);
+
+                    effect = store.get<ESM::MagicEffect>().find(lastEffect.mEffectID); // use last effect of list for color of VFX_Hands
 
                     const ESM::Static* castStatic = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>().find ("VFX_Hands");
-                    if (mAnimation->getNode("Bip01 L Hand"))
-                        mAnimation->addEffect("meshes\\" + castStatic->mModel, -1, false, "Bip01 L Hand", effect->mParticle);
 
-                    if (mAnimation->getNode("Bip01 R Hand"))
-                        mAnimation->addEffect("meshes\\" + castStatic->mModel, -1, false, "Bip01 R Hand", effect->mParticle);
+                    for (int iter = 0; iter < spell->mEffects.mList.size(); ++iter) // play hands vfx for each effect
+                    {
+                        if (mAnimation->getNode("Bip01 L Hand"))
+                            mAnimation->addEffect("meshes\\" + castStatic->mModel, -1, false, "Bip01 L Hand", effect->mParticle);
 
-                    switch(lasteffect.mRange)
+                        if (mAnimation->getNode("Bip01 R Hand"))
+                            mAnimation->addEffect("meshes\\" + castStatic->mModel, -1, false, "Bip01 R Hand", effect->mParticle);
+                    }
+
+                    const ESM::ENAMstruct &firstEffect = spell->mEffects.mList.at(0); // first effect used for casting animation
+
+                    switch(firstEffect.mRange)
                     {
                         case 0: mAttackType = "self"; break;
                         case 1: mAttackType = "touch"; break;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1245,7 +1245,7 @@ bool CharacterController::updateWeaponState()
 
                     const ESM::Static* castStatic = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>().find ("VFX_Hands");
 
-                    for (int iter = 0; iter < spell->mEffects.mList.size(); ++iter) // play hands vfx for each effect
+                    for (size_t iter = 0; iter < spell->mEffects.mList.size(); ++iter) // play hands vfx for each effect
                     {
                         if (mAnimation->getNode("Bip01 L Hand"))
                             mAnimation->addEffect("meshes\\" + castStatic->mModel, -1, false, "Bip01 L Hand", effect->mParticle);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -356,7 +356,6 @@ namespace MWMechanics
 
         ESM::EffectList reflectedEffects;
         std::vector<ActiveSpells::ActiveEffect> appliedLastingEffects;
-        bool firstAppliedEffect = true;
         bool anyHarmfulEffect = false;
 
         // HACK: cache target's magic effects here, and add any applied effects to it. Use the cached effects for determining resistance.
@@ -545,20 +544,15 @@ namespace MWMechanics
 
                 if (target.getClass().isActor() || magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration)
                 {
-                    // Play sound, only for the first effect
-                    if (firstAppliedEffect)
-                    {
-                        static const std::string schools[] = {
-                            "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
-                        };
+                    static const std::string schools[] = {
+                        "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
+                    };
 
-                        MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-                        if(!magicEffect->mHitSound.empty())
-                            sndMgr->playSound3D(target, magicEffect->mHitSound, 1.0f, 1.0f);
-                        else
-                            sndMgr->playSound3D(target, schools[magicEffect->mData.mSchool]+" hit", 1.0f, 1.0f);
-                        firstAppliedEffect = false;
-                    }
+                    MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+                    if(!magicEffect->mHitSound.empty())
+                        sndMgr->playSound3D(target, magicEffect->mHitSound, 1.0f, 1.0f);
+                    else
+                        sndMgr->playSound3D(target, schools[magicEffect->mData.mSchool]+" hit", 1.0f, 1.0f);
 
                     // Add VFX
                     const ESM::Static* castStatic;

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -2,7 +2,7 @@
 
 #include <cfloat>
 #include <limits>
-#include <stdio.h>
+#include <iomanip>
 
 #include <boost/format.hpp>
 
@@ -339,13 +339,11 @@ namespace MWMechanics
         
         if (projectileEffects.mList.size() > 1) // add a VFX_Multiple projectile if there are multiple projectile effects
         {
+            std::ostringstream ID;
+            ID << "VFX_Multiple" << projectileEffects.mList.size();
             std::vector<std::string>::iterator it;
             it = projectileIDs.begin();
-            char numstr[8];
-            sprintf(numstr, "%d", (int)(effects.mList.size()));
-            std::string ID = "VFX_Multiple";
-            ID = ID + numstr;
-            it = projectileIDs.insert(it, ID);
+            it = projectileIDs.insert(it, ID.str());
         }
 
         // Fall back to a "caster to target" direction if we have no other means of determining it

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -307,6 +307,9 @@ namespace MWMechanics
         std::string sound;
         
         osg::Vec3f fallbackDirection (0,1,0);
+
+        bool isFirstProjectile = true;
+
         for (std::vector<ESM::ENAMstruct>::const_iterator iter (effects.mList.begin());
             iter!=effects.mList.end(); ++iter)
         {
@@ -335,8 +338,18 @@ namespace MWMechanics
                    osg::Vec3f(mTarget.getRefData().getPosition().asVec3())-
                    osg::Vec3f(mCaster.getRefData().getPosition().asVec3());
             
-            MWBase::Environment::get().getWorld()->launchMagicBolt(model, sound, mId, speed,
+            // Only send the effects data with the first projectile, so we don't have the impact sounds
+            // playing multiple times.
+            if (isFirstProjectile)
+                MWBase::Environment::get().getWorld()->launchMagicBolt(model, sound, mId, speed,
                                                        false, effects, mCaster, mSourceName, fallbackDirection);
+            else
+            {
+                const ESM::EffectList empty;
+                MWBase::Environment::get().getWorld()->launchMagicBolt(model, sound, mId, speed,
+                                                       false, empty, mCaster, mSourceName, fallbackDirection);
+            }
+            isFirstProjectile = false;
         }
     }
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -304,9 +304,7 @@ namespace MWMechanics
         if (count != 0)
             speed /= count;
 
-        std::string projectileID;
         std::vector<std::string> projectileIDs;
-        std::string sound;
         std::vector<std::string> sounds;
         ESM::EffectList projectileEffects;
         
@@ -321,23 +319,22 @@ namespace MWMechanics
             const ESM::MagicEffect *magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find (
                 iter->mEffectID);
 
-            projectileID = magicEffect->mBolt;
-            if (projectileID.empty())
-                projectileID = "VFX_DefaultBolt";
-            projectileIDs.push_back(projectileID);
+            if (magicEffect->mBolt.empty())
+                projectileIDs.push_back("VFX_DefaultBolt");
+            else
+                projectileIDs.push_back(magicEffect->mBolt);
 
             static const std::string schools[] = {
                 "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
             };
             if (!magicEffect->mBoltSound.empty())
-                sound = magicEffect->mBoltSound;
+                sounds.push_back(magicEffect->mBoltSound);
             else
-                sound = schools[magicEffect->mData.mSchool] + " bolt";
-            sounds.push_back(sound);
+                sounds.push_back(schools[magicEffect->mData.mSchool] + " bolt");
             projectileEffects.mList.push_back(*iter);
         }
         
-        if (projectileEffects.mList.size() > 1) // add a VFX_Multiple projectile if there are multiple projectile effects
+        if (projectileEffects.mList.size() > 1) // insert a VFX_Multiple projectile if there are multiple projectile effects
         {
             std::ostringstream ID;
             ID << "VFX_Multiple" << projectileEffects.mList.size();

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -345,7 +345,7 @@ namespace MWMechanics
                                                        false, effects, mCaster, mSourceName, fallbackDirection);
             else
             {
-                const ESM::EffectList empty;
+                ESM::EffectList empty;
                 MWBase::Environment::get().getWorld()->launchMagicBolt(model, sound, mId, speed,
                                                        false, empty, mCaster, mSourceName, fallbackDirection);
             }

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -304,11 +304,12 @@ namespace MWMechanics
             speed /= count;
 
         std::string model;
+        std::vector<std::string> models;
         std::string sound;
+        std::vector<std::string> sounds;
+        ESM::EffectList projectileEffects;
         
-        osg::Vec3f fallbackDirection (0,1,0);
-
-        bool isFirstProjectile = true;
+        osg::Vec3f fallbackDirection (0,1,0);     
 
         for (std::vector<ESM::ENAMstruct>::const_iterator iter (effects.mList.begin());
             iter!=effects.mList.end(); ++iter)
@@ -322,6 +323,7 @@ namespace MWMechanics
             model = magicEffect->mBolt;
             if (model.empty())
                 model = "VFX_DefaultBolt";
+            models.push_back(model);
 
             static const std::string schools[] = {
                 "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
@@ -330,6 +332,9 @@ namespace MWMechanics
                 sound = magicEffect->mBoltSound;
             else
                 sound = schools[magicEffect->mData.mSchool] + " bolt";
+            sounds.push_back(sound);
+            projectileEffects.mList.push_back(*iter);
+        }
 
             // Fall back to a "caster to target" direction if we have no other means of determining it
             // (e.g. when cast by a non-actor)
@@ -338,19 +343,8 @@ namespace MWMechanics
                    osg::Vec3f(mTarget.getRefData().getPosition().asVec3())-
                    osg::Vec3f(mCaster.getRefData().getPosition().asVec3());
             
-            // Only send the effects data with the first projectile, so we don't have the impact sounds
-            // playing multiple times.
-            if (isFirstProjectile)
-                MWBase::Environment::get().getWorld()->launchMagicBolt(model, sound, mId, speed,
-                                                       false, effects, mCaster, mSourceName, fallbackDirection);
-            else
-            {
-                ESM::EffectList empty;
-                MWBase::Environment::get().getWorld()->launchMagicBolt(model, sound, mId, speed,
-                                                       false, empty, mCaster, mSourceName, fallbackDirection);
-            }
-            isFirstProjectile = false;
-        }
+            MWBase::Environment::get().getWorld()->launchMagicBolt(models, sounds, mId, speed,
+                                                       false, projectileEffects, mCaster, mSourceName, fallbackDirection);
     }
 
     void CastSpell::inflict(const MWWorld::Ptr &target, const MWWorld::Ptr &caster,

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -2,6 +2,7 @@
 
 #include <cfloat>
 #include <limits>
+#include <stdio.h>
 
 #include <boost/format.hpp>
 
@@ -341,7 +342,7 @@ namespace MWMechanics
             std::vector<std::string>::iterator it;
             it = projectileIDs.begin();
             char numstr[8];
-            sprintf(numstr, "%zd", (effects.mList.size()));
+            sprintf(numstr, "%d", (int)(effects.mList.size()));
             std::string ID = "VFX_Multiple";
             ID = ID + numstr;
             it = projectileIDs.insert(it, ID);

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -94,9 +94,8 @@ namespace MWMechanics
 
         void playSpellCastingEffects(const std::string &spellid);
 
-        /// Get the models, sounds and speeds for all projectiles
-        /// in the given effects, and launch them.
-        void getProjectileInfoAndLaunch (const ESM::EffectList& effects);
+        /// Launch a bolt with the given effects.
+        void launchMagicBolt (const ESM::EffectList& effects);
 
         /// @note \a target can be any type of object, not just actors.
         /// @note \a caster can be any type of object, or even an empty object.

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -94,6 +94,10 @@ namespace MWMechanics
 
         void playSpellCastingEffects(const std::string &spellid);
 
+        /// Get the models, sounds and speeds for all projectiles
+        /// in the given effects, and launch them.
+        void getProjectileInfoAndLaunch (const ESM::EffectList& effects);
+
         /// @note \a target can be any type of object, not just actors.
         /// @note \a caster can be any type of object, or even an empty object.
         void inflict (const MWWorld::Ptr& target, const MWWorld::Ptr& caster,

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1296,13 +1296,14 @@ namespace MWRender
     void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, std::string texture)
     {
         if (!mObjectRoot.get())
+        {
+            std::cout << "no objectroot" << std::endl;
             return;
-
+        }
         // Early out if we already have this effect
         for (std::vector<EffectParams>::iterator it = mEffects.begin(); it != mEffects.end(); ++it)
             if (it->mLoop && loop && it->mEffectId == effectId && it->mBoneName == bonename)
                 return;
-
         EffectParams params;
         params.mModelName = model;
         osg::ref_ptr<osg::Group> parentNode;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1296,14 +1296,13 @@ namespace MWRender
     void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, std::string texture)
     {
         if (!mObjectRoot.get())
-        {
-            std::cout << "no objectroot" << std::endl;
             return;
-        }
+
         // Early out if we already have this effect
         for (std::vector<EffectParams>::iterator it = mEffects.begin(); it != mEffects.end(); ++it)
             if (it->mLoop && loop && it->mEffectId == effectId && it->mBoneName == bonename)
                 return;
+
         EffectParams params;
         params.mModelName = model;
         osg::ref_ptr<osg::Group> parentNode;

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -102,7 +102,10 @@ namespace MWWorld
                 std::ostringstream nodeName;
                 nodeName << "Dummy" << std::setw(2) << std::setfill('0') << iter;
                 const ESM::Weapon* weapon = MWBase::Environment::get().getWorld()->getStore().get<ESM::Weapon>().find (state.mIdMagic.at(iter));
-                mResourceSystem->getSceneManager()->getInstance("meshes\\" + weapon->mModel, attachTo);
+                SceneUtil::FindByNameVisitor findVisitor(nodeName.str());
+                attachTo->accept(findVisitor);
+                if (findVisitor.mFoundNode)
+                    mResourceSystem->getSceneManager()->getInstance("meshes\\" + weapon->mModel, findVisitor.mFoundNode);
             }
 
         SceneUtil::DisableFreezeOnCullVisitor disableFreezeOnCullVisitor;

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -1,6 +1,6 @@
 #include "projectilemanager.hpp"
 
-#include <stdio.h>
+#include <iomanip>
 
 #include <osg/PositionAttitudeTransform>
 
@@ -99,10 +99,8 @@ namespace MWWorld
         if (state.mIdMagic.size() > 1)
             for (size_t iter = 1; iter != state.mIdMagic.size(); ++iter)
             {
-                char numstr[8];
-                sprintf(numstr, "%d", (int)iter);
-                std::string node = "Dummy0";
-                node = node + numstr;
+                std::ostringstream nodeName;
+                nodeName << "Dummy" << std::setw(2) << std::setfill('0') << iter;
                 const ESM::Weapon* weapon = MWBase::Environment::get().getWorld()->getStore().get<ESM::Weapon>().find (state.mIdMagic.at(iter));
                 mResourceSystem->getSceneManager()->getInstance("meshes\\" + weapon->mModel, attachTo);
             }

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -1,5 +1,7 @@
 #include "projectilemanager.hpp"
 
+#include <stdio.h>
+
 #include <osg/PositionAttitudeTransform>
 
 #include <components/esm/esmwriter.hpp>
@@ -92,13 +94,13 @@ namespace MWWorld
             attachTo = rotateNode;
         }
 
-        mResourceSystem->getSceneManager()->getInstance(model, attachTo);
+        osg::ref_ptr<osg::Node> ptr = mResourceSystem->getSceneManager()->getInstance(model, attachTo);
 
         if (state.mIdMagic.size() > 1)
             for (size_t iter = 1; iter != state.mIdMagic.size(); ++iter)
             {
                 char numstr[8];
-                sprintf(numstr, "%zd", iter);
+                sprintf(numstr, "%d", (int)iter);
                 std::string node = "Dummy0";
                 node = node + numstr;
                 const ESM::Weapon* weapon = MWBase::Environment::get().getWorld()->getStore().get<ESM::Weapon>().find (state.mIdMagic.at(iter));

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -168,9 +168,11 @@ namespace MWWorld
         createModel(state, ptr.getClass().getModel(ptr), pos, orient, true);
 
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-        if (projectileIDs.size() == 1)
-            state.mSound = sndMgr->playSound3D(pos, sounds.at(0), 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop);
-
+        for (size_t it = 0; it != sounds.size(); it++)
+        {
+            state.mSound.push_back(sndMgr->playSound3D(pos, sounds.at(it), 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop));
+        }
+            
         mMagicBolts.push_back(state);
     }
 
@@ -212,8 +214,10 @@ namespace MWWorld
             osg::Vec3f pos(it->mNode->getPosition());
             osg::Vec3f newPos = pos + direction * duration * speed;
 
-            if (it->mSound.get())
-                it->mSound->setPosition(newPos);
+            for (size_t soundIter = 0; soundIter != it->mSound.size(); soundIter++)
+            {
+                it->mSound.at(soundIter)->setPosition(newPos);
+            }
 
             it->mNode->setPosition(newPos);
 
@@ -253,7 +257,11 @@ namespace MWWorld
                 MWBase::Environment::get().getWorld()->explodeSpell(pos, it->mEffects, caster, result.mHitObject,
                                                                     ESM::RT_Target, it->mSpellId, it->mSourceName);
 
-                MWBase::Environment::get().getSoundManager()->stopSound(it->mSound);
+                for (size_t soundIter = 0; soundIter != it->mSound.size(); soundIter++)
+                {
+                    MWBase::Environment::get().getSoundManager()->stopSound(it->mSound.at(soundIter));
+                }
+
                 mParent->removeChild(it->mNode);
 
                 it = mMagicBolts.erase(it);
@@ -333,7 +341,10 @@ namespace MWWorld
         for (std::vector<MagicBoltState>::iterator it = mMagicBolts.begin(); it != mMagicBolts.end(); ++it)
         {
             mParent->removeChild(it->mNode);
-            MWBase::Environment::get().getSoundManager()->stopSound(it->mSound);
+            for (size_t soundIter = 0; soundIter != it->mSound.size(); soundIter++)
+            {
+                MWBase::Environment::get().getSoundManager()->stopSound(it->mSound.at(soundIter));
+            }
         }
         mMagicBolts.clear();
     }
@@ -442,8 +453,8 @@ namespace MWWorld
             createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), true);
 
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            state.mSound = sndMgr->playSound3D(esm.mPosition, esm.mSound, 1.0f, 1.0f,
-                                               MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop);
+            state.mSound.push_back(sndMgr->playSound3D(esm.mPosition, esm.mSound, 1.0f, 1.0f,
+                                               MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop));
             state.mSoundId.push_back(esm.mSound);
 
             mMagicBolts.push_back(state);

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -486,6 +486,10 @@ namespace MWWorld
             state.mActorId = esm.mActorId;
             state.mStack = esm.mStack;
             state.mEffects = getMagicBoltData(state.mIdMagic, state.mSoundIds, state.mSpeed, esm.mEffects);
+            state.mSpeed = esm.mSpeed; // speed is derived from non-projectile effects as well as
+                                       // projectile effects, so we can't calculate it from the save
+                                       // file's effect list, which is already trimmed of non-projectile
+                                       // effects. We need to use the stored value.
 
             std::string model;
             try

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -49,7 +49,7 @@ namespace MWWorld
                 MWRender::RenderingManager* rendering, MWPhysics::PhysicsSystem* physics);
 
         /// If caster is an actor, the actor's facing orientation is used. Otherwise fallbackDirection is used.
-        void launchMagicBolt (const std::string& model, const std::string &sound, const std::string &spellId,
+        void launchMagicBolt (const std::vector<std::string>& models, const std::vector<std::string> &sounds, const std::string &spellId,
                                      float speed, bool stack, const ESM::EffectList& effects,
                                        const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
 
@@ -84,8 +84,11 @@ namespace MWWorld
 
             MWWorld::Ptr getCaster();
 
-            // MW-id of this projectile
-            std::string mId;
+            // MW-ids of a magic projectile
+            std::vector<std::string> mIdMagic;
+
+            // MW-id of an arrow projectile
+            std::string mIdArrow;
         };
 
         struct MagicBoltState : public State
@@ -102,7 +105,7 @@ namespace MWWorld
             bool mStack;
 
             MWBase::SoundPtr mSound;
-            std::string mSoundId;
+            std::vector<std::string> mSoundId;
         };
 
         struct ProjectileState : public State

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -104,8 +104,8 @@ namespace MWWorld
 
             bool mStack;
 
-            std::vector<MWBase::SoundPtr> mSound;
-            std::vector<std::string> mSoundId;
+            std::vector<MWBase::SoundPtr> mSounds;
+            std::vector<std::string> mSoundIds;
         };
 
         struct ProjectileState : public State

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -49,9 +49,8 @@ namespace MWWorld
                 MWRender::RenderingManager* rendering, MWPhysics::PhysicsSystem* physics);
 
         /// If caster is an actor, the actor's facing orientation is used. Otherwise fallbackDirection is used.
-        void launchMagicBolt (const std::vector<std::string>& projectileIDs, const std::vector<std::string> &sounds, const std::string &spellId,
-                                     float speed, bool stack, const ESM::EffectList& effects,
-                                       const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
+        void launchMagicBolt (const std::string &spellId, bool stack, const ESM::EffectList& effects,
+                              const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
 
         void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
                                        const osg::Vec3f& pos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength);

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -49,7 +49,7 @@ namespace MWWorld
                 MWRender::RenderingManager* rendering, MWPhysics::PhysicsSystem* physics);
 
         /// If caster is an actor, the actor's facing orientation is used. Otherwise fallbackDirection is used.
-        void launchMagicBolt (const std::vector<std::string>& models, const std::vector<std::string> &sounds, const std::string &spellId,
+        void launchMagicBolt (const std::vector<std::string>& projectileIDs, const std::vector<std::string> &sounds, const std::string &spellId,
                                      float speed, bool stack, const ESM::EffectList& effects,
                                        const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
 

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -104,7 +104,7 @@ namespace MWWorld
 
             bool mStack;
 
-            MWBase::SoundPtr mSound;
+            std::vector<MWBase::SoundPtr> mSound;
             std::vector<std::string> mSoundId;
         };
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3163,8 +3163,9 @@ namespace MWWorld
         {
             const ESM::MagicEffect* effect = getStore().get<ESM::MagicEffect>().find(effectIt->mEffectID);
 
-            if (effectIt->mArea <= 0)
-                continue; // Not an area effect
+            if (effectIt->mArea <= 0 || effectIt->mRange != rangeType)
+                continue; // Not an area effect or not right range type
+
 
             // Spawn the explosion orb effect
             const ESM::Static* areaStatic;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2705,11 +2705,11 @@ namespace MWWorld
         mProjectileManager->launchProjectile(actor, projectile, worldPos, orient, bow, speed, attackStrength);
     }
 
-    void World::launchMagicBolt (const std::vector<std::string> &models, const std::vector<std::string> &sounds, const std::string &spellId,
+    void World::launchMagicBolt (const std::vector<std::string> &projectileIDs, const std::vector<std::string> &sounds, const std::string &spellId,
                                  float speed, bool stack, const ESM::EffectList& effects,
                                    const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection)
     {
-        mProjectileManager->launchMagicBolt(models, sounds, spellId, speed, stack, effects, caster, sourceName, fallbackDirection);
+        mProjectileManager->launchMagicBolt(projectileIDs, sounds, spellId, speed, stack, effects, caster, sourceName, fallbackDirection);
     }
 
     const std::vector<std::string>& World::getContentFiles() const

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2705,11 +2705,10 @@ namespace MWWorld
         mProjectileManager->launchProjectile(actor, projectile, worldPos, orient, bow, speed, attackStrength);
     }
 
-    void World::launchMagicBolt (const std::vector<std::string> &projectileIDs, const std::vector<std::string> &sounds, const std::string &spellId,
-                                 float speed, bool stack, const ESM::EffectList& effects,
-                                   const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection)
+    void World::launchMagicBolt (const std::string &spellId, bool stack, const ESM::EffectList& effects,
+                                 const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection)
     {
-        mProjectileManager->launchMagicBolt(projectileIDs, sounds, spellId, speed, stack, effects, caster, sourceName, fallbackDirection);
+        mProjectileManager->launchMagicBolt(spellId, stack, effects, caster, sourceName, fallbackDirection);
     }
 
     const std::vector<std::string>& World::getContentFiles() const

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2705,11 +2705,11 @@ namespace MWWorld
         mProjectileManager->launchProjectile(actor, projectile, worldPos, orient, bow, speed, attackStrength);
     }
 
-    void World::launchMagicBolt (const std::string& model, const std::string &sound, const std::string &spellId,
+    void World::launchMagicBolt (const std::vector<std::string> &models, const std::vector<std::string> &sounds, const std::string &spellId,
                                  float speed, bool stack, const ESM::EffectList& effects,
                                    const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection)
     {
-        mProjectileManager->launchMagicBolt(model, sound, spellId, speed, stack, effects, caster, sourceName, fallbackDirection);
+        mProjectileManager->launchMagicBolt(models, sounds, spellId, speed, stack, effects, caster, sourceName, fallbackDirection);
     }
 
     const std::vector<std::string>& World::getContentFiles() const

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -594,7 +594,7 @@ namespace MWWorld
              */
             virtual void castSpell (const MWWorld::Ptr& actor);
 
-            virtual void launchMagicBolt (const std::vector<std::string>& models, const std::vector<std::string>& sounds, const std::string& spellId,
+            virtual void launchMagicBolt (const std::vector<std::string>& projectileIDs, const std::vector<std::string>& sounds, const std::string& spellId,
                                           float speed, bool stack, const ESM::EffectList& effects,
                                            const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -594,9 +594,8 @@ namespace MWWorld
              */
             virtual void castSpell (const MWWorld::Ptr& actor);
 
-            virtual void launchMagicBolt (const std::vector<std::string>& projectileIDs, const std::vector<std::string>& sounds, const std::string& spellId,
-                                          float speed, bool stack, const ESM::EffectList& effects,
-                                           const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
+            virtual void launchMagicBolt (const std::string& spellId, bool stack, const ESM::EffectList& effects,
+                                          const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
                                            const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength);
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -594,7 +594,7 @@ namespace MWWorld
              */
             virtual void castSpell (const MWWorld::Ptr& actor);
 
-            virtual void launchMagicBolt (const std::string& model, const std::string& sound, const std::string& spellId,
+            virtual void launchMagicBolt (const std::vector<std::string>& models, const std::vector<std::string>& sounds, const std::string& spellId,
                                           float speed, bool stack, const ESM::EffectList& effects,
                                            const MWWorld::Ptr& caster, const std::string& sourceName, const osg::Vec3f& fallbackDirection);
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,


### PR DESCRIPTION
For https://bugs.openmw.org/issues/3519.

This includes the following changes. All are to recreate behavior from the original engine.

1. Allow all the magic effect hit sounds of a spell to play when the spell hits a target.
2. Play all visual and sound effects when casting a spell with multiple magic effects.
3. Shoot all projectiles of spells with multiple magic effects.
4. Make the shot projectiles all have the same speed, which is the average of all the magic effects in the spell, including ones without their own projectiles (self-cast effects, etc.).
5. Use the last magic effect of a spell to determine the color of the magic effect on the hands when casting. The first magic effect, however, is used to determine what animation is played (on Self, on Touch or on Target). The hand effect is played for each magic effect, so the more magic effects, the thicker the hand effect looks.
6. Since I made all the projectiles shoot, I put all of the magic effects into the first projectile only, as otherwise the sounds of all of the magic effects would play for each projectile when they struck a target.
7. Fixed a bug with the spell explosions where a ranged effect could be exploded like a touched spell due to a missing check.

I had no problems with shooting different effects as different projectiles. They seem to all have the same collision and all disappear together when they strike something. In the original engine there is a swirling effect when there are multiple effects in a projectile spell, but I couldn't tell from testing whether that swirling effect has any effect on collision. I have not implemented this swirling effect.
