### PR TITLE
Editor: Limit pathgrid creation to valid cells (Bug #3345)

### DIFF
--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -10,6 +10,7 @@
 #include "../../model/world/idtable.hpp"
 
 #include "../widget/droplineedit.hpp"
+#include "idvalidator.hpp"
 
 std::string CSVWorld::PathgridCreator::getId() const
 {
@@ -40,6 +41,7 @@ CSVWorld::PathgridCreator::PathgridCreator(
     CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Cell;
     mCell = new CSVWidget::DropLineEdit(displayType, this);
     mCell->setCompleter(completionManager.getCompleter(displayType).get());
+    mCell->setValidator(new IdValidator(relaxedIdRules, this));
     insertBeforeButtons(mCell, true);
 
     connect(mCell, SIGNAL (textChanged(const QString&)), this, SLOT (cellChanged()));

--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -1,6 +1,16 @@
 #include "pathgridcreator.hpp"
 
+#include <QComboBox>
+#include <QLabel>
+#include <QSortFilterProxyModel>
+#include <QStringListModel>
+
 #include "../../model/world/data.hpp"
+
+std::string CSVWorld::PathgridCreator::getId() const
+{
+    return mCell->currentText().toUtf8().constData();
+}
 
 CSVWorld::PathgridCreator::PathgridCreator(
     CSMWorld::Data& data,
@@ -8,21 +18,57 @@ CSVWorld::PathgridCreator::PathgridCreator(
     const CSMWorld::UniversalId& id,
     bool relaxedIdRules
 ) : GenericCreator(data, undoStack, id, relaxedIdRules)
-{}
+{
+    setManualEditing(false);
+
+    QLabel *label = new QLabel("Cell ID", this);
+    insertBeforeButtons(label, false);
+
+    // Create combo box with case-insensitive sorting.
+    mCell = new QComboBox(this);
+    QSortFilterProxyModel *proxyModel = new QSortFilterProxyModel;
+    QStringListModel *listModel = new QStringListModel;
+    proxyModel->setSourceModel(listModel);
+    proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+    mCell->setModel(proxyModel);
+    insertBeforeButtons(mCell, true);
+
+    // Populate combo box with cells that don't have a pathgrid yet.
+    const CSMWorld::IdCollection<CSMWorld::Pathgrid>& pathgrids = getData().getPathgrids();
+    const CSMWorld::IdCollection<CSMWorld::Cell>& cells = getData().getCells();
+    const int cellCount = cells.getSize();
+    for (int i = 0; i < cellCount; ++i)
+    {
+        std::string cellId = cells.getId(i);
+        if (pathgrids.searchId(cellId) == -1)
+        {
+            mCell->addItem(QString::fromStdString(cellId));
+        }
+    }
+
+    mCell->model()->sort(0);
+    mCell->setCurrentIndex(0);
+}
 
 std::string CSVWorld::PathgridCreator::getErrors() const
 {
-    std::string pathgridId = getId();
+    std::string cellId = getId();
 
     // Check user input for any errors.
+    // The last two checks, cell with existing pathgrid and non-existent cell,
+    // shouldn't be needed but we absolutely want to make sure they never happen.
     std::string errors;
-    if (pathgridId.empty())
+    if (cellId.empty())
     {
-        errors = "No Pathgrid ID entered";
+        errors = "No cell ID selected";
     }
-    else if (getData().getPathgrids().searchId(pathgridId) > -1)
+    else if (getData().getPathgrids().searchId(cellId) > -1)
     {
-        errors = "Pathgrid with this ID already exists";
+        errors = "Pathgrid for selected cell ID already exists";
+    }
+    else if (getData().getCells().searchId(cellId) == -1)
+    {
+        errors = "Cell with selected cell ID does not exist";
     }
 
     return errors;

--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -48,6 +48,8 @@ CSVWorld::PathgridCreator::PathgridCreator(
 
     mCell->model()->sort(0);
     mCell->setCurrentIndex(0);
+
+    connect(mCell, SIGNAL (currentIndexChanged(const QString&)), this, SLOT (cellChanged()));
 }
 
 std::string CSVWorld::PathgridCreator::getErrors() const
@@ -72,4 +74,20 @@ std::string CSVWorld::PathgridCreator::getErrors() const
     }
 
     return errors;
+}
+
+void CSVWorld::PathgridCreator::focus()
+{
+    mCell->setFocus();
+}
+
+void CSVWorld::PathgridCreator::reset()
+{
+    CSVWorld::GenericCreator::reset();
+    mCell->setCurrentIndex(0);
+}
+
+void CSVWorld::PathgridCreator::cellChanged()
+{
+    update();
 }

--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -33,22 +33,9 @@ CSVWorld::PathgridCreator::PathgridCreator(
     mCell->setModel(proxyModel);
     insertBeforeButtons(mCell, true);
 
-    // Populate combo box with cells that don't have a pathgrid yet.
-    const CSMWorld::IdCollection<CSMWorld::Pathgrid>& pathgrids = getData().getPathgrids();
-    const CSMWorld::IdCollection<CSMWorld::Cell>& cells = getData().getCells();
-    const int cellCount = cells.getSize();
-    for (int i = 0; i < cellCount; ++i)
-    {
-        std::string cellId = cells.getId(i);
-        if (pathgrids.searchId(cellId) == -1)
-        {
-            mCell->addItem(QString::fromStdString(cellId));
-        }
-    }
+    setupCellsInput();
 
-    mCell->model()->sort(0);
-    mCell->setCurrentIndex(0);
-
+    connect(&getData(), SIGNAL (idListChanged()), this, SLOT (setupCellsInput()));
     connect(mCell, SIGNAL (currentIndexChanged(const QString&)), this, SLOT (cellChanged()));
 }
 
@@ -90,4 +77,25 @@ void CSVWorld::PathgridCreator::reset()
 void CSVWorld::PathgridCreator::cellChanged()
 {
     update();
+}
+
+void CSVWorld::PathgridCreator::setupCellsInput()
+{
+    mCell->clear();
+
+    // Populate combo box with cells that don't have a pathgrid yet.
+    const CSMWorld::IdCollection<CSMWorld::Pathgrid>& pathgrids = getData().getPathgrids();
+    const CSMWorld::IdCollection<CSMWorld::Cell>& cells = getData().getCells();
+    const int cellCount = cells.getSize();
+    for (int i = 0; i < cellCount; ++i)
+    {
+        std::string cellId = cells.getId(i);
+        if (pathgrids.searchId(cellId) == -1)
+        {
+            mCell->addItem(QString::fromStdString(cellId));
+        }
+    }
+
+    mCell->model()->sort(0);
+    mCell->setCurrentIndex(0);
 }

--- a/apps/opencs/view/world/pathgridcreator.hpp
+++ b/apps/opencs/view/world/pathgridcreator.hpp
@@ -1,9 +1,25 @@
 #ifndef PATHGRIDCREATOR_HPP
 #define PATHGRIDCREATOR_HPP
 
-class QComboBox;
-
 #include "genericcreator.hpp"
+
+namespace CSMDoc
+{
+    class Document;
+}
+
+namespace CSMWorld
+{
+    class Data;
+    class IdCompletionManager;
+    class IdTable;
+    class UniversalId;
+}
+
+namespace CSVWidget
+{
+    class DropLineEdit;
+}
 
 namespace CSVWorld
 {
@@ -12,12 +28,15 @@ namespace CSVWorld
     {
         Q_OBJECT
 
-        QComboBox *mCell;
+        CSVWidget::DropLineEdit *mCell;
 
         private:
 
-            /// \return Cell ID selected by user.
+            /// \return Cell ID entered by user.
             virtual std::string getId() const;
+
+            /// \return reference to table containing pathgrids.
+            CSMWorld::IdTable& getPathgridsTable() const;
 
         public:
 
@@ -25,7 +44,15 @@ namespace CSVWorld
                 CSMWorld::Data& data,
                 QUndoStack& undoStack,
                 const CSMWorld::UniversalId& id,
+                CSMWorld::IdCompletionManager& completionManager,
                 bool relaxedIdRules = false);
+
+            /// \brief Set cell ID input widget to ID of record to be cloned.
+            /// \param originId Cell ID to be cloned.
+            /// \param type Type of record to be cloned.
+            virtual void cloneMode(
+                const std::string& originId,
+                const CSMWorld::UniversalId::Type type);
 
             /// \return Error description for current user input.
             virtual std::string getErrors() const;
@@ -33,16 +60,23 @@ namespace CSVWorld
             /// \brief Set focus to cell ID input widget.
             virtual void focus();
 
-            /// \brief Reset selected cell ID.
+            /// \brief Clear cell ID input widget.
             virtual void reset();
 
         private slots:
 
             /// \brief Check user input for errors.
             void cellChanged();
+    };
 
-            /// \brief Setup cells in combo box.
-            void setupCellsInput();
+    /// \brief Creator factory for pathgrid record creator.
+    class PathgridCreatorFactory : public CreatorFactoryBase
+    {
+        public:
+
+            virtual Creator *makeCreator(
+                CSMDoc::Document& document,
+                const CSMWorld::UniversalId& id) const;
     };
 }
 

--- a/apps/opencs/view/world/pathgridcreator.hpp
+++ b/apps/opencs/view/world/pathgridcreator.hpp
@@ -40,6 +40,9 @@ namespace CSVWorld
 
             /// \brief Check user input for errors.
             void cellChanged();
+
+            /// \brief Setup cells in combo box.
+            void setupCellsInput();
     };
 }
 

--- a/apps/opencs/view/world/pathgridcreator.hpp
+++ b/apps/opencs/view/world/pathgridcreator.hpp
@@ -29,6 +29,17 @@ namespace CSVWorld
 
             /// \return Error description for current user input.
             virtual std::string getErrors() const;
+
+            /// \brief Set focus to cell ID input widget.
+            virtual void focus();
+
+            /// \brief Reset selected cell ID.
+            virtual void reset();
+
+        private slots:
+
+            /// \brief Check user input for errors.
+            void cellChanged();
     };
 }
 

--- a/apps/opencs/view/world/pathgridcreator.hpp
+++ b/apps/opencs/view/world/pathgridcreator.hpp
@@ -1,6 +1,8 @@
 #ifndef PATHGRIDCREATOR_HPP
 #define PATHGRIDCREATOR_HPP
 
+class QComboBox;
+
 #include "genericcreator.hpp"
 
 namespace CSVWorld
@@ -9,6 +11,13 @@ namespace CSVWorld
     class PathgridCreator : public GenericCreator
     {
         Q_OBJECT
+
+        QComboBox *mCell;
+
+        private:
+
+            /// \return Cell ID selected by user.
+            virtual std::string getId() const;
 
         public:
 

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -76,7 +76,7 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, InfoCreatorFactory>);
 
     manager.add (CSMWorld::UniversalId::Type_Pathgrids,
-        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<PathgridCreator> >);
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, PathgridCreatorFactory>);
 
     manager.add (CSMWorld::UniversalId::Type_Globals,
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<GlobalCreator> >);
@@ -174,7 +174,7 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, JournalCreatorFactory> (false));
 
     manager.add (CSMWorld::UniversalId::Type_Pathgrid,
-        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<PathgridCreator> > (false));
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, PathgridCreatorFactory> (false));
 
     manager.add (CSMWorld::UniversalId::Type_DebugProfile,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<GenericCreator, CSMWorld::Scope_Project | CSMWorld::Scope_Session> > (false));


### PR DESCRIPTION
[Bug #3345](https://bugs.openmw.org/issues/3345)

The issue is described as cloned/added pathgrids being lost after reopening saved omwgame file. When looking into it more, it appears it's an issue with adding a pathgrid for a cell that doesn't exist.

This addresses the problem by using a combo box in the pathgrid creator to limit user input only to existing cells that don't have a pathgrid yet. The combo box is repopulated when background data changes to handle added/removed cells/pathgrids. Also, the create button isn't enabled until it verifies that the selected cell doesn't have a pathgrid already and that the cell exists.