### PR TITLE
Fix for merchants not overstocking

### DIFF
--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -580,7 +580,16 @@ void MWWorld::ContainerStore::restock (const ESM::InventoryList& items, const MW
             //Restocking static item - just restock to the max count
             int currentCount = count(itemOrList);
             if (currentCount < std::abs(it->mCount))
+            {
                 addInitialItem(itemOrList, owner, -(std::abs(it->mCount) - currentCount), true);
+            }
+            // Don't need to restock, but should update the amount to be restocked.
+            else if (currentCount > std::abs(it->mCount))
+            {
+                // Removing const here. Unavoidable without major reworks, but mCount was never itself declared const.
+                int& constRemovedCount = const_cast<int&>(it->mCount);
+                constRemovedCount = -currentCount;
+            }
         }
     }
     flagAsModified();


### PR DESCRIPTION
- A link back to the bug report or forum discussion that prompted the change
  - [https://bugs.openmw.org/issues/2473](https://bugs.openmw.org/issues/2473)
- Summary of the changes made
  - Reworked how MWWorld::ContainerStore::restock() functions. Overstocking merchants now mostly works like it does in vanilla.
  - Current issues.
    - Unsure if the code removed is doing something with containers that I did not notice - I did not know what to look for to verify one way or the other.
    - Some merchants still sell the same item in two stacks to begin with, rather than in one stack. Example: Nalcarya of White Haven sells 2 stacks of 3 diamonds, rather than 1 stack of 6 diamonds. (Only one is initially restockable.)
    - The wiki says that there should be an option for vanilla behavior and for current OpenMW behavior, but I don't know how to implement options like that. If there is something that I could look at, I can implement this as an option.
    - Comments in code are not finalized - some are leftover from the older code.
- Reasoning / motivation behind the change
  - Brings results of buying/selling closer to vanilla functionality. As an aside, all this should allow for is saving users from buying restockable items 5 at a time.
- What testing you have carried out to verify the change
  - Bought and sold items from Ajira and Nalcarya, while comparing the results to what happened in the vanilla engine.