### PR TITLE
Make dispel an instant effect again (Fixes #3695)

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -613,6 +613,14 @@ namespace MWMechanics
                 return true;
             }
         }
+        else if (target.getClass().isActor())
+        {
+            if (effectId == ESM::MagicEffect::Dispel)
+            {
+                target.getClass().getCreatureStats(target).getActiveSpells().purgeAll(magnitude);
+                return true;
+            }        
+        }
         else if (target.getClass().isActor() && target == getPlayer())
         {
             MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(mCaster);
@@ -1139,9 +1147,6 @@ namespace MWMechanics
             break;
         case ESM::MagicEffect::CureCorprusDisease:
             actor.getClass().getCreatureStats(actor).getSpells().purgeCorprusDisease();
-            break;
-        case ESM::MagicEffect::Dispel:
-            actor.getClass().getCreatureStats(actor).getActiveSpells().purgeAll(magnitude);
             break;
         case ESM::MagicEffect::RemoveCurse:
             actor.getClass().getCreatureStats(actor).getSpells().purgeCurses();


### PR DESCRIPTION
Fixes the problem of dispel not always working that was introduced when I made it a non-instant spell.

Unfortunately, this means the icon will again disappear immediately on casting, but it's more important that the spell work.

In the original engine, dispel is not instant, it applies over what seems to be 1 second, so even an effect applied to the player (or probably any actor) can be dispelled after casting if its within that second. This is OK for 100% dispel spells, but I can't understand what's happening with dispel spells of less than 100%. It seems like dispel under a certain percentage will always fail, and over a certain percentage will always succeed, but the percentage seemed to change. I did have one or two times when some effects were dispelled while some remained. Anyway, it certainly does not seem that, for example, a 30% dispel spell will succeed 30% of the time.

The Morrowind Code Patch lists as a fix

- Dispel no longer (invisibly) stacks with itself if you keep casting it.

but I didn't notice if this was happening. I was testing without the code patch.

Edit: The Morrowind Code Patch's description on nexusmods says "Dispel fix. Dispel is a chance-based effect, but it would invisibly stack with itself if cast multiple times, until any dispel would always succeed. This makes dispel work as described." But when I was testing it seemed at low percentages dispel would always fail even after multiple casts, which seems to contradict this. 

Found a discussion of the dispel bug. No idea if this person is correct but they sound like they've done some reverse engineering.

> The dispel bug is just unbelieveable in how it's coded.
> - There's a (global) temp variable for the dispel magnitude. But they don't clear it before or after use.
> - The spell effect mechanic is to increase the dispel magnitude over the spell duration (like a restore > spell) instead of turning it on once and off once.
> - The method for rolling on the dispel chance is broken.
> - The dispel chance is applied every frame without regard to the frame time delta. It should be applied only once.

From http://www.gamesas.com/repairing-the-cogs-morrowind-t63780-150.html

