### PR TITLE
Handle SDL event 0x304 by doing nothing (#3670)

### DIFF
--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -108,6 +108,8 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
                 case SDL_TEXTINPUT:
                     mKeyboardListener->textInput(evt.text);
                     break;
+                case SDL_KEYMAPCHANGED:
+                    break;
                 case SDL_JOYHATMOTION: //As we manage everything with GameController, don't even bother with these.
                 case SDL_JOYAXISMOTION:
                 case SDL_JOYBUTTONDOWN:


### PR DESCRIPTION
Fixes [#3670](https://bugs.openmw.org/issues/3670) by recognizing the SDL_KEYMAPCHANGED event without acting on it. Changing the keyboard layout while playing should mostly happen on accident and should (as far as I can tell) not be acted upon.

Tested by running openmw from the terminal and then changing the keyboard-layout via shortcut.
After tabbing back out of the game there will be no warning "Unhandled SDL event of type 0x304".