### PR TITLE
Fix default values of some GMSTs

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -422,14 +422,15 @@ namespace MWWorld
         gmst["fNPCHealthBarTime"] = ESM::Variant(5.f);
         gmst["fNPCHealthBarFade"] = ESM::Variant(1.f);
         gmst["fFleeDistance"] = ESM::Variant(3000.f);
+        gmst["sMaxSale"] = ESM::Variant("Max Sale");
 
         // Werewolf (BM)
-        gmst["fWereWolfRunMult"] = ESM::Variant(1.f);
-        gmst["fWereWolfSilverWeaponDamageMult"] = ESM::Variant(1.f);
-        gmst["iWerewolfFightMod"] = ESM::Variant(1);
+        gmst["fWereWolfRunMult"] = ESM::Variant(1.3f);
+        gmst["fWereWolfSilverWeaponDamageMult"] = ESM::Variant(2.f);
+        gmst["iWerewolfFightMod"] = ESM::Variant(100);
         gmst["iWereWolfFleeMod"] = ESM::Variant(100);
         gmst["iWereWolfLevelToAttack"] = ESM::Variant(20);
-        gmst["iWereWolfBounty"] = ESM::Variant(10000);
+        gmst["iWereWolfBounty"] = ESM::Variant(1000);
         gmst["fCombatDistanceWerewolfMod"] = ESM::Variant(0.3f);
 
         std::map<std::string, ESM::Variant> globals;

--- a/files/mygui/openmw_trade_window.layout
+++ b/files/mygui/openmw_trade_window.layout
@@ -61,7 +61,7 @@
             </Widget>
 
             <Widget type="AutoSizedButton" skin="MW_Button" position="0 60 60 24" name="MaxSaleButton" align="Left Top">
-                <Property key="Caption" value="Max. Sale"/> <!-- GMST sMaxSale doesn't work -->
+                <Property key="Caption" value="#{sMaxSale}"/>
             </Widget>
         </Widget>
 


### PR DESCRIPTION
Regarding the "GMST sMaxSale doesn't work" comment: sMaxSale is only defined in Tribunal.esm (as "Seller Max") and Bloodmoon.esm (as "Max Sale") and NOT defined in Morrowind.esm. Morrowind executable defaults to "Max Sale".

Werewolf GMST values were taken from Bloodmoon.esm. On https://wiki.openmw.org/index.php?title=GMSTs_(status) these appear to have been taken from Tribunal.esm instead of Bloodmoon.esm -- according to our old D code, Bethesda seems to have fallen for the GMST contamination bug in a Tribunal patch, hence why Tribunal contains (incorrect) fallback values for Bloodmoon GMSTs...