### PR TITLE
Fix dereference of null pointer warning

### DIFF
--- a/apps/essimporter/importer.cpp
+++ b/apps/essimporter/importer.cpp
@@ -51,6 +51,7 @@ namespace
         {
             for (int x=0; x<128; ++x)
             {
+                assert(image->data(x,y));
                 *(image->data(x,y)+2) = *it++;
                 *(image->data(x,y)+1) = *it++;
                 *image->data(x,y) = *it++;


### PR DESCRIPTION
This fixes the Clang warning about a dereference of a null pointer.

Is this warning just a false positive? Anyway, putting in an assert statement seems to have quieted it.