### PR TITLE
Verification results are ordered by Type in alphabetical order.

### DIFF
--- a/apps/opencs/model/tools/reportmodel.cpp
+++ b/apps/opencs/model/tools/reportmodel.cpp
@@ -37,7 +37,7 @@ int CSMTools::ReportModel::columnCount (const QModelIndex & parent) const
 
 QVariant CSMTools::ReportModel::data (const QModelIndex & index, int role) const
 {
-	if (role!=Qt::DisplayRole && role!=Qt::UserRole)
+    if (role!=Qt::DisplayRole && role!=Qt::UserRole)
         return QVariant();
 
     switch (index.column())

--- a/apps/opencs/model/tools/reportmodel.cpp
+++ b/apps/opencs/model/tools/reportmodel.cpp
@@ -44,11 +44,11 @@ QVariant CSMTools::ReportModel::data (const QModelIndex & index, int role) const
     {
         case Column_Type:
 
-        	if(role == Qt::UserRole)
-        		return QString::fromUtf8 (
-        				mRows.at (index.row()).mId.getTypeName().c_str());
-        	else
-        		return static_cast<int> (mRows.at (index.row()).mId.getType());
+            if(role == Qt::UserRole)
+                return QString::fromUtf8 (
+                    mRows.at (index.row()).mId.getTypeName().c_str());
+            else
+                return static_cast<int> (mRows.at (index.row()).mId.getType());
 
         case Column_Id:
         {

--- a/apps/opencs/model/tools/reportmodel.cpp
+++ b/apps/opencs/model/tools/reportmodel.cpp
@@ -147,6 +147,21 @@ void CSMTools::ReportModel::add (const CSMDoc::Message& message)
     endInsertRows();
 }
 
+void CSMTools::ReportModel::addSorted (const CSMDoc::Message& message)
+{
+    beginInsertRows (QModelIndex(), mRows.size(), mRows.size());
+
+    std::vector<CSMDoc::Message>::iterator it = mRows.begin();
+    for(; it < mRows.end(); ++it)
+    {
+        if(message.mId.getTypeName().compare(it->mId.getTypeName()) > 0)
+            break;
+    }
+    mRows.insert(it, message);
+
+    endInsertRows();
+}
+
 void CSMTools::ReportModel::flagAsReplaced (int index)
 {
     CSMDoc::Message& line = mRows.at (index);

--- a/apps/opencs/model/tools/reportmodel.cpp
+++ b/apps/opencs/model/tools/reportmodel.cpp
@@ -37,14 +37,18 @@ int CSMTools::ReportModel::columnCount (const QModelIndex & parent) const
 
 QVariant CSMTools::ReportModel::data (const QModelIndex & index, int role) const
 {
-    if (role!=Qt::DisplayRole)
+	if (role!=Qt::DisplayRole && role!=Qt::UserRole)
         return QVariant();
 
     switch (index.column())
     {
         case Column_Type:
 
-            return static_cast<int> (mRows.at (index.row()).mId.getType());
+        	if(role == Qt::UserRole)
+        		return QString::fromUtf8 (
+        				mRows.at (index.row()).mId.getTypeName().c_str());
+        	else
+        		return static_cast<int> (mRows.at (index.row()).mId.getType());
 
         case Column_Id:
         {

--- a/apps/opencs/model/tools/reportmodel.hpp
+++ b/apps/opencs/model/tools/reportmodel.hpp
@@ -45,6 +45,8 @@ namespace CSMTools
             
             void add (const CSMDoc::Message& message);
 
+            void addSorted (const CSMDoc::Message& message);
+
             void flagAsReplaced (int index);
                 
             const CSMWorld::UniversalId& getUniversalId (int row) const;

--- a/apps/opencs/model/tools/tools.cpp
+++ b/apps/opencs/model/tools/tools.cpp
@@ -276,5 +276,5 @@ void CSMTools::Tools::verifierMessage (const CSMDoc::Message& message, int type)
     std::map<int, int>::iterator iter = mActiveReports.find (type);
 
     if (iter!=mActiveReports.end())
-        mReports[iter->second]->add (message);
+        mReports[iter->second]->addSorted (message);
 }

--- a/apps/opencs/view/tools/reporttable.cpp
+++ b/apps/opencs/view/tools/reporttable.cpp
@@ -157,6 +157,7 @@ CSVTools::ReportTable::ReportTable (CSMDoc::Document& document,
 
     mProxyModel = new QSortFilterProxyModel (this);
     mProxyModel->setSourceModel (mModel);
+    mProxyModel->setSortRole(Qt::UserRole);
 
     setModel (mProxyModel);
     setColumnHidden (2, true);


### PR DESCRIPTION
The ReportModel::data method didn't know why it was called, now the proxy model sets the role to Qt::UserRole when the data is being sorted. So if UserRole is passed to data a QString (i.e. the Type name) is returned instead of the Type id.