### PR TITLE
Fix AppVeyor warnings

### DIFF
--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -149,9 +149,9 @@ void Objects::removeCell(const MWWorld::CellStore* store)
 
             if (ptr.getClass().isNpc() && ptr.getRefData().getCustomData())
             {
-                MWWorld::InventoryStore& store = ptr.getClass().getInventoryStore(ptr);
-                store.setInvListener(NULL, ptr);
-                store.setContListener(NULL);
+                MWWorld::InventoryStore& invStore = ptr.getClass().getInventoryStore(ptr);
+                invStore.setInvListener(NULL, ptr);
+                invStore.setContListener(NULL);
             }
 
             mObjects.erase(iter++);

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -335,7 +335,4 @@ namespace ESM
             }
         }
     }
-
-    const int Land::LAND_SIZE;
-
 }

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -240,8 +240,8 @@ namespace ESMTerrain
                 // Only relevant for chunks smaller than (contained in) one cell
                 rowStart += (origin.x() - startCellX) * ESM::Land::LAND_SIZE;
                 colStart += (origin.y() - startCellY) * ESM::Land::LAND_SIZE;
-                int rowEnd = std::min(static_cast<int>(rowStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), ESM::Land::LAND_SIZE);
-                int colEnd = std::min(static_cast<int>(colStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), ESM::Land::LAND_SIZE);
+                int rowEnd = std::min(static_cast<int>(rowStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
+                int colEnd = std::min(static_cast<int>(colStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
 
                 vertY = vertY_;
                 for (int col=colStart; col<colEnd; col += increment)


### PR DESCRIPTION
Fixes two AppVeyor warnings.

One is a warning in the msvc 2013 environment about a double definition of LAND_SIZE.

The other is a warning in the msvc 2015 environment about a function parameter being overridden.