### PR TITLE
Make Book records display skill IDs instead of attribute IDs for teached skills. (Fixes Bug #3746.)

### DIFF
--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -494,7 +494,7 @@ void Record<ESM::Book>::print()
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
     std::cout << "  IsScroll: " << mData.mData.mIsScroll << std::endl;
-    std::cout << "  SkillID: " << mData.mData.mSkillID << std::endl;
+    std::cout << "  SkillId: " << mData.mData.mSkillId << std::endl;
     std::cout << "  Enchantment Points: " << mData.mData.mEnchant << std::endl;
     if (mPrintPlain)
     {

--- a/apps/essimporter/converter.hpp
+++ b/apps/essimporter/converter.hpp
@@ -202,7 +202,7 @@ public:
         bool isDeleted = false;
 
         book.load(esm, isDeleted);
-        if (book.mData.mSkillID == -1)
+        if (book.mData.mSkillId == -1)
             mContext->mPlayer.mObject.mNpcStats.mUsedIds.push_back(Misc::StringUtils::lowerCase(book.mId));
 
         mRecords[book.mId] = book;

--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -316,7 +316,7 @@ QVariant CSMWorld::BookRefIdAdapter::getData (const RefIdColumn *column,
         return record.get().mData.mIsScroll!=0;
 
     if (column==mSkill)
-        return record.get().mData.mSkillID;
+        return record.get().mData.mSkillId;
 
     if (column==mText)
         return QString::fromUtf8 (record.get().mText.c_str());
@@ -335,7 +335,7 @@ void CSMWorld::BookRefIdAdapter::setData (const RefIdColumn *column, RefIdData& 
     if (column==mScroll)
         book.mData.mIsScroll = value.toInt();
     else if (column==mSkill)
-        book.mData.mSkillID = value.toInt();
+        book.mData.mSkillId = value.toInt();
     else if (column==mText)
         book.mText = value.toString().toUtf8().data();
     else

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -294,8 +294,8 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Scroll, ColumnBase::Display_Boolean));
     const RefIdColumn *scroll = &mColumns.back();
 
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_Attribute, ColumnBase::Display_Attribute));
-    const RefIdColumn *attribute = &mColumns.back();
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_Skill, ColumnBase::Display_SkillId));
+    const RefIdColumn *skill = &mColumns.back();
 
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Text, ColumnBase::Display_LongString));
     const RefIdColumn *text = &mColumns.back();
@@ -659,7 +659,7 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mAdapters.insert (std::make_pair (UniversalId::Type_Armor,
         new ArmorRefIdAdapter (enchantableColumns, armorType, health, armor, partRef)));
     mAdapters.insert (std::make_pair (UniversalId::Type_Book,
-        new BookRefIdAdapter (enchantableColumns, scroll, attribute, text)));
+        new BookRefIdAdapter (enchantableColumns, scroll, skill, text)));
     mAdapters.insert (std::make_pair (UniversalId::Type_Clothing,
         new ClothingRefIdAdapter (enchantableColumns, clothingType, partRef)));
     mAdapters.insert (std::make_pair (UniversalId::Type_Container,

--- a/apps/openmw/mwworld/actionread.cpp
+++ b/apps/openmw/mwworld/actionread.cpp
@@ -44,7 +44,7 @@ namespace MWWorld
         MWMechanics::NpcStats& npcStats = actor.getClass().getNpcStats (actor);
 
         // Skill gain from books
-        if (ref->mBase->mData.mSkillID >= 0 && ref->mBase->mData.mSkillID < ESM::Skill::Length
+        if (ref->mBase->mData.mSkillId >= 0 && ref->mBase->mData.mSkillID < ESM::Skill::Length
                 && !npcStats.hasBeenUsed (ref->mBase->mId))
         {
             MWWorld::LiveCellRef<ESM::NPC> *playerRef = actor.get<ESM::NPC>();
@@ -54,7 +54,7 @@ namespace MWWorld
                     playerRef->mBase->mClass
                 );
 
-            npcStats.increaseSkill (ref->mBase->mData.mSkillID, *class_, true);
+            npcStats.increaseSkill (ref->mBase->mData.mSkillId, *class_, true);
 
             npcStats.flagAsUsed (ref->mBase->mId);
         }

--- a/apps/openmw/mwworld/actionread.cpp
+++ b/apps/openmw/mwworld/actionread.cpp
@@ -44,7 +44,7 @@ namespace MWWorld
         MWMechanics::NpcStats& npcStats = actor.getClass().getNpcStats (actor);
 
         // Skill gain from books
-        if (ref->mBase->mData.mSkillId >= 0 && ref->mBase->mData.mSkillID < ESM::Skill::Length
+        if (ref->mBase->mData.mSkillId >= 0 && ref->mBase->mData.mSkillId < ESM::Skill::Length
                 && !npcStats.hasBeenUsed (ref->mBase->mId))
         {
             MWWorld::LiveCellRef<ESM::NPC> *playerRef = actor.get<ESM::NPC>();

--- a/components/esm/loadbook.cpp
+++ b/components/esm/loadbook.cpp
@@ -84,7 +84,7 @@ namespace ESM
         mData.mWeight = 0;
         mData.mValue = 0;
         mData.mIsScroll = 0;
-        mData.mSkillID = 0;
+        mData.mSkillId = 0;
         mData.mEnchant = 0;
         mName.clear();
         mModel.clear();

--- a/components/esm/loadbook.hpp
+++ b/components/esm/loadbook.hpp
@@ -21,7 +21,7 @@ struct Book
     struct BKDTstruct
     {
         float mWeight;
-        int mValue, mIsScroll, mSkillID, mEnchant;
+        int mValue, mIsScroll, mSkillId, mEnchant;
     };
 
     BKDTstruct mData;


### PR DESCRIPTION
Makes Book records display skill IDs instead of attribute IDs for teached skills. Please note that everything else already was in place -- the member variable mSkillID, the getData function, and the setData function. The verifier does not check the entry in the first place.

Related issue:
- Bug #3746: OpenMW-CS: Book records show attribute IDs instead of skill IDs for teached skills entry. (https://bugs.openmw.org/issues/3746)

Tests:
I tested the changes by creating a new .omwaddon file and changing some of the skill books' teached skills (including one which I changed to "none") in OpenMW-CS. Loading the add-on in OpenMW resulted in the correct skills increasing.