### PR TITLE
Flavor Text support

### DIFF
--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -330,6 +330,8 @@ namespace CSMWorld
             { ColumnId_WeatherName, "Type" },
             { ColumnId_WeatherChance, "Percent Chance" },
 
+            { ColumnId_FlavorText, "Flavor Text" },
+
             { ColumnId_UseValue1, "Use value 1" },
             { ColumnId_UseValue2, "Use value 2" },
             { ColumnId_UseValue3, "Use value 3" },

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -329,6 +329,8 @@ namespace CSMWorld
             ColumnId_WeatherName = 295,
             ColumnId_WeatherChance = 296,
 
+            ColumnId_FlavorText = 297,
+
             // Allocated to a separate value range, so we don't get a collision should we ever need
             // to extend the number of use values.
             ColumnId_UseValue1 = 0x10000,

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -247,6 +247,7 @@ namespace CSMWorld
         const RefIdColumn *mIcon;
         const RefIdColumn *mWeight;
         const RefIdColumn *mValue;
+        const RefIdColumn *mFlavorText;
 
         InventoryColumns (const NameColumns& base) : NameColumns (base) {}
     };
@@ -291,6 +292,9 @@ namespace CSMWorld
         if (column==mInventory.mValue)
             return record.get().mData.mValue;
 
+        if (column==mInventory.mFlavorText)
+            return QString::fromUtf8 (record.get().mFlavorText.c_str());
+
         return NameRefIdAdapter<RecordT>::getData (column, data, index);
     }
 
@@ -308,6 +312,8 @@ namespace CSMWorld
             record2.mData.mWeight = value.toFloat();
         else if (column==mInventory.mValue)
             record2.mData.mValue = value.toInt();
+        else if (column==mInventory.mFlavorText)
+            record2.mFlavorText = value.toString().toUtf8().constData();
         else
         {
             NameRefIdAdapter<RecordT>::setData (column, data, index, value);

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -70,6 +70,8 @@ CSMWorld::RefIdCollection::RefIdCollection()
     inventoryColumns.mWeight = &mColumns.back();
     mColumns.push_back (RefIdColumn (Columns::ColumnId_CoinValue, ColumnBase::Display_Integer));
     inventoryColumns.mValue = &mColumns.back();
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_FlavorText, ColumnBase::Display_LongString));
+    inventoryColumns.mFlavorText = &mColumns.back();
 
     IngredientColumns ingredientColumns (inventoryColumns);
     mColumns.push_back (RefIdColumn (Columns::ColumnId_EffectList,

--- a/apps/openmw/mwclass/apparatus.cpp
+++ b/apps/openmw/mwclass/apparatus.cpp
@@ -109,6 +109,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
         text += "\n#{sQuality}: " + MWGui::ToolTips::toString(ref->mBase->mData.mQuality);

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -216,6 +216,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/book.cpp
+++ b/apps/openmw/mwclass/book.cpp
@@ -123,6 +123,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -172,6 +172,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -122,6 +122,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -154,6 +154,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -119,6 +119,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -150,6 +150,7 @@ namespace MWClass
 
         info.caption = ref->mBase->mName + countString;
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         if (ref->mRef.getSoul() != "")
         {

--- a/apps/openmw/mwclass/potion.cpp
+++ b/apps/openmw/mwclass/potion.cpp
@@ -114,6 +114,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -119,6 +119,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/repair.cpp
+++ b/apps/openmw/mwclass/repair.cpp
@@ -122,6 +122,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         std::string text;
 

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -256,6 +256,7 @@ namespace MWClass
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
         info.icon = ref->mBase->mIcon;
+        info.flavorText = ref->mBase->mFlavorText;
 
         const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -56,6 +56,7 @@ namespace MWGui
         mRemainingDelay = mDelay;
         mFlavorDelay = Settings::Manager::getFloat("tooltip flavor delay", "GUI");
         mRemainingFlavorDelay = mDelay+mFlavorDelay;
+        mFlavorWidth = Settings::Manager::getInt("tooltip flavor width", "GUI");
 
         for (unsigned int i=0; i < mMainWidget->getChildCount(); ++i)
         {
@@ -569,7 +570,6 @@ namespace MWGui
 
         if(showFlavorText && info.flavorText != "")
         {
-            const int flavorTextWidth = 300;
             const int flavorTextMargin = 4; // space between general tooltip and flavor text tooltip
 
             MyGUI::Widget* toolTipFlavorWidget = mDynamicToolTipBox->createWidget<MyGUI::Widget>("Widget",
@@ -577,16 +577,16 @@ namespace MWGui
             toolTipFlavorWidget->changeWidgetSkin(boxSkin);
 
             MyGUI::EditBox* flavorText = toolTipFlavorWidget->createWidget<MyGUI::EditBox>("SandText",
-                MyGUI::IntCoord(padding.left, padding.top, flavorTextWidth-padding.left*2, viewportSize.height), MyGUI::Align::Default, "ToolTipFlavorText");
+                MyGUI::IntCoord(padding.left, padding.top, mFlavorWidth-padding.left*2, viewportSize.height), MyGUI::Align::Default, "ToolTipFlavorText");
             flavorText->setProperty("MultiLine", "true");
             flavorText->setProperty("WordWrap", "true");
             flavorText->setProperty("TextAlign", "Left Top");
             flavorText->setCaptionWithReplacing(info.flavorText);
             flavorText->setSize(flavorText->getTextSize()); // set height of EditBox to height of text
-            toolTipFlavorWidget->setSize(MyGUI::IntSize(flavorTextWidth, flavorText->getTextSize().height+padding.top*2));
+            toolTipFlavorWidget->setSize(MyGUI::IntSize(mFlavorWidth, flavorText->getTextSize().height+padding.top*2));
 
             // update total tooltip size
-            totalSize.width += flavorTextWidth+flavorTextMargin;
+            totalSize.width += mFlavorWidth+flavorTextMargin;
             totalSize.height = std::max(totalSize.height, toolTipFlavorWidget->getHeight());
 
             // move widget to different sides depending on where is the most free space
@@ -600,10 +600,10 @@ namespace MWGui
 
             if(toolTipWidget->getHeight() < toolTipFlavorWidget->getHeight())
             {
-                // if bottom cut
+                // if bottom cut, move up
                 if( (tooltipPosition.top + toolTipFlavorWidget->getHeight()) > viewportSize.height )
                     toolTipWidgetPos.top = (tooltipPosition.top + toolTipFlavorWidget->getHeight()) - viewportSize.height;
-                // if top cut
+                // if top cut, move down
                 if( (tooltipPosition.top - toolTipWidgetPos.top) < 0 )
                     toolTipWidgetPos.top = tooltipPosition.top;
             }

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -558,7 +558,7 @@ namespace MWGui
 
         totalSize += MyGUI::IntSize(padding.left*2, padding.top*2);
 
-        // make sure that scratched text doesn't overflow out of widget (into flavor text)
+        // make sure that stretched text doesn't overflow out of widget (into flavor text)
         toolTipWidget->setSize(totalSize);
 
         // get default tooltip position
@@ -567,7 +567,7 @@ namespace MWGui
         MyGUI::IntPoint tooltipPosition = MyGUI::IntPoint(mousePos.left, mousePos.top);
         position(tooltipPosition, totalSize, viewportSize);
 
-        if(mRemainingFlavorDelay <= 0 && (info.flavorText != "" || true))
+        if(mRemainingFlavorDelay <= 0 && info.flavorText != "")
         {
             const int flavorTextWidth = 300;
             const int flavorTextMargin = 4; // space between general tooltip and flavor text tooltip
@@ -581,7 +581,7 @@ namespace MWGui
             flavorText->setProperty("MultiLine", "true");
             flavorText->setProperty("WordWrap", "true");
             flavorText->setProperty("TextAlign", "Left Top");
-            flavorText->setCaptionWithReplacing("Daedric weapons are made from raw ebony which has been refined using the craft and magical substances of the lesser minions of Oblivion. The process is not a pleasant one for the Daedra involved, and the weapons retain echoes of preternaturally prolonged suffering endured during manufacture. Daedric weapons are the most rare and expensive weapons known in Tamriel. \n#{setting=GUI,color crosshair owned}");
+            flavorText->setCaptionWithReplacing(info.flavorText);
             flavorText->setSize(flavorText->getTextSize()); // set height of EditBox to height of text
             toolTipFlavorWidget->setSize(MyGUI::IntSize(flavorTextWidth, flavorText->getTextSize().height+padding.top*2));
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -35,6 +35,8 @@ namespace MWGui
         , mHorizontalScrollIndex(0)
         , mDelay(0.0)
         , mRemainingDelay(0.0)
+        , mFlavorDelay(0.0)
+        , mRemainingFlavorDelay(0.0)
         , mLastMouseX(0)
         , mLastMouseY(0)
         , mEnabled(true)
@@ -52,12 +54,14 @@ namespace MWGui
 
         mDelay = Settings::Manager::getFloat("tooltip delay", "GUI");
         mRemainingDelay = mDelay;
+        mFlavorDelay = Settings::Manager::getFloat("tooltip flavor delay", "GUI");
+        mRemainingFlavorDelay = mDelay+mFlavorDelay;
 
         for (unsigned int i=0; i < mMainWidget->getChildCount(); ++i)
         {
             mMainWidget->getChildAt(i)->setVisible(false);
         }
-        
+
         mShowOwned = Settings::Manager::getInt("show owned", "Game");
     }
 
@@ -80,19 +84,33 @@ namespace MWGui
             mMainWidget->getChildAt(i)->setVisible(false);
         }
 
-        const MyGUI::IntSize &viewSize = MyGUI::RenderManager::getInstance().getViewSize();
-
         if (!mEnabled)
         {
             return;
         }
 
+        const MyGUI::IntSize &viewSize = MyGUI::RenderManager::getInstance().getViewSize();
+        const MyGUI::IntPoint& mousePos = MyGUI::InputManager::getInstance().getMousePosition();
+
+        // process delays
+        if (mousePos.left == mLastMouseX && mousePos.top == mLastMouseY)
+        {
+            mRemainingDelay -= frameDuration;
+            mRemainingFlavorDelay -= frameDuration;
+        }
+        else
+        {
+            mHorizontalScrollIndex = 0;
+            mRemainingDelay = mDelay;
+            mRemainingFlavorDelay = mDelay+mFlavorDelay;
+        }
+        mLastMouseX = mousePos.left;
+        mLastMouseY = mousePos.top;
+
         bool guiMode = MWBase::Environment::get().getWindowManager()->isGuiMode();
 
         if (guiMode)
         {
-            const MyGUI::IntPoint& mousePos = MyGUI::InputManager::getInstance().getMousePosition();
-
             if (MWBase::Environment::get().getWindowManager()->getWorldMouseOver() && ((MWBase::Environment::get().getWindowManager()->getMode() == GM_Console)
                 || (MWBase::Environment::get().getWindowManager()->getMode() == GM_Container)
                 || (MWBase::Environment::get().getWindowManager()->getMode() == GM_Inventory)))
@@ -112,40 +130,20 @@ namespace MWGui
                     if (info.caption.empty())
                         info.caption=mFocusObject.getCellRef().getRefId();
                     info.icon="";
-                    tooltipSize = createToolTip(info, true);
+                    createToolTip(info, true);
                 }
                 else
-                    tooltipSize = getToolTipViaPtr(mFocusObject.getRefData().getCount(), true);
-
-                MyGUI::IntPoint tooltipPosition = MyGUI::InputManager::getInstance().getMousePosition();
-                position(tooltipPosition, tooltipSize, viewSize);
-
-                setCoord(tooltipPosition.left, tooltipPosition.top, tooltipSize.width, tooltipSize.height);
+                    getToolTipViaPtr(mFocusObject.getRefData().getCount(), true);
             }
 
             else
             {
-                if (mousePos.left == mLastMouseX && mousePos.top == mLastMouseY)
-                {
-                    mRemainingDelay -= frameDuration;
-                }
-                else
-                {
-                    mHorizontalScrollIndex = 0;
-                    mRemainingDelay = mDelay;
-                }
-                mLastMouseX = mousePos.left;
-                mLastMouseY = mousePos.top;
-
-
                 if (mRemainingDelay > 0)
                     return;
 
                 MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getMouseFocusWidget();
                 if (focus == 0)
                     return;
-
-                MyGUI::IntSize tooltipSize;
 
                 // try to go 1 level up until there is a widget that has tooltip
                 // this is necessary because some skin elements are actually separate widgets
@@ -178,22 +176,22 @@ namespace MWGui
                     ToolTipInfo info;
                     info.text = data.caption;
                     info.notes = data.notes;
-                    tooltipSize = createToolTip(info, false);
+                    createToolTip(info, false);
                 }
                 else if (type == "ItemPtr")
                 {
                     mFocusObject = *focus->getUserData<MWWorld::Ptr>();
-                    tooltipSize = getToolTipViaPtr(mFocusObject.getRefData().getCount(), false);
+                    getToolTipViaPtr(mFocusObject.getRefData().getCount(), false);
                 }
                 else if (type == "ItemModelIndex")
                 {
                     std::pair<ItemModel::ModelIndex, ItemModel*> pair = *focus->getUserData<std::pair<ItemModel::ModelIndex, ItemModel*> >();
                     mFocusObject = pair.second->getItem(pair.first).mBase;
-                    tooltipSize = getToolTipViaPtr(pair.second->getItem(pair.first).mCount, false);
+                    getToolTipViaPtr(pair.second->getItem(pair.first).mCount, false);
                 }
                 else if (type == "ToolTipInfo")
                 {
-                    tooltipSize = createToolTip(*focus->getUserData<MWGui::ToolTipInfo>(), false);
+                    createToolTip(*focus->getUserData<MWGui::ToolTipInfo>(), false);
                 }
                 else if (type == "AvatarItemSelection")
                 {
@@ -203,7 +201,7 @@ namespace MWGui
 
                     mFocusObject = item;
                     if (!mFocusObject.isEmpty ())
-                        tooltipSize = getToolTipViaPtr(mFocusObject.getRefData().getCount(), false);
+                        getToolTipViaPtr(mFocusObject.getRefData().getCount(), false);
                 }
                 else if (type == "Spell")
                 {
@@ -236,7 +234,7 @@ namespace MWGui
                         info.text = "#{sSchool}: " + sSchoolNames[school];
                     }
                     info.effects = effects;
-                    tooltipSize = createToolTip(info, false);
+                    createToolTip(info, false);
                 }
                 else if (type == "Layout")
                 {
@@ -272,18 +270,17 @@ namespace MWGui
                             w->setUserString(key, it->second);
                     }
 
-                    tooltipSize = tooltip->getSize();
+                    MyGUI::IntSize tooltipSize = tooltip->getSize();
 
                     tooltip->setCoord(0, 0, tooltipSize.width, tooltipSize.height);
+
+                    // get postion and set cordinates
+                    MyGUI::IntPoint tooltipPosition = MyGUI::InputManager::getInstance().getMousePosition();
+                    position(tooltipPosition, tooltipSize, viewSize);
+                    setCoord(tooltipPosition.left, tooltipPosition.top, tooltipSize.width, tooltipSize.height);
                 }
                 else
                     throw std::runtime_error ("unknown tooltip type");
-
-                MyGUI::IntPoint tooltipPosition = MyGUI::InputManager::getInstance().getMousePosition();
-
-                position(tooltipPosition, tooltipSize, viewSize);
-
-                setCoord(tooltipPosition.left, tooltipPosition.top, tooltipSize.width, tooltipSize.height);
             }
         }
         else
@@ -346,7 +343,7 @@ namespace MWGui
 
         return tooltipSize;
     }
-    
+
     bool ToolTips::checkOwned()
     {
         if(!mFocusObject.isEmpty())
@@ -354,9 +351,9 @@ namespace MWGui
             const MWWorld::CellRef& cellref = mFocusObject.getCellRef();
             MWWorld::Ptr ptr = MWMechanics::getPlayer();
             MWWorld::Ptr victim;
-            
+
             MWBase::MechanicsManager* mm = MWBase::Environment::get().getMechanicsManager();
-            bool allowed = mm->isAllowedToUse(ptr, cellref, victim); 
+            bool allowed = mm->isAllowedToUse(ptr, cellref, victim);
 
             return !allowed;
         }
@@ -369,18 +366,14 @@ namespace MWGui
     MyGUI::IntSize ToolTips::createToolTip(const MWGui::ToolTipInfo& info, bool isFocusObject)
     {
         mDynamicToolTipBox->setVisible(true);
-        
+        MyGUI::Widget* toolTipWidget = mDynamicToolTipBox->createWidget<MyGUI::Widget>("Widget",
+            MyGUI::IntCoord(0, 0, 300, 300), MyGUI::Align::Left | MyGUI::Align::Top, "toolTipWidget");
+
+        // get and set tooltip skin name
+        std::string boxSkin = "HUD_Box_NoTransp";
         if(mShowOwned == 1 || mShowOwned == 3)
-        {
-            if(isFocusObject && checkOwned())
-            {
-                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_Owned");
-            }
-            else
-            {
-                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp");
-            }
-        }
+            boxSkin = (isFocusObject && checkOwned()) ? "HUD_Box_NoTransp_Owned" : "HUD_Box_NoTransp";
+        toolTipWidget->changeWidgetSkin(boxSkin);
 
         std::string caption = info.caption;
         std::string image = info.icon;
@@ -421,14 +414,14 @@ namespace MWGui
 
         std::string realImage = MWBase::Environment::get().getWindowManager()->correctIconPath(image);
 
-        MyGUI::EditBox* captionWidget = mDynamicToolTipBox->createWidget<MyGUI::EditBox>("NormalText", MyGUI::IntCoord(0, 0, 300, 300), MyGUI::Align::Left | MyGUI::Align::Top, "ToolTipCaption");
+        MyGUI::EditBox* captionWidget = toolTipWidget->createWidget<MyGUI::EditBox>("NormalText", MyGUI::IntCoord(0, 0, 300, 300), MyGUI::Align::Left | MyGUI::Align::Top, "ToolTipCaption");
         captionWidget->setProperty("Static", "true");
         captionWidget->setCaptionWithReplacing(caption);
         MyGUI::IntSize captionSize = captionWidget->getTextSize();
 
         int captionHeight = std::max(caption != "" ? captionSize.height : 0, imageSize);
 
-        MyGUI::EditBox* textWidget = mDynamicToolTipBox->createWidget<MyGUI::EditBox>("SandText", MyGUI::IntCoord(0, captionHeight+imageCaptionVPadding, 300, 300-captionHeight-imageCaptionVPadding), MyGUI::Align::Stretch, "ToolTipText");
+        MyGUI::EditBox* textWidget = toolTipWidget->createWidget<MyGUI::EditBox>("SandText", MyGUI::IntCoord(0, captionHeight+imageCaptionVPadding, 300, 300-captionHeight-imageCaptionVPadding), MyGUI::Align::Stretch, "ToolTipText");
         textWidget->setProperty("Static", "true");
         textWidget->setProperty("MultiLine", "true");
         textWidget->setProperty("WordWrap", info.wordWrap ? "true" : "false");
@@ -442,10 +435,10 @@ namespace MWGui
 
         for (std::vector<std::string>::const_iterator it = info.notes.begin(); it != info.notes.end(); ++it)
         {
-            MyGUI::ImageBox* icon = mDynamicToolTipBox->createWidget<MyGUI::ImageBox>("MarkerButton",
+            MyGUI::ImageBox* icon = toolTipWidget->createWidget<MyGUI::ImageBox>("MarkerButton",
                 MyGUI::IntCoord(padding.left, totalSize.height+padding.top, 8, 8), MyGUI::Align::Default);
             icon->setColour(MyGUI::Colour(1.0f, 0.3f, 0.3f));
-            MyGUI::EditBox* edit = mDynamicToolTipBox->createWidget<MyGUI::EditBox>("SandText",
+            MyGUI::EditBox* edit = toolTipWidget->createWidget<MyGUI::EditBox>("SandText",
                 MyGUI::IntCoord(padding.left+8+4, totalSize.height+padding.top, 300-padding.left-8-4, 300-totalSize.height),
                                                                                     MyGUI::Align::Default);
             edit->setEditMultiLine(true);
@@ -459,7 +452,7 @@ namespace MWGui
 
         if (!info.effects.empty())
         {
-            MyGUI::Widget* effectArea = mDynamicToolTipBox->createWidget<MyGUI::Widget>("",
+            MyGUI::Widget* effectArea = toolTipWidget->createWidget<MyGUI::Widget>("",
                 MyGUI::IntCoord(padding.left, totalSize.height, 300-padding.left, 300-totalSize.height),
                 MyGUI::Align::Stretch);
 
@@ -477,7 +470,7 @@ namespace MWGui
 
         if (enchant)
         {
-            MyGUI::Widget* enchantArea = mDynamicToolTipBox->createWidget<MyGUI::Widget>("",
+            MyGUI::Widget* enchantArea = toolTipWidget->createWidget<MyGUI::Widget>("",
                 MyGUI::IntCoord(padding.left, totalSize.height, 300-padding.left, 300-totalSize.height),
                 MyGUI::Align::Stretch);
 
@@ -556,7 +549,7 @@ namespace MWGui
 
         if (image != "")
         {
-            MyGUI::ImageBox* imageWidget = mDynamicToolTipBox->createWidget<MyGUI::ImageBox>("ImageBox",
+            MyGUI::ImageBox* imageWidget = toolTipWidget->createWidget<MyGUI::ImageBox>("ImageBox",
                 MyGUI::IntCoord((totalSize.width - captionSize.width - imageCaptionHPadding)/2, 0, imageSize, imageSize),
                 MyGUI::Align::Left | MyGUI::Align::Top);
             imageWidget->setImageTexture(realImage);
@@ -564,6 +557,64 @@ namespace MWGui
         }
 
         totalSize += MyGUI::IntSize(padding.left*2, padding.top*2);
+
+        // make sure that scratched text doesn't overflow out of widget (into flavor text)
+        toolTipWidget->setSize(totalSize);
+
+        // get default tooltip position
+        const MyGUI::IntSize viewportSize = MyGUI::RenderManager::getInstance().getViewSize();
+        const MyGUI::IntPoint mousePos = MyGUI::InputManager::getInstance().getMousePosition();
+        MyGUI::IntPoint tooltipPosition = MyGUI::IntPoint(mousePos.left, mousePos.top);
+        position(tooltipPosition, totalSize, viewportSize);
+
+        if(mRemainingFlavorDelay <= 0 && (info.flavorText != "" || true))
+        {
+            const int flavorTextWidth = 300;
+            const int flavorTextMargin = 4; // space between general tooltip and flavor text tooltip
+
+            MyGUI::Widget* toolTipFlavorWidget = mDynamicToolTipBox->createWidget<MyGUI::Widget>("Widget",
+                MyGUI::IntCoord(0, 0, 300, 300), MyGUI::Align::Left | MyGUI::Align::Top, "toolTipFlavorWidget");
+            toolTipFlavorWidget->changeWidgetSkin(boxSkin);
+
+            MyGUI::EditBox* flavorText = toolTipFlavorWidget->createWidget<MyGUI::EditBox>("SandText",
+                MyGUI::IntCoord(padding.left, padding.top, flavorTextWidth-padding.left*2, viewportSize.height), MyGUI::Align::Default, "ToolTipFlavorText");
+            flavorText->setProperty("MultiLine", "true");
+            flavorText->setProperty("WordWrap", "true");
+            flavorText->setProperty("TextAlign", "Left Top");
+            flavorText->setCaptionWithReplacing("Daedric weapons are made from raw ebony which has been refined using the craft and magical substances of the lesser minions of Oblivion. The process is not a pleasant one for the Daedra involved, and the weapons retain echoes of preternaturally prolonged suffering endured during manufacture. Daedric weapons are the most rare and expensive weapons known in Tamriel. \n#{setting=GUI,color crosshair owned}");
+            flavorText->setSize(flavorText->getTextSize()); // set height of EditBox to height of text
+            toolTipFlavorWidget->setSize(MyGUI::IntSize(flavorTextWidth, flavorText->getTextSize().height+padding.top*2));
+
+            // update total tooltip size
+            totalSize.width += flavorTextWidth+flavorTextMargin;
+            totalSize.height = std::max(totalSize.height, toolTipFlavorWidget->getHeight());
+
+            // move widget to different sides depending on where is the most free space
+            MyGUI::IntPoint toolTipWidgetPos = MyGUI::IntPoint(0, 0);
+            MyGUI::IntPoint toolTipFlavorWidgetPos = MyGUI::IntPoint(0, 0);
+
+            if( tooltipPosition.left > (viewportSize.width - tooltipPosition.left - toolTipWidget->getWidth()) )
+                toolTipWidgetPos.left = toolTipFlavorWidget->getWidth()+flavorTextMargin; // left
+            else
+                toolTipFlavorWidgetPos.left = toolTipWidget->getWidth()+flavorTextMargin; // right
+
+            if(toolTipWidget->getHeight() < toolTipFlavorWidget->getHeight())
+            {
+                // if bottom cut
+                if( (tooltipPosition.top + toolTipFlavorWidget->getHeight()) > viewportSize.height )
+                    toolTipWidgetPos.top = (tooltipPosition.top + toolTipFlavorWidget->getHeight()) - viewportSize.height;
+                // if top cut
+                if( (tooltipPosition.top - toolTipWidgetPos.top) < 0 )
+                    toolTipWidgetPos.top = tooltipPosition.top;
+            }
+
+            toolTipWidget->setPosition(toolTipWidgetPos);
+            toolTipFlavorWidget->setPosition(toolTipFlavorWidgetPos);
+            tooltipPosition -= toolTipWidgetPos;
+        }
+
+        // Set position and size of tooltip
+        setCoord(tooltipPosition.left, tooltipPosition.top, totalSize.width, totalSize.height);
 
         return totalSize;
     }
@@ -836,6 +887,13 @@ namespace MWGui
     {
         mDelay = delay;
         mRemainingDelay = mDelay;
+        mRemainingFlavorDelay = mDelay+mFlavorDelay;
+    }
+
+    void ToolTips::setFlavorDelay(float delay)
+    {
+        mFlavorDelay = delay;
+        mRemainingFlavorDelay = mDelay+mFlavorDelay;
     }
 
 }

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -37,6 +37,7 @@ namespace MWGui
         , mRemainingDelay(0.0)
         , mFlavorDelay(0.0)
         , mRemainingFlavorDelay(0.0)
+        , mFlavorWidth(300)
         , mLastMouseX(0)
         , mLastMouseY(0)
         , mEnabled(true)
@@ -86,17 +87,15 @@ namespace MWGui
         }
 
         if (!mEnabled)
-        {
             return;
-        }
 
         const MyGUI::IntSize &viewSize = MyGUI::RenderManager::getInstance().getViewSize();
-        const MyGUI::IntPoint& mousePos = MyGUI::InputManager::getInstance().getMousePosition();
-
         bool guiMode = MWBase::Environment::get().getWindowManager()->isGuiMode();
 
         if (guiMode)
         {
+            const MyGUI::IntPoint& mousePos = MyGUI::InputManager::getInstance().getMousePosition();
+
             if (MWBase::Environment::get().getWindowManager()->getWorldMouseOver() && ((MWBase::Environment::get().getWindowManager()->getMode() == GM_Console)
                 || (MWBase::Environment::get().getWindowManager()->getMode() == GM_Container)
                 || (MWBase::Environment::get().getWindowManager()->getMode() == GM_Inventory)))

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -123,6 +123,7 @@ namespace MWGui
         // time (after showing normal tooltip) when flavor text tooltip will be shown
         float mFlavorDelay;
         float mRemainingFlavorDelay; // remaining time until flavor text tooltip will show
+        int mFlavorWidth; // width of flavor text tooltip
 
         int mLastMouseX;
         int mLastMouseY;

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -99,10 +99,10 @@ namespace MWGui
 
         MWWorld::ConstPtr mFocusObject;
 
-        MyGUI::IntSize getToolTipViaPtr (int count, bool image=true);
+        MyGUI::IntSize getToolTipViaPtr (int count, bool image=true, bool showFlavorText=false);
         ///< @return requested tooltip size
 
-        MyGUI::IntSize createToolTip(const ToolTipInfo& info, bool isFocusObject);
+        MyGUI::IntSize createToolTip(const ToolTipInfo& info, bool isFocusObject, bool showFlavorText=false);
         ///< @return requested tooltip size
         /// @param isFocusObject Is the object this tooltips originates from mFocusObject?
 

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -42,6 +42,8 @@ namespace MWGui
 
         bool isPotion; // potions do not show target in the tooltip
         bool wordWrap;
+
+        std::string flavorText;
     };
 
     class ToolTips : public Layout
@@ -57,6 +59,7 @@ namespace MWGui
         bool getFullHelp() const;
 
         void setDelay(float delay);
+        void setFlavorDelay(float delay);
 
         void setFocusObject(const MWWorld::ConstPtr& focus);
         void setFocusObjectScreenCoords(float min_x, float min_y, float max_x, float max_y);
@@ -87,10 +90,10 @@ namespace MWGui
         static void createRaceToolTip(MyGUI::Widget* widget, const ESM::Race* playerRace);
         static void createClassToolTip(MyGUI::Widget* widget, const ESM::Class& playerClass);
         static void createMagicEffectToolTip(MyGUI::Widget* widget, short id);
-        
+
         bool checkOwned();
         /// Returns True if taking mFocusObject would be crime
- 
+
     private:
         MyGUI::Widget* mDynamicToolTipBox;
 
@@ -117,13 +120,17 @@ namespace MWGui
         float mDelay;
         float mRemainingDelay; // remaining time until tooltip will show
 
+        // time (after showing normal tooltip) when flavor text tooltip will be shown
+        float mFlavorDelay;
+        float mRemainingFlavorDelay; // remaining time until flavor text tooltip will show
+
         int mLastMouseX;
         int mLastMouseY;
 
         bool mEnabled;
 
         bool mFullHelp;
-        
+
         int mShowOwned;
     };
 }

--- a/components/esm/loadalch.cpp
+++ b/components/esm/loadalch.cpp
@@ -44,6 +44,9 @@ namespace ESM
                 case ESM::FourCC<'E','N','A','M'>::value:
                     mEffects.add(esm);
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -74,6 +77,7 @@ namespace ESM
         esm.writeHNOCString("SCRI", mScript);
         esm.writeHNOCString("FNAM", mName);
         esm.writeHNT("ALDT", mData, 12);
+        esm.writeHNOCString("FTXT", mFlavorText);
         mEffects.save(esm);
     }
 
@@ -87,5 +91,6 @@ namespace ESM
         mIcon.clear();
         mScript.clear();
         mEffects.mList.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadalch.hpp
+++ b/components/esm/loadalch.hpp
@@ -30,7 +30,7 @@ struct Potion
     };
     ALDTstruct mData;
 
-    std::string mId, mName, mModel, mIcon, mScript;
+    std::string mId, mName, mModel, mIcon, mScript, mFlavorText;
     EffectList mEffects;
 
     void load(ESMReader &esm, bool &isDeleted);

--- a/components/esm/loadappa.cpp
+++ b/components/esm/loadappa.cpp
@@ -39,6 +39,9 @@ namespace ESM
                 case ESM::FourCC<'I','T','E','X'>::value:
                     mIcon = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -70,6 +73,7 @@ namespace ESM
         esm.writeHNT("AADT", mData, 16);
         esm.writeHNOCString("SCRI", mScript);
         esm.writeHNCString("ITEX", mIcon);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Apparatus::blank()
@@ -82,5 +86,6 @@ namespace ESM
         mIcon.clear();
         mScript.clear();
         mName.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadappa.hpp
+++ b/components/esm/loadappa.hpp
@@ -36,7 +36,7 @@ struct Apparatus
     };
 
     AADTstruct mData;
-    std::string mId, mModel, mIcon, mScript, mName;
+    std::string mId, mModel, mIcon, mScript, mName, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadarmo.cpp
+++ b/components/esm/loadarmo.cpp
@@ -77,6 +77,9 @@ namespace ESM
                 case ESM::FourCC<'I','N','D','X'>::value:
                     mParts.add(esm);
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -110,6 +113,7 @@ namespace ESM
         esm.writeHNOCString("ITEX", mIcon);
         mParts.save(esm);
         esm.writeHNOCString("ENAM", mEnchant);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Armor::blank()
@@ -126,5 +130,6 @@ namespace ESM
         mIcon.clear();
         mScript.clear();
         mEnchant.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadarmo.hpp
+++ b/components/esm/loadarmo.hpp
@@ -94,7 +94,7 @@ struct Armor
     AODTstruct mData;
     PartReferenceList mParts;
 
-    std::string mId, mName, mModel, mIcon, mScript, mEnchant;
+    std::string mId, mName, mModel, mIcon, mScript, mEnchant, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadbook.cpp
+++ b/components/esm/loadbook.cpp
@@ -45,6 +45,9 @@ namespace ESM
                 case ESM::FourCC<'T','E','X','T'>::value:
                     mText = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -77,6 +80,7 @@ namespace ESM
         esm.writeHNOCString("ITEX", mIcon);
         esm.writeHNOString("TEXT", mText);
         esm.writeHNOCString("ENAM", mEnchant);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Book::blank()
@@ -92,5 +96,6 @@ namespace ESM
         mScript.clear();
         mEnchant.clear();
         mText.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadbook.hpp
+++ b/components/esm/loadbook.hpp
@@ -25,7 +25,7 @@ struct Book
     };
 
     BKDTstruct mData;
-    std::string mName, mModel, mIcon, mScript, mEnchant, mText;
+    std::string mName, mModel, mIcon, mScript, mEnchant, mText, mFlavorText;
     std::string mId;
 
     void load(ESMReader &esm, bool &isDeleted);

--- a/components/esm/loadclot.cpp
+++ b/components/esm/loadclot.cpp
@@ -47,6 +47,9 @@ namespace ESM
                 case ESM::FourCC<'I','N','D','X'>::value:
                     mParts.add(esm);
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -83,6 +86,7 @@ namespace ESM
         mParts.save(esm);
 
         esm.writeHNOCString("ENAM", mEnchant);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Clothing::blank()
@@ -97,5 +101,6 @@ namespace ESM
         mIcon.clear();
         mEnchant.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadclot.hpp
+++ b/components/esm/loadclot.hpp
@@ -46,7 +46,7 @@ struct Clothing
 
     PartReferenceList mParts;
 
-    std::string mId, mName, mModel, mIcon, mEnchant, mScript;
+    std::string mId, mName, mModel, mIcon, mEnchant, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadingr.cpp
+++ b/components/esm/loadingr.cpp
@@ -39,6 +39,9 @@ namespace ESM
                 case ESM::FourCC<'I','T','E','X'>::value:
                     mIcon = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -93,6 +96,7 @@ namespace ESM
         esm.writeHNT("IRDT", mData, 56);
         esm.writeHNOCString("SCRI", mScript);
         esm.writeHNOCString("ITEX", mIcon);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Ingredient::blank()
@@ -110,5 +114,6 @@ namespace ESM
         mModel.clear();
         mIcon.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadingr.hpp
+++ b/components/esm/loadingr.hpp
@@ -29,7 +29,7 @@ struct Ingredient
     };
 
     IRDTstruct mData;
-    std::string mId, mName, mModel, mIcon, mScript;
+    std::string mId, mName, mModel, mIcon, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadligh.cpp
+++ b/components/esm/loadligh.cpp
@@ -42,6 +42,9 @@ namespace ESM
                 case ESM::FourCC<'S','N','A','M'>::value:
                     mSound = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -73,6 +76,7 @@ namespace ESM
         esm.writeHNT("LHDT", mData, 24);
         esm.writeHNOCString("SCRI", mScript);
         esm.writeHNOCString("SNAM", mSound);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Light::blank()
@@ -88,5 +92,6 @@ namespace ESM
         mModel.clear();
         mIcon.clear();
         mName.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadligh.hpp
+++ b/components/esm/loadligh.hpp
@@ -45,7 +45,7 @@ struct Light
 
     LHDTstruct mData;
 
-    std::string mSound, mScript, mModel, mIcon, mName, mId;
+    std::string mSound, mScript, mModel, mIcon, mName, mId, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadlock.cpp
+++ b/components/esm/loadlock.cpp
@@ -39,6 +39,9 @@ namespace ESM
                 case ESM::FourCC<'I','T','E','X'>::value:
                     mIcon = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -71,6 +74,7 @@ namespace ESM
         esm.writeHNT("LKDT", mData, 16);
         esm.writeHNOString("SCRI", mScript);
         esm.writeHNOCString("ITEX", mIcon);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Lockpick::blank()
@@ -83,5 +87,6 @@ namespace ESM
         mModel.clear();
         mIcon.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadlock.hpp
+++ b/components/esm/loadlock.hpp
@@ -25,7 +25,7 @@ struct Lockpick
     }; // Size = 16
 
     Data mData;
-    std::string mId, mName, mModel, mIcon, mScript;
+    std::string mId, mName, mModel, mIcon, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadmisc.cpp
+++ b/components/esm/loadmisc.cpp
@@ -39,6 +39,9 @@ namespace ESM
                 case ESM::FourCC<'I','T','E','X'>::value:
                     mIcon = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -70,6 +73,7 @@ namespace ESM
         esm.writeHNT("MCDT", mData, 12);
         esm.writeHNOCString("SCRI", mScript);
         esm.writeHNOCString("ITEX", mIcon);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Miscellaneous::blank()
@@ -81,5 +85,6 @@ namespace ESM
         mModel.clear();
         mIcon.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadmisc.hpp
+++ b/components/esm/loadmisc.hpp
@@ -30,7 +30,7 @@ struct Miscellaneous
     };
     MCDTstruct mData;
 
-    std::string mId, mName, mModel, mIcon, mScript;
+    std::string mId, mName, mModel, mIcon, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadprob.cpp
+++ b/components/esm/loadprob.cpp
@@ -39,6 +39,9 @@ namespace ESM
                 case ESM::FourCC<'I','T','E','X'>::value:
                     mIcon = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -71,6 +74,7 @@ namespace ESM
         esm.writeHNT("PBDT", mData, 16);
         esm.writeHNOString("SCRI", mScript);
         esm.writeHNOCString("ITEX", mIcon);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Probe::blank()
@@ -83,5 +87,6 @@ namespace ESM
         mModel.clear();
         mIcon.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadprob.hpp
+++ b/components/esm/loadprob.hpp
@@ -25,7 +25,7 @@ struct Probe
     }; // Size = 16
 
     Data mData;
-    std::string mId, mName, mModel, mIcon, mScript;
+    std::string mId, mName, mModel, mIcon, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadrepa.cpp
+++ b/components/esm/loadrepa.cpp
@@ -39,6 +39,9 @@ namespace ESM
                 case ESM::FourCC<'I','T','E','X'>::value:
                     mIcon = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -71,6 +74,7 @@ namespace ESM
         esm.writeHNT("RIDT", mData, 16);
         esm.writeHNOString("SCRI", mScript);
         esm.writeHNOCString("ITEX", mIcon);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Repair::blank()
@@ -83,5 +87,6 @@ namespace ESM
         mModel.clear();
         mIcon.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadrepa.hpp
+++ b/components/esm/loadrepa.hpp
@@ -25,7 +25,7 @@ struct Repair
     }; // Size = 16
 
     Data mData;
-    std::string mId, mName, mModel, mIcon, mScript;
+    std::string mId, mName, mModel, mIcon, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/components/esm/loadweap.cpp
+++ b/components/esm/loadweap.cpp
@@ -42,6 +42,9 @@ namespace ESM
                 case ESM::FourCC<'E','N','A','M'>::value:
                     mEnchant = esm.getHString();
                     break;
+                case ESM::FourCC<'F','T','X','T'>::value:
+                    mFlavorText = esm.getHString();
+                    break;
                 case ESM::SREC_DELE:
                     esm.skipHSub();
                     isDeleted = true;
@@ -72,6 +75,7 @@ namespace ESM
         esm.writeHNOCString("SCRI", mScript);
         esm.writeHNOCString("ITEX", mIcon);
         esm.writeHNOCString("ENAM", mEnchant);
+        esm.writeHNOCString("FTXT", mFlavorText);
     }
 
     void Weapon::blank()
@@ -93,5 +97,6 @@ namespace ESM
         mIcon.clear();
         mEnchant.clear();
         mScript.clear();
+        mFlavorText.clear();
     }
 }

--- a/components/esm/loadweap.hpp
+++ b/components/esm/loadweap.hpp
@@ -67,7 +67,7 @@ struct Weapon
 
     WPDTstruct mData;
 
-    std::string mId, mName, mModel, mIcon, mEnchant, mScript;
+    std::string mId, mName, mModel, mIcon, mEnchant, mScript, mFlavorText;
 
     void load(ESMReader &esm, bool &isDeleted);
     void save(ESMWriter &esm, bool isDeleted = false) const;

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -4,7 +4,7 @@
     <Widget type="Widget" layer="Popup" position="0 0 300 300" name="_Main">
 
         <!-- Dynamically constructed tooltip goes here -->
-        <Widget type="Widget" skin="HUD_Box_NoTransp" position="0 0 300 300" align="Stretch" name="DynamicToolTipBox">
+        <Widget type="Widget" position="0 0 300 300" align="Stretch" name="DynamicToolTipBox">
         </Widget>
 
         <!-- Text tooltip, one line -->

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -108,6 +108,8 @@ menu transparency = 0.84
 # Time until tool tip appears when hovering over an object (0.0 is
 # instantly, 1.0 is the maximum delay of about 1.5 seconds).
 tooltip delay = 0.0
+# time (after showing normal tooltip) until flavor text tool tip appears when hovering over object
+tooltip flavor delay = 2.0
 
 # Stretch menus, load screens, etc. to the window aspect ratio.
 stretch menu background = false

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -110,6 +110,8 @@ menu transparency = 0.84
 tooltip delay = 0.0
 # time (after showing normal tooltip) until flavor text tool tip appears when hovering over object
 tooltip flavor delay = 2.0
+# width of flavor text tooltip
+tooltip flavor width = 300
 
 # Stretch menus, load screens, etc. to the window aspect ratio.
 stretch menu background = false


### PR DESCRIPTION
Adds in "Flavor Text" text field in OpenMW-CS for all item types. 
- Items that don't have this value empty will display tooltip with flavor text next to standard tooltip (after specified delay).
- Flavor text will be displayed only in "Inventory mode" (right click, merchants, etc...)
- Width of flavor text tooltip and delay between displaying standard tooltip and flavor text tooltip can be changed with new options in settings-default.cfg

Screenshots: https://imgur.com/a/7yGT9
Forum thread: https://forum.openmw.org/viewtopic.php?f=3&t=3802

Note: 
I am still not sure if I completely understand how code for OpenMW-CS works, so someone who does should probably check that I did not forget to do something important.

EDIT:
bug ticket: https://bugs.openmw.org/issues/3688
