### PR TITLE
Implement water sounds

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -493,7 +493,7 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
     mEnvironment.setWindowManager (window);
 
     // Create sound system
-    mEnvironment.setSoundManager (new MWSound::SoundManager(mVFS.get(), mUseSound));
+    mEnvironment.setSoundManager (new MWSound::SoundManager(mVFS.get(), mFallbackMap, mUseSound));
 
     if (!mSkipMenu)
     {

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -11,6 +11,8 @@
 
 #include <components/settings/settings.hpp>
 
+#include <components/fallback/fallback.hpp>
+
 #include "../mwbase/soundmanager.hpp"
 
 namespace VFS
@@ -44,6 +46,8 @@ namespace MWSound
     {
         const VFS::Manager* mVFS;
 
+        Fallback::Map mFallback;
+
         std::auto_ptr<Sound_Output> mOutput;
 
         // Caches available music tracks by <playlist name, (sound files) >
@@ -55,6 +59,13 @@ namespace MWSound
         float mMusicVolume;
         float mVoiceVolume;
         float mFootstepsVolume;
+
+        int mNearWaterRadius;
+        int mNearWaterPoints;
+        float mNearWaterIndoorTolerance;
+        float mNearWaterOutdoorTolerance;
+        std::string mNearWaterIndoorID;
+        std::string mNearWaterOutdoorID;
 
         typedef std::auto_ptr<std::deque<Sound_Buffer> > SoundBufferList;
         // List of sound buffers, grown as needed. New enties are added to the
@@ -94,6 +105,7 @@ namespace MWSound
         int mPausedSoundTypes;
 
         MWBase::SoundPtr mUnderwaterSound;
+        MWBase::SoundPtr mNearWaterSound;
 
         Sound_Buffer *insertSound(const std::string &soundId, const ESM::Sound *sound);
 
@@ -108,6 +120,7 @@ namespace MWSound
         void streamMusicFull(const std::string& filename);
         void updateSounds(float duration);
         void updateRegionSound(float duration);
+        void updateWaterSound(float duration);
 
         float volumeFromType(PlayType type) const;
 
@@ -119,7 +132,7 @@ namespace MWSound
         friend class OpenAL_Output;
 
     public:
-        SoundManager(const VFS::Manager* vfs, bool useSound);
+        SoundManager(const VFS::Manager* vfs, const std::map<std::string, std::string>& fallbackMap, bool useSound);
         virtual ~SoundManager();
 
         virtual void processChangedSettings(const Settings::CategorySettingVector& settings);


### PR DESCRIPTION
Implements: https://bugs.openmw.org/issues/451

The water volume factor has been reverse-engineered. However, the "Water Layer" sound (ESM::Sound volume = 102 or 0.4) is much quieter in OpenMW than in vanilla MW. I think this may be due to the exponential nature of this formula: https://github.com/OpenMW/openmw/blob/be14ce414e53cdc84513c84200418ccd9174d943/apps/openmw/mwsound/soundmanagerimp.cpp#L143.

This can also be observed with `PlaySound "Water Layer"`.