### PR TITLE
added ability to reload shaders from game console via command "reloadshaders"

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -567,6 +567,9 @@ namespace MWBase
 
             /// Return physical or rendering half extents of the given actor.
             virtual osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const = 0;
+
+            /// Trying to reload all loaded shaders, could be very useful for developlent purposes
+            virtual void reloadShaders() = 0;
     };
 }
 

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1251,6 +1251,18 @@ namespace MWScript
                 MWBase::Environment::get().getWorld()->createOverrideRecord(listCopy);
             }
         };
+        
+        class OpReloadShaders : public Interpreter::Opcode0
+        {
+        public:
+
+            virtual void execute(Interpreter::Runtime& runtime)
+            {
+                MWBase::Environment::get().getWorld()->reloadShaders();
+
+                runtime.getContext().report("Reloading shaders...");
+            }
+        };
 
         void installOpcodes (Interpreter::Interpreter& interpreter)
         {
@@ -1348,6 +1360,7 @@ namespace MWScript
             interpreter.installSegment5 (Compiler::Misc::opcodeRemoveFromLevCreature, new OpRemoveFromLevCreature);
             interpreter.installSegment5 (Compiler::Misc::opcodeAddToLevItem, new OpAddToLevItem);
             interpreter.installSegment5 (Compiler::Misc::opcodeRemoveFromLevItem, new OpRemoveFromLevItem);
+            interpreter.installSegment5(Compiler::Misc::opcodeReloadShaders, new OpReloadShaders);
         }
     }
 }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -12,6 +12,7 @@
 #include <components/files/collections.hpp>
 #include <components/misc/resourcehelpers.hpp>
 #include <components/resource/resourcesystem.hpp>
+#include <components/resource/scenemanager.hpp>
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 
@@ -3344,4 +3345,8 @@ namespace MWWorld
         mRendering->preloadCommonAssets();
     }
 
+    void World::reloadShaders()
+    {
+        mRendering->getResourceSystem()->getSceneManager()->reloadShaders();
+    }
 }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -668,6 +668,9 @@ namespace MWWorld
 
             /// Return physical or rendering half extents of the given actor.
             virtual osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const;
+
+            /// Trying to reload all loaded shaders, could be very useful for developlent purposes
+            virtual void reloadShaders();
     };
 }
 

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -316,6 +316,7 @@ namespace Compiler
             extensions.registerInstruction ("removefromlevcreature", "ccl", opcodeRemoveFromLevCreature);
             extensions.registerInstruction ("addtolevitem", "ccl", opcodeAddToLevItem);
             extensions.registerInstruction ("removefromlevitem", "ccl", opcodeRemoveFromLevItem);
+            extensions.registerInstruction ("reloadshaders", "", opcodeReloadShaders);
         }
     }
 

--- a/components/compiler/opcodes.hpp
+++ b/components/compiler/opcodes.hpp
@@ -292,6 +292,7 @@ namespace Compiler
         const int opcodeRemoveFromLevCreature = 0x20002fc;
         const int opcodeAddToLevItem = 0x20002fd;
         const int opcodeRemoveFromLevItem = 0x20002fe;
+        const int opcodeReloadShaders = 0x2000306;
     }
 
     namespace Sky

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -271,6 +271,11 @@ namespace Resource
         mShaderManager->setShaderPath(path);
     }
 
+    void SceneManager::reloadShaders()
+    {
+        mShaderManager->reloadShaders();
+    }
+
     /// @brief Callback to read image files from the VFS.
     class ImageReadCallback : public osgDB::ReadFileCallback
     {

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -72,6 +72,8 @@ namespace Resource
 
         void setShaderPath(const std::string& path);
 
+        void reloadShaders();
+
         /// Get a read-only copy of this scene "template"
         /// @note If the given filename does not exist or fails to load, an error marker mesh will be used instead.
         ///  If even the error marker mesh can not be found, an exception is thrown.

--- a/components/shader/shadermanager.hpp
+++ b/components/shader/shadermanager.hpp
@@ -32,6 +32,7 @@ namespace Shader
 
         osg::ref_ptr<osg::Program> getProgram(osg::ref_ptr<osg::Shader> vertexShader, osg::ref_ptr<osg::Shader> fragmentShader);
 
+        void reloadShaders();
 
     private:
         std::string mPath;


### PR DESCRIPTION
With possibility to reload shaders modern graphics development will be easy because no need to reload the game after changing something at shaders. But I'm not sure that my adding of a new command (which, as I understand, will be supported at scripts, and it's definitely excessively ) is good idea, so maybe there is better way to implement it :)

Discussion on forum: https://forum.openmw.org/viewtopic.php?f=3&t=4076&sid=f3d7b4a496155034985d55ccf6633b39#p45376