### PR TITLE
Recognize special faction ID "FFFF" during topic info verification

### DIFF
--- a/apps/opencs/model/tools/topicinfocheck.cpp
+++ b/apps/opencs/model/tools/topicinfocheck.cpp
@@ -108,7 +108,7 @@ void CSMTools::TopicInfoCheckStage::perform(int stage, CSMDoc::Messages& message
         verifyCell(topicInfo.mCell, id, messages);
     }
 
-    if (!topicInfo.mFaction.empty())
+    if (!topicInfo.mFaction.empty() && !topicInfo.mFactionLess)
     {
         if (verifyId(topicInfo.mFaction, mFactions, id, messages))
         {


### PR DESCRIPTION
Faction "FFFF" means that the speaker must not belong to a faction.

Fixes: https://bugs.openmw.org/issues/3564