### PR TITLE
[RFC] Movement solver experiments

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -419,7 +419,7 @@ namespace MWPhysics
 
                     if ((newVelocity-velocity).length2() < 0.01)
                         break;
-                    if ((velocity * origVelocity) <= 0.f)
+                    if ((newVelocity * origVelocity) <= 0.f)
                         break; // ^ dot product
 
                     velocity = newVelocity;

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -402,17 +402,18 @@ namespace MWPhysics
                     reflectdir.normalize();
 
                     osg::Vec3f newVelocity = slide(reflectdir, tracer.mPlaneNormal)*movelen;
+
+                    // Do not allow sliding upward if there is gravity.
+                    // Stepping will have taken care of that.
+                    if(!(newPosition.z() < swimlevel || isFlying))
+                        newVelocity.z() = std::min(newVelocity.z(), 0.0f);
+
                     if ((newVelocity-velocity).length2() < 0.01)
                         break;
                     if ((velocity * origVelocity) <= 0.f)
                         break; // ^ dot product
 
                     velocity = newVelocity;
-
-                    // Do not allow sliding upward if there is gravity. Stepping will have taken
-                    // care of that.
-                    if(!(newPosition.z() < swimlevel || isFlying))
-                        velocity.z() = std::min(velocity.z(), 0.0f);
                 }
             }
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -395,6 +395,13 @@ namespace MWPhysics
                     break;
                 }
 
+                // We are touching something.
+                if (tracer.mFraction < 1E-9f)
+                {
+                    // Try to separate by backing off slighly to unstuck the solver
+                    const osg::Vec3f backOff = (newPosition - tracer.mHitPoint) * 1E-3f;
+                    newPosition += backOff;
+                }
 
                 // We hit something. Check if we can step up.
                 float hitHeight = tracer.mHitPoint.z() - tracer.mEndPos.z() + halfExtents.z();

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -407,7 +407,7 @@ namespace MWPhysics
                 float hitHeight = tracer.mHitPoint.z() - tracer.mEndPos.z() + halfExtents.z();
                 osg::Vec3f oldPosition = newPosition;
                 bool result = false;
-                if (hitHeight < sStepSizeUp)
+                if (hitHeight < sStepSizeUp && !isActor(tracer.mHitObject))
                 {
                     // Try to step up onto it.
                     // NOTE: stepMove does not allow stepping over, modifies newPosition if successful

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -366,10 +366,7 @@ namespace MWPhysics
                    newPosition.z() <= swimlevel)
                 {
                     const osg::Vec3f down(0,0,-1);
-                    float movelen = velocity.normalize();
-                    osg::Vec3f reflectdir = reflect(velocity, down);
-                    reflectdir.normalize();
-                    velocity = slide(reflectdir, down)*movelen;
+                    velocity = slide(velocity, down);
                     // NOTE: remainingTime is unchanged before the loop continues
                     continue; // velocity updated, calculate nextpos again
                 }
@@ -413,12 +410,7 @@ namespace MWPhysics
                 else
                 {
                     // Can't move this way, try to find another spot along the plane
-                    osg::Vec3f direction = velocity;
-                    float movelen = direction.normalize();
-                    osg::Vec3f reflectdir = reflect(velocity, tracer.mPlaneNormal);
-                    reflectdir.normalize();
-
-                    osg::Vec3f newVelocity = slide(reflectdir, tracer.mPlaneNormal)*movelen;
+                    osg::Vec3f newVelocity = slide(velocity, tracer.mPlaneNormal);
 
                     // Do not allow sliding upward if there is gravity.
                     // Stepping will have taken care of that.

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -229,7 +229,7 @@ namespace MWPhysics
                 collisionWorld->rayTest(from, to, resultCallback1);
 
                 if (resultCallback1.hasHit() &&
-                        ( (toOsg(resultCallback1.m_hitPointWorld) - tracer.mEndPos).length() > 35
+                        ( (toOsg(resultCallback1.m_hitPointWorld) - tracer.mEndPos).length2() > 35*35
                         || getSlope(tracer.mPlaneNormal) > sMaxSlope))
                 {
                     actor->setOnGround(getSlope(toOsg(resultCallback1.m_hitNormalWorld)) <= sMaxSlope);
@@ -370,7 +370,7 @@ namespace MWPhysics
                 // NOTE: stepMove modifies newPosition if successful
                 const float minStep = 10.f;
                 StepMoveResult result = stepMove(colobj, newPosition, velocity*remainingTime, remainingTime, collisionWorld);
-                if (result == Result_MaxSlope && (velocity*remainingTime).length() < minStep) // to make sure the maximum stepping distance isn't framerate-dependent or movement-speed dependent
+                if (result == Result_MaxSlope && (velocity*remainingTime).length2() < minStep*minStep) // to make sure the maximum stepping distance isn't framerate-dependent or movement-speed dependent
                 {
                     osg::Vec3f normalizedVelocity = velocity;
                     normalizedVelocity.normalize();

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -396,10 +396,16 @@ namespace MWPhysics
                 }
 
 
+                // We hit something. Check if we can step up.
+                float hitHeight = tracer.mHitPoint.z() - tracer.mEndPos.z() + halfExtents.z();
                 osg::Vec3f oldPosition = newPosition;
-                // We hit something. Try to step up onto it. (NOTE: stepMove does not allow stepping over)
-                // NOTE: stepMove modifies newPosition if successful
-                bool result = stepper.step(newPosition, velocity*remainingTime, remainingTime);
+                bool result = false;
+                if (hitHeight < sStepSizeUp)
+                {
+                    // Try to step up onto it.
+                    // NOTE: stepMove does not allow stepping over, modifies newPosition if successful
+                    result = stepper.step(newPosition, velocity*remainingTime, remainingTime);
+                }
                 if (result)
                 {
                     // don't let pure water creatures move out of water after stepMove

--- a/apps/openmw/mwphysics/trace.cpp
+++ b/apps/openmw/mwphysics/trace.cpp
@@ -78,6 +78,7 @@ void ActorTracer::doTrace(const btCollisionObject *actor, const osg::Vec3f& star
         mFraction = newTraceCallback.m_closestHitFraction;
         mPlaneNormal = osg::Vec3f(tracehitnormal.x(), tracehitnormal.y(), tracehitnormal.z());
         mEndPos = (end-start)*mFraction + start;
+        mHitPoint = toOsg(newTraceCallback.m_hitPointWorld);
         mHitObject = newTraceCallback.m_hitCollisionObject;
     }
     else
@@ -85,6 +86,7 @@ void ActorTracer::doTrace(const btCollisionObject *actor, const osg::Vec3f& star
         mEndPos = end;
         mPlaneNormal = osg::Vec3f(0.0f, 0.0f, 1.0f);
         mFraction = 1.0f;
+        mHitPoint = end;
         mHitObject = NULL;
     }
 }

--- a/apps/openmw/mwphysics/trace.h
+++ b/apps/openmw/mwphysics/trace.h
@@ -15,6 +15,7 @@ namespace MWPhysics
     {
         osg::Vec3f mEndPos;
         osg::Vec3f mPlaneNormal;
+        osg::Vec3f mHitPoint;
         const btCollisionObject* mHitObject;
 
         float mFraction;


### PR DESCRIPTION
This is my most recent modification set. The last commit is probably the most interesting, skips redundant step up check, and also step over/down when previous step over already hit an obstacle.

It is possible to skip even more step up checks whenever there was no change in position from one to next iteration. 

I've also been looking at using hitPointWorld from the cast. But the hit point reported is not always reliable (despite a high hit point, step over still can succeed), need to figure out what is going on there before trying to use it.