### PR TITLE
Add unarmed attack selection to chooseBestAttack()

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -362,9 +362,9 @@ namespace MWMechanics
             }
         }
 
-        // Original engine behavior seems to be to back up during ranged combat
-        // according to fCombatDistance or opponent's weapon range, unless opponent
-        // is also using a ranged weapon
+        // Below behavior for backing up during ranged combat differs from vanilla.
+        // Vanilla is observed as backing up only as far as fCombatDistance or
+        // opponent's weapon range, or not backing up if opponent is also using a ranged weapon
         if (isDistantCombat && distToTarget < rangeAttack / 4)
         {
             mMovement.mPosition[1] = -1;
@@ -468,6 +468,8 @@ std::string chooseBestAttack(const ESM::Weapon* weapon)
         else
             attackType = "chop";
     }
+    else
+        MWMechanics::CharacterController::setAttackTypeRandomly(attackType);
 
     return attackType;
 }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1312,9 +1312,9 @@ bool CharacterController::updateWeaponState()
                     mAttackType = "shoot";
                 else
                 {
-                    if (isWeapon)
+                    if(mPtr == getPlayer())
                     {
-                        if(mPtr == getPlayer())
+                        if (isWeapon)
                         {
                             if (Settings::Manager::getBool("best attack", "Game"))        
                             {
@@ -1324,10 +1324,10 @@ bool CharacterController::updateWeaponState()
                             else
                                 setAttackTypeBasedOnMovement();
                         }
-                        // else if (mPtr != getPlayer()) use mAttackType already set by AiCombat
+                        else
+                            setAttackTypeRandomly(mAttackType);                       
                     }
-                    else
-                        setAttackTypeRandomly();
+                    // else if (mPtr != getPlayer()) use mAttackType set by AiCombat
                 }
 
                 mAnimation->play(mCurrentWeapon, priorityWeapon,
@@ -2188,17 +2188,6 @@ void CharacterController::updateMagicEffects()
     mAnimation->setLightEffect(light);
 }
 
-void CharacterController::setAttackTypeRandomly()
-{
-    float random = Misc::Rng::rollProbability();
-    if (random >= 2/3.f)
-        mAttackType = "thrust";
-    else if (random >= 1/3.f)
-        mAttackType = "slash";
-    else
-        mAttackType = "chop";
-}
-
 void CharacterController::setAttackTypeBasedOnMovement()
 {
     float *move = mPtr.getClass().getMovementSettings(mPtr).mPosition;
@@ -2238,6 +2227,17 @@ void CharacterController::setAttackingOrSpell(bool attackingOrSpell)
 void CharacterController::setAIAttackType(std::string attackType)
 {
     mAttackType = attackType;
+}
+
+void CharacterController::setAttackTypeRandomly(std::string& attackType)
+{
+    float random = Misc::Rng::rollProbability();
+    if (random >= 2/3.f)
+        attackType = "thrust";
+    else if (random >= 1/3.f)
+        attackType = "slash";
+    else
+        attackType = "chop";
 }
 
 bool CharacterController::readyToPrepareAttack() const

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -198,7 +198,6 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     bool mAttackingOrSpell;
 
     void setAttackTypeBasedOnMovement();
-    void setAttackTypeRandomly();
 
     void refreshCurrentAnims(CharacterState idle, CharacterState movement, JumpingState jump, bool force=false);
     void refreshHitRecoilAnims();
@@ -270,6 +269,7 @@ public:
 
     void setAttackingOrSpell(bool attackingOrSpell);
     void setAIAttackType(std::string attackType); // set and used by AiCombat
+    static void setAttackTypeRandomly(std::string& attackType);
 
     bool readyToPrepareAttack() const;
     bool readyToStartAttack() const;


### PR DESCRIPTION
Fixes the animation error mentioned in https://github.com/OpenMW/openmw/pull/1048. You can use the attached save game there to test.

I don't have a good understanding of the AI combat routines, so I'm not sure whether this is the best way to fix this issue, and perhaps @mrcheko or @scrawl would like to offer a different solution.

I have only seen the animation problem mentioned in the other PR with NPCs using bound weapons. I think what might have been happening is that the ESM::Weapon pointer being passed to chooseBestAttack() was inaccurate (pointing to a no longer equipped weapon? emptied?) because the weapon changed due to a bound weapon spell. The problem doesn't always occur, so it might be tied to something like an animation being interrupted by a hit or a spell casting, etc. I addressed the problem by getting the weapon from the active weapon slot immediately before calling chooseBestAttack(), to be sure the weapon pointer is accurate.

I also noticed that MSVC was giving a warning about chooseBestAttack() not giving a return value in the case of a NULL weapon, so to silence that I added random attack selection for that case instead of relying on the random attack selection in the character controller. Adding this in actually would have masked this animation problem, though. I verified that this PR fixes the animation problem through updating the weapon pointer, not through the random attack selection.