### PR TITLE
OpenMW-CS: Highlight each variable name in a unique colour (Feature #2508)

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -152,6 +152,7 @@ void CSMPrefs::State::declare()
         setRange (0, 10000);
     declareInt ("error-height", "Initial height of the error panel", 100).
         setRange (100, 10000);
+    declareBool ("unique-name-colour", "Highlight each variable name in a unique colour", false);
     declareSeparator();
     declareColour ("colour-int", "Highlight Colour: Integer Literals", QColor ("darkmagenta"));
     declareColour ("colour-float", "Highlight Colour: Float Literals", QColor ("magenta"));

--- a/apps/opencs/view/world/scripthighlighter.cpp
+++ b/apps/opencs/view/world/scripthighlighter.cpp
@@ -3,7 +3,7 @@
 #include <sstream>
 #include <limits>
 
-#include <boost/functional/hash.hpp>
+#include <QString>
 
 #include <components/compiler/scanner.hpp>
 #include <components/compiler/extensions0.hpp>
@@ -88,11 +88,9 @@ void CSVWorld::ScriptHighlighter::highlight (const Compiler::TokenLoc& loc, Type
 
 QColor CSVWorld::ScriptHighlighter::hashedHighlightColour(const std::string& name)
 {
-    boost::hash<std::string> hash;
-
     // need to scale hash value into range [0, 359]
-    return QColor::fromHsl(static_cast<double>(hash(name))
-                           / std::numeric_limits<size_t>::max() * 359,
+    return QColor::fromHsl(static_cast<double>(qHash(QString::fromStdString(name)))
+                           / std::numeric_limits<unsigned>::max() * 359,
                            255, 240);
 }
 

--- a/apps/opencs/view/world/scripthighlighter.cpp
+++ b/apps/opencs/view/world/scripthighlighter.cpp
@@ -1,6 +1,9 @@
 #include "scripthighlighter.hpp"
 
 #include <sstream>
+#include <limits>
+
+#include <boost/functional/hash.hpp>
 
 #include <components/compiler/scanner.hpp>
 #include <components/compiler/extensions0.hpp>
@@ -72,13 +75,31 @@ void CSVWorld::ScriptHighlighter::highlight (const Compiler::TokenLoc& loc, Type
     // compensate for bug in Compiler::Scanner (position of token is the character after the token)
     index -= length;
 
-    setFormat (index, length, mScheme[type]);
+    QTextCharFormat scheme = mScheme[type];
+    if (mUniqueNameColour && type == Type_Name)
+    {
+        QTextCharFormat format;
+        format.setBackground(hashedHighlightColour(loc.mLiteral));
+        scheme.merge(format);
+    }
+
+    setFormat (index, length, scheme);
+}
+
+QColor CSVWorld::ScriptHighlighter::hashedHighlightColour(const std::string& name)
+{
+    boost::hash<std::string> hash;
+
+    // need to scale hash value into range [0, 359]
+    return QColor::fromHsl(static_cast<double>(hash(name))
+                           / std::numeric_limits<size_t>::max() * 359,
+                           255, 240);
 }
 
 CSVWorld::ScriptHighlighter::ScriptHighlighter (const CSMWorld::Data& data, Mode mode,
     QTextDocument *parent)
 : QSyntaxHighlighter (parent), Compiler::Parser (mErrorHandler, mContext), mContext (data),
-  mMode (mode)
+  mMode (mode), mUniqueNameColor (false)
 {
     QColor color ("black");
     QTextCharFormat format;
@@ -114,6 +135,12 @@ bool CSVWorld::ScriptHighlighter::settingChanged (const CSMPrefs::Setting *setti
 {
     if (setting->getParent()->getKey()=="Scripts")
     {
+        if (setting->getKey() == "unique-name-colour")
+        {
+            mUniqueNameColour = setting->isTrue();
+            return true;
+        }
+
         static const char *const colours[Type_Id+2] =
         {
             "colour-int", "colour-float", "colour-name", "colour-keyword",

--- a/apps/opencs/view/world/scripthighlighter.cpp
+++ b/apps/opencs/view/world/scripthighlighter.cpp
@@ -99,7 +99,7 @@ QColor CSVWorld::ScriptHighlighter::hashedHighlightColour(const std::string& nam
 CSVWorld::ScriptHighlighter::ScriptHighlighter (const CSMWorld::Data& data, Mode mode,
     QTextDocument *parent)
 : QSyntaxHighlighter (parent), Compiler::Parser (mErrorHandler, mContext), mContext (data),
-  mMode (mode), mUniqueNameColor (false)
+  mMode (mode), mUniqueNameColour (false)
 {
     QColor color ("black");
     QTextCharFormat format;

--- a/apps/opencs/view/world/scripthighlighter.hpp
+++ b/apps/opencs/view/world/scripthighlighter.hpp
@@ -2,8 +2,10 @@
 #define CSV_WORLD_SCRIPTHIGHLIGHTER_H
 
 #include <map>
+#include <string>
 
 #include <QSyntaxHighlighter>
+#include <QColor>
 
 #include <components/compiler/nullerrorhandler.hpp>
 #include <components/compiler/parser.hpp>
@@ -47,6 +49,7 @@ namespace CSVWorld
             CSMWorld::ScriptContext mContext;
             std::map<Type, QTextCharFormat> mScheme;
             Mode mMode;
+            bool mUniqueNameColour;
 
         private:
 
@@ -84,6 +87,8 @@ namespace CSVWorld
             ///< Handle EOF token.
 
             void highlight (const Compiler::TokenLoc& loc, Type type);
+
+            static QColor hashedHighlightColour(const std::string&);
 
         public:
 


### PR DESCRIPTION
https://bugs.openmw.org/issues/2508
Adds a setting in the preferences menu to highlight each different variable name in a unique colour. The colours generated seem to work well but could be easily tweaked if improvements were needed.
(By the way, what is the convention for spelling "colour" in OpenMW? I've seen both "color" and "colour" used, but "colour" seems more common.)