### PR TITLE
[Do not merge yet] Added check before attempting to remove actor's collision object

### DIFF
--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -47,7 +47,7 @@ Actor::Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<const Resource::BulletShape> 
     updateScale();
     updatePosition();
 
-    updateCollisionMask();
+    addCollisionMask(getCollisionMask());
 }
 
 Actor::~Actor()
@@ -70,18 +70,26 @@ void Actor::enableCollisionBody(bool collision)
     }
 }
 
+void Actor::addCollisionMask(int collisionMask)
+{
+    mCollisionWorld->addCollisionObject(mCollisionObject.get(), CollisionType_Actor, collisionMask);
+}
+
 void Actor::updateCollisionMask()
 {
-    if (mCollisionObject.get()->getWorldArrayIndex() >= 0)
-    {
-        mCollisionWorld->removeCollisionObject(mCollisionObject.get());
-    }
+    mCollisionWorld->removeCollisionObject(mCollisionObject.get());
+    addCollisionMask(getCollisionMask());
+}
+
+int Actor::getCollisionMask()
+{
     int collisionMask = CollisionType_World | CollisionType_HeightMap;
     if (mExternalCollisionMode)
         collisionMask |= CollisionType_Actor | CollisionType_Projectile | CollisionType_Door;
     if (mCanWaterWalk)
         collisionMask |= CollisionType_Water;
-    mCollisionWorld->addCollisionObject(mCollisionObject.get(), CollisionType_Actor, collisionMask);
+    return collisionMask;
+    
 }
 
 void Actor::updatePosition()

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -72,7 +72,10 @@ void Actor::enableCollisionBody(bool collision)
 
 void Actor::updateCollisionMask()
 {
-    mCollisionWorld->removeCollisionObject(mCollisionObject.get());
+    if (mCollisionObject.get()->getWorldArrayIndex() >= 0)
+    {
+        mCollisionWorld->removeCollisionObject(mCollisionObject.get());
+    }
     int collisionMask = CollisionType_World | CollisionType_HeightMap;
     if (mExternalCollisionMode)
         collisionMask |= CollisionType_Actor | CollisionType_Projectile | CollisionType_Door;

--- a/apps/openmw/mwphysics/actor.hpp
+++ b/apps/openmw/mwphysics/actor.hpp
@@ -139,6 +139,8 @@ namespace MWPhysics
     private:
         /// Removes then re-adds the collision object to the dynamics world
         void updateCollisionMask();
+        void addCollisionMask(int collisionMask);
+        int getCollisionMask();
 
         bool mCanWaterWalk;
         bool mWalkingOnWater;

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1463,7 +1463,10 @@ namespace MWPhysics
     {
         if (mWaterCollisionObject.get())
         {
-            mCollisionWorld->removeCollisionObject(mWaterCollisionObject.get());
+            if (mWaterCollisionObject.get()->getWorldArrayIndex() >= 0)
+            {
+                mCollisionWorld->removeCollisionObject(mWaterCollisionObject.get());
+            }
         }
 
         if (!mWaterEnabled)

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1463,14 +1463,14 @@ namespace MWPhysics
     {
         if (mWaterCollisionObject.get())
         {
-            if (mWaterCollisionObject.get()->getWorldArrayIndex() >= 0)
-            {
-                mCollisionWorld->removeCollisionObject(mWaterCollisionObject.get());
-            }
+            mCollisionWorld->removeCollisionObject(mWaterCollisionObject.get());
         }
 
         if (!mWaterEnabled)
+        {
+            mWaterCollisionObject.reset();
             return;
+        }
 
         mWaterCollisionObject.reset(new btCollisionObject());
         mWaterCollisionShape.reset(new btStaticPlaneShape(btVector3(0,0,1), mWaterHeight));


### PR DESCRIPTION
Bullet 2.8.5 and Windows 8.1 x64:

Attempting to start debug builds of OpenMW fails on an assert at line 260 of [btCollisionWorld](https://github.com/bulletphysics/bullet3/blob/master/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp).

This is caused by the `updateCollisionMask()` method during actor initialization. The method attempts to remove the actor's collision object when the collision object does not yet exist in the world. 

Not only does this fail the assert in debug builds, it also causes the collision world to search for the actor's collision object manually.