### PR TITLE
Make water walking mechanics closer to original MW

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -223,7 +223,7 @@ namespace MWMechanics
         return 1 - resistance / 100.f;
     }
 
-    /// Check if the given affect can be applied to the target. If \a castByPlayer, emits a message box on failure.
+    /// Check if the given effect can be applied to the target. If \a castByPlayer, emits a message box on failure.
     bool checkEffectTarget (int effectId, const MWWorld::Ptr& target, const MWWorld::Ptr& caster, bool castByPlayer)
     {
         switch (effectId)

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -59,6 +59,8 @@ namespace MWMechanics
     float getEffectMultiplier(short effectId, const MWWorld::Ptr& actor, const MWWorld::Ptr& caster,
                               const ESM::Spell* spell = NULL, const MagicEffects* effects = NULL);
 
+    bool checkEffectTarget (int effectId, const MWWorld::Ptr& target, const MWWorld::Ptr& caster, bool castByPlayer);
+
     int getEffectiveEnchantmentCastCost (float castCost, const MWWorld::Ptr& actor);
 
     void effectTick(CreatureStats& creatureStats, const MWWorld::Ptr& actor, const MWMechanics::EffectKey& effectKey, float magnitude);

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -123,6 +123,8 @@ namespace MWPhysics
 
             bool isOnGround (const MWWorld::Ptr& actor);
 
+            bool canMoveToWaterSurface (const MWWorld::ConstPtr &actor, const float waterlevel);
+
             /// Get physical half extents (scaled) of the given actor.
             osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor) const;
 

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -515,8 +515,8 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
                     MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find (
                     effectIt->mEffectID);
 
-                // Fully resisted?
-                if (params[i].mMultiplier == 0)
+                // Fully resisted or can't be applied to target?
+                if (params[i].mMultiplier == 0 || !MWMechanics::checkEffectTarget(effectIt->mEffectID, actor, actor, actor == MWMechanics::getPlayer()))
                     continue;
 
                 float magnitude = effectIt->mMagnMin + (effectIt->mMagnMax - effectIt->mMagnMin) * params[i].mRandom;
@@ -770,6 +770,9 @@ void MWWorld::InventoryStore::visitEffectSources(MWMechanics::EffectSourceVisito
         for (std::vector<ESM::ENAMstruct>::const_iterator effectIt (enchantment.mEffects.mList.begin());
             effectIt!=enchantment.mEffects.mList.end(); ++effectIt)
         {
+            // Don't get spell icon display information for enchantments that weren't actually applied
+            if (mMagicEffects.get(MWMechanics::EffectKey(*effectIt)).getMagnitude() == 0)
+                continue;
             const EffectParams& params = mPermanentMagicEffectMagnitudes[(**iter).getCellRef().getRefId()][i];
             float magnitude = effectIt->mMagnMin + (effectIt->mMagnMax - effectIt->mMagnMin) * params.mRandom;
             magnitude *= params.mMultiplier;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2078,11 +2078,16 @@ namespace MWWorld
         if (!cell->getCell()->hasWater())
             return true;
 
-        // Based on observations from the original engine, the depth
-        // limit at which water walking can still be cast on a target
-        // in water appears to be the same as what the highest swimmable
-        // z position would be with SwimHeightScale + 1.
-        return !isUnderwater(target, mSwimHeightScale + 1);
+        float waterlevel = cell->getWaterLevel();
+
+        // SwimHeightScale affects the upper z position an actor can swim to 
+        // while in water. Based on observation from the original engine,
+        // the upper z position you get with a +1 SwimHeightScale is the depth
+        // limit for being able to cast water walking on an underwater target.
+        if (isUnderwater(target, mSwimHeightScale + 1) || (isUnderwater(cell, target.getRefData().getPosition().asVec3()) && !mPhysics->canMoveToWaterSurface(target, waterlevel)))
+            return false; // not castable if too deep or if not enough room to move actor to surface
+        else
+            return true;
     }
 
     bool World::isOnGround(const MWWorld::Ptr &ptr) const


### PR DESCRIPTION
When testing the recent water walking PR, I noticed that if you attempted to cast without room for the spell to move you out of the water, the spell would still succeed and you would have the visual "on hit" effect played, before the effect was then removed in applyQueuedMovement(), where the check for enough room was.

In original Morrowind if there is not room to be moved out of the water, you will get the "You cannot cast this effect right now." message and you don't have the on hit visual effect. This even happens if collision is disabled. This PR replicates this, and the effect doesn't have to be removed later any more since it won't be applied in the first place because the check for enough room is done before applying the effect.