### PR TITLE
Chargen menus fixes

### DIFF
--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -160,22 +160,31 @@ namespace MWGui
 
     void ReviewDialog::setHealth(const MWMechanics::DynamicStat<float>& value)
     {
-        mHealth->setValue(static_cast<int>(value.getCurrent()), static_cast<int>(value.getModified()));
-        std::string valStr =  MyGUI::utility::toString(value.getCurrent()) + "/" + MyGUI::utility::toString(value.getModified());
+        int current = std::max(0, static_cast<int>(value.getCurrent()));
+        int modified = static_cast<int>(value.getModified());
+
+        mHealth->setValue(current, modified);
+        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
         mHealth->setUserString("Caption_HealthDescription", "#{sHealthDesc}\n" + valStr);
     }
 
     void ReviewDialog::setMagicka(const MWMechanics::DynamicStat<float>& value)
     {
-        mMagicka->setValue(static_cast<int>(value.getCurrent()), static_cast<int>(value.getModified()));
-        std::string valStr =  MyGUI::utility::toString(value.getCurrent()) + "/" + MyGUI::utility::toString(value.getModified());
+        int current = std::max(0, static_cast<int>(value.getCurrent()));
+        int modified = static_cast<int>(value.getModified());
+
+        mMagicka->setValue(current, modified);
+        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
         mMagicka->setUserString("Caption_HealthDescription", "#{sMagDesc}\n" + valStr);
     }
 
     void ReviewDialog::setFatigue(const MWMechanics::DynamicStat<float>& value)
     {
-        mFatigue->setValue(static_cast<int>(value.getCurrent()), static_cast<int>(value.getModified()));
-        std::string valStr =  MyGUI::utility::toString(value.getCurrent()) + "/" + MyGUI::utility::toString(value.getModified());
+        int current = std::max(0, static_cast<int>(value.getCurrent()));
+        int modified = static_cast<int>(value.getModified());
+
+        mFatigue->setValue(current, modified);
+        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
         mFatigue->setUserString("Caption_HealthDescription", "#{sFatDesc}\n" + valStr);
     }
 

--- a/files/mygui/openmw_chargen_race.layout
+++ b/files/mygui/openmw_chargen_race.layout
@@ -84,7 +84,7 @@
                 <Property key="Caption" value="#{sBack}"/>
             </Widget>
             <Widget type="AutoSizedButton" skin="MW_Button" position="532 397 42 23" name="OKButton">
-                <Property key="Caption" value="#{sOK]"/>
+                <Property key="Caption" value="#{sOK}"/>
             </Widget>
         </Widget>
     </Widget>

--- a/files/mygui/openmw_resources.xml
+++ b/files/mygui/openmw_resources.xml
@@ -68,11 +68,13 @@
     <Resource type="ResourceLayout" name="MW_StatNameValue" version="3.2.0">
         <Widget type="Widget" skin="" position="0 0 200 18" name="Root">
             <Property key="NeedMouse" value="true"/>
-            <Widget type="TextBox" skin="SandText" position="0 0 160 18" align="Left HStretch" name="StatName">
+            <Widget type="TextBox" skin="SandText" position="0 0 168 18" align="Left HStretch" name="StatName">
                 <Property key="NeedMouse" value="false"/>
+                <Property key="TextAlign" value="Left"/>
             </Widget>
-            <Widget type="TextBox" skin="SandTextRight" position="160 0 40 18" align="Right Top" name="StatValue">
+            <Widget type="TextBox" skin="SandTextRight" position="168 0 32 18" align="Right Top" name="StatValue">
                 <Property key="NeedMouse" value="false"/>
+                <Property key="TextAlign" value="Right"/>
             </Widget>
         </Widget>
     </Resource>

--- a/files/mygui/openmw_text.skin.xml
+++ b/files/mygui/openmw_text.skin.xml
@@ -139,24 +139,24 @@ color_misc=0,205,205 # ????
 
     <Resource type="ResourceSkin" name="MW_ChargeBar_Blue" size="204 18">
         <Child type="ProgressBar" skin="MW_Progress_Blue" offset="0 0 204 18" align="Right Top Stretch" name="Bar"/>
-        <Child type="TextBox" skin="ProgressText" offset="0 1 204 14" align="Right Top Stretch" name="BarText"/>
+        <Child type="TextBox" skin="ProgressText" offset="0 0 204 16" align="Right Top Stretch" name="BarText"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_DynamicStat_Red" size="204 18">
         <Child type="TextBox" skin="SandText" offset="0 0 100 18" align="Left Top" name="Text"/>
         <Child type="ProgressBar" skin="MW_Progress_Red" offset="74 0 130 18" align="Right Top" name="Bar"/>
-        <Child type="TextBox" skin="ProgressText" offset="74 0 130 18" align="Right Top" name="BarText"/>
+        <Child type="TextBox" skin="ProgressText" offset="74 0 130 14" align="Right Top" name="BarText"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_DynamicStat_Blue" size="204 18">
         <Child type="TextBox" skin="SandText" offset="0 0 100 18" align="Left Top" name="Text"/>
         <Child type="ProgressBar" skin="MW_Progress_Blue" offset="74 0 130 18" align="Right Top" name="Bar"/>
-        <Child type="TextBox" skin="ProgressText" offset="74 0 130 18" align="Right Top" name="BarText"/>
+        <Child type="TextBox" skin="ProgressText" offset="74 0 130 14" align="Right Top" name="BarText"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_DynamicStat_Green" size="204 18">
         <Child type="TextBox" skin="SandText" offset="0 0 100 18" align="Left Top" name="Text"/>
         <Child type="ProgressBar" skin="MW_Progress_Green" offset="74 0 130 18" align="Right Top" name="Bar"/>
-        <Child type="TextBox" skin="ProgressText" offset="74 0 130 18" align="Right Top" name="BarText"/>
+        <Child type="TextBox" skin="ProgressText" offset="74 0 130 14" align="Right Top" name="BarText"/>
     </Resource>
 </MyGUI>


### PR DESCRIPTION
1. Health, magicka and fatigue tooltips in review menu now show integer values instead of float (as in stats menu).
2. Fixed vertical offset of text on the dynamic stats progress bars in review menu.
3. Fixed layout of skill bonuses in racemenu (skill name can fit up to 16 symbols with default font, skill bonus - up to 4 digit, as in vanilla game). 
This fix need to correctly show "Spear", "Heavy armor" and "Short blade" skills with a russian translation.

These changes tested with both default and Pelagiad font on a russian-translated game.