### PR TITLE
Disable fixed time steps.

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1346,7 +1346,7 @@ namespace MWPhysics
         mMovementResults.clear();
 
         mTimeAccum += dt;
-        const float physicsDt = 1.f/60.0f;
+        const float physicsDt = dt;//1.f/60.0f;
 
         const int maxAllowedSteps = 20;
         int numSteps = mTimeAccum / (physicsDt);


### PR DESCRIPTION
[Do not merge]

My testing so far shows an overall more stable frame rate with higher min fps. It will cause a reduced max fps, once you go above 60, but that could be 'fixed' too by skipping steps.

From what I see nothing really requires fixed dt. Is that correct?

A proper fix would probably need a full movement solver rewrite, optimized for fixed dt, that maybe doesn't use tracing at all due to its high cpu costs.