### PR TITLE
Adjustments to AI combat engaging and disengaging

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -310,13 +310,14 @@ namespace MWMechanics
         if (!actor1.getClass().isMobile(actor1))
             return;
 
+        const std::list<MWWorld::Ptr>& playerFollowersAndEscorters = getActorsSidingWith(getPlayer());
         bool aggressive;
 
-        if (againstPlayer)
+        if (againstPlayer || std::find(playerFollowersAndEscorters.begin(), playerFollowersAndEscorters.end(), actor2) != playerFollowersAndEscorters.end())
         {
-            // followers with high fight should not engage in combat with the player (e.g. bm_bear_black_summon)
-            const std::list<MWWorld::Ptr>& followers = getActorsSidingWith(actor2);
-            if (std::find(followers.begin(), followers.end(), actor1) != followers.end())
+            // Player followers and escorters with high fight should not initiate combat with the player or with
+            // other player followers or escorters
+            if (std::find(playerFollowersAndEscorters.begin(), playerFollowersAndEscorters.end(), actor1) != playerFollowersAndEscorters.end())
                 return;
 
             aggressive = MWBase::Environment::get().getMechanicsManager()->isAggressive(actor1, actor2);
@@ -369,7 +370,8 @@ namespace MWMechanics
         {
             bool LOS = MWBase::Environment::get().getWorld()->getLOS(actor1, actor2);
 
-            if (againstPlayer) LOS &= MWBase::Environment::get().getMechanicsManager()->awarenessCheck(actor2, actor1);
+            if (againstPlayer || std::find(playerFollowersAndEscorters.begin(), playerFollowersAndEscorters.end(), actor2) != playerFollowersAndEscorters.end())
+                LOS &= MWBase::Environment::get().getMechanicsManager()->awarenessCheck(actor2, actor1);
 
             if (LOS)
             {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -338,11 +338,24 @@ namespace MWMechanics
                 aggressive = true;
         }
 
+        // Initiate combat with the player if we are already in combat with a player follower or escorter
+        const std::list<MWWorld::Ptr>& playerFollowersAndEscorters = getActorsSidingWith(getPlayer());
+        if (!aggressive && againstPlayer)
+        {
+            for (std::list<MWWorld::Ptr>::const_iterator it = playerFollowersAndEscorters.begin(); it != playerFollowersAndEscorters.end(); ++it)
+            {
+                if (creatureStats1.getAiSequence().isInCombat(*it))
+                {
+                    MWBase::Environment::get().getMechanicsManager()->startCombat(actor1, actor2);
+                    return;
+                }
+            }
+        }
+
         // Otherwise, don't initiate combat with an unreachable target
         if (!aggressive && !MWMechanics::canFight(actor1,actor2))
             return;
 
-        const std::list<MWWorld::Ptr>& playerFollowersAndEscorters = getActorsSidingWith(getPlayer());
         if (!aggressive && (againstPlayer || std::find(playerFollowersAndEscorters.begin(), playerFollowersAndEscorters.end(), actor2) != playerFollowersAndEscorters.end()))
         {
             // Player followers and escorters with high fight should not initiate combat here with the player or with

--- a/apps/openmw/mwmechanics/aicombat.hpp
+++ b/apps/openmw/mwmechanics/aicombat.hpp
@@ -59,7 +59,8 @@ namespace MWMechanics
 
             int mTargetActorId;
 
-            void attack(const MWWorld::Ptr& actor, const MWWorld::Ptr& target, AiCombatStorage& storage, CharacterController& characterController);
+            /// Returns true if combat should end
+            bool attack(const MWWorld::Ptr& actor, const MWWorld::Ptr& target, AiCombatStorage& storage, CharacterController& characterController);
 
             void updateLOS(const MWWorld::Ptr& actor, const MWWorld::Ptr& target, float duration, AiCombatStorage& storage);
 


### PR DESCRIPTION
(Fixes [#3690](https://bugs.openmw.org/issues/3690))

This fixes this issue by making enemies start combat with player allies on sight.

I also did a general cleanup of the function. I avoided touching the part that is modified in another PR https://github.com/OpenMW/openmw/pull/921, so there shouldn't be any merge conflict there.