### PR TITLE
Vanilla style progress bars

### DIFF
--- a/files/mygui/openmw_progress.skin.xml
+++ b/files/mygui/openmw_progress.skin.xml
@@ -51,6 +51,12 @@
             <State name="normal" offset="0 0 16 8"/>
         </BasisSkin>
     </Resource>
+    <Resource type="ResourceSkin" name="MW_Progress_Loading_Small" size="16 8" texture="white" >
+        <Property key="Colour" value="0 0.615 0.620"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
+            <State name="normal" offset="0 0 16 8"/>
+        </BasisSkin>
+    </Resource>
     <Resource type="ResourceSkin" name="ProgressText" size="16 16">
         <Property key="FontName" value="Default"/>
         <Property key="TextAlign" value="Top HCenter"/>
@@ -67,7 +73,7 @@
         <Property key="TrackFill" value="1"/>
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="TransparentBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_Progress_Green" size="64 12">
@@ -75,7 +81,7 @@
         <Property key="TrackFill" value="1"/>
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="TransparentBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_Progress_Blue" size="64 12">
@@ -83,13 +89,13 @@
         <Property key="TrackFill" value="1"/>
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="TransparentBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_Progress_Drowning_Full" size="64 6">
         <Property key="TrackSkin" value="MW_Progress_Drowning_Full_Small"/>
         <Property key="TrackFill" value="1"/>
-        <Child type="Widget" skin="BlackBG" offset="2 2 60 2" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="TransparentBG" offset="2 2 60 2" align="Stretch" name="Client"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_ProgressScroll_Loading" size="64 6">
@@ -99,8 +105,8 @@
         <Property key="VerticalAlignment" value="false"/>
         <Property key="MoveToClick" value="false"/>
 
-        <Child type="Widget" skin="BlackBG" offset="2 2 60 2" align="Stretch" name="Client"/>
-        <Child type="Button" skin="MW_BigTrack_Progress_Green_Small" offset="0 0 1 6" align="Left VStretch" name="Track"/>
+        <Child type="Widget" skin="TransparentBG" offset="2 2 60 2" align="Stretch" name="Client"/>
+        <Child type="Button" skin="MW_Progress_Loading_Small" offset="0 0 1 6" align="Left VStretch" name="Track"/>
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 6" align="Stretch"/>
     </Resource>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -9,6 +9,10 @@
         </BasisSkin>
     </Resource>
 
+    <Resource type="ResourceSkin" name="TransparentBG" size="8 8" texture="transparent">
+        <Property key="Colour" value="#{fontcolour=background}"/>
+    </Resource>
+
     <!-- Define the borders for pin button (up) -->
     <Resource type="ResourceSkin" name="PU_B" size="12 2" texture="textures\menu_rightbuttonup_bottom.dds">
         <Property key="NeedMouse" value="false"/>


### PR DESCRIPTION
All progress bars in vanilla game have no own background. OpenMW bars have, and they looks much darker than original ones, because bar background blends with widget background.
This commit sets transparent background for all progress bars, also sets correct color (without red component) for loading progress bar.