### PR TITLE
Fix frame rate drop during actor update

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1597,17 +1597,16 @@ namespace MWMechanics
     }
 
     void Actors::getActorsSidingWith(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out, std::map<const MWWorld::Ptr, const std::set<MWWorld::Ptr> >& cachedAllies) {
-        std::list<MWWorld::Ptr> followers = getActorsSidingWith(actor);
-
         // If we have already found actor's allies, use the cache
         std::map<const MWWorld::Ptr, const std::set<MWWorld::Ptr> >::const_iterator search = cachedAllies.find(actor);
         if (search != cachedAllies.end())
-            out = search->second;
+            out.insert(search->second.begin(), search->second.end());
         else
         {
+            std::list<MWWorld::Ptr> followers = getActorsSidingWith(actor);
             for (std::list<MWWorld::Ptr>::iterator it = followers.begin(); it != followers.end(); ++it)
                 if (out.insert(*it).second)
-                    getActorsSidingWith(*it, out);
+                    getActorsSidingWith(*it, out, cachedAllies);
 
             // Cache ptrs and their sets of allies
             cachedAllies.insert(std::make_pair(actor, out));

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -88,7 +88,7 @@ namespace MWMechanics
                 @Notes: If againstPlayer = true then actor2 should be the Player.
                         If one of the combatants is creature it should be actor1.
             */
-            void engageCombat(const MWWorld::Ptr& actor1, const MWWorld::Ptr& actor2, bool againstPlayer);
+            void engageCombat(const MWWorld::Ptr& actor1, const MWWorld::Ptr& actor2, std::map<const MWWorld::Ptr, const std::set<MWWorld::Ptr> >& cachedAllies, bool againstPlayer);
 
             void updateHeadTracking(const MWWorld::Ptr& actor, const MWWorld::Ptr& targetActor,
                                             MWWorld::Ptr& headTrackTarget, float& sqrHeadTrackDistance);
@@ -127,6 +127,8 @@ namespace MWMechanics
             void getActorsFollowing(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out);
             /// Recursive version of getActorsSidingWith
             void getActorsSidingWith(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out);
+            /// Recursive version of getActorsSidingWith that takes, adds to and returns a cache of actors mapped to their allies
+            void getActorsSidingWith(const MWWorld::Ptr &actor, std::set<MWWorld::Ptr>& out, std::map<const MWWorld::Ptr, const std::set<MWWorld::Ptr> >& cachedAllies);
 
             /// Get the list of AiFollow::mFollowIndex for all actors following this target
             std::list<int> getActorsFollowingIndices(const MWWorld::Ptr& actor);


### PR DESCRIPTION
This fixes the frame rate drop caused by my earlier PR that changed how combat decisions are made.

The frame rate drop can be seen clearly at Tel Branora, where there are several NPCs following another one. With this PR there I don't see a noticeable frame rate drop here anymore on my system.

There was unnecessary processing going on when finding an actors allies (those in follow or escort relationships). This fix works by first finding the "top" of the follow/escort hierarchy, then working down from there. It should also work for cases where actors are following/escorting each other.