### PR TITLE
Hide WorldButton when in game mode

### DIFF
--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -774,6 +774,12 @@ namespace MWGui
         mLastScrollWindowCoordinates = currentCoordinates;
     }
 
+    void MapWindow::setVisible(bool visible)
+    {
+        WindowBase::setVisible(visible);
+        mButton->setVisible(visible && MWBase::Environment::get().getWindowManager()->isGuiMode());
+    }
+
     void MapWindow::renderGlobalMap()
     {
         mGlobalMapRender->render();

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -204,6 +204,7 @@ namespace MWGui
         void setCellName(const std::string& cellName);
 
         virtual void setAlpha(float alpha);
+        void setVisible(bool visible);
 
         void renderGlobalMap();
 


### PR DESCRIPTION
The patch improves the map window by hiding the world/local button in game mode, i.e., "non-GUI" mode. In my opinion, this makes a pinned map window a better replacement for the minimap (the world button is useless in game mode because it cannot be pressed anyway). Illustration: http://i.imgur.com/WDZbztj.png

This is my first contribution to the OpenMW project, so please review the patch (it's only a few lines of code). Basically, the hiding functionality is implemented by overriding `WindowBase::setVisible()` in `mapwindow.cpp`. An alternative approach would have been to implement `MapWindow::showButton()` method and call it from `windowmanagerimp.cpp`, but this would have required more code and logic. However, I'm not really a C++ programmer (I write mostly C), so I can't tell if overriding a virtual base class method is considered a bad practice in this context.