### PR TITLE
 MWWorld::Cells: make cache size configurable

### DIFF
--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -7,6 +7,7 @@
 #include <components/esm/defs.hpp>
 #include <components/esm/cellstate.hpp>
 #include <components/loadinglistener/loadinglistener.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -88,7 +89,7 @@ void MWWorld::Cells::writeCell (ESM::ESMWriter& writer, CellStore& cell) const
 
 MWWorld::Cells::Cells (const MWWorld::ESMStore& store, std::vector<ESM::ESMReader>& reader)
 : mStore (store), mReader (reader),
-  mIdCache (40, std::pair<std::string, CellStore *> ("", (CellStore*)0)), /// \todo make cache size configurable
+  mIdCache (Settings::Manager::getInt("pointers cache size", "Cells"), std::pair<std::string, CellStore *> ("", (CellStore*)0)),
   mIdCacheIndex (0)
 {}
 

--- a/docs/source/reference/modding/settings/cells.rst
+++ b/docs/source/reference/modding/settings/cells.rst
@@ -164,3 +164,12 @@ cache expiry delay
 
 The amount of time (in seconds) that a preloaded texture or object will stay in cache
 after it is no longer referenced or required, for example, when all cells containing this texture have been unloaded.
+
+pointers cache size
+------------------
+
+:Type:		integer
+:Range:		>0
+:Default:	40
+
+The count of object pointers, that will be saved for a faster search by object ID.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -76,6 +76,9 @@ preload cell expiry delay = 5
 # How long to keep models/textures/collision shapes in cache after they're no longer referenced/required (in seconds)
 cache expiry delay = 5
 
+# The count of pointers, that will be saved for a faster search by object ID.
+pointers cache size = 40
+
 [Terrain]
 
 # If true, use paging and LOD algorithms to display the entire terrain. If false, only display terrain of the loaded cells


### PR DESCRIPTION
This PR consists of two parts:
1) Makes mIdCache size in cells.cpp configurable (implements TODO from cells.cpp).
2) Makes World::searchPtr() check cache first when activeOnly = false.

In current OpenMW master searchPtr() first iterates through active cells (slow), only then checks cache and inactive cells.

This PR also allows to workaround [bug #3242](https://bugs.openmw.org/issues/3242) with
`pointers cache size = 400`

EDIT: second part was reverted.