### PR TITLE
Replace "Female" check box with a combo box, part 2/2 (fixes #3757)

### DIFF
--- a/apps/opencs/model/world/columnimp.hpp
+++ b/apps/opencs/model/world/columnimp.hpp
@@ -1757,6 +1757,41 @@ namespace CSMWorld
             return true;
         }
     };
+    
+    template<typename ESXRecordT>
+    struct GenderNpcColumn : public Column<ESXRecordT>
+    {
+        GenderNpcColumn()
+            : Column<ESXRecordT>(Columns::ColumnId_GenderNpc, ColumnBase::Display_GenderNpc)
+        {}
+
+        virtual QVariant get(const Record<ESXRecordT>& record) const
+        {
+            // Implemented this way to allow additional gender types in the future.
+            if ((record.get().mData.mFlags & ESM::BodyPart::BPF_Female) == ESM::BodyPart::BPF_Female)
+                return 1;
+
+            return 0;
+        }
+
+        virtual void set(Record<ESXRecordT>& record, const QVariant& data)
+        {
+            ESXRecordT record2 = record.get();
+
+            // Implemented this way to allow additional gender types in the future.
+            if (data.toInt() == 1)
+                record2.mData.mFlags = (record2.mData.mFlags & ~ESM::BodyPart::BPF_Female) | ESM::BodyPart::BPF_Female;
+            else
+                record2.mData.mFlags = record2.mData.mFlags & ~ESM::BodyPart::BPF_Female;
+
+            record.setModified(record2);
+        }
+
+        virtual bool isEditable() const
+        {
+            return true;
+        }
+    };
 
     template<typename ESXRecordT>
     struct EnchantmentTypeColumn : public Column<ESXRecordT>

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -363,7 +363,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     mBodyParts.addColumn (new FixedRecordTypeColumn<ESM::BodyPart> (UniversalId::Type_BodyPart));
     mBodyParts.addColumn (new BodyPartTypeColumn<ESM::BodyPart>);
     mBodyParts.addColumn (new VampireColumn<ESM::BodyPart>);
-    mBodyParts.addColumn (new FlagColumn<ESM::BodyPart> (Columns::ColumnId_Female, ESM::BodyPart::BPF_Female));
+    mBodyParts.addColumn(new GenderNpcColumn<ESM::BodyPart>);
     mBodyParts.addColumn (new FlagColumn<ESM::BodyPart> (Columns::ColumnId_Playable,
         ESM::BodyPart::BPF_NotPlayable, ColumnBase::Flag_Table | ColumnBase::Flag_Dialogue, true));
 


### PR DESCRIPTION
Replaces the "Female" check box in BodyPart records with a "Gender" combo box. This is the second of two related fixes, the first one covering NPC records.

Related issue:
- Fixes #3757: Editor: Replace "Female" check box in BodyPart records with "Gender" combo box (https://bugs.openmw.org/issues/3757)

Tests:
The changes were successfully tested in OpenMW-CS by manipulating several BodyPart records.