### PR TITLE
Fix for incorrect gun sounds with the Clean Hunter Rifles mod

### DIFF
--- a/apps/openmw/mwscript/soundextensions.cpp
+++ b/apps/openmw/mwscript/soundextensions.cpp
@@ -12,6 +12,9 @@
 #include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 
+#include "../mwworld/inventorystore.hpp"
+#include "../mwworld/class.hpp"
+
 #include "interpretercontext.hpp"
 #include "ref.hpp"
 
@@ -183,8 +186,22 @@ namespace MWScript
                     int index = runtime[0].mInteger;
                     runtime.pop();
 
-                    runtime.push (MWBase::Environment::get().getSoundManager()->getSoundPlaying (
-                        ptr, runtime.getStringLiteral (index)));
+                    bool ret = MWBase::Environment::get().getSoundManager()->getSoundPlaying (
+                                    ptr, runtime.getStringLiteral (index));
+
+                    // GetSoundPlaying called on an equipped item should also look for sounds played by the equipping actor.
+                    if (!ret && ptr.getContainerStore())
+                    {
+                        MWWorld::Ptr cont = MWBase::Environment::get().getWorld()->findContainer(ptr);
+
+                        if (!cont.isEmpty() && cont.getClass().hasInventoryStore(cont) && cont.getClass().getInventoryStore(cont).isEquipped(ptr))
+                        {
+                            ret = MWBase::Environment::get().getSoundManager()->getSoundPlaying (
+                                        cont, runtime.getStringLiteral (index));
+                        }
+                    }
+
+                    runtime.push(ret);
                 }
         };
 


### PR DESCRIPTION
Fixes: https://bugs.openmw.org/issues/3781
Mod: http://mw.modhistory.com/download-90-10875 
Forum post: https://forum.openmw.org/viewtopic.php?f=40&t=4193&p=46232

The mod overrides crossbow sounds like so (script is attached to the weapon):
```
    If ( Player -> HasItemEquipped "A_3PJM_GUN_Xs" )
        If ( GetSoundPlaying "crossBOWPULL" == 1 )
            Player -> stopsound "crossBOWPULL"
            Player -> playsound "apjm_revolver_slow"
        endif
        
        if ( getsoundplaying "crossbowshoot" == 1 )
            player-> stopsound "crossbowshoot"
            Playsound "APJM_gunshot"
        endif
    endif
```
Apparently GetSoundPlaying called on an equipped item should also look for sounds played by the equipping actor. Don't ask me why. It's also super inconsistent - e.g. same does not apply to StopSound. Why the mod's author didn't just use "Player->GetSoundPlaying" I have no clue either.