### PR TITLE
Remove evil "implicit GetJournalIndex" hack from expression parser

### DIFF
--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -311,22 +311,6 @@ namespace Compiler
                 return true;
             }
 
-            // die in a fire, Morrowind script compiler!
-            if (const Extensions *extensions = getContext().getExtensions())
-            {
-                if (getContext().isJournalId (name2))
-                {
-                    // JournalID used as an argument. Use the index of that JournalID
-                    Generator::pushString (mCode, mLiterals, name2);
-                    int keyword = extensions->searchKeyword ("getjournalindex");
-                    extensions->generateFunctionCode (keyword, mCode, mLiterals, mExplicit, 0);
-                    mNextOperand = false;
-                    mOperands.push_back ('l');
-
-                    return true;
-                }
-            }
-
             if (mExplicit.empty() && getContext().isId (name2))
             {
                 mExplicit = name2;

--- a/files/openmw.cfg
+++ b/files/openmw.cfg
@@ -8,3 +8,6 @@ resources=${OPENMW_RESOURCE_FILES}
 script-blacklist=Museum
 script-blacklist=MockChangeScript
 script-blacklist=doortestwarp
+script-blacklist=WereChange2Script
+script-blacklist=wereDreamScript2
+script-blacklist=wereDreamScript3

--- a/files/openmw.cfg.local
+++ b/files/openmw.cfg.local
@@ -9,3 +9,6 @@ resources=./resources
 script-blacklist=Museum
 script-blacklist=MockChangeScript
 script-blacklist=doortestwarp
+script-blacklist=WereChange2Script
+script-blacklist=wereDreamScript2
+script-blacklist=wereDreamScript3


### PR DESCRIPTION
I'm assuming the hack was added to silence syntax errors in these Bloodmoon scripts:
* WereChange2Script
* wereDreamScript2
* wereDreamScript3

...which used `if ( BM_BearHunt1 == 0 )` instead of `if ( GetJournalIndex BM_BearHunt1 == 0 )`. Thing is, these scripts are unused. Moreover, they produce corrupt bytecode and result in runtime errors in vanilla MW:
```
Script Error: EXPRESSION in testscript
Left eval
```

This implicit GetJournalIndex behavior seems to be completely made up by us, so I'm getting rid of it and blacklisting the unused scripts instead. Another reason why this hack is evil is that it breaks when parsing the following expression, thinking -> is unexpected:
```
( "AA_Laurenna"->GetMysticism )
```
Where "AA_Laurenna" is an NPC ID clashing with a journal ID.