### PR TITLE
Allow deleting spells that have the "always succeeds" flag

### DIFF
--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -11,6 +11,7 @@
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/player.hpp"
 
 #include "../mwmechanics/spellcasting.hpp"
 #include "../mwmechanics/spells.hpp"
@@ -122,8 +123,15 @@ namespace MWGui
         const ESM::Spell* spell =
             MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(spellId);
 
-        if (spell->mData.mFlags & ESM::Spell::F_Always
-            || spell->mData.mType == ESM::Spell::ST_Power)
+        MWWorld::Ptr player = MWMechanics::getPlayer();
+        std::string raceId = player.get<ESM::NPC>()->mBase->mRace;
+        const std::string& signId =
+            MWBase::Environment::get().getWorld()->getPlayer().getBirthSign();
+        const ESM::Race* race = MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(raceId);
+        const ESM::BirthSign* birthsign = MWBase::Environment::get().getWorld()->getStore().get<ESM::BirthSign>().find(signId);
+
+        // can't delete racial spells, birthsign spells or powers 
+        if (race->mPowers.exists(spell->mId) || birthsign->mPowers.exists(spell->mId) || spell->mData.mType == ESM::Spell::ST_Power)
         {
             MWBase::Environment::get().getWindowManager()->messageBox("#{sDeleteSpellError}");
         }


### PR DESCRIPTION
I tried three spells, two that have the always succeed flag already, and manually adding it to one, but in all cases I could delete it in original Morrowind but not in OpenMW. I'm curious why this condition was added in the first place.