### PR TITLE
OpenMW-CS: Only display editable nested tables (Bug #3277)

### DIFF
--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -578,40 +578,31 @@ void CSVWorld::EditWidget::remake(int row)
                         fixedRows = true;
                 }
 
-                NestedTable* table =
-                    new NestedTable(mDocument, id, mNestedModels.back(), this, editable, fixedRows);
-                table->resizeColumnsToContents();
-                if (!editable)
+                // Create and display nested table only if it's editable.
+                if (editable)
                 {
-                    // Disallow table editing, selection, and focus.
-                    // This allows user to scroll through table but not edit items.
-                    // Disabling table doesn't allow user to scroll.
-                    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
-                    table->setSelectionMode(QAbstractItemView::NoSelection);
-                    table->setFocusPolicy(Qt::NoFocus);
-                    table->setToolTip("Currently read-only");
+                    NestedTable* table =
+                        new NestedTable(mDocument, id, mNestedModels.back(), this, editable, fixedRows);
+                    table->resizeColumnsToContents();
+
+                    int rows = mTable->rowCount(mTable->index(row, i));
+                    int rowHeight = (rows == 0) ? table->horizontalHeader()->height() : table->rowHeight(0);
+                    int headerHeight = table->horizontalHeader()->height();
+                    int tableMaxHeight = (5 * rowHeight) + headerHeight + (2 * table->frameWidth());
+                    table->setMinimumHeight(tableMaxHeight);
+
+                    QString headerText = mTable->headerData (i, Qt::Horizontal, Qt::DisplayRole).toString();
+                    QLabel* label = new QLabel (headerText, mMainWidget);
+                    label->setSizePolicy (QSizePolicy::Fixed, QSizePolicy::Fixed);
+
+                    tablesLayout->addWidget(label);
+                    tablesLayout->addWidget(table);
+
+                    connect(table,
+                            SIGNAL(editRequest(const CSMWorld::UniversalId &, const std::string &)),
+                            this,
+                            SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)));
                 }
-
-                int rows = mTable->rowCount(mTable->index(row, i));
-                int rowHeight = (rows == 0) ? table->horizontalHeader()->height() : table->rowHeight(0);
-                int tableMaxHeight = (5 * rowHeight)
-                    + table->horizontalHeader()->height() + 2 * table->frameWidth();
-                table->setMinimumHeight(tableMaxHeight);
-
-                QLabel* label =
-                    new QLabel (mTable->headerData (i, Qt::Horizontal, Qt::DisplayRole).toString(), mMainWidget);
-
-                label->setSizePolicy (QSizePolicy::Fixed, QSizePolicy::Fixed);
-                if(!editable)
-                    label->setEnabled(false);
-
-                tablesLayout->addWidget(label);
-                tablesLayout->addWidget(table);
-
-                connect(table,
-                        SIGNAL(editRequest(const CSMWorld::UniversalId &, const std::string &)),
-                        this,
-                        SIGNAL(editIdRequest(const CSMWorld::UniversalId &, const std::string &)));
             }
             else if (!(flags & CSMWorld::ColumnBase::Flag_Dialogue_List))
             {

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -583,13 +583,13 @@ void CSVWorld::EditWidget::remake(int row)
                 table->resizeColumnsToContents();
                 if (!editable)
                 {
-                    // Make table look disabled without actually disabling.
-                    // This allows user to scroll through table without
-                    // being able to edit items.
+                    // Disallow table editing, selection, and focus.
+                    // This allows user to scroll through table but not edit items.
+                    // Disabling table doesn't allow user to scroll.
                     table->setEditTriggers(QAbstractItemView::NoEditTriggers);
                     table->setSelectionMode(QAbstractItemView::NoSelection);
                     table->setFocusPolicy(Qt::NoFocus);
-                    table->setStyleSheet("background-color: whitesmoke");
+                    table->setToolTip("Currently read-only");
                 }
 
                 int rows = mTable->rowCount(mTable->index(row, i));

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -583,8 +583,13 @@ void CSVWorld::EditWidget::remake(int row)
                 table->resizeColumnsToContents();
                 if (!editable)
                 {
+                    // Make table look disabled without actually disabling.
+                    // This allows user to scroll through table without
+                    // being able to edit items.
                     table->setEditTriggers(QAbstractItemView::NoEditTriggers);
-                    table->setEnabled(false);
+                    table->setSelectionMode(QAbstractItemView::NoSelection);
+                    table->setFocusPolicy(Qt::NoFocus);
+                    table->setStyleSheet("background-color: whitesmoke");
                 }
 
                 int rows = mTable->rowCount(mTable->index(row, i));


### PR DESCRIPTION
This is an idea for fixing [bug 3277](http://bugs.openmw.org/issues/3277). Instead of disabling the table this sets it to disallow edits, selection, and focus. The background color is also changed (not doing so  causes the table items to not appear disabled). Doing this instead of disabling the table allows the user to still scroll through the table items.