### PR TITLE
Adds missing recharge and repair sounds

### DIFF
--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -12,6 +12,7 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
@@ -137,9 +138,15 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
         item.getCellRef().setEnchantmentCharge(
             std::min(item.getCellRef().getEnchantmentCharge() + restored, static_cast<float>(enchantment->mData.mCharge)));
 
+        MWBase::Environment::get().getSoundManager()->playSound("Enchant Success",1,1);
+
         player.getClass().getContainerStore(player).restack(item);
 
         player.getClass().skillUsageSucceeded (player, ESM::Skill::Enchant, 0);
+    }
+    else
+    {
+        MWBase::Environment::get().getSoundManager()->playSound("Enchant Fail",1,1);
     }
 
     gem.getContainerStore()->remove(gem, 1, player);

--- a/apps/openmw/mwgui/repair.cpp
+++ b/apps/openmw/mwgui/repair.cpp
@@ -11,6 +11,7 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/soundmanager.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
 
@@ -62,6 +63,8 @@ void Repair::exit()
 
 void Repair::startRepairItem(const MWWorld::Ptr &item)
 {
+    MWBase::Environment::get().getSoundManager()->playSound("Item Repair Up",1,1);
+
     mRepair.setTool(item);
 
     mToolIcon->setItem(item);

--- a/apps/openmw/mwmechanics/repair.cpp
+++ b/apps/openmw/mwmechanics/repair.cpp
@@ -99,6 +99,9 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
             if (Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), mTool.getCellRef().getRefId()))
             {
                 mTool = *iter;
+
+                MWBase::Environment::get().getSoundManager()->playSound("Item Repair Up",1,1);
+
                 break;
             }
         }


### PR DESCRIPTION
Just adds some missing sounds:
1. When opening repair dialog (manual, not merchant).
2. When repair tool charges = 0 and game takes a new tool of the same type from stack.
3. When player uses a soulgem to recharge an enchanted item.