### PR TITLE
Make actors with non-portable lights in inventory glow

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -23,7 +23,7 @@ add_openmw_dir (mwrender
     actors objects renderingmanager animation rotatecontroller sky npcanimation vismask
     creatureanimation effectmanager util renderinginterface pathgrid rendermode weaponanimation
     bulletdebugdraw globalmap characterpreview camera localmap water terrainstorage ripplesimulation
-    renderbin
+    renderbin actoranimation
     )
 
 add_openmw_dir (mwinput

--- a/apps/openmw/mwrender/actoranimation.hpp
+++ b/apps/openmw/mwrender/actoranimation.hpp
@@ -1,0 +1,58 @@
+#ifndef GAME_RENDER_ACTORANIMATION_H
+#define GAME_RENDER_ACTORANIMATION_H
+
+#include <map>
+
+#include <osg/ref_ptr>
+
+#include "../mwworld/containerstore.hpp"
+
+#include "animation.hpp"
+
+namespace osg
+{
+    class Node;
+}
+
+namespace MWWorld
+{
+    class ConstPtr;
+}
+
+namespace SceneUtil
+{
+    class LightSource;
+    class LightListCallback;
+}
+
+namespace MWRender
+{
+
+class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
+{
+    public:
+        ActorAnimation(const MWWorld::Ptr &ptr, osg::ref_ptr<osg::Group> parentNode, Resource::ResourceSystem* resourceSystem,
+                       bool disableListener=false);
+        virtual ~ActorAnimation();
+
+        virtual void itemAdded(const MWWorld::ConstPtr& item, int count);
+        virtual void itemRemoved(const MWWorld::ConstPtr& item, int count);
+
+    protected:
+        virtual void objectRootReset();
+
+    private:
+        void addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM::Light* esmLight);
+        void removeHiddenItemLight(const MWWorld::ConstPtr& item);
+
+        SceneUtil::LightListCallback* findLightListCallback();
+
+        typedef std::map<MWWorld::ConstPtr, osg::ref_ptr<SceneUtil::LightSource> > ItemLightMap;
+        ItemLightMap mItemLights;
+
+        bool mListenerDisabled;
+};
+
+}
+
+#endif

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1151,6 +1151,8 @@ namespace MWRender
         }
 
         mObjectRoot->addCullCallback(new SceneUtil::LightListCallback);
+
+        objectRootReset();
     }
 
     osg::Group* Animation::getObjectRoot()

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -307,6 +307,8 @@ protected:
      */
     void setObjectRoot(const std::string &model, bool forceskeleton, bool baseonly, bool isCreature);
 
+    virtual void objectRootReset() {}
+
     /** Adds the keyframe controllers in the specified model as a new animation source. Note that the .nif
      * file extension will be replaced with .kf.
      * @note Later added animation sources have the highest priority when it comes to finding a particular animation.

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -18,7 +18,7 @@ namespace MWRender
 
 CreatureAnimation::CreatureAnimation(const MWWorld::Ptr &ptr,
                                      const std::string& model, Resource::ResourceSystem* resourceSystem)
-  : Animation(ptr, osg::ref_ptr<osg::Group>(ptr.getRefData().getBaseNode()), resourceSystem)
+  : ActorAnimation(ptr, osg::ref_ptr<osg::Group>(ptr.getRefData().getBaseNode()), resourceSystem)
 {
     MWWorld::LiveCellRef<ESM::Creature> *ref = mPtr.get<ESM::Creature>();
 
@@ -34,7 +34,7 @@ CreatureAnimation::CreatureAnimation(const MWWorld::Ptr &ptr,
 
 
 CreatureWeaponAnimation::CreatureWeaponAnimation(const MWWorld::Ptr &ptr, const std::string& model, Resource::ResourceSystem* resourceSystem)
-    : Animation(ptr, osg::ref_ptr<osg::Group>(ptr.getRefData().getBaseNode()), resourceSystem)
+    : ActorAnimation(ptr, osg::ref_ptr<osg::Group>(ptr.getRefData().getBaseNode()), resourceSystem)
     , mShowWeapons(false)
     , mShowCarriedLeft(false)
 {
@@ -48,7 +48,7 @@ CreatureWeaponAnimation::CreatureWeaponAnimation(const MWWorld::Ptr &ptr, const 
             addAnimSource("meshes\\xbase_anim.nif");
         addAnimSource(model);
 
-        mPtr.getClass().getInventoryStore(mPtr).setListener(this, mPtr);
+        mPtr.getClass().getInventoryStore(mPtr).setInvListener(this, mPtr);
 
         updateParts();
     }

--- a/apps/openmw/mwrender/creatureanimation.hpp
+++ b/apps/openmw/mwrender/creatureanimation.hpp
@@ -1,7 +1,7 @@
 #ifndef GAME_RENDER_CREATUREANIMATION_H
 #define GAME_RENDER_CREATUREANIMATION_H
 
-#include "animation.hpp"
+#include "actoranimation.hpp"
 #include "weaponanimation.hpp"
 #include "../mwworld/inventorystore.hpp"
 
@@ -12,7 +12,7 @@ namespace MWWorld
 
 namespace MWRender
 {
-    class CreatureAnimation : public Animation
+    class CreatureAnimation : public ActorAnimation
     {
     public:
         CreatureAnimation(const MWWorld::Ptr &ptr, const std::string& model, Resource::ResourceSystem* resourceSystem);
@@ -22,7 +22,7 @@ namespace MWRender
     // For creatures with weapons and shields
     // Animation is already virtual anyway, so might as well make a separate class.
     // Most creatures don't need weapons/shields, so this will save some memory.
-    class CreatureWeaponAnimation : public Animation, public WeaponAnimation, public MWWorld::InventoryStoreListener
+    class CreatureWeaponAnimation : public ActorAnimation, public WeaponAnimation, public MWWorld::InventoryStoreListener
     {
     public:
         CreatureWeaponAnimation(const MWWorld::Ptr &ptr, const std::string& model, Resource::ResourceSystem* resourceSystem);

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -16,6 +16,7 @@
 #include <components/sceneutil/attach.hpp>
 #include <components/sceneutil/visitor.hpp>
 #include <components/sceneutil/skeleton.hpp>
+#include <components/sceneutil/lightmanager.hpp>
 
 #include <components/nifosg/nifloader.hpp> // TextKeyMapHolder
 
@@ -272,8 +273,8 @@ NpcAnimation::~NpcAnimation()
             // No need to getInventoryStore() to reset, if none exists
             // This is to avoid triggering the listener via ensureCustomData()->autoEquip()->fireEquipmentChanged()
             // all from within this destructor. ouch!
-           && mPtr.getRefData().getCustomData() && mPtr.getClass().getInventoryStore(mPtr).getListener() == this)
-        mPtr.getClass().getInventoryStore(mPtr).setListener(NULL, mPtr);
+           && mPtr.getRefData().getCustomData() && mPtr.getClass().getInventoryStore(mPtr).getInvListener() == this)
+        mPtr.getClass().getInventoryStore(mPtr).setInvListener(NULL, mPtr);
 
     // do not detach (delete) parts yet, this is done so the background thread can handle the deletion
     for(size_t i = 0;i < ESM::PRT_Count;i++)
@@ -285,7 +286,7 @@ NpcAnimation::~NpcAnimation()
 
 NpcAnimation::NpcAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group> parentNode, Resource::ResourceSystem* resourceSystem,
                            bool disableListener, bool disableSounds, ViewMode viewMode, float firstPersonFieldOfView)
-  : Animation(ptr, parentNode, resourceSystem),
+  : ActorAnimation(ptr, parentNode, resourceSystem, disableListener),
     mListenerDisabled(disableListener),
     mViewMode(viewMode),
     mShowWeapons(false),
@@ -310,7 +311,7 @@ NpcAnimation::NpcAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group> par
     updateNpcBase();
 
     if (!disableListener)
-        mPtr.getClass().getInventoryStore(mPtr).setListener(this, mPtr);
+        mPtr.getClass().getInventoryStore(mPtr).setInvListener(this, mPtr);
 }
 
 void NpcAnimation::setViewMode(NpcAnimation::ViewMode viewMode)

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -5,6 +5,7 @@
 
 #include "../mwworld/inventorystore.hpp"
 
+#include "actoranimation.hpp"
 #include "weaponanimation.hpp"
 
 namespace ESM
@@ -19,7 +20,7 @@ namespace MWRender
 class NeckController;
 class HeadAnimationTime;
 
-class NpcAnimation : public Animation, public WeaponAnimation, public MWWorld::InventoryStoreListener
+class NpcAnimation : public ActorAnimation, public WeaponAnimation, public MWWorld::InventoryStoreListener
 {
 public:
     virtual void equipmentChanged();

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -136,6 +136,17 @@ int MWWorld::ContainerStore::count(const std::string &id)
     return total;
 }
 
+MWWorld::ContainerStoreListener* MWWorld::ContainerStore::getContListener() const
+{
+    return mListener;
+}
+
+
+void MWWorld::ContainerStore::setContListener(MWWorld::ContainerStoreListener* listener)
+{
+    mListener = listener;
+}
+
 MWWorld::ContainerStoreIterator MWWorld::ContainerStore::unstack(const Ptr &ptr, const Ptr& container, int count)
 {
     if (ptr.getRefData().getCount() <= count)
@@ -292,6 +303,9 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr
             item.getRefData().getLocals().setVarByInt(script, "onpcadd", 1);
     }
 
+    if (mListener)
+        mListener->itemAdded(item, count);
+
     return it;
 }
 
@@ -397,6 +411,9 @@ int MWWorld::ContainerStore::remove(const Ptr& item, int count, const Ptr& actor
     }
 
     flagAsModified();
+
+    if (mListener)
+        mListener->itemRemoved(item, count - toRemove);
 
     // number of removed items
     return count - toRemove;

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -31,6 +31,13 @@ namespace MWWorld
 {
     class ContainerStoreIterator;
 
+    class ContainerStoreListener
+    {
+        public:
+            virtual void itemAdded(const ConstPtr& item, int count) {}
+            virtual void itemRemoved(const ConstPtr& item, int count) {}
+    };
+
     class ContainerStore
     {
         public:
@@ -72,6 +79,8 @@ namespace MWWorld
             std::map<std::pair<std::string, std::string>, int> mLevelledItemMap;
             ///< Stores result of levelled item spawns. <(refId, spawningGroup), count>
             /// This is used to restock levelled items(s) if the old item was sold.
+
+            ContainerStoreListener* mListener;
 
             mutable float mCachedWeight;
             mutable bool mWeightUpToDate;
@@ -142,6 +151,9 @@ namespace MWWorld
 
             /// @return How many items with refID \a id are in this container?
             int count (const std::string& id);
+
+            ContainerStoreListener* getContListener() const;
+            void setContListener(ContainerStoreListener* listener);
 
         protected:
             ContainerStoreIterator addNewStack (const ConstPtr& ptr, int count);

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -606,12 +606,12 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::unequipItemQuantity(con
     return unstack(item, actor, item.getRefData().getCount() - count);
 }
 
-MWWorld::InventoryStoreListener* MWWorld::InventoryStore::getListener()
+MWWorld::InventoryStoreListener* MWWorld::InventoryStore::getInvListener()
 {
     return mListener;
 }
 
-void MWWorld::InventoryStore::setListener(InventoryStoreListener *listener, const Ptr& actor)
+void MWWorld::InventoryStore::setInvListener(InventoryStoreListener *listener, const Ptr& actor)
 {
     mListener = listener;
     updateMagicEffects(actor);

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -197,10 +197,10 @@ namespace MWWorld
             /// in the slot (they can be re-stacked so its count may be different
             /// than the requested count).
 
-            void setListener (InventoryStoreListener* listener, const Ptr& actor);
+            void setInvListener (InventoryStoreListener* listener, const Ptr& actor);
             ///< Set a listener for various events, see \a InventoryStoreListener
 
-            InventoryStoreListener* getListener();
+            InventoryStoreListener* getInvListener();
 
             void visitEffectSources (MWMechanics::EffectSourceVisitor& visitor);
 

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -359,6 +359,10 @@ namespace SceneUtil
             for (unsigned int i=0; i<lights.size(); ++i)
             {
                 const LightManager::LightSourceViewBound& l = lights[i];
+
+                if (mIgnoredLightSources.count(l.mLightSource))
+                    continue;
+
                 if (l.mViewBound.intersects(nodeBound))
                     mLightList.push_back(&l);
             }

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENMW_COMPONENTS_SCENEUTIL_LIGHTMANAGER_H
 #define OPENMW_COMPONENTS_SCENEUTIL_LIGHTMANAGER_H
 
+#include <set>
+
 #include <osg/Light>
 
 #include <osg/Group>
@@ -157,16 +159,20 @@ namespace SceneUtil
             : osg::Object(copy, copyop), osg::NodeCallback(copy, copyop)
             , mLightManager(copy.mLightManager)
             , mLastFrameNumber(0)
+            , mIgnoredLightSources(copy.mIgnoredLightSources)
         {}
 
         META_Object(SceneUtil, LightListCallback)
 
         void operator()(osg::Node* node, osg::NodeVisitor* nv);
 
+        std::set<SceneUtil::LightSource*>& getIgnoredLightSources() { return mIgnoredLightSources; }
+
     private:
         LightManager* mLightManager;
         unsigned int mLastFrameNumber;
         LightManager::LightList mLightList;
+        std::set<SceneUtil::LightSource*> mIgnoredLightSources;
     };
 
 }

--- a/components/sceneutil/lightutil.cpp
+++ b/components/sceneutil/lightutil.cpp
@@ -36,7 +36,6 @@ namespace SceneUtil
         light->setLinearAttenuation(linearAttenuation);
         light->setQuadraticAttenuation(quadraticAttenuation);
         light->setConstantAttenuation(0.f);
-
     }
 
     void addLight (osg::Group* node, const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior, bool outQuadInLin, bool useQuadratic,
@@ -68,6 +67,14 @@ namespace SceneUtil
             attachTo = trans;
         }
 
+        osg::ref_ptr<LightSource> lightSource = createLightSource(esmLight, lightMask, isExterior, outQuadInLin, useQuadratic, quadraticValue,
+                                                                  quadraticRadiusMult, useLinear, linearRadiusMult, linearValue);
+        attachTo->addChild(lightSource);
+    }
+
+    osg::ref_ptr<LightSource> createLightSource(const ESM::Light* esmLight, unsigned int lightMask, bool isExterior, bool outQuadInLin, bool useQuadratic, float quadraticValue,
+                                                float quadraticRadiusMult, bool useLinear, float linearRadiusMult, float linearValue, const osg::Vec4f& ambient)
+    {
         osg::ref_ptr<SceneUtil::LightSource> lightSource (new SceneUtil::LightSource);
         osg::ref_ptr<osg::Light> light (new osg::Light);
         lightSource->setNodeMask(lightMask);
@@ -85,7 +92,7 @@ namespace SceneUtil
             diffuse.a() = 1;
         }
         light->setDiffuse(diffuse);
-        light->setAmbient(osg::Vec4f(0,0,0,1));
+        light->setAmbient(ambient);
         light->setSpecular(osg::Vec4f(0,0,0,0));
 
         lightSource->setLight(light);
@@ -103,7 +110,6 @@ namespace SceneUtil
 
         lightSource->addUpdateCallback(ctrl);
 
-        attachTo->addChild(lightSource);
+        return lightSource;
     }
-
 }

--- a/components/sceneutil/lightutil.hpp
+++ b/components/sceneutil/lightutil.hpp
@@ -1,6 +1,9 @@
 #ifndef OPENMW_COMPONENTS_LIGHTUTIL_H
 #define OPENMW_COMPONENTS_LIGHTUTIL_H
 
+#include <osg/ref_ptr>
+#include <osg/Vec4f>
+
 namespace osg
 {
     class Group;
@@ -13,6 +16,7 @@ namespace ESM
 
 namespace SceneUtil
 {
+    class LightSource;
 
     /// @brief Convert an ESM::Light to a SceneUtil::LightSource, and add it to a sub graph.
     /// @note If the sub graph contains a node named "AttachLight" (case insensitive), then the light is added to that.
@@ -26,6 +30,15 @@ namespace SceneUtil
     void addLight (osg::Group* node, const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior, bool outQuadInLin, bool useQuadratic,
                    float quadraticValue, float quadraticRadiusMult, bool useLinear, float linearRadiusMult,
                    float linearValue);
+
+    /// @brief Convert an ESM::Light to a SceneUtil::LightSource, and return it.
+    /// @param esmLight The light definition coming from the game files containing radius, color, flicker, etc.
+    /// @param lightMask Mask to assign to the newly created LightSource.
+    /// @param isExterior Is the light outside? May be used for deciding which attenuation settings to use.
+    /// @param ambient Ambient component of the light.
+    /// @par Attenuation parameters come from the game INI file.
+    osg::ref_ptr<LightSource> createLightSource (const ESM::Light* esmLight, unsigned int lightMask, bool isExterior, bool outQuadInLin, bool useQuadratic,
+                   float quadraticValue, float quadraticRadiusMult, bool useLinear, float linearRadiusMult, float linearValue, const osg::Vec4f& ambient=osg::Vec4f(0,0,0,1));
 
 }
 


### PR DESCRIPTION
Adding non-portable lights (such as "blade light" or "yellow light") to an actor's inventory should cause him to glow. This only applies to creatures and NPCs, not to containers.

Implements:
* https://bugs.openmw.org/issues/2042
* https://bugs.openmw.org/issues/3338