### PR TITLE
ESSImporter: Import mark location

### DIFF
--- a/apps/essimporter/convertplayer.cpp
+++ b/apps/essimporter/convertplayer.cpp
@@ -47,6 +47,34 @@ namespace ESSImport
         controls.mVanityModeDisabled = pcdt.mPNAM.mPlayerFlags & PCDT::PlayerFlags_VanityModeDisabled;
         controls.mWeaponDrawingDisabled = pcdt.mPNAM.mPlayerFlags & PCDT::PlayerFlags_WeaponDrawingDisabled;
         controls.mSpellDrawingDisabled = pcdt.mPNAM.mPlayerFlags & PCDT::PlayerFlags_SpellDrawingDisabled;
+
+        if (pcdt.mHasMark)
+        {
+            out.mHasMark = 1;
+
+            const PCDT::PNAM::MarkLocation& mark = pcdt.mPNAM.mMarkLocation;
+
+            ESM::CellId cell;
+            cell.mWorldspace = ESM::CellId::sDefaultWorldspace;
+            cell.mPaged = true;
+
+            cell.mIndex.mX = mark.mCellX;
+            cell.mIndex.mY = mark.mCellY;
+
+            // TODO: Figure out a better way to detect interiors. (0, 0) is a valid exterior cell.
+            if (mark.mCellX == 0 && mark.mCellY == 0)
+            {
+                cell.mWorldspace = pcdt.mMNAM;
+                cell.mPaged = false;
+            }
+
+            out.mMarkedCell = cell;
+            out.mMarkedPosition.pos[0] = mark.mX;
+            out.mMarkedPosition.pos[1] = mark.mY;
+            out.mMarkedPosition.pos[2] = mark.mZ;
+            out.mMarkedPosition.rot[0] = out.mMarkedPosition.rot[1] = 0.0f;
+            out.mMarkedPosition.rot[2] = mark.mRotZ;
+        }
     }
 
 }

--- a/apps/essimporter/importercontext.hpp
+++ b/apps/essimporter/importercontext.hpp
@@ -63,7 +63,7 @@ namespace ESSImport
             playerCellId.mIndex.mX = playerCellId.mIndex.mY = 0;
             mPlayer.mCellId = playerCellId;
             //mPlayer.mLastKnownExteriorPosition
-            mPlayer.mHasMark = 0; // TODO
+            mPlayer.mHasMark = 0;
             mPlayer.mCurrentCrimeId = 0; // TODO
             mPlayer.mObject.blank();
             mPlayer.mObject.mRef.mRefID = "player"; // REFR.mRefID would be PlayerSaveGame

--- a/apps/essimporter/importplayer.cpp
+++ b/apps/essimporter/importplayer.cpp
@@ -23,9 +23,12 @@ namespace ESSImport
             mKnownDialogueTopics.push_back(esm.getHString());
         }
 
+        mHasMark = false;
         if (esm.isNextSub("MNAM"))
-            esm.skipHSub(); // If this field is here it seems to specify the interior cell the player is in,
-                            // but it's not always here, so it's kinda useless
+        {
+            mHasMark = true;
+            mMNAM = esm.getHString();
+        }
 
         esm.getHNT(mPNAM, "PNAM");
 
@@ -50,8 +53,12 @@ namespace ESSImport
         if (esm.isNextSub("NAM3"))
             esm.skipHSub();
 
+        mHasENAM = false;
         if (esm.isNextSub("ENAM"))
-            esm.skipHSub();
+        {
+            mHasENAM = true;
+            esm.getHT(mENAM);
+        }
 
         if (esm.isNextSub("LNAM"))
             esm.skipHSub();

--- a/apps/essimporter/importplayer.hpp
+++ b/apps/essimporter/importplayer.hpp
@@ -42,8 +42,11 @@ struct PCDT
     {
         PlayerFlags_ViewSwitchDisabled = 0x1,
         PlayerFlags_ControlsDisabled = 0x4,
+        PlayerFlags_Sleeping = 0x10,
+        PlayerFlags_Waiting = 0x40,
         PlayerFlags_WeaponDrawn = 0x80,
         PlayerFlags_SpellDrawn = 0x100,
+        PlayerFlags_InJail = 0x200,
         PlayerFlags_JumpingDisabled = 0x1000,
         PlayerFlags_LookingDisabled = 0x2000,
         PlayerFlags_VanityModeDisabled = 0x4000,
@@ -68,18 +71,43 @@ struct PCDT
 
     struct PNAM
     {
+        struct MarkLocation
+        {
+            float mX, mY, mZ; // worldspace position
+            float mRotZ; // Z angle in radians
+            int mCellX, mCellY; // grid coordinates; for interior cells this is always (0, 0)
+        };
+
         int mPlayerFlags; // controls, camera and draw state
         unsigned int mLevelProgress;
         float mSkillProgress[27]; // skill progress, non-uniform scaled
         unsigned char mSkillIncreases[8]; // number of skill increases for each attribute
-        unsigned char mUnknown3[84];
+        int mTelekinesisRangeBonus; // in units; seems redundant
+        float mVisionBonus; // range: <0.0, 1.0>; affected by light spells and Get/Mod/SetPCVisionBonus
+        int mDetectKeyMagnitude; // seems redundant
+        int mDetectEnchantmentMagnitude; // seems redundant
+        int mDetectAnimalMagnitude; // seems redundant
+        MarkLocation mMarkLocation;
+        unsigned char mUnknown3[40];
         unsigned char mSpecIncreases[3]; // number of skill increases for each specialization
         unsigned char mUnknown4;
+    };
+
+    struct ENAM
+    {
+        int mCellX;
+        int mCellY;
     };
 #pragma pack(pop)
 
     std::vector<FNAM> mFactions;
     PNAM mPNAM;
+
+    bool mHasMark;
+    std::string mMNAM; // mark cell name; can also be sDefaultCellname or region name
+
+    bool mHasENAM;
+    ENAM mENAM; // last exterior cell
 
     void load(ESM::ESMReader& esm);
 };


### PR DESCRIPTION
This implementation has one limitation -- a mark at the (0, 0) exterior cell won't be imported correctly. I couldn't find a good way of determining whether the mark cell belongs to an interior or an exterior worldspace. I use the fact that for interior cells the grid coordinate data is set to (0, 0).
