### PR TITLE
Don't play area vfx for 0-area touch spells that hit non-actors

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3176,7 +3176,8 @@ namespace MWWorld
 
             if (effectIt->mArea <= 0)
             {
-                mRendering->spawnEffect("meshes\\" + areaStatic->mModel, texture, origin, 1.0f);
+                if (effectIt->mRange == ESM::RT_Target)
+                    mRendering->spawnEffect("meshes\\" + areaStatic->mModel, texture, origin, 1.0f);
                 continue;
             }
             else


### PR DESCRIPTION
I noticed this problem while working on https://github.com/OpenMW/openmw/pull/1072. "On touch" spells with area 0 are playing their area effect when cast on non-actors. This is due to my earlier PR https://github.com/OpenMW/openmw/pull/1049/files.