### PR TITLE
Purge existing levitation effects when levitation is disabled (fixes #3766)

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -596,6 +596,21 @@ namespace MWMechanics
             }
         }
 
+        // purge levitate effect if levitation is disabled
+        // check only modifier, because base value can be setted from SetFlying console command.
+        if (MWBase::Environment::get().getWorld()->isLevitationEnabled() == false && effects.get(ESM::MagicEffect::Levitate).getModifier() > 0)
+        {
+            creatureStats.getSpells().purgeEffect(ESM::MagicEffect::Levitate);
+            creatureStats.getActiveSpells().purgeEffect(ESM::MagicEffect::Levitate);
+            if (ptr.getClass().hasInventoryStore(ptr))
+                ptr.getClass().getInventoryStore(ptr).purgeEffect(ESM::MagicEffect::Levitate);
+
+            if (ptr == getPlayer())
+            {
+                MWBase::Environment::get().getWindowManager()->messageBox ("#{sLevitateDisabled}");
+            }
+        }
+
         // attributes
         for(int i = 0;i < ESM::Attribute::Length;++i)
         {


### PR DESCRIPTION
This PR adds an ability to purge existing levitation effects, when actor is in area with disabled levitation (see [bug #3766](https://bugs.openmw.org/issues/3766)).
Tested with both spells and enchanted items (include items with constant effects).

Test cases:
1. Cast any levitation spell and run 'coc "mournhold, godsreach"' in console.
2. Run 'player->setFlying 100' and then run 'coc "mournhold, godsreach"'

Note:
I call getModifier() instead of getMagnitude() since I do not know how we should handle "SetFlying" command.
It seems "SetFlying" sets mBase of effect. Should I discard mBase and show message, or leave the current behaviour?