### PR TITLE
Don't make NPCs or player speak while underwater

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -633,6 +633,12 @@ namespace MWDialogue
             return;
         }
 
+        if (actor.getClass().isNpc() && MWBase::Environment::get().getWorld()->isSwimming(actor))
+        {
+            // NPCs don't talk while submerged
+            return;
+        }
+
         const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
         const ESM::Dialogue *dial = store.get<ESM::Dialogue>().find(topic);
 


### PR DESCRIPTION
Fixes https://bugs.openmw.org/issues/3851.

In the original engine, NPCs and the player actually won't speak when they are about waist-deep. I could have used isWading() for a knee-deep check, or created a new function for a waist-deep check, but I went for using isSwimming(). This seems to be enough to keep characters from talking while they're mouth is underwater, while still allowing them to talk when waist-deep.