### PR TITLE
Swap enchant type when purge selected soulgem (bug #3878)

### DIFF
--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -273,7 +273,9 @@ namespace MWGui
         else
         {
             setSoulGem(MWWorld::Ptr());
+            mEnchanting.nextCastStyle();
             updateLabels();
+            updateEffectsView();
         }
     }
 


### PR DESCRIPTION
Just fixes bug [#3878](https://bugs.openmw.org/issues/3878).

Note: Morrowind also swaps enchant type every time when soulgem select dialog is opened, but I am not sure that we should replicate this case.