### PR TITLE
Fix more warnings

### DIFF
--- a/apps/openmw/mwgui/charactercreation.cpp
+++ b/apps/openmw/mwgui/charactercreation.cpp
@@ -246,8 +246,8 @@ namespace MWGui
                     mReviewDialog->setBirthSign(player.getBirthSign());
 
                     {
-                        MWWorld::Ptr player = MWMechanics::getPlayer();
-                        const MWMechanics::CreatureStats& stats = player.getClass().getCreatureStats(player);
+                        MWWorld::Ptr playerPtr = MWMechanics::getPlayer();
+                        const MWMechanics::CreatureStats& stats = playerPtr.getClass().getCreatureStats(playerPtr);
 
                         mReviewDialog->setHealth ( stats.getHealth()  );
                         mReviewDialog->setMagicka( stats.getMagicka() );

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -114,9 +114,7 @@ void adjustCommandedActor (const MWWorld::Ptr& actor)
     }
 
     if (!check.mCommanded && hasCommandPackage)
-    {
         stats.getAiSequence().erase(it);
-    }
 }
 
 void getRestorationPerHourOfSleep (const MWWorld::Ptr& ptr, float& health, float& magicka)
@@ -707,16 +705,8 @@ namespace MWMechanics
 
         // any value of calm > 0 will stop the actor from fighting
         if ((effects.get(ESM::MagicEffect::CalmHumanoid).getMagnitude() > 0 && ptr.getClass().isNpc())
-                || (effects.get(ESM::MagicEffect::CalmCreature).getMagnitude() > 0 && !ptr.getClass().isNpc()))
-        {
-            for (std::list<AiPackage*>::const_iterator it = creatureStats.getAiSequence().begin(); it != creatureStats.getAiSequence().end(); )
-            {
-                if ((*it)->getTypeId() == AiPackage::TypeIdCombat)
-                    it = creatureStats.getAiSequence().erase(it);
-                else
-                    ++it;
-            }
-        }
+            || (effects.get(ESM::MagicEffect::CalmCreature).getMagnitude() > 0 && !ptr.getClass().isNpc()))
+            creatureStats.getAiSequence().stopCombat();
 
         // Update bound effects
         // Note: in vanilla MW multiple bound items of the same type can be created by different spells.

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -78,7 +78,7 @@ class CheckActorCommanded : public MWMechanics::EffectSourceVisitor
     MWWorld::Ptr mActor;
 public:
     bool mCommanded;
-    CheckActorCommanded(MWWorld::Ptr actor)
+    CheckActorCommanded(const MWWorld::Ptr& actor)
         : mActor(actor)
     , mCommanded(false){}
 
@@ -149,7 +149,7 @@ namespace MWMechanics
         MWWorld::Ptr mActor;
         bool mTrapped;
     public:
-        SoulTrap(MWWorld::Ptr trappedCreature)
+        SoulTrap(const MWWorld::Ptr& trappedCreature)
             : mCreature(trappedCreature)
             , mTrapped(false)
         {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -795,7 +795,7 @@ namespace MWMechanics
         NpcStats &stats = ptr.getClass().getNpcStats(ptr);
 
         // When npc stats are just initialized, mTimeToStartDrowning == -1 and we should get value from GMST
-        static const int fHoldBreathTime = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fHoldBreathTime")->getFloat();
+        static const float fHoldBreathTime = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fHoldBreathTime")->getFloat();
         if (stats.getTimeToStartDrowning() == -1.f)
             stats.setTimeToStartDrowning(fHoldBreathTime);
 
@@ -835,10 +835,7 @@ namespace MWMechanics
             }
         }
         else
-        {
-            static const float fHoldBreathTime = world->getStore().get<ESM::GameSetting>().find("fHoldBreathTime")->getFloat();
             stats.setTimeToStartDrowning(fHoldBreathTime);
-        }
     }
 
     void Actors::updateEquippedLight (const MWWorld::Ptr& ptr, float duration)

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -96,16 +96,16 @@ std::list<AiPackage*>::const_iterator AiSequence::end() const
     return mPackages.end();
 }
 
-std::list<AiPackage*>::const_iterator AiSequence::erase(std::list<AiPackage*>::const_iterator package)
+void AiSequence::erase(std::list<AiPackage*>::const_iterator package)
 {
     // Not sure if manually terminated packages should trigger mDone, probably not?
     for(std::list<AiPackage*>::iterator it = mPackages.begin(); it != mPackages.end(); ++it)
     {
         if (package == it)
         {
-            AiPackage* packagePtr = *it;
-            delete packagePtr;
-            return mPackages.erase(it);
+            delete *it;
+            mPackages.erase(it);
+            return;
         }
     }
     throw std::runtime_error("can't find package to erase");

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -64,7 +64,7 @@ namespace MWMechanics
             std::list<AiPackage*>::const_iterator begin() const;
             std::list<AiPackage*>::const_iterator end() const;
 
-            std::list<AiPackage*>::const_iterator erase (std::list<AiPackage*>::const_iterator package);
+            void erase (std::list<AiPackage*>::const_iterator package);
 
             /// Returns currently executing AiPackage type
             /** \see enum AiPackage::TypeId **/

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -893,7 +893,7 @@ namespace MWMechanics
         storage.mAllowedNodes.push_back(PathFinder::MakePathgridPoint(vectorStart + delta));
     }
 
-    void AiWander::SetCurrentNodeToClosestAllowedNode(osg::Vec3f npcPos, AiWanderStorage& storage)
+    void AiWander::SetCurrentNodeToClosestAllowedNode(const osg::Vec3f& npcPos, AiWanderStorage& storage)
     {
         float distanceToClosestNode = std::numeric_limits<float>::max();
         unsigned int index = 0;

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -122,7 +122,7 @@ namespace MWMechanics
             /// convert point from local (i.e. cell) to world coordinates
             void ToWorldCoordinates(ESM::Pathgrid::Point& point, const ESM::Cell * cell);
 
-            void SetCurrentNodeToClosestAllowedNode(osg::Vec3f npcPos, AiWanderStorage& storage);
+            void SetCurrentNodeToClosestAllowedNode(const osg::Vec3f& npcPos, AiWanderStorage& storage);
 
             void AddNonPathGridAllowedPoints(osg::Vec3f npcPos, const ESM::Pathgrid * pathGrid, int pointIndex, AiWanderStorage& storage);
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2242,7 +2242,7 @@ void CharacterController::setAttackingOrSpell(bool attackingOrSpell)
     mAttackingOrSpell = attackingOrSpell;
 }
 
-void CharacterController::setAIAttackType(std::string attackType)
+void CharacterController::setAIAttackType(const std::string& attackType)
 {
     mAttackType = attackType;
 }

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -268,7 +268,7 @@ public:
     bool isSneaking() const;
 
     void setAttackingOrSpell(bool attackingOrSpell);
-    void setAIAttackType(std::string attackType); // set and used by AiCombat
+    void setAIAttackType(const std::string& attackType);
     static void setAttackTypeRandomly(std::string& attackType);
 
     bool readyToPrepareAttack() const;

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -21,7 +21,7 @@ namespace MWMechanics
         , mSelfEnchanting(false)
     {}
 
-    void Enchanting::setOldItem(MWWorld::Ptr oldItem)
+    void Enchanting::setOldItem(const MWWorld::Ptr& oldItem)
     {
         mOldItemPtr=oldItem;
         if(!itemEmpty())
@@ -39,7 +39,7 @@ namespace MWMechanics
         mNewItemName=s;
     }
 
-    void Enchanting::setEffect(ESM::EffectList effectList)
+    void Enchanting::setEffect(const ESM::EffectList& effectList)
     {
         mEffectList=effectList;
     }
@@ -49,7 +49,7 @@ namespace MWMechanics
         return mCastStyle;
     }
 
-    void Enchanting::setSoulGem(MWWorld::Ptr soulGem)
+    void Enchanting::setSoulGem(const MWWorld::Ptr& soulGem)
     {
         mSoulGemPtr=soulGem;
     }
@@ -269,7 +269,7 @@ namespace MWMechanics
         mSelfEnchanting = selfEnchanting;
     }
 
-    void Enchanting::setEnchanter(MWWorld::Ptr enchanter)
+    void Enchanting::setEnchanter(const MWWorld::Ptr& enchanter)
     {
         mEnchanter = enchanter;
     }

--- a/apps/openmw/mwmechanics/enchanting.hpp
+++ b/apps/openmw/mwmechanics/enchanting.hpp
@@ -29,14 +29,14 @@ namespace MWMechanics
 
         public:
             Enchanting();
-            void setEnchanter(MWWorld::Ptr enchanter);
+            void setEnchanter(const MWWorld::Ptr& enchanter);
             void setSelfEnchanting(bool selfEnchanting);
-            void setOldItem(MWWorld::Ptr oldItem);
+            void setOldItem(const MWWorld::Ptr& oldItem);
             MWWorld::Ptr getOldItem() { return mOldItemPtr; }
             MWWorld::Ptr getGem() { return mSoulGemPtr; }
             void setNewItemName(const std::string& s);
-            void setEffect(ESM::EffectList effectList);
-            void setSoulGem(MWWorld::Ptr soulGem);
+            void setEffect(const ESM::EffectList& effectList);
+            void setSoulGem(const MWWorld::Ptr& soulGem);
             bool create(); //Return true if created, false if failed.
             void nextCastStyle(); //Set enchant type to next possible type (for mOldItemPtr object)
             int getCastStyle() const;

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -15,7 +15,7 @@ namespace
     // Chooses a reachable end pathgrid point.  start is assumed reachable.
     std::pair<int, bool> getClosestReachablePoint(const ESM::Pathgrid* grid,
                                                   const MWWorld::CellStore *cell,
-                                                  const osg::Vec3f pos, int start)
+                                                  const osg::Vec3f& pos, int start)
     {
         assert(grid && !grid->mPoints.empty());
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -794,7 +794,7 @@ namespace MWPhysics
         btVector3 mContactPoint;
         btScalar mLeastDistSqr;
 
-        DeepestNotMeContactTestResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*> targets, const btVector3 &origin)
+        DeepestNotMeContactTestResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3 &origin)
           : mMe(me), mTargets(targets), mOrigin(origin), mObject(NULL), mContactPoint(0,0,0),
             mLeastDistSqr(std::numeric_limits<float>::max())
         { }
@@ -912,7 +912,7 @@ namespace MWPhysics
     class ClosestNotMeRayResultCallback : public btCollisionWorld::ClosestRayResultCallback
     {
     public:
-        ClosestNotMeRayResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*> targets, const btVector3& from, const btVector3& to)
+        ClosestNotMeRayResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3& from, const btVector3& to)
             : btCollisionWorld::ClosestRayResultCallback(from, to)
             , mMe(me), mTargets(targets)
         {
@@ -938,7 +938,7 @@ namespace MWPhysics
         const std::vector<const btCollisionObject*> mTargets;
     };
 
-    PhysicsSystem::RayResult PhysicsSystem::castRay(const osg::Vec3f &from, const osg::Vec3f &to, MWWorld::ConstPtr ignore, std::vector<MWWorld::Ptr> targets, int mask, int group) const
+    PhysicsSystem::RayResult PhysicsSystem::castRay(const osg::Vec3f &from, const osg::Vec3f &to, const MWWorld::ConstPtr& ignore, std::vector<MWWorld::Ptr> targets, int mask, int group) const
     {
         btVector3 btFrom = toBullet(from);
         btVector3 btTo = toBullet(to);

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -114,7 +114,7 @@ namespace MWPhysics
             };
 
             /// @param me Optional, a Ptr to ignore in the list of results. targets are actors to filter for, ignoring all other actors.
-            RayResult castRay(const osg::Vec3f &from, const osg::Vec3f &to, MWWorld::ConstPtr ignore = MWWorld::ConstPtr(),
+            RayResult castRay(const osg::Vec3f &from, const osg::Vec3f &to, const MWWorld::ConstPtr& ignore = MWWorld::ConstPtr(),
                     std::vector<MWWorld::Ptr> targets = std::vector<MWWorld::Ptr>(),
                     int mask = CollisionType_World|CollisionType_HeightMap|CollisionType_Actor|CollisionType_Door, int group=0xff) const;
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -282,7 +282,7 @@ namespace MWRender
     class GlowUpdater : public SceneUtil::StateSetUpdater
     {
     public:
-        GlowUpdater(int texUnit, osg::Vec4f color, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures,
+        GlowUpdater(int texUnit, const osg::Vec4f& color, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures,
             osg::Node* node, float duration, Resource::ResourceSystem* resourcesystem)
             : mTexUnit(texUnit)
             , mColor(color)
@@ -383,7 +383,7 @@ namespace MWRender
             return mDone;
         }
 
-        void setColor(osg::Vec4f color)
+        void setColor(const osg::Vec4f& color)
         {
             mColor = color;
             mColorChanged = true;
@@ -1362,7 +1362,7 @@ namespace MWRender
                             useQuadratic, quadraticValue, quadraticRadiusMult, useLinear, linearRadiusMult, linearValue);
     }
 
-    void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, std::string texture)
+    void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, const std::string& texture)
     {
         if (!mObjectRoot.get())
             return;

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -362,7 +362,7 @@ public:
      * @param texture override the texture specified in the model's materials - if empty, do not override
      * @note Will not add an effect twice.
      */
-    void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", std::string texture = "");
+    void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", const std::string& texture = "");
     void removeEffect (int effectId);
     void getLoopingEffects (std::vector<int>& out) const;
 

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -105,7 +105,7 @@ namespace MWRender
     };
 
     CharacterPreview::CharacterPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem,
-                                       MWWorld::Ptr character, int sizeX, int sizeY, const osg::Vec3f& position, const osg::Vec3f& lookAt)
+                                       const MWWorld::Ptr& character, int sizeX, int sizeY, const osg::Vec3f& position, const osg::Vec3f& lookAt)
         : mParent(parent)
         , mResourceSystem(resourceSystem)
         , mPosition(position)
@@ -244,7 +244,7 @@ namespace MWRender
     // --------------------------------------------------------------------------------------------------
 
 
-    InventoryPreview::InventoryPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem, MWWorld::Ptr character)
+    InventoryPreview::InventoryPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem, const MWWorld::Ptr& character)
         : CharacterPreview(parent, resourceSystem, character, 512, 1024, osg::Vec3f(0, 700, 71), osg::Vec3f(0,0,71))
     {
     }

--- a/apps/openmw/mwrender/characterpreview.hpp
+++ b/apps/openmw/mwrender/characterpreview.hpp
@@ -28,7 +28,7 @@ namespace MWRender
     class CharacterPreview
     {
     public:
-        CharacterPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem, MWWorld::Ptr character, int sizeX, int sizeY,
+        CharacterPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem, const MWWorld::Ptr& character, int sizeX, int sizeY,
                          const osg::Vec3f& position, const osg::Vec3f& lookAt);
         virtual ~CharacterPreview();
 
@@ -73,7 +73,7 @@ namespace MWRender
     {
     public:
 
-        InventoryPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem, MWWorld::Ptr character);
+        InventoryPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem, const MWWorld::Ptr& character);
 
         void updatePtr(const MWWorld::Ptr& ptr);
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -99,7 +99,7 @@ private:
 private:
     void resetBlinkTimer();
 public:
-    HeadAnimationTime(MWWorld::Ptr reference);
+    HeadAnimationTime(const MWWorld::Ptr& reference);
 
     void updatePtr(const MWWorld::Ptr& updated);
 
@@ -128,7 +128,7 @@ public:
     {
     }
 
-    void setOffset(osg::Vec3f offset)
+    void setOffset(const osg::Vec3f& offset)
     {
         mOffset = offset;
     }
@@ -155,7 +155,7 @@ private:
 
 // --------------------------------------------------------------------------------------------------------------
 
-HeadAnimationTime::HeadAnimationTime(MWWorld::Ptr reference)
+HeadAnimationTime::HeadAnimationTime(const MWWorld::Ptr& reference)
     : mReference(reference), mTalkStart(0), mTalkStop(0), mBlinkStart(0), mBlinkStop(0), mEnabled(true), mValue(0)
 {
     resetBlinkTimer();

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -37,7 +37,7 @@ class Animation;
 class PtrHolder : public osg::Object
 {
 public:
-    PtrHolder(MWWorld::Ptr ptr)
+    PtrHolder(const MWWorld::Ptr& ptr)
         : mPtr(ptr)
     {
     }

--- a/apps/openmw/mwrender/util.cpp
+++ b/apps/openmw/mwrender/util.cpp
@@ -14,7 +14,7 @@ namespace MWRender
 class TextureOverrideVisitor : public osg::NodeVisitor
     {
     public:
-        TextureOverrideVisitor(std::string texture, Resource::ResourceSystem* resourcesystem)
+        TextureOverrideVisitor(const std::string& texture, Resource::ResourceSystem* resourcesystem)
             : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
             , mTexture(texture)
             , mResourcesystem(resourcesystem)

--- a/apps/openmw/mwscript/interpretercontext.cpp
+++ b/apps/openmw/mwscript/interpretercontext.cpp
@@ -137,7 +137,7 @@ namespace MWScript
 
 
     InterpreterContext::InterpreterContext (
-        MWScript::Locals *locals, MWWorld::Ptr reference, const std::string& targetId)
+        MWScript::Locals *locals, const MWWorld::Ptr& reference, const std::string& targetId)
     : mLocals (locals), mReference (reference), mTargetId (targetId)
     {
         // If we run on a reference (local script, dialogue script or console with object

--- a/apps/openmw/mwscript/interpretercontext.hpp
+++ b/apps/openmw/mwscript/interpretercontext.hpp
@@ -51,7 +51,7 @@ namespace MWScript
 
         public:
 
-            InterpreterContext (MWScript::Locals *locals, MWWorld::Ptr reference,
+            InterpreterContext (MWScript::Locals *locals, const MWWorld::Ptr& reference,
                 const std::string& targetId = "");
             ///< The ownership of \a locals is not transferred. 0-pointer allowed.
 

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -255,7 +255,7 @@ namespace MWWorld
         return MWBase::Environment::get().getMechanicsManager()->getEnemiesNearby(getPlayer()).size() != 0;
     }
 
-    void Player::markPosition(CellStore *markedCell, ESM::Position markedPosition)
+    void Player::markPosition(CellStore *markedCell, const ESM::Position& markedPosition)
     {
         mMarkedCell = markedCell;
         mMarkedPosition = markedPosition;

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -61,7 +61,7 @@ namespace MWWorld
         void setWerewolfSkillsAttributes();
 
         // For mark/recall magic effects
-        void markPosition (CellStore* markedCell, ESM::Position markedPosition);
+        void markPosition (CellStore* markedCell, const ESM::Position& markedPosition);
         void getMarkedPosition (CellStore*& markedCell, ESM::Position& markedPosition) const;
 
         /// Interiors can not always be mapped to a world position. However

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2989,7 +2989,7 @@ namespace MWWorld
 
     struct AddDetectedReferenceVisitor
     {
-        AddDetectedReferenceVisitor(std::vector<Ptr>& out, Ptr detector, World::DetectionType type, float squaredDist)
+        AddDetectedReferenceVisitor(std::vector<Ptr>& out, const Ptr& detector, World::DetectionType type, float squaredDist)
             : mOut(out), mDetector(detector), mSquaredDist(squaredDist), mType(type)
         {
         }

--- a/components/esm/esmwriter.hpp
+++ b/components/esm/esmwriter.hpp
@@ -86,7 +86,7 @@ private:
         // Prevent using writeHNT with strings. This already happened by accident and results in
         // state being discarded without any error on writing or reading it. :(
         // writeHNString and friends must be used instead.
-        void writeHNT(const std::string &name, std::string data)
+        void writeHNT(const std::string& name, const std::string& data)
         {
         }
         void writeT(const std::string& data)

--- a/components/nifosg/controller.cpp
+++ b/components/nifosg/controller.cpp
@@ -218,7 +218,7 @@ UVController::UVController()
 {
 }
 
-UVController::UVController(const Nif::NiUVData *data, std::set<int> textureUnits)
+UVController::UVController(const Nif::NiUVData *data, const std::set<int>& textureUnits)
     : mUTrans(data->mKeyList[0], 0.f)
     , mVTrans(data->mKeyList[1], 0.f)
     , mUScale(data->mKeyList[2], 1.f)
@@ -381,14 +381,14 @@ void MaterialColorController::apply(osg::StateSet *stateset, osg::NodeVisitor *n
     }
 }
 
-FlipController::FlipController(const Nif::NiFlipController *ctrl, std::vector<osg::ref_ptr<osg::Texture2D> > textures)
+FlipController::FlipController(const Nif::NiFlipController *ctrl, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures)
     : mTexSlot(ctrl->mTexSlot)
     , mDelta(ctrl->mDelta)
     , mTextures(textures)
 {
 }
 
-FlipController::FlipController(int texSlot, float delta, std::vector<osg::ref_ptr<osg::Texture2D> > textures)
+FlipController::FlipController(int texSlot, float delta, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures)
     : mTexSlot(texSlot)
     , mDelta(delta)
     , mTextures(textures)

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -223,7 +223,7 @@ namespace NifOsg
     public:
         UVController();
         UVController(const UVController&,const osg::CopyOp&);
-        UVController(const Nif::NiUVData *data, std::set<int> textureUnits);
+        UVController(const Nif::NiUVData *data, const std::set<int>& textureUnits);
 
         META_Object(NifOsg,UVController)
 
@@ -297,8 +297,8 @@ namespace NifOsg
         std::vector<osg::ref_ptr<osg::Texture2D> > mTextures;
 
     public:
-        FlipController(const Nif::NiFlipController* ctrl, std::vector<osg::ref_ptr<osg::Texture2D> > textures);
-        FlipController(int texSlot, float delta, std::vector<osg::ref_ptr<osg::Texture2D> > textures);
+        FlipController(const Nif::NiFlipController* ctrl, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures);
+        FlipController(int texSlot, float delta, const std::vector<osg::ref_ptr<osg::Texture2D> >& textures);
         FlipController();
         FlipController(const FlipController& copy, const osg::CopyOp& copyop);
 


### PR DESCRIPTION
Fixed the following warnings from CPPCheck

> The interator 'it' is invalid after the element it pointed to has been erased. Dereferencing or comparing it with another iterator is invalid operation.

For aisequence.cpp, line 108

This was in AISequence::erase. Also, this function is used in two spots. One doesn't take the return value, and the other was doing the same thing as AISequence::stopCombat, so in addition to fixing the warning, I changed that call to stopCombat and made AISequence::erase a void return function.

> Parameter --- is passed by value. It could be passed as a (const) reference which is usually faster and recommended in C++

This showed for several files. I changed them all to const references.

And from MSVC, I fixed two shadowing warnings from recent commits.