### PR TITLE
Replace "Scroll" check box with a combo box (fixes #3748)

### DIFF
--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -131,6 +131,7 @@ namespace CSMWorld
             Display_InfoCondComp,
             Display_String32,
             Display_LongString256,
+            Display_BookType,
 
             Display_EffectSkill,     // must display at least one, unlike Display_Skill
             Display_EffectAttribute, // must display at least one, unlike Display_Attribute

--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -98,7 +98,7 @@ namespace CSMWorld
             { ColumnId_ArmorType, "Armor Type" },
             { ColumnId_Health, "Health" },
             { ColumnId_ArmorValue, "Armor Value" },
-            { ColumnId_Scroll, "Scroll" },
+            { ColumnId_BookType, "Book Type" },
             { ColumnId_ClothingType, "Clothing Type" },
             { ColumnId_WeightCapacity, "Weight Capacity" },
             { ColumnId_OrganicContainer, "Organic Container" },
@@ -553,6 +553,11 @@ namespace
         "AI Wander", "AI Travel", "AI Follow", "AI Escort", "AI Activate", 0
     };
 
+    static const char *sBookType[] =
+    {
+        "Book", "Scroll", 0
+    };
+
     const char **getEnumNames (CSMWorld::Columns::ColumnId column)
     {
         switch (column)
@@ -582,6 +587,7 @@ namespace
             case CSMWorld::Columns::ColumnId_AiPackageType: return sAiPackageType;
             case CSMWorld::Columns::ColumnId_InfoCondFunc: return CSMWorld::ConstInfoSelectWrapper::FunctionEnumStrings;
             case CSMWorld::Columns::ColumnId_InfoCondComp: return CSMWorld::ConstInfoSelectWrapper::RelationEnumStrings;
+            case CSMWorld::Columns::ColumnId_BookType: return sBookType;
 
             default: return 0;
         }

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -92,7 +92,7 @@ namespace CSMWorld
             ColumnId_ArmorType = 77,
             ColumnId_Health = 78,
             ColumnId_ArmorValue = 79,
-            ColumnId_Scroll = 80,
+            ColumnId_BookType = 80,
             ColumnId_ClothingType = 81,
             ColumnId_WeightCapacity = 82,
             ColumnId_OrganicContainer = 83,

--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -313,7 +313,7 @@ QVariant CSMWorld::BookRefIdAdapter::getData (const RefIdColumn *column,
         data.getRecord (RefIdData::LocalIndex (index, UniversalId::Type_Book)));
 
     if (column==mBookType)
-        return record.get().mData.mIsScroll!=0;
+        return record.get().mData.mIsScroll;
 
     if (column==mSkill)
         return record.get().mData.mSkillId;

--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -301,9 +301,9 @@ void CSMWorld::ArmorRefIdAdapter::setData (const RefIdColumn *column, RefIdData&
 }
 
 CSMWorld::BookRefIdAdapter::BookRefIdAdapter (const EnchantableColumns& columns,
-    const RefIdColumn *scroll, const RefIdColumn *skill, const RefIdColumn *text)
+    const RefIdColumn *bookType, const RefIdColumn *skill, const RefIdColumn *text)
 : EnchantableRefIdAdapter<ESM::Book> (UniversalId::Type_Book, columns),
-    mScroll (scroll), mSkill (skill), mText (text)
+    mBookType (bookType), mSkill (skill), mText (text)
 {}
 
 QVariant CSMWorld::BookRefIdAdapter::getData (const RefIdColumn *column,
@@ -312,7 +312,7 @@ QVariant CSMWorld::BookRefIdAdapter::getData (const RefIdColumn *column,
     const Record<ESM::Book>& record = static_cast<const Record<ESM::Book>&> (
         data.getRecord (RefIdData::LocalIndex (index, UniversalId::Type_Book)));
 
-    if (column==mScroll)
+    if (column==mBookType)
         return record.get().mData.mIsScroll!=0;
 
     if (column==mSkill)
@@ -332,7 +332,7 @@ void CSMWorld::BookRefIdAdapter::setData (const RefIdColumn *column, RefIdData& 
 
     ESM::Book book = record.get();
 
-    if (column==mScroll)
+    if (column==mBookType)
         book.mData.mIsScroll = value.toInt();
     else if (column==mSkill)
         book.mData.mSkillId = value.toInt();

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -694,13 +694,13 @@ namespace CSMWorld
 
     class BookRefIdAdapter : public EnchantableRefIdAdapter<ESM::Book>
     {
-            const RefIdColumn *mScroll;
+            const RefIdColumn *mBookType;
             const RefIdColumn *mSkill;
             const RefIdColumn *mText;
 
         public:
 
-            BookRefIdAdapter (const EnchantableColumns& columns, const RefIdColumn *scroll,
+            BookRefIdAdapter (const EnchantableColumns& columns, const RefIdColumn *bookType,
                 const RefIdColumn *skill, const RefIdColumn *text);
 
             virtual QVariant getData (const RefIdColumn *column, const RefIdData& data, int index)

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -291,8 +291,8 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.push_back (RefIdColumn (Columns::ColumnId_ArmorValue, ColumnBase::Display_Integer));
     const RefIdColumn *armor = &mColumns.back();
 
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_Scroll, ColumnBase::Display_Boolean));
-    const RefIdColumn *scroll = &mColumns.back();
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_BookType, ColumnBase::Display_BookType));
+    const RefIdColumn *bookType = &mColumns.back();
 
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Skill, ColumnBase::Display_SkillId));
     const RefIdColumn *skill = &mColumns.back();
@@ -659,7 +659,7 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mAdapters.insert (std::make_pair (UniversalId::Type_Armor,
         new ArmorRefIdAdapter (enchantableColumns, armorType, health, armor, partRef)));
     mAdapters.insert (std::make_pair (UniversalId::Type_Book,
-        new BookRefIdAdapter (enchantableColumns, scroll, skill, text)));
+        new BookRefIdAdapter (enchantableColumns, bookType, skill, text)));
     mAdapters.insert (std::make_pair (UniversalId::Type_Clothing,
         new ClothingRefIdAdapter (enchantableColumns, clothingType, partRef)));
     mAdapters.insert (std::make_pair (UniversalId::Type_Container,

--- a/apps/opencs/view/doc/viewmanager.cpp
+++ b/apps/opencs/view/doc/viewmanager.cpp
@@ -107,6 +107,7 @@ CSVDoc::ViewManager::ViewManager (CSMDoc::DocumentManager& documentManager)
         { CSMWorld::ColumnBase::Display_IngredEffectId, CSMWorld::Columns::ColumnId_EffectId, true },
         { CSMWorld::ColumnBase::Display_EffectSkill, CSMWorld::Columns::ColumnId_Skill, false },
         { CSMWorld::ColumnBase::Display_EffectAttribute, CSMWorld::Columns::ColumnId_Attribute, false },
+        { CSMWorld::ColumnBase::Display_BookType, CSMWorld::Columns::ColumnId_BookType, false},
     };
 
     for (std::size_t i=0; i<sizeof (sMapping)/sizeof (Mapping); ++i)


### PR DESCRIPTION
Replaces the "Scroll" check box in Book records with a "Book Type" combo box.

Related issue:
- Fixes #3748: OpenMW-CS: Replace "Scroll" check box in Book records with "Book Type" combo box. (https://bugs.openmw.org/issues/3748)

Tests:
The changes were successfully tested in OpenMW-CS by manipulating several Book records. Please note that the actual logic behind this entry is not implemented yet: Books which are of type "Scroll" can have an enchantment attached, normal books ("Book") cannot.