### PR TITLE
Use "sLevel" GMST instead of hardcoded text in load game menu

### DIFF
--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -169,7 +169,7 @@ namespace MWGui
                         className = "?"; // From an older savegame format that did not support custom classes properly.
                 }
 
-                title << " (#{sLevel} " << it->getSignature().mPlayerLevel << " " << className << ")";
+                title << " (#{sLevel} " << it->getSignature().mPlayerLevel << " " << MyGUI::TextIterator::toTagsString(className) << ")";
 
                 mCharacterSelection->addItem (MyGUI::LanguageManager::getInstance().replaceTags(title.str()));
 

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -7,6 +7,7 @@
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_ListBox.h>
 #include <MyGUI_InputManager.h>
+#include <MyGUI_LanguageManager.h>
 
 #include <osgDB/ReadFile>
 #include <osg/Texture2D>
@@ -168,9 +169,9 @@ namespace MWGui
                         className = "?"; // From an older savegame format that did not support custom classes properly.
                 }
 
-                title << " (Level " << it->getSignature().mPlayerLevel << " " << className << ")";
+                title << " (#{sLevel} " << it->getSignature().mPlayerLevel << " " << className << ")";
 
-                mCharacterSelection->addItem (title.str());
+                mCharacterSelection->addItem (MyGUI::LanguageManager::getInstance().replaceTags(title.str()));
 
                 if (mCurrentCharacter == &*it ||
                     (!mCurrentCharacter && !mSaving && directory==Misc::StringUtils::lowerCase (


### PR DESCRIPTION
Since ComboBox texts are not translated, we can translate text manually before adding it to ComboBox.