### PR TITLE
Reenable macOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
  - linux
-# - osx
+ - osx
 osx_image: xcode7.2
 language: cpp
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "jybGzAdUbqt9vWR/GEnRd96BgAi/7Zd1+2HK68j/i/8+/1YH2XxLOy4Jv/DUBhBlJIkxs/Xv8dRcUlFOclZDHX1d/9Qnsqd3oUVkD7k1y7cTOWy9TBQaE/v/kZo3LpzA3xPwwthrb0BvqIbOfIELi5fS5s8ba85WFRg3AX70wWE="
+   - macos_qt_formula=qt@5.5
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ script:
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./openmw_test_suite; fi
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then cd .. && ./CI/check_tabs.sh; fi
 notifications:
-  recipients:
-    - corrmage+travis-ci@gmail.com
   email:
+    recipients:
+      - corrmage+travis-ci@gmail.com
     on_success: change
     on_failure: always
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
  - linux
  - osx
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: cpp
 sudo: required
 dist: trusty

--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -5,7 +5,7 @@ brew update
 brew rm cmake || true
 brew rm pkgconfig || true
 brew rm qt5 || true
-brew install cmake pkgconfig qt55
+brew install cmake pkgconfig $macos_qt_formula
 
 curl http://downloads.openmw.org/osx/dependencies/openmw-deps-263d4a8.zip -o ~/openmw-deps.zip
 unzip ~/openmw-deps.zip -d /private/tmp/openmw-deps > /dev/null

--- a/CI/before_script.osx.sh
+++ b/CI/before_script.osx.sh
@@ -4,7 +4,7 @@ export CXX=clang++
 export CC=clang
 
 DEPENDENCIES_ROOT="/private/tmp/openmw-deps/openmw-deps"
-QT_PATH="/usr/local/opt/qt55"
+QT_PATH=`brew --prefix qt@5.5`
 
 mkdir build
 cd build

--- a/CI/before_script.osx.sh
+++ b/CI/before_script.osx.sh
@@ -4,7 +4,7 @@ export CXX=clang++
 export CC=clang
 
 DEPENDENCIES_ROOT="/private/tmp/openmw-deps/openmw-deps"
-QT_PATH=`brew --prefix qt@5.5`
+QT_PATH=`brew --prefix $macos_qt_formula`
 
 mkdir build
 cd build


### PR DESCRIPTION
Recent failures were caused by internal changes in package manager, Homebrew. Qt prefix path is now being fetched dynamically to make CI script more resilient.