### PR TITLE
Options to show hidden weapon parameters

### DIFF
--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -1,6 +1,7 @@
 #include "weapon.hpp"
 
 #include <components/esm/loadweap.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -261,8 +262,8 @@ namespace MWClass
 
         std::string text;
 
-        // weapon type & damage. arrows / bolts don't have his info.
-        if (ref->mBase->mData.mType < 12)
+        // weapon type & damage
+        if ((ref->mBase->mData.mType < 12 || Settings::Manager::getBool("show projectile damage", "Game")) && ref->mBase->mData.mType < 14)
         {
             text += "\n#{sType} ";
 
@@ -279,6 +280,8 @@ namespace MWClass
             mapping[ESM::Weapon::MarksmanBow] = std::make_pair("sSkillMarksman", "");
             mapping[ESM::Weapon::MarksmanCrossbow] = std::make_pair("sSkillMarksman", "");
             mapping[ESM::Weapon::MarksmanThrown] = std::make_pair("sSkillMarksman", "");
+            mapping[ESM::Weapon::Arrow] = std::make_pair("sSkillMarksman", "");
+            mapping[ESM::Weapon::Bolt] = std::make_pair("sSkillMarksman", "");
 
             std::string type = mapping[ref->mBase->mData.mType].first;
             std::string oneOrTwoHanded = mapping[ref->mBase->mData.mType].second;

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -321,6 +321,14 @@ namespace MWClass
                     + MWGui::ToolTips::toString(ref->mBase->mData.mHealth);
         }
 
+        // add reach and attack speed for melee weapon
+        if (ref->mBase->mData.mType < 9 && Settings::Manager::getBool("show melee info", "Game"))
+        {
+            text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mReach, "#{sRange}");
+
+            text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mSpeed, "#{sAttributeSpeed}");
+        }
+
         text += MWGui::ToolTips::getWeightString(ref->mBase->mData.mWeight, "#{sWeight}");
         text += MWGui::ToolTips::getValueString(ref->mBase->mData.mValue, "#{sValue}");
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -594,6 +594,14 @@ namespace MWGui
             return "\n" + prefix + ": " + toString(weight);
     }
 
+    std::string ToolTips::getPercentString(const float value, const std::string& prefix)
+    {
+        if (value == 0)
+            return "";
+        else
+            return "\n" + prefix + ": " + toString(value*100) +"%";
+    }
+
     std::string ToolTips::getValueString(const int value, const std::string& prefix)
     {
         if (value == 0)

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -63,6 +63,7 @@ namespace MWGui
         ///< set the screen-space position of the tooltip for focused object
 
         static std::string getWeightString(const float weight, const std::string& prefix);
+        static std::string getPercentString(const float value, const std::string& prefix);
         static std::string getValueString(const int value, const std::string& prefix);
         ///< @return "prefix: value" or "" if value is 0
 

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -12,6 +12,28 @@ Enable visual clues for items owned by NPCs when the crosshair is on the object.
 
 The default value is 0 (no clues). This setting can only be configured by editing the settings configuration file.
 
+show projectile damage
+----------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, damage bonus of arrows and bolts will be showed on item tooltip.
+
+The default value is false. This setting can only be configured by editing the settings configuration file.
+
+show melee info
+---------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, melee weapons reach and speed will be showed on item tooltip.
+
+The default value is false. This setting can only be configured by editing the settings configuration file.
+
 best attack
 -----------
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -146,6 +146,9 @@ crosshair = true
 # no color, 1 is tool tip only, 2 is crosshair only, and 3 is both).
 show owned = 0
 
+# Show damage bonus of arrow and bolts.
+show projectile damage = false
+
 # Always use the best mode of attack: e.g. chop, slash or thrust.
 best attack = false
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -149,6 +149,9 @@ show owned = 0
 # Show damage bonus of arrow and bolts.
 show projectile damage = false
 
+# Show additional melee weapon info: reach and attack speed
+show melee info = false
+
 # Always use the best mode of attack: e.g. chop, slash or thrust.
 best attack = false
 


### PR DESCRIPTION
1) Option to show damage of arrows and bolts through tooltip ([Feature #2923](https://bugs.openmw.org/issues/2923)).
Disabled by default. Add 
`show projectile damage = true`
to [Game] section in settings.cfg to enable it.

2) Option to show attack speed and reach of melee weapons through tooltip
This option is not needed for clean Morrowind, but it useful for plugins ([Weapon Range Balance](http://www.nexusmods.com/morrowind/mods/6051/) for example).
Disabled by default. Add 
`show melee info = true`
to [Game] section in settings.cfg to enable it.