### PR TITLE
prevent running in circles around path points

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -19,12 +19,15 @@
 #include "actorutil.hpp"
 #include "coordinateconverter.hpp"
 
+#include <osg/Quat>
+
 MWMechanics::AiPackage::~AiPackage() {}
 
 MWMechanics::AiPackage::AiPackage() : 
     mTimer(AI_REACTION_TIME + 1.0f), // to force initial pathbuild
     mIsShortcutting(false),
-    mShortcutProhibited(false), mShortcutFailPos()
+    mShortcutProhibited(false), mShortcutFailPos(),
+    mRotateOnTheRunChecks(0)
 {
 }
 
@@ -104,6 +107,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const ESM::Pathgr
             if (wasShortcutting || doesPathNeedRecalc(dest, actor.getCell())) // if need to rebuild path
             {
                 mPathFinder.buildSyncedPath(start, dest, actor.getCell());
+                mRotateOnTheRunChecks = 3;
 
                 // give priority to go directly on target if there is minimal opportunity
                 if (destInLOS && mPathFinder.getPath().size() > 1)
@@ -143,7 +147,13 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const ESM::Pathgr
     }
     else
     {
-        actor.getClass().getMovementSettings(actor).mPosition[1] = 1; // run to target
+        if (mRotateOnTheRunChecks == 0
+            || isReachableRotatingOnTheRun(actor, *mPathFinder.getPath().begin())) // to prevent circling around a path point
+        {
+            actor.getClass().getMovementSettings(actor).mPosition[1] = 1; // move to the target
+            if (mRotateOnTheRunChecks > 0) mRotateOnTheRunChecks--;
+        }
+
         // handle obstacles on the way
         evadeObstacles(actor, duration, pos);
     }
@@ -291,4 +301,33 @@ bool MWMechanics::AiPackage::isNearInactiveCell(const ESM::Position& actorPos)
     {
         return false;
     }
+}
+
+bool MWMechanics::AiPackage::isReachableRotatingOnTheRun(const MWWorld::Ptr& actor, const ESM::Pathgrid::Point& dest)
+{
+    // get actor's shortest radius for moving in circle
+    float speed = actor.getClass().getSpeed(actor);
+    speed += speed * 0.1f; // 10% real speed inaccuracy
+    float radius = speed / MAX_VEL_ANGULAR_RADIANS;
+
+    // get radius direction to the center
+    const float* rot = actor.getRefData().getPosition().rot;
+    osg::Quat quatRot(rot[0], -osg::X_AXIS, rot[1], -osg::Y_AXIS, rot[2], -osg::Z_AXIS);
+    osg::Vec3f dir = quatRot * osg::Y_AXIS; // actor's orientation direction is a tangent to circle
+    osg::Vec3f radiusDir = dir ^ osg::Z_AXIS; // radius is perpendicular to a tangent
+    radiusDir.normalize();
+    radiusDir *= radius;
+    
+    // pick up the nearest center candidate
+    osg::Vec3f dest_ = PathFinder::MakeOsgVec3(dest);
+    osg::Vec3f pos = actor.getRefData().getPosition().asVec3();
+    osg::Vec3f center1 = pos - radiusDir;
+    osg::Vec3f center2 = pos + radiusDir;
+    osg::Vec3f center = (center1 - dest_).length2() < (center2 - dest_).length2() ? center1 : center2;
+
+    float distToDest = (center - dest_).length();
+
+    // if pathpoint is reachable for the actor rotating on the run:
+    // no points of actor's circle should be farther from the center than destination point
+    return (radius <= distToDest);
 }

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -97,6 +97,9 @@ namespace MWMechanics
 
             bool isTargetMagicallyHidden(const MWWorld::Ptr& target);
 
+            /// Return if actor's rotation speed is sufficient to rotate to the destination pathpoint on the run. Otherwise actor should rotate while standing.
+            static bool isReachableRotatingOnTheRun(const MWWorld::Ptr& actor, const ESM::Pathgrid::Point& dest);
+
         protected:
             /// Handles path building and shortcutting with obstacles avoiding
             /** \return If the actor has arrived at his destination **/
@@ -122,6 +125,8 @@ namespace MWMechanics
             float mTimer;
 
             osg::Vec3f mLastActorPos;
+
+            short mRotateOnTheRunChecks; // attempts to check rotation to the pathpoint on the run possibility
 
             bool mIsShortcutting;   // if shortcutting at the moment
             bool mShortcutProhibited; // shortcutting may be prohibited after unsuccessful attempt


### PR DESCRIPTION
Basically circling around a pathpoint happens rarely. But recently the problem was observed again in the quest of escorting Itermerel due to his high running speed. Easiest way to watch this is by downloading the save
https://github.com/OpenMW/openmw/files/456674/Test.zip (provided by Allofich [here](https://github.com/OpenMW/openmw/pull/1048#issuecomment-244936686)). Note: may require to load more than once to observe.

So I wrote a function which checks beforehand if circling will occur (the more speed actor has the more probability that it will happen). This function also minimizes any unnecessary possible loops around pathpoints when reaching them.
Explanation how the `isReachableRotatingOnTheRun` works:
![can_rotate_on_the_run](https://cloud.githubusercontent.com/assets/6162466/18412546/0efd356a-779a-11e6-86e7-61578b4e3c94.png) 
_On the left: running in circles will happen, on the right: no_
P - actor's position
dir - actor's orientation/looking direction
D - destination pathpoint (has a smaller circle around, radius = 32 (`PathTolerance`))
C - center of actor's smallest moving circle (depends on his speed; bigger circle, radius = 53 for Itermerel)
So if function returns false - then actor is not moving while continues to rotate to the pathpoint. When orientation is sufficient for actor to be able to rotate in time then he starts to move. If actor's speed is not as high as e.g. Itermerel's, then the old behaviour is preserved - actor rotates on the run.

@scrawl 
I have some doubts though: why do we use negative axes to determine actor's orientation (https://github.com/OpenMW/openmw/blob/master/apps/openmw/mwworld/scene.cpp#L46)? Is that because of our angles vs OSG ones clockwise / counter-clockwise mismatch?
I managed to get correct results only with negative axes.