### PR TITLE
Implement NiSphericalCollider (Closes #3644)

### DIFF
--- a/components/nif/controlled.cpp
+++ b/components/nif/controlled.cpp
@@ -87,6 +87,15 @@ namespace Nif
         nif->skip(17);
     }
 
+    void NiSphericalCollider::read(NIFStream* nif)
+    {
+        Controlled::read(nif);
+
+        mBounceFactor = nif->getFloat();
+        mRadius = nif->getFloat();
+        mCenter = nif->getVector3();
+    }
+
 
 
 

--- a/components/nif/controlled.hpp
+++ b/components/nif/controlled.hpp
@@ -111,6 +111,16 @@ public:
     float mPlaneDistance;
 };
 
+class NiSphericalCollider : public Controlled
+{
+public:
+    float mBounceFactor;
+    float mRadius;
+    osg::Vec3f mCenter;
+
+    void read(NIFStream *nif);
+};
+
 class NiParticleRotation : public Controlled
 {
 public:

--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -89,6 +89,7 @@ static std::map<std::string,RecordFactoryEntry> makeFactory()
     newFactory.insert(makeEntry("NiStringExtraData",          &construct <NiStringExtraData>           , RC_NiStringExtraData             ));
     newFactory.insert(makeEntry("NiGravity",                  &construct <NiGravity>                   , RC_NiGravity                     ));
     newFactory.insert(makeEntry("NiPlanarCollider",           &construct <NiPlanarCollider>            , RC_NiPlanarCollider              ));
+    newFactory.insert(makeEntry("NiSphericalCollider",        &construct <NiSphericalCollider>         , RC_NiSphericalCollider           ));
     newFactory.insert(makeEntry("NiParticleGrowFade",         &construct <NiParticleGrowFade>          , RC_NiParticleGrowFade            ));
     newFactory.insert(makeEntry("NiParticleColorModifier",    &construct <NiParticleColorModifier>     , RC_NiParticleColorModifier       ));
     newFactory.insert(makeEntry("NiParticleRotation",         &construct <NiParticleRotation>          , RC_NiParticleRotation            ));

--- a/components/nif/record.hpp
+++ b/components/nif/record.hpp
@@ -92,7 +92,8 @@ enum RecordType
   RC_NiSequenceStreamHelper,
   RC_NiSourceTexture,
   RC_NiSkinInstance,
-  RC_RootCollisionNode
+  RC_RootCollisionNode,
+  RC_NiSphericalCollider
 };
 
 /// Base class for all records

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -871,6 +871,13 @@ namespace NifOsg
                     const Nif::NiPlanarCollider* planarcollider = static_cast<const Nif::NiPlanarCollider*>(colliders.getPtr());
                     program->addOperator(new PlanarCollider(planarcollider));
                 }
+                else if (colliders->recType == Nif::RC_NiSphericalCollider)
+                {
+                    const Nif::NiSphericalCollider* sphericalcollider = static_cast<const Nif::NiSphericalCollider*>(colliders.getPtr());
+                    program->addOperator(new SphericalCollider(sphericalcollider));
+                }
+                else
+                    std::cerr << "Unhandled particle collider " << colliders->recName << " in " << mFilename << std::endl;
             }
         }
 

--- a/components/nifosg/particle.hpp
+++ b/components/nifosg/particle.hpp
@@ -16,6 +16,7 @@ namespace Nif
 {
     class NiGravity;
     class NiPlanarCollider;
+    class NiSphericalCollider;
     class NiColorData;
 }
 
@@ -108,6 +109,23 @@ namespace NifOsg
         float mBounceFactor;
         osg::Plane mPlane;
         osg::Plane mPlaneInParticleSpace;
+    };
+
+    class SphericalCollider : public osgParticle::Operator
+    {
+    public:
+        SphericalCollider(const Nif::NiSphericalCollider* collider);
+        SphericalCollider();
+        SphericalCollider(const SphericalCollider& copy, const osg::CopyOp& copyop);
+
+        META_Object(NifOsg, SphericalCollider)
+
+        virtual void beginOperate(osgParticle::Program* program);
+        virtual void operate(osgParticle::Particle* particle, double dt);
+    private:
+        float mBounceFactor;
+        osg::BoundingSphere mSphere;
+        osg::BoundingSphere mSphereInParticleSpace;
     };
 
     class GrowFadeAffector : public osgParticle::Operator


### PR DESCRIPTION
Implements: https://bugs.openmw.org/issues/3644

A few notes:

* I'm not completely sure of the significance of the vector **u**. I guess the `(u.length2() < mSphereInParticleSpace.radius2())` check could be replaced with `discriminant > 0` and the discriminant formula could be modified to not use **u**. I decided to leave it in to make sure the behavior matches vanilla's.
* Tunneling should be prevented by `(k < dt)`, although the particle is not moved to the point of contact. Edit: Particles inside the sphere can escape if given large initial velocities and/or bounceFactor, but that is also true in vanilla MW.