### PR TITLE
Fix Clang and OS X Travis CI warnings

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -179,15 +179,6 @@ namespace
         {
         }
 
-        virtual void apply(osg::Group& node)
-        {
-            traverse(node);
-        }
-        virtual void apply(osg::MatrixTransform& node)
-        {
-            traverse(node);
-        }
-
         void remove()
         {
             for (RemoveVec::iterator it = mToRemove.begin(); it != mToRemove.end(); ++it)
@@ -207,6 +198,15 @@ namespace
         virtual void apply(osg::Drawable& drw)
         {
             applyImpl(drw);
+        }
+
+        virtual void apply(osg::Group& node)
+        {
+            traverse(node);
+        }
+        virtual void apply(osg::MatrixTransform& node)
+        {
+            traverse(node);
         }
 
         void applyImpl(osg::Node& node)
@@ -238,6 +238,15 @@ namespace
         virtual void apply(osg::Drawable& drw)
         {
             applyImpl(drw);
+        }
+
+        virtual void apply(osg::Group& node)
+        {
+            traverse(node);
+        }
+        virtual void apply(osg::MatrixTransform& node)
+        {
+            traverse(node);
         }
 
         void applyImpl(osg::Node& node)


### PR DESCRIPTION
This is a suggestion for fixing the warnings in the Clang and OS X Travis CI builds about overridden virtual functions in animation.cpp.

I don't really know what the effects of this might be, so this is just a suggestion since it seems to satisfy the compilers. The game ran without obvious problems in a quick test.