### PR TITLE
[Incomplete] Bug #2777: Fix for disintegration efffects eliminated by framerate

### DIFF
--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -269,7 +269,7 @@ void loadCell(ESM::Cell &cell, ESM::ESMReader &esm, Arguments& info)
         std::cout << "    Faction: '" << ref.mFaction << "'" << std::endl;
         std::cout << "    Faction rank: '" << ref.mFactionRank << "'" << std::endl;
         std::cout << "    Enchantment charge: '" << ref.mEnchantmentCharge << "'\n";
-        std::cout << "    Uses/health: '" << ref.mChargeInt << "'\n";
+        std::cout << "    Uses/health: '" << ref.mCharge << "'\n";
         std::cout << "    Gold value: '" << ref.mGoldValue << "'\n";
         std::cout << "    Blocked: '" << static_cast<int>(ref.mReferenceBlocked) << "'" << std::endl;
         std::cout << "    Deleted: " << deleted << std::endl;

--- a/apps/essimporter/importinventory.cpp
+++ b/apps/essimporter/importinventory.cpp
@@ -40,9 +40,9 @@ namespace ESSImport
                 bool isDeleted = false;
                 item.ESM::CellRef::loadData(esm, isDeleted);
 
-                int charge=-1;
+                float charge = -1;
                 esm.getHNOT(charge, "XHLT");
-                item.mChargeInt = charge;
+                item.mCharge = charge;
 
                 if (newStack)
                     mItems.push_back(item);

--- a/apps/essimporter/importinventory.cpp
+++ b/apps/essimporter/importinventory.cpp
@@ -40,7 +40,7 @@ namespace ESSImport
                 bool isDeleted = false;
                 item.ESM::CellRef::loadData(esm, isDeleted);
 
-                float charge = -1;
+                int charge = -1;
                 esm.getHNOT(charge, "XHLT");
                 item.mCharge = charge;
 

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -194,7 +194,7 @@ namespace MWClass
 
     void Light::setRemainingUsageTime (const MWWorld::Ptr& ptr, float duration) const
     {
-        ptr.getCellRef().setChargeFloat(duration);
+        ptr.getCellRef().setCharge(duration);
     }
 
     float Light::getRemainingUsageTime (const MWWorld::ConstPtr& ptr) const

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -975,19 +975,25 @@ namespace MWMechanics
             {
                 if (!item->getClass().hasItemHealth(*item))
                     return false;
-                int charge = item->getClass().getItemHealth(*item);
+                int itemHealth = item->getClass().getItemHealth(*item);
 
-                if (charge == 0)
+                if (itemHealth == 0)
                     return false;
 
-                // FIXME: charge should be a float, not int so that damage < 1 per frame can be applied.
-                // This was also a bug in the original engine.
+                float charge = item->getCellRef().getChargeFloat();
+                if (std::abs(charge - -1) < .00001f) {
+                    charge = item->getClass().getItemMaxHealth(*item);
+                }
+
                 charge -=
-                        std::min(static_cast<int>(disintegrate),
+                        std::min((disintegrate),
                                  charge);
+                if (charge < 0.5f) {
+                    charge = 0;
+                }
                 item->getCellRef().setCharge(charge);
 
-                if (charge == 0)
+                if (item->getClass().getItemHealth(*item) == 0)
                 {
                     // Will unequip the broken item and try to find a replacement
                     if (ptr != getPlayer())

--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -81,7 +81,7 @@ namespace MWWorld
 
     int CellRef::getCharge() const
     {
-        return (int) std::round(mCellRef.mCharge);
+        return (int) round(mCellRef.mCharge);
     }
 
     float CellRef::getChargeFloat() const

--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -81,29 +81,20 @@ namespace MWWorld
 
     int CellRef::getCharge() const
     {
-        return mCellRef.mChargeInt;
-    }
-
-    void CellRef::setCharge(int charge)
-    {
-        if (charge != mCellRef.mChargeInt)
-        {
-            mChanged = true;
-            mCellRef.mChargeInt = charge;
-        }
+        return (int) std::round(mCellRef.mCharge);
     }
 
     float CellRef::getChargeFloat() const
     {
-        return mCellRef.mChargeFloat;
+        return mCellRef.mCharge;
     }
 
-    void CellRef::setChargeFloat(float charge)
+    void CellRef::setCharge(float charge)
     {
-        if (charge != mCellRef.mChargeFloat)
+        if (std::abs(charge - mCellRef.mCharge) > .00001f)
         {
             mChanged = true;
-            mCellRef.mChargeFloat = charge;
+            mCellRef.mCharge = charge;
         }
     }
 

--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -61,10 +61,9 @@ namespace MWWorld
         // For weapon or armor, this is the remaining item health.
         // For tools (lockpicks, probes, repair hammer) it is the remaining uses.
         // If this returns int(-1) it means full health.
-        int getCharge() const;
-        float getChargeFloat() const; // Implemented as union with int charge
-        void setCharge(int charge);
-        void setChargeFloat(float charge);
+        int getCharge() const; // Returns rounded mCharge value as int
+        float getChargeFloat() const; // Returns mCharge value without modification
+        void setCharge(float charge); // Replace mCharge with new value
 
         // The NPC that owns this object (and will get angry if you steal it)
         std::string getOwner() const;

--- a/apps/openmw/mwworld/manualref.cpp
+++ b/apps/openmw/mwworld/manualref.cpp
@@ -15,7 +15,7 @@ namespace
         cellRef.mRefID = name;
         cellRef.mScale = 1;
         cellRef.mFactionRank = 0;
-        cellRef.mChargeInt = -1;
+        cellRef.mCharge = -1;
         cellRef.mGoldValue = 1;
         cellRef.mEnchantmentCharge = -1;
         cellRef.mTeleport = false;

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -89,7 +89,7 @@ void ESM::CellRef::loadData(ESMReader &esm, bool &isDeleted)
                 esm.getHT(mEnchantmentCharge);
                 break;
             case ESM::FourCC<'I','N','T','V'>::value:
-                esm.getHT(mChargeInt);
+                esm.getHT(mCharge);
                 break;
             case ESM::FourCC<'N','A','M','9'>::value:
                 esm.getHT(mGoldValue);
@@ -155,8 +155,8 @@ void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory, bool
     if (mEnchantmentCharge != -1)
         esm.writeHNT("XCHG", mEnchantmentCharge);
 
-    if (mChargeInt != -1)
-        esm.writeHNT("INTV", mChargeInt);
+    if (std::abs(mCharge - -1) > .00001f)
+        esm.writeHNT("INTV", mCharge);
 
     if (mGoldValue != 1) {
         esm.writeHNT("NAM9", mGoldValue);
@@ -195,7 +195,7 @@ void ESM::CellRef::blank()
     mSoul.clear();
     mFaction.clear();
     mFactionRank = -2;
-    mChargeInt = -1;
+    mCharge = -1;
     mEnchantmentCharge = -1;
     mGoldValue = 0;
     mDestCell.clear();

--- a/components/esm/cellref.hpp
+++ b/components/esm/cellref.hpp
@@ -64,11 +64,7 @@ namespace ESM
             // For tools (lockpicks, probes, repair hammer) it is the remaining uses.
             // For lights it is remaining time.
             // This could be -1 if the charge was not touched yet (i.e. full).
-            union
-            {
-                int mChargeInt;     // Used by everything except lights
-                float mChargeFloat; // Used only by lights
-            };
+            float mCharge;
 
             // Remaining enchantment charge. This could be -1 if the charge was not touched yet (i.e. full).
             float mEnchantmentCharge;


### PR DESCRIPTION
Bug: [#2777](https://bugs.openmw.org/issues/2777)

Idea:

- Only one `mCharge`, a float value, in `esm::CellRef`.

- `setCharge(float)` is used everywhere, replacing both `setCharge(int)` and `setChargeFloat(float)`. It changes `mCharge` if `(std::abs(newCharge - oldCharge) > .00001f)`. which should be enough precision for 1 point of disintegration spread out over 100k ticks; if I've done my math correctly. Maybe this is overkill.

- `int getCharge()` (for usual functions) will now return the rounded charge value as an int. `float getChargeFloat()` (for lights and disintegration effects) will return the unrounded value.

Testing:

The implementation seems to work fine, except that about 1 in 10 disintegration points aren't being applied. A constant effect amulet with 1 point of disintegration worked without visible issue. A spell that applies ten points of disintegration applied 9-10 (0 points before this fix). A spell that applies 100 points of disintegration applied 92-99 (64-80 points before this fix). NPC's seem to take normal durability damage. Lights still extinguish in the proper amount of time.

If there are any mistakes or problems with my code, please don't hesitate to let me know! I'm particularly worried that this will effect savegames in some negative way.