### PR TITLE
Replace light emitter check boxes with a combo box (fixes #3752)

### DIFF
--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -133,6 +133,7 @@ namespace CSMWorld
             Display_LongString256,
             Display_BookType,
             Display_BloodType,
+            Display_EmitterType,
 
             Display_EffectSkill,     // must display at least one, unlike Display_Skill
             Display_EffectAttribute, // must display at least one, unlike Display_Attribute

--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -123,10 +123,8 @@ namespace CSMWorld
             { ColumnId_Dynamic, "Dynamic" },
             { ColumnId_Portable, "Portable" },
             { ColumnId_NegativeLight, "Negative Light" },
-            { ColumnId_Flickering, "Flickering" },
-            { ColumnId_SlowFlickering, "Slow Flickering" },
-            { ColumnId_Pulsing, "Pulsing" },
-            { ColumnId_SlowPulsing, "Slow Pulsing" },
+            { ColumnId_EmitterType, "Emitter Type" },
+            
             { ColumnId_Fire, "Fire" },
             { ColumnId_OffByDefault, "Off by default" },
             { ColumnId_IsKey, "Is Key" },
@@ -563,6 +561,11 @@ namespace
         "Default (Red)", "Skeleton Blood (White)", "Metal Blood (Golden)", 0
     };
 
+    static const char *sEmitterType[] =
+    {
+        "<None>", "Flickering", "Flickering (Slow)", "Pulsing", "Pulsing (Slow)", 0
+    };
+
     const char **getEnumNames (CSMWorld::Columns::ColumnId column)
     {
         switch (column)
@@ -594,6 +597,7 @@ namespace
             case CSMWorld::Columns::ColumnId_InfoCondComp: return CSMWorld::ConstInfoSelectWrapper::RelationEnumStrings;
             case CSMWorld::Columns::ColumnId_BookType: return sBookType;
             case CSMWorld::Columns::ColumnId_BloodType: return sBloodType;
+            case CSMWorld::Columns::ColumnId_EmitterType: return sEmitterType;
 
             default: return 0;
         }

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -118,10 +118,8 @@ namespace CSMWorld
             ColumnId_Dynamic = 103,
             ColumnId_Portable = 104,
             ColumnId_NegativeLight = 105,
-            ColumnId_Flickering = 106,
-            ColumnId_SlowFlickering = 107,
-            ColumnId_Pulsing = 108,
-            ColumnId_SlowPulsing = 109,
+            ColumnId_EmitterType = 106,
+            // unused (3x)
             ColumnId_Fire = 110,
             ColumnId_OffByDefault = 111,
             ColumnId_IsKey = 112,

--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -628,6 +628,25 @@ QVariant CSMWorld::LightRefIdAdapter::getData (const RefIdColumn *column, const 
     if (column==mColumns.mSound)
         return QString::fromUtf8 (record.get().mSound.c_str());
 
+    if (column == mColumns.mEmitterType)
+    {
+        int mask = ESM::Light::Flicker | ESM::Light::FlickerSlow | ESM::Light::Pulse | ESM::Light::PulseSlow;
+
+        if ((record.get().mData.mFlags & mask) == ESM::Light::Flicker)
+            return 1;
+
+        if ((record.get().mData.mFlags & mask) == ESM::Light::FlickerSlow)
+            return 2;
+
+        if ((record.get().mData.mFlags & mask) == ESM::Light::Pulse)
+            return 3;
+
+        if ((record.get().mData.mFlags & mask) == ESM::Light::PulseSlow)
+            return 4;
+
+        return 0;
+    }
+
     std::map<const RefIdColumn *, unsigned int>::const_iterator iter =
         mColumns.mFlags.find (column);
 
@@ -653,6 +672,21 @@ void CSMWorld::LightRefIdAdapter::setData (const RefIdColumn *column, RefIdData&
         light.mData.mColor = value.toInt();
     else if (column==mColumns.mSound)
         light.mSound = value.toString().toUtf8().constData();
+    else if (column == mColumns.mEmitterType)
+    {
+        int mask = ~(ESM::Light::Flicker | ESM::Light::FlickerSlow | ESM::Light::Pulse | ESM::Light::PulseSlow);
+
+        if (value.toInt() == 0)
+            light.mData.mFlags = light.mData.mFlags & mask;
+        else if (value.toInt() == 1)
+            light.mData.mFlags = (light.mData.mFlags & mask) | ESM::Light::Flicker;
+        else if (value.toInt() == 2)
+            light.mData.mFlags = (light.mData.mFlags & mask) | ESM::Light::FlickerSlow;
+        else if (value.toInt() == 3)
+            light.mData.mFlags = (light.mData.mFlags & mask) | ESM::Light::Pulse;
+        else
+            light.mData.mFlags = (light.mData.mFlags & mask) | ESM::Light::PulseSlow;
+    }
     else
     {
         std::map<const RefIdColumn *, unsigned int>::const_iterator iter =

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -802,6 +802,7 @@ namespace CSMWorld
         const RefIdColumn *mRadius;
         const RefIdColumn *mColor;
         const RefIdColumn *mSound;
+        const RefIdColumn *mEmitterType;
         std::map<const RefIdColumn *, unsigned int> mFlags;
 
         LightColumns (const InventoryColumns& columns);

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -443,6 +443,9 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Sound, ColumnBase::Display_Sound));
     lightColumns.mSound = &mColumns.back();
 
+    mColumns.push_back(RefIdColumn(Columns::ColumnId_EmitterType, ColumnBase::Display_EmitterType));
+    lightColumns.mEmitterType = &mColumns.back();
+
     static const struct
     {
         int mName;
@@ -452,10 +455,6 @@ CSMWorld::RefIdCollection::RefIdCollection()
         { Columns::ColumnId_Dynamic, ESM::Light::Dynamic },
         { Columns::ColumnId_Portable, ESM::Light::Carry },
         { Columns::ColumnId_NegativeLight, ESM::Light::Negative },
-        { Columns::ColumnId_Flickering, ESM::Light::Flicker },
-        { Columns::ColumnId_SlowFlickering, ESM::Light::FlickerSlow },
-        { Columns::ColumnId_Pulsing, ESM::Light::Pulse },
-        { Columns::ColumnId_SlowPulsing, ESM::Light::PulseSlow },
         { Columns::ColumnId_Fire, ESM::Light::Fire },
         { Columns::ColumnId_OffByDefault, ESM::Light::OffDefault },
         { -1, 0 }

--- a/apps/opencs/view/doc/viewmanager.cpp
+++ b/apps/opencs/view/doc/viewmanager.cpp
@@ -108,7 +108,8 @@ CSVDoc::ViewManager::ViewManager (CSMDoc::DocumentManager& documentManager)
         { CSMWorld::ColumnBase::Display_EffectSkill, CSMWorld::Columns::ColumnId_Skill, false },
         { CSMWorld::ColumnBase::Display_EffectAttribute, CSMWorld::Columns::ColumnId_Attribute, false },
         { CSMWorld::ColumnBase::Display_BookType, CSMWorld::Columns::ColumnId_BookType, false},
-        { CSMWorld::ColumnBase::Display_BloodType, CSMWorld::Columns::ColumnId_BloodType, false}
+        { CSMWorld::ColumnBase::Display_BloodType, CSMWorld::Columns::ColumnId_BloodType, false},
+        { CSMWorld::ColumnBase::Display_EmitterType, CSMWorld::Columns::ColumnId_EmitterType, false}
     };
 
     for (std::size_t i=0; i<sizeof (sMapping)/sizeof (Mapping); ++i)


### PR DESCRIPTION
Replaces the four emitter check boxes in Light records with an "Emitter Type" combo box.

Related issue:
- Fixes #3752: Editor: Replace emitter check boxes in Light records with "Emitter Type" combo box (https://bugs.openmw.org/issues/3752)

Tests:
The changes were successfully tested in OpenMW-CS by manipulating several Light records. Please note that this fix also prevents users from erroneously assigning two or more emitter types at the same time. (I don't know which one would prevail in that case.)