### PR TITLE
Use correct vfx for teleport spells

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -646,14 +646,28 @@ namespace MWMechanics
             if (target != getPlayer())
                 return false;
 
+            MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
+
             if (effectId == ESM::MagicEffect::DivineIntervention)
             {
                 MWBase::Environment::get().getWorld()->teleportToClosestMarker(target, "divinemarker");
+                anim->removeEffect(ESM::MagicEffect::DivineIntervention);
+                const ESM::Static* fx = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>()
+                    .search("VFX_Summon_end");
+                if (fx)
+                    MWBase::Environment::get().getWorld()->spawnEffect("meshes\\" + fx->mModel,
+                        "", mCaster.getRefData().getPosition().asVec3());
                 return true;
             }
             else if (effectId == ESM::MagicEffect::AlmsiviIntervention)
             {
                 MWBase::Environment::get().getWorld()->teleportToClosestMarker(target, "templemarker");
+                anim->removeEffect(ESM::MagicEffect::AlmsiviIntervention);
+                const ESM::Static* fx = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>()
+                    .search("VFX_Summon_end");
+                if (fx)
+                    MWBase::Environment::get().getWorld()->spawnEffect("meshes\\" + fx->mModel,
+                        "", mCaster.getRefData().getPosition().asVec3());
                 return true;
             }
 
@@ -674,6 +688,7 @@ namespace MWMechanics
                     MWWorld::ActionTeleport action(markedCell->isExterior() ? "" : markedCell->getCell()->mName,
                                             markedPosition, false);
                     action.execute(target);
+                    anim->removeEffect(ESM::MagicEffect::Recall);
                 }
                 return true;
             }


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/2048.

Recreates following behavior observed from original game
1. Divine and Almsivi Intervention remove the spell's "on hit" vfx on the player after teleporting and create a scale 1.0 "VFX_Summon_end" at the post-teleport position of the player. The VFX_Summon_end is stationary and does not follow the player.
2. Recall removes the spell's "on hit" vfx on the player after teleporting but does not add any effects post-teleport. If no Mark spell has been cast, the spell plays the on hit vfx on the player like a normal spell and doesn't do anything. This is also what happens if an NPC casts Recall, Almsivi or Divine Intervention.