### PR TITLE
Make combat engagement logic more like vanilla

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -325,22 +325,38 @@ namespace MWClass
 
     void Creature::onHit(const MWWorld::Ptr &ptr, float damage, bool ishealth, const MWWorld::Ptr &object, const MWWorld::Ptr &attacker, const osg::Vec3f &hitPosition, bool successful) const
     {
-        // NOTE: 'object' and/or 'attacker' may be empty.
+        MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
 
-        if (!attacker.isEmpty() && !ptr.getClass().getCreatureStats(ptr).getAiSequence().isInCombat(attacker))
-            getCreatureStats(ptr).setAttacked(true);
+        // NOTE: 'object' and/or 'attacker' may be empty.        
+        if (!attacker.isEmpty() && !stats.getAiSequence().isInCombat(attacker))
+            stats.setAttacked(true);
 
         // Self defense
         bool setOnPcHitMe = true; // Note OnPcHitMe is not set for friendly hits.
         
         // No retaliation for totally static creatures (they have no movement or attacks anyway)
         if (isMobile(ptr) && !attacker.isEmpty())
-        {
             setOnPcHitMe = MWBase::Environment::get().getMechanicsManager()->actorAttacked(ptr, attacker);
+
+        // Attacker and target store each other as hitattemptactor if they have no one stored yet
+        if (!attacker.isEmpty() && !ptr.isEmpty())
+        {
+            MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
+            // First handle the attacked actor
+            if (stats.getHitAttemptActor().isEmpty()
+                && (statsAttacker.getAiSequence().isInCombat(ptr)
+                    || attacker == MWMechanics::getPlayer()))
+                stats.setHitAttemptActor(attacker);
+
+            // Next handle the attacking actor
+            if (statsAttacker.getHitAttemptActor().isEmpty()
+                && (statsAttacker.getAiSequence().isInCombat(ptr)
+                    || attacker == MWMechanics::getPlayer()))
+                statsAttacker.setHitAttemptActor(ptr);
         }
 
         if (!object.isEmpty())
-            getCreatureStats(ptr).setLastHitAttemptObject(object.getCellRef().getRefId());
+            stats.setLastHitAttemptObject(object.getCellRef().getRefId());
 
         if (setOnPcHitMe && !attacker.isEmpty() && attacker == MWMechanics::getPlayer())
         {
@@ -358,7 +374,7 @@ namespace MWClass
         }
 
         if (!object.isEmpty())
-            getCreatureStats(ptr).setLastHitObject(object.getCellRef().getRefId());
+            stats.setLastHitObject(object.getCellRef().getRefId());
 
         if (damage > 0.0f && !object.isEmpty())
             MWMechanics::resistNormalWeapon(ptr, attacker, object, damage);
@@ -371,16 +387,13 @@ namespace MWClass
             if (!attacker.isEmpty())
             {
                 // Check for knockdown
-                float agilityTerm = getCreatureStats(ptr).getAttribute(ESM::Attribute::Agility).getModified() * getGmst().fKnockDownMult->getFloat();
-                float knockdownTerm = getCreatureStats(ptr).getAttribute(ESM::Attribute::Agility).getModified()
+                float agilityTerm = stats.getAttribute(ESM::Attribute::Agility).getModified() * getGmst().fKnockDownMult->getFloat();
+                float knockdownTerm = stats.getAttribute(ESM::Attribute::Agility).getModified()
                         * getGmst().iKnockDownOddsMult->getInt() * 0.01f + getGmst().iKnockDownOddsBase->getInt();
                 if (ishealth && agilityTerm <= damage && knockdownTerm <= Misc::Rng::roll0to99())
-                {
-                    getCreatureStats(ptr).setKnockedDown(true);
-
-                }
+                    stats.setKnockedDown(true);
                 else
-                    getCreatureStats(ptr).setHitRecovery(true); // Is this supposed to always occur?
+                    stats.setHitRecovery(true); // Is this supposed to always occur?
             }
 
             damage = std::max(1.f, damage);
@@ -395,15 +408,15 @@ namespace MWClass
 
                 MWBase::Environment::get().getSoundManager()->playSound3D(ptr, "Health Damage", 1.0f, 1.0f);
 
-                MWMechanics::DynamicStat<float> health(getCreatureStats(ptr).getHealth());
+                MWMechanics::DynamicStat<float> health(stats.getHealth());
                 health.setCurrent(health.getCurrent() - damage);
-                getCreatureStats(ptr).setHealth(health);
+                stats.setHealth(health);
             }
             else
             {
-                MWMechanics::DynamicStat<float> fatigue(getCreatureStats(ptr).getFatigue());
+                MWMechanics::DynamicStat<float> fatigue(stats.getFatigue());
                 fatigue.setCurrent(fatigue.getCurrent() - damage, true);
-                getCreatureStats(ptr).setFatigue(fatigue);
+                stats.setFatigue(fatigue);
             }
         }
     }

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -343,16 +343,16 @@ namespace MWClass
         {
             MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
             // First handle the attacked actor
-            if (stats.getHitAttemptActor().isEmpty()
+            if ((stats.getHitAttemptActorId() == -1)
                 && (statsAttacker.getAiSequence().isInCombat(ptr)
                     || attacker == MWMechanics::getPlayer()))
-                stats.setHitAttemptActor(attacker);
+                stats.setHitAttemptActorId(statsAttacker.getActorId());
 
             // Next handle the attacking actor
-            if (statsAttacker.getHitAttemptActor().isEmpty()
+            if ((statsAttacker.getHitAttemptActorId() == -1)
                 && (statsAttacker.getAiSequence().isInCombat(ptr)
                     || attacker == MWMechanics::getPlayer()))
-                statsAttacker.setHitAttemptActor(ptr);
+                statsAttacker.setHitAttemptActorId(stats.getActorId());
         }
 
         if (!object.isEmpty())

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -672,16 +672,16 @@ namespace MWClass
         {
             MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
             // First handle the attacked actor
-            if (stats.getHitAttemptActor().isEmpty()
+            if ((stats.getHitAttemptActorId() == -1)
                 && (statsAttacker.getAiSequence().isInCombat(ptr)
                     || attacker == MWMechanics::getPlayer()))
-                stats.setHitAttemptActor(attacker);
+                stats.setHitAttemptActorId(statsAttacker.getActorId());
 
             // Next handle the attacking actor
-            if (statsAttacker.getHitAttemptActor().isEmpty()
+            if ((statsAttacker.getHitAttemptActorId() == -1)
                 && (statsAttacker.getAiSequence().isInCombat(ptr)
                     || attacker == MWMechanics::getPlayer()))
-                statsAttacker.setHitAttemptActor(ptr);
+                statsAttacker.setHitAttemptActorId(stats.getActorId());
         }
 
         if (!object.isEmpty())

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -654,22 +654,38 @@ namespace MWClass
     void Npc::onHit(const MWWorld::Ptr &ptr, float damage, bool ishealth, const MWWorld::Ptr &object, const MWWorld::Ptr &attacker, const osg::Vec3f &hitPosition, bool successful) const
     {
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-
-        // NOTE: 'object' and/or 'attacker' may be empty.
-
-        bool wasDead = getCreatureStats(ptr).isDead();
+        MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+        bool wasDead = stats.isDead();
 
         // Note OnPcHitMe is not set for friendly hits.
         bool setOnPcHitMe = true;
-        if (!attacker.isEmpty() && !ptr.getClass().getCreatureStats(ptr).getAiSequence().isInCombat(attacker))
-        {
-            getCreatureStats(ptr).setAttacked(true);
 
+        // NOTE: 'object' and/or 'attacker' may be empty.
+        if (!attacker.isEmpty() && !stats.getAiSequence().isInCombat(attacker))
+        {
+            stats.setAttacked(true);
             setOnPcHitMe = MWBase::Environment::get().getMechanicsManager()->actorAttacked(ptr, attacker);
         }
 
+        // Attacker and target store each other as hitattemptactor if they have no one stored yet
+        if (!attacker.isEmpty() && !ptr.isEmpty())
+        {
+            MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
+            // First handle the attacked actor
+            if (stats.getHitAttemptActor().isEmpty()
+                && (statsAttacker.getAiSequence().isInCombat(ptr)
+                    || attacker == MWMechanics::getPlayer()))
+                stats.setHitAttemptActor(attacker);
+
+            // Next handle the attacking actor
+            if (statsAttacker.getHitAttemptActor().isEmpty()
+                && (statsAttacker.getAiSequence().isInCombat(ptr)
+                    || attacker == MWMechanics::getPlayer()))
+                statsAttacker.setHitAttemptActor(ptr);
+        }
+
         if (!object.isEmpty())
-            getCreatureStats(ptr).setLastHitAttemptObject(object.getCellRef().getRefId());
+            stats.setLastHitAttemptObject(object.getCellRef().getRefId());
 
         if (setOnPcHitMe && !attacker.isEmpty() && attacker == MWMechanics::getPlayer())
         {
@@ -687,7 +703,7 @@ namespace MWClass
         }
 
         if (!object.isEmpty())
-            getCreatureStats(ptr).setLastHitObject(object.getCellRef().getRefId());
+            stats.setLastHitObject(object.getCellRef().getRefId());
 
 
         if (damage > 0.0f && !object.isEmpty())
@@ -706,21 +722,16 @@ namespace MWClass
 
             int chance = store.get<ESM::GameSetting>().find("iVoiceHitOdds")->getInt();
             if (Misc::Rng::roll0to99() < chance)
-            {
                 MWBase::Environment::get().getDialogueManager()->say(ptr, "hit");
-            }
 
             // Check for knockdown
-            float agilityTerm = getCreatureStats(ptr).getAttribute(ESM::Attribute::Agility).getModified() * gmst.fKnockDownMult->getFloat();
-            float knockdownTerm = getCreatureStats(ptr).getAttribute(ESM::Attribute::Agility).getModified()
+            float agilityTerm = stats.getAttribute(ESM::Attribute::Agility).getModified() * gmst.fKnockDownMult->getFloat();
+            float knockdownTerm = stats.getAttribute(ESM::Attribute::Agility).getModified()
                     * gmst.iKnockDownOddsMult->getInt() * 0.01f + gmst.iKnockDownOddsBase->getInt();
             if (ishealth && agilityTerm <= damage && knockdownTerm <= Misc::Rng::roll0to99())
-            {
-                getCreatureStats(ptr).setKnockedDown(true);
-
-            }
+                stats.setKnockedDown(true);
             else
-                getCreatureStats(ptr).setHitRecovery(true); // Is this supposed to always occur?
+                stats.setHitRecovery(true); // Is this supposed to always occur?
 
             if (damage > 0 && ishealth)
             {
@@ -799,13 +810,13 @@ namespace MWClass
             }
             MWMechanics::DynamicStat<float> health(getCreatureStats(ptr).getHealth());
             health.setCurrent(health.getCurrent() - damage);
-            getCreatureStats(ptr).setHealth(health);
+            stats.setHealth(health);
         }
         else
         {
             MWMechanics::DynamicStat<float> fatigue(getCreatureStats(ptr).getFatigue());
             fatigue.setCurrent(fatigue.getCurrent() - damage, true);
-            getCreatureStats(ptr).setFatigue(fatigue);
+            stats.setFatigue(fatigue);
         }
 
         if (!wasDead && getCreatureStats(ptr).isDead())

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -314,13 +314,12 @@ namespace MWMechanics
             if (creatureStats1.getAiSequence().isInCombat(*it))
                 continue;
 
-            if (!it->getClass().getCreatureStats(*it).getHitAttemptActor().isEmpty()
-                && it->getClass().getCreatureStats(*it).getHitAttemptActor() == actor2)
+            if (creatureStats2.matchesActorId(it->getClass().getCreatureStats(*it).getHitAttemptActorId()))
             {
                 MWBase::Environment::get().getMechanicsManager()->startCombat(actor1, actor2);
                 // Also set the same hit attempt actor. Otherwise, if fighting the player, they may stop combat
                 // if the player gets out of reach, while the ally would continue combat with the player
-                creatureStats1.setHitAttemptActor(actor2);
+                creatureStats1.setHitAttemptActorId(it->getClass().getCreatureStats(*it).getHitAttemptActorId());
                 return;             
             }
 
@@ -963,7 +962,7 @@ namespace MWMechanics
                     if (player.getClass().getNpcStats(player).getBounty() >= cutoff * iCrimeThresholdMultiplier)
                     {
                         MWBase::Environment::get().getMechanicsManager()->startCombat(ptr, player);
-                        creatureStats.setHitAttemptActor(player); // Stops the guard from quitting combat if player is unreachable
+                        creatureStats.setHitAttemptActorId(player.getClass().getCreatureStats(player).getActorId()); // Stops the guard from quitting combat if player is unreachable
                     }
                     else
                         creatureStats.getAiSequence().stack(AiPursue(player), ptr);
@@ -1092,9 +1091,9 @@ namespace MWMechanics
                     || !iter->first.getClass().getCreatureStats(iter->first).getAiSequence().isInCombat()
                     || !inProcessingRange))
                 {
-                    iter->first.getClass().getCreatureStats(iter->first).setHitAttemptActor(NULL);
-                    if (player.getClass().getCreatureStats(player).getHitAttemptActor() == iter->first)
-                        player.getClass().getCreatureStats(player).setHitAttemptActor(NULL);
+                    iter->first.getClass().getCreatureStats(iter->first).setHitAttemptActorId(-1);
+                    if (player.getClass().getCreatureStats(player).getHitAttemptActorId() == iter->first.getClass().getCreatureStats(iter->first).getActorId())
+                        player.getClass().getCreatureStats(player).setHitAttemptActorId(-1);
                 }
 
                 const MWWorld::Ptr playerHitAttemptActor = MWBase::Environment::get().getWorld()->searchPtrViaActorId(player.getClass().getCreatureStats(player).getHitAttemptActorId());

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -20,6 +20,7 @@
 #include "combat.hpp"
 #include "coordinateconverter.hpp"
 #include "actorutil.hpp"
+#include "mechanicsmanagerimp.hpp"
 
 namespace
 {
@@ -233,9 +234,14 @@ namespace MWMechanics
             storage.stopAttack();
             characterController.setAttackingOrSpell(false);
             storage.mActionCooldown = 0.f;
-            if (target == MWMechanics::getPlayer())
+            // Continue combat if target is player or player follower/escorter and an attack has been attempted
+            const std::list<MWWorld::Ptr>& playerFollowersAndEscorters = MWBase::Environment::get().getMechanicsManager()->getActorsSidingWith(MWMechanics::getPlayer());
+            bool targetSidesWithPlayer = (std::find(playerFollowersAndEscorters.begin(), playerFollowersAndEscorters.end(), target) != playerFollowersAndEscorters.end());
+            if ((target == MWMechanics::getPlayer() || targetSidesWithPlayer)
+                && ((actor.getClass().getCreatureStats(actor).getHitAttemptActor() == target)
+                || (target.getClass().getCreatureStats(target).getHitAttemptActor() == actor)))
                 forceFlee = true;
-            else
+            else // Otherwise end combat
                 return true;
         }
 

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -238,8 +238,8 @@ namespace MWMechanics
             const std::list<MWWorld::Ptr>& playerFollowersAndEscorters = MWBase::Environment::get().getMechanicsManager()->getActorsSidingWith(MWMechanics::getPlayer());
             bool targetSidesWithPlayer = (std::find(playerFollowersAndEscorters.begin(), playerFollowersAndEscorters.end(), target) != playerFollowersAndEscorters.end());
             if ((target == MWMechanics::getPlayer() || targetSidesWithPlayer)
-                && ((actor.getClass().getCreatureStats(actor).getHitAttemptActor() == target)
-                || (target.getClass().getCreatureStats(target).getHitAttemptActor() == actor)))
+                && ((actor.getClass().getCreatureStats(actor).getHitAttemptActorId() == target.getClass().getCreatureStats(target).getActorId())
+                || (target.getClass().getCreatureStats(target).getHitAttemptActorId() == actor.getClass().getCreatureStats(actor).getActorId())))
                 forceFlee = true;
             else // Otherwise end combat
                 return true;

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -371,6 +371,16 @@ namespace MWMechanics
         return mLastHitAttemptObject;
     }
 
+    void CreatureStats::setHitAttemptActor(const MWWorld::Ptr& actor)
+    {
+        mHitAttemptActor = actor;
+    }
+
+    const MWWorld::Ptr &CreatureStats::getHitAttemptActor() const
+    {
+        return mHitAttemptActor;
+    }
+
     void CreatureStats::addToFallHeight(float height)
     {
         mFallHeight += height;

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -21,7 +21,7 @@ namespace MWMechanics
           mTalkedTo (false), mAlarmed (false), mAttacked (false),
           mKnockdown(false), mKnockdownOneFrame(false), mKnockdownOverOneFrame(false),
           mHitRecovery(false), mBlock(false), mMovementFlags(0),
-          mFallHeight(0), mRecalcMagicka(false), mLastRestock(0,0), mGoldPool(0), mActorId(-1),
+          mFallHeight(0), mRecalcMagicka(false), mLastRestock(0,0), mGoldPool(0), mActorId(-1), mHitAttemptActorId(-1),
           mDeathAnimation(-1), mTimeOfDeath(), mLevel (0)
     {
         for (int i=0; i<4; ++i)
@@ -371,14 +371,14 @@ namespace MWMechanics
         return mLastHitAttemptObject;
     }
 
-    void CreatureStats::setHitAttemptActor(const MWWorld::Ptr& actor)
+    void CreatureStats::setHitAttemptActorId(int actorId)
     {
-        mHitAttemptActor = actor;
+        mHitAttemptActorId = actorId;
     }
 
-    const MWWorld::Ptr &CreatureStats::getHitAttemptActor() const
+    int CreatureStats::getHitAttemptActorId() const
     {
-        return mHitAttemptActor;
+        return mHitAttemptActorId;
     }
 
     void CreatureStats::addToFallHeight(float height)
@@ -531,6 +531,7 @@ namespace MWMechanics
         state.mActorId = mActorId;
         state.mDeathAnimation = mDeathAnimation;
         state.mTimeOfDeath = mTimeOfDeath.toEsm();
+        state.mHitAttemptActorId = mHitAttemptActorId;
 
         mSpells.writeState(state.mSpells);
         mActiveSpells.writeState(state.mActiveSpells);
@@ -579,6 +580,7 @@ namespace MWMechanics
         mActorId = state.mActorId;
         mDeathAnimation = state.mDeathAnimation;
         mTimeOfDeath = MWWorld::TimeStamp(state.mTimeOfDeath);
+        mHitAttemptActorId = state.mHitAttemptActorId;
 
         mSpells.readState(state.mSpells);
         mActiveSpells.readState(state.mActiveSpells);

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -53,6 +53,9 @@ namespace MWMechanics
         std::string mLastHitObject; // The last object to hit this actor
         std::string mLastHitAttemptObject; // The last object to attempt to hit this actor
 
+        MWWorld::Ptr mHitAttemptActor; // Stores an actor that attacked this actor. Only one is stored at a time,
+                                       // and it is not changed if a different actor attacks. It is cleared when combat ends.
+
         bool mRecalcMagicka;
 
         // For merchants: the last time items were restocked and gold pool refilled.
@@ -241,9 +244,11 @@ namespace MWMechanics
         bool getStance (Stance flag) const;
 
         void setLastHitObject(const std::string &objectid);
-        void setLastHitAttemptObject(const std::string &objectid);
         const std::string &getLastHitObject() const;
+        void setLastHitAttemptObject(const std::string &objectid);
         const std::string &getLastHitAttemptObject() const;
+        void setHitAttemptActor(const MWWorld::Ptr &actor);
+        const MWWorld::Ptr &getHitAttemptActor() const;
 
         // Note, this is just a cache to avoid checking the whole container store every frame. We don't need to store it in saves.
         // TODO: Put it somewhere else?

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -53,9 +53,6 @@ namespace MWMechanics
         std::string mLastHitObject; // The last object to hit this actor
         std::string mLastHitAttemptObject; // The last object to attempt to hit this actor
 
-        MWWorld::Ptr mHitAttemptActor; // Stores an actor that attacked this actor. Only one is stored at a time,
-                                       // and it is not changed if a different actor attacks. It is cleared when combat ends.
-
         bool mRecalcMagicka;
 
         // For merchants: the last time items were restocked and gold pool refilled.
@@ -65,6 +62,8 @@ namespace MWMechanics
         int mGoldPool;
 
         int mActorId;
+        int mHitAttemptActorId; // Stores an actor that attacked this actor. Only one is stored at a time,
+                                // and it is not changed if a different actor attacks. It is cleared when combat ends.
 
         // The index of the death animation that was played, or -1 if none played
         signed char mDeathAnimation;
@@ -247,8 +246,8 @@ namespace MWMechanics
         const std::string &getLastHitObject() const;
         void setLastHitAttemptObject(const std::string &objectid);
         const std::string &getLastHitAttemptObject() const;
-        void setHitAttemptActor(const MWWorld::Ptr &actor);
-        const MWWorld::Ptr &getHitAttemptActor() const;
+        void setHitAttemptActorId(const int actorId);
+        int getHitAttemptActorId() const;
 
         // Note, this is just a cache to avoid checking the whole container store every frame. We don't need to store it in saves.
         // TODO: Put it somewhere else?

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1214,48 +1214,51 @@ namespace MWMechanics
         }
     }
 
-    bool MechanicsManager::actorAttacked(const MWWorld::Ptr &ptr, const MWWorld::Ptr &attacker)
+    bool MechanicsManager::actorAttacked(const MWWorld::Ptr &target, const MWWorld::Ptr &attacker)
     {
-        if (ptr == getPlayer())
+        std::list<MWWorld::Ptr> followersAttacker = getActorsSidingWith(attacker);
+        std::list<MWWorld::Ptr> followersTarget = getActorsSidingWith(target);
+
+        MWMechanics::CreatureStats& statsTarget = target.getClass().getCreatureStats(target);
+
+        if (target == getPlayer())
             return false;
 
-        std::list<MWWorld::Ptr> followers = getActorsSidingWith(attacker);
-        MWMechanics::CreatureStats& targetStats = ptr.getClass().getCreatureStats(ptr);
-        if (std::find(followers.begin(), followers.end(), ptr) != followers.end())
+        if (std::find(followersAttacker.begin(), followersAttacker.end(), target) != followersAttacker.end())
         {
-            targetStats.friendlyHit();
+            statsTarget.friendlyHit();
 
-            if (targetStats.getFriendlyHits() < 4)
+            if (statsTarget.getFriendlyHits() < 4)
             {
-                MWBase::Environment::get().getDialogueManager()->say(ptr, "hit");
+                MWBase::Environment::get().getDialogueManager()->say(target, "hit");
                 return false;
             }
         }
 
         // Attacking an NPC that is already in combat with any other NPC is not a crime
-        AiSequence& seq = targetStats.getAiSequence();
+        AiSequence& seq = statsTarget.getAiSequence();
         bool isFightingNpc = false;
         for (std::list<AiPackage*>::const_iterator it = seq.begin(); it != seq.end(); ++it)
         {
             if ((*it)->getTypeId() == AiPackage::TypeIdCombat)
             {
-                MWWorld::Ptr target = (*it)->getTarget();
-                if (!target.isEmpty() && target.getClass().isNpc())
+                MWWorld::Ptr target2 = (*it)->getTarget();
+                if (!target2.isEmpty() && target2.getClass().isNpc())
                     isFightingNpc = true;
             }
         }
 
-        if (ptr.getClass().isNpc() && !attacker.isEmpty() && !seq.isInCombat(attacker)
-                && !isAggressive(ptr, attacker) && !isFightingNpc)
-            commitCrime(attacker, ptr, MWBase::MechanicsManager::OT_Assault);
+        if (target.getClass().isNpc() && !attacker.isEmpty() && !seq.isInCombat(attacker)
+                && !isAggressive(target, attacker) && !isFightingNpc)
+            commitCrime(attacker, target, MWBase::MechanicsManager::OT_Assault);
 
-        if (!attacker.isEmpty() && (attacker.getClass().getCreatureStats(attacker).getAiSequence().isInCombat(ptr)
+        if (!attacker.isEmpty() && (attacker.getClass().getCreatureStats(attacker).getAiSequence().isInCombat(target)
                                     || attacker == getPlayer())
                 && !seq.isInCombat(attacker))
         {
             // Attacker is in combat with us, but we are not in combat with the attacker yet. Time to fight back.
             // Note: accidental or collateral damage attacks are ignored.
-            startCombat(ptr, attacker);
+            startCombat(target, attacker);
         }
 
         return true;
@@ -1365,6 +1368,7 @@ namespace MWMechanics
             // if guard starts combat with player, guards pursuing player should do the same
             if (ptr.getClass().isClass(ptr, "Guard"))
             {
+                ptr.getClass().getCreatureStats(ptr).setHitAttemptActor(target); // Stops guard from ending combat if player is unreachable
                 for (Actors::PtrActorMap::const_iterator iter = mActors.begin(); iter != mActors.end(); ++iter)
                 {
                     if (iter->first.getClass().isClass(iter->first, "Guard"))
@@ -1374,6 +1378,7 @@ namespace MWMechanics
                         {
                             aiSeq.stopPursuit();
                             aiSeq.stack(MWMechanics::AiCombat(target), ptr);
+                            iter->first.getClass().getCreatureStats(iter->first).setHitAttemptActor(target); // Stops guard from ending combat if player is unreachable
                         }
                     }
                 }

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1368,7 +1368,7 @@ namespace MWMechanics
             // if guard starts combat with player, guards pursuing player should do the same
             if (ptr.getClass().isClass(ptr, "Guard"))
             {
-                ptr.getClass().getCreatureStats(ptr).setHitAttemptActor(target); // Stops guard from ending combat if player is unreachable
+                ptr.getClass().getCreatureStats(ptr).setHitAttemptActorId(target.getClass().getCreatureStats(target).getActorId()); // Stops guard from ending combat if player is unreachable
                 for (Actors::PtrActorMap::const_iterator iter = mActors.begin(); iter != mActors.end(); ++iter)
                 {
                     if (iter->first.getClass().isClass(iter->first, "Guard"))
@@ -1378,7 +1378,7 @@ namespace MWMechanics
                         {
                             aiSeq.stopPursuit();
                             aiSeq.stack(MWMechanics::AiCombat(target), ptr);
-                            iter->first.getClass().getCreatureStats(iter->first).setHitAttemptActor(target); // Stops guard from ending combat if player is unreachable
+                            iter->first.getClass().getCreatureStats(iter->first).setHitAttemptActorId(target.getClass().getCreatureStats(target).getActorId()); // Stops guard from ending combat if player is unreachable
                         }
                     }
                 }

--- a/components/esm/creaturestats.cpp
+++ b/components/esm/creaturestats.cpp
@@ -90,6 +90,9 @@ void ESM::CreatureStats::load (ESMReader &esm)
     mActorId = -1;
     esm.getHNOT (mActorId, "ACID");
 
+    mHitAttemptActorId = -1;
+    esm.getHNOT(mHitAttemptActorId, "HAID");
+
     mDeathAnimation = -1;
     esm.getHNOT (mDeathAnimation, "DANM");
 
@@ -203,6 +206,9 @@ void ESM::CreatureStats::save (ESMWriter &esm) const
     if (mActorId != -1)
         esm.writeHNT ("ACID", mActorId);
 
+    if (mHitAttemptActorId != -1)
+        esm.writeHNT("HAID", mHitAttemptActorId);
+
     if (mDeathAnimation != -1)
         esm.writeHNT ("DANM", mDeathAnimation);
 
@@ -240,6 +246,7 @@ void ESM::CreatureStats::blank()
     mTradeTime.mDay = 0;
     mGoldPool = 0;
     mActorId = -1;
+    mHitAttemptActorId = -1;
     mHasAiSettings = false;
     mDead = false;
     mDeathAnimationFinished = false;

--- a/components/esm/creaturestats.hpp
+++ b/components/esm/creaturestats.hpp
@@ -38,6 +38,7 @@ namespace ESM
         ESM::TimeStamp mTradeTime;
         int mGoldPool;
         int mActorId;
+        int mHitAttemptActorId;
 
         bool mDead;
         bool mDeathAnimationFinished;

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -153,6 +153,10 @@ show effect duration = false
 # Prevents merchants from equipping items that are sold to them.
 prevent merchant equipping = false
 
+# Makes player followers and escorters start combat with enemies who have started combat with them
+# or the player. Otherwise they wait for the enemies or the player to do an attack first.
+followers attack on sight = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
(Fixes #2678, Fixes #3705)

This is my attempt to make the combat engagement AI similar to vanilla behavior, based on observations. Much of it involves how AI characters allied to each other through Follow or Escort packages engage in combat.

I tried to recreate the following:
1) Enemies will stop combat with the player or a player ally if no hit attempt (either from the player/player ally or from the enemy) has occurred yet, and they can't reach the player/player ally any more (such as from the player leaving the water). This fixes the "water creatures won't stop combat" bug.

2) AI that is allied with other AI or with the player through Follow or Escort packages will start combat with anyone who exchanges a hit attempt with one of their allies, regardless of LOS.

3) AI that is allied with other AI will go into combat with anyone one of their allies is in combat with even before a hit attempt, but in this case they have to be aware of them (LOS, etc.)

4) If AI that is engaged in combat by two or more enemies who are allied with each other, it will engage in combat back with them regardless of LOS. This doesn't apply for player allies, though, they wait for an attack to be exchanged first.

5) Guards will fight against any creatures in combat, except for ones that are running follow or escort packages.