### PR TITLE
Ini-importer progress bar fills the whole width of the ui element now

### DIFF
--- a/files/ui/settingspage.ui
+++ b/files/ui/settingspage.ui
@@ -131,14 +131,17 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QProgressBar" name="progressBar">
-          <property name="maximum">
-           <number>4</number>
-          </property>
-         </widget>
-        </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="progressBar">
+        <property name="maximum">
+         <number>4</number>
+        </property>
+        <property name="textVisible">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Changed the progress bar on the settings tab of the launcher to fill the whole width of the ui element it resides in.