### PR TITLE
Fixed count widget buttons alignment

### DIFF
--- a/files/mygui/openmw_count_window.layout
+++ b/files/mygui/openmw_count_window.layout
@@ -16,13 +16,15 @@
             <Property key="Page" value="1"/>
             <Property key="WheelPage" value="1"/>
         </Widget>
-        <Widget type="HBox" skin="" position="0 91 140 24" align="Center Bottom">
-            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 53 24" align="Center Top" name="OkButton">
+        <Widget type="HBox" skin="" position="0 91 592 24" align="Center Bottom HStretch">
+            <Widget type="Spacer" />
+            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 53 24" align="Left Top" name="OkButton">
                 <Property key="Caption" value="#{sOk}"/>
             </Widget>
-            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 86 24" align="Center Top" name="CancelButton">
+            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 86 24" align="Right Top" name="CancelButton">
                 <Property key="Caption" value="#{sCancel}"/>
             </Widget>
+            <Widget type="Spacer" />
         </Widget>
     </Widget>
     <CodeGeneratorSettings/>


### PR DESCRIPTION
Fixes regression in [PR #1246](https://github.com/OpenMW/openmw/pull/1246) (see last 4 comments).

Since we calculate widget width in the code, I had to calculate buttons position in code too.
@scrawl, this PR was created by your request.