### PR TITLE
Don't make Command spells cancel AI packages

### DIFF
--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -37,6 +37,7 @@ namespace MWMechanics
             MWWorld::Ptr getTarget() const;
             virtual bool sideWithTarget() const { return true; }
             virtual bool followTargetThroughDoors() const { return true; }
+            virtual bool shouldCancelPreviousAi() const { return !mCommanded; }
 
             virtual AiFollow *clone() const;
 


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3649.

Ｗander, travel packages, etc. should not be erased by command. Try using a command spell on an NPC traveling at Dren Plantation, for example.