### PR TITLE
Move actors out of the water if there's room for them. Fixes #1138

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1328,10 +1328,12 @@ namespace MWPhysics
                     waterCollision = true;
                 else if (physicActor->getCollisionMode())
                 {
+                    const float halfZ = physicActor->getHalfExtents().z();
                     const osg::Vec3f actorPosition = physicActor->getPosition();
-                    const osg::Vec3f destinationPosition(actorPosition.x(), actorPosition.y(), waterlevel + physicActor->getHalfExtents().z());
+                    const osg::Vec3f startingPosition(actorPosition.x(), actorPosition.y(), actorPosition.z() + halfZ);
+                    const osg::Vec3f destinationPosition(actorPosition.x(), actorPosition.y(), waterlevel + halfZ);
                     ActorTracer tracer;
-                    tracer.doTrace(physicActor->getCollisionObject(), actorPosition, destinationPosition, mCollisionWorld);
+                    tracer.doTrace(physicActor->getCollisionObject(), startingPosition, destinationPosition, mCollisionWorld);
                     if (tracer.mFraction >= 1.0f)
                     {
                         waterCollision = true;

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1329,13 +1329,13 @@ namespace MWPhysics
                 else if (physicActor->getCollisionMode())
                 {
                     const osg::Vec3f actorPosition = physicActor->getPosition();
-                    const osg::Vec3f destinationPosition(actorPosition.x(), actorPosition.y(), waterlevel);
+                    const osg::Vec3f destinationPosition(actorPosition.x(), actorPosition.y(), waterlevel + physicActor->getHalfExtents().z());
                     ActorTracer tracer;
                     tracer.doTrace(physicActor->getCollisionObject(), actorPosition, destinationPosition, mCollisionWorld);
                     if (tracer.mFraction >= 1.0f)
                     {
                         waterCollision = true;
-                        physicActor->setPosition(destinationPosition);
+                        physicActor->setPosition(osg::Vec3f(actorPosition.x(), actorPosition.y(), waterlevel));
                     }
                     else
                     {


### PR DESCRIPTION
Based on the diff by Stanislav Zhukov, with a check thrown in to make sure there's room.

I did manage to get stuck when I cast it under a sloped roof (Hlormaren, Sewers), but [806](https://bugs.openmw.org/issues/806) would fix that.
