### PR TITLE
Use osgDB::ifstream and osgDB::ofstream

### DIFF
--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -292,7 +292,7 @@ bool CS::Editor::makeIPCServer()
         mPid /= "openmw-cs.pid";
         bool pidExists = boost::filesystem::exists(mPid);
 
-        mPidFile.open(mPid);
+        mPidFile.open(mPid.string().c_str());
 
         mLock = boost::interprocess::file_lock(mPid.string().c_str());
         if(!mLock.try_lock())

--- a/apps/opencs/editor.hpp
+++ b/apps/opencs/editor.hpp
@@ -4,7 +4,8 @@
 #include <memory>
 
 #include <boost/interprocess/sync/file_lock.hpp>
-#include <boost/filesystem/fstream.hpp>
+
+#include <osgDB/fstream>
 
 #include <QObject>
 #include <QString>
@@ -61,7 +62,7 @@ namespace CS
             boost::filesystem::path mResources;
             boost::filesystem::path mPid;
             boost::interprocess::file_lock mLock;
-            boost::filesystem::ofstream mPidFile;
+            osgDB::ofstream mPidFile;
             bool mFsStrict;
             CSVTools::Merge mMerge;
 

--- a/apps/opencs/model/doc/document.cpp
+++ b/apps/opencs/model/doc/document.cpp
@@ -1,8 +1,9 @@
 #include "document.hpp"
 
 #include <cassert>
-#include <fstream>
 #include <iostream>
+
+#include <osgDB/fstream>
 
 #include <boost/filesystem.hpp>
 
@@ -291,15 +292,15 @@ CSMDoc::Document::Document (const VFS::Manager* vfs, const Files::ConfigurationM
         boost::filesystem::path customFiltersPath (configuration.getUserDataPath());
         customFiltersPath /= "defaultfilters";
 
-        std::ofstream destination (mProjectPath.string().c_str(), std::ios::binary);
+        osgDB::ofstream destination (mProjectPath.string().c_str(), std::ios::binary);
 
         if (boost::filesystem::exists (customFiltersPath))
         {
-            destination << std::ifstream(customFiltersPath.string().c_str(), std::ios::binary).rdbuf();
+            destination << osgDB::ifstream(customFiltersPath.string().c_str(), std::ios::binary).rdbuf();
         }
         else
         {
-            destination << std::ifstream(std::string(mResDir.string() + "/defaultfilters").c_str(), std::ios::binary).rdbuf();
+            destination << osgDB::ifstream(std::string(mResDir.string() + "/defaultfilters").c_str(), std::ios::binary).rdbuf();
         }
     }
 

--- a/apps/opencs/model/doc/savingstages.cpp
+++ b/apps/opencs/model/doc/savingstages.cpp
@@ -1,7 +1,5 @@
 #include "savingstages.hpp"
 
-#include <fstream>
-
 #include <boost/filesystem.hpp>
 
 #include <QUndoStack>
@@ -30,7 +28,7 @@ void CSMDoc::OpenSaveStage::perform (int stage, Messages& messages)
     mState.start (mDocument, mProjectFile);
 
     mState.getStream().open (
-        mProjectFile ? mState.getPath() : mState.getTmpPath(),
+        mProjectFile ? mState.getPath().string().c_str() : mState.getTmpPath().string().c_str(),
         std::ios::binary);
 
     if (!mState.getStream().is_open())

--- a/apps/opencs/model/doc/savingstate.cpp
+++ b/apps/opencs/model/doc/savingstate.cpp
@@ -48,7 +48,7 @@ const boost::filesystem::path& CSMDoc::SavingState::getTmpPath() const
     return mTmpPath;
 }
 
-boost::filesystem::ofstream& CSMDoc::SavingState::getStream()
+osgDB::ofstream& CSMDoc::SavingState::getStream()
 {
     return mStream;
 }

--- a/apps/opencs/model/doc/savingstate.hpp
+++ b/apps/opencs/model/doc/savingstate.hpp
@@ -5,8 +5,9 @@
 #include <map>
 #include <deque>
 
+#include <osgDB/fstream>
+
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <components/esm/esmwriter.hpp>
 
@@ -23,7 +24,7 @@ namespace CSMDoc
             boost::filesystem::path mPath;
             boost::filesystem::path mTmpPath;
             ToUTF8::Utf8Encoder mEncoder;
-            boost::filesystem::ofstream mStream;
+            osgDB::ofstream mStream;
             ESM::ESMWriter mWriter;
             boost::filesystem::path mProjectPath;
             bool mProjectFile;
@@ -43,7 +44,7 @@ namespace CSMDoc
 
             const boost::filesystem::path& getTmpPath() const;
 
-            boost::filesystem::ofstream& getStream();
+            osgDB::ofstream& getStream();
 
             ESM::ESMWriter& getWriter();
 

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -3,8 +3,6 @@
 #include <stdexcept>
 #include <iomanip>
 
-#include <boost/filesystem/fstream.hpp>
-
 #include <osgViewer/ViewerEventHandlers>
 #include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
@@ -417,9 +415,9 @@ void OMW::Engine::createWindow(Settings::Manager& settings)
 
 void OMW::Engine::setWindowIcon()
 {
-    boost::filesystem::ifstream windowIconStream;
+    osgDB::ifstream windowIconStream;
     std::string windowIcon = (mResDir / "mygui" / "openmw.png").string();
-    windowIconStream.open(windowIcon, std::ios_base::in | std::ios_base::binary);
+    windowIconStream.open(windowIcon.c_str(), std::ios_base::in | std::ios_base::binary);
     if (windowIconStream.fail())
         std::cerr << "Error: Failed to open " << windowIcon << std::endl;
     osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension("png");
@@ -598,8 +596,8 @@ public:
 
         } while (boost::filesystem::exists(stream.str()));
 
-        boost::filesystem::ofstream outStream;
-        outStream.open(boost::filesystem::path(stream.str()), std::ios::binary);
+        osgDB::ofstream outStream;
+        outStream.open(boost::filesystem::path(stream.str()).string().c_str(), std::ios::binary);
 
         osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension(mScreenshotFormat);
         if (!readerwriter)

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -10,9 +10,10 @@
 #include <SDL_main.h>
 #include "engine.hpp"
 
+#include <osgDB/fstream>
+
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream_buffer.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #if defined(_WIN32)
 // For OutputDebugString
@@ -308,7 +309,7 @@ int main(int argc, char**argv)
     std::ostream oldcout(cout_rdbuf);
     std::ostream oldcerr(cerr_rdbuf);
 
-    boost::filesystem::ofstream logfile;
+    osgDB::ofstream logfile;
 
     std::auto_ptr<OMW::Engine> engine;
 
@@ -325,7 +326,7 @@ int main(int argc, char**argv)
         std::cerr.rdbuf (&sb);
 #else
         // Redirect cout and cerr to openmw.log
-        logfile.open (boost::filesystem::path(cfgMgr.getLogPath() / "/openmw.log"));
+        logfile.open (boost::filesystem::path(cfgMgr.getLogPath() / "/openmw.log").string().c_str());
 
         coutsb.open (Tee(logfile, oldcout));
         cerrsb.open (Tee(logfile, oldcerr));

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -2,8 +2,9 @@
 
 #include <MyGUI_EditBox.h>
 
+#include <osgDB/fstream>
+
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <components/compiler/exception.hpp>
 #include <components/compiler/extensions0.hpp>
@@ -214,7 +215,7 @@ namespace MWGui
     void Console::executeFile (const std::string& path)
     {
         namespace bfs = boost::filesystem;
-        bfs::ifstream stream ((bfs::path(path)));
+        osgDB::ifstream stream((bfs::path(path).string().c_str()));
 
         if (!stream.is_open())
             printError ("failed to open file: " + path);

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -16,7 +16,6 @@
 #include <osgDB/ReadFile>
 
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <osgUtil/IncrementalCompileOperation>
 #include <osgUtil/CullVisitor>
@@ -194,8 +193,8 @@ public:
 osg::ref_ptr<osg::Image> readPngImage (const std::string& file)
 {
     // use boost in favor of osgDB::readImage, to handle utf-8 path issues on Windows
-    boost::filesystem::ifstream inStream;
-    inStream.open(file, std::ios_base::in | std::ios_base::binary);
+    osgDB::ifstream inStream;
+    inStream.open(file.c_str(), std::ios_base::in | std::ios_base::binary);
     if (inStream.fail())
         std::cerr << "Error: Failed to open " << file << std::endl;
     osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension("png");

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -15,7 +15,6 @@
 
 #include <osgDB/Registry>
 
-#include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include "../mwbase/environment.hpp"
@@ -284,7 +283,7 @@ void MWState::StateManager::saveGame (const std::string& description, const Slot
             throw std::runtime_error("Write operation failed (memory stream)");
 
         // All good, write to file
-        boost::filesystem::ofstream filestream (slot->mPath, std::ios::binary);
+        osgDB::ofstream filestream (slot->mPath.string().c_str(), std::ios::binary);
         filestream << stream.rdbuf();
 
         if (filestream.fail())

--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -25,8 +25,9 @@
 
 #include <stdexcept>
 
+#include <osgDB/fstream>
+
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 using namespace std;
 using namespace Bsa;
@@ -74,7 +75,7 @@ void BSAFile::readHeader()
     assert(!isLoaded);
 
     namespace bfs = boost::filesystem;
-    bfs::ifstream input(bfs::path(filename), std::ios_base::binary);
+    osgDB::ifstream input(bfs::path(filename).string().c_str(), std::ios_base::binary);
 
     // Total archive size
     std::streamoff fsize = 0;

--- a/components/esm/esmwriter.cpp
+++ b/components/esm/esmwriter.cpp
@@ -1,7 +1,7 @@
 #include "esmwriter.hpp"
 
 #include <cassert>
-#include <fstream>
+#include <ostream>
 #include <stdexcept>
 
 #include <components/to_utf8/to_utf8.hpp>

--- a/components/files/androidpath.cpp
+++ b/components/files/androidpath.cpp
@@ -7,7 +7,6 @@
 #include <pwd.h>
 #include "androidpath.h"
 #include <unistd.h>
-#include <boost/filesystem/fstream.hpp>
 
 
 class Buffer {

--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -7,10 +7,11 @@
 
 #include <components/files/escape.hpp>
 
+#include <osgDB/fstream>
+
 #include <boost/bind.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
 /**
@@ -144,7 +145,7 @@ bool ConfigurationManager::loadConfig(const boost::filesystem::path& path,
         if (!mSilent)
             std::cout << "Loading config file: " << cfgFile.string() << "... ";
 
-        boost::filesystem::ifstream configFileStreamUnfiltered(cfgFile);
+        osgDB::ifstream configFileStreamUnfiltered(cfgFile.string().c_str());
         boost::iostreams::filtering_istream configFileStream;
         configFileStream.push(escape_hash_filter());
         configFileStream.push(configFileStreamUnfiltered);

--- a/components/files/linuxpath.cpp
+++ b/components/files/linuxpath.cpp
@@ -6,7 +6,8 @@
 #include <cstring>
 #include <pwd.h>
 #include <unistd.h>
-#include <boost/filesystem/fstream.hpp>
+
+#include <osgDB/fstream>
 
 #include <components/misc/stringops.hpp>
 
@@ -99,7 +100,7 @@ boost::filesystem::path LinuxPath::getInstallPath() const
 
         if (boost::filesystem::is_regular_file(wineDefaultRegistry))
         {
-            boost::filesystem::ifstream file(wineDefaultRegistry);
+            osgDB::ifstream file(wineDefaultRegistry.string().c_str());
             bool isRegEntry = false;
             std::string line;
             std::string mwpath;

--- a/components/files/macospath.cpp
+++ b/components/files/macospath.cpp
@@ -5,7 +5,8 @@
 #include <cstdlib>
 #include <pwd.h>
 #include <unistd.h>
-#include <boost/filesystem/fstream.hpp>
+
+#include <osgDB/fstream>
 
 #include <components/misc/stringops.hpp>
 
@@ -90,7 +91,7 @@ boost::filesystem::path MacOsPath::getInstallPath() const
 
         if (boost::filesystem::is_regular_file(wineDefaultRegistry))
         {
-            boost::filesystem::ifstream file(wineDefaultRegistry);
+            osgDB::ifstream file(wineDefaultRegistry.string().c_str());
             bool isRegEntry = false;
             std::string line;
             std::string mwpath;

--- a/components/myguiplatform/myguidatamanager.cpp
+++ b/components/myguiplatform/myguidatamanager.cpp
@@ -2,8 +2,9 @@
 
 #include <MyGUI_DataFileStream.h>
 
+#include <osgDB/fstream>
+
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <iostream>
 
@@ -18,9 +19,9 @@ void DataManager::setResourcePath(const std::string &path)
 MyGUI::IDataStream *DataManager::getData(const std::string &name)
 {
     std::string fullpath = getDataPath(name);
-    std::auto_ptr<boost::filesystem::ifstream> stream;
-    stream.reset(new boost::filesystem::ifstream);
-    stream->open(fullpath, std::ios::binary);
+    std::auto_ptr<osgDB::ifstream> stream;
+    stream.reset(new osgDB::ifstream);
+    stream->open(fullpath.c_str(), std::ios::binary);
     if (stream->fail())
     {
         std::cerr << "DataManager::getData: Failed to open '" << name << "'" << std::endl;

--- a/components/myguiplatform/myguiloglistener.cpp
+++ b/components/myguiplatform/myguiloglistener.cpp
@@ -9,7 +9,7 @@ namespace osgMyGUI
 {
     void CustomLogListener::open()
     {
-        mStream.open(boost::filesystem::path(mFileName), std::ios_base::out);
+        mStream.open(boost::filesystem::path(mFileName).string().c_str(), std::ios_base::out);
     }
 
     void CustomLogListener::close()

--- a/components/myguiplatform/myguiloglistener.hpp
+++ b/components/myguiplatform/myguiloglistener.hpp
@@ -2,7 +2,9 @@
 #define OPENMW_COMPONENTS_MYGUIPLATFORM_LOGLISTENER_H
 
 #include <string>
-#include <boost/filesystem/fstream.hpp>
+#include <string.h>
+
+#include <osgDB/fstream>
 
 #include <MyGUI_ILogListener.h>
 #include <MyGUI_LogSource.h>
@@ -33,7 +35,7 @@ namespace osgMyGUI
         const std::string& getFileName() const { return mFileName; }
 
     private:
-        boost::filesystem::ofstream mStream;
+        osgDB::ofstream mStream;
         std::string mFileName;
     };
 

--- a/components/sceneutil/writescene.cpp
+++ b/components/sceneutil/writescene.cpp
@@ -4,8 +4,6 @@
 
 #include <osgDB/Registry>
 
-#include <boost/filesystem/fstream.hpp>
-
 #include "serialize.hpp"
 
 void SceneUtil::writeScene(osg::Node *node, const std::string& filename, const std::string& format)
@@ -16,8 +14,8 @@ void SceneUtil::writeScene(osg::Node *node, const std::string& filename, const s
     if (!rw)
         throw std::runtime_error("can not find readerwriter for " + format);
 
-    boost::filesystem::ofstream stream;
-    stream.open(filename);
+    osgDB::ofstream stream;
+    stream.open(filename.c_str());
 
     osg::ref_ptr<osgDB::Options> options = new osgDB::Options;
     options->setPluginStringData("fileType", format);

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -6,7 +6,8 @@
 
 #include <components/misc/stringops.hpp>
 
-#include <boost/filesystem/fstream.hpp>
+#include <osgDB/fstream>
+
 #include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -69,8 +70,8 @@ public:
     void loadSettingsFile (const std::string& file, CategorySettingValueMap& settings)
     {
         mFile = file;
-        boost::filesystem::ifstream stream;
-        stream.open(boost::filesystem::path(file));
+        osgDB::ifstream stream;
+        stream.open(boost::filesystem::path(file).string().c_str());
         std::cout << "Loading settings file: " << file << std::endl;
         std::string currentCategory;
         mLine = 0;
@@ -140,9 +141,9 @@ public:
         // Open the existing settings.cfg file to copy comments.  This might not be the same file
         // as the output file if we're copying the setting from the default settings.cfg for the
         // first time.  A minor change in API to pass the source file might be in order here.
-        boost::filesystem::ifstream istream;
+        osgDB::ifstream istream;
         boost::filesystem::path ipath(file);
-        istream.open(ipath);
+        istream.open(ipath.string().c_str());
 
         // Create a new string stream to write the current settings to.  It's likely that the
         // input file and the output file are the same, so this stream serves as a temporary file
@@ -322,8 +323,8 @@ public:
         // Now install the newly written file in the requested place.
         if (changed) {
             std::cout << "Updating settings file: " << ipath << std::endl;
-            boost::filesystem::ofstream ofstream;
-            ofstream.open(ipath);
+            osgDB::ofstream ofstream;
+            ofstream.open(ipath.string().c_str());
             ofstream << ostream.rdbuf();
             ofstream.close();
         }

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -1,14 +1,14 @@
 #include "shadermanager.hpp"
 
-#include <fstream>
 #include <iostream>
 #include <algorithm>
 
 #include <osg/Program>
 
+#include <osgDB/fstream>
+
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <OpenThreads/ScopedLock>
@@ -44,8 +44,8 @@ namespace Shader
             }
             std::string includeFilename = source.substr(start+1, end-(start+1));
             boost::filesystem::path includePath = shaderPath / includeFilename;
-            boost::filesystem::ifstream includeFstream;
-            includeFstream.open(includePath);
+            osgDB::ifstream includeFstream;
+            includeFstream.open(includePath.string().c_str());
             if (includeFstream.fail())
             {
                 std::cerr << "Failed to open " << includePath.string() << std::endl;
@@ -110,8 +110,8 @@ namespace Shader
         if (templateIt == mShaderTemplates.end())
         {
             boost::filesystem::path p = (boost::filesystem::path(mPath) / shaderTemplate);
-            boost::filesystem::ifstream stream;
-            stream.open(p);
+            osgDB::ifstream stream;
+            stream.open(p.string().c_str());
             if (stream.fail())
             {
                 std::cerr << "Failed to open " << p.string() << std::endl;

--- a/components/translation/translation.cpp
+++ b/components/translation/translation.cpp
@@ -1,6 +1,6 @@
 #include "translation.hpp"
 
-#include <boost/filesystem/fstream.hpp>
+#include <osgDB/fstream>
 
 #include <components/misc/stringops.hpp>
 
@@ -34,8 +34,8 @@ namespace Translation
 
         if (dataFileCollections.getCollection (extension).doesExist (fileName))
         {
-            boost::filesystem::ifstream stream (
-                dataFileCollections.getCollection (extension).getPath (fileName));
+            osgDB::ifstream stream(
+                dataFileCollections.getCollection(extension).getPath(fileName).string().c_str());
 
             if (!stream.is_open())
                 throw std::runtime_error ("failed to open translation file: " + fileName);

--- a/components/version/version.cpp
+++ b/components/version/version.cpp
@@ -1,7 +1,8 @@
 #include "version.hpp"
 
+#include <osgDB/fstream>
+
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 namespace Version
 {
@@ -10,7 +11,7 @@ Version getOpenmwVersion(const std::string &resourcePath)
 {
     boost::filesystem::path path (resourcePath + "/version");
 
-    boost::filesystem::ifstream stream (path);
+    osgDB::ifstream stream (path.string().c_str());
 
     Version v;
     std::getline(stream, v.mVersion);


### PR DESCRIPTION
Replacing all usage of std::ifstream or std::ofstream, or boost::filesystem::ifstream or boost::filesystem::ofstream with the osgDB equivalents gets rid of all LNK4006 warnings in MSVC builds, which are about ignoring second definitions of already defined symbols.

The game and saving and loading, etc. seems to work in both OpenMW and OpenMW-CS.