### PR TITLE
Don't update ripple simulation when paused

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -458,9 +458,9 @@ namespace MWRender
         {
             mEffectManager->update(dt);
             mSky->update(dt);
+            mWater->update(dt);
         }
 
-        mWater->update(dt);
         mCamera->update(dt, paused);
 
         osg::Vec3f focal, cameraPos;


### PR DESCRIPTION
While looking at the ripple simulation code I noticed that the update code for the ripple simulation code continues to be run even when the game is paused, which seems wrong to me.