### PR TITLE
Don't let intimidate bring disposition below 0 (Fixes #3584)

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -448,6 +448,12 @@ namespace MWDialogue
     {
         MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Dialogue);
 
+        // Clamp permanent disposition change so that final disposition doesn't go below 0 (could happen with intimidate)
+        
+        float curDisp = static_cast<float>(MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, false));
+        if (curDisp + mPermanentDispositionChange < 0)
+            mPermanentDispositionChange = -curDisp;
+
         // Apply disposition change to NPC's base disposition
         if (mActor.getClass().isNpc())
         {


### PR DESCRIPTION
Failed intimidate attempts had no check to prevent them from bringing disposition below 0. Testing in original MW indicates that disposition doesn't go below 0 there.