### PR TITLE
OpenMW-CS: Add block commenting/uncommenting action in script editor (Feature #3274)

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -326,6 +326,10 @@ void CSMPrefs::State::declare()
     declareShortcut ("orbit-roll-right", "Roll Right", QKeySequence(Qt::Key_E));
     declareShortcut ("orbit-speed-mode", "Toggle Speed Mode", QKeySequence(Qt::Key_F));
     declareShortcut ("orbit-center-selection", "Center On Selected", QKeySequence(Qt::Key_C));
+
+    declareSubcategory ("Script Editor");
+    declareShortcut ("script-editor-comment", "Comment Selection", QKeySequence());
+    declareShortcut ("script-editor-uncomment", "Uncomment Selection", QKeySequence());
 }
 
 void CSMPrefs::State::declareCategory (const std::string& key)

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -7,6 +7,7 @@
 #include <QString>
 #include <QPainter>
 #include <QTextDocumentFragment>
+#include <QMenu>
 
 #include "../../model/doc/document.hpp"
 
@@ -284,12 +285,32 @@ void CSVWorld::ScriptEdit::updateLineNumberArea(const QRect &rect, int dy)
         updateLineNumberAreaWidth(0);
 }
 
+void CSVWorld::ScriptEdit::commentSelection()
+{
+
+}
+
+void CSVWorld::ScriptEdit::uncommentSelection()
+{
+
+}
+
 void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)
 {
     QPlainTextEdit::resizeEvent(e);
 
     QRect cr = contentsRect();
     mLineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberAreaWidth(), cr.height()));
+}
+
+void CSVWorld::ScriptEdit::contextMenuEvent(QContextMenuEvent *event)
+{
+    QMenu *menu = createStandardContextMenu();
+    menu->addAction("Comment Selection", this, SLOT(commentSelection()));
+    menu->addAction("Uncomment Selection", this, SLOT(uncommentSelection()));
+
+    menu->exec(event->globalPos());
+    delete menu;
 }
 
 void CSVWorld::ScriptEdit::lineNumberAreaPaintEvent(QPaintEvent *event)

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -88,19 +88,15 @@ CSVWorld::ScriptEdit::ScriptEdit(
                   <<CSMWorld::UniversalId::Type_Script
                   <<CSMWorld::UniversalId::Type_Region;
 
-    mContextMenu = createStandardContextMenu();
+    mCommentAction = new QAction (tr ("Comment Selection"), this);
+    connect(mCommentAction, SIGNAL (triggered()), this, SLOT (commentSelection()));
+    CSMPrefs::Shortcut *commentShortcut = new CSMPrefs::Shortcut("script-editor-comment", this);
+    commentShortcut->associateAction(mCommentAction);
 
-    QAction* comment = new QAction (tr ("Comment Selection"), this);
-    connect(comment, SIGNAL (triggered()), this, SLOT (commentSelection()));
-    CSMPrefs::Shortcut* commentShortcut = new CSMPrefs::Shortcut("script-editor-comment", this);
-    commentShortcut->associateAction(comment);
-    mContextMenu->addAction(comment);
-
-    QAction* uncomment = new QAction (tr ("Uncomment Selection"), this);
-    connect(uncomment, SIGNAL (triggered()), this, SLOT (uncommentSelection()));
-    CSMPrefs::Shortcut* uncommentShortcut = new CSMPrefs::Shortcut("script-editor-uncomment", this);
-    uncommentShortcut->associateAction(uncomment);
-    mContextMenu->addAction(uncomment);
+    mUncommentAction = new QAction (tr ("Uncomment Selection"), this);
+    connect(mUncommentAction, SIGNAL (triggered()), this, SLOT (uncommentSelection()));
+    CSMPrefs::Shortcut *uncommentShortcut = new CSMPrefs::Shortcut("script-editor-uncomment", this);
+    uncommentShortcut->associateAction(mUncommentAction);
 
     mHighlighter = new ScriptHighlighter (document.getData(), mode, ScriptEdit::document());
 
@@ -361,7 +357,12 @@ void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)
 
 void CSVWorld::ScriptEdit::contextMenuEvent(QContextMenuEvent *event)
 {
-    mContextMenu->exec(event->globalPos());
+    QMenu *menu = createStandardContextMenu();
+    menu->addAction(mCommentAction);
+    menu->addAction(mUncommentAction);
+
+    menu->exec(event->globalPos());
+    delete menu;
 }
 
 void CSVWorld::ScriptEdit::lineNumberAreaPaintEvent(QPaintEvent *event)

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -14,6 +14,7 @@
 #include "../../model/world/universalid.hpp"
 #include "../../model/world/tablemimedata.hpp"
 #include "../../model/prefs/state.hpp"
+#include "../../model/prefs/shortcut.hpp"
 
 CSVWorld::ScriptEdit::ChangeLock::ChangeLock (ScriptEdit& edit) : mEdit (edit)
 {
@@ -86,6 +87,20 @@ CSVWorld::ScriptEdit::ScriptEdit(
                   <<CSMWorld::UniversalId::Type_Weapon
                   <<CSMWorld::UniversalId::Type_Script
                   <<CSMWorld::UniversalId::Type_Region;
+
+    mContextMenu = createStandardContextMenu();
+
+    QAction* comment = new QAction (tr ("Comment Selection"), this);
+    connect(comment, SIGNAL (triggered()), this, SLOT (commentSelection()));
+    CSMPrefs::Shortcut* commentShortcut = new CSMPrefs::Shortcut("script-editor-comment", this);
+    commentShortcut->associateAction(comment);
+    mContextMenu->addAction(comment);
+
+    QAction* uncomment = new QAction (tr ("Uncomment Selection"), this);
+    connect(uncomment, SIGNAL (triggered()), this, SLOT (uncommentSelection()));
+    CSMPrefs::Shortcut* uncommentShortcut = new CSMPrefs::Shortcut("script-editor-uncomment", this);
+    uncommentShortcut->associateAction(uncomment);
+    mContextMenu->addAction(uncomment);
 
     mHighlighter = new ScriptHighlighter (document.getData(), mode, ScriptEdit::document());
 
@@ -295,7 +310,7 @@ void CSVWorld::ScriptEdit::commentSelection()
     end.setPosition(end.selectionEnd());
     end.movePosition(QTextCursor::EndOfLine);
 
-    for (; begin < end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down))
+    for (; begin < end; begin.movePosition(QTextCursor::EndOfLine), begin.movePosition(QTextCursor::Right))
     {
         begin.insertText(";");
     }
@@ -311,7 +326,7 @@ void CSVWorld::ScriptEdit::uncommentSelection()
     end.setPosition(end.selectionEnd());
     end.movePosition(QTextCursor::EndOfLine);
 
-    for (; begin < end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down)) {
+    for (; begin < end; begin.movePosition(QTextCursor::EndOfLine), begin.movePosition(QTextCursor::Right)) {
         begin.select(QTextCursor::LineUnderCursor);
         QString line = begin.selectedText();
 
@@ -346,12 +361,7 @@ void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)
 
 void CSVWorld::ScriptEdit::contextMenuEvent(QContextMenuEvent *event)
 {
-    QMenu *menu = createStandardContextMenu();
-    menu->addAction("Comment Selection", this, SLOT(commentSelection()));
-    menu->addAction("Uncomment Selection", this, SLOT(uncommentSelection()));
-
-    menu->exec(event->globalPos());
-    delete menu;
+    mContextMenu->exec(event->globalPos());
 }
 
 void CSVWorld::ScriptEdit::lineNumberAreaPaintEvent(QPaintEvent *event)

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -306,10 +306,14 @@ void CSVWorld::ScriptEdit::commentSelection()
     end.setPosition(end.selectionEnd());
     end.movePosition(QTextCursor::EndOfLine);
 
+    begin.beginEditBlock();
+
     for (; begin < end; begin.movePosition(QTextCursor::EndOfLine), begin.movePosition(QTextCursor::Right))
     {
         begin.insertText(";");
     }
+
+    begin.endEditBlock();
 }
 
 void CSVWorld::ScriptEdit::uncommentSelection()
@@ -321,6 +325,8 @@ void CSVWorld::ScriptEdit::uncommentSelection()
 
     end.setPosition(end.selectionEnd());
     end.movePosition(QTextCursor::EndOfLine);
+
+    begin.beginEditBlock();
 
     for (; begin < end; begin.movePosition(QTextCursor::EndOfLine), begin.movePosition(QTextCursor::Right)) {
         begin.select(QTextCursor::LineUnderCursor);
@@ -345,6 +351,8 @@ void CSVWorld::ScriptEdit::uncommentSelection()
             begin.insertText(line);
         }
     }
+
+    begin.endEditBlock();
 }
 
 void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)
@@ -358,6 +366,16 @@ void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)
 void CSVWorld::ScriptEdit::contextMenuEvent(QContextMenuEvent *event)
 {
     QMenu *menu = createStandardContextMenu();
+
+    // remove redo/undo since they are disabled
+    QList<QAction*> menuActions = menu->actions();
+    for (QList<QAction*>::iterator i = menuActions.begin(); i < menuActions.end(); ++i)
+    {
+        if ((*i)->text().contains("Undo") || (*i)->text().contains("Redo"))
+        {
+            (*i)->setVisible(false);
+        }
+    }
     menu->addAction(mCommentAction);
     menu->addAction(mUncommentAction);
 

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -293,9 +293,9 @@ void CSVWorld::ScriptEdit::commentSelection()
     begin.movePosition(QTextCursor::StartOfLine);
 
     end.setPosition(end.selectionEnd());
-    end.movePosition(QTextCursor::StartOfLine);
+    end.movePosition(QTextCursor::EndOfLine);
 
-    for (; begin <= end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down))
+    for (; begin < end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down))
     {
         begin.insertText(";");
     }
@@ -309,12 +309,14 @@ void CSVWorld::ScriptEdit::uncommentSelection()
     begin.movePosition(QTextCursor::StartOfLine);
 
     end.setPosition(end.selectionEnd());
-    end.movePosition(QTextCursor::StartOfLine);
+    end.movePosition(QTextCursor::EndOfLine);
 
-    for (; begin <= end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down)) {
-        // loop through line until a nonspace character is reached
+    for (; begin < end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down)) {
         begin.select(QTextCursor::LineUnderCursor);
         QString line = begin.selectedText();
+
+        if (line.size() == 0)
+            continue;
 
         // get first nonspace character in line
         int index;
@@ -326,10 +328,11 @@ void CSVWorld::ScriptEdit::uncommentSelection()
 
         if (index != line.size() && line[index] == ';')
         {
+            // remove the semicolon
             line.remove(index, 1);
+            // put the line back
+            begin.insertText(line);
         }
-
-        begin.insertText(line);
     }
 }
 

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -287,12 +287,50 @@ void CSVWorld::ScriptEdit::updateLineNumberArea(const QRect &rect, int dy)
 
 void CSVWorld::ScriptEdit::commentSelection()
 {
+    QTextCursor begin = textCursor();
+    QTextCursor end = begin;
+    begin.setPosition(begin.selectionStart());
+    begin.movePosition(QTextCursor::StartOfLine);
 
+    end.setPosition(end.selectionEnd());
+    end.movePosition(QTextCursor::StartOfLine);
+
+    for (; begin <= end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down))
+    {
+        begin.insertText(";");
+    }
 }
 
 void CSVWorld::ScriptEdit::uncommentSelection()
 {
+    QTextCursor begin = textCursor();
+    QTextCursor end = begin;
+    begin.setPosition(begin.selectionStart());
+    begin.movePosition(QTextCursor::StartOfLine);
 
+    end.setPosition(end.selectionEnd());
+    end.movePosition(QTextCursor::StartOfLine);
+
+    for (; begin <= end; begin.movePosition(QTextCursor::StartOfLine), begin.movePosition(QTextCursor::Down)) {
+        // loop through line until a nonspace character is reached
+        begin.select(QTextCursor::LineUnderCursor);
+        QString line = begin.selectedText();
+
+        // get first nonspace character in line
+        int index;
+        for (index = 0; index != line.size(); ++index)
+        {
+            if (!line[index].isSpace())
+                break;
+        }
+
+        if (index != line.size() && line[index] == ';')
+        {
+            line.remove(index, 1);
+        }
+
+        begin.insertText(line);
+    }
 }
 
 void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -6,6 +6,7 @@
 #include <QVector>
 #include <QTimer>
 #include <QFont>
+#include <QAction>
 
 #include "../../model/world/universalid.hpp"
 
@@ -54,7 +55,8 @@ namespace CSVWorld
             QFont mDefaultFont;
             QFont mMonoFont;
             int mTabCharCount;
-            QMenu *mContextMenu;
+            QAction *mCommentAction;
+            QAction *mUncommentAction;
 
         protected:
 

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -54,6 +54,7 @@ namespace CSVWorld
             QFont mDefaultFont;
             QFont mMonoFont;
             int mTabCharCount;
+            QMenu *mContextMenu;
 
         protected:
 

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -77,6 +77,8 @@ namespace CSVWorld
 
             virtual void resizeEvent(QResizeEvent *e);
 
+            virtual void contextMenuEvent(QContextMenuEvent *event);
+
         private:
 
             QVector<CSMWorld::UniversalId::Type> mAllowedTypes;
@@ -111,6 +113,10 @@ namespace CSVWorld
             void updateLineNumberAreaWidth(int newBlockCount);
 
             void updateLineNumberArea(const QRect &, int);
+
+            void commentSelection();
+
+            void uncommentSelection();
     };
 
     class LineNumberArea : public QWidget


### PR DESCRIPTION
https://bugs.openmw.org/issues/3274
Adds a context menu option to block comment/uncomment code in the script editor. Also adds a keyboard shortcut which can be changed in the "Key Bindings" section of the preferences panel. I'm not sure if it should be given its own category, but it doesn't seem to fit in any of the others. There's probably also a better way to add the menu item/shortcut.