### PR TITLE
Prevent respawned references from being added to the scene twice

### DIFF
--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -38,6 +38,8 @@ Objects::~Objects()
 
 void Objects::insertBegin(const MWWorld::Ptr& ptr)
 {
+    assert(mObjects.find(ptr) == mObjects.end());
+
     osg::ref_ptr<osg::Group> cellnode;
 
     CellMap::iterator found = mCellSceneNodes.find(ptr.getCell());
@@ -90,9 +92,8 @@ void Objects::insertCreature(const MWWorld::Ptr &ptr, const std::string &mesh, b
     else
         anim = new CreatureAnimation(ptr, mesh, mResourceSystem);
 
-    ptr.getClass().getContainerStore(ptr).setContListener(static_cast<ActorAnimation*>(anim.get()));
-
-    mObjects.insert(std::make_pair(ptr, anim));
+    if (mObjects.insert(std::make_pair(ptr, anim)).second)
+        ptr.getClass().getContainerStore(ptr).setContListener(static_cast<ActorAnimation*>(anim.get()));
 }
 
 void Objects::insertNPC(const MWWorld::Ptr &ptr)
@@ -102,10 +103,11 @@ void Objects::insertNPC(const MWWorld::Ptr &ptr)
 
     osg::ref_ptr<NpcAnimation> anim (new NpcAnimation(ptr, osg::ref_ptr<osg::Group>(ptr.getRefData().getBaseNode()), mResourceSystem));
 
-    ptr.getClass().getInventoryStore(ptr).setInvListener(anim.get(), ptr);
-    ptr.getClass().getInventoryStore(ptr).setContListener(anim.get());
-
-    mObjects.insert(std::make_pair(ptr, anim));
+    if (mObjects.insert(std::make_pair(ptr, anim)).second)
+    {
+        ptr.getClass().getInventoryStore(ptr).setInvListener(anim.get(), ptr);
+        ptr.getClass().getInventoryStore(ptr).setContListener(anim.get());
+    }
 }
 
 bool Objects::removeObject (const MWWorld::Ptr& ptr)

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -54,6 +54,12 @@ namespace
     void addObject(const MWWorld::Ptr& ptr, MWPhysics::PhysicsSystem& physics,
                    MWRender::RenderingManager& rendering)
     {
+        if (ptr.getRefData().getBaseNode() || physics.getActor(ptr))
+        {
+            std::cerr << "Warning: Tried to add " << ptr.getCellRef().getRefId() << " to the scene twice" << std::endl;
+            return;
+        }
+
         bool useAnim = ptr.getClass().useAnim();
         std::string model = ptr.getClass().getModel(ptr);
         if (useAnim)


### PR DESCRIPTION
Fixes: https://bugs.openmw.org/issues/3864

Reproduction steps:
- Suppose there is a respawnable guard in Gnaar Mok.
- Move him outside of his original cell to a faraway cell, relative to which the original cell is inactive, and kill him there.
- Unload the cell where the guard died (e.g. by entering some interior).
- Wait for the guard to respawn.
- COC to Gnaar Mok to load the original cell.

What happens afterwards is that the guard is added to the scene twice - once by the respawn routine (which calls `MWWorld::moveObject` - moving from an inactive cell to an active cell adds the guard to the scene), and then by `InsertVisitor`. Now if a reference is added to the scene twice, certain oddities may happen such as the crash described in the bug report:

```c++
void Objects::insertNPC(const MWWorld::Ptr &ptr)
{
    insertBegin(ptr);
    ptr.getRefData().getBaseNode()->setNodeMask(Mask_Actor);

    osg::ref_ptr<NpcAnimation> anim (new NpcAnimation(ptr, osg::ref_ptr<osg::Group>(ptr.getRefData().getBaseNode()), mResourceSystem));

    ptr.getClass().getInventoryStore(ptr).setInvListener(anim.get(), ptr);
    ptr.getClass().getInventoryStore(ptr).setContListener(anim.get());

    mObjects.insert(std::make_pair(ptr, anim));
}
```

If insertNPC is called the second time, `anim` is unref'd upon leaving the function scope, as `mObjects.insert` is no-op if the `ptr` key is already present. The listeners will then point to a deleted object.

