### PR TITLE
Editor: reset camera after cell drag and drop

### DIFF
--- a/apps/opencs/view/render/cameracontroller.cpp
+++ b/apps/opencs/view/render/cameracontroller.cpp
@@ -632,6 +632,11 @@ namespace CSVRender
         getCamera()->getViewMatrix().orthoNormal(getCamera()->getViewMatrix());
     }
 
+    void OrbitCameraController::reset()
+    {
+        mInitialized = false;
+    }
+
     void OrbitCameraController::onActivate()
     {
         mInitialized = false;

--- a/apps/opencs/view/render/cameracontroller.cpp
+++ b/apps/opencs/view/render/cameracontroller.cpp
@@ -637,11 +637,6 @@ namespace CSVRender
         mInitialized = false;
     }
 
-    void OrbitCameraController::onActivate()
-    {
-        mInitialized = false;
-    }
-
     void OrbitCameraController::initialize()
     {
         static const int DefaultStartDistance = 10000.f;

--- a/apps/opencs/view/render/cameracontroller.hpp
+++ b/apps/opencs/view/render/cameracontroller.hpp
@@ -159,6 +159,9 @@ namespace CSVRender
 
             void update(double dt);
 
+            /// \brief Flag controller to be re-initialized.
+            void reset();
+
         private:
 
             void onActivate();

--- a/apps/opencs/view/render/cameracontroller.hpp
+++ b/apps/opencs/view/render/cameracontroller.hpp
@@ -63,8 +63,6 @@ namespace CSVRender
 
         protected:
 
-            virtual void onActivate(){}
-
             void addShortcut(CSMPrefs::Shortcut* shortcut);
 
         private:
@@ -163,8 +161,6 @@ namespace CSVRender
             void reset();
 
         private:
-
-            void onActivate();
 
             void initialize();
 

--- a/apps/opencs/view/render/unpagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/unpagedworldspacewidget.cpp
@@ -15,6 +15,7 @@
 #include "../widget/scenetooltoggle.hpp"
 #include "../widget/scenetooltoggle2.hpp"
 
+#include "cameracontroller.hpp"
 #include "mask.hpp"
 #include "tagbase.hpp"
 
@@ -93,6 +94,7 @@ bool CSVRender::UnpagedWorldspaceWidget::handleDrop (const std::vector<CSMWorld:
 
     mCell.reset (new Cell (getDocument().getData(), mRootNode, mCellId));
     mCamPositionSet = false;
+    mOrbitCamControl->reset();
 
     update();
     emit cellChanged(*universalIdData.begin());

--- a/apps/opencs/view/render/unpagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/unpagedworldspacewidget.cpp
@@ -92,6 +92,7 @@ bool CSVRender::UnpagedWorldspaceWidget::handleDrop (const std::vector<CSMWorld:
     mCellId = universalIdData.begin()->getId();
 
     mCell.reset (new Cell (getDocument().getData(), mRootNode, mCellId));
+    mCamPositionSet = false;
 
     update();
     emit cellChanged(*universalIdData.begin());


### PR DESCRIPTION
[Bug #3484](https://bugs.openmw.org/issues/3484)

When a cell is initially rendered a default camera position gets set [here](https://github.com/OpenMW/openmw/blob/master/apps/opencs/view/render/scenewidget.cpp#L312). If that cell is replaced by another via drag and drop the camera position isn't changed because *mCamPositionSet* is still set to true. When replacing cells, this change flags the camera position as not being set so it gets updated.