### PR TITLE
Change AI equip logic

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -291,9 +291,15 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                 {
                     if (old.getTypeName() == typeid(ESM::Armor).name())
                     {
-                        if (old.getClass().getEffectiveArmorRating(old, actor) >= test.getClass().getEffectiveArmorRating(test, actor))
-                            // old armor had better armor rating
+                        if (old.get<ESM::Armor>()->mBase->mData.mType < test.get<ESM::Armor>()->mBase->mData.mType)
                             continue;
+
+                        if (old.get<ESM::Armor>()->mBase->mData.mType == test.get<ESM::Armor>()->mBase->mData.mType)
+                        {
+                            if (old.getClass().getEffectiveArmorRating(old, actor) >= test.getClass().getEffectiveArmorRating(test, actor))
+                                // old armor had better armor rating
+                                continue;
+                        }
                     }
                     // suitable armor should replace already equipped clothing
                 }


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3754.

There are two issues there. One NPC, Val, is choosing to not equip armor instead of equip her armor due to equal armor rating. In the original engine this seems to be the reverse, with equipping armor preferred even if the armor rating is the same.

The other issue is that the NPC Nargol gra-Uftharz is equipping her bracers rather than her gauntlets in OpenMW, while she equips the gauntlets in the original engine. The bracers and gauntlets have equal armor rating. From testing in the original engine, it looks to me like NPCs always favor gauntlets over bracers, regardless of stats. I'm not quite sure how to handle this. It seems bug-like, but it also affects the appearance of an NPC, in this case... I decided to recreate the original engine behavior by default and allow setting the AI to treat bracers and gauntlets equally as an option.