### PR TITLE
Fix trying to access stats on non-actors

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -328,7 +328,7 @@ namespace MWClass
         MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
 
         // NOTE: 'object' and/or 'attacker' may be empty.        
-        if (!attacker.isEmpty() && !stats.getAiSequence().isInCombat(attacker))
+        if (!attacker.isEmpty() && attacker.getClass().isActor() && !stats.getAiSequence().isInCombat(attacker))
             stats.setAttacked(true);
 
         // Self defense
@@ -339,7 +339,7 @@ namespace MWClass
             setOnPcHitMe = MWBase::Environment::get().getMechanicsManager()->actorAttacked(ptr, attacker);
 
         // Attacker and target store each other as hitattemptactor if they have no one stored yet
-        if (!attacker.isEmpty() && !ptr.isEmpty())
+        if (!attacker.isEmpty() && attacker.getClass().isActor() && !ptr.isEmpty() && ptr.getClass().isActor())
         {
             MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
             // First handle the attacked actor

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -661,14 +661,14 @@ namespace MWClass
         bool setOnPcHitMe = true;
 
         // NOTE: 'object' and/or 'attacker' may be empty.
-        if (!attacker.isEmpty() && !stats.getAiSequence().isInCombat(attacker))
+        if (!attacker.isEmpty() && attacker.getClass().isActor() && !stats.getAiSequence().isInCombat(attacker))
         {
             stats.setAttacked(true);
             setOnPcHitMe = MWBase::Environment::get().getMechanicsManager()->actorAttacked(ptr, attacker);
         }
 
         // Attacker and target store each other as hitattemptactor if they have no one stored yet
-        if (!attacker.isEmpty() && !ptr.isEmpty())
+        if (!attacker.isEmpty() && attacker.getClass().isActor() && !ptr.isEmpty() && ptr.getClass().isActor())
         {
             MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
             // First handle the attacked actor

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1216,13 +1216,12 @@ namespace MWMechanics
 
     bool MechanicsManager::actorAttacked(const MWWorld::Ptr &target, const MWWorld::Ptr &attacker)
     {
+        if (target == getPlayer() || !attacker.getClass().isActor())
+            return false;
+
         std::list<MWWorld::Ptr> followersAttacker = getActorsSidingWith(attacker);
-        std::list<MWWorld::Ptr> followersTarget = getActorsSidingWith(target);
 
         MWMechanics::CreatureStats& statsTarget = target.getClass().getCreatureStats(target);
-
-        if (target == getPlayer())
-            return false;
 
         if (std::find(followersAttacker.begin(), followersAttacker.end(), target) != followersAttacker.end())
         {


### PR DESCRIPTION
There were a few spots where framelistener errors would happen with traps due to trying to access creaturestats on a non-actor. Part of this (when the player activates a trap) was due to my recent PR, but there was also a pre-existing problem when AI activated traps. You can try the attached save. An AI actor will use a trapped chest right after it is loaded. Without this PR it may crash, and lower or turn off your sound volume first. With this PR it should be fine.

This also fixes AI actors having the attacked flag set when hit by a trap. They shouldn't, according to a test I did with the original engine. After using the trap the NPC should still give his normal greeting when you activate him instead of the "go away" one that happens if he has been attacked. 