### PR TITLE
Use spell effect particle textures

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1235,10 +1235,8 @@ bool CharacterController::updateWeaponState()
                     MWMechanics::CastSpell cast(mPtr, NULL);
                     cast.playSpellCastingEffects(spellid);
 
-                    const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);
-                    
-                    const ESM::ENAMstruct &lastEffect = spell->mEffects.mList.at(spell->mEffects.mList.size() - 1);
-
+                    const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);                   
+                    const ESM::ENAMstruct &lastEffect = spell->mEffects.mList.back();
                     const ESM::MagicEffect *effect;
 
                     effect = store.get<ESM::MagicEffect>().find(lastEffect.mEffectID); // use last effect of list for color of VFX_Hands

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -541,12 +541,17 @@ namespace MWMechanics
                     else
                         castStatic = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>().find ("VFX_DefaultHit");
 
+                    std::string texture = "";
+
+                    if (!magicEffect->mParticle.empty() && !(magicEffect->mData.mFlags & ESM::MagicEffect::Harmful))
+                        texture = magicEffect->mParticle;
+
                     // TODO: VFX are no longer active after saving/reloading the game
                     bool loop = (magicEffect->mData.mFlags & ESM::MagicEffect::ContinuousVfx) != 0;
                     // Note: in case of non actor, a free effect should be fine as well
                     MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(target);
                     if (anim)
-                        anim->addEffect("meshes\\" + castStatic->mModel, magicEffect->mIndex, loop, "");
+                        anim->addEffect("meshes\\" + castStatic->mModel, magicEffect->mIndex, loop, "", texture);
                 }
             }
         }

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -30,7 +30,6 @@
 
 namespace MWMechanics
 {
-
     ESM::Skill::SkillEnum spellSchoolToSkill(int school)
     {
         std::map<int, ESM::Skill::SkillEnum> schoolSkillMap; // maps spell school to skill id

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -543,6 +543,7 @@ namespace MWMechanics
 
                     std::string texture = "";
 
+                    // Use particle textures for non-harmful effects
                     if (!magicEffect->mParticle.empty() && !(magicEffect->mData.mFlags & ESM::MagicEffect::Harmful))
                         texture = magicEffect->mParticle;
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -543,7 +543,7 @@ namespace MWMechanics
 
                     std::string texture = "";
 
-                    // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+                    // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
                     if (magicEffect->mHit.empty() || magicEffect->mHit == "VFX_DefaultHit" || magicEffect->mHit == "VFX_MysticismHit"
                         || magicEffect->mHit == "VFX_SoulTrapHit")                        
                         texture = magicEffect->mParticle;
@@ -937,7 +937,7 @@ namespace MWMechanics
 
             MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
 
-            if (mCaster.getClass().isActor()) // TODO: Non-actors (except for large statics?) should also create a spell cast vfx
+            if (mCaster.getClass().isActor()) // TODO: Non-actors should also create a spell cast vfx
             {
                 const ESM::Static* castStatic;
                 std::string texture = "";
@@ -947,7 +947,7 @@ namespace MWMechanics
                 else
                     castStatic = store.get<ESM::Static>().find ("VFX_DefaultCast");
 
-                // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+                // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
                 if (effect->mCasting.empty() || effect->mCasting == "VFX_DefaultCast" || effect->mCasting == "VFX_ShieldCast")
                         texture = effect->mParticle;
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -541,12 +541,7 @@ namespace MWMechanics
                     else
                         castStatic = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>().find ("VFX_DefaultHit");
 
-                    std::string texture = "";
-
-                    // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
-                    if (magicEffect->mHit.empty() || magicEffect->mHit == "VFX_DefaultHit" || magicEffect->mHit == "VFX_MysticismHit"
-                        || magicEffect->mHit == "VFX_SoulTrapHit")                        
-                        texture = magicEffect->mParticle;
+                    std::string texture = magicEffect->mParticle;
 
                     // TODO: VFX are no longer active after saving/reloading the game
                     bool loop = (magicEffect->mData.mFlags & ESM::MagicEffect::ContinuousVfx) != 0;
@@ -940,16 +935,13 @@ namespace MWMechanics
             if (mCaster.getClass().isActor()) // TODO: Non-actors should also create a spell cast vfx
             {
                 const ESM::Static* castStatic;
-                std::string texture = "";
 
                 if (!effect->mCasting.empty())
                     castStatic = store.get<ESM::Static>().find (effect->mCasting);
                 else
                     castStatic = store.get<ESM::Static>().find ("VFX_DefaultCast");
 
-                // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
-                if (effect->mCasting.empty() || effect->mCasting == "VFX_DefaultCast" || effect->mCasting == "VFX_ShieldCast")
-                        texture = effect->mParticle;
+                std::string texture = effect->mParticle;
 
                 animation->addEffect("meshes\\" + castStatic->mModel, effect->mIndex, false, "", texture);
             }

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -543,8 +543,9 @@ namespace MWMechanics
 
                     std::string texture = "";
 
-                    // Use particle textures for non-harmful effects
-                    if (!magicEffect->mParticle.empty() && !(magicEffect->mData.mFlags & ESM::MagicEffect::Harmful))
+                    // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+                    if (magicEffect->mHit.empty() || magicEffect->mHit == "VFX_DefaultHit" || magicEffect->mHit == "VFX_MysticismHit"
+                        || magicEffect->mHit == "VFX_SoulTrapHit")                        
                         texture = magicEffect->mParticle;
 
                     // TODO: VFX are no longer active after saving/reloading the game
@@ -939,12 +940,18 @@ namespace MWMechanics
             if (mCaster.getClass().isActor()) // TODO: Non-actors (except for large statics?) should also create a spell cast vfx
             {
                 const ESM::Static* castStatic;
+                std::string texture = "";
+
                 if (!effect->mCasting.empty())
                     castStatic = store.get<ESM::Static>().find (effect->mCasting);
                 else
                     castStatic = store.get<ESM::Static>().find ("VFX_DefaultCast");
 
-                animation->addEffect("meshes\\" + castStatic->mModel, effect->mIndex);
+                // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+                if (effect->mCasting.empty() || effect->mCasting == "VFX_DefaultCast" || effect->mCasting == "VFX_ShieldCast")
+                        texture = effect->mParticle;
+
+                animation->addEffect("meshes\\" + castStatic->mModel, effect->mIndex, false, "", texture);
             }
 
             if (!mCaster.getClass().isActor())

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1342,7 +1342,7 @@ namespace MWRender
         SceneUtil::AssignControllerSourcesVisitor assignVisitor(boost::shared_ptr<SceneUtil::ControllerSource>(params.mAnimTime));
         node->accept(assignVisitor);
 
-        overrideTexture(texture, mResourceSystem, node);
+        overrideFirstRootTexture(texture, mResourceSystem, node);
 
         // TODO: in vanilla morrowind the effect is scaled based on the host object's bounding box.
 

--- a/apps/openmw/mwrender/effectmanager.cpp
+++ b/apps/openmw/mwrender/effectmanager.cpp
@@ -25,7 +25,7 @@ EffectManager::~EffectManager()
     clear();
 }
 
-void EffectManager::addEffect(const std::string &model, const std::string& textureOverride, const osg::Vec3f &worldPosition, float scale)
+void EffectManager::addEffect(const std::string &model, const std::string& textureOverride, const osg::Vec3f &worldPosition, float scale, bool isMagicVFX)
 {
     osg::ref_ptr<osg::Node> node = mResourceSystem->getSceneManager()->getInstance(model);
 
@@ -46,7 +46,10 @@ void EffectManager::addEffect(const std::string &model, const std::string& textu
     SceneUtil::AssignControllerSourcesVisitor assignVisitor(effect.mAnimTime);
     node->accept(assignVisitor);
 
-    overrideFirstRootTexture(textureOverride, mResourceSystem, node);
+    if (isMagicVFX)
+        overrideFirstRootTexture(textureOverride, mResourceSystem, node);
+    else
+        overrideTexture(textureOverride, mResourceSystem, node);
 
     mParentNode->addChild(trans);
     mResourceSystem->getSceneManager()->notifyAttached(node);

--- a/apps/openmw/mwrender/effectmanager.cpp
+++ b/apps/openmw/mwrender/effectmanager.cpp
@@ -46,7 +46,7 @@ void EffectManager::addEffect(const std::string &model, const std::string& textu
     SceneUtil::AssignControllerSourcesVisitor assignVisitor(effect.mAnimTime);
     node->accept(assignVisitor);
 
-    overrideTexture(textureOverride, mResourceSystem, node);
+    overrideFirstRootTexture(textureOverride, mResourceSystem, node);
 
     mParentNode->addChild(trans);
     mResourceSystem->getSceneManager()->notifyAttached(node);

--- a/apps/openmw/mwrender/effectmanager.hpp
+++ b/apps/openmw/mwrender/effectmanager.hpp
@@ -33,7 +33,7 @@ namespace MWRender
         ~EffectManager();
 
         /// Add an effect. When it's finished playing, it will be removed automatically.
-        void addEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPosition, float scale);
+        void addEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPosition, float scale, bool isMagicVFX = true);
 
         void update(float dt);
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -994,7 +994,7 @@ void NpcAnimation::permanentEffectAdded(const ESM::MagicEffect *magicEffect, boo
         bool loop = (magicEffect->mData.mFlags & ESM::MagicEffect::ContinuousVfx) != 0;
         // Don't play particle VFX unless the effect is new or it should be looping.
         if (isNew || loop)
-            addEffect("meshes\\" + castStatic->mModel, magicEffect->mIndex, loop, "");
+            addEffect("meshes\\" + castStatic->mModel, magicEffect->mIndex, loop, "", magicEffect->mParticle);
     }
 }
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -970,12 +970,12 @@ Resource::ResourceSystem* NpcAnimation::getResourceSystem()
     return mResourceSystem;
 }
 
-void NpcAnimation::permanentEffectAdded(const ESM::MagicEffect *magicEffect, bool isNew, bool playSound)
+void NpcAnimation::permanentEffectAdded(const ESM::MagicEffect *magicEffect, bool isNew)
 {
     // During first auto equip, we don't play any sounds.
     // Basically we don't want sounds when the actor is first loaded,
     // the items should appear as if they'd always been equipped.
-    if (playSound)
+    if (isNew)
     {
         static const std::string schools[] = {
             "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -23,7 +23,7 @@ class NpcAnimation : public Animation, public WeaponAnimation, public MWWorld::I
 {
 public:
     virtual void equipmentChanged();
-    virtual void permanentEffectAdded(const ESM::MagicEffect *magicEffect, bool isNew, bool playSound);
+    virtual void permanentEffectAdded(const ESM::MagicEffect *magicEffect, bool isNew);
 
 public:
     typedef std::map<ESM::PartReferenceType,std::string> PartBoneMap;

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -742,9 +742,9 @@ namespace MWRender
         mObjects->updatePtr(old, updated);
     }
 
-    void RenderingManager::spawnEffect(const std::string &model, const std::string &texture, const osg::Vec3f &worldPosition, float scale)
+    void RenderingManager::spawnEffect(const std::string &model, const std::string &texture, const osg::Vec3f &worldPosition, float scale, bool isMagicVFX)
     {
-        mEffectManager->addEffect(model, texture, worldPosition, scale);
+        mEffectManager->addEffect(model, texture, worldPosition, scale, isMagicVFX);
     }
 
     void RenderingManager::notifyWorldSpaceChanged()

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -138,7 +138,7 @@ namespace MWRender
 
         SkyManager* getSkyManager();
 
-        void spawnEffect(const std::string &model, const std::string &texture, const osg::Vec3f &worldPosition, float scale = 1.f);
+        void spawnEffect(const std::string &model, const std::string &texture, const osg::Vec3f &worldPosition, float scale = 1.f, bool isMagicVFX = true);
 
         /// Clear all savegame-specific data
         void clear();

--- a/apps/openmw/mwrender/util.cpp
+++ b/apps/openmw/mwrender/util.cpp
@@ -65,7 +65,7 @@ void overrideTexture(const std::string &texture, Resource::ResourceSystem *resou
     else
         stateset = new osg::StateSet;
 
-    stateset->setTextureAttribute(0, tex, osg::StateAttribute::PROTECTED);
+    stateset->setTextureAttribute(0, tex, osg::StateAttribute::OVERRIDE);
 
     node->setStateSet(stateset);
 }

--- a/apps/openmw/mwrender/util.cpp
+++ b/apps/openmw/mwrender/util.cpp
@@ -14,7 +14,7 @@ namespace MWRender
 class TextureOverrideVisitor : public osg::NodeVisitor
     {
     public:
-        TextureOverrideVisitor(size_t refID, std::string texture, Resource::ResourceSystem* resourcesystem)
+        TextureOverrideVisitor(int refID, std::string texture, Resource::ResourceSystem* resourcesystem)
             : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
             , mRefID(refID)
             , mTexture(texture)

--- a/apps/openmw/mwrender/util.cpp
+++ b/apps/openmw/mwrender/util.cpp
@@ -14,9 +14,8 @@ namespace MWRender
 class TextureOverrideVisitor : public osg::NodeVisitor
     {
     public:
-        TextureOverrideVisitor(int refID, std::string texture, Resource::ResourceSystem* resourcesystem)
+        TextureOverrideVisitor(std::string texture, Resource::ResourceSystem* resourcesystem)
             : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
-            , mRefID(refID)
             , mTexture(texture)
             , mResourcesystem(resourcesystem)
         {
@@ -26,26 +25,21 @@ class TextureOverrideVisitor : public osg::NodeVisitor
         {
             int index;
             osg::ref_ptr<osg::Node> nodePtr(&node);
-            if (node.getUserValue("NiTexturingPropertyIndex", index))
+            if (node.getUserValue("overrideFx", index))
             {
-                if (mRefID == index) 
+                if (index == 1) 
                     overrideTexture(mTexture, mResourcesystem, nodePtr);
             }
             traverse(node);
         }
-        int mRefID;
         std::string mTexture;
         Resource::ResourceSystem* mResourcesystem;
 };
 
 void overrideFirstRootTexture(const std::string &texture, Resource::ResourceSystem *resourceSystem, osg::ref_ptr<osg::Node> node)
 {
-        int index;
-        if (node->getUserValue("overrideIndex", index))
-        {
-            TextureOverrideVisitor overrideVisitor(index, texture, resourceSystem);
-            node->accept(overrideVisitor);
-        }
+    TextureOverrideVisitor overrideVisitor(texture, resourceSystem);
+    node->accept(overrideVisitor);
 }
 
 void overrideTexture(const std::string &texture, Resource::ResourceSystem *resourceSystem, osg::ref_ptr<osg::Node> node)

--- a/apps/openmw/mwrender/util.hpp
+++ b/apps/openmw/mwrender/util.hpp
@@ -17,6 +17,8 @@ namespace Resource
 
 namespace MWRender
 {
+    void overrideFirstRootTexture(const std::string &texture, Resource::ResourceSystem *resourceSystem, osg::ref_ptr<osg::Node> node);
+
     void overrideTexture(const std::string& texture, Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Node> node);
 
     // Node callback to entirely skip the traversal.

--- a/apps/openmw/mwrender/util.hpp
+++ b/apps/openmw/mwrender/util.hpp
@@ -17,6 +17,8 @@ namespace Resource
 
 namespace MWRender
 {
+    // Overrides the texture of nodes in the mesh that had the same NiTexturingProperty as the first NiTexturingProperty of the .NIF file's root node,
+    // if it had a NiTexturingProperty. Used for applying "particle textures" to magic effects.
     void overrideFirstRootTexture(const std::string &texture, Resource::ResourceSystem *resourceSystem, osg::ref_ptr<osg::Node> node);
 
     void overrideTexture(const std::string& texture, Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Node> node);

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -415,7 +415,7 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
                     // Basically we don't want sounds when the actor is first loaded,
                     // the items should appear as if they'd always been equipped.
                     mListener->permanentEffectAdded(magicEffect, !mFirstAutoEquip,
-                                                        !mFirstAutoEquip && effectIt == enchantment.mEffects.mList.begin());
+                                                        !mFirstAutoEquip);
                 }
 
                 if (magnitude)

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -414,8 +414,7 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
                     // During first auto equip, we don't play any sounds.
                     // Basically we don't want sounds when the actor is first loaded,
                     // the items should appear as if they'd always been equipped.
-                    mListener->permanentEffectAdded(magicEffect, !mFirstAutoEquip,
-                                                        !mFirstAutoEquip);
+                    mListener->permanentEffectAdded(magicEffect, !mFirstAutoEquip);
                 }
 
                 if (magnitude)

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -32,7 +32,7 @@ namespace MWWorld
          *              If it isn't new, non-looping VFX should not be played.
          * @param playSound Play effect sound?
          */
-        virtual void permanentEffectAdded (const ESM::MagicEffect *magicEffect, bool isNew, bool playSound) {}
+        virtual void permanentEffectAdded (const ESM::MagicEffect *magicEffect, bool isNew) {}
 
     };
 

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -79,7 +79,10 @@ namespace
         {
             const ESM::MagicEffect *magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find (
                 effects.mList.begin()->mEffectID);
-            texture = magicEffect->mParticle;
+
+            // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+            if (magicEffect->mBolt.empty() || magicEffect->mBolt == "VFX_DefaultBolt" || magicEffect->mBolt == "VFX_DestructBolt")
+                texture = magicEffect->mParticle;
         }
         
         if (projectileEffects.mList.size() > 1) // insert a VFX_Multiple projectile if there are multiple projectile effects

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -74,7 +74,8 @@ namespace
         if (count != 0)
             speed /= count;
 
-        if (projectileEffects.mList.size() == 1)
+        // in the original engine, the particle texture is only used if there is only one projectile
+        if (projectileEffects.mList.size() == 1) 
         {
             const ESM::MagicEffect *magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find (
                 effects.mList.begin()->mEffectID);

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -80,7 +80,7 @@ namespace
             const ESM::MagicEffect *magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find (
                 effects.mList.begin()->mEffectID);
 
-            // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+            // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
             if (magicEffect->mBolt.empty() || magicEffect->mBolt == "VFX_DefaultBolt" || magicEffect->mBolt == "VFX_DestructBolt")
                 texture = magicEffect->mParticle;
         }

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -41,6 +41,7 @@ namespace
     ESM::EffectList getMagicBoltData(std::vector<std::string>& projectileIDs, std::vector<std::string>& sounds, float& speed, std::string& texture, const ESM::EffectList& effects)
     {
         int count = 0;
+        speed = 0.0f;
         ESM::EffectList projectileEffects;
         for (std::vector<ESM::ENAMstruct>::const_iterator iter (effects.mList.begin());
             iter!=effects.mList.end(); ++iter)

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -122,7 +122,7 @@ namespace MWWorld
         void moveProjectiles(float dt);
         void moveMagicBolts(float dt);
 
-        void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient, bool rotate);
+        void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient, bool rotate, std::string texture = "");
         void update (State& state, float duration);
 
         void operator=(const ProjectileManager&);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3163,11 +3163,7 @@ namespace MWWorld
             const ESM::MagicEffect* effect = getStore().get<ESM::MagicEffect>().find(effectIt->mEffectID);
 
             if ((effectIt->mArea <= 0 && !ignore.isEmpty() && ignore.getClass().isActor()) || effectIt->mRange != rangeType)
-<<<<<<< fe3a033642f21393bc267afa4edcc373c9d5f80b
                 continue; // Not right range type, or not area effect and hit an actor
-=======
-                continue; // Not right range type
->>>>>>> Use particle texture for "hit" effects
 
             // Spawn the explosion orb effect
             const ESM::Static* areaStatic;
@@ -3176,13 +3172,19 @@ namespace MWWorld
             else
                 areaStatic = getStore().get<ESM::Static>().find ("VFX_DefaultArea");
 
+            std::string texture = "";
+
+            // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+            if (effect->mArea.empty() || effect->mArea == "VFX_DefaultArea")
+                texture = effect->mParticle;
+
             if (effectIt->mArea <= 0)
             {
-                mRendering->spawnEffect("meshes\\" + areaStatic->mModel, "", origin, 1.0f);
+                mRendering->spawnEffect("meshes\\" + areaStatic->mModel, texture, origin, 1.0f);
                 continue;
             }
             else
-                mRendering->spawnEffect("meshes\\" + areaStatic->mModel, "", origin, static_cast<float>(effectIt->mArea * 2));              
+                mRendering->spawnEffect("meshes\\" + areaStatic->mModel, texture, origin, static_cast<float>(effectIt->mArea * 2));              
 
             // Play explosion sound (make sure to use NoTrack, since we will delete the projectile now)
             static const std::string schools[] = {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3172,11 +3172,7 @@ namespace MWWorld
             else
                 areaStatic = getStore().get<ESM::Static>().find ("VFX_DefaultArea");
 
-            std::string texture = "";
-
-            // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
-            if (effect->mArea.empty() || effect->mArea == "VFX_DefaultArea")
-                texture = effect->mParticle;
+            std::string texture = effect->mParticle;
 
             if (effectIt->mArea <= 0)
             {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3145,7 +3145,7 @@ namespace MWWorld
         modelName << roll;
         std::string model = "meshes\\" + getFallback()->getFallbackString(modelName.str());
 
-        mRendering->spawnEffect(model, texture, worldPosition);
+        mRendering->spawnEffect(model, texture, worldPosition, 1.0f, false);
     }
 
     void World::spawnEffect(const std::string &model, const std::string &textureOverride, const osg::Vec3f &worldPos)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3162,7 +3162,7 @@ namespace MWWorld
         {
             const ESM::MagicEffect* effect = getStore().get<ESM::MagicEffect>().find(effectIt->mEffectID);
 
-            if ((effectIt->mArea <= 0 && !ignore.isEmpty() && ignore.getClass().isActor()) || effectIt->mRange != rangeType)
+            if (effectIt->mRange != rangeType || (effectIt->mArea <= 0 && !ignore.isEmpty() && ignore.getClass().isActor()))
                 continue; // Not right range type, or not area effect and hit an actor
 
             // Spawn the explosion orb effect

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3174,7 +3174,7 @@ namespace MWWorld
 
             std::string texture = "";
 
-            // TODO: Choosing whether to apply the override texture should be chosen based on nodes in the .NIF file.
+            // TODO: Applying the override texture should depend on texture properties in the .NIF file and not use special cases.
             if (effect->mArea.empty() || effect->mArea == "VFX_DefaultArea")
                 texture = effect->mParticle;
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3163,7 +3163,11 @@ namespace MWWorld
             const ESM::MagicEffect* effect = getStore().get<ESM::MagicEffect>().find(effectIt->mEffectID);
 
             if ((effectIt->mArea <= 0 && !ignore.isEmpty() && ignore.getClass().isActor()) || effectIt->mRange != rangeType)
+<<<<<<< fe3a033642f21393bc267afa4edcc373c9d5f80b
                 continue; // Not right range type, or not area effect and hit an actor
+=======
+                continue; // Not right range type
+>>>>>>> Use particle texture for "hit" effects
 
             // Spawn the explosion orb effect
             const ESM::Static* areaStatic;

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -369,7 +369,7 @@ namespace NifOsg
             return created;
         }
 
-        void applyNodeProperties(const Nif::Node *nifNode, osg::Node *applyTo, SceneUtil::CompositeStateSetUpdater* composite, Resource::ImageManager* imageManager, std::vector<int>& boundTextures, int animflags, bool isRootNode)
+        void applyNodeProperties(const Nif::Node *nifNode, osg::Node *applyTo, SceneUtil::CompositeStateSetUpdater* composite, Resource::ImageManager* imageManager, std::vector<int>& boundTextures, int animflags)
         {
             const Nif::PropertyList& props = nifNode->props;
             bool foundFirstRootTexturingProperty = false;
@@ -382,7 +382,7 @@ namespace NifOsg
                     // effect "particle texture" is used. For non-root nodes we keep setting until we have the highest
                     // numbered one, which is the one that displays in the game and can be overridden if it matches the
                     // lowest one on the root.
-                    if (!foundFirstRootTexturingProperty && isRootNode && props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
+                    if (!foundFirstRootTexturingProperty && nifNode->parent == NULL && props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
                     {
                         int index = props[i].getPtr()->recIndex;
                         applyTo->setUserValue("overrideIndex", index);  
@@ -651,7 +651,7 @@ namespace NifOsg
 
             osg::ref_ptr<SceneUtil::CompositeStateSetUpdater> composite = new SceneUtil::CompositeStateSetUpdater;
 
-            applyNodeProperties(nifNode, node, composite, imageManager, boundTextures, animflags, node == rootNode);
+            applyNodeProperties(nifNode, node, composite, imageManager, boundTextures, animflags);
 
             if (nifNode->recType == Nif::RC_NiTriShape && !skipMeshes)
             {

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -277,11 +277,13 @@ namespace NifOsg
     public:
         /// @param filename used for warning messages.
         LoaderImpl(const std::string& filename)
-            : mFilename(filename)
+            : mFilename(filename), mFirstRootTextureIndex(-1), mFoundFirstRootTexturingProperty(false)
         {
 
         }
         std::string mFilename;
+        size_t mFirstRootTextureIndex;
+        bool mFoundFirstRootTexturingProperty;
 
         static void loadKf(Nif::NIFFilePtr nif, KeyframeHolder& target)
         {
@@ -372,26 +374,21 @@ namespace NifOsg
         void applyNodeProperties(const Nif::Node *nifNode, osg::Node *applyTo, SceneUtil::CompositeStateSetUpdater* composite, Resource::ImageManager* imageManager, std::vector<int>& boundTextures, int animflags)
         {
             const Nif::PropertyList& props = nifNode->props;
-            bool foundFirstRootTexturingProperty = false;
             for (size_t i = 0; i <props.length(); ++i)
             {
                 if (!props[i].empty())
                 {
-                    // store the recIndex of the NiTexturingProperty. Used for spells when overriding textures.
-                    // Get the lowest numbered one for the root node. This is what is overridden when a spell
-                    // effect "particle texture" is used. For non-root nodes we keep setting until we have the highest
-                    // numbered one, which is the one that displays in the game and can be overridden if it matches the
-                    // lowest one on the root.
-                    if (!foundFirstRootTexturingProperty && nifNode->parent == NULL && props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
+                    // Get the lowest numbered recIndex of the NiTexturingProperty root node.
+                    // This is what is overridden when a spell effect "particle texture" is used.
+                    if (nifNode->parent == NULL && !mFoundFirstRootTexturingProperty && props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
                     {
-                        int index = props[i].getPtr()->recIndex;
-                        applyTo->setUserValue("overrideIndex", index);  
-                        foundFirstRootTexturingProperty = true;
+                        mFirstRootTextureIndex = props[i].getPtr()->recIndex;
+                        mFoundFirstRootTexturingProperty = true;
                     }
                     else if (props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
                     {
-                        int index = props[i].getPtr()->recIndex;
-                        applyTo->setUserValue("NiTexturingPropertyIndex", index);                
+                        if (props[i].getPtr()->recIndex == mFirstRootTextureIndex)
+                            applyTo->setUserValue("overrideFx", 1);                
                     }
                     handleProperty(props[i].getPtr(), applyTo, composite, imageManager, boundTextures, animflags);
                 }              


### PR DESCRIPTION
For https://bugs.openmw.org/issues/3534.

This implements using the particle texture of some spell effects to override the texture.

I tested (I think) all effects in the original engine, and based on that, the following ESM::Statics and ESM::Weapons display differently depending on the particle texture of their magic effect.

VFX_DestructBolt
VFX_DefaultBolt

VFX_DefaultHit
VFX_MysticismHit
VFX_SoulTrapHit

VFX_DefaultArea

VFX_DefaultCast
VFX_ShieldCast

VFX_Hands

Those are implemented in this PR, so this PR works for vanilla game data. However, what seems to really decide whether the texture is used is whether the .NIF file has, directly under the top node, a NITexturingProperty node with a NiSourceTexture node under it defining a texture. I determined this from various tests and looking at the files with NifSkope. It also looks like the original engine only overrides one of these textures, I think maybe the latter one. For example, for e\SoulTrapHit.NIF and e\magic_cast_S.NIF, which both have two NiTexturingProperty nodes with textures under the top node, only part of the effect is overridden by the particle texture.

w\magic_target_myst.NIF has two NiTexturingProperty nodes directly under the top node, but does not seem to show a difference from using the particle texture. Maybe the texture that is being overridden is unused or is hard to notice.

I'm not sure how to determine from the .NIF file whether or which nodes to override with the particle texture, so I'm leaving that for future work or, if scrawl or someone can offer some guidance, maybe it could be put in this PR. The NiTexturingProperty node is unnamed according to NifSkope, and I wasn't able to locate it and override it using SceneUtil::FindByNameVisitor. Also, if we want to override only the latter texture (assuming that is what the original is doing), I'm not sure if FindByNameVisitor is usable for that. 