### PR TITLE
Crash fix when item is disabled before it casts spell.

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -913,7 +913,7 @@ namespace MWMechanics
 
             MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
 
-            if (mCaster.getClass().isActor()) // TODO: Non-actors should also create a spell cast vfx
+            if (animation && mCaster.getClass().isActor()) // TODO: Non-actors should also create a spell cast vfx even if they are disabled (animation == NULL)
             {
                 const ESM::Static* castStatic;
 
@@ -927,7 +927,7 @@ namespace MWMechanics
                 animation->addEffect("meshes\\" + castStatic->mModel, effect->mIndex, false, "", texture);
             }
 
-            if (!mCaster.getClass().isActor())
+            if (animation && !mCaster.getClass().isActor())
                 animation->addSpellCastGlow(effect);
 
             static const std::string schools[] = {


### PR DESCRIPTION
Madd leveler has item with such script:

Begin Madd_Leveler_Effect
	Disable
	Short doOnce
	If ( doOnce == 0 )
		Set doOnce To 1
		Cast "mlEffectSpell" Player
	EndIf
End

If add this item with PlaceAtPC openmw will crash.