### PR TITLE
Fix teleportation being unreachable

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -613,13 +613,10 @@ namespace MWMechanics
                 return true;
             }
         }
-        else if (target.getClass().isActor())
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::Dispel)
         {
-            if (effectId == ESM::MagicEffect::Dispel)
-            {
-                target.getClass().getCreatureStats(target).getActiveSpells().purgeAll(magnitude);
-                return true;
-            }        
+            target.getClass().getCreatureStats(target).getActiveSpells().purgeAll(magnitude);
+            return true;
         }
         else if (target.getClass().isActor() && target == getPlayer())
         {


### PR DESCRIPTION
#1180 made `else if(target.getClass().isActor() && target == getPlayer()`) unreachable by adding `else if(target.getClass().isActor())` above it.