### PR TITLE
Improved hands bodyparts selection fallback

### DIFF
--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -90,6 +90,9 @@ private:
 
     osg::ref_ptr<NeckController> mFirstPersonNeckController;
 
+    static bool isFirstPersonPart(const ESM::BodyPart* bodypart);
+    static bool isFemalePart(const ESM::BodyPart* bodypart);
+
 protected:
     virtual void addControllers();
 


### PR DESCRIPTION
Fixes  [bug #2594](https://bugs.openmw.org/issues/2594).

If we can not found 1st-person hand bodypart for current gender, we should try fallbacks in this order:
1. Try to use 3d person skin for same gender
2. Try to use 1st person skin for opposite gender
3. Try to use 3d person skin for opposite gender

We already have similar logic for armor/clothing hands.

In current implementation we select only first bodypart that matchs **any** of these three conditions, even if better substitution will be found later in list.

UPDATE:
Females can use male bodyparts as fallback, but males can not use female bodyparts as fallback.
