### PR TITLE
Fix a few Cppcheck warnings

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -500,8 +500,7 @@ namespace MWMechanics
         {
             // get the range of the target's weapon
             float rangeAttackOfTarget = 0.f;
-            bool isRangedCombat = false;
-            MWWorld::Ptr targetWeapon = MWWorld::Ptr();         
+            MWWorld::Ptr targetWeapon = MWWorld::Ptr();
             const MWWorld::Class& targetClass = target.getClass();
 
             if (targetClass.hasInventoryStore(target))
@@ -516,7 +515,10 @@ namespace MWMechanics
             boost::shared_ptr<Action> targetWeaponAction (new ActionWeapon(targetWeapon));
 
             if (targetWeaponAction.get())
+            {
+                bool isRangedCombat = false;
                 rangeAttackOfTarget = targetWeaponAction->getCombatRange(isRangedCombat);
+            }
               
             // apply sideway movement (kind of dodging) with some probability
             // if actor is within range of target's weapon

--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -171,10 +171,10 @@ void MWMechanics::Alchemy::updateEffects()
         if (fPotionT1DurMult<=0)
             throw std::runtime_error ("invalid gmst: fPotionT1DurMult");
 
-        float magnitude = magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude ?
-            1 : (x / fPotionT1MagMul) / magicEffect->mData.mBaseCost;
-        float duration = magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration ?
-            1 : (x / fPotionT1DurMult) / magicEffect->mData.mBaseCost;
+        float magnitude = (magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude) ?
+            1.0f : (x / fPotionT1MagMul) / magicEffect->mData.mBaseCost;
+        float duration = (magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration) ?
+            1.0f : (x / fPotionT1DurMult) / magicEffect->mData.mBaseCost;
 
         if (!(magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
             applyTools (magicEffect->mData.mFlags, magnitude);

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -230,13 +230,6 @@ namespace MWPhysics
             return direction - project(direction, planeNormal);
         }
 
-        static inline osg::Vec3f reflect(const osg::Vec3& velocity, const osg::Vec3f& normal)
-        {
-            return velocity - (normal * (normal * velocity)) * 2;
-            //                                  ^ dot product
-        }
-
-
     public:
         static osg::Vec3f traceDown(const MWWorld::Ptr &ptr, const osg::Vec3f& position, Actor* actor, btCollisionWorld* collisionWorld, float maxHeight)
         {

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -211,7 +211,7 @@ namespace MWPhysics
             float mTimeAccum;
 
             float mWaterHeight;
-            float mWaterEnabled;
+            bool mWaterEnabled;
 
             std::auto_ptr<btCollisionObject> mWaterCollisionObject;
             std::auto_ptr<btCollisionShape> mWaterCollisionShape;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1058,11 +1058,9 @@ namespace MWRender
             float timepassed = duration * state.mSpeedMult;
             while(state.mPlaying)
             {
-                float targetTime;
-
                 if (!state.shouldLoop())
                 {
-                    targetTime = state.getTime() + timepassed;
+                    float targetTime = state.getTime() + timepassed;
                     if(textkey == textkeys.end() || textkey->first > targetTime)
                     {
                         if(mAccumCtrl && state.mTime == mAnimationTimePtr[0]->getTimePtr())

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -538,13 +538,9 @@ namespace MWWorld
         std::cout << "Changing to interior\n";
 
         // unload
-        int current = 0;
         CellStoreCollection::iterator active = mActiveCells.begin();
         while (active!=mActiveCells.end())
-        {
             unloadCell (active++);
-            ++current;
-        }
 
         int refsToLoad = cell->count();
         loadingListener->setProgressRange(refsToLoad);


### PR DESCRIPTION
This fixes a few warnings that I saw after using the code analysis tool Cppcheck.

Fixes:
Boolean value assigned to floating point variable
physicssystem.cpp
Lines 1497, 1506

The scope of the variable 'isRangedCombat' can be reduced.
aicombat.cpp
Line 503

The scope of the variable 'targetTime' can be reduced.
animation.cpp
Line 1061

Variable 'current' is modified but its new value is never used
scene.cpp
Line 545

Suspicious calculation. Please use parentheses to clarify the code.
alchemy.cpp
Line 174, 176

Also, it shows

Unused private function: 'MovementSolver::reflect'
physicssystem.cpp
Line 233

but I left it there in case it is maybe still wanted.