### PR TITLE
Do not show uncarriable lights in item views

### DIFF
--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -173,6 +173,16 @@ namespace MWClass
         return info;
     }
 
+    bool Light::showsInInventory (const MWWorld::ConstPtr& ptr) const
+    {
+        const ESM::Light* light = ptr.get<ESM::Light>()->mBase;
+
+        if (!(light->mData.mFlags & ESM::Light::Carry))
+            return false;
+
+        return Class::showsInInventory(ptr);
+    }
+
     boost::shared_ptr<MWWorld::Action> Light::use (const MWWorld::Ptr& ptr) const
     {
         boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));

--- a/apps/openmw/mwclass/light.hpp
+++ b/apps/openmw/mwclass/light.hpp
@@ -26,6 +26,8 @@ namespace MWClass
             virtual MWGui::ToolTipInfo getToolTipInfo (const MWWorld::ConstPtr& ptr, int count) const;
             ///< @return the content of the tool tip to be displayed. raises exception if the object has no tooltip.
 
+            virtual bool showsInInventory (const MWWorld::ConstPtr& ptr) const;
+
             virtual boost::shared_ptr<MWWorld::Action> activate (const MWWorld::Ptr& ptr,
                 const MWWorld::Ptr& actor) const;
             ///< Generate action for activation

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -77,10 +77,8 @@ void InventoryItemModel::update()
     for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
     {
         MWWorld::Ptr item = *it;
-        // NOTE: Don't show WerewolfRobe objects in the inventory, or allow them to be taken.
-        // Vanilla likely uses a hack like this since there's no other way to prevent it from
-        // being shown or taken.
-        if(item.getCellRef().getRefId() == "werewolfrobe")
+
+        if (!item.getClass().showsInInventory(item))
             continue;
 
         ItemStack newItem (item, this, item.getRefData().getCount());

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -545,10 +545,7 @@ namespace MWGui
         if(invStore.getSlot(slot) != invStore.end())
         {
             MWWorld::Ptr item = *invStore.getSlot(slot);
-            // NOTE: Don't allow users to select WerewolfRobe objects in the inventory. Vanilla
-            // likely uses a hack like this since there's no other way to prevent it from being
-            // taken.
-            if(item.getCellRef().getRefId() == "werewolfrobe")
+            if (!item.getClass().showsInInventory(item))
                 return MWWorld::Ptr();
             return item;
         }

--- a/apps/openmw/mwgui/tradeitemmodel.cpp
+++ b/apps/openmw/mwgui/tradeitemmodel.cpp
@@ -163,6 +163,10 @@ namespace MWGui
                 MWWorld::Ptr base = item.mBase;
                 if(Misc::StringUtils::ciEqual(base.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
                     continue;
+
+                if (!base.getClass().showsInInventory(base))
+                    return;
+
                 if(!base.getClass().canSell(base, services))
                     continue;
 

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -277,6 +277,14 @@ namespace MWWorld
         throw std::runtime_error ("class does not have a tool tip");
     }
 
+    bool Class::showsInInventory (const ConstPtr& ptr) const
+    {
+        // NOTE: Don't show WerewolfRobe objects in the inventory, or allow them to be taken.
+        // Vanilla likely uses a hack like this since there's no other way to prevent it from
+        // being shown or taken.
+        return (ptr.getCellRef().getRefId() != "werewolfrobe");
+    }
+
     bool Class::hasToolTip (const ConstPtr& ptr) const
     {
         return false;

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -98,6 +98,11 @@ namespace MWWorld
             virtual MWGui::ToolTipInfo getToolTipInfo (const ConstPtr& ptr, int count) const;
             ///< @return the content of the tool tip to be displayed. raises exception if the object has no tooltip.
 
+            virtual bool showsInInventory (const ConstPtr& ptr) const;
+            ///< Return whether ptr shows in inventory views.
+            /// Hidden items are not displayed and cannot be (re)moved by the user.
+            /// \return True if shown, false if hidden.
+
             virtual MWMechanics::NpcStats& getNpcStats (const Ptr& ptr) const;
             ///< Return NPC stats or throw an exception, if class does not have NPC stats
             /// (default implementation: throw an exception)


### PR DESCRIPTION
Some scripts (e.g. _bladeScript_) rely on these items being inaccessible by the user.

This PR also prevents traders from selling the _WerewolfRobe_ item.
