### PR TITLE
Make AI not go hostile when absorbing/reflecting

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -413,10 +413,6 @@ namespace MWMechanics
             float magnitudeMult = 1;
             if (magicEffect->mData.mFlags & ESM::MagicEffect::Harmful && target.getClass().isActor())
             {
-                // Notify the target actor they've been hit
-                if (target != caster && !caster.isEmpty())
-                    target.getClass().onHit(target, 0.0f, true, MWWorld::Ptr(), caster, osg::Vec3f(), true);
-
                 if (absorbed)
                     continue;
 
@@ -449,6 +445,10 @@ namespace MWMechanics
                 // If player is attempting to cast a harmful spell, show the target's HP bar
                 if (castByPlayer && target != caster)
                     MWBase::Environment::get().getWindowManager()->setEnemy(target);
+
+                // Notify the target actor they've been hit
+                if (target != caster && !caster.isEmpty())
+                    target.getClass().onHit(target, 0.0f, true, MWWorld::Ptr(), caster, osg::Vec3f(), true);
             }
 
             if (magnitudeMult > 0 && !absorbed)


### PR DESCRIPTION
A while ago as part of a PR I changed AI response to hostile spells. OpenMW behavior at the time was for AI to consider a spell it reflected or resisted as an attack against it, but not to consider an absorbed one so. Original engine behavior is to consider a resisted one as an attack, but not a reflected or absorbed one. I changed it so all were considered as attacks, because it seemed most realistic to me.

Later there was a forum discussion https://forum.openmw.org/viewtopic.php?f=2&t=3979 and I decided then, and still think now, that we should probably just follow the way the original engine does things as far as these design decisions go. So, this small change sets the behavior to be like the original engine.