### PR TITLE
Drain and Fortify fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     Bug #2862: [macOS] Can't quit launcher using Command-Q or OpenMW->Quit
     Bug #2872: Tab completion in console doesn't work with explicit reference
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
+    Bug #3049: Drain and Fortify effects are not properly applied on health, magicka and fatigue
     Bug #3249: Fixed revert function not updating views properly
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3486: [Mod] NPC Commands does not work
@@ -33,6 +34,7 @@
     Bug #4215: OpenMW shows book text after last EOL tag
     Bug #4221: Characters get stuck in V-shaped terrain
     Bug #4230: AiTravel package issues break some Tribunal quests
+    Bug #4231: Infected rats from the "Crimson Plague" quest rendered unconscious by change in Drain Fatigue functionality
     Bug #4251: Stationary NPCs do not return to their position after combat
     Bug #4274: Pre-0.43 death animations are not forward-compatible with 0.43+
     Bug #4286: Scripted animations can be interrupted

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -546,7 +546,7 @@ namespace MWMechanics
         float diff = (static_cast<int>(magickaFactor*intelligence)) - magicka.getBase();
         float currentToBaseRatio = (magicka.getCurrent() / magicka.getBase());
         magicka.setModified(magicka.getModified() + diff, 0);
-        magicka.setCurrent(magicka.getBase() * currentToBaseRatio);
+        magicka.setCurrent(magicka.getBase() * currentToBaseRatio, false, true);
         creatureStats.setMagicka(magicka);
     }
 
@@ -577,8 +577,14 @@ namespace MWMechanics
         float normalizedEncumbrance = ptr.getClass().getNormalizedEncumbrance(ptr);
         if (normalizedEncumbrance > 1)
             normalizedEncumbrance = 1;
+ 
+        // Current fatigue can be above base value due to a fortify effect.
+        // In that case stop here and don't try to restore.
+        DynamicStat<float> fatigue = stats.getFatigue();
+        if (fatigue.getCurrent() >= fatigue.getBase())
+            return;
 
-        // restore fatigue
+        // Restore fatigue
         float fFatigueReturnBase = settings.find("fFatigueReturnBase")->getFloat ();
         float fFatigueReturnMult = settings.find("fFatigueReturnMult")->getFloat ();
         float fEndFatigueMult = settings.find("fEndFatigueMult")->getFloat ();
@@ -586,7 +592,6 @@ namespace MWMechanics
         float x = fFatigueReturnBase + fFatigueReturnMult * (1 - normalizedEncumbrance);
         x *= fEndFatigueMult * endurance;
 
-        DynamicStat<float> fatigue = stats.getFatigue();
         fatigue.setCurrent (fatigue.getCurrent() + 3600 * x);
         stats.setFatigue (fatigue);
     }
@@ -598,16 +603,20 @@ namespace MWMechanics
 
         MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats (ptr);
 
-        int endurance = stats.getAttribute (ESM::Attribute::Endurance).getModified ();
+        // Current fatigue can be above base value due to a fortify effect.
+        // In that case stop here and don't try to restore.
+        DynamicStat<float> fatigue = stats.getFatigue();
+        if (fatigue.getCurrent() >= fatigue.getBase())
+            return;
 
-        // restore fatigue
+        // Restore fatigue
+        int endurance = stats.getAttribute(ESM::Attribute::Endurance).getModified();
         const MWWorld::Store<ESM::GameSetting>& settings = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
         static const float fFatigueReturnBase = settings.find("fFatigueReturnBase")->getFloat ();
         static const float fFatigueReturnMult = settings.find("fFatigueReturnMult")->getFloat ();
 
         float x = fFatigueReturnBase + fFatigueReturnMult * endurance;
 
-        DynamicStat<float> fatigue = stats.getFatigue();
         fatigue.setCurrent (fatigue.getCurrent() + duration * x);
         stats.setFatigue (fatigue);
     }
@@ -723,7 +732,7 @@ namespace MWMechanics
         for(int i = 0;i < 3;++i)
         {
             DynamicStat<float> stat = creatureStats.getDynamic(i);
-            stat.setModifier(effects.get(ESM::MagicEffect::FortifyHealth+i).getMagnitude() -
+            stat.setCurrentModifier(effects.get(ESM::MagicEffect::FortifyHealth+i).getMagnitude() -
                              effects.get(ESM::MagicEffect::DrainHealth+i).getMagnitude(),
                              // Magicka can be decreased below zero due to a fortify effect wearing off
                              // Fatigue can be decreased below zero meaning the actor will be knocked out

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -697,6 +697,19 @@ namespace MWMechanics
             }
         }
 
+        // dynamic stats
+        for (int i = 0; i < 3; ++i)
+        {
+            DynamicStat<float> stat = creatureStats.getDynamic(i);
+            stat.setCurrentModifier(effects.get(ESM::MagicEffect::FortifyHealth + i).getMagnitude() -
+                effects.get(ESM::MagicEffect::DrainHealth + i).getMagnitude(),
+                // Magicka can be decreased below zero due to a fortify effect wearing off
+                // Fatigue can be decreased below zero meaning the actor will be knocked out
+                i == 1 || i == 2);
+
+            creatureStats.setDynamic(i, stat);
+        }
+
         // attributes
         for(int i = 0;i < ESM::Attribute::Length;++i)
         {
@@ -726,19 +739,6 @@ namespace MWMechanics
                     }
                 }
             }
-        }
-
-        // dynamic stats
-        for(int i = 0;i < 3;++i)
-        {
-            DynamicStat<float> stat = creatureStats.getDynamic(i);
-            stat.setCurrentModifier(effects.get(ESM::MagicEffect::FortifyHealth+i).getMagnitude() -
-                             effects.get(ESM::MagicEffect::DrainHealth+i).getMagnitude(),
-                             // Magicka can be decreased below zero due to a fortify effect wearing off
-                             // Fatigue can be decreased below zero meaning the actor will be knocked out
-                             i == 1 || i == 2);
-
-            creatureStats.setDynamic(i, stat);
         }
 
         // AI setting modifiers

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -195,6 +195,7 @@ namespace MWMechanics
             mDead = true;
 
             mDynamic[index].setModifier(0);
+            mDynamic[index].setCurrentModifier(0);
             mDynamic[index].setCurrent(0);
 
             if (MWBase::Environment::get().getWorld()->getGodModeState())

--- a/apps/openmw/mwmechanics/stat.hpp
+++ b/apps/openmw/mwmechanics/stat.hpp
@@ -17,6 +17,7 @@ namespace MWMechanics
     {
             T mBase;
             T mModified;
+            T mCurrentModified;
 
         public:
             typedef T Type;
@@ -28,7 +29,9 @@ namespace MWMechanics
             const T& getBase() const;
 
             T getModified() const;
+            T getCurrentModified() const;
             T getModifier() const;
+            T getCurrentModifier() const;
 
             /// Set base and modified to \a value.
             void set (const T& value);
@@ -36,9 +39,15 @@ namespace MWMechanics
             /// Set base and adjust modified accordingly.
             void setBase (const T& value);
 
-            /// Set modified value an adjust base accordingly.
+            /// Set modified value and adjust base accordingly.
             void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max());
+
+            /// Set "current modified," used for drain and fortify. Unlike the regular modifier
+            /// this just adds and subtracts from the current value without changing the maximum.
+            void setCurrentModified(T value);
+
             void setModifier (const T& modifier);
+            void setCurrentModifier (const T& modifier);
 
             void writeState (ESM::StatState<T>& state) const;
             void readState (const ESM::StatState<T>& state);
@@ -73,6 +82,7 @@ namespace MWMechanics
 
             const T& getBase() const;
             T getModified() const;
+            T getCurrentModified() const;
             const T& getCurrent() const;
 
             /// Set base, modified and current to \a value.
@@ -81,11 +91,16 @@ namespace MWMechanics
             /// Set base and adjust modified accordingly.
             void setBase (const T& value);
 
-            /// Set modified value an adjust base accordingly.
+            /// Set modified value and adjust base accordingly.
             void setModified (T value, const T& min, const T& max = std::numeric_limits<T>::max());
 
-            void setCurrent (const T& value, bool allowDecreaseBelowZero = false);
-            void setModifier (const T& modifier, bool allowCurrentDecreaseBelowZero=false);
+            /// Set "current modified," used for drain and fortify. Unlike the regular modifier
+            /// this just adds and subtracts from the current value without changing the maximum.
+            void setCurrentModified(T value);
+
+            void setCurrent (const T& value, bool allowDecreaseBelowZero = false, bool allowIncreaseAboveModified = false);
+            void setModifier (const T& modifier, bool allowCurrentToDecreaseBelowZero=false);
+            void setCurrentModifier (const T& modifier, bool allowCurrentToDecreaseBelowZero = false);
 
             void writeState (ESM::StatState<T>& state) const;
             void readState (const ESM::StatState<T>& state);

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -261,6 +261,7 @@ namespace MWScript
                         .getDynamic (mIndex));
 
                     stat.setModified (diff + stat.getModified(), 0);
+                    stat.setCurrentModified (diff + stat.getCurrentModified());
 
                     stat.setCurrent (diff + current);
 


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3049, https://bugs.openmw.org/issues/2796 and https://bugs.openmw.org/issues/2680.

Adds a new variable mDrainAndFortifyModifier to the health, magicka and fatigue stats, which is used to track the sum of drain and fortify modifiers, which are applied to the current values, rather than the modified values as they are now.

This new variable could be saved in saved games. Instead, right now when a game is loaded I set it to a value that would never be used to indicate that a saved game was just loaded and the variable should be updated to the correct value once without applying the modifiers.

I also took out some unnecessary processing on dead actors. Otherwise the drained/fortified modifiers would be reversed on character death (since the effects were done), and show a positive health if the player opened the inventory during the death animation after dying from a drain effect.

Note that if the code from this PR is used on an existing saved game, any drain and fortify effects should be removed first or else the stats won't be correct.
