### PR TITLE
Fix shadowing warnings

### DIFF
--- a/apps/opencs/model/filter/parser.cpp
+++ b/apps/opencs/model/filter/parser.cpp
@@ -313,7 +313,7 @@ boost::shared_ptr<CSMFilter::Node> CSMFilter::Parser::parseNAry (const Token& ke
 
         nodes.push_back (node);
 
-        Token token = getNextToken();
+        token = getNextToken();
 
         if (!token || (token.mType!=Token::Type_Close && token.mType!=Token::Type_Comma))
         {

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -219,12 +219,12 @@ bool CSVRender::Cell::referenceDataChanged (const QModelIndex& topLeft,
     }
 
     // add new objects
-    for (std::map<std::string, bool>::iterator iter (ids.begin()); iter!=ids.end(); ++iter)
+    for (std::map<std::string, bool>::iterator mapIter (ids.begin()); mapIter!=ids.end(); ++mapIter)
     {
-        if (!iter->second)
+        if (!mapIter->second)
         {
             mObjects.insert (std::make_pair (
-                iter->first, new Object (mData, mCellNode, iter->first, false)));
+                mapIter->first, new Object (mData, mCellNode, mapIter->first, false)));
 
             modified = true;
         }

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -658,8 +658,7 @@ void CSVWorld::EditWidget::remake(int row)
                     int displayRole = tree->nestedHeaderData (i, col,
                             Qt::Horizontal, CSMWorld::ColumnBase::Role_Display).toInt();
 
-                    CSMWorld::ColumnBase::Display display =
-                        static_cast<CSMWorld::ColumnBase::Display> (displayRole);
+                    display = static_cast<CSMWorld::ColumnBase::Display> (displayRole);
 
                    mNestedTableDispatcher->makeDelegate (display);
 

--- a/apps/opencs/view/world/dragrecordtable.cpp
+++ b/apps/opencs/view/world/dragrecordtable.cpp
@@ -67,8 +67,8 @@ void CSVWorld::DragRecordTable::dropEvent(QDropEvent *event)
     CSMWorld::ColumnBase::Display display = getIndexDisplayType(index);
     if (CSVWorld::DragDropUtils::canAcceptData(*event, display))
     {
-        const CSMWorld::TableMimeData *data = CSVWorld::DragDropUtils::getTableMimeData(*event);
-        if (data->fromDocument(mDocument))
+        const CSMWorld::TableMimeData *tableMimeData = CSVWorld::DragDropUtils::getTableMimeData(*event);
+        if (tableMimeData->fromDocument(mDocument))
         {
             CSMWorld::UniversalId id = CSVWorld::DragDropUtils::getAcceptedData(*event, display);
             QVariant newIndexData = QString::fromUtf8(id.getId().c_str());

--- a/apps/openmw/mwdialogue/journalimp.cpp
+++ b/apps/openmw/mwdialogue/journalimp.cpp
@@ -187,12 +187,12 @@ namespace MWDialogue
             state.save (writer);
             writer.endRecord (ESM::REC_QUES);
 
-            for (Topic::TEntryIter iter (quest.begin()); iter!=quest.end(); ++iter)
+            for (Topic::TEntryIter entryIter (quest.begin()); entryIter!=quest.end(); ++entryIter)
             {
                 ESM::JournalEntry entry;
                 entry.mType = ESM::JournalEntry::Type_Quest;
                 entry.mTopic = quest.getTopic();
-                iter->write (entry);
+                entryIter->write (entry);
                 writer.startRecord (ESM::REC_JOUR);
                 entry.save (writer);
                 writer.endRecord (ESM::REC_JOUR);
@@ -213,12 +213,12 @@ namespace MWDialogue
         {
             const Topic& topic = iter->second;
 
-            for (Topic::TEntryIter iter (topic.begin()); iter!=topic.end(); ++iter)
+            for (Topic::TEntryIter entryIter (topic.begin()); entryIter!=topic.end(); ++entryIter)
             {
                 ESM::JournalEntry entry;
                 entry.mType = ESM::JournalEntry::Type_Topic;
                 entry.mTopic = topic.getTopic();
-                iter->write (entry);
+                entryIter->write (entry);
                 writer.startRecord (ESM::REC_JOUR);
                 entry.save (writer);
                 writer.endRecord (ESM::REC_JOUR);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -978,8 +978,8 @@ namespace MWRender
             {
                 const NifOsg::TextKeyMap &keys = (*animiter)->getTextKeys();
 
-                const AnimSource::ControllerMap& ctrls = (*animiter)->mControllerMap[0];
-                for (AnimSource::ControllerMap::const_iterator it = ctrls.begin(); it != ctrls.end(); ++it)
+                const AnimSource::ControllerMap& ctrls2 = (*animiter)->mControllerMap[0];
+                for (AnimSource::ControllerMap::const_iterator it = ctrls2.begin(); it != ctrls2.end(); ++it)
                 {
                     if (Misc::StringUtils::ciEqual(it->first, mAccumRoot->getName()))
                     {

--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -172,37 +172,37 @@ namespace MWRender
 
                         unsigned char r,g,b;
 
-                        float y = 0;
+                        float y2 = 0;
                         if (landData)
-                            y = (landData->mWnam[vertexY * 9 + vertexX] << 4) / 2048.f;
+                            y2 = (landData->mWnam[vertexY * 9 + vertexX] << 4) / 2048.f;
                         else
-                            y = (SCHAR_MIN << 4) / 2048.f;
-                        if (y < 0)
+                            y2 = (SCHAR_MIN << 4) / 2048.f;
+                        if (y2 < 0)
                         {
-                            r = static_cast<unsigned char>(14 * y + 38);
-                            g = static_cast<unsigned char>(20 * y + 56);
-                            b = static_cast<unsigned char>(18 * y + 51);
+                            r = static_cast<unsigned char>(14 * y2 + 38);
+                            g = static_cast<unsigned char>(20 * y2 + 56);
+                            b = static_cast<unsigned char>(18 * y2 + 51);
                         }
-                        else if (y < 0.3f)
+                        else if (y2 < 0.3f)
                         {
-                            if (y < 0.1f)
-                                y *= 8.f;
+                            if (y2 < 0.1f)
+                                y2 *= 8.f;
                             else
                             {
-                                y -= 0.1f;
-                                y += 0.8f;
+                                y2 -= 0.1f;
+                                y2 += 0.8f;
                             }
-                            r = static_cast<unsigned char>(66 - 32 * y);
-                            g = static_cast<unsigned char>(48 - 23 * y);
-                            b = static_cast<unsigned char>(33 - 16 * y);
+                            r = static_cast<unsigned char>(66 - 32 * y2);
+                            g = static_cast<unsigned char>(48 - 23 * y2);
+                            b = static_cast<unsigned char>(33 - 16 * y2);
                         }
                         else
                         {
-                            y -= 0.3f;
-                            y *= 1.428f;
-                            r = static_cast<unsigned char>(34 - 29 * y);
-                            g = static_cast<unsigned char>(25 - 20 * y);
-                            b = static_cast<unsigned char>(17 - 12 * y);
+                            y2 -= 0.3f;
+                            y2 *= 1.428f;
+                            r = static_cast<unsigned char>(34 - 29 * y2);
+                            g = static_cast<unsigned char>(25 - 20 * y2);
+                            b = static_cast<unsigned char>(17 - 12 * y2);
                         }
 
                         data[texelY * mWidth * 3 + texelX * 3] = r;

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -450,10 +450,10 @@ void MWWorld::ContainerStore::addInitialItem (const std::string& id, const std::
             }
             else
             {
-                std::string id = MWMechanics::getLevelledItem(ref.getPtr().get<ESM::ItemLevList>()->mBase, false);
-                if (id.empty())
+                std::string itemId = MWMechanics::getLevelledItem(ref.getPtr().get<ESM::ItemLevList>()->mBase, false);
+                if (itemId.empty())
                     return;
-                addInitialItem(id, owner, count, false, levItemList->mId);
+                addInitialItem(itemId, owner, count, false, levItemList->mId);
             }
         }
         else


### PR DESCRIPTION
Fixed some more MSVC/AppVeyor shadowing warnings.

For a few of the doubled variable names I simply added a "2" to the end because no other name for the variable easily came to mind. Is this acceptable?