### PR TITLE
New option in settings allowing to add multiple identical effects in spellcreation

### DIFF
--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -5,6 +5,7 @@
 
 #include <components/esm/records.hpp>
 #include <components/widgets/list.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/soundmanager.hpp"
@@ -498,6 +499,8 @@ namespace MWGui
         mAddEffectDialog.eventEffectRemoved += MyGUI::newDelegate(this, &EffectEditorBase::onEffectRemoved);
 
         mAddEffectDialog.setVisible (false);
+
+        mUniqueEffectsOnly = Settings::Manager::getBool("unique spell effects", "Game");
     }
 
     EffectEditorBase::~EffectEditorBase()
@@ -638,12 +641,15 @@ namespace MWGui
         }
         else
         {
-            for (std::vector<ESM::ENAMstruct>::const_iterator it = mEffects.begin(); it != mEffects.end(); ++it)
+            if (mUniqueEffectsOnly)
             {
-                if (it->mEffectID == mSelectedKnownEffectId)
+                for (std::vector<ESM::ENAMstruct>::const_iterator it = mEffects.begin(); it != mEffects.end(); ++it)
                 {
-                    MWBase::Environment::get().getWindowManager()->messageBox ("#{sOnetypeEffectMessage}");
-                    return;
+                    if (it->mEffectID == mSelectedKnownEffectId)
+                    {
+                        MWBase::Environment::get().getWindowManager()->messageBox ("#{sOnetypeEffectMessage}");
+                        return;
+                    }
                 }
             }
 

--- a/apps/openmw/mwgui/spellcreationdialog.hpp
+++ b/apps/openmw/mwgui/spellcreationdialog.hpp
@@ -122,6 +122,8 @@ namespace MWGui
 
         std::vector<ESM::ENAMstruct> mEffects;
 
+        bool mUniqueEffectsOnly;
+
         void onEffectAdded(ESM::ENAMstruct effect);
         void onEffectModified(ESM::ENAMstruct effect);
         void onEffectRemoved(ESM::ENAMstruct effect);

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -145,6 +145,10 @@ difficulty = 0
 # Show duration of magic effect and lights in the spells window.
 show effect duration = false
 
+# Do not allow to add same effect multiple times in spell creation
+# Example: [fire damage 10pts for 1s]+[fire damage 1-2pts for 10s] is possible if disabled
+unique spell effects = true
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
This small pull request adds option in settings to disable checking for identical effects in spell creation.

This makes it possible to for example create spells with both:
- firedamage 30-50pts 1s
- firedamage 1-4pts 10s  

old forum thread: https://forum.openmw.org/viewtopic.php?f=2&t=3545

EDIT:
bug ticket: https://bugs.openmw.org/issues/3687
