### PR TITLE
Bug #3647: Reduced loudness of multiple projectiles to a sum total of volume 1

### DIFF
--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -284,7 +284,7 @@ namespace MWWorld
         float volumeCalculation = 1.0f;
         if (state.mSoundIds.size() > 1)
         {
-            volumeCalculation = (1.0f / (std::log10(state.mSoundIds.size() + 1.0f)));
+            volumeCalculation = (1.0f / (std::log10(state.mSoundIds.size()) + 1.0f));
         }
         for (size_t it = 0; it != state.mSoundIds.size(); it++)
         {
@@ -578,7 +578,7 @@ namespace MWWorld
             float volumeCalculation = 1.0f;
             if (state.mSoundIds.size() > 1)
             {
-                volumeCalculation = (1.0f / (std::log10(state.mSoundIds.size() + 1.0f)));
+                volumeCalculation = (1.0f / (std::log10(state.mSoundIds.size()) + 1.0f));
             }
             for (size_t soundIter = 0; soundIter != state.mSoundIds.size(); soundIter++)
             {

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -281,9 +281,14 @@ namespace MWWorld
         createModel(state, ptr.getClass().getModel(ptr), pos, orient, true, true, texture);
 
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+        float volumeCalculation = 1.0f;
+        if (state.mSoundIds.size() > 1)
+        {
+            volumeCalculation = (1.0f / (std::log10(state.mSoundIds.size() + 1.0f)));
+        }
         for (size_t it = 0; it != state.mSoundIds.size(); it++)
         {
-            state.mSounds.push_back(sndMgr->playSound3D(pos, state.mSoundIds.at(it), 1.0f, 1.0f, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop));
+            state.mSounds.push_back(sndMgr->playSound3D(pos, state.mSoundIds.at(it), volumeCalculation, 1.0f, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop));
         }
             
         mMagicBolts.push_back(state);
@@ -570,10 +575,14 @@ namespace MWWorld
             createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), true, true, texture);
 
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            
+            float volumeCalculation = 1.0f;
+            if (state.mSoundIds.size() > 1)
+            {
+                volumeCalculation = (1.0f / (std::log10(state.mSoundIds.size() + 1.0f)));
+            }
             for (size_t soundIter = 0; soundIter != state.mSoundIds.size(); soundIter++)
             {
-                state.mSounds.push_back(sndMgr->playSound3D(esm.mPosition, state.mSoundIds.at(soundIter), 1.0f, 1.0f,
+                state.mSounds.push_back(sndMgr->playSound3D(esm.mPosition, state.mSoundIds.at(soundIter), volumeCalculation, 1.0f,
                                         MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Loop));
             }
 


### PR DESCRIPTION
[Issue tracker link](https://bugs.openmw.org/issues/3647)

Related to [feature #3519](https://bugs.openmw.org/issues/3519)

Playing every magical effect's audio simultaneously increases the total volume of the projectile cast by log10(number of sounds) [{citation}](https://soundphysics.ius.edu/?page_id=807). This is making a few assumptions about their wave properties, but is at least a reasonable approximation. Calculating the volume with 1 / (log10(number of sounds) + 1) counteracts this effect.

1 sound = 100% volume per sound
2 sounds = 77% volume per sound
8 sounds = 53% volume per sound

Testing this fix, the volumes now seem equivalent, at least to my ears.

Please let me know if I can make any style improvements. Still a lot to learn here!