### PR TITLE
Use local config path from configuration manager in the launcher

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -293,6 +293,7 @@ bool Launcher::MainDialog::setupGameSettings()
 {
     mGameSettings.clear();
 
+    QString localPath = QString::fromUtf8(mCfgMgr.getLocalPath().string().c_str());
     QString userPath = QString::fromUtf8(mCfgMgr.getUserConfigPath().string().c_str());
     QString globalPath = QString::fromUtf8(mCfgMgr.getGlobalPath().string().c_str());
 
@@ -320,7 +321,7 @@ bool Launcher::MainDialog::setupGameSettings()
     // Now the rest - priority: user > local > global
     QStringList paths;
     paths.append(globalPath + QString("openmw.cfg"));
-    paths.append(QString("openmw.cfg"));
+    paths.append(localPath + QString("openmw.cfg"));
     paths.append(userPath + QString("openmw.cfg"));
 
     foreach (const QString &path, paths) {


### PR DESCRIPTION
Should be harmless for Linux & Windows, but quite important for macOS as a prerequisite for https://bugs.openmw.org/issues/3566.

I accidentally commited this right to master and then reverted. Sorry about that, confused upstream & origin remotes in my local repo.