### PR TITLE
Fix base referencables not overwriting other base referencables in the editor.

### DIFF
--- a/apps/opencs/model/world/refiddata.hpp
+++ b/apps/opencs/model/world/refiddata.hpp
@@ -175,6 +175,12 @@ namespace CSMWorld
             {
                 mContainer[index].setModified(record);
             }
+            else
+            {
+                // Overwrite
+                mContainer[index].setModified(record);
+                mContainer[index].merge();
+            }
         }
 
         return index;


### PR DESCRIPTION
This fixes [bug#3561](http://bugs.openmw.org/issues/3561#change-16304). Previously, the data was just being ignored.