### PR TITLE
Disable NPC collision only when death animation has finished (#3666)

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1271,8 +1271,6 @@ namespace MWMechanics
                 stats.getActiveSpells().clear();
                 calculateCreatureStatModifiers(iter->first, 0);
 
-                MWBase::Environment::get().getWorld()->enableActorCollision(iter->first, false);
-
                 if (cls.isEssential(iter->first))
                     MWBase::Environment::get().getWindowManager()->messageBox("#{sKilledEssential}");
             }
@@ -1289,6 +1287,11 @@ namespace MWMechanics
                 {
                     //player's death animation is over
                     MWBase::Environment::get().getStateManager()->askLoadRecent();
+                }
+                else
+                {
+                    // NPC death animation is over, disable actor collision
+                    MWBase::Environment::get().getWorld()->enableActorCollision(iter->first, false);
                 }
 
                 // Play Death Music if it was the player dying


### PR DESCRIPTION
Fixes [#3666](https://bugs.openmw.org/issues/3666) by disabling collision of dead NPCs only when their death animation has finished.

Tested by spawning an ash zombie via console (placeatpc ash_zombie 1,0,0),
then killing it and trying to walk through it. It's only possible when the animation has finished.
Also killed Fargoth a few times in vanilla and openmw...just to be sure! :-)

This doesn't affect disposal of corpses ([#3528](https://bugs.openmw.org/issues/3528)).
