### PR TITLE
Slowfall now reduces momentum based on magnitude when jumping

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -450,8 +450,8 @@ namespace MWPhysics
                 if (inertia.z() < 0)
                     inertia.z() *= slowFall;
                 if (slowFall < 1.f) {
-                    inertia.x() = 0;
-                    inertia.y() = 0;
+                    inertia.x() *= slowFall;
+                    inertia.y() *= slowFall;
                 }
                 physicActor->setInertialForce(inertia);
             }


### PR DESCRIPTION
Allows Constant Effect Slowfall to work as in MW.

The 0.40 branch added a stop-dead lateral movement to the Slowfall effect that is absent from the standard Morrowind implementation.

This brings it more in line by applying the Slowfall effect magnitude to the lateral momentum instead of just stopping the character completely.

Many people in standard Morrowind advocate the use of a constant effect Slowfall enchantment. With the stop-dead implementation, any lateral jumping with a slowfall effect enabled was next to impossible.

Related to bug https://bugs.openmw.org/issues/3508