### PR TITLE
Fix shadowing warnings

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -326,7 +326,7 @@ bool Launcher::MainDialog::setupGameSettings()
     foreach (const QString &path, paths) {
         qDebug() << "Loading config file:" << path.toUtf8().constData();
 
-        QFile file(path);
+        file.setFileName(path);
         if (file.exists()) {
             if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
                 cfgError(tr("Error opening OpenMW configuration file"),

--- a/apps/opencs/model/tools/mergestages.cpp
+++ b/apps/opencs/model/tools/mergestages.cpp
@@ -184,7 +184,7 @@ void CSMTools::MergeLandTexturesStage::perform (int stage, CSMDoc::Messages& mes
             CSMWorld::LandTexture texture =
                 mState.mSource.getData().getLandTextures().getRecord (index).get();
 
-            std::ostringstream stream;
+            stream.clear();
             stream << mNext->second-1 << "_0";
 
             texture.mIndex = mNext->second-1;

--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -191,7 +191,7 @@ void CSMWorld::IdTable::setRecord (const std::string& id, const RecordBase& reco
 
     if (index==-1)
     {
-        int index = mIdCollection->getAppendIndex (id, type);
+        index = mIdCollection->getAppendIndex (id, type);
 
         beginInsertRows (QModelIndex(), index, index);
 

--- a/apps/opencs/model/world/refcollection.cpp
+++ b/apps/opencs/model/world/refcollection.cpp
@@ -63,7 +63,7 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
                     std::cerr << "Position: #" << index.first << " " << index.second
                         <<", Target #"<< mref.mTarget[0] << " " << mref.mTarget[1] << std::endl;
 
-                    std::ostringstream stream;
+                    stream.clear();
                     stream << "#" << mref.mTarget[0] << " " << mref.mTarget[1];
                     ref.mCell = stream.str(); // overwrite
                 }

--- a/apps/openmw/mwclass/creaturelevlist.cpp
+++ b/apps/openmw/mwclass/creaturelevlist.cpp
@@ -118,9 +118,9 @@ namespace MWClass
             }
 
             const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
-            MWWorld::ManualRef ref(store, id);
-            ref.getPtr().getCellRef().setPosition(ptr.getCellRef().getPosition());
-            MWWorld::Ptr placed = MWBase::Environment::get().getWorld()->placeObject(ref.getPtr(), ptr.getCell() , ptr.getCellRef().getPosition());
+            MWWorld::ManualRef manualRef(store, id);
+            manualRef.getPtr().getCellRef().setPosition(ptr.getCellRef().getPosition());
+            MWWorld::Ptr placed = MWBase::Environment::get().getWorld()->placeObject(manualRef.getPtr(), ptr.getCell() , ptr.getCellRef().getPosition());
             customData.mSpawnActorId = placed.getClass().getCreatureStats(placed).getActorId();
             customData.mSpawn = false;
         }

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -200,15 +200,15 @@ namespace MWGui
         std::set<MWMechanics::EffectKey> effectIds = mAlchemy->listEffects();
         Widgets::SpellEffectList list;
         unsigned int effectIndex=0;
-        for (std::set<MWMechanics::EffectKey>::iterator it = effectIds.begin(); it != effectIds.end(); ++it)
+        for (std::set<MWMechanics::EffectKey>::iterator it2 = effectIds.begin(); it2 != effectIds.end(); ++it2)
         {
             Widgets::SpellEffectParams params;
-            params.mEffectID = it->mId;
-            const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(it->mId);
+            params.mEffectID = it2->mId;
+            const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(it2->mId);
             if (magicEffect->mData.mFlags & ESM::MagicEffect::TargetSkill)
-                params.mSkill = it->mArg;
+                params.mSkill = it2->mArg;
             else if (magicEffect->mData.mFlags & ESM::MagicEffect::TargetAttribute)
-                params.mAttribute = it->mArg;
+                params.mAttribute = it2->mArg;
             params.mIsConstant = true;
             params.mNoTarget = true;
 

--- a/apps/openmw/mwgui/birth.cpp
+++ b/apps/openmw/mwgui/birth.cpp
@@ -226,7 +226,7 @@ namespace MWGui
                 coord.top += lineHeight;
 
                 end = categories[category].spells.end();
-                for (std::vector<std::string>::const_iterator it = categories[category].spells.begin(); it != end; ++it)
+                for (it = categories[category].spells.begin(); it != end; ++it)
                 {
                     const std::string &spellId = *it;
                     spellWidget = mSpellArea->createWidget<Widgets::MWSpell>("MW_StatName", coord, MyGUI::Align::Default, std::string("Spell") + MyGUI::utility::toString(i));

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -85,8 +85,8 @@ void InventoryItemModel::update()
 
         if (mActor.getClass().hasInventoryStore(mActor))
         {
-            MWWorld::InventoryStore& store = mActor.getClass().getInventoryStore(mActor);
-            if (store.isEquipped(newItem.mBase))
+            MWWorld::InventoryStore& invStore = mActor.getClass().getInventoryStore(mActor);
+            if (invStore.isEquipped(newItem.mBase))
                 newItem.mType = ItemStack::Type_Equipped;
         }
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -256,7 +256,7 @@ namespace MWGui
                         std::string key = it->first.substr(0, underscorePos);
                         std::string widgetName = it->first.substr(underscorePos+1, it->first.size()-(underscorePos+1));
 
-                        std::string type = "Property";
+                        type = "Property";
                         size_t caretPos = key.find("^");
                         if (caretPos != std::string::npos)
                         {

--- a/apps/openmw/mwmechanics/aiactivate.cpp
+++ b/apps/openmw/mwmechanics/aiactivate.cpp
@@ -41,9 +41,7 @@ namespace MWMechanics
         if (pathTo(actor, dest, duration, MWBase::Environment::get().getWorld()->getMaxActivationDistance())) //Stop when you get in activation range
         {
             // activate when reached
-            MWWorld::Ptr target = MWBase::Environment::get().getWorld()->getPtr(mObjectId,false);
             MWBase::Environment::get().getWorld()->activate(target, actor);
-
             return true;
         }
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -686,9 +686,9 @@ namespace MWRender
                 state.mAutoDisable = autodisable;
                 mStates[groupname] = state;
 
-                NifOsg::TextKeyMap::const_iterator textkey(textkeys.lower_bound(state.getTime()));
                 if (state.mPlaying)
                 {
+                    NifOsg::TextKeyMap::const_iterator textkey(textkeys.lower_bound(state.getTime()));
                     while(textkey != textkeys.end() && textkey->first <= state.getTime())
                     {
                         handleTextKey(state, groupname, textkey, textkeys);
@@ -976,14 +976,14 @@ namespace MWRender
 
             while(!(velocity > 1.0f) && ++animiter != mAnimSources.rend())
             {
-                const NifOsg::TextKeyMap &keys = (*animiter)->getTextKeys();
+                const NifOsg::TextKeyMap &keys2 = (*animiter)->getTextKeys();
 
                 const AnimSource::ControllerMap& ctrls2 = (*animiter)->mControllerMap[0];
                 for (AnimSource::ControllerMap::const_iterator it = ctrls2.begin(); it != ctrls2.end(); ++it)
                 {
                     if (Misc::StringUtils::ciEqual(it->first, mAccumRoot->getName()))
                     {
-                        velocity = calcAnimVelocity(keys, it->second, mAccumulate, groupname);
+                        velocity = calcAnimVelocity(keys2, it->second, mAccumulate, groupname);
                         break;
                     }
                 }

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -221,10 +221,10 @@ namespace MWRender
             groupname = "inventoryhandtohand";
         else
         {
-            const std::string &type = iter->getTypeName();
-            if(type == typeid(ESM::Lockpick).name() || type == typeid(ESM::Probe).name())
+            const std::string &typeName = iter->getTypeName();
+            if(typeName == typeid(ESM::Lockpick).name() || typeName == typeid(ESM::Probe).name())
                 groupname = "inventoryweapononehand";
-            else if(type == typeid(ESM::Weapon).name())
+            else if(typeName == typeid(ESM::Weapon).name())
             {
                 MWWorld::LiveCellRef<ESM::Weapon> *ref = iter->get<ESM::Weapon>();
 

--- a/apps/openmw/mwrender/ripplesimulation.cpp
+++ b/apps/openmw/mwrender/ripplesimulation.cpp
@@ -39,11 +39,11 @@ namespace
         {
             std::ostringstream texname;
             texname << "textures/water/" << tex << std::setw(2) << std::setfill('0') << i << ".dds";
-            osg::ref_ptr<osg::Texture2D> tex (new osg::Texture2D(resourceSystem->getImageManager()->getImage(texname.str())));
-            tex->setWrap(osg::Texture::WRAP_S, osg::Texture::REPEAT);
-            tex->setWrap(osg::Texture::WRAP_T, osg::Texture::REPEAT);
-            resourceSystem->getSceneManager()->applyFilterSettings(tex);
-            textures.push_back(tex);
+            osg::ref_ptr<osg::Texture2D> tex2 (new osg::Texture2D(resourceSystem->getImageManager()->getImage(texname.str())));
+            tex2->setWrap(osg::Texture::WRAP_S, osg::Texture::REPEAT);
+            tex2->setWrap(osg::Texture::WRAP_T, osg::Texture::REPEAT);
+            resourceSystem->getSceneManager()->applyFilterSettings(tex2);
+            textures.push_back(tex2);
         }
 
         osg::ref_ptr<NifOsg::FlipController> controller (new NifOsg::FlipController(0, 0.3f/rippleFrameCount, textures));

--- a/apps/openmw/mwscript/locals.cpp
+++ b/apps/openmw/mwscript/locals.cpp
@@ -238,15 +238,15 @@ namespace MWScript
                 else
                 {
                     char type =  declarations.getType (iter->first);
-                    char index = declarations.getIndex (iter->first);
+                    char index2 = declarations.getIndex (iter->first);
 
                     try
                     {
                         switch (type)
                         {
-                            case 's': mShorts.at (index) = iter->second.getInteger(); break;
-                            case 'l': mLongs.at (index) = iter->second.getInteger(); break;
-                            case 'f': mFloats.at (index) = iter->second.getFloat(); break;
+                            case 's': mShorts.at (index2) = iter->second.getInteger(); break;
+                            case 'l': mLongs.at (index2) = iter->second.getInteger(); break;
+                            case 'f': mFloats.at (index2) = iter->second.getFloat(); break;
 
                             // silently ignore locals that don't exist anymore
                         }

--- a/apps/wizard/existinginstallationpage.cpp
+++ b/apps/wizard/existinginstallationpage.cpp
@@ -63,13 +63,13 @@ bool Wizard::ExistingInstallationPage::validatePage()
                                    The Wizard needs to update settings in this file.<br><br> \
                                    Press \"Browse...\" to specify the location manually.<br>"));
 
-        QAbstractButton *browseButton =
+        QAbstractButton *browseButton2 =
                 msgBox.addButton(QObject::tr("B&rowse..."), QMessageBox::ActionRole);
 
         msgBox.exec();
 
         QString iniFile;
-        if (msgBox.clickedButton() == browseButton) {
+        if (msgBox.clickedButton() == browseButton2) {
             iniFile = QFileDialog::getOpenFileName(
                         this,
                         QObject::tr("Select configuration file"),

--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -165,7 +165,7 @@ void Wizard::MainWizard::setupGameSettings()
     foreach (const QString &path, paths) {
         qDebug() << "Loading config file:" << path.toUtf8().constData();
 
-        QFile file(path);
+        file.setFileName(path);
         if (file.exists()) {
             if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
                 QMessageBox msgBox;

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -192,8 +192,8 @@ void ContentSelectorView::ContentSelector::setGameFileSelected(int index, bool s
     const ContentSelectorModel::EsmFile* file = mContentModel->item(fileName);
     if (file != NULL)
     {
-        QModelIndex index(mContentModel->indexFromItem(file));
-        mContentModel->setData(index, selected, Qt::UserRole + 1);
+        QModelIndex index2(mContentModel->indexFromItem(file));
+        mContentModel->setData(index2, selected, Qt::UserRole + 1);
     }
 }
 


### PR DESCRIPTION
Fixes most of the remaining MSVC shadowing warnings. The only ones left I saw being mentioned by AppVeyor were in Boost, and in instances of QT "foreach" statements, which I'm not familiar with so I left as they were for now.

In apps/openmw/mwscript/locals.cpp "index2" (renamed from "index") is a char taking a value from a function returning an int. Is this correct?

I also didn't fix the shadowing of item in updateButton() in the wizard's componentselectionpage.cpp. The function parameter is also "item" and isn't being used. It looks definitely wrong but I'm not familiar with that code area so I didn't touch it for now.