### PR TITLE
add support for GLES, when compiling on armhf/armv7 devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,7 @@ endif(WIN32)
 # Extern
 add_subdirectory (extern/osg-ffmpeg-videoplayer)
 add_subdirectory (extern/oics)
-if (USE_QT)
+if (BUILD_OPENCS)
     add_subdirectory (extern/osgQt)
 endif()
 

--- a/components/myguiplatform/myguirendermanager.hpp
+++ b/components/myguiplatform/myguirendermanager.hpp
@@ -1,6 +1,10 @@
 #ifndef OPENMW_COMPONENTS_MYGUIPLATFORM_MYGUIRENDERMANAGER_H
 #define OPENMW_COMPONENTS_MYGUIPLATFORM_MYGUIRENDERMANAGER_H
 
+#if defined(OPENGL_ES)
+#  include <GLES/gl.h>
+#endif
+
 #include <MyGUI_RenderManager.h>
 
 #include <osg/ref_ptr>

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -1,6 +1,10 @@
 #ifndef OPENMW_COMPONENTS_SCENEUTIL_LIGHTMANAGER_H
 #define OPENMW_COMPONENTS_SCENEUTIL_LIGHTMANAGER_H
 
+#if defined(OPENGL_ES)
+#  include <GLES/gl.h>
+#endif
+
 #include <osg/Light>
 
 #include <osg/Group>

--- a/components/sceneutil/lightutil.hpp
+++ b/components/sceneutil/lightutil.hpp
@@ -1,6 +1,10 @@
 #ifndef OPENMW_COMPONENTS_LIGHTUTIL_H
 #define OPENMW_COMPONENTS_LIGHTUTIL_H
 
+#if defined(OPENGL_ES)
+#  include <GLES/gl.h>
+#endif
+
 namespace osg
 {
     class Group;


### PR DESCRIPTION
Includes the necessary flags for compiling against GLES instead of GL. This is a noop on most systems, but required on armhf.

This should not impact Android builds.