### PR TITLE
Prevent NPC from chosing farther pathgrid node.

### DIFF
--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -231,6 +231,16 @@ namespace MWMechanics
         {
             mPath = pathgridGraph.aStarSearch(startNode, endNode.first);
 
+            // If startNode (the closest node to startPoint) is farther from destination than
+            // startPoint and second path node is closer to destination then
+            // drop startNode and use the next path node.
+            if (mPath.size() > 1) {
+                float endTo1stNodeLength2 = DistanceSquared(mPathgrid->mPoints[startNode], endPointInLocalCoords);
+                float endTo2ndNodeLength2 = DistanceSquared(*(++mPath.begin()), endPointInLocalCoords);
+                if (endTo1stNodeLength2 > startToEndLength2 && endTo2ndNodeLength2 < endTo1stNodeLength2)
+                    mPath.pop_front();
+            }
+
             // convert supplied path to world coordinates
             for (std::list<ESM::Pathgrid::Point>::iterator iter(mPath.begin()); iter != mPath.end(); ++iter)
             {

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -237,8 +237,7 @@ namespace MWMechanics
                 osg::Vec3f secondNodeVec3f = MakeOsgVec3(secondNode);
                 osg::Vec3f toSecondNodeVec3f = secondNodeVec3f - firstNodeVec3f;
                 osg::Vec3f toStartPointVec3f = startPointInLocalCoords - firstNodeVec3f;
-                float cos = (toSecondNodeVec3f * toStartPointVec3f) / (toSecondNodeVec3f.length() * toStartPointVec3f.length());
-                if (cos > 0) {
+                if (toSecondNodeVec3f * toStartPointVec3f > 0) {
                     ESM::Pathgrid::Point temp(secondNode);
                     converter.toWorld(temp);
                     bool isPathClear = !MWBase::Environment::get().getWorld()->castRay(


### PR DESCRIPTION
It prevents guard from changing the direction as I mentioned here https://bugs.openmw.org/issues/3587
This happens because the guard uses shortcut and then bumps into an obstacle and returns to the nearest pathgrid node.
Though I'm not sure that this patch is the best way to fix this behaviour (maybe guard should always use pathgrid instead of shortcut?). But anyway it seems that this patch might be useful in general.
