### PR TITLE
Adjustments to RemoveItem behavior

### DIFF
--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -144,7 +144,8 @@ namespace MWScript
                         if (::Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), item))
                             itemName = iter->getClass().getName(*iter);
 
-                    int numRemoved = store.remove(item, count, ptr);
+                    // Actors should not equip a replacement when items are removed with RemoveItem
+                    int numRemoved = store.remove(item, count, ptr, false);
 
                     // Spawn a messagebox (only for items removed from player's inventory)
                     if ((numRemoved > 0)
@@ -199,7 +200,8 @@ namespace MWScript
                     else
                     {
                         boost::shared_ptr<MWWorld::Action> action = it->getClass().use(*it);
-                        action->execute(ptr);
+                        // No equip sound for actors other than the player
+                        action->execute(ptr, true);
                     }
                 }
         };

--- a/apps/openmw/mwworld/action.cpp
+++ b/apps/openmw/mwworld/action.cpp
@@ -22,9 +22,9 @@ MWWorld::Action::Action (bool keepSound, const Ptr& target) : mKeepSound (keepSo
 
 MWWorld::Action::~Action() {}
 
-void MWWorld::Action::execute (const Ptr& actor)
+void MWWorld::Action::execute (const Ptr& actor, bool noSound)
 {
-    if(!mSoundId.empty())
+    if(!mSoundId.empty() && !noSound)
     {
         if(mKeepSound && actor == MWMechanics::getPlayer())
             MWBase::Environment::get().getSoundManager()->playSound(mSoundId, 1.0, 1.0,

--- a/apps/openmw/mwworld/action.hpp
+++ b/apps/openmw/mwworld/action.hpp
@@ -37,7 +37,7 @@ namespace MWWorld
             virtual bool isNullAction() { return false; }
             ///< Is running this action a no-op? (default false)
 
-            void execute (const Ptr& actor);
+            void execute (const Ptr& actor, bool noSound = false);
 
             void setSound (const std::string& id);
             void setSoundOffset(float offset);

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -398,13 +398,13 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::addNewStack (const Cons
     return it;
 }
 
-int MWWorld::ContainerStore::remove(const std::string& itemId, int count, const Ptr& actor)
+int MWWorld::ContainerStore::remove(const std::string& itemId, int count, const Ptr& actor, bool equipReplacement)
 {
     int toRemove = count;
 
     for (ContainerStoreIterator iter(begin()); iter != end() && toRemove > 0; ++iter)
         if (Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), itemId))
-            toRemove -= remove(*iter, toRemove, actor);
+            toRemove -= remove(*iter, toRemove, actor, equipReplacement);
 
     flagAsModified();
 
@@ -412,7 +412,7 @@ int MWWorld::ContainerStore::remove(const std::string& itemId, int count, const 
     return count - toRemove;
 }
 
-int MWWorld::ContainerStore::remove(const Ptr& item, int count, const Ptr& actor)
+int MWWorld::ContainerStore::remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement)
 {
     assert(this == item.getContainerStore());
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -142,12 +142,12 @@ namespace MWWorld
             ContainerStoreIterator add(const std::string& id, int count, const Ptr& actorPtr);
             ///< Utility to construct a ManualRef and call add(ptr, count, actorPtr, true)
 
-            int remove(const std::string& itemId, int count, const Ptr& actor);
+            int remove(const std::string& itemId, int count, const Ptr& actor, bool equipReplacement = true);
             ///< Remove \a count item(s) designated by \a itemId from this container.
             ///
             /// @return the number of items actually removed
 
-            virtual int remove(const Ptr& item, int count, const Ptr& actor);
+            virtual int remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement = true);
             ///< Remove \a count item(s) designated by \a item from this inventory.
             ///
             /// @return the number of items actually removed

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -654,7 +654,7 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::getSelectedEnchantItem(
     return mSelectedEnchantItem;
 }
 
-int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor)
+int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement)
 {
     int retCount = ContainerStore::remove(item, count, actor);
 
@@ -676,8 +676,9 @@ int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor
     }
 
     // If an armor/clothing item is removed, try to find a replacement,
-    // but not for the player nor werewolves.
-    if (wasEquipped && (actor != MWMechanics::getPlayer())
+    // but not for the player nor werewolves, and not if the RemoveItem script command
+    // was used (equipReplacement is false)
+    if (equipReplacement && wasEquipped && (actor != MWMechanics::getPlayer())
             && actor.getClass().isNpc() && !actor.getClass().getNpcStats(actor).isWerewolf())
     {
         std::string type = item.getTypeName();

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -177,7 +177,7 @@ namespace MWWorld
             virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2) const;
             ///< @return true if the two specified objects can stack with each other
 
-            virtual int remove(const Ptr& item, int count, const Ptr& actor);
+            virtual int remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement = true);
             ///< Remove \a count item(s) designated by \a item from this inventory.
             ///
             /// @return the number of items actually removed


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3796.

The problem is caused because in OpenMW NPCs would always try to equip a replacement when RemoveItem was used. The mod relies on the behavior of the original engine, which is that a replacement is not equipped. A replacement _is_ equipped in the original engine when you click to remove items from the inventory of a dead body or companion.

This also fixes the issue of the loud equipping noise. Only the player has equip sounds in the original engine.

This PR doesn't do anything about the
`Failed to load 'meshes/add world art': Resource 'meshes/add world art' not found, using marker_error.nif instead`
messages I mentioned in the comments there. That happens because the mod uses items that have no art files attached.