### PR TITLE
Implement using telekinesis with touch spells

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3187,6 +3187,9 @@ namespace MWWorld
             if (effectIt->mRange != rangeType || (effectIt->mArea <= 0 && !ignore.isEmpty() && ignore.getClass().isActor()))
                 continue; // Not right range type, or not area effect and hit an actor
 
+            if (effectIt->mRange == ESM::RT_Touch && (!ignore.isEmpty()) && (!ignore.getClass().isActor() && !ignore.getClass().canBeActivated(ignore)))
+                continue; // Don't play explosion for touch spells on non-activatable objects
+
             // Spawn the explosion orb effect
             const ESM::Static* areaStatic;
             if (!effect->mArea.empty())

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1020,12 +1020,7 @@ namespace MWWorld
             facedObject = getFacedObject(getMaxActivationDistance() * 50, false);
         else
         {
-            float telekinesisRangeBonus =
-                    mPlayer->getPlayer().getClass().getCreatureStats(mPlayer->getPlayer()).getMagicEffects()
-                    .get(ESM::MagicEffect::Telekinesis).getMagnitude();
-            telekinesisRangeBonus = feetToGameUnits(telekinesisRangeBonus);
-
-            float activationDistance = getMaxActivationDistance() + telekinesisRangeBonus;
+            float activationDistance = getActivationDistancePlusTelekinesis();
 
             facedObject = getFacedObject(activationDistance, true);
 
@@ -2642,7 +2637,7 @@ namespace MWWorld
 
         // Get the target to use for "on touch" effects, using the facing direction from Head node
         MWWorld::Ptr target;
-        float distance = getMaxActivationDistance();
+        float distance = getActivationDistancePlusTelekinesis();
 
         osg::Vec3f hitPosition = actor.getRefData().getPosition().asVec3();
         osg::Vec3f origin = getActorHeadTransform(actor).getTrans();
@@ -2674,11 +2669,15 @@ namespace MWWorld
         {
             target = result1.mHitObject;
             hitPosition = result1.mHitPos;
+            if (!target.isEmpty() && dist1 > getMaxActivationDistance() && !target.getClass().allowTelekinesis(target))
+            target = NULL;
         }
         else if (result2.mHit)
         {
             target = result2.mHitObject;
             hitPosition = result2.mHitPointWorld;
+            if (!target.isEmpty() && dist2 > getMaxActivationDistance() && !target.getClass().allowTelekinesis(target))
+            target = NULL;
         }
 
         // When targeting an actor that is in combat with an "on touch" spell, 
@@ -3009,6 +3008,18 @@ namespace MWWorld
         // Looks like there is no GMST for this. This factor was determined in experiments
         // with the Telekinesis effect.
         return feet * 22;
+    }
+
+    float World::getActivationDistancePlusTelekinesis()
+    {
+        float telekinesisRangeBonus =
+                    mPlayer->getPlayer().getClass().getCreatureStats(mPlayer->getPlayer()).getMagicEffects()
+                    .get(ESM::MagicEffect::Telekinesis).getMagnitude();
+        telekinesisRangeBonus = feetToGameUnits(telekinesisRangeBonus);
+
+        float activationDistance = getMaxActivationDistance() + telekinesisRangeBonus;
+
+        return activationDistance;
     }
 
     MWWorld::Ptr World::getPlayerPtr()

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2669,15 +2669,15 @@ namespace MWWorld
         {
             target = result1.mHitObject;
             hitPosition = result1.mHitPos;
-            if (!target.isEmpty() && dist1 > getMaxActivationDistance() && !target.getClass().allowTelekinesis(target))
-            target = NULL;
+            if (dist1 > getMaxActivationDistance() && !target.isEmpty() && (target.getClass().isActor() || !target.getClass().canBeActivated(target)))
+                target = NULL;
         }
         else if (result2.mHit)
         {
             target = result2.mHitObject;
             hitPosition = result2.mHitPointWorld;
-            if (!target.isEmpty() && dist2 > getMaxActivationDistance() && !target.getClass().allowTelekinesis(target))
-            target = NULL;
+            if (dist2 > getMaxActivationDistance() && !target.isEmpty() && (target.getClass().isActor() || !target.getClass().canBeActivated(target)))
+                target = NULL;
         }
 
         // When targeting an actor that is in combat with an "on touch" spell, 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -168,6 +168,7 @@ namespace MWWorld
             int mDaysInPrison;
 
             float feetToGameUnits(float feet);
+            float getActivationDistancePlusTelekinesis();
 
             MWWorld::ConstPtr getClosestMarker( const MWWorld::Ptr &ptr, const std::string &id );
             MWWorld::ConstPtr getClosestMarkerFromExteriorPosition( const osg::Vec3f& worldPos, const std::string &id );


### PR DESCRIPTION
For https://bugs.openmw.org/issues/3560.

In original Morrowind, when telekinesis is active you can use touch spells on things effected by telekinesis. In practice, this means you can use the "Lock" and "Open" touch spells at range by combining them with telekinesis.

This opened up another small issue, in that it would allow combining telekinesis with area effect explosions from touch spells to remotely hit NPCs by casting on nearby objects. While it might be a kind of interesting gameplay mechanic, original Morrowind seems to intentionally not allow this. In original Morrowind, if you cast a touch spell with an area explosion on an non-actor object, normally the game does play a silent explosion effect. This silent explosion also happens if you combine a touch spell with telekinesis. But it won't create the explosion if its near an NPC, so you can't, as far as I can see, use telekinesis to remotely explode touch spells and hit NPCs with the area damage.

We could put in this exception but the silent explosions are odd anyway and have no gameplay use it would seem. For now at least, I just took out touch effects causing an explosion in OpenMW unless they are used on an actor.