### PR TITLE
Fixed magicka calculation on chargen (bug #3694)

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -73,6 +73,8 @@ namespace MWMechanics
         MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats (ptr);
         MWMechanics::NpcStats& npcStats = ptr.getClass().getNpcStats (ptr);
 
+        npcStats.setNeedRecalcDynamicStats(true);
+
         const ESM::NPC *player = ptr.get<ESM::NPC>()->mBase;
 
         // reset


### PR DESCRIPTION
See [this](https://forum.openmw.org/viewtopic.php?f=8&t=4035) forum thread.
This fix just recalculates dynamic stats on review dialog whatever we changed intelligence from default 30, or no.