### PR TITLE
Fix MSVC warnings

### DIFF
--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -155,7 +155,7 @@ namespace ESMTerrain
                                             osg::ref_ptr<osg::Vec4Array> colours)
     {
         // LOD level n means every 2^n-th vertex is kept
-        size_t increment = 1 << lodLevel;
+        size_t increment = static_cast<size_t>(1) << lodLevel;
 
         osg::Vec2f origin = center - osg::Vec2f(size/2.f, size/2.f);
 

--- a/components/terrain/buffercache.cpp
+++ b/components/terrain/buffercache.cpp
@@ -23,7 +23,7 @@ osg::ref_ptr<IndexArrayType> createIndexBuffer(unsigned int flags, unsigned int 
 
     bool anyDeltas = (lodDeltas[Terrain::North] || lodDeltas[Terrain::South] || lodDeltas[Terrain::West] || lodDeltas[Terrain::East]);
 
-    size_t increment = 1 << lodLevel;
+    size_t increment = static_cast<size_t>(1) << lodLevel;
     assert(increment < verts);
 
     osg::ref_ptr<IndexArrayType> indices (new IndexArrayType(osg::PrimitiveSet::TRIANGLES));
@@ -75,7 +75,7 @@ osg::ref_ptr<IndexArrayType> createIndexBuffer(unsigned int flags, unsigned int 
 
         // South
         size_t row = 0;
-        size_t outerStep = 1 << (lodDeltas[Terrain::South] + lodLevel);
+        size_t outerStep = static_cast<size_t>(1) << (lodDeltas[Terrain::South] + lodLevel);
         for (size_t col = 0; col < verts-1; col += outerStep)
         {
             indices->push_back(verts*col+row);

--- a/components/terrain/storage.cpp
+++ b/components/terrain/storage.cpp
@@ -1,1 +1,0 @@
-#include "storage.hpp"

--- a/extern/oics/tinyxml.cpp
+++ b/extern/oics/tinyxml.cpp
@@ -48,7 +48,7 @@ FILE* TiXmlFOpen( const char* filename, const char* mode )
 		memset(wname, 0, sizeof(*wname) * (len + 1));
 		wchar_t wmode[32] = { 0 };
 
-		MultiByteToWideChar(CP_UTF8, 0, filename, len, wname, len);
+		MultiByteToWideChar(CP_UTF8, 0, filename, static_cast<int>(len), wname, static_cast<int>(len));
 		MultiByteToWideChar(CP_UTF8, 0, mode, -1, wmode, sizeof(wmode) / sizeof(*wmode));
 
 		#if defined(_MSC_VER) && (_MSC_VER >= 1400 )


### PR DESCRIPTION
Not a lot going on right now, so here's a few fixes for warnings I see when compiling with Visual Studio 2015.

Warnings fixed are:

openmw\extern\oics\tinyxml.cpp(51): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data

openmw\components\terrain\buffercache.cpp(26): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
openmw\components\terrain\buffercache.cpp(223): note: see reference to function template instantiation 'osg::ref_ptr<osg::DrawElementsUShort> `anonymous-namespace'::createIndexBuffer<osg::DrawElementsUShort>(unsigned int,unsigned int)' being compiled

openmw\components\terrain\buffercache.cpp(78): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)

openmw\components\esmterrain\storage.cpp(158): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)

storage.cpp.obj : warning LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library