### PR TITLE
Bug #2777: Fix for disintegration efffects eliminated by framerate (attempt #2)

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -980,8 +980,10 @@ namespace MWMechanics
                 if (charge == 0)
                     return false;
 
-                // FIXME: charge should be a float, not int so that damage < 1 per frame can be applied.
-                // This was also a bug in the original engine.
+                // Store remainder of disintegrate amount (automatically subtracted if > 1)
+                item->getCellRef().applyChargeRemainderToBeSubtracted(disintegrate - std::floor(disintegrate));
+
+                charge = item->getClass().getItemHealth(*item);
                 charge -=
                         std::min(static_cast<int>(disintegrate),
                                  charge);

--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -107,7 +107,6 @@ namespace MWWorld
             {
                 mCellRef.mChargeInt -= static_cast<int>(mCellRef.mChargeIntRemainder);
             }
-               
             mCellRef.mChargeIntRemainder = newChargeRemainder;
         }
     }

--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -93,6 +93,25 @@ namespace MWWorld
         }
     }
 
+    void CellRef::applyChargeRemainderToBeSubtracted(float chargeRemainder)
+    {
+        mCellRef.mChargeIntRemainder += std::abs(chargeRemainder);
+        if (mCellRef.mChargeIntRemainder > 1.0f)
+        {
+            float newChargeRemainder = (mCellRef.mChargeIntRemainder - std::floor(mCellRef.mChargeIntRemainder));
+            if (mCellRef.mChargeInt <= static_cast<int>(mCellRef.mChargeIntRemainder))
+            {
+                mCellRef.mChargeInt = 0;
+            }
+            else
+            {
+                mCellRef.mChargeInt -= static_cast<int>(mCellRef.mChargeIntRemainder);
+            }
+               
+            mCellRef.mChargeIntRemainder = newChargeRemainder;
+        }
+    }
+
     float CellRef::getChargeFloat() const
     {
         return mCellRef.mChargeFloat;

--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -65,7 +65,7 @@ namespace MWWorld
         float getChargeFloat() const; // Implemented as union with int charge
         void setCharge(int charge);
         void setChargeFloat(float charge);
-        void applyChargeRemainderToBeSubtracted(float chargeRemainder);
+        void applyChargeRemainderToBeSubtracted(float chargeRemainder); // Stores remainders and applies if > 1
 
         // The NPC that owns this object (and will get angry if you steal it)
         std::string getOwner() const;

--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -65,6 +65,7 @@ namespace MWWorld
         float getChargeFloat() const; // Implemented as union with int charge
         void setCharge(int charge);
         void setChargeFloat(float charge);
+        void applyChargeRemainderToBeSubtracted(float chargeRemainder);
 
         // The NPC that owns this object (and will get angry if you steal it)
         std::string getOwner() const;

--- a/apps/openmw/mwworld/manualref.cpp
+++ b/apps/openmw/mwworld/manualref.cpp
@@ -16,6 +16,7 @@ namespace
         cellRef.mScale = 1;
         cellRef.mFactionRank = 0;
         cellRef.mChargeInt = -1;
+        cellRef.mChargeIntRemainder = 0.0f;
         cellRef.mGoldValue = 1;
         cellRef.mEnchantmentCharge = -1;
         cellRef.mTeleport = false;

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -196,6 +196,7 @@ void ESM::CellRef::blank()
     mFaction.clear();
     mFactionRank = -2;
     mChargeInt = -1;
+    mChargeIntRemainder = 0.0f;
     mEnchantmentCharge = -1;
     mGoldValue = 0;
     mDestCell.clear();

--- a/components/esm/cellref.hpp
+++ b/components/esm/cellref.hpp
@@ -69,6 +69,7 @@ namespace ESM
                 int mChargeInt;     // Used by everything except lights
                 float mChargeFloat; // Used only by lights
             };
+            float mChargeIntRemainder; // Used by everythign except lights (amount of charge not applied to mChargeInt)
 
             // Remaining enchantment charge. This could be -1 if the charge was not touched yet (i.e. full).
             float mEnchantmentCharge;

--- a/components/esm/cellref.hpp
+++ b/components/esm/cellref.hpp
@@ -69,7 +69,7 @@ namespace ESM
                 int mChargeInt;     // Used by everything except lights
                 float mChargeFloat; // Used only by lights
             };
-            float mChargeIntRemainder; // Used by everythign except lights (amount of charge not applied to mChargeInt)
+            float mChargeIntRemainder; // Stores amount of charge not subtracted from mChargeInt
 
             // Remaining enchantment charge. This could be -1 if the charge was not touched yet (i.e. full).
             float mEnchantmentCharge;


### PR DESCRIPTION
Bug: [#2777](https://bugs.openmw.org/issues/2777)
Original pull request: [#1150](https://github.com/OpenMW/openmw/pull/1150)

Idea:

- Add a float to `ESM::CellRef` called `mChargeIntRemainder`, representing the unsubtracted remainder of subtractions applied to `mChargeInt`.

- Add a method to `MWWorld:CellRef` called `applyChargeRemainderToBeSubtracted(float)`. This method increases `mChargeIntRemainder` by the given value, and applies the subtraction when `mChargeIntRemainder > 1`.

Disintegration is the only use of the new method and variable right now. Everything else should be unaffected, if I'm reading the code correctly.

Testing:

Disintegration works well, with 98-99% of the effect applied, regardless of magnitude. There seem to be no save or plugin compatibility issues on my end with this much-more lightweight fix. The remainder will not be saved or loaded, but I think this is fine to maintain compatibility, and should not have much effect.