### PR TITLE
Use loop fallback for movement animations

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -465,7 +465,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
             }
 
             mAnimation->play(mCurrentMovement, Priority_Movement, movemask, false,
-                             1.f, ((mode!=2)?"start":"loop start"), "stop", 0.0f, ~0ul);
+                             1.f, ((mode!=2)?"start":"loop start"), "stop", 0.0f, ~0ul, true);
         }
     }
 }


### PR DESCRIPTION
The .kf files attached to the bug report are missing loop keys for some animation groups related to movement.

Fixes: https://bugs.openmw.org/issues/3578