### PR TITLE
Fix the "Not Local" dialog test

### DIFF
--- a/apps/opencs/model/world/infoselectwrapper.cpp
+++ b/apps/opencs/model/world/infoselectwrapper.cpp
@@ -371,7 +371,6 @@ void CSMWorld::ConstInfoSelectWrapper::updateComparisonType()
         case Function_NotClass:
         case Function_NotRace:
         case Function_NotCell:
-        case Function_NotLocal:
         case Function_PcExpelled:
         case Function_PcCommonDisease:
         case Function_PcBlightDisease:
@@ -454,6 +453,7 @@ void CSMWorld::ConstInfoSelectWrapper::updateComparisonType()
         // Numeric
         case Function_Global:
         case Function_Local:
+        case Function_NotLocal:
 
         case Function_Health_Percent:
         case Function_PcHealthPercent:
@@ -560,7 +560,6 @@ std::pair<int, int> CSMWorld::ConstInfoSelectWrapper::getValidIntRange() const
         case Function_NotClass:
         case Function_NotRace:
         case Function_NotCell:
-        case Function_NotLocal:
         case Function_PcExpelled:
         case Function_PcCommonDisease:
         case Function_PcBlightDisease:
@@ -657,6 +656,7 @@ std::pair<int, int> CSMWorld::ConstInfoSelectWrapper::getValidIntRange() const
         // Numeric
         case Function_Global:
         case Function_Local:
+        case Function_NotLocal:
             return std::pair<int, int>(IntMin, IntMax);
 
         case Function_PcMagicka:

--- a/apps/openmw/mwdialogue/filter.hpp
+++ b/apps/openmw/mwdialogue/filter.hpp
@@ -33,6 +33,8 @@ namespace MWDialogue
             bool testDisposition (const ESM::DialInfo& info, bool invert=false) const;
             ///< Is the actor disposition toward the player high enough (or low enough, if \a invert is true)?
 
+            bool testFunctionLocal(const SelectWrapper& select) const;
+
             bool testSelectStruct (const SelectWrapper& select) const;
 
             bool testSelectStructNumeric (const SelectWrapper& select) const;

--- a/apps/openmw/mwdialogue/selectwrapper.cpp
+++ b/apps/openmw/mwdialogue/selectwrapper.cpp
@@ -210,7 +210,7 @@ MWDialogue::SelectWrapper::Type MWDialogue::SelectWrapper::getType() const
 
     static const Function numericFunctions[] =
     {
-        Function_Global, Function_Local,
+        Function_Global, Function_Local, Function_NotLocal,
         Function_PcDynamicStat, Function_PcHealthPercent,
         Function_HealthPercent,
         Function_None // end marker
@@ -232,7 +232,7 @@ MWDialogue::SelectWrapper::Type MWDialogue::SelectWrapper::getType() const
     static const Function invertedBooleanFunctions[] =
     {
         Function_NotId, Function_NotFaction, Function_NotClass,
-        Function_NotRace, Function_NotCell, Function_NotLocal,
+        Function_NotRace, Function_NotCell,
         Function_None // end marker
     };
 


### PR DESCRIPTION
The `Not Local` dialog test was incorrectly assumed to _only_ test the existence of the local variable while ignoring the comparison condition. This PR makes `Not Local` negate the `Local` test, as is the case in the original engine. OpenMW-CS has been updated to reflect this change in verification.

Fixes: https://bugs.openmw.org/issues/3577
Partially fixes: https://bugs.openmw.org/issues/3564