### PR TITLE
Implemented "paying" for travelling followers

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <list>
+#include <set>
 #include <stdint.h>
 
 namespace osg
@@ -199,6 +200,10 @@ namespace MWBase
             virtual std::list<MWWorld::Ptr> getActorsFighting(const MWWorld::Ptr& actor) = 0;
 
             virtual std::list<MWWorld::Ptr> getEnemiesNearby(const MWWorld::Ptr& actor) = 0;
+
+            /// Recursive versions of above methods
+            virtual void getActorsFollowing(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out) = 0;
+            virtual void getActorsSidingWith(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out) = 0;
 
             virtual void playerLoaded() = 0;
 

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -74,27 +74,14 @@ namespace MWGui
             price = static_cast<int>(d / gmst.find("fTravelMult")->getFloat());
         }
 
-        // Add price for the followers in range
+        price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
+
+        // Add price for the travelling followers
         std::set<MWWorld::Ptr> followers;
-        MWBase::Environment::get().getMechanicsManager()->getActorsFollowing(player, followers);
-
-        int travellingFollowers = 0;
-        for(std::set<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
-        {
-            MWWorld::Ptr follower = *it;
-
-            std::string script = follower.getClass().getScript(follower);
-            if (!script.empty() && follower.getRefData().getLocals().getIntVar(script, "stayoutside") == 1)
-                continue;
-
-            if ((follower.getRefData().getPosition().asVec3() - player.getRefData().getPosition().asVec3()).length2() <= 800*800)
-                ++travellingFollowers;
-        }
+        MWWorld::ActionTeleport::getFollowersToTeleport(player, followers);
 
         // Apply followers cost, in vanilla one follower travels for free
-        price *= std::max(1, travellingFollowers);
-
-        price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
+        price *= std::max(1, static_cast<int>(followers.size()));
 
         MyGUI::Button* toAdd = mDestinationsView->createWidget<MyGUI::Button>("SandTextButton", 0, mCurrentY, 200, sLineHeight, MyGUI::Align::Default);
         toAdd->setEnabled(price <= playerGold);

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -78,7 +78,7 @@ namespace MWGui
         std::set<MWWorld::Ptr> followers;
         MWBase::Environment::get().getMechanicsManager()->getActorsFollowing(player, followers);
 
-        unsigned int travellingFollowers = 0;
+        int travellingFollowers = 0;
         for(std::set<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
         {
             MWWorld::Ptr follower = *it;
@@ -92,7 +92,7 @@ namespace MWGui
         }
 
         // Apply followers cost, in vanilla one follower travels for free
-        price *= travellingFollowers;
+        price *= std::max(1, travellingFollowers);
 
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1482,6 +1482,20 @@ namespace MWMechanics
         return list;
     }
 
+    void Actors::getActorsFollowing(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out) {
+        std::list<MWWorld::Ptr> followers = getActorsFollowing(actor);
+        for(std::list<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
+            if (out.insert(*it).second)
+                getActorsFollowing(*it, out);
+    }
+
+    void Actors::getActorsSidingWith(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out) {
+        std::list<MWWorld::Ptr> followers = getActorsSidingWith(actor);
+        for(std::list<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
+            if (out.insert(*it).second)
+                getActorsSidingWith(*it, out);
+    }
+
     std::list<int> Actors::getActorsFollowingIndices(const MWWorld::Ptr &actor)
     {
         std::list<int> list;

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -123,6 +123,11 @@ namespace MWMechanics
             std::list<MWWorld::Ptr> getActorsSidingWith(const MWWorld::Ptr& actor);
             std::list<MWWorld::Ptr> getActorsFollowing(const MWWorld::Ptr& actor);
 
+            /// Recursive version of getActorsFollowing
+            void getActorsFollowing(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out);
+            /// Recursive version of getActorsSidingWith
+            void getActorsSidingWith(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out);
+
             /// Get the list of AiFollow::mFollowIndex for all actors following this target
             std::list<int> getActorsFollowingIndices(const MWWorld::Ptr& actor);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -978,18 +978,6 @@ namespace MWMechanics
     }
 
 
-    void getFollowers (const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out)
-    {
-        std::list<MWWorld::Ptr> followers = MWBase::Environment::get().getMechanicsManager()->getActorsSidingWith(actor);
-        for(std::list<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
-        {
-            if (out.insert(*it).second)
-            {
-                getFollowers(*it, out);
-            }
-        }
-    }
-
     bool MechanicsManager::commitCrime(const MWWorld::Ptr &player, const MWWorld::Ptr &victim, OffenseType type, int arg, bool victimAware)
     {
         // NOTE: victim may be empty
@@ -1013,7 +1001,7 @@ namespace MWMechanics
 
         // get the player's followers / allies (works recursively) that will not report crimes
         std::set<MWWorld::Ptr> playerFollowers;
-        getFollowers(player, playerFollowers);
+        getActorsSidingWith(player, playerFollowers);
 
         // Did anyone see it?
         bool crimeSeen = false;
@@ -1435,6 +1423,14 @@ namespace MWMechanics
 
     std::list<MWWorld::Ptr> MechanicsManager::getEnemiesNearby(const MWWorld::Ptr& actor) {
         return mActors.getEnemiesNearby(actor);
+    }
+
+    void MechanicsManager::getActorsFollowing(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out) {
+        mActors.getActorsFollowing(actor, out);
+    }
+
+    void MechanicsManager::getActorsSidingWith(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out) {
+        mActors.getActorsSidingWith(actor, out);
     }
 
     int MechanicsManager::countSavedGameRecords() const

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -165,6 +165,11 @@ namespace MWMechanics
             virtual std::list<MWWorld::Ptr> getActorsFighting(const MWWorld::Ptr& actor);
             virtual std::list<MWWorld::Ptr> getEnemiesNearby(const MWWorld::Ptr& actor);
 
+            /// Recursive version of getActorsFollowing
+            virtual void getActorsFollowing(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out);
+            /// Recursive version of getActorsSidingWith
+            virtual void getActorsSidingWith(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out);
+
             virtual bool toggleAI();
             virtual bool isAIActive();
 

--- a/apps/openmw/mwworld/actionteleport.cpp
+++ b/apps/openmw/mwworld/actionteleport.cpp
@@ -20,22 +20,12 @@ namespace MWWorld
     {
         if (mTeleportFollowers)
         {
-            //find any NPC that is following the actor and teleport him too
+            // Find any NPCs that are following the actor and teleport them with him
             std::set<MWWorld::Ptr> followers;
-            MWBase::Environment::get().getMechanicsManager()->getActorsFollowing(actor, followers);
+            getFollowersToTeleport(actor, followers);
 
-            for(std::set<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
-            {
-                MWWorld::Ptr follower = *it;
-
-                std::string script = follower.getClass().getScript(follower);
-                if (!script.empty() && follower.getRefData().getLocals().getIntVar(script, "stayoutside") == 1)
-                    continue;
-
-                if ((follower.getRefData().getPosition().asVec3() - actor.getRefData().getPosition().asVec3()).length2()
-                        <= 800*800)
-                    teleport(*it);
-            }
+            for (std::set<MWWorld::Ptr>::iterator it = followers.begin(); it != followers.end(); ++it)
+                teleport(*it);
         }
 
         teleport(actor);
@@ -64,6 +54,23 @@ namespace MWWorld
             }
             else
                 world->moveObject(actor,world->getInterior(mCellName),mPosition.pos[0],mPosition.pos[1],mPosition.pos[2]);
+        }
+    }
+
+    void ActionTeleport::getFollowersToTeleport(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out) {
+        std::set<MWWorld::Ptr> followers;
+        MWBase::Environment::get().getMechanicsManager()->getActorsFollowing(actor, followers);
+
+        for(std::set<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
+        {
+            MWWorld::Ptr follower = *it;
+
+            std::string script = follower.getClass().getScript(follower);
+            if (!script.empty() && follower.getRefData().getLocals().getIntVar(script, "stayoutside") == 1)
+                continue;
+
+            if ((follower.getRefData().getPosition().asVec3() - actor.getRefData().getPosition().asVec3()).length2() <= 800*800)
+                out.insert(follower);
         }
     }
 }

--- a/apps/openmw/mwworld/actionteleport.cpp
+++ b/apps/openmw/mwworld/actionteleport.cpp
@@ -8,23 +8,6 @@
 
 #include "player.hpp"
 
-namespace
-{
-
-    void getFollowers (const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out)
-    {
-        std::list<MWWorld::Ptr> followers = MWBase::Environment::get().getMechanicsManager()->getActorsFollowing(actor);
-        for(std::list<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
-        {
-            if (out.insert(*it).second)
-            {
-                getFollowers(*it, out);
-            }
-        }
-    }
-
-}
-
 namespace MWWorld
 {
     ActionTeleport::ActionTeleport (const std::string& cellName,
@@ -39,7 +22,8 @@ namespace MWWorld
         {
             //find any NPC that is following the actor and teleport him too
             std::set<MWWorld::Ptr> followers;
-            getFollowers(actor, followers);
+            MWBase::Environment::get().getMechanicsManager()->getActorsFollowing(actor, followers);
+
             for(std::set<MWWorld::Ptr>::iterator it = followers.begin();it != followers.end();++it)
             {
                 MWWorld::Ptr follower = *it;

--- a/apps/openmw/mwworld/actionteleport.hpp
+++ b/apps/openmw/mwworld/actionteleport.hpp
@@ -1,6 +1,7 @@
 #ifndef GAME_MWWORLD_ACTIONTELEPORT_H
 #define GAME_MWWORLD_ACTIONTELEPORT_H
 
+#include <set>
 #include <string>
 
 #include <components/esm/defs.hpp>
@@ -23,9 +24,12 @@ namespace MWWorld
 
         public:
 
-            ActionTeleport (const std::string& cellName, const ESM::Position& position, bool teleportFollowers);
             ///< If cellName is empty, an exterior cell is assumed.
             /// @param teleportFollowers Whether to teleport any following actors of the target actor as well.
+            ActionTeleport (const std::string& cellName, const ESM::Position& position, bool teleportFollowers);
+
+            /// Outputs every actor follower who is in teleport range and wasn't ordered to not enter interiors
+            static void getFollowersToTeleport(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out);
     };
 }
 

--- a/apps/openmw/mwworld/actionteleport.hpp
+++ b/apps/openmw/mwworld/actionteleport.hpp
@@ -24,7 +24,7 @@ namespace MWWorld
 
         public:
 
-            ///< If cellName is empty, an exterior cell is assumed.
+            /// If cellName is empty, an exterior cell is assumed.
             /// @param teleportFollowers Whether to teleport any following actors of the target actor as well.
             ActionTeleport (const std::string& cellName, const ESM::Position& position, bool teleportFollowers);
 


### PR DESCRIPTION
Player now pays for the following actors when travelling with the exception of the first follower who travels for free, by an addition replaced two versions of getFollowers by getActorsFollowing and getActorsSidingWith methods in MechanicsManager & Actor classes.