### PR TITLE
Adjust AI follow distances

### DIFF
--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -92,16 +92,23 @@ bool AiFollow::execute (const MWWorld::Ptr& actor, CharacterController& characte
 
     ESM::Position pos = actor.getRefData().getPosition(); //position of the actor
 
-    float followDistance = 180;
-    // When there are multiple actors following the same target, they form a group with each group member at 180*(i+1) distance to the target
-    int i=0;
+    // The distances below are approximations based on observations of the original engine.
+    // If only one actor is following the target, it uses 186.
+    // If there are multiple actors following the same target, they form a group with each group member at 313 + (130 * i) distance to the target.
+
+    short followDistance = 186;
     std::list<int> followers = MWBase::Environment::get().getMechanicsManager()->getActorsFollowingIndices(target);
-    followers.sort();
-    for (std::list<int>::iterator it = followers.begin(); it != followers.end(); ++it)
+    if (followers.size() >= 2)
     {
-        if (*it == mFollowIndex)
-            followDistance *= (i+1);
-        ++i;
+        followDistance = 313;
+        short i = 0;
+        followers.sort();
+        for (std::list<int>::iterator it = followers.begin(); it != followers.end(); ++it)
+        {
+            if (*it == mFollowIndex)
+                followDistance += 130 * i;
+            ++i;
+        }
     }
 
     if (!mAlwaysFollow) //Update if you only follow for a bit
@@ -139,7 +146,7 @@ bool AiFollow::execute (const MWWorld::Ptr& actor, CharacterController& characte
 
     if (!storage.mMoving) 
     {
-        const float threshold = 10; // to avoid constant switching between moving/stopping
+        const short threshold = 10; // to avoid constant switching between moving/stopping
         followDistance += threshold;
     }
 


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3225.

As noted there, there is more to this issue to get the following distances the same as the original engine, but doing that would be a more complicated fix that would need to differentiate between AI packages placed on NPC records in the editor and those issued through scripting.

The spacing distances I shot for were, using the GetDistance command, about 184 for a single NPC follower, and about 311 + (130 * i) for 2 or more followers. 
