### PR TITLE
Remove psuedonym from AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,7 +17,7 @@ Programmers
     aegis
     Aleksandar Jovanov
     Alex Haddad (rainChu)
-    Alex McKibben (WeirdSexy)
+    Alex McKibben
     alexanderkjall
     Alexander Nadeau (wareya)
     Alexander Olofsson (Ace)
@@ -159,7 +159,6 @@ Packagers
 Public Relations and Translations
 ---------------------------------
 
-    Alex McKibben (WeirdSexy) - Podcaster
     Artem Kotsynyak (greye) - Russian News Writer
     Jim Clauwaert (Zedd) - Public Outreach
     Julien Voisin (jvoisin/ap0) - French News Writer


### PR DESCRIPTION
Removed myself from public relations as podcaster as well. Someone else is doing that now.

I doubt this file is very up-to-date anyway, heh.