### PR TITLE
Don't let Weakness to Magicka affect paralysis

### DIFF
--- a/components/esm/loadmgef.cpp
+++ b/components/esm/loadmgef.cpp
@@ -356,8 +356,7 @@ short MagicEffect::getWeaknessEffect(short effect)
     effects[Corprus] = WeaknessToCorprusDisease;
     effects[Poison] = WeaknessToPoison;
 
-    // Weakness to magicka or -1 ?
-    effects[Paralyze] = WeaknessToMagicka;
+    effects[Paralyze] = -1;
 
     if (effects.find(effect) != effects.end())
         return effects[effect];


### PR DESCRIPTION
In the original engine the chance to resist paralysis is not effected by Weakness to Magicka, or any other of the weakness effects. Confirmed through testing.

You can confirm by creating a character with the Apprentice birthsign, or giving them "elfborn ability," which gives 50% Weakness to Magicka. Select Fargoth in Seyda Neen and have him cast paralysis on you through the console. In OpenMW master branch it will succeed, while it won't in original MW or with this PR your character will resist it. Use "tms" (toggle magic stats) in MW and you can see that no negative resistance is being applied.