### PR TITLE
Handle SDL event 0x304 by doing nothing (#3670)

### DIFF
--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -108,6 +108,11 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
                 case SDL_TEXTINPUT:
                     mKeyboardListener->textInput(evt.text);
                     break;
+
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+                case SDL_KEYMAPCHANGED:
+                    break;
+#endif
                 case SDL_JOYHATMOTION: //As we manage everything with GameController, don't even bother with these.
                 case SDL_JOYAXISMOTION:
                 case SDL_JOYBUTTONDOWN:

--- a/components/sdlutil/sdlinputwrapper.hpp
+++ b/components/sdlutil/sdlinputwrapper.hpp
@@ -6,6 +6,7 @@
 #include <osg/ref_ptr>
 
 #include <SDL_events.h>
+#include <SDL_version.h>
 
 #include "OISCompat.hpp"
 #include "events.hpp"


### PR DESCRIPTION
Fixes [#3670](https://bugs.openmw.org/issues/3670) by recognizing the SDL_KEYMAPCHANGED event without acting on it. This shouldn't cause any issues because controls are mapped to scancodes, not keycodes.

Tested by running openmw from the terminal and then changing the keyboard-layout via shortcut.
After tabbing back out of the game there will be no warning "Unhandled SDL event of type 0x304".

This is an updated version of my previous pull request which adds a version guard for SDL versions below 2.0.4.