### PR TITLE
Abilities affecting attributes add to base value rather than modified value

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1733,6 +1733,7 @@ namespace MWMechanics
 
     void Actors::updateMagicEffects(const MWWorld::Ptr &ptr)
     {
+        ptr.getClass().getCreatureStats(ptr).updateAbilityAttributeState();
         adjustMagicEffects(ptr);
         calculateCreatureStatModifiers(ptr, 0.f);
         if (ptr.getClass().isNpc())

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -668,4 +668,40 @@ namespace MWMechanics
     {
         return mSummonGraveyard;
     }
+
+    void CreatureStats::updateAbilityAttributeState()
+    {
+        // Make abilities affect base attribute.
+        const std::map<Spells::SpellKey, int> abilities = mSpells.getAllAbilityAttributeStates();
+
+        for (std::map<Spells::SpellKey, int>::const_iterator iter = abilities.begin(); iter != abilities.end(); ++iter)
+        {
+            const ESM::Spell *spell = iter->first;
+
+            if (mSpells.getSpecificAbilityAttributeState(spell) == ESM::Spell::AAS_Unchanged)
+            {
+                for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != spell->mEffects.mList.end(); ++it)
+                {
+                    if (it->mAttribute == -1)
+                        continue; // Only care about attributes.
+
+                    // Birthsigns do not have ranges for attributes.
+                    setAttribute(it->mAttribute, getAttribute(it->mAttribute).getBase() + it->mMagnMax);
+                }
+                mSpells.setSpecificAbilityAttributeState(spell, ESM::Spell::AAS_Changed);
+            }
+            else if (mSpells.getSpecificAbilityAttributeState(spell) == ESM::Spell::AAS_Remove)
+            {
+                for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != spell->mEffects.mList.end(); ++it)
+                {
+                    if (it->mAttribute == -1)
+                        continue; // Only care about attributes.
+
+                    // Birthsigns do not have ranges for attributes.
+                    setAttribute(it->mAttribute, getAttribute(it->mAttribute).getBase() - it->mMagnMax);
+                }
+                mSpells.removeSpecificAbilityAttributeState(spell);
+            }
+        }
+    }
 }

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -88,6 +88,9 @@ namespace MWMechanics
         DrawState_ getDrawState() const;
         void setDrawState(DrawState_ state);
 
+        /// Update abilities that impact attributes. Needs to be called after clearing all spells.
+        void updateAbilityAttributeState();
+
         bool needToRecalcDynamicStats();
         void setNeedRecalcDynamicStats(bool val);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -80,6 +80,7 @@ namespace MWMechanics
         // reset
         creatureStats.setLevel(player->mNpdt52.mLevel);
         creatureStats.getSpells().clear();
+        creatureStats.updateAbilityAttributeState();
         creatureStats.modifyMagicEffects(MagicEffects());
 
         for (int i=0; i<27; ++i)
@@ -144,21 +145,7 @@ namespace MWMechanics
             for (std::vector<std::string>::const_iterator iter (sign->mPowers.mList.begin());
                 iter!=sign->mPowers.mList.end(); ++iter)
             {
-                const ESM::Spell *spell = creatureStats.getSpells().add (*iter);
-
-                // Make abilities that fortify attributes add to base value rather than modified value.
-                if (spell->mData.mType==ESM::Spell::ST_Ability)
-                {
-                    for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != spell->mEffects.mList.end(); ++it)
-                    {
-                        if (it->mAttribute == -1)
-                            continue; // Only care about attributes.
-
-                        // Birthsigns do not have ranges for attributes.
-                        creatureStats.setAttribute(it->mAttribute,
-                            creatureStats.getAttribute(it->mAttribute).getBase() + it->mMagnMax);
-                    }
-                }
+                creatureStats.getSpells().add (*iter);
             }
         }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -144,7 +144,21 @@ namespace MWMechanics
             for (std::vector<std::string>::const_iterator iter (sign->mPowers.mList.begin());
                 iter!=sign->mPowers.mList.end(); ++iter)
             {
-                creatureStats.getSpells().add (*iter);
+                const ESM::Spell *spell = creatureStats.getSpells().add (*iter);
+
+                // Make abilities that fortify attributes add to base value rather than modified value.
+                if (spell->mData.mType==ESM::Spell::ST_Ability)
+                {
+                    for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != spell->mEffects.mList.end(); ++it)
+                    {
+                        if (it->mAttribute == -1)
+                            continue; // Only care about attributes.
+
+                        // Birthsigns do not have ranges for attributes.
+                        creatureStats.setAttribute(it->mAttribute,
+                            creatureStats.getAttribute(it->mAttribute).getBase() + it->mMagnMax);
+                    }
+                }
             }
         }
 

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -58,7 +58,18 @@ namespace MWMechanics
                         random = iter->second.mEffectRands.at(i);
 
                     float magnitude = it->mMagnMin + (it->mMagnMax - it->mMagnMin) * random;
-                    mEffects.add (*it, magnitude);
+
+                    // Only blank out abilities that modify attributes.
+                    // Already added to base value.
+                    if (spell->mData.mType == ESM::Spell::ST_Ability && it->mAttribute != -1)
+                    {
+                        mEffects.add(*it, 0);
+                    }
+                    else
+                    {
+                        mEffects.add(*it, magnitude);
+                    }
+
                     mSourcedEffects[spell].add(MWMechanics::EffectKey(*it), magnitude);
 
                     ++i;
@@ -116,9 +127,11 @@ namespace MWMechanics
         }
     }
 
-    void Spells::add (const std::string& spellId)
+    const ESM::Spell* Spells::add (const std::string& spellId)
     {
-        add(getSpell(spellId));
+        const ESM::Spell* spell = getSpell(spellId);
+        add(spell);
+        return spell;
     }
 
     void Spells::remove (const std::string& spellId)

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -61,30 +61,12 @@ namespace MWMechanics
                     float magnitude = it->mMagnMin + (it->mMagnMax - it->mMagnMin) * random;
                     float sourcedMagnitude = magnitude;
 
-                    // Only blank out birthsign abilities that modify attributes.
-                    // Already added to base value.
-                    if (spell->mData.mType == ESM::Spell::ST_Ability && it->mAttribute != -1)
+                    // Blank out ability effects that modify attributes
+                    if ((spell->mData.mType == ESM::Spell::ST_Ability) && (getSpecificAbilityAttributeState(spell) != ESM::Spell::AAS_Null))
                     {
-                        // Birthsign
-                        const std::string &signId = MWBase::Environment::get().getWorld()->getPlayer().getBirthSign();
-                        
-                        if (!signId.empty())
-                        {
-                            const ESM::BirthSign *sign =
-                                MWBase::Environment::get().getWorld()->getStore().get<ESM::BirthSign>().find(signId);
-
-                            for (std::vector<std::string>::const_iterator iter(sign->mPowers.mList.begin());
-                                iter != sign->mPowers.mList.end(); ++iter)
-                            {
-                                if (spell == getSpell(*iter))
-                                {
-                                    magnitude = 0;
-                                    break;
-                                }
-                            }
-                        }
+                        magnitude = 0;
                     }
-
+                    
                     mEffects.add(*it, magnitude);
                     mSourcedEffects[spell].add(MWMechanics::EffectKey(*it), sourcedMagnitude);
 
@@ -136,6 +118,22 @@ namespace MWMechanics
                 mCorprusSpells[spell] = corprus;
             }
 
+            if (spell->mData.mType == ESM::Spell::ST_Ability)
+            {
+                std::map<SpellKey, int>::const_iterator it = mAbilityAttributeStates.find(spell);
+                if (it == mAbilityAttributeStates.end())
+                {
+                    for (unsigned int i = 0; i < spell->mEffects.mList.size(); ++i)
+                    {
+                        if (spell->mEffects.mList[i].mAttribute == -1)
+                            continue; // Only care about attributes.
+
+                        // Add to spells that can change base attributes if not already in map.
+                        mAbilityAttributeStates[spell] = ESM::Spell::AAS_Unchanged;
+                    }
+                }
+            }
+
             SpellParams params;
             params.mEffectRands = random;
             mSpells.insert (std::make_pair (spell, params));
@@ -143,11 +141,9 @@ namespace MWMechanics
         }
     }
 
-    const ESM::Spell* Spells::add (const std::string& spellId)
+    void Spells::add (const std::string& spellId)
     {
-        const ESM::Spell* spell = getSpell(spellId);
-        add(spell);
-        return spell;
+        add(getSpell(spellId));
     }
 
     void Spells::remove (const std::string& spellId)
@@ -156,6 +152,7 @@ namespace MWMechanics
         TContainer::iterator iter = mSpells.find (spell);
 
         std::map<SpellKey, CorprusStats>::iterator corprusIt = mCorprusSpells.find(spell);
+        std::map<SpellKey, int>::iterator attrIt = mAbilityAttributeStates.find(spell);
 
         // if it's corprus, remove negative and keep positive effects
         if (corprusIt != mCorprusSpells.end())
@@ -174,6 +171,20 @@ namespace MWMechanics
                 }
             }
             mCorprusSpells.erase(corprusIt);
+        }
+
+        if (attrIt != mAbilityAttributeStates.end())
+        {
+            if (getSpecificAbilityAttributeState(spell) == ESM::Spell::AAS_Changed)
+            {
+                // If an ability gets removed, allow caller to remove permanent benefits
+                setSpecificAbilityAttributeState(spell, ESM::Spell::AAS_Remove);
+            }
+            else if (getSpecificAbilityAttributeState(spell) != ESM::Spell::AAS_Remove)
+            {
+                // Unless it had no such benefits, then erase it
+                mAbilityAttributeStates.erase(attrIt);
+            }
         }
 
         if (iter!=mSpells.end())
@@ -197,6 +208,19 @@ namespace MWMechanics
 
     void Spells::clear()
     {
+        // Can not undo any attribute changes here, so caller must do so.
+        for (std::map<Spells::SpellKey, int>::iterator iter = mAbilityAttributeStates.begin(); iter != mAbilityAttributeStates.end(); ++iter)
+        {
+            if (iter->second == ESM::Spell::AAS_Changed)
+            {
+                iter->second = ESM::Spell::AAS_Remove;
+            }
+            else
+            {
+                mAbilityAttributeStates.erase(iter);
+            }
+        }
+
         mSpells.clear();
         mSpellsChanged = true;
     }
@@ -417,6 +441,40 @@ namespace MWMechanics
     void Spells::usePower(const ESM::Spell* spell)
     {
         mUsedPowers[spell] = MWBase::Environment::get().getWorld()->getTimeStamp();
+    }
+
+    int Spells::getSpecificAbilityAttributeState(const ESM::Spell* spell) const
+    {
+        std::map<SpellKey, int>::const_iterator it = mAbilityAttributeStates.find(spell);
+        if (it == mAbilityAttributeStates.end())
+        {
+            // Does not affect base attribute
+            return ESM::Spell::AAS_Null;
+        }
+        else
+        {
+            return it->second;
+        }
+    }
+
+    void Spells::setSpecificAbilityAttributeState(const ESM::Spell* spell, int state)
+    {
+        mAbilityAttributeStates[spell] = state;
+    }
+
+    void Spells::removeSpecificAbilityAttributeState(const ESM::Spell* spell)
+    {
+        std::map<SpellKey, int>::iterator attrIt = mAbilityAttributeStates.find(spell);
+
+        if (attrIt != mAbilityAttributeStates.end())
+        {
+            mAbilityAttributeStates.erase(attrIt);
+        }
+    }
+
+    const std::map<Spells::SpellKey, int>& Spells::getAllAbilityAttributeStates() const
+    {
+        return mAbilityAttributeStates;
     }
 
     void Spells::readState(const ESM::SpellState &state)

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -8,7 +8,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwworld/player.hpp"
 
 #include "../mwworld/esmstore.hpp"
 
@@ -66,7 +65,7 @@ namespace MWMechanics
                     {
                         magnitude = 0;
                     }
-                    
+
                     mEffects.add(*it, magnitude);
                     mSourcedEffects[spell].add(MWMechanics::EffectKey(*it), sourcedMagnitude);
 

--- a/apps/openmw/mwmechanics/spells.hpp
+++ b/apps/openmw/mwmechanics/spells.hpp
@@ -95,7 +95,7 @@ namespace MWMechanics
             bool hasSpell(const std::string& spell) const;
             bool hasSpell(const ESM::Spell* spell) const;
 
-            void add (const std::string& spell);
+            const ESM::Spell* add (const std::string& spell);
             ///< Adding a spell that is already listed in *this is a no-op.
 
             void add (const ESM::Spell* spell);

--- a/apps/openmw/mwmechanics/spells.hpp
+++ b/apps/openmw/mwmechanics/spells.hpp
@@ -62,6 +62,8 @@ namespace MWMechanics
 
             std::map<SpellKey, CorprusStats> mCorprusSpells;
 
+            std::map<SpellKey, int> mAbilityAttributeStates;
+
             mutable bool mSpellsChanged;
             mutable MagicEffects mEffects;
             mutable std::map<SpellKey, MagicEffects> mSourcedEffects;
@@ -83,6 +85,11 @@ namespace MWMechanics
             bool canUsePower (const ESM::Spell* spell) const;
             void usePower (const ESM::Spell* spell);
 
+            int getSpecificAbilityAttributeState(const ESM::Spell* spell) const;
+            void setSpecificAbilityAttributeState(const ESM::Spell* spell, int state);
+            void removeSpecificAbilityAttributeState(const ESM::Spell* spell);
+            const std::map<SpellKey, int>& getAllAbilityAttributeStates() const;
+
             void purgeCommonDisease();
             void purgeBlightDisease();
             void purgeCorprusDisease();
@@ -95,7 +102,7 @@ namespace MWMechanics
             bool hasSpell(const std::string& spell) const;
             bool hasSpell(const ESM::Spell* spell) const;
 
-            const ESM::Spell* add (const std::string& spell);
+            void add (const std::string& spell);
             ///< Adding a spell that is already listed in *this is a no-op.
 
             void add (const ESM::Spell* spell);

--- a/components/esm/loadspel.hpp
+++ b/components/esm/loadspel.hpp
@@ -34,6 +34,14 @@ struct Spell
         F_Always = 4 // Casting always succeeds
     };
 
+    enum AbilityAttributeState
+    {
+        AAS_Null = 0,      // Not an ability that affects attributes
+        AAS_Unchanged = 1, // Ability has not yet affected attributes
+        AAS_Changed = 2,   // Ability has affected attributes
+        AAS_Remove = 3       // Ability has been disabled, undo changes and remove
+    };
+
     struct SPDTstruct
     {
         int mType; // SpellType


### PR DESCRIPTION
- A link back to the bug report or forum discussion that prompted the change
  - [http://bugs.openmw.org/issues/1751](http://bugs.openmw.org/issues/1751).
- Summary of the changes made
  - Modified the birthsign part of the character creation code to add attribute fortification to the base value of the attribute rather than the modified value. Also changed Spells::rebuildEffects() to give a magnitude of 0 for abilities that modify attributes so that the ability isn't double counted.
- Reasoning / motivation behind the change
  - Original engine did not count birthsigns like The Lady and The Steed as normal fortify spells, but rather as an actual increase to the character's attributes. This change duplicates the original behavior. 
- What testing you have carried out to verify the change
  - Went through character creation and verified that The Lady and the Steed functioned as in the original engine - values are increased without being highlighted, and the fortify attribute effect still shows up in the effects list.
  - Did not check to see if this change interfered with effects from corprus, or anything else that might have been counted as an ability, rather than a spell.
