### PR TITLE
Ignored light sources fix

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -19,6 +19,7 @@
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
+#include "../mwmechanics/actorutil.hpp"
 
 #include "vismask.hpp"
 
@@ -104,8 +105,8 @@ void ActorAnimation::addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM
 
     mInsert->addChild(lightSource);
 
-    if (SceneUtil::LightListCallback* callback = mLightListCallback)
-        callback->getIgnoredLightSources().insert(lightSource.get());
+    if (mLightListCallback && mPtr == MWMechanics::getPlayer())
+        mLightListCallback->getIgnoredLightSources().insert(lightSource.get());
 
     mItemLights.insert(std::make_pair(item, lightSource));
 }
@@ -116,11 +117,11 @@ void ActorAnimation::removeHiddenItemLight(const MWWorld::ConstPtr& item)
     if (iter == mItemLights.end())
         return;
 
-    if (SceneUtil::LightListCallback* callback = mLightListCallback)
+    if (mLightListCallback && mPtr == MWMechanics::getPlayer())
     {
-        std::set<SceneUtil::LightSource*>::iterator ignoredIter = callback->getIgnoredLightSources().find(iter->second.get());
-        if (ignoredIter != callback->getIgnoredLightSources().end())
-            callback->getIgnoredLightSources().erase(ignoredIter);
+        std::set<SceneUtil::LightSource*>::iterator ignoredIter = mLightListCallback->getIgnoredLightSources().find(iter->second.get());
+        if (ignoredIter != mLightListCallback->getIgnoredLightSources().end())
+            mLightListCallback->getIgnoredLightSources().erase(ignoredIter);
     }
 
     mInsert->removeChild(iter->second);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1157,8 +1157,6 @@ namespace MWRender
         if (!mLightListCallback)
             mLightListCallback = new SceneUtil::LightListCallback;
         mObjectRoot->addCullCallback(mLightListCallback);
-
-        objectRootReset();
     }
 
     osg::Group* Animation::getObjectRoot()

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -310,8 +310,6 @@ protected:
      */
     void setObjectRoot(const std::string &model, bool forceskeleton, bool baseonly, bool isCreature);
 
-    virtual void objectRootReset() {}
-
     /** Adds the keyframe controllers in the specified model as a new animation source. Note that the .nif
      * file extension will be replaced with .kf.
      * @note Later added animation sources have the highest priority when it comes to finding a particular animation.


### PR DESCRIPTION
Only the player's lights should be added to the list of ignored light sources. Last time I tested this, I thought non-player actors were affected too, but it's likely I was mistakenly adding the light item to my inventory instead of the other actor's.

I have also removed some unused/unneeded code from the previous PR.

Fixes: https://bugs.openmw.org/issues/3588