### PR TITLE
Change several spell effects from instant to non-instant

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -448,8 +448,7 @@ namespace MWDialogue
     {
         MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Dialogue);
 
-        // Clamp permanent disposition change so that final disposition doesn't go below 0 (could happen with intimidate)
-        
+        // Clamp permanent disposition change so that final disposition doesn't go below 0 (could happen with intimidate)       
         float curDisp = static_cast<float>(MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor, false));
         if (curDisp + mPermanentDispositionChange < 0)
             mPermanentDispositionChange = -curDisp;

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -463,7 +463,8 @@ namespace MWMechanics
                 }
                 else // target.getClass().isActor() == true
                 {
-                    if (effectIt->mDuration == 0)
+                    bool hasDuration = !(magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration);
+                    if (hasDuration && effectIt->mDuration == 0)
                     {
                         // duration 0 means apply full magnitude instantly
                         bool wasDead = target.getClass().getCreatureStats(target).isDead();
@@ -479,7 +480,10 @@ namespace MWMechanics
                         ActiveSpells::ActiveEffect effect;
                         effect.mEffectId = effectIt->mEffectID;
                         effect.mArg = MWMechanics::EffectKey(*effectIt).mArg;
-                        effect.mDuration = static_cast<float>(effectIt->mDuration);
+                        if (!hasDuration)
+                            effect.mDuration = 1.0f;
+                        else
+                            effect.mDuration = static_cast<float>(effectIt->mDuration);
                         effect.mMagnitude = magnitude;
 
                         targetEffects.add(MWMechanics::EffectKey(*effectIt), MWMechanics::EffectParam(effect.mMagnitude));

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -463,8 +463,7 @@ namespace MWMechanics
                 }
                 else // target.getClass().isActor() == true
                 {
-                    bool hasDuration = !(magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration);
-                    if (hasDuration && effectIt->mDuration == 0)
+                    if (effectIt->mDuration == 0)
                     {
                         // duration 0 means apply full magnitude instantly
                         bool wasDead = target.getClass().getCreatureStats(target).isDead();
@@ -610,36 +609,8 @@ namespace MWMechanics
                 return true;
             }
         }
-        else if (target.getClass().isActor())
+        else if (target.getClass().isActor() && target == getPlayer())
         {
-            switch (effectId)
-            {
-            case ESM::MagicEffect::CurePoison:
-                target.getClass().getCreatureStats(target).getActiveSpells().purgeEffect(ESM::MagicEffect::Poison);
-                return true;
-            case ESM::MagicEffect::CureParalyzation:
-                target.getClass().getCreatureStats(target).getActiveSpells().purgeEffect(ESM::MagicEffect::Paralyze);
-                return true;
-            case ESM::MagicEffect::CureCommonDisease:
-                target.getClass().getCreatureStats(target).getSpells().purgeCommonDisease();
-                return true;
-            case ESM::MagicEffect::CureBlightDisease:
-                target.getClass().getCreatureStats(target).getSpells().purgeBlightDisease();
-                return true;
-            case ESM::MagicEffect::CureCorprusDisease:
-                target.getClass().getCreatureStats(target).getSpells().purgeCorprusDisease();
-                return true;
-            case ESM::MagicEffect::Dispel:
-                target.getClass().getCreatureStats(target).getActiveSpells().purgeAll(magnitude);
-                return true;
-            case ESM::MagicEffect::RemoveCurse:
-                target.getClass().getCreatureStats(target).getSpells().purgeCurses();
-                return true;
-            }
-
-            if (target != getPlayer())
-                return false;
-
             MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
 
             if (effectId == ESM::MagicEffect::DivineIntervention)
@@ -662,7 +633,6 @@ namespace MWMechanics
                     anim->addEffect("meshes\\" + fx->mModel, -1);
                 return true;
             }
-
             else if (effectId == ESM::MagicEffect::Mark)
             {
                 MWBase::Environment::get().getWorld()->getPlayer().markPosition(
@@ -1149,6 +1119,27 @@ namespace MWMechanics
             break;
         }
 
+        case ESM::MagicEffect::CurePoison:
+            actor.getClass().getCreatureStats(actor).getActiveSpells().purgeEffect(ESM::MagicEffect::Poison);
+            break;
+        case ESM::MagicEffect::CureParalyzation:
+            actor.getClass().getCreatureStats(actor).getActiveSpells().purgeEffect(ESM::MagicEffect::Paralyze);
+            break;
+        case ESM::MagicEffect::CureCommonDisease:
+            actor.getClass().getCreatureStats(actor).getSpells().purgeCommonDisease();
+            break;
+        case ESM::MagicEffect::CureBlightDisease:
+            actor.getClass().getCreatureStats(actor).getSpells().purgeBlightDisease();
+            break;
+        case ESM::MagicEffect::CureCorprusDisease:
+            actor.getClass().getCreatureStats(actor).getSpells().purgeCorprusDisease();
+            break;
+        case ESM::MagicEffect::Dispel:
+            actor.getClass().getCreatureStats(actor).getActiveSpells().purgeAll(magnitude);
+            break;
+        case ESM::MagicEffect::RemoveCurse:
+            actor.getClass().getCreatureStats(actor).getSpells().purgeCurses();
+            break;
         }
 
         if (receivedMagicDamage && actor == getPlayer())


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/2054.

Several spells applied instantly and then removed in OpenMW actually are applied over a duration of 1 in original Morrowind.

This is true for Cure Common Disease, Cure Blight Disease, Cure Corprus Disease, Cure Poison, Cure Paralyzation and Dispel. Remove Curse was also being treated as instant but it can receive a variable duration.

You can confirm this in original Morrowind by casting a spell or drinking a potion with Cure Common Disease. Select yourself in the console and type "addspell chills" to give yourself the disease immediately afterwards, while the icon still is showing, and the disease will be removed even though it is after the cure effect was applied. The ToggleMagicStats command will also show that the cure effect is repeatedly being applied. I also tested this for Cure Poison and Cure Paralyzation, so I assume it to be true for all of them.

I put these effects alongside an effect explicitly set to duration 1 and they all finished at the same time, so duration 1 seems to be correct. Duration 1 is also what the TES Construction Set shows.

I was going to explicitly give these effects a duration of 1 in OpenMW's code, but they seem to all get 1 anyway just by reading the duration from the spell effects.