### PR TITLE
Corrections for bound equipment

### DIFF
--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -146,9 +146,6 @@ namespace MWClass
 
         float epsilon = 0.0005f;
 
-        if (ref->mBase->mData.mWeight == 0)
-            return ESM::Skill::Unarmored;
-
         if (ref->mBase->mData.mWeight <= iWeight * gmst.find ("fLightMaxMod")->getFloat() + epsilon)
             return ESM::Skill::LightArmor;
 

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -217,16 +217,19 @@ namespace MWClass
         std::string text;
 
         // get armor type string (light/medium/heavy)
-        int armorType = getEquipmentSkill(ptr);
         std::string typeText;
-        if (armorType == ESM::Skill::LightArmor)
-            typeText = "#{sLight}";
-        else if (armorType == ESM::Skill::MediumArmor)
-            typeText = "#{sMedium}";
-        else if (armorType == ESM::Skill::HeavyArmor)
-            typeText = "#{sHeavy}";
-        else // if (armorType == ESM::Skill::Unarmored)
+        if (ref->mBase->mData.mWeight == 0)
             typeText = "";
+        else
+        {
+            int armorType = getEquipmentSkill(ptr);       
+            if (armorType == ESM::Skill::LightArmor)
+                typeText = "#{sLight}";
+            else if (armorType == ESM::Skill::MediumArmor)
+                typeText = "#{sMedium}";
+            else
+                typeText = "#{sHeavy}";
+        }
 
         text += "\n#{sArmorRating}: " + MWGui::ToolTips::toString(getEffectiveArmorRating(ptr,
             MWMechanics::getPlayer()));

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1160,7 +1160,6 @@ namespace MWClass
 
                 switch(boots->getClass().getEquipmentSkill(*boots))
                 {
-                    case ESM::Skill::Unarmored:
                     case ESM::Skill::LightArmor:
                         return (name == "left") ? "FootLightLeft" : "FootLightRight";
                     case ESM::Skill::MediumArmor:


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3579.

Also redoes the fixes of https://github.com/OpenMW/openmw/pull/1021 and https://github.com/OpenMW/openmw/pull/1020. I had falsely thought that bound equipment should be treated as "unarmored" when I did those.

Actually, 0-weight armor should play the sounds of light armor and raise light armor skill. It should display no weight tooltip and not use any armor skill for calculating armor rating.