### PR TITLE
Minor GUI fixes

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -232,8 +232,10 @@ namespace MWMechanics
         invStore.autoEquip(ptr);
     }
 
+    // mWatchedTimeToStartDrowning = -1 for correct drowning state check,
+    // if stats.getTimeToStartDrowning() == 0 already on game start
     MechanicsManager::MechanicsManager()
-    : mWatchedTimeToStartDrowning(0), mWatchedStatsEmpty (true), mUpdatePlayer (true), mClassSelected (false),
+    : mWatchedTimeToStartDrowning(-1), mWatchedStatsEmpty (true), mUpdatePlayer (true), mClassSelected (false),
       mRaceSelected (false), mAI(true)
     {
         //buildPlayer no longer here, needs to be done explicitly after all subsystems are up and running
@@ -324,9 +326,6 @@ namespace MWMechanics
                 winMgr->setValue(fbar, stats.getFatigue());
             }
 
-            // FIXME: if game is just started and actor is already drowning (on savegame loading),
-            // drowning bar will be hidden, because
-            // getTimeToStartDrowning = mWatchedTimeToStartDrowning = 0.
             if(stats.getTimeToStartDrowning() != mWatchedTimeToStartDrowning)
             {
                 const float fHoldBreathTime = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -1064,16 +1064,20 @@ namespace MWMechanics
             adjustDynamicStat(creatureStats, effectKey.mId-ESM::MagicEffect::RestoreHealth, magnitude);
             break;
         case ESM::MagicEffect::DamageHealth:
-        case ESM::MagicEffect::DamageMagicka:
-        case ESM::MagicEffect::DamageFatigue:
             receivedMagicDamage = true;
             adjustDynamicStat(creatureStats, effectKey.mId-ESM::MagicEffect::DamageHealth, -magnitude);
             break;
+        case ESM::MagicEffect::DamageMagicka:
+        case ESM::MagicEffect::DamageFatigue:
+            adjustDynamicStat(creatureStats, effectKey.mId-ESM::MagicEffect::DamageHealth, -magnitude);
+            break;
         case ESM::MagicEffect::AbsorbHealth:
-        case ESM::MagicEffect::AbsorbMagicka:
-        case ESM::MagicEffect::AbsorbFatigue:
             if (magnitude > 0.f)
                 receivedMagicDamage = true;
+            adjustDynamicStat(creatureStats, effectKey.mId-ESM::MagicEffect::AbsorbHealth, -magnitude);
+            break;
+        case ESM::MagicEffect::AbsorbMagicka:
+        case ESM::MagicEffect::AbsorbFatigue:
             adjustDynamicStat(creatureStats, effectKey.mId-ESM::MagicEffect::AbsorbHealth, -magnitude);
             break;
 


### PR DESCRIPTION
1. Fixes p.4 of [bug #3801](https://bugs.openmw.org/issues/3801). Issue can be closed now.
2. Damage and absorb magicka\fatigue spells in vanilla have not hit overlay (since there is no health damage), in OpenMW have. Fixed.