### PR TITLE
Stop combat when adding an AI package to an actor

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -93,6 +93,7 @@ public:
     }
 };
 
+// Check for command effects having ended and remove package if necessary
 void adjustCommandedActor (const MWWorld::Ptr& actor)
 {
     CheckActorCommanded check(actor);
@@ -112,13 +113,7 @@ void adjustCommandedActor (const MWWorld::Ptr& actor)
         }
     }
 
-    if (check.mCommanded && !hasCommandPackage)
-    {
-        // FIXME: don't use refid string
-        MWMechanics::AiFollow package("player", true);
-        stats.getAiSequence().stack(package, actor);
-    }
-    else if (!check.mCommanded && hasCommandPackage)
+    if (!check.mCommanded && hasCommandPackage)
     {
         stats.getAiSequence().erase(it);
     }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -84,10 +84,8 @@ public:
                              const std::string& sourceName, const std::string& sourceId, int casterActorId,
                         float magnitude, float remainingTime = -1, float totalTime = -1)
     {
-        MWWorld::Ptr player = MWMechanics::getPlayer();
-        if (    ((key.mId == ESM::MagicEffect::CommandHumanoid && mActor.getClass().isNpc())
-                || (key.mId == ESM::MagicEffect::CommandCreature && mActor.getTypeName() == typeid(ESM::Creature).name()))
-            && casterActorId == player.getClass().getCreatureStats(player).getActorId()
+        if (((key.mId == ESM::MagicEffect::CommandHumanoid && mActor.getClass().isNpc())
+            || (key.mId == ESM::MagicEffect::CommandCreature && mActor.getTypeName() == typeid(ESM::Creature).name()))
             && magnitude >= mActor.getClass().getCreatureStats(mActor).getLevel())
                 mCommanded = true;
     }

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -281,6 +281,10 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor)
         }
     }
 
+    // Stop combat when a non-combat AI package is added
+    if (isActualAiPackage(package.getTypeId()))
+        stopCombat();
+
     // remove previous packages if required
     if (package.shouldCancelPreviousAi())
     {

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -492,9 +492,9 @@ namespace MWMechanics
                         appliedLastingEffects.push_back(effect);
 
                         // Command spells should have their effect, including taking the target out of combat, each time the spell successfully affects the target
-                        if (effectIt->mEffectID == ESM::MagicEffect::CommandHumanoid && target.getClass().isNpc()
-                        || (effectIt->mEffectID == ESM::MagicEffect::CommandCreature && target.getTypeName() == typeid(ESM::Creature).name())
-                        && caster == getPlayer() && magnitude >= target.getClass().getCreatureStats(target).getLevel())
+                        if (((effectIt->mEffectID == ESM::MagicEffect::CommandHumanoid && target.getClass().isNpc())
+                        || (effectIt->mEffectID == ESM::MagicEffect::CommandCreature && target.getTypeName() == typeid(ESM::Creature).name()))
+                        && !caster.isEmpty() && caster.getClass().isActor() && target != getPlayer() && magnitude >= target.getClass().getCreatureStats(target).getLevel())
                         {
                             MWMechanics::AiFollow package(caster.getCellRef().getRefId(), true);
                             target.getClass().getCreatureStats(target).getAiSequence().stack(package, target);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -27,6 +27,7 @@
 #include "magiceffects.hpp"
 #include "npcstats.hpp"
 #include "actorutil.hpp"
+#include "aifollow.hpp"
 
 namespace MWMechanics
 {
@@ -489,6 +490,15 @@ namespace MWMechanics
                         targetEffects.add(MWMechanics::EffectKey(*effectIt), MWMechanics::EffectParam(effect.mMagnitude));
 
                         appliedLastingEffects.push_back(effect);
+
+                        // Command spells should have their effect, including taking the target out of combat, each time the spell successfully affects the target
+                        if (effectIt->mEffectID == ESM::MagicEffect::CommandHumanoid && target.getClass().isNpc()
+                        || (effectIt->mEffectID == ESM::MagicEffect::CommandCreature && target.getTypeName() == typeid(ESM::Creature).name())
+                        && caster == getPlayer() && magnitude >= target.getClass().getCreatureStats(target).getLevel())
+                        {
+                            MWMechanics::AiFollow package(caster.getCellRef().getRefId(), true);
+                            target.getClass().getCreatureStats(target).getAiSequence().stack(package, target);
+                        }
 
                         // For absorb effects, also apply the effect to the caster - but with a negative
                         // magnitude, since we're transferring stats from the target to the caster


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3722.

Not only Command spells, but giving an actor a package like AIWander or AIFollow through the console should cancel their combat.