### PR TITLE
Coverity fixes

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -217,7 +217,7 @@ namespace MWBase
             virtual bool toggleSky() = 0;
             ///< \return Resulting mode
 
-            virtual void changeWeather(const std::string& region, unsigned int id) = 0;
+            virtual void changeWeather(const std::string& region, const unsigned int id) = 0;
 
             virtual int getCurrentWeather() const = 0;
 

--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -47,7 +47,7 @@ AiFollow::AiFollow(const std::string &actorId, bool commanded)
 }
 
 AiFollow::AiFollow(const ESM::AiSequence::AiFollow *follow)
-    : mCommanded(follow->mCommanded), mRemainingDuration(follow->mRemainingDuration)
+    : mAlwaysFollow(follow->mAlwaysFollow), mCommanded(follow->mCommanded), mRemainingDuration(follow->mRemainingDuration)
     , mX(follow->mData.mX), mY(follow->mData.mY), mZ(follow->mData.mZ)
     , mActorRefId(follow->mTargetId), mActorId(-1)
     , mCellId(follow->mCellId), mActive(follow->mActive), mFollowIndex(mFollowIndexCounter++)

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -694,6 +694,7 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
     , mAnimation(anim)
     , mIdleState(CharState_None)
     , mMovementState(CharState_None)
+    , mMovementAnimSpeed(0.f)
     , mAdjustMovementAnimSpeed(false)
     , mHasMovedInXY(false)
     , mMovementAnimationControlled(true)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -316,7 +316,7 @@ namespace MWWorld
             virtual bool toggleSky();
             ///< \return Resulting mode
 
-            virtual void changeWeather (const std::string& region, unsigned int id);
+            virtual void changeWeather (const std::string& region, const unsigned int id);
 
             virtual int getCurrentWeather() const;
 


### PR DESCRIPTION
A few Coverity fixes.

The following are fixed.

In worldimp.cpp
CID 152151 (#1 of 1): Failed to override method (BAD_OVERRIDE)
bad_override: Method MWWorld::World::changeWeather hides but does not override MWBase::World::changeWeather because some type qualifiers do not match.

In character.cpp
CID 132181 (#2 of 2): Uninitialized scalar field (UNINIT_CTOR)
14. uninit_member: Non-static class member mMovementAnimSpeed is not initialized in this constructor nor in any functions that it calls.

In aifollow.cpp
CID 152188 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
4. uninit_member: Non-static class member mAlwaysFollow is not initialized in this constructor nor in any functions that it calls.

The aifollow one was a bug. AI characters would not reliably execute the time limit or position check for a follow package after loading a saved game that was saved while they were running the package.