### PR TITLE
Auto-equip weapons

### DIFF
--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -115,6 +115,8 @@ namespace MWWorld
             virtual void storeEquipmentState (const MWWorld::LiveCellRefBase& ref, int index, ESM::InventoryState& inventory) const;
             virtual void readEquipmentState (const MWWorld::ContainerStoreIterator& iter, int index, const ESM::InventoryState& inventory);
 
+            bool canActorAutoEquip(const MWWorld::Ptr& actor, const MWWorld::Ptr& item);
+
         public:
 
             InventoryStore();

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -145,6 +145,9 @@ difficulty = 0
 # Show duration of magic effect and lights in the spells window.
 show effect duration = false
 
+# Prevents merchants from equipping items that are sold to them.
+prevent merchant equipping = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Fixes: https://bugs.openmw.org/issues/3562

This also removes some owner checks preventing merchants from equipping armor or clothing that is sold to them. I couldn't find any such checks in vanilla MW, and testing proved they can indeed equip items sold to them.

Reversed code for auto-equipping weapons:
```python
weaponSkills = [5, 6, 7, 22, 23, 4]
skillVisited = [False, False, False, False, False, False]

for _ in range(len(weaponSkills)):
    max = 0
    maxWeaponSkill = None

    for i in range(len(weaponSkills)):
        skill_val = npc.skills[weaponSkills[i]]

        if skill_val > max and skillVisited[i] == False:
            max = skill_val
            maxWeaponSkill = i

    if maxWeaponSkill is None:
        break

    max = 0
    stack = None
    for itemStack in inventory:
        item = itemStack.item
        if item is not weapon: # Unlike in OpenMW, ammunition (arrows and bolts) is not classified as weapon.
            continue

        if weaponTypeToSkill(item.weapon.type) == weaponSkills[maxWeaponSkill]:
            if item.weapon.chopMax >= max:
                max = item.weapon.chopMax
                stack = itemStack

            if item.weapon.slashMax >= max:
                max = item.weapon.slashMax
                stack = itemStack

            if item.weapon.thrustMax >= max:
                max = item.weapon.thrustMax
                stack = itemStack

    if stack is not None:
        if stack.something08 != 0: # No idea what this is.
            npc.equipItem(stack.item, stack.something08.something00, 0, 0)
        else:
            npc.equipItem(stack.item, 0, 0, 0)
        break

    skillVisited[maxWeaponSkill] = True
```