### PR TITLE
[macOS] Move all resources files inside application bundles (fixes #3566)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 # Set up common paths
 if (APPLE)
     set(MORROWIND_DATA_FILES "./data" CACHE PATH "location of Morrowind data files")
-    set(OPENMW_RESOURCE_FILES "./resources" CACHE PATH "location of OpenMW resources files")
+    set(OPENMW_RESOURCE_FILES "../Resources/resources" CACHE PATH "location of OpenMW resources files")
 elseif(UNIX)
     # Paths
     SET(BINDIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Where to install binaries")
@@ -286,6 +286,11 @@ endif (APPLE)
 # Set up DEBUG define
 set_directory_properties(PROPERTIES COMPILE_DEFINITIONS_DEBUG DEBUG=1)
 
+if (NOT APPLE)
+    set(OPENMW_MYGUI_FILES_ROOT ${OpenMW_BINARY_DIR})
+    set(OPENMW_SHADERS_ROOT ${OpenMW_BINARY_DIR})
+endif ()
+
 add_subdirectory(files/)
 
 # Specify build paths
@@ -307,11 +312,15 @@ endif (APPLE)
 configure_file(${OpenMW_SOURCE_DIR}/files/settings-default.cfg
     "${OpenMW_BINARY_DIR}/settings-default.cfg")
 
-configure_file(${OpenMW_SOURCE_DIR}/files/openmw.cfg.local
-    "${OpenMW_BINARY_DIR}/openmw.cfg")
-
-configure_file(${OpenMW_SOURCE_DIR}/files/openmw.cfg
-    "${OpenMW_BINARY_DIR}/openmw.cfg.install")
+if (NOT APPLE)
+    configure_file(${OpenMW_SOURCE_DIR}/files/openmw.cfg.local
+        "${OpenMW_BINARY_DIR}/openmw.cfg")
+    configure_file(${OpenMW_SOURCE_DIR}/files/openmw.cfg
+        "${OpenMW_BINARY_DIR}/openmw.cfg.install")
+else ()
+    configure_file(${OpenMW_SOURCE_DIR}/files/openmw.cfg
+        "${OpenMW_BINARY_DIR}/openmw.cfg")
+endif ()
 
 configure_file(${OpenMW_SOURCE_DIR}/files/openmw-cs.cfg
     "${OpenMW_BINARY_DIR}/openmw-cs.cfg")
@@ -725,14 +734,7 @@ if (APPLE)
       configure_file("${QT_COCOA_PLUGIN_PATH}" "${OPENCS_BUNDLE_NAME}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}" COPYONLY)
     endif ()
 
-    set(INSTALL_SUBDIR OpenMW)
-
-    install(DIRECTORY "${APP_BUNDLE_DIR}" USE_SOURCE_PERMISSIONS DESTINATION "${INSTALL_SUBDIR}" COMPONENT Runtime)
-    install(DIRECTORY "${OpenMW_BINARY_DIR}/resources" DESTINATION "${INSTALL_SUBDIR}" COMPONENT Runtime)
-    install(FILES "${OpenMW_BINARY_DIR}/openmw.cfg.install" RENAME "openmw.cfg" DESTINATION "${INSTALL_SUBDIR}" COMPONENT Runtime)
-    install(FILES "${OpenMW_BINARY_DIR}/settings-default.cfg" DESTINATION "${INSTALL_SUBDIR}" COMPONENT Runtime)
-    install(FILES "${OpenMW_BINARY_DIR}/gamecontrollerdb.txt" DESTINATION "${INSTALL_SUBDIR}" COMPONENT Runtime)
-    install(FILES "${OpenMW_BINARY_DIR}/openmw-cs.cfg" DESTINATION "${INSTALL_SUBDIR}" COMPONENT Runtime)
+    install(DIRECTORY "${APP_BUNDLE_DIR}" USE_SOURCE_PERMISSIONS DESTINATION "." COMPONENT Runtime)
 
     set(CPACK_GENERATOR "DragNDrop")
     set(CPACK_PACKAGE_VERSION ${OPENMW_VERSION})
@@ -740,8 +742,8 @@ if (APPLE)
     set(CPACK_PACKAGE_VERSION_MINOR ${OPENMW_VERSION_MINOR})
     set(CPACK_PACKAGE_VERSION_PATCH ${OPENMW_VERSION_RELEASE})
 
-    set(INSTALLED_OPENMW_APP "\${CMAKE_INSTALL_PREFIX}/${INSTALL_SUBDIR}/${APP_BUNDLE_NAME}")
-    set(INSTALLED_OPENCS_APP "\${CMAKE_INSTALL_PREFIX}/${INSTALL_SUBDIR}/${OPENCS_BUNDLE_NAME}")
+    set(INSTALLED_OPENMW_APP "\${CMAKE_INSTALL_PREFIX}/${APP_BUNDLE_NAME}")
+    set(INSTALLED_OPENCS_APP "\${CMAKE_INSTALL_PREFIX}/${OPENCS_BUNDLE_NAME}")
 
     install(CODE "
         set(BU_CHMOD_BUNDLE_ITEMS ON)
@@ -785,8 +787,8 @@ if (APPLE)
         set(${plugins_var} ${PLUGINS} PARENT_SCOPE)
     endfunction (install_plugins_for_bundle)
 
-    install_plugins_for_bundle("${INSTALL_SUBDIR}/${APP_BUNDLE_NAME}" PLUGINS)
-    install_plugins_for_bundle("${INSTALL_SUBDIR}/${OPENCS_BUNDLE_NAME}" OPENCS_PLUGINS)
+    install_plugins_for_bundle("${APP_BUNDLE_NAME}" PLUGINS)
+    install_plugins_for_bundle("${OPENCS_BUNDLE_NAME}" OPENCS_PLUGINS)
 
     set(PLUGINS ${PLUGINS} "${INSTALLED_OPENMW_APP}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}")
     set(OPENCS_PLUGINS ${OPENCS_PLUGINS} "${INSTALLED_OPENCS_APP}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}")

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -35,14 +35,6 @@ int main(int argc, char *argv[])
         // Now we make sure the current dir is set to application path
         QDir dir(QCoreApplication::applicationDirPath());
 
-        #ifdef Q_OS_MAC
-        if (dir.dirName() == "MacOS") {
-            dir.cdUp();
-            dir.cdUp();
-            dir.cdUp();
-        }
-        #endif
-
         QDir::setCurrent(dir.absolutePath());
 
         Launcher::MainDialog mainWin;

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -162,9 +162,15 @@ endif()
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(APPLE)
-    set (OPENCS_MAC_ICON ${CMAKE_SOURCE_DIR}/files/mac/openmw-cs.icns)
+    set (OPENCS_MAC_ICON "${CMAKE_SOURCE_DIR}/files/mac/openmw-cs.icns")
+    set (OPENCS_CFG "${OpenMW_BINARY_DIR}/openmw-cs.cfg")
+    set (OPENCS_DEFAULT_FILTERS_FILE "${OpenMW_BINARY_DIR}/resources/defaultfilters")
+    set (OPENCS_OPENMW_CFG "${OpenMW_BINARY_DIR}/openmw.cfg")
 else()
     set (OPENCS_MAC_ICON "")
+    set (OPENCS_CFG "")
+    set (OPENCS_DEFAULT_FILTERS_FILE "")
+    set (OPENCS_OPENMW_CFG "")
 endif(APPLE)
 
 add_executable(openmw-cs
@@ -174,12 +180,23 @@ add_executable(openmw-cs
     ${OPENCS_MOC_SRC}
     ${OPENCS_RES_SRC}
     ${OPENCS_MAC_ICON}
+    ${OPENCS_CFG}
+    ${OPENCS_DEFAULT_FILTERS_FILE}
+    ${OPENCS_OPENMW_CFG}
 )
 
 if(APPLE)
+    set(OPENCS_BUNDLE_NAME "OpenMW-CS")
+    set(OPENCS_BUNDLE_RESOURCES_DIR "${OpenMW_BINARY_DIR}/${OPENCS_BUNDLE_NAME}.app/Contents/Resources")
+
+    set(OPENMW_MYGUI_FILES_ROOT ${OPENCS_BUNDLE_RESOURCES_DIR})
+    set(OPENMW_SHADERS_ROOT ${OPENCS_BUNDLE_RESOURCES_DIR})
+
+    add_subdirectory(../../files/ ${CMAKE_CURRENT_BINARY_DIR}/files)
+
     set_target_properties(openmw-cs PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${OpenMW_BINARY_DIR}"
-        OUTPUT_NAME "OpenMW-CS"
+        OUTPUT_NAME ${OPENCS_BUNDLE_NAME}
         MACOSX_BUNDLE_ICON_FILE "openmw-cs.icns"
         MACOSX_BUNDLE_BUNDLE_NAME "OpenCS"
         MACOSX_BUNDLE_GUI_IDENTIFIER "org.openmw.opencs"
@@ -190,6 +207,16 @@ if(APPLE)
 
     set_source_files_properties(${OPENCS_MAC_ICON} PROPERTIES
         MACOSX_PACKAGE_LOCATION Resources)
+    set_source_files_properties(${OPENCS_CFG} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources)
+    set_source_files_properties(${OPENCS_DEFAULT_FILTERS_FILE} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources/resources)
+    set_source_files_properties(${OPENCS_OPENMW_CFG} PROPERTIES
+        MACOSX_PACKAGE_LOCATION Resources)
+
+    add_custom_command(TARGET openmw-cs
+        POST_BUILD
+        COMMAND cp "${OpenMW_BINARY_DIR}/resources/version" "${OPENCS_BUNDLE_RESOURCES_DIR}/resources")
 endif(APPLE)
 
 target_link_libraries(openmw-cs
@@ -227,5 +254,5 @@ endif()
 
 
 if(APPLE)
-    INSTALL(TARGETS openmw-cs BUNDLE DESTINATION OpenMW COMPONENT BUNDLE)
+    INSTALL(TARGETS openmw-cs BUNDLE DESTINATION "." COMPONENT BUNDLE)
 endif()

--- a/apps/opencs/main.cpp
+++ b/apps/opencs/main.cpp
@@ -62,11 +62,6 @@ int main(int argc, char *argv[])
 
     #ifdef Q_OS_MAC
         QDir dir(QCoreApplication::applicationDirPath());
-        if (dir.dirName() == "MacOS") {
-            dir.cdUp();
-            dir.cdUp();
-            dir.cdUp();
-        }
         QDir::setCurrent(dir.absolutePath());
     #endif
 

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -179,6 +179,21 @@ target_link_libraries(openmw ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 if(APPLE)
+    set(BUNDLE_RESOURCES_DIR "${APP_BUNDLE_DIR}/Contents/Resources")
+
+    set(OPENMW_MYGUI_FILES_ROOT ${BUNDLE_RESOURCES_DIR})
+    set(OPENMW_SHADERS_ROOT ${BUNDLE_RESOURCES_DIR})
+
+    add_subdirectory(../../files/ ${CMAKE_CURRENT_BINARY_DIR}/files)
+
+    configure_file("${OpenMW_BINARY_DIR}/settings-default.cfg" ${BUNDLE_RESOURCES_DIR} COPYONLY)
+    configure_file("${OpenMW_BINARY_DIR}/openmw.cfg" ${BUNDLE_RESOURCES_DIR} COPYONLY)
+    configure_file("${OpenMW_BINARY_DIR}/gamecontrollerdb.txt" ${BUNDLE_RESOURCES_DIR} COPYONLY)
+
+    add_custom_command(TARGET openmw
+        POST_BUILD
+        COMMAND cp "${OpenMW_BINARY_DIR}/resources/version" "${BUNDLE_RESOURCES_DIR}/resources")
+
     find_library(COCOA_FRAMEWORK Cocoa)
     find_library(IOKIT_FRAMEWORK IOKit)
     target_link_libraries(openmw ${COCOA_FRAMEWORK} ${IOKIT_FRAMEWORK})

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -352,9 +352,8 @@ int main(int argc, char**argv)
 #endif
 
 #ifdef __APPLE__
-        // FIXME: set current dir to bundle path
-        //boost::filesystem::path bundlePath = boost::filesystem::path(Ogre::macBundlePath()).parent_path();
-        //boost::filesystem::current_path(bundlePath);
+        boost::filesystem::path binary_path = boost::filesystem::system_complete(boost::filesystem::path(argv[0]));
+        boost::filesystem::current_path(binary_path.parent_path());
 #endif
 
         engine.reset(new OMW::Engine(cfgMgr));

--- a/apps/wizard/main.cpp
+++ b/apps/wizard/main.cpp
@@ -20,12 +20,6 @@ int main(int argc, char *argv[])
     QDir dir(QCoreApplication::applicationDirPath());
 
     #ifdef Q_OS_MAC
-    if (dir.dirName() == "MacOS") {
-        dir.cdUp();
-        dir.cdUp();
-        dir.cdUp();
-    }
-
     // force Qt to load only LOCAL plugins, don't touch system Qt installation
     QDir pluginsPath(QCoreApplication::applicationDirPath());
     pluginsPath.cdUp();

--- a/components/files/macospath.cpp
+++ b/components/files/macospath.cpp
@@ -68,7 +68,7 @@ boost::filesystem::path MacOsPath::getCachePath() const
 
 boost::filesystem::path MacOsPath::getLocalPath() const
 {
-    return boost::filesystem::path("./");
+    return boost::filesystem::path("../Resources/");
 }
 
 boost::filesystem::path MacOsPath::getGlobalDataPath() const

--- a/files/mygui/CMakeLists.txt
+++ b/files/mygui/CMakeLists.txt
@@ -1,6 +1,10 @@
+if (NOT DEFINED OPENMW_MYGUI_FILES_ROOT)
+    return()
+endif()
+
 # Copy resource files into the build directory
 set(SDIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(DDIR ${OpenMW_BINARY_DIR}/resources/mygui)
+set(DDIR ${OPENMW_MYGUI_FILES_ROOT}/resources/mygui)
 
 set(MYGUI_FILES
     core.skin

--- a/files/shaders/CMakeLists.txt
+++ b/files/shaders/CMakeLists.txt
@@ -1,6 +1,10 @@
+if (NOT DEFINED OPENMW_SHADERS_ROOT)
+    return()
+endif()
+
 # Copy resource files into the build directory
 set(SDIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(DDIR ${OpenMW_BINARY_DIR}/resources/shaders)
+set(DDIR ${OPENMW_SHADERS_ROOT}/resources/shaders)
 
 set(SHADER_FILES
     water_vertex.glsl


### PR DESCRIPTION
The following files previously being siblings of both app bundles were moved inside bundles:

* `gamecontrollerdb.txt`
    * `OpenMW.app/Contents/Resources/gamecontrollerdb.txt`
* `openmw.cfg`
    * `OpenMW.app/Contents/Resources/openmw.cfg`
    * `OpenMW-CS.app/Contents/Resources/openmw.cfg`
* `openmw-cs.cfg`
    * `OpenMW-CS.app/Contents/Resources/openmw-cs.cfg`
* `settings-default.cfg`
    * `OpenMW.app/Contents/Resources/settings-default.cfg`
* `resources/defaultfilters`
    * `OpenMW-CS.app/Contents/Resources/resources/defaultfilters`
* `resources/mygui`
    * `OpenMW.app/Contents/Resources/resources/mygui`
* `resources/shaders`
    * `OpenMW.app/Contents/Resources/resources/shaders`
    * `OpenMW-CS.app/Contents/Resources/resources/shaders`
* `resources/version`
    * `OpenMW.app/Contents/Resources/resources/version`
    * `OpenMW-CS.app/Contents/Resources/resources/version`

Fixes https://bugs.openmw.org/issues/3566.

Related forum thread: http://forum.openmw.org/viewtopic.php?f=6&t=3822.

Technically this makes both apps completely independent on OS X.
The only dependency between them is "Run OpenMW" feature of OpenMW-CS, it relies on the fact that OpenMW.app is sibling of OpenMW-CS.app. This issue can be addressed later with some kind of "Locate OpenMW" dialog in OpenMW-CS.