### PR TITLE
Fix interactive ID validity checks

### DIFF
--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -157,7 +157,7 @@ struct TypesetBookImpl : TypesetBook
     StyleImpl * hitTestWithMargin (int left, int top)
     {
         StyleImpl * hit = hitTest(left, top);
-        if (hit && hit->mInteractiveId > 0)
+        if (hit && hit->mInteractiveId != 0)
             return hit;
 
         const int maxMargin = 10;
@@ -174,7 +174,7 @@ struct TypesetBookImpl : TypesetBook
                 else
                     hit = hitTest(left+margin, top);
 
-                if (hit && hit->mInteractiveId > 0)
+                if (hit && hit->mInteractiveId != 0)
                     return hit;
             }
         }


### PR DESCRIPTION
Since `hit->mInteractiveId` is usually a pointer cast to intptr_t, it's possible that `hit->mInteractiveId > 0` may evaluate to false even if the ID is valid. This may or may not fix https://bugs.openmw.org/issues/3575.