### PR TITLE
Fix AI melee attack

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -687,21 +687,11 @@ std::string chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &m
         //hand-to-hand deal equal damage for each type
         float roll = Misc::Rng::rollClosedProbability();
         if(roll <= 0.333f)  //side punch
-        {
-            movement.mPosition[0] = (Misc::Rng::rollClosedProbability() < 0.5f) ? 1.0f : -1.0f;
-            movement.mPosition[1] = 0;
             attackType = "slash";
-        }
         else if(roll <= 0.666f) //forward punch
-        {
-            movement.mPosition[1] = 1;
             attackType = "thrust";
-        }
         else
-        {
-            movement.mPosition[1] = movement.mPosition[0] = 0;
             attackType = "chop";
-        }
     }
     else
     {
@@ -712,21 +702,11 @@ std::string chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &m
 
         float roll = Misc::Rng::rollClosedProbability() * (slash + chop + thrust);
         if(roll <= slash)
-        {
-            movement.mPosition[0] = (Misc::Rng::rollClosedProbability() < 0.5f) ? 1.0f : -1.0f;
-            movement.mPosition[1] = 0;
             attackType = "slash";
-        }
         else if(roll <= (slash + thrust))
-        {
-            movement.mPosition[1] = 1;
             attackType = "thrust";
-        }
         else
-        {
-            movement.mPosition[1] = movement.mPosition[0] = 0;
             attackType = "chop";
-        }
     }
 
     return attackType;

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -23,7 +23,7 @@ namespace
 {
 
     //chooses an attack depending on probability to avoid uniformity
-    std::string chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &movement);
+    std::string chooseBestAttack(const ESM::Weapon* weapon);
 
     osg::Vec3f AimDirToMovingTarget(const MWWorld::Ptr& actor, const MWWorld::Ptr& target, const osg::Vec3f& vLastTargetPos,
         float duration, int weapType, float strength);
@@ -630,7 +630,7 @@ namespace MWMechanics
                 characterController.setAttackingOrSpell(true);
 
                 if (!distantCombat)
-                    characterController.setAIAttackType(chooseBestAttack(weapon, mMovement));
+                    characterController.setAIAttackType(chooseBestAttack(weapon));
 
                 mStrength = Misc::Rng::rollClosedProbability();
 
@@ -678,7 +678,7 @@ namespace MWMechanics
 namespace
 {
 
-std::string chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &movement)
+std::string chooseBestAttack(const ESM::Weapon* weapon)
 {
     std::string attackType;
 

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -23,7 +23,7 @@ namespace
 {
 
     //chooses an attack depending on probability to avoid uniformity
-    ESM::Weapon::AttackType chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &movement);
+    std::string chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &movement);
 
     osg::Vec3f AimDirToMovingTarget(const MWWorld::Ptr& actor, const MWWorld::Ptr& target, const osg::Vec3f& vLastTargetPos,
         float duration, int weapType, float strength);
@@ -630,7 +630,7 @@ namespace MWMechanics
                 characterController.setAttackingOrSpell(true);
 
                 if (!distantCombat)
-                    chooseBestAttack(weapon, mMovement);
+                    characterController.setAIAttackType(chooseBestAttack(weapon, mMovement));
 
                 mStrength = Misc::Rng::rollClosedProbability();
 
@@ -678,9 +678,9 @@ namespace MWMechanics
 namespace
 {
 
-ESM::Weapon::AttackType chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &movement)
+std::string chooseBestAttack(const ESM::Weapon* weapon, MWMechanics::Movement &movement)
 {
-    ESM::Weapon::AttackType attackType;
+    std::string attackType;
 
     if (weapon == NULL)
     {
@@ -690,17 +690,17 @@ ESM::Weapon::AttackType chooseBestAttack(const ESM::Weapon* weapon, MWMechanics:
         {
             movement.mPosition[0] = (Misc::Rng::rollClosedProbability() < 0.5f) ? 1.0f : -1.0f;
             movement.mPosition[1] = 0;
-            attackType = ESM::Weapon::AT_Slash;
+            attackType = "slash";
         }
         else if(roll <= 0.666f) //forward punch
         {
             movement.mPosition[1] = 1;
-            attackType = ESM::Weapon::AT_Thrust;
+            attackType = "thrust";
         }
         else
         {
             movement.mPosition[1] = movement.mPosition[0] = 0;
-            attackType = ESM::Weapon::AT_Chop;
+            attackType = "chop";
         }
     }
     else
@@ -715,17 +715,17 @@ ESM::Weapon::AttackType chooseBestAttack(const ESM::Weapon* weapon, MWMechanics:
         {
             movement.mPosition[0] = (Misc::Rng::rollClosedProbability() < 0.5f) ? 1.0f : -1.0f;
             movement.mPosition[1] = 0;
-            attackType = ESM::Weapon::AT_Slash;
+            attackType = "slash";
         }
         else if(roll <= (slash + thrust))
         {
             movement.mPosition[1] = 1;
-            attackType = ESM::Weapon::AT_Thrust;
+            attackType = "thrust";
         }
         else
         {
             movement.mPosition[1] = movement.mPosition[0] = 0;
-            attackType = ESM::Weapon::AT_Chop;
+            attackType = "chop";
         }
     }
 

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -682,18 +682,7 @@ std::string chooseBestAttack(const ESM::Weapon* weapon)
 {
     std::string attackType;
 
-    if (weapon == NULL)
-    {
-        //hand-to-hand deal equal damage for each type
-        float roll = Misc::Rng::rollClosedProbability();
-        if(roll <= 0.333f)  //side punch
-            attackType = "slash";
-        else if(roll <= 0.666f) //forward punch
-            attackType = "thrust";
-        else
-            attackType = "chop";
-    }
-    else
+    if (weapon != NULL)
     {
         //the more damage attackType deals the more probability it has
         int slash = (weapon->mData.mSlash[0] + weapon->mData.mSlash[1])/2;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1208,7 +1208,6 @@ bool CharacterController::updateWeaponState()
         if(mUpperBodyState == UpperCharState_WeapEquiped && (mHitState == CharState_None || mHitState == CharState_Block))
         {
             MWBase::Environment::get().getWorld()->breakInvisibility(mPtr);
-            mAttackType.clear();
             if(mWeaponType == WeapType_Spell)
             {
                 // Unset casting flag, otherwise pressing the mouse button down would
@@ -1309,14 +1308,17 @@ bool CharacterController::updateWeaponState()
                 {
                     if (isWeapon)
                     {
-                        if(mPtr == getPlayer() &&
-                                Settings::Manager::getBool("best attack", "Game"))
+                        if(mPtr == getPlayer())
                         {
-                            MWWorld::ContainerStoreIterator weapon = mPtr.getClass().getInventoryStore(mPtr).getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-                            mAttackType = getBestAttack(weapon->get<ESM::Weapon>()->mBase);
+                            if (Settings::Manager::getBool("best attack", "Game"))        
+                            {
+                                MWWorld::ContainerStoreIterator weapon = mPtr.getClass().getInventoryStore(mPtr).getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+                                mAttackType = getBestAttack(weapon->get<ESM::Weapon>()->mBase);
+                            }
+                            else
+                                setAttackTypeBasedOnMovement();
                         }
-                        else
-                            setAttackTypeBasedOnMovement();
+                        // else if (mPtr != getPlayer()) use mAttackType already set by AiCombat
                     }
                     else
                         setAttackTypeRandomly();
@@ -2225,6 +2227,11 @@ bool CharacterController::isSneaking() const
 void CharacterController::setAttackingOrSpell(bool attackingOrSpell)
 {
     mAttackingOrSpell = attackingOrSpell;
+}
+
+void CharacterController::setAIAttackType(std::string attackType)
+{
+    mAttackType = attackType;
 }
 
 bool CharacterController::readyToPrepareAttack() const

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -269,6 +269,7 @@ public:
     bool isSneaking() const;
 
     void setAttackingOrSpell(bool attackingOrSpell);
+    void setAIAttackType(std::string attackType); // set and used by AiCombat
 
     bool readyToPrepareAttack() const;
     bool readyToStartAttack() const;


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3521.

The AI currently does not use the melee attack chosen by chooseBestAttack() in aicombat.cpp most of the time, because its attack is being chosen by movement in character.cpp, and the timing of the movement from chooseBestAttack() isn't coinciding with the attack.

In the original engine the attacks of NPCs appear to be unrelated to their movement. They can do any of the attacks while standing still. This PR recreates that behavior to always allow the attack from chooseBestAttack() to play. From chooseBestAttack(), I set the attack of the NPC's charactercontroller. Another option would be to move the chooseBestAttack() method into the charactercontroller. I'm not sure which is better. I chose to leave chooseBestAttack() where it was, as the code for the attacktype selection would probably be expected to be found in aicombat.

I removed a clearing of the attack variable in the charactercontroller for this purpose, but I haven't found this to cause any problems.

I removed the movements that were associated with the attacks in chooseBestAttack(), because they are no longer serving that function and because they cause what I see as unwanted behavior, such as NPCs running into their target whenever they attempt a stab attack. Removing those movements produces behavior more similar to the original engine's melee movements.

