### PR TITLE
[Bug #2771] Handle SDL event 0x302 by doing nothing

### DIFF
--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -103,6 +103,8 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
                         mViewer->getEventQueue()->keyRelease(osgGA::GUIEventAdapter::KEY_F3);
 
                     break;
+                case SDL_TEXTEDITING:
+                    break;
                 case SDL_TEXTINPUT:
                     mKeyboardListener->textInput(evt.text);
                     break;


### PR DESCRIPTION
Bug [#2771](https://bugs.openmw.org/issues/2771)

`sdlutil::sdlinputwrapper` does not recognize `SDL_TEXTEDITING` events. OpenMW creates an event of this type whenever the game window loses focus while the console is open. Currently, the event causes an error message, and otherwise does nothing else.

This fix removes the error message by recognizing the event without acting on it. As the event was unhandled in the first place, I believe this fix will not affect anything else.