### PR TITLE
OpenMW-CS: Highlight occurrences when cursor is placed over a name (Feature #2509)

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -152,6 +152,7 @@ void CSMPrefs::State::declare()
         setRange (0, 10000);
     declareInt ("error-height", "Initial height of the error panel", 100).
         setRange (100, 10000);
+    declareBool ("highlight-occurrences", "Highlight other occurrences of selected names", true);
     declareSeparator();
     declareColour ("colour-int", "Highlight Colour: Integer Literals", QColor ("darkmagenta"));
     declareColour ("colour-float", "Highlight Colour: Float Literals", QColor ("magenta"));

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -156,6 +156,7 @@ void CSMPrefs::State::declare()
     declareColour ("colour-int", "Highlight Colour: Integer Literals", QColor ("darkmagenta"));
     declareColour ("colour-float", "Highlight Colour: Float Literals", QColor ("magenta"));
     declareColour ("colour-name", "Highlight Colour: Names", QColor ("grey"));
+    declareColour ("colour-highlight", "Highlight Colour: Highlighting", QColor("palegreen"));
     declareColour ("colour-keyword", "Highlight Colour: Keywords", QColor ("red"));
     declareColour ("colour-special", "Highlight Colour: Special Characters", QColor ("darkorange"));
     declareColour ("colour-comment", "Highlight Colour: Comments", QColor ("green"));

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -49,6 +49,7 @@ CSVWorld::ScriptEdit::ScriptEdit(
     mDefaultFont(font()),
     mMonoFont(QFont("Monospace")),
     mTabCharCount(4),
+    mMarkOccurrences(true),
     mMarkOccurrencesRunning(false),
     mDocument(document),
     mWhiteListQoutes("^[a-z|_]{1}[a-z|0-9|_]{0,}$", Qt::CaseInsensitive)
@@ -233,6 +234,13 @@ void CSVWorld::ScriptEdit::settingChanged(const CSMPrefs::Setting *setting)
         mTabCharCount = setting->toInt();
         setTabWidth();
     }
+    else if (*setting == "Scripts/highlight-occurrences")
+    {
+        mMarkOccurrences = setting->isTrue();
+        mHighlighter->setMarkedWord("");
+        updateHighlighting();
+        mHighlighter->setMarkOccurrences(mMarkOccurrences);
+    }
 }
 
 void CSVWorld::ScriptEdit::idListChanged()
@@ -295,16 +303,19 @@ void CSVWorld::ScriptEdit::markOccurrences()
     if (mMarkOccurrencesRunning)
         return;
 
-    mMarkOccurrencesRunning = true;
+    if (mMarkOccurrences)
+    {
+        mMarkOccurrencesRunning = true;
 
-    QTextCursor cursor = textCursor();
-    cursor.select(QTextCursor::WordUnderCursor);
-    QString word = cursor.selectedText();
+        QTextCursor cursor = textCursor();
+        cursor.select(QTextCursor::WordUnderCursor);
+        QString word = cursor.selectedText();
 
-    mHighlighter->setMarkedWord(word.toStdString());
-    mHighlighter->rehighlight();
+        mHighlighter->setMarkedWord(word.toStdString());
+        mHighlighter->rehighlight();
 
-    mMarkOccurrencesRunning = false;
+        mMarkOccurrencesRunning = false;
+    }
 }
 
 void CSVWorld::ScriptEdit::resizeEvent(QResizeEvent *e)

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -54,6 +54,7 @@ namespace CSVWorld
             QFont mDefaultFont;
             QFont mMonoFont;
             int mTabCharCount;
+            bool mMarkOccurrences;
             bool mMarkOccurrencesRunning;
 
         protected:

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -54,6 +54,7 @@ namespace CSVWorld
             QFont mDefaultFont;
             QFont mMonoFont;
             int mTabCharCount;
+            bool mMarkOccurrencesRunning;
 
         protected:
 
@@ -111,6 +112,8 @@ namespace CSVWorld
             void updateLineNumberAreaWidth(int newBlockCount);
 
             void updateLineNumberArea(const QRect &, int);
+
+            void markOccurrences();
     };
 
     class LineNumberArea : public QWidget

--- a/apps/opencs/view/world/scriptedit.hpp
+++ b/apps/opencs/view/world/scriptedit.hpp
@@ -56,7 +56,6 @@ namespace CSVWorld
             QFont mMonoFont;
             int mTabCharCount;
             bool mMarkOccurrences;
-            bool mMarkOccurrencesRunning;
             QAction *mCommentAction;
             QAction *mUncommentAction;
 

--- a/apps/opencs/view/world/scripthighlighter.cpp
+++ b/apps/opencs/view/world/scripthighlighter.cpp
@@ -72,7 +72,11 @@ void CSVWorld::ScriptHighlighter::highlight (const Compiler::TokenLoc& loc, Type
     // compensate for bug in Compiler::Scanner (position of token is the character after the token)
     index -= length;
 
-    setFormat (index, length, mScheme[type]);
+    QTextCharFormat scheme = mScheme[type];
+    if (loc.mLiteral == mMarkedWord)
+        scheme.merge(mScheme[Type_Highlight]);
+
+    setFormat (index, length, scheme);
 }
 
 CSVWorld::ScriptHighlighter::ScriptHighlighter (const CSMWorld::Data& data, Mode mode,
@@ -105,6 +109,11 @@ void CSVWorld::ScriptHighlighter::highlightBlock (const QString& text)
     catch (...) {} // ignore syntax errors
 }
 
+void CSVWorld::ScriptHighlighter::setMarkedWord(const std::string& name)
+{
+    mMarkedWord = name;
+}
+
 void CSVWorld::ScriptHighlighter::invalidateIds()
 {
     mContext.invalidateIds();
@@ -117,7 +126,7 @@ bool CSVWorld::ScriptHighlighter::settingChanged (const CSMPrefs::Setting *setti
         static const char *const colours[Type_Id+2] =
         {
             "colour-int", "colour-float", "colour-name", "colour-keyword",
-            "colour-special", "colour-comment", "colour-id",
+            "colour-special", "colour-comment", "colour-highlight", "colour-id",
             0
         };
 
@@ -125,7 +134,10 @@ bool CSVWorld::ScriptHighlighter::settingChanged (const CSMPrefs::Setting *setti
             if (setting->getKey()==colours[i])
             {
                 QTextCharFormat format;
-                format.setForeground (setting->toColor());
+                if (i == Type_Highlight)
+                    format.setBackground (setting->toColor());
+                else
+                    format.setForeground (setting->toColor());
                 mScheme[static_cast<Type> (i)] = format;
                 return true;
             }

--- a/apps/opencs/view/world/scripthighlighter.cpp
+++ b/apps/opencs/view/world/scripthighlighter.cpp
@@ -73,7 +73,7 @@ void CSVWorld::ScriptHighlighter::highlight (const Compiler::TokenLoc& loc, Type
     index -= length;
 
     QTextCharFormat scheme = mScheme[type];
-    if (loc.mLiteral == mMarkedWord)
+    if (mMarkOccurrences && loc.mLiteral == mMarkedWord)
         scheme.merge(mScheme[Type_Highlight]);
 
     setFormat (index, length, scheme);
@@ -107,6 +107,11 @@ void CSVWorld::ScriptHighlighter::highlightBlock (const QString& text)
         scanner.scan (*this);
     }
     catch (...) {} // ignore syntax errors
+}
+
+void CSVWorld::ScriptHighlighter::setMarkOccurrences(bool flag)
+{
+    mMarkOccurrences = flag;
 }
 
 void CSVWorld::ScriptHighlighter::setMarkedWord(const std::string& name)

--- a/apps/opencs/view/world/scripthighlighter.cpp
+++ b/apps/opencs/view/world/scripthighlighter.cpp
@@ -73,7 +73,7 @@ void CSVWorld::ScriptHighlighter::highlight (const Compiler::TokenLoc& loc, Type
     index -= length;
 
     QTextCharFormat scheme = mScheme[type];
-    if (mMarkOccurrences && loc.mLiteral == mMarkedWord)
+    if (mMarkOccurrences && type == Type_Name && loc.mLiteral == mMarkedWord)
         scheme.merge(mScheme[Type_Highlight]);
 
     setFormat (index, length, scheme);

--- a/apps/opencs/view/world/scripthighlighter.hpp
+++ b/apps/opencs/view/world/scripthighlighter.hpp
@@ -49,6 +49,7 @@ namespace CSVWorld
             CSMWorld::ScriptContext mContext;
             std::map<Type, QTextCharFormat> mScheme;
             Mode mMode;
+            bool mMarkOccurrences;
             std::string mMarkedWord;
 
         private:
@@ -93,6 +94,8 @@ namespace CSVWorld
             ScriptHighlighter (const CSMWorld::Data& data, Mode mode, QTextDocument *parent);
 
             virtual void highlightBlock (const QString& text);
+
+            void setMarkOccurrences(bool);
 
             void setMarkedWord(const std::string& name);
 

--- a/apps/opencs/view/world/scripthighlighter.hpp
+++ b/apps/opencs/view/world/scripthighlighter.hpp
@@ -2,6 +2,7 @@
 #define CSV_WORLD_SCRIPTHIGHLIGHTER_H
 
 #include <map>
+#include <string>
 
 #include <QSyntaxHighlighter>
 
@@ -30,7 +31,8 @@ namespace CSVWorld
                 Type_Keyword = 3,
                 Type_Special = 4,
                 Type_Comment = 5,
-                Type_Id = 6
+                Type_Highlight = 6,
+                Type_Id = 7
             };
 
             enum Mode
@@ -47,6 +49,7 @@ namespace CSVWorld
             CSMWorld::ScriptContext mContext;
             std::map<Type, QTextCharFormat> mScheme;
             Mode mMode;
+            std::string mMarkedWord;
 
         private:
 
@@ -90,6 +93,8 @@ namespace CSVWorld
             ScriptHighlighter (const CSMWorld::Data& data, Mode mode, QTextDocument *parent);
 
             virtual void highlightBlock (const QString& text);
+
+            void setMarkedWord(const std::string& name);
 
             void invalidateIds();
 


### PR DESCRIPTION
https://bugs.openmw.org/issues/2509
Adds a setting to the script editor to enable highlighting other occurrences of a selected name. Currently it highlights all types of tokens, but it could be modified to highlight only variables. I had to use a flag in ScriptEdit::markOccurrences() to ensure it is only running once for each ScriptEdit instance, because otherwise QTextCursor::select() sends the changeHighlighting signal and it ends up being called recursively. I could have used a different signal to fix this, such as cursorPositionChanged, but that would probably impact performance more.
I also had to do some rebasing after I accidentally pushed the previous pull request from master branch, so I hope everything's still OK for a merge.