### PR TITLE
Fix shadowing warnings

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -324,10 +324,10 @@ bool Launcher::MainDialog::setupGameSettings()
     paths.append(localPath + QString("openmw.cfg"));
     paths.append(userPath + QString("openmw.cfg"));
 
-    foreach (const QString &path, paths) {
-        qDebug() << "Loading config file:" << path.toUtf8().constData();
+    foreach (const QString &path2, paths) {
+        qDebug() << "Loading config file:" << path2.toUtf8().constData();
 
-        file.setFileName(path);
+        file.setFileName(path2);
         if (file.exists()) {
             if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
                 cfgError(tr("Error opening OpenMW configuration file"),
@@ -347,13 +347,13 @@ bool Launcher::MainDialog::setupGameSettings()
     QStringList dataDirs;
 
     // Check if the paths actually contain data files
-    foreach (const QString path, mGameSettings.getDataDirs()) {
-        QDir dir(path);
+    foreach (const QString path3, mGameSettings.getDataDirs()) {
+        QDir dir(path3);
         QStringList filters;
         filters << "*.esp" << "*.esm" << "*.omwgame" << "*.omwaddon";
 
         if (!dir.entryList(filters).isEmpty())
-            dataDirs.append(path);
+            dataDirs.append(path3);
     }
 
     if (dataDirs.isEmpty())

--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -162,10 +162,10 @@ void Wizard::MainWizard::setupGameSettings()
     paths.append(QLatin1String("openmw.cfg"));
     paths.append(globalPath + QLatin1String("openmw.cfg"));
 
-    foreach (const QString &path, paths) {
-        qDebug() << "Loading config file:" << path.toUtf8().constData();
+    foreach (const QString &path2, paths) {
+        qDebug() << "Loading config file:" << path2.toUtf8().constData();
 
-        file.setFileName(path);
+        file.setFileName(path2);
         if (file.exists()) {
             if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
                 QMessageBox msgBox;


### PR DESCRIPTION
This fixes the last of the shadowing warnings in MSVC 2015 builds, except for a couple about "size_type" in feed_args.hpp from Boost. I guess that might be caused by overlap between Boost and btAlignedAllocator.h from Bullet, but I don't know how to fix that or if it can be.

While looking into the remaining warnings, I found that it looks like MSVC 2015 gives a shadowing warning if a Qt "foreach" statement is nested in another one. Qt's site even has an example nesting foreach statements, and this gives the warning. Doesn't matter much, of course, but I went ahead and rewrote these to avoid nesting foreach statements to get rid of the warnings. This is for file selection in openmw-launcher and it seems to still be working fine after the changes.