### PR TITLE
Added check to prevent attempted wandering of empty paths

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -473,8 +473,8 @@ namespace MWMechanics
     void AiWander::onWalkingStatePerFrameActions(const MWWorld::Ptr& actor, 
         float duration, AiWanderStorage& storage, ESM::Position& pos)
     {
-        // Are we there yet?
-        if (pathTo(actor, mPathFinder.getPath().back(), duration, DESTINATION_TOLERANCE))
+        // Is there no destination or are we there yet?
+        if ((!mPathFinder.isPathConstructed()) || pathTo(actor, mPathFinder.getPath().back(), duration, DESTINATION_TOLERANCE))
         {
             stopWalking(actor, storage);
             storage.setState(Wander_ChooseAction);


### PR DESCRIPTION
Windows 8.1 x64

Debug builds are crashing due to empty paths in Actors' pathfinding at the `AiWander::onWalkingStatePerFrameActions` method. This fix adds an additional test before the check to see if an Actor has arrived at their destination. If `mPathFinder` is not constructed (i.e. the list of nodes is empty), the Actor will now treat this as arriving at their destination, and stop walking. I'm not sure if it would be better to stick with the existing `Wander_Walking` state and do nothing. I can't see any difference in behavior with either option.

I believe that the empty paths might be the result of an attempt to wander to an inaccessible node, but I haven't been able to track this down. Any insight would be appreciated.