### PR TITLE
Fix animation state not saving in some cases

### DIFF
--- a/apps/openmw/mwworld/refdata.cpp
+++ b/apps/openmw/mwworld/refdata.cpp
@@ -238,7 +238,7 @@ namespace MWWorld
 
     bool RefData::hasChanged() const
     {
-        return mChanged;
+        return mChanged || !mAnimationState.empty();
     }
 
     bool RefData::activate()

--- a/components/esm/animationstate.cpp
+++ b/components/esm/animationstate.cpp
@@ -5,6 +5,11 @@
 
 namespace ESM
 {
+    bool AnimationState::empty() const
+    {
+        return mScriptedAnims.empty();
+    }
+
     void AnimationState::load(ESMReader& esm)
     {
         mScriptedAnims.clear();

--- a/components/esm/animationstate.hpp
+++ b/components/esm/animationstate.hpp
@@ -26,6 +26,8 @@ namespace ESM
         typedef std::vector<ScriptedAnimation> ScriptedAnimations;
         ScriptedAnimations mScriptedAnims;
 
+        bool empty() const;
+
         void load(ESMReader& esm);
         void save(ESMWriter& esm) const;
     };


### PR DESCRIPTION
References with animation state changed but otherwise identical to their content file counterparts
were previously considered unchanged and thus dropped while saving.