### PR TITLE
Disable weapons and spells cycling in GUI mode

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1955,12 +1955,14 @@ namespace MWGui
 
     void WindowManager::cycleSpell(bool next)
     {
-        mSpellWindow->cycle(next);
+        if (!isGuiMode())
+            mSpellWindow->cycle(next);
     }
 
     void WindowManager::cycleWeapon(bool next)
     {
-        mInventoryWindow->cycle(next);
+        if (!isGuiMode())
+            mInventoryWindow->cycle(next);
     }
 
     void WindowManager::setConsoleSelectedObject(const MWWorld::Ptr &object)


### PR DESCRIPTION
This commit disables cycling in GUI mode (bugs [#2409](https://bugs.openmw.org/issues/2409), [#2483](https://bugs.openmw.org/issues/2483), [#2645](https://bugs.openmw.org/issues/2645)).