### PR TITLE
Editor: Change creator ID validation

### DIFF
--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -70,6 +70,7 @@ opencs_units (view/world
     cellcreator pathgridcreator referenceablecreator startscriptcreator referencecreator scenesubview
     infocreator scriptedit dialoguesubview previewsubview regionmap dragrecordtable nestedtable
     dialoguespinbox recordbuttonbar tableeditidaction scripterrortable extendedcommandconfigurator
+    bodypartcreator
     )
 
 opencs_units_noqt (view/world

--- a/apps/opencs/view/world/bodypartcreator.cpp
+++ b/apps/opencs/view/world/bodypartcreator.cpp
@@ -1,0 +1,54 @@
+#include "bodypartcreator.hpp"
+
+#include <QCheckBox>
+
+#include "../../model/world/data.hpp"
+#include "../../model/world/universalid.hpp"
+
+std::string CSVWorld::BodyPartCreator::getId() const
+{
+    std::string id = CSVWorld::GenericCreator::getId();
+
+    if (mFirstPerson->isChecked())
+    {
+        id += ".1st";
+    }
+
+    return id;
+}
+
+CSVWorld::BodyPartCreator::BodyPartCreator(
+    CSMWorld::Data& data,
+    QUndoStack& undoStack,
+    const CSMWorld::UniversalId& id
+) : GenericCreator(data, undoStack, id)
+{
+    mFirstPerson = new QCheckBox("First Person", this);
+    insertBeforeButtons(mFirstPerson, false);
+
+    connect(mFirstPerson, SIGNAL(clicked(bool)), this, SLOT(checkboxClicked()));
+}
+
+std::string CSVWorld::BodyPartCreator::getErrors() const
+{
+    std::string errors;
+
+    std::string id = getId();
+    if (getData().hasId(id))
+    {
+        errors = "ID is already in use";
+    }
+
+    return errors;
+}
+
+void CSVWorld::BodyPartCreator::reset()
+{
+    CSVWorld::GenericCreator::reset();
+    mFirstPerson->setChecked(false);
+}
+
+void CSVWorld::BodyPartCreator::checkboxClicked()
+{
+    update();
+}

--- a/apps/opencs/view/world/bodypartcreator.hpp
+++ b/apps/opencs/view/world/bodypartcreator.hpp
@@ -1,0 +1,47 @@
+#ifndef BODYPARTCREATOR_HPP
+#define BODYPARTCREATOR_HPP
+
+class QCheckBox;
+
+#include "genericcreator.hpp"
+
+namespace CSMWorld
+{
+    class Data;
+    class UniversalId;
+}
+
+namespace CSVWorld
+{
+    /// \brief Record creator for body parts.
+    class BodyPartCreator : public GenericCreator
+    {
+        Q_OBJECT
+
+        QCheckBox *mFirstPerson;
+
+        private:
+
+            /// \return ID entered by user.
+            virtual std::string getId() const;
+
+        public:
+
+            BodyPartCreator(
+                CSMWorld::Data& data,
+                QUndoStack& undoStack,
+                const CSMWorld::UniversalId& id);
+
+            /// \return Error description for current user input.
+            virtual std::string getErrors() const;
+
+            /// \brief Clear ID and checkbox input widgets.
+            virtual void reset();
+
+        private slots:
+
+            void checkboxClicked();
+    };
+}
+
+#endif // BODYPARTCREATOR_HPP

--- a/apps/opencs/view/world/infocreator.cpp
+++ b/apps/opencs/view/world/infocreator.cpp
@@ -48,6 +48,8 @@ CSVWorld::InfoCreator::InfoCreator (CSMWorld::Data& data, QUndoStack& undoStack,
     QLabel *label = new QLabel ("Topic", this);
     insertBeforeButtons (label, false);
 
+    // Add topic/journal ID input with auto-completion.
+    // Only existing topic/journal IDs are accepted so no ID validation is performed.
     CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Topic;
     if (getCollectionId().getType() == CSMWorld::UniversalId::Type_JournalInfos)
     {

--- a/apps/opencs/view/world/infocreator.cpp
+++ b/apps/opencs/view/world/infocreator.cpp
@@ -45,16 +45,20 @@ CSVWorld::InfoCreator::InfoCreator (CSMWorld::Data& data, QUndoStack& undoStack,
     const CSMWorld::UniversalId& id, CSMWorld::IdCompletionManager& completionManager)
 : GenericCreator (data, undoStack, id)
 {
-    QLabel *label = new QLabel ("Topic", this);
+    // Determine if we're dealing with topics or journals.
+    CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Topic;
+    QString labelText = "Topic";
+    if (getCollectionId().getType() == CSMWorld::UniversalId::Type_JournalInfos)
+    {
+        displayType = CSMWorld::ColumnBase::Display_Journal;
+        labelText = "Journal";
+    }
+
+    QLabel *label = new QLabel (labelText, this);
     insertBeforeButtons (label, false);
 
     // Add topic/journal ID input with auto-completion.
     // Only existing topic/journal IDs are accepted so no ID validation is performed.
-    CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Topic;
-    if (getCollectionId().getType() == CSMWorld::UniversalId::Type_JournalInfos)
-    {
-        displayType = CSMWorld::ColumnBase::Display_Journal;
-    }
     mTopic = new CSVWidget::DropLineEdit(displayType, this);
     mTopic->setCompleter(completionManager.getCompleter(displayType).get());
     insertBeforeButtons (mTopic, true);

--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -32,7 +32,7 @@ CSVWorld::PathgridCreator::PathgridCreator(
 {
     setManualEditing(false);
 
-    QLabel *label = new QLabel("Cell ID", this);
+    QLabel *label = new QLabel("Cell", this);
     insertBeforeButtons(label, false);
 
     // Add cell ID input with auto-completion.

--- a/apps/opencs/view/world/pathgridcreator.cpp
+++ b/apps/opencs/view/world/pathgridcreator.cpp
@@ -10,7 +10,6 @@
 #include "../../model/world/idtable.hpp"
 
 #include "../widget/droplineedit.hpp"
-#include "idvalidator.hpp"
 
 std::string CSVWorld::PathgridCreator::getId() const
 {
@@ -28,9 +27,8 @@ CSVWorld::PathgridCreator::PathgridCreator(
     CSMWorld::Data& data,
     QUndoStack& undoStack,
     const CSMWorld::UniversalId& id,
-    CSMWorld::IdCompletionManager& completionManager,
-    bool relaxedIdRules
-) : GenericCreator(data, undoStack, id, relaxedIdRules)
+    CSMWorld::IdCompletionManager& completionManager
+) : GenericCreator(data, undoStack, id)
 {
     setManualEditing(false);
 
@@ -38,10 +36,10 @@ CSVWorld::PathgridCreator::PathgridCreator(
     insertBeforeButtons(label, false);
 
     // Add cell ID input with auto-completion.
+    // Only existing cell IDs are accepted so no ID validation is performed.
     CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Cell;
     mCell = new CSVWidget::DropLineEdit(displayType, this);
     mCell->setCompleter(completionManager.getCompleter(displayType).get());
-    mCell->setValidator(new IdValidator(relaxedIdRules, this));
     insertBeforeButtons(mCell, true);
 
     connect(mCell, SIGNAL (textChanged(const QString&)), this, SLOT (cellChanged()));
@@ -65,8 +63,6 @@ std::string CSVWorld::PathgridCreator::getErrors() const
     std::string cellId = getId();
 
     // Check user input for any errors.
-    // The last two checks, cell with existing pathgrid and non-existent cell,
-    // shouldn't be needed but we absolutely want to make sure they never happen.
     std::string errors;
     if (cellId.empty())
     {

--- a/apps/opencs/view/world/pathgridcreator.hpp
+++ b/apps/opencs/view/world/pathgridcreator.hpp
@@ -44,8 +44,7 @@ namespace CSVWorld
                 CSMWorld::Data& data,
                 QUndoStack& undoStack,
                 const CSMWorld::UniversalId& id,
-                CSMWorld::IdCompletionManager& completionManager,
-                bool relaxedIdRules = false);
+                CSMWorld::IdCompletionManager& completionManager);
 
             /// \brief Set cell ID input widget to ID of record to be cloned.
             /// \param originId Cell ID to be cloned.

--- a/apps/opencs/view/world/referencecreator.cpp
+++ b/apps/opencs/view/world/referencecreator.cpp
@@ -35,6 +35,8 @@ CSVWorld::ReferenceCreator::ReferenceCreator (CSMWorld::Data& data, QUndoStack& 
     QLabel *label = new QLabel ("Cell", this);
     insertBeforeButtons (label, false);
 
+    // Add cell ID input with auto-completion.
+    // Only existing cell IDs are accepted so no ID validation is performed.
     mCell = new CSVWidget::DropLineEdit(CSMWorld::ColumnBase::Display_Cell, this);
     mCell->setCompleter(completionManager.getCompleter(CSMWorld::ColumnBase::Display_Cell).get());
     insertBeforeButtons (mCell, true);

--- a/apps/opencs/view/world/startscriptcreator.cpp
+++ b/apps/opencs/view/world/startscriptcreator.cpp
@@ -34,7 +34,7 @@ CSVWorld::StartScriptCreator::StartScriptCreator(
     setManualEditing(false);
 
     // Add script ID input label.
-    QLabel *label = new QLabel("Script ID", this);
+    QLabel *label = new QLabel("Script", this);
     insertBeforeButtons(label, false);
 
     // Add script ID input with auto-completion.

--- a/apps/opencs/view/world/startscriptcreator.cpp
+++ b/apps/opencs/view/world/startscriptcreator.cpp
@@ -29,7 +29,7 @@ CSVWorld::StartScriptCreator::StartScriptCreator(
     QUndoStack &undoStack,
     const CSMWorld::UniversalId &id,
     CSMWorld::IdCompletionManager& completionManager
-) : GenericCreator(data, undoStack, id, true)
+) : GenericCreator(data, undoStack, id)
 {
     setManualEditing(false);
 
@@ -38,6 +38,7 @@ CSVWorld::StartScriptCreator::StartScriptCreator(
     insertBeforeButtons(label, false);
 
     // Add script ID input with auto-completion.
+    // Only existing script IDs are accepted so no ID validation is performed.
     CSMWorld::ColumnBase::Display displayType = CSMWorld::ColumnBase::Display_Script;
     mScript = new CSVWidget::DropLineEdit(displayType, this);
     mScript->setCompleter(completionManager.getCompleter(displayType).get());

--- a/apps/opencs/view/world/subviews.cpp
+++ b/apps/opencs/view/world/subviews.cpp
@@ -17,6 +17,7 @@
 #include "infocreator.hpp"
 #include "pathgridcreator.hpp"
 #include "previewsubview.hpp"
+#include "bodypartcreator.hpp"
 
 void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
 {
@@ -41,7 +42,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         CSMWorld::UniversalId::Type_Birthsigns,
         CSMWorld::UniversalId::Type_Spells,
         CSMWorld::UniversalId::Type_Enchantments,
-        CSMWorld::UniversalId::Type_BodyParts,
         CSMWorld::UniversalId::Type_SoundGens,
 
         CSMWorld::UniversalId::Type_None // end marker
@@ -50,6 +50,9 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
     for (int i=0; sTableTypes[i]!=CSMWorld::UniversalId::Type_None; ++i)
         manager.add (sTableTypes[i],
             new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<GenericCreator> >);
+
+    manager.add (CSMWorld::UniversalId::Type_BodyParts,
+        new CSVDoc::SubViewFactoryWithCreator<TableSubView, CreatorFactory<BodyPartCreator> >);
 
     manager.add (CSMWorld::UniversalId::Type_StartScripts,
         new CSVDoc::SubViewFactoryWithCreator<TableSubView, StartScriptCreatorFactory>);
@@ -129,7 +132,6 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         CSMWorld::UniversalId::Type_Sound,
         CSMWorld::UniversalId::Type_Faction,
         CSMWorld::UniversalId::Type_Enchantment,
-        CSMWorld::UniversalId::Type_BodyPart,
         CSMWorld::UniversalId::Type_SoundGen,
 
         CSMWorld::UniversalId::Type_None // end marker
@@ -139,6 +141,9 @@ void CSVWorld::addSubViewFactories (CSVDoc::SubViewFactoryManager& manager)
         manager.add (sTableTypes2[i],
             new CSVDoc::SubViewFactoryWithCreator<DialogueSubView,
             CreatorFactory<GenericCreator> > (false));
+
+    manager.add (CSMWorld::UniversalId::Type_BodyPart,
+        new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, CreatorFactory<BodyPartCreator> > (false));
 
     manager.add (CSMWorld::UniversalId::Type_StartScript,
         new CSVDoc::SubViewFactoryWithCreator<DialogueSubView, StartScriptCreatorFactory>(false));


### PR DESCRIPTION
[Bug #2838](https://bugs.openmw.org/issues/2838)
[Previous Discussion](https://github.com/OpenMW/openmw/pull/1227)

This contains a few changes related to ID validation:

- Documents why ID validation isn't used in some cases
- Changes mislabeled input and makes labels match style of other labels
- ~~Allows '.' in IDs~~
- Adds creator subclass for body parts to allow first person parts to be added

After thinking about it more, I believe it makes sense to not have an input validator set up for certain creator subclasses. These classes are restricted to existing record IDs so the input validation is important where those records are created but not in these particular subclasses. We just need to make sure it matches an existing ID plus any other rules specific to the creator subclass.