### PR TITLE
Chargen menus fixes

### DIFF
--- a/apps/openmw/mwgui/charactercreation.cpp
+++ b/apps/openmw/mwgui/charactercreation.cpp
@@ -13,6 +13,7 @@
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/player.hpp"
 
 #include "textinput.hpp"
 #include "race.hpp"
@@ -230,10 +231,19 @@ namespace MWGui
                     MWBase::Environment::get().getWindowManager()->removeDialog(mReviewDialog);
                     mReviewDialog = 0;
                     mReviewDialog = new ReviewDialog();
-                    mReviewDialog->setPlayerName(mPlayerName);
-                    mReviewDialog->setRace(mPlayerRaceId);
-                    mReviewDialog->setClass(mPlayerClass);
-                    mReviewDialog->setBirthSign(mPlayerBirthSignId);
+
+                    MWBase::World *world = MWBase::Environment::get().getWorld();
+
+                    const ESM::NPC *playerNpc = world->getPlayerPtr().get<ESM::NPC>()->mBase;
+
+                    const MWWorld::Player player = world->getPlayer();
+
+                    const ESM::Class *playerClass = world->getStore().get<ESM::Class>().find(playerNpc->mClass);
+
+                    mReviewDialog->setPlayerName(playerNpc->mName);
+                    mReviewDialog->setRace(playerNpc->mRace);
+                    mReviewDialog->setClass(*playerClass);
+                    mReviewDialog->setBirthSign(player.getBirthSign());
 
                     {
                         MWWorld::Ptr player = MWMechanics::getPlayer();

--- a/apps/openmw/mwgui/race.cpp
+++ b/apps/openmw/mwgui/race.cpp
@@ -146,6 +146,7 @@ namespace MWGui
 
         const ESM::NPC& proto = mPreview->getPrototype();
         setRaceId(proto.mRace);
+        setGender(proto.isMale() ? GM_Male : GM_Female);
         recountParts();
 
         for (unsigned int i=0; i<mAvailableHeads.size(); ++i)


### PR DESCRIPTION
1. Reviewmenu fields filled by values from player stats (fixes [bug #2628](https://bugs.openmw.org/issues/2628)).
2. When you create a female character, type "enableracemenu" in console and try to change head/hairs, PC gender will be changed to male. Fixed by saving a current proto gender.