### PR TITLE
Update to implementation of projectile lights

### DIFF
--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -262,7 +262,7 @@ namespace MWWorld
             lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
             lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
         }
-        int numberOfEffects = ((MagicBoltState&)state).mEffects.mList.size();
+        int numberOfEffects = state.mEffects.mList.size();
         lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
             , lightDiffuseGreen / numberOfEffects
             , lightDiffuseBlue / numberOfEffects
@@ -572,7 +572,7 @@ namespace MWWorld
                 lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
                 lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
             }
-            int numberOfEffects = ((MagicBoltState&)state).mEffects.mList.size();
+            int numberOfEffects = state.mEffects.mList.size();
             lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
                 , lightDiffuseGreen / numberOfEffects
                 , lightDiffuseBlue / numberOfEffects

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -93,6 +93,31 @@ namespace
         }
         return projectileEffects;
     }
+
+    osg::Vec4 getMagicBoltLightDiffuseColor(const ESM::EffectList& effects)
+    {
+        // Calculate combined light diffuse color from magical effects
+        osg::Vec4 lightDiffuseColor;
+        float lightDiffuseRed = 0.0f;
+        float lightDiffuseGreen = 0.0f;
+        float lightDiffuseBlue = 0.0f;
+        for (std::vector<ESM::ENAMstruct>::const_iterator iter(effects.mList.begin());
+            iter != effects.mList.end(); ++iter)
+        {
+            const ESM::MagicEffect *magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
+                iter->mEffectID);
+            lightDiffuseRed += (static_cast<float>(magicEffect->mData.mRed) / 255.f);
+            lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
+            lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
+        }
+        int numberOfEffects = effects.mList.size();
+        lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
+            , lightDiffuseGreen / numberOfEffects
+            , lightDiffuseBlue / numberOfEffects
+            , 1.0f);
+
+        return lightDiffuseColor;
+    }
 }
 
 namespace MWWorld
@@ -249,25 +274,7 @@ namespace MWWorld
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), state.mIdMagic.at(0));
         MWWorld::Ptr ptr = ref.getPtr();
 
-        // Calculate combined light color from magical effects
-        osg::Vec4 lightDiffuseColor;
-        float lightDiffuseRed = 0.0f;
-        float lightDiffuseGreen = 0.0f;
-        float lightDiffuseBlue = 0.0f;
-        for (std::vector<ESM::ENAMstruct>::const_iterator it = state.mEffects.mList.begin(); it != state.mEffects.mList.end(); ++it)
-        {
-            const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
-                it->mEffectID);
-            lightDiffuseRed += (static_cast<float>(magicEffect->mData.mRed) / 255.f);
-            lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
-            lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
-        }
-        int numberOfEffects = state.mEffects.mList.size();
-        lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
-            , lightDiffuseGreen / numberOfEffects
-            , lightDiffuseBlue / numberOfEffects
-            , 1.0f);
-
+        osg::Vec4 lightDiffuseColor = getMagicBoltLightDiffuseColor(effects);
         createModel(state, ptr.getClass().getModel(ptr), pos, orient, true, true, lightDiffuseColor, texture);
 
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
@@ -292,8 +299,7 @@ namespace MWWorld
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), projectile.getCellRef().getRefId());
         MWWorld::Ptr ptr = ref.getPtr();
 
-        osg::Vec4 lightDiffuseColor = osg::Vec4(0.814f, 0.682f, 0.652f, 1.0f);
-        createModel(state, ptr.getClass().getModel(ptr), pos, orient, false, false, lightDiffuseColor);
+        createModel(state, ptr.getClass().getModel(ptr), pos, orient, false, false, osg::Vec4(0,0,0,0));
 
         mProjectiles.push_back(state);
     }
@@ -523,8 +529,7 @@ namespace MWWorld
                 return true;
             }
 
-            osg::Vec4 lightDiffuseColor = osg::Vec4(0.814f, 0.682f, 0.652f, 1.0f);
-            createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), false, false, lightDiffuseColor);
+            createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), false, false, osg::Vec4(0,0,0,0));
 
             mProjectiles.push_back(state);
             return true;
@@ -559,25 +564,7 @@ namespace MWWorld
                 return true;
             }
 
-            // Calculate combined light color from magical effects
-            osg::Vec4 lightDiffuseColor;
-            float lightDiffuseRed = 0.0f;
-            float lightDiffuseGreen = 0.0f;
-            float lightDiffuseBlue = 0.0f;
-            for (std::vector<ESM::ENAMstruct>::const_iterator it = state.mEffects.mList.begin(); it != state.mEffects.mList.end(); ++it)
-            {
-                const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
-                    it->mEffectID);
-                lightDiffuseRed += (static_cast<float>(magicEffect->mData.mRed) / 255.f);
-                lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
-                lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
-            }
-            int numberOfEffects = state.mEffects.mList.size();
-            lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
-                , lightDiffuseGreen / numberOfEffects
-                , lightDiffuseBlue / numberOfEffects
-                , 1.0f);
-
+            osg::Vec4 lightDiffuseColor = getMagicBoltLightDiffuseColor(esm.mEffects);
             createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), true, true, lightDiffuseColor, texture);
 
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -136,7 +136,8 @@ namespace MWWorld
     };
 
 
-    void ProjectileManager::createModel(State &state, const std::string &model, const osg::Vec3f& pos, const osg::Quat& orient, bool rotate, bool createLight, std::string texture)
+    void ProjectileManager::createModel(State &state, const std::string &model, const osg::Vec3f& pos, const osg::Quat& orient,
+                                        bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture)
     {
         state.mNode = new osg::PositionAttitudeTransform;
         state.mNode->setNodeMask(MWRender::Mask_Effect);
@@ -169,34 +170,6 @@ namespace MWWorld
 
         if (createLight)
         {
-            // Case: magical effects (combine colors of individual effects)
-            osg::Vec4 lightDiffuseColor;
-            if (state.mIdMagic.size() > 0)
-            {
-                float lightDiffuseRed = 0.0f;
-                float lightDiffuseGreen = 0.0f;
-                float lightDiffuseBlue = 0.0f;
-                for (std::vector<ESM::ENAMstruct>::const_iterator it = ((MagicBoltState&)state).mEffects.mList.begin(); it != ((MagicBoltState&)state).mEffects.mList.end(); ++it)
-                {
-                    const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
-                        it->mEffectID);
-                    lightDiffuseRed += ((float) magicEffect->mData.mRed / 255.f);
-                    lightDiffuseGreen += ((float) magicEffect->mData.mGreen / 255.f);
-                    lightDiffuseBlue += ((float) magicEffect->mData.mBlue / 255.f);
-                }
-                int numberOfEffects = ((MagicBoltState&)state).mEffects.mList.size();
-                lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
-                    , lightDiffuseGreen / numberOfEffects
-                    , lightDiffuseBlue / numberOfEffects
-                    , 1.0f);
-            }
-            else
-            {
-                // Case: no magical effects, but still creating light
-                lightDiffuseColor = osg::Vec4(0.814f, 0.682f, 0.652f, 1.0f);
-            }
-
-            // Add light
             osg::ref_ptr<osg::Light> projectileLight(new osg::Light);
             projectileLight->setAmbient(osg::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
             projectileLight->setDiffuse(lightDiffuseColor);
@@ -206,12 +179,10 @@ namespace MWWorld
             projectileLight->setQuadraticAttenuation(0.f);
             projectileLight->setPosition(osg::Vec4(pos, 1.0));
             
-            // Add light source
             SceneUtil::LightSource* projectileLightSource = new SceneUtil::LightSource;
             projectileLightSource->setNodeMask(MWRender::Mask_Lighting);
             projectileLightSource->setRadius(66.f);
             
-            // Attach to scene node
             state.mNode->addChild(projectileLightSource);
             projectileLightSource->setLight(projectileLight);
         }
@@ -278,7 +249,26 @@ namespace MWWorld
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), state.mIdMagic.at(0));
         MWWorld::Ptr ptr = ref.getPtr();
 
-        createModel(state, ptr.getClass().getModel(ptr), pos, orient, true, true, texture);
+        // Calculate combined light color from magical effects
+        osg::Vec4 lightDiffuseColor;
+        float lightDiffuseRed = 0.0f;
+        float lightDiffuseGreen = 0.0f;
+        float lightDiffuseBlue = 0.0f;
+        for (std::vector<ESM::ENAMstruct>::const_iterator it = state.mEffects.mList.begin(); it != state.mEffects.mList.end(); ++it)
+        {
+            const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
+                it->mEffectID);
+            lightDiffuseRed += (static_cast<float>(magicEffect->mData.mRed) / 255.f);
+            lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
+            lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
+        }
+        int numberOfEffects = ((MagicBoltState&)state).mEffects.mList.size();
+        lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
+            , lightDiffuseGreen / numberOfEffects
+            , lightDiffuseBlue / numberOfEffects
+            , 1.0f);
+
+        createModel(state, ptr.getClass().getModel(ptr), pos, orient, true, true, lightDiffuseColor, texture);
 
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
         for (size_t it = 0; it != state.mSoundIds.size(); it++)
@@ -302,7 +292,8 @@ namespace MWWorld
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), projectile.getCellRef().getRefId());
         MWWorld::Ptr ptr = ref.getPtr();
 
-        createModel(state, ptr.getClass().getModel(ptr), pos, orient, false, false);
+        osg::Vec4 lightDiffuseColor = osg::Vec4(0.814f, 0.682f, 0.652f, 1.0f);
+        createModel(state, ptr.getClass().getModel(ptr), pos, orient, false, false, lightDiffuseColor);
 
         mProjectiles.push_back(state);
     }
@@ -532,7 +523,8 @@ namespace MWWorld
                 return true;
             }
 
-            createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), false, false);
+            osg::Vec4 lightDiffuseColor = osg::Vec4(0.814f, 0.682f, 0.652f, 1.0f);
+            createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), false, false, lightDiffuseColor);
 
             mProjectiles.push_back(state);
             return true;
@@ -567,7 +559,26 @@ namespace MWWorld
                 return true;
             }
 
-            createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), true, true, texture);
+            // Calculate combined light color from magical effects
+            osg::Vec4 lightDiffuseColor;
+            float lightDiffuseRed = 0.0f;
+            float lightDiffuseGreen = 0.0f;
+            float lightDiffuseBlue = 0.0f;
+            for (std::vector<ESM::ENAMstruct>::const_iterator it = state.mEffects.mList.begin(); it != state.mEffects.mList.end(); ++it)
+            {
+                const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
+                    it->mEffectID);
+                lightDiffuseRed += (static_cast<float>(magicEffect->mData.mRed) / 255.f);
+                lightDiffuseGreen += (static_cast<float>(magicEffect->mData.mGreen) / 255.f);
+                lightDiffuseBlue += (static_cast<float>(magicEffect->mData.mBlue) / 255.f);
+            }
+            int numberOfEffects = ((MagicBoltState&)state).mEffects.mList.size();
+            lightDiffuseColor = osg::Vec4(lightDiffuseRed / numberOfEffects
+                , lightDiffuseGreen / numberOfEffects
+                , lightDiffuseBlue / numberOfEffects
+                , 1.0f);
+
+            createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), true, true, lightDiffuseColor, texture);
 
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
             

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -122,7 +122,8 @@ namespace MWWorld
         void moveProjectiles(float dt);
         void moveMagicBolts(float dt);
 
-        void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient, bool rotate, bool createLight, std::string texture = "");
+        void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient,
+                            bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture = "");
         void update (State& state, float duration);
 
         void operator=(const ProjectileManager&);


### PR DESCRIPTION
As mentioned [here](https://github.com/OpenMW/openmw/pull/1144), the previous pull request had potentially-unsafe casts that needed to be resolved.

A projectile's light diffuse color is now calculated beforehand and passed to the createModel method. C-style casts were removed, also.