### PR TITLE
Don't let water-only creatures prevent resting

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1535,7 +1535,7 @@ namespace MWMechanics
         for(std::vector<MWWorld::Ptr>::const_iterator iter(neighbors.begin());iter != neighbors.end();++iter)
         {
             const CreatureStats &stats = iter->getClass().getCreatureStats(*iter);
-            if (stats.isDead() || *iter == actor)
+            if (stats.isDead() || *iter == actor || iter->getClass().isPureWaterCreature(*iter))
                 continue;
             const bool isFollower = std::find(followers.begin(), followers.end(), *iter) != followers.end();
             if (stats.getAiSequence().isInCombat(actor) || (MWBase::Environment::get().getMechanicsManager()->isAggressive(*iter, actor) && !isFollower))


### PR DESCRIPTION
For https://bugs.openmw.org/issues/3542.

I asked for confirmation in that bug report, but after some further testing I think it's pretty clear what is happening in original Morrowind. Any enemy, not just slaughterfish or other aquatic ones, will only prevent resting if it is outside of the water. Try spawning a non-aquatic creature in the water or a hostile NPC and you can see that they will not stop you from resting until they leave the water.

For this PR, I've enabled what I believe was the intended behavior of original Morrowind, that aquatic creatures do not prevent rest because they cannot reach the player and are not a threat. Non-aquatic creatures and NPCs can leave the water and be a threat, so resting will still be prevented.