### PR TITLE
Editor fixes

### DIFF
--- a/apps/opencs/model/doc/runner.cpp
+++ b/apps/opencs/model/doc/runner.cpp
@@ -81,7 +81,7 @@ void CSMDoc::Runner::start (bool delayed)
         arguments << ("--script-run="+mStartup->fileName());;
 
         arguments <<
-            QString::fromUtf8 (("--data="+mProjectPath.parent_path().string()).c_str());
+            QString::fromUtf8 (("--data=\""+mProjectPath.parent_path().string()+"\"").c_str());
 
         for (std::vector<std::string>::const_iterator iter (mContentFiles.begin());
             iter!=mContentFiles.end(); ++iter)

--- a/apps/opencs/view/render/instancemode.cpp
+++ b/apps/opencs/view/render/instancemode.cpp
@@ -92,7 +92,7 @@ osg::Vec3f CSVRender::InstanceMode::getScreenCoords(const osg::Vec3f& pos)
 }
 
 CSVRender::InstanceMode::InstanceMode (WorldspaceWidget *worldspaceWidget, QWidget *parent)
-: EditMode (worldspaceWidget, QIcon (":placeholder"), Mask_Reference, "Instance editing",
+: EditMode (worldspaceWidget, QIcon (":placeholder"), Mask_Reference | Mask_Terrain, "Instance editing",
   parent), mSubMode (0), mSubModeId ("move"), mSelectionMode (0), mDragMode (DragMode_None),
   mDragAxis (-1), mLocked (false), mUnitScaleDist(1)
 {


### PR DESCRIPTION
The first commit makes the editor more usable by adding the terrain mask to what is interactable. This means it is possible to drop objects on terrain. Additionally, clicking on the terrain will not select an unseen object beneath the terrain (and it stops tool tips from doing the same).

The second commit fixes [bug#3520](https://bugs.openmw.org/issues/3520). Turns out that the command line interpreter doesn't like unquoted paths with spaces.