### PR TITLE
Clean-up saves by dropping references with invalid RefNums

### DIFF
--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -137,6 +137,9 @@ namespace
                     iter->load (state);
                     return;
                 }
+
+            std::cerr << "Dropping reference to " << state.mRef.mRefID << " (invalid content file link)" << std::endl;
+            return;
         }
 
         // new reference


### PR DESCRIPTION
Fixes: https://bugs.openmw.org/issues/1956
Relevant thread: https://forum.openmw.org/viewtopic.php?f=40&t=4016

I gave it some thought and couldn't come up with a situation where doing this would be harmful. I'm a bit skeptical, though, because of this comment on the bug report:
> With a changed RefNum, the connection to the object in the savegame is lost, so there's really nothing we can do.
