### PR TITLE
Fix actors colliding with noclipping player

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1338,6 +1338,7 @@ namespace MWPhysics
             bool cmode = found->second->getCollisionMode();
             cmode = !cmode;
             found->second->enableCollisionMode(cmode);
+            found->second->enableCollisionBody(cmode);
             return cmode;
         }
 


### PR DESCRIPTION
Player with collisions disabled could still obstruct movement of other actors.