### PR TITLE
Replace "Female" check box with a combo box, part 1/2 (fixes #3756)

### DIFF
--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -138,6 +138,7 @@ namespace CSMWorld
             Display_EffectSkill,     // must display at least one, unlike Display_Skill
             Display_EffectAttribute, // must display at least one, unlike Display_Attribute
             Display_IngredEffectId,  // display none allowed, unlike Display_EffectId
+            Display_GenderNpc,		 // must display at least one, unlike Display_Gender
 
             //top level columns that nest other columns
             Display_NestedHeader

--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -138,7 +138,7 @@ namespace CSMWorld
             Display_EffectSkill,     // must display at least one, unlike Display_Skill
             Display_EffectAttribute, // must display at least one, unlike Display_Attribute
             Display_IngredEffectId,  // display none allowed, unlike Display_EffectId
-            Display_GenderNpc,		 // must display at least one, unlike Display_Gender
+            Display_GenderNpc,       // must display at least one, unlike Display_Gender
 
             //top level columns that nest other columns
             Display_NestedHeader

--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -283,6 +283,7 @@ namespace CSMWorld
             { ColumnId_NpcMisc, "NPC Misc" },
             { ColumnId_Level, "Level" },
             { ColumnId_NpcFactionID, "Faction ID" },
+            { ColumnId_GenderNpc, "Gender"},
             { ColumnId_Mana, "Mana" },
             { ColumnId_Fatigue, "Fatigue" },
             { ColumnId_NpcDisposition, "NPC Disposition" },

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -276,7 +276,7 @@ namespace CSMWorld
             ColumnId_NpcMisc = 251,
             ColumnId_Level = 252,
             ColumnId_NpcFactionID = 253,
-            // unused
+            ColumnId_GenderNpc = 254,
             ColumnId_Mana = 255,
             ColumnId_Fatigue = 256,
             ColumnId_NpcDisposition = 257,

--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -756,7 +756,8 @@ CSMWorld::NpcColumns::NpcColumns (const ActorColumns& actorColumns)
   mAttributes(NULL),
   mSkills(NULL),
   mMisc(NULL),
-  mBloodType(NULL)
+  mBloodType(NULL),
+  mGender(NULL)
 {}
 
 CSMWorld::NpcRefIdAdapter::NpcRefIdAdapter (const NpcColumns& columns)
@@ -808,6 +809,15 @@ QVariant CSMWorld::NpcRefIdAdapter::getData (const RefIdColumn *column, const Re
         return 0;
     }
 
+    if (column == mColumns.mGender)
+    {
+        // Implemented this way to allow additional gender types in the future.
+        if ((record.get().mFlags & ESM::NPC::Female) == ESM::NPC::Female)
+            return 1;
+
+        return 0;
+    }
+
     std::map<const RefIdColumn *, unsigned int>::const_iterator iter =
         mColumns.mFlags.find (column);
 
@@ -845,6 +855,14 @@ void CSMWorld::NpcRefIdAdapter::setData (const RefIdColumn *column, RefIdData& d
             npc.mFlags = (npc.mFlags & mask) | ESM::NPC::Metal;
         else
             npc.mFlags = npc.mFlags & mask;
+    }
+    else if (column == mColumns.mGender)
+    {
+        // Implemented this way to allow additional gender types in the future.
+        if (value.toInt() == 1)
+            npc.mFlags = (npc.mFlags & ~ESM::NPC::Female) | ESM::NPC::Female;
+        else
+            npc.mFlags = npc.mFlags & ~ESM::NPC::Female;
     }
     else
     {

--- a/apps/opencs/model/world/refidadapterimp.hpp
+++ b/apps/opencs/model/world/refidadapterimp.hpp
@@ -852,6 +852,7 @@ namespace CSMWorld
         const RefIdColumn *mSkills;     // depends on npc type
         const RefIdColumn *mMisc;       // may depend on npc type, e.g. FactionID
         const RefIdColumn *mBloodType;
+        const RefIdColumn *mGender;
 
         NpcColumns (const ActorColumns& actorColumns);
     };

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -486,8 +486,8 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Head, ColumnBase::Display_BodyPart));
     npcColumns.mHead = &mColumns.back();
 
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_Female, ColumnBase::Display_Boolean));
-    npcColumns.mFlags.insert (std::make_pair (&mColumns.back(), ESM::NPC::Female));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_GenderNpc, ColumnBase::Display_GenderNpc));
+    npcColumns.mGender = &mColumns.back();
 
     npcColumns.mFlags.insert (std::make_pair (essential, ESM::NPC::Essential));
 

--- a/apps/opencs/view/doc/viewmanager.cpp
+++ b/apps/opencs/view/doc/viewmanager.cpp
@@ -107,9 +107,10 @@ CSVDoc::ViewManager::ViewManager (CSMDoc::DocumentManager& documentManager)
         { CSMWorld::ColumnBase::Display_IngredEffectId, CSMWorld::Columns::ColumnId_EffectId, true },
         { CSMWorld::ColumnBase::Display_EffectSkill, CSMWorld::Columns::ColumnId_Skill, false },
         { CSMWorld::ColumnBase::Display_EffectAttribute, CSMWorld::Columns::ColumnId_Attribute, false },
-        { CSMWorld::ColumnBase::Display_BookType, CSMWorld::Columns::ColumnId_BookType, false},
-        { CSMWorld::ColumnBase::Display_BloodType, CSMWorld::Columns::ColumnId_BloodType, false},
-        { CSMWorld::ColumnBase::Display_EmitterType, CSMWorld::Columns::ColumnId_EmitterType, false}
+        { CSMWorld::ColumnBase::Display_BookType, CSMWorld::Columns::ColumnId_BookType, false },
+        { CSMWorld::ColumnBase::Display_BloodType, CSMWorld::Columns::ColumnId_BloodType, false },
+        { CSMWorld::ColumnBase::Display_EmitterType, CSMWorld::Columns::ColumnId_EmitterType, false },
+        { CSMWorld::ColumnBase::Display_GenderNpc, CSMWorld::Columns::ColumnId_Gender, false }
     };
 
     for (std::size_t i=0; i<sizeof (sMapping)/sizeof (Mapping); ++i)


### PR DESCRIPTION
Replaces the "Female" check box in NPC records with a "Gender" combo box. This is the first of two related fixes, the second one covering BodyPart records.

Related issue:
- Fixes #3756: Editor: Replace "Female" check box in NPC records with "Gender" combo box (https://bugs.openmw.org/issues/3756)

Tests:
The changes were successfully tested in OpenMW-CS by manipulating several NPC records.