### PR TITLE
Service menus layout fixes

### DIFF
--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -26,8 +26,6 @@ namespace MWGui
         , mLastPos(0)
         , mCurrentY(0)
     {
-        setCoord(0, 0, 450, 300);
-
         getWidget(mCancelButton, "CancelButton");
         getWidget(mPlayerGold, "PlayerGold");
         getWidget(mSpellsView, "SpellsView");
@@ -68,7 +66,7 @@ namespace MWGui
 
         toAdd->setUserData(price);
         toAdd->setCaptionWithReplacing(spell->mName+"   -   "+MyGUI::utility::toString(price)+"#{sgp}");
-        toAdd->setSize(toAdd->getTextSize().width,sLineHeight);
+        toAdd->setSize(mSpellsView->getWidth(),sLineHeight);
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &SpellBuyingWindow::onMouseWheel);
         toAdd->setUserString("ToolTipType", "Spell");
         toAdd->setUserString("Spell", spellId);

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -28,8 +28,6 @@ namespace MWGui
         WindowBase("openmw_travel_window.layout")
         , mCurrentY(0)
     {
-        setCoord(0, 0, 450, 300);
-
         getWidget(mCancelButton, "CancelButton");
         getWidget(mPlayerGold, "PlayerGold");
         getWidget(mSelect, "Select");

--- a/files/mygui/openmw_alchemy_window.layout
+++ b/files/mygui/openmw_alchemy_window.layout
@@ -6,12 +6,14 @@
 
         <!-- Name -->
 
-        <Widget type="TextBox" skin="SandText" position="10 10 65 24">
+        <Widget type="TextBox" skin="SandText" position="10 8 65 30">
             <Property key="Caption" value="#{sName}"/>
             <Property key="TextAlign" value="Left"/>
         </Widget>
 
-        <Widget type="EditBox" skin="MW_TextEdit" position="70 10 492 24" align="Top Left HStretch" name="NameEdit"/>
+        <Widget type="EditBox" skin="MW_TextEdit" position="70 8 492 30" align="Top Left HStretch" name="NameEdit">
+            <Property key="MaxTextLength" value="31"/>
+        </Widget>
 
 
         <!-- Apparatus -->

--- a/files/mygui/openmw_enchanting_dialog.layout
+++ b/files/mygui/openmw_enchanting_dialog.layout
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 560 400" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 560 448" align="Center" name="_Main">
 
-        <Widget type="HBox" position="12 12 250 30">
+        <Widget type="HBox" position="12 9 273 30">
+            <Property key="Spacing" value="8"/>
 
             <Widget type="AutoSizedTextBox" skin="NormalText">
                 <Property key="Caption" value="#{sName}"/>
@@ -14,6 +15,7 @@
 
             <Widget type="EditBox" skin="MW_TextEdit" position="0 0 30 30" name="NameEdit">
                 <UserString key="HStretch" value="true"/>
+                <Property key="MaxTextLength" value="31"/>
             </Widget>
 
             <Widget type="Widget">
@@ -23,7 +25,7 @@
 
         <!-- Item -->
 
-        <Widget type="HBox" position="12 48 400 59">
+        <Widget type="HBox" position="12 48 265 59">
             <Property key="Spacing" value="8"/>
 
             <Widget type="AutoSizedTextBox" skin="NormalText">
@@ -35,7 +37,9 @@
             <Widget type="ItemWidget" skin="MW_ItemIconBox" position="0 0 50 50" name="ItemBox">
             </Widget>
 
-            <Widget type="Widget" position="0 0 8 0"/>
+            <Widget type="Widget" position="0 0 8 0">
+                <UserString key="HStretch" value="true"/>
+            </Widget>
 
             <Widget type="AutoSizedTextBox" skin="NormalText">
                 <Property key="Caption" value="#{sSoulGem}"/>
@@ -49,7 +53,7 @@
         </Widget>
 
         <!-- Values -->
-        <Widget type="VBox" position="320 8 222 72">
+        <Widget type="VBox" position="320 7 222 72">
             <Widget type="HBox">
                 <UserString key="HStretch" value="true"/>
                 <Widget type="AutoSizedTextBox" skin="NormalText">
@@ -95,29 +99,29 @@
         </Widget>
 
         <!-- Available effects -->
-        <Widget type="TextBox" skin="NormalText" position="12 108 300 24">
+        <Widget type="TextBox" skin="NormalText" position="12 109 300 24">
             <Property key="Caption" value="#{sMagicEffects}"/>
             <UserString key="ToolTipType" value="Layout"/>
             <UserString key="ToolTipLayout" value="TextToolTip"/>
             <UserString key="Caption_Text" value="#{sEnchantmentHelp9}"/>
         </Widget>
-        <Widget type="MWList" skin="MW_SimpleList" position="12 136 202 209" name="AvailableEffects">
+        <Widget type="MWList" skin="MW_SimpleList" position="12 136 202 269" name="AvailableEffects">
         </Widget>
 
         <!-- Used effects -->
-        <Widget type="TextBox" skin="NormalText" position="226 108 300 24">
+        <Widget type="TextBox" skin="NormalText" position="226 109 300 24">
             <Property key="Caption" value="#{sEffects}"/>
             <UserString key="ToolTipType" value="Layout"/>
             <UserString key="ToolTipLayout" value="TextToolTip"/>
             <UserString key="Caption_Text" value="#{sEnchantmentHelp10}"/>
         </Widget>
-        <Widget type="Widget" skin="MW_Box" position="226 136 316 209">
-            <Widget type="ScrollView" skin="MW_ScrollViewH" position="4 4 308 201" name="UsedEffects">
+        <Widget type="Widget" skin="MW_Box" position="226 136 316 269">
+            <Widget type="ScrollView" skin="MW_ScrollViewH" position="4 4 308 261" name="UsedEffects">
                 <Property key="CanvasAlign" value="Left Top"/>
             </Widget>
         </Widget>
 
-        <Widget type="HBox" position="0 340 558 60">
+        <Widget type="HBox" position="0 392 558 60">
             <Property key="Padding" value="16"/>
 
             <Widget type="AutoSizedButton" skin="MW_Button" name="TypeButton">

--- a/files/mygui/openmw_merchantrepair.layout
+++ b/files/mygui/openmw_merchantrepair.layout
@@ -4,25 +4,25 @@
     <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 418 248" align="Center" name="_Main">
         <Property key="Visible" value="false"/>
 
-        <Widget type="TextBox" skin="SandText" position="8 18 418 24" align="Right Top">
+        <Widget type="TextBox" skin="SandText" position="8 24 418 24" align="Right Top">
             <Property key="TextAlign" value="Left"/>
             <Property key="Caption" value="#{sRepairServiceTitle}"/>
         </Widget>
-        <Widget type="TextBox" skin="NormalText" position="0 0 418 24" align="Right Top">
+        <Widget type="TextBox" skin="NormalText" position="0 3 418 24" align="Right Top">
             <Property key="TextAlign" value="Center"/>
             <Property key="Caption" value="#{sServiceRepairTitle}"/>
         </Widget>
 
         <Widget type="Widget" skin="MW_Box" position="10 46 389 156" align="Left Stretch">
-            <Widget type="ScrollView" skin="MW_ScrollView" position="4 4 381 147" align="Left Top Stretch" name="RepairView">
+            <Widget type="ScrollView" skin="MW_ScrollView" position="4 4 381 145" align="Left Top Stretch" name="RepairView">
                 <Property key="CanvasAlign" value="Left"/>
             </Widget>
         </Widget>
 
-        <Widget type="TextBox" skin="SandText" position="10 206 300 24" name="PlayerGold" align="Right Top">
+        <Widget type="TextBox" skin="SandText" position="10 208 300 24" name="PlayerGold" align="Right Top">
             <Property key="TextAlign" value="Left"/>
         </Widget>
-        <Widget type="AutoSizedButton" skin="MW_Button" position="343 210 56 24" name="OkButton" align="Right Top">
+        <Widget type="AutoSizedButton" skin="MW_Button" position="343 209 56 24" name="OkButton" align="Right Top">
             <Property key="ExpandDirection" value="Left"/>
             <Property key="Caption" value="#{sOK}"/>
         </Widget>

--- a/files/mygui/openmw_scroll.skin.xml
+++ b/files/mygui/openmw_scroll.skin.xml
@@ -4,12 +4,12 @@
 
     <Resource type="ResourceSkin" name="MW_ScrollView" size="516 516">
         <Child type="Widget" skin="" offset="0 0 502 516" align="Stretch" name="Client"/>
-        <Child type="MWScrollBar" skin="MW_VScroll" offset="498 3 14 509" align="Right Top VStretch" name="VScroll"/>
+        <Child type="MWScrollBar" skin="MW_VScroll" offset="498 3 14 513" align="Right Top VStretch" name="VScroll"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_ScrollViewH" size="516 516">
         <Child type="Widget" skin="" offset="0 0 516 502" align="Stretch" name="Client"/>
-        <Child type="MWScrollBar" skin="MW_HScroll" offset="3 498 509 14" align="Left Bottom HStretch" name="HScroll"/>
+        <Child type="MWScrollBar" skin="MW_HScroll" offset="3 498 513 14" align="Left Bottom HStretch" name="HScroll"/>
     </Resource>
 
 </MyGUI>

--- a/files/mygui/openmw_spell_buying_window.layout
+++ b/files/mygui/openmw_spell_buying_window.layout
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 450 306" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 450 288" align="Center" name="_Main">
         <Property key="Visible" value="false"/>
 
-        <Widget type="TextBox" skin="SandText" position="8 10 450 18" align="Right Top">
+        <Widget type="TextBox" skin="SandText" position="8 24 450 18" align="Right Top">
             <Property key="TextAlign" value="Left"/>
             <Property key="Caption" value="#{sSpellServiceTitle}"/>
         </Widget>
-        <Widget type="TextBox" skin="NormalText" position="0 0 450 18" align="Right Top">
+        <Widget type="TextBox" skin="NormalText" position="0 4 434 18" align="Center Top">
             <Property key="TextAlign" value="Center"/>
             <Property key="Caption" value="#{sServiceSpellsTitle}"/>
         </Widget>
 
-        <Widget type="Widget" skin="MW_Box" position="6 31 430 225" align="Left Stretch">
-            <Widget type="ScrollView" skin="MW_ScrollView" position="4 4 422 217" align="Left Top Stretch" name="SpellsView">
+        <Widget type="Widget" skin="MW_Box" position="6 41 429 204" align="Left Stretch">
+            <Widget type="ScrollView" skin="MW_ScrollView" position="2 2 427 198" align="Left Top Stretch" name="SpellsView">
                 <Property key="CanvasAlign" value="Left"/>
             </Widget>
         </Widget>
 
-        <Widget type="TextBox" skin="SandText" position="8 255 24 24" name="PlayerGold" align="Right Top">
+        <Widget type="TextBox" skin="SandText" position="8 250 24 24" name="PlayerGold" align="Right Top">
             <Property key="TextAlign" value="Right"/>
         </Widget>
-        <Widget type="AutoSizedButton" skin="MW_Button" position="375 260 60 24" name="CancelButton" align="Right Top">
+        <Widget type="AutoSizedButton" skin="MW_Button" position="375 251 60 24" name="CancelButton" align="Right Top">
             <Property key="ExpandDirection" value="Left"/>
             <Property key="Caption" value="#{sOK}"/>
         </Widget>

--- a/files/mygui/openmw_spellcreation_dialog.layout
+++ b/files/mygui/openmw_spellcreation_dialog.layout
@@ -13,6 +13,7 @@
 
             <Widget type="EditBox" skin="MW_TextEdit" position="0 0 30 30" name="NameEdit">
                 <UserString key="HStretch" value="true"/>
+                <Property key="MaxTextLength" value="31"/>
             </Widget>
 
             <Widget type="Widget"/>

--- a/files/mygui/openmw_travel_window.layout
+++ b/files/mygui/openmw_travel_window.layout
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 450 304" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 500 250" align="Center" name="_Main">
         <Property key="Visible" value="false"/>
 
-        <Widget type="TextBox" skin="SandText" position="8 10 24 24" name="Select" align="Right Top">
+        <Widget type="TextBox" skin="SandText" position="8 22 24 24" name="Select" align="Right Top">
             <Property key="TextAlign" value="Right"/>
             <Property key="Caption" value="#{sTravelServiceTitle}"/>
         </Widget>
-        <Widget type="TextBox" skin="SandText" position="0 0 24 24" name="Travel" align="Right Top">
-            <Property key="TextAlign" value="Right"/>
-            <Property key="Caption" value="#D8C09A#{sServiceTravelTitle}"/>
+        <Widget type="TextBox" skin="NormalText" position="0 4 484 24" name="Travel" align="Center Top">
+            <Property key="TextAlign" value="Center"/>
+            <Property key="Caption" value="#{sServiceTravelTitle}"/>
         </Widget>
 
 
-        <Widget type="Widget" skin="MW_Box" position="6 31 430 225" align="Left Stretch">
-            <Widget type="ScrollView" skin="MW_ScrollView" position="4 4 422 217" align="Left Top Stretch" name="DestinationsView">
+        <Widget type="Widget" skin="MW_Box" position="6 42 480 165" align="Left Stretch">
+            <Widget type="ScrollView" skin="MW_ScrollView" position="4 4 472 160" align="Left Top Stretch" name="DestinationsView">
                 <Property key="CanvasAlign" value="Left"/>
             </Widget>
         </Widget>
 
-        <Widget type="TextBox" skin="SandText" position="8 255 24 24" name="PlayerGold" align="Right Top">
+        <Widget type="TextBox" skin="SandText" position="6 211 24 24" name="PlayerGold" align="Right Top">
             <Property key="TextAlign" value="Right"/>
         </Widget>
-        <Widget type="AutoSizedButton" skin="MW_Button" position="375 261 60 24" name="CancelButton" align="Right Top">
+        <Widget type="AutoSizedButton" skin="MW_Button" position="425 212 60 24" name="CancelButton" align="Right Top">
             <Property key="ExpandDirection" value="Left"/>
             <Property key="Caption" value="#{sCancel}"/>
         </Widget>


### PR DESCRIPTION
Fixed layout of service menus to looks line vanilla ones.
Windows affected:
1) Alchemy
2) Enchanting
3) Travelling
4) Spell buying
5) Spell creation
6) Merchant repair

Note:
Maximal text input length in these fields is capped by 31 symbols now, as in Morrowind (see [bug #3831](https://bugs.openmw.org/issues/3831)). I will revert it, if we do not need this feature.