### PR TITLE
Fix for segmentation fault on entering a cell

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -229,6 +229,9 @@ namespace MWMechanics
         osg::Vec3f vAimDir = MWBase::Environment::get().getWorld()->aimToTarget(actor, target);
         float distToTarget = MWBase::Environment::get().getWorld()->getHitDistance(actor, target);
 
+        if (!currentAction)
+            return;
+
         storage.mReadyToAttack = (currentAction->isAttackingOrSpell() && distToTarget <= rangeAttack);
         
         // can't fight if attacker can't go where target is.  E.g. A fish can't attack person on land.


### PR DESCRIPTION
OpenMW 0.40 crashes whenever you enter a cell in which there is an NPC attacking you. 

## How to reproduce:
- Attack a NPC indoors
- move towards a door to an external cel
- as you're being attacked, activate the door
- on reentering the cell, the game will crash with a segmentation fault (SIGNAL 11)

## Reason: 
dereferencing a null pointer. ( "currentAction->isAttackingOrSpell()" in aicombat.cpp:235)

## Crash log: 
[mwcrash.txt](https://github.com/OpenMW/openmw/files/501906/mwcrash.txt)

## Fix
- Check whether the shared_ptr is NULL by using std::shared_ptr::operator bool, if so, prevent the attack by returning from AiCombat::attack(...).
- This only seems to happen on the very first entry to a new cell and does not interfere with combat.