### PR TITLE
Multiple spelling fixes

### DIFF
--- a/apps/essimporter/importscri.hpp
+++ b/apps/essimporter/importscri.hpp
@@ -13,7 +13,7 @@ namespace ESM
 namespace ESSImport
 {
 
-    /// Local variable assigments for a running script
+    /// Local variable assignments for a running script
     struct SCRI
     {
         std::string mScript;

--- a/apps/opencs/model/prefs/shortcut.hpp
+++ b/apps/opencs/model/prefs/shortcut.hpp
@@ -29,7 +29,7 @@ namespace CSMPrefs
             enum SecondaryMode
             {
                 SM_Replace, ///< The secondary signal replaces the regular signal when the modifier is active
-                SM_Detach,  ///< The secondary signal is emitted independant of the regular signal, even if not active
+                SM_Detach,  ///< The secondary signal is emitted independent of the regular signal, even if not active
                 SM_Ignore   ///< The secondary signal will not ever be emitted
             };
 

--- a/apps/opencs/model/tools/referenceablecheck.cpp
+++ b/apps/opencs/model/tools/referenceablecheck.cpp
@@ -659,7 +659,7 @@ void CSMTools::ReferenceableCheckStage::npcCheck (
     {
         if ((npc.mFlags & ESM::NPC::Autocalc) == 0) //0x0010 = autocalculated flag
         {
-            messages.push_back (std::make_pair (id, npc.mId + " mNpdtType or flags mismatch!")); //should not happend?
+            messages.push_back (std::make_pair (id, npc.mId + " mNpdtType or flags mismatch!")); //should not happen?
             return;
         }
 
@@ -915,7 +915,7 @@ void CSMTools::ReferenceableCheckStage::inventoryListCheck(
                 id + " contains non-existing item (" + itemName + ")"));
         else
         {
-            // Needs to accomodate Containers, Creatures, and NPCs
+            // Needs to accommodate containers, creatures, and NPCs
             switch (localIndex.second)
             {
             case CSMWorld::UniversalId::Type_Potion:

--- a/apps/opencs/model/world/idtree.cpp
+++ b/apps/opencs/model/world/idtree.cpp
@@ -198,12 +198,12 @@ QModelIndex CSMWorld::IdTree::parent (const QModelIndex& index) const
         return QModelIndex();
 
     unsigned int id = index.internalId();
-    const std::pair<int, int>& adress(unfoldIndexAddress(id));
+    const std::pair<int, int>& address(unfoldIndexAddress(id));
 
-    if (adress.first >= this->rowCount() || adress.second >= this->columnCount())
+    if (address.first >= this->rowCount() || address.second >= this->columnCount())
         throw "Parent index is not present in the model";
 
-    return createIndex(adress.first, adress.second);
+    return createIndex(address.first, address.second);
 }
 
 unsigned int CSMWorld::IdTree::foldIndexAddress (const QModelIndex& index) const

--- a/apps/opencs/view/render/cellwater.cpp
+++ b/apps/opencs/view/render/cellwater.cpp
@@ -50,7 +50,7 @@ namespace CSVRender
             updateCellData(mData.getCells().getRecord(cellIndex));
         }
 
-        // Keep water existance/height up to date
+        // Keep water existence/height up to date
         QAbstractItemModel* cells = mData.getTableModel(CSMWorld::UniversalId::Type_Cells);
         connect(cells, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)),
             this, SLOT(cellDataChanged(const QModelIndex&, const QModelIndex&)));

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -516,7 +516,7 @@ void CSVRender::PagedWorldspaceWidget::useViewHint (const std::string& hint)
                 // Current coordinate
                 int x, y;
 
-                // Loop throught all the coordinates to add them to selection
+                // Loop through all the coordinates to add them to selection
                 while (stream >> ignore1 >> ignore2 >> x >> y)
                     selection.add (CSMWorld::CellCoordinates (x, y));
                                

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -214,7 +214,7 @@ SceneWidget::SceneWidget(boost::shared_ptr<Resource::ResourceSystem> resourceSys
 
 SceneWidget::~SceneWidget()
 {
-    // Since we're holding on to the scene templates past the existance of this graphics context, we'll need to manually release the created objects
+    // Since we're holding on to the scene templates past the existence of this graphics context, we'll need to manually release the created objects
     mResourceSystem->getSceneManager()->releaseGLObjects(mView->getCamera()->getGraphicsContext()->getState());
 }
 

--- a/apps/opencs/view/world/regionmap.hpp
+++ b/apps/opencs/view/world/regionmap.hpp
@@ -45,8 +45,8 @@ namespace CSVWorld
             ///< \note Non-existent cells are not listed.
 
             QModelIndexList getSelectedCells (bool existent = true, bool nonExistent = false) const;
-            ///< \param existant Include existant cells.
-            /// \param nonExistant Include non-existant cells.
+            ///< \param existent Include existent cells.
+            /// \param nonExistent Include non-existent cells.
 
             QModelIndexList getMissingRegionCells() const;
             ///< Unselected cells within all regions that have at least one selected cell.

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -233,7 +233,7 @@ namespace MWBase
             virtual void removeDialog(MWGui::Layout* dialog) = 0;
 
             ///Gracefully attempts to exit the topmost GUI mode
-            /** No guarentee of actually closing the window **/
+            /** No guarantee of actually closing the window **/
             virtual void exitCurrentGuiMode() = 0;
 
             virtual void messageBox (const std::string& message, enum MWGui::ShowInDialogueMode showInDialogueMode = MWGui::ShowInDialogueMode_IfPossible) = 0;

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -174,7 +174,7 @@ namespace MWDialogue
                     executeScript (info->mResultScript);
                     mLastTopic = Misc::StringUtils::lowerCase(it->mId);
 
-                    // update topics again to accomodate changes resulting from executeScript
+                    // update topics again to accommodate changes resulting from executeScript
                     updateTopics();
 
                     return;

--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -152,7 +152,7 @@ bool AiFollow::execute (const MWWorld::Ptr& actor, CharacterController& characte
 
         if (dist > 450)
             actor.getClass().getCreatureStats(actor).setMovementFlag(MWMechanics::CreatureStats::Flag_Run, true); //Make NPC run
-        else if (dist < 325) //Have a bit of a dead zone, otherwise npc will constantly flip between running and not when right on the edge of the running threshhold
+        else if (dist < 325) //Have a bit of a dead zone, otherwise npc will constantly flip between running and not when right on the edge of the running threshold
             actor.getClass().getCreatureStats(actor).setMovementFlag(MWMechanics::CreatureStats::Flag_Run, false); //make NPC walk
     }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -236,7 +236,7 @@ namespace MWMechanics
     : mWatchedTimeToStartDrowning(0), mWatchedStatsEmpty (true), mUpdatePlayer (true), mClassSelected (false),
       mRaceSelected (false), mAI(true)
     {
-        //buildPlayer no longer here, needs to be done explicitely after all subsystems are up and running
+        //buildPlayer no longer here, needs to be done explicitly after all subsystems are up and running
     }
 
     void MechanicsManager::add(const MWWorld::Ptr& ptr)

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -19,7 +19,7 @@ namespace MWMechanics
     bool proximityToDoor(const MWWorld::Ptr& actor,
                          float minSqr = MIN_DIST_TO_DOOR_SQUARED);
 
-    /// Returns door pointer within range. No guarentee is given as too which one
+    /// Returns door pointer within range. No guarantee is given as to which one
     /** \return Pointer to the door, or NULL if none exists **/
     MWWorld::Ptr getNearbyDoor(const MWWorld::Ptr& actor,
                          float minSqr = MIN_DIST_TO_DOOR_SQUARED);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -491,7 +491,7 @@ namespace MWMechanics
                         appliedLastingEffects.push_back(effect);
 
                         // For absorb effects, also apply the effect to the caster - but with a negative
-                        // magnitude, since we're transfering stats from the target to the caster
+                        // magnitude, since we're transferring stats from the target to the caster
                         if (!caster.isEmpty() && caster.getClass().isActor())
                         {
                             for (int i=0; i<5; ++i)

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -302,7 +302,7 @@ protected:
 
     /** Sets the root model of the object.
      *
-     * Note that you must make sure all animation sources are cleared before reseting the object
+     * Note that you must make sure all animation sources are cleared before resetting the object
      * root. All nodes previously retrieved with getNode will also become invalidated.
      * @param forceskeleton Wrap the object root in a Skeleton, even if it contains no skinned parts. Use this if you intend to add skinned parts manually.
      * @param baseonly If true, then any meshes or particle systems in the model are ignored

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -1069,7 +1069,7 @@ inline void WeatherManager::calculateResult(const int weatherID, const float gam
         mResult.mSunDiscColor = lerp(osg::Vec4f(1,1,1,1), current.mSunDiscSunsetColor, factor);
         // The SunDiscSunsetColor in the INI isn't exactly the resulting color on screen, most likely because
         // MW applied the color to the ambient term as well. After the ambient and emissive terms are added together, the fixed pipeline
-        // would then clamp the total lighting to (1,1,1). A noticable change in color tone can be observed when only one of the color components gets clamped.
+        // would then clamp the total lighting to (1,1,1). A noticeable change in color tone can be observed when only one of the color components gets clamped.
         // Unfortunately that means we can't use the INI color as is, have to replicate the above nonsense.
         mResult.mSunDiscColor = mResult.mSunDiscColor + osg::componentMultiply(mResult.mSunDiscColor, mResult.mAmbientColor);
         for (int i=0; i<3; ++i)

--- a/apps/wizard/inisettings.cpp
+++ b/apps/wizard/inisettings.cpp
@@ -198,8 +198,8 @@ bool Wizard::IniSettings::parseInx(const QString &path)
             const QString section(array.left(index));
 
             // Figure how many characters to read for the key
-            int lenght = array.indexOf("\x06", section.length() + 3) - (section.length() + 3);
-            const QString key(array.mid(section.length() + 3, lenght));
+            int length = array.indexOf("\x06", section.length() + 3) - (section.length() + 3);
+            const QString key(array.mid(section.length() + 3, length));
 
             QString value(array.mid(section.length() + key.length() + 6));
 


### PR DESCRIPTION
Fixed multiple spelling mistakes. Most of the changes only affect comments, but there are also two modified variable names (not referenced from anywhere else). I double-checked everything and made sure the code is building without errors.

Files with changes to variable names are:
- apps/opencs/model/world/idtree.cpp
- apps/wizard/inisettings.cpp

NOTE: I'm not quite sure if I should open separate pull requests for each fix since there are quite a few. If you would like to have them seperate, just say so and I'll resubmit.

This is my first pull request, please be gentle! :-)