### PR TITLE
Make InventoryStore::purgeEffect() purge all effects with argument ID instead only first 

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -938,7 +938,6 @@ void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sou
                     mMagicEffects.add (*effectIt, -magnitude);
 
                 params[i].mMultiplier = 0;
-                break;
             }
         }
     }


### PR DESCRIPTION
Just fixes  [bug #3839](https://bugs.openmw.org/issues/3839).