### PR TITLE
Tooltips layout fixes

### DIFF
--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -183,7 +183,7 @@ namespace MWGui
         int modified = static_cast<int>(value.getModified());
 
         MyGUI::Widget* w;
-        std::string valStr = MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
+        std::string valStr = MyGUI::utility::toString(current) + " / " + MyGUI::utility::toString(modified);
         if (id == "HBar")
         {
             mHealth->setProgressRange(modified);

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -164,7 +164,7 @@ namespace MWGui
         int modified = static_cast<int>(value.getModified());
 
         mHealth->setValue(current, modified);
-        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
+        std::string valStr =  MyGUI::utility::toString(current) + " / " + MyGUI::utility::toString(modified);
         mHealth->setUserString("Caption_HealthDescription", "#{sHealthDesc}\n" + valStr);
     }
 
@@ -174,7 +174,7 @@ namespace MWGui
         int modified = static_cast<int>(value.getModified());
 
         mMagicka->setValue(current, modified);
-        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
+        std::string valStr =  MyGUI::utility::toString(current) + " / " + MyGUI::utility::toString(modified);
         mMagicka->setUserString("Caption_HealthDescription", "#{sMagDesc}\n" + valStr);
     }
 
@@ -184,7 +184,7 @@ namespace MWGui
         int modified = static_cast<int>(value.getModified());
 
         mFatigue->setValue(current, modified);
-        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
+        std::string valStr =  MyGUI::utility::toString(current) + " / " + MyGUI::utility::toString(modified);
         mFatigue->setUserString("Caption_HealthDescription", "#{sFatDesc}\n" + valStr);
     }
 

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -154,7 +154,7 @@ namespace MWGui
 
         // health, magicka, fatigue tooltip
         MyGUI::Widget* w;
-        std::string valStr =  MyGUI::utility::toString(current) + "/" + MyGUI::utility::toString(modified);
+        std::string valStr =  MyGUI::utility::toString(current) + " / " + MyGUI::utility::toString(modified);
         if (id == "HBar")
         {
             getWidget(w, "Health");

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -618,13 +618,13 @@ namespace MWGui
                         if (rankData.mSkill1 > 0)
                             text += "\n#{sNeedOneSkill} " + MyGUI::utility::toString(rankData.mSkill1);
                         if (rankData.mSkill2 > 0)
-                            text += "\n#{sNeedTwoSkills} " + MyGUI::utility::toString(rankData.mSkill2);
+                            text += " #{sand} #{sNeedTwoSkills} " + MyGUI::utility::toString(rankData.mSkill2);
                     }
                 }
 
                 w->setUserString("ToolTipType", "Layout");
-                w->setUserString("ToolTipLayout", "TextToolTip");
-                w->setUserString("Caption_Text", text);
+                w->setUserString("ToolTipLayout", "FactionToolTip");
+                w->setUserString("Caption_FactionText", text);
             }
         }
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -709,20 +709,28 @@ namespace MWGui
 
     void ToolTips::createSpecializationToolTip(MyGUI::Widget* widget, const std::string& name, int specId)
     {
-        widget->setUserString("Caption_CenteredCaption", name);
+        widget->setUserString("Caption_Caption", name);
         std::string specText;
         // get all skills of this specialisation
         const MWWorld::Store<ESM::Skill> &skills =
             MWBase::Environment::get().getWorld()->getStore().get<ESM::Skill>();
 
+        bool isFirst = true;
         MWWorld::Store<ESM::Skill>::iterator it = skills.begin();
         for (; it != skills.end(); ++it)
         {
             if (it->second.mData.mSpecialization == specId)
-                specText += std::string("\n#{") + ESM::Skill::sSkillNameIds[it->first] + "}";
+            {
+                if (isFirst)
+                    isFirst = false;
+                else
+                    specText += "\n";
+
+                specText += std::string("#{") + ESM::Skill::sSkillNameIds[it->first] + "}";
+            }
         }
-        widget->setUserString("Caption_CenteredCaptionText", specText);
-        widget->setUserString("ToolTipLayout", "TextWithCenteredCaptionToolTip");
+        widget->setUserString("Caption_ColumnText", specText);
+        widget->setUserString("ToolTipLayout", "SpecializationToolTip");
         widget->setUserString("ToolTipType", "Layout");
     }
 
@@ -795,7 +803,7 @@ namespace MWGui
         widget->setUserString("Caption_CenteredCaption", playerRace->mName);
         widget->setUserString("Caption_CenteredCaptionText", playerRace->mDescription);
         widget->setUserString("ToolTipType", "Layout");
-        widget->setUserString("ToolTipLayout", "TextWithCenteredCaptionToolTip");
+        widget->setUserString("ToolTipLayout", "RaceToolTip");
     }
 
     void ToolTips::createClassToolTip(MyGUI::Widget* widget, const ESM::Class& playerClass)

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -785,7 +785,7 @@ namespace MWGui
             {
                 if (it == categories[category].spells.begin())
                 {
-                    text += std::string("\n#{fontcolourhtml=header}") + std::string("#{") + categories[category].label + "}";
+                    text += std::string("\n\n#{fontcolourhtml=header}") + std::string("#{") + categories[category].label + "}";
                 }
 
                 const std::string &spellId = *it;

--- a/files/mygui/openmw_stats_window.layout
+++ b/files/mygui/openmw_stats_window.layout
@@ -87,12 +87,12 @@
                     <Widget type="AutoSizedTextBox" skin="NormalText" position="0 0 95 18" name="Race_str" align="Left Top">
                         <Property key="Caption" value="#{sRace}"/>
                         <UserString key="ToolTipType" value="Layout"/>
-                        <UserString key="ToolTipLayout" value="TextWithCenteredCaptionToolTip"/>
+                        <UserString key="ToolTipLayout" value="RaceToolTip"/>
                     </Widget>
                     <Widget type="TextBox" skin="SandTextRight" position="104 0 200 18" name="RaceText" align="Left Top">
                         <Property key="TextAlign" value="Right Top"/>
                         <UserString key="ToolTipType" value="Layout"/>
-                        <UserString key="ToolTipLayout" value="TextWithCenteredCaptionToolTip"/>
+                        <UserString key="ToolTipLayout" value="RaceToolTip"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
                 </Widget>

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -18,11 +18,23 @@
         </Widget>
 
         <!-- Text tooltip, multiline -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 300" align="Stretch" name="TextToolTip">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 0" align="Stretch" name="TextToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="6"/>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 8 284 284" align="Left Top" name="Text">
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 8 268 0" align="Left Top" name="Text">
+                <Property key="MultiLine" value="true"/>
+                <Property key="WordWrap" value="true"/>
+                <Property key="TextAlign" value="Left Top"/>
+            </Widget>
+        </Widget>
+
+        <!-- Faction tooltip -->
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 0" align="Stretch" name="FactionToolTip">
+            <Property key="AutoResize" value="true"/>
+            <Property key="Padding" value="12"/>
+
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 8 436 0" align="Left Top" name="FactionText">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
@@ -263,9 +275,9 @@
         </Widget>
 
         <!-- Magic effect tooltip -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 52" align="Stretch" name="MagicEffectToolTip">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 0" align="Stretch" name="MagicEffectToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="12"/>
 
             <Widget type="HBox">
                 <UserString key="HStretch" value="true"/>
@@ -274,13 +286,13 @@
                 <Widget type="ImageBox" skin="ImageBox" position="8 8 32 32" align="Left Top" name="MagicEffectImage"/>
 
                 <Widget type="VBox">
-                    <Widget type="AutoSizedTextBox" skin="NormalText" position="44 8 252 16" align="Left Top" name="MagicEffectName">
+                    <Widget type="AutoSizedTextBox" skin="NormalText" position="44 8 404 16" align="Left Top" name="MagicEffectName">
                         <Property key="TextAlign" value="Left"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
 
 
-                    <Widget type="AutoSizedTextBox" skin="SandText" position="44 24 252 16" align="Left Top" name="MagicEffectSchool">
+                    <Widget type="AutoSizedTextBox" skin="SandText" position="44 24 404 16" align="Left Top" name="MagicEffectSchool">
                         <Property key="TextAlign" value="Left"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
@@ -288,7 +300,7 @@
 
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 284 0" align="Left Top" name="MagicEffectDescription">
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 436 0" align="Left Top" name="MagicEffectDescription">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -123,20 +123,21 @@
         </Widget>
 
         <!-- Attribute tooltip -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 300" align="Stretch" name="AttributeToolTip">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 0" align="Stretch" name="AttributeToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="12"/>
+            <Property key="Spacing" value="8"/>
 
             <Widget type="HBox">
                 <Property key="Spacing" value="8"/>
                 <Widget type="ImageBox" skin="ImageBox" position="8 8 32 32" align="Left Top" name="AttributeImage"/>
 
-                <Widget type="AutoSizedEditBox" skin="NormalText" position="44 8 252 32" align="Left Top" name="AttributeName">
+                <Widget type="AutoSizedEditBox" skin="NormalText" position="44 8 392 32" align="Left Top" name="AttributeName">
                     <Property key="TextAlign" value="Left VCenter"/>
                 </Widget>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 284 248" align="Left Top" name="AttributeDescription">
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 436 248" align="Left Top" name="AttributeDescription">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
@@ -144,9 +145,9 @@
         </Widget>
 
         <!-- Skill tooltip -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 98" align="Stretch" name="SkillToolTip">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 98" align="Stretch" name="SkillToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="12"/>
 
             <Widget type="HBox">
                 <UserString key="HStretch" value="true"/>
@@ -154,30 +155,35 @@
                 <Widget type="ImageBox" skin="ImageBox" position="8 8 32 32" align="Left Top" name="SkillImage"/>
 
                 <Widget type="VBox">
-                    <Widget type="AutoSizedTextBox" skin="NormalText" position="44 8 252 16" align="Left Top" name="SkillName">
+                    <Widget type="AutoSizedTextBox" skin="NormalText" position="44 8 0 16" align="Left Top" name="SkillName">
                         <Property key="TextAlign" value="Left"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
 
-                    <Widget type="AutoSizedTextBox" skin="SandText" position="44 24 252 16" align="Left Top" name="SkillAttribute">
+                    <Widget type="AutoSizedTextBox" skin="SandText" position="44 24 0 16" align="Left Top" name="SkillAttribute">
                         <Property key="TextAlign" value="Left"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
                 </Widget>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 320 0" align="Left Top" name="SkillDescription">
+            <Widget type="Widget" skin="" position="0 0 0 2" align="Left Top" />
+
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 430 0" align="Left Top" name="SkillDescription">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
+                <Property key="Spacing" value="28"/>
             </Widget>
 
-            <Widget type="AutoSizedTextBox" skin="SandText" position="8 48 284 18" align="Left Bottom" name="SkillMaxed">
+            <Widget type="Widget" skin="" position="0 0 0 2" align="Left Top" />
+
+            <Widget type="AutoSizedTextBox" skin="SandText" position="8 48 444 18" align="Left Bottom" name="SkillMaxed">
                 <Property key="Caption" value="#{sSkillMaxReached}"/>
                 <Property key="TextAlign" value="Center"/>
             </Widget>
             <Widget type="VBox" name="SkillProgressVBox">
-                <Widget type="AutoSizedTextBox" skin="NormalText" position="8 48 284 18" align="Left Bottom">
+                <Widget type="AutoSizedTextBox" skin="NormalText" position="8 48 444 18" align="Left Bottom">
                     <Property key="Caption" value="#{sSkillProgress}"/>
                     <Property key="TextAlign" value="Center"/>
                 </Widget>
@@ -191,9 +197,9 @@
         </Widget>
 
         <!-- Skill tooltip (without progress bar) -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 52" align="Stretch" name="SkillNoProgressToolTip">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 52" align="Stretch" name="SkillNoProgressToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="12"/>
 
             <Widget type="HBox">
                 <UserString key="HStretch" value="true"/>
@@ -202,22 +208,25 @@
                 <Widget type="ImageBox" skin="ImageBox" position="8 8 32 32" align="Left Top" name="SkillNoProgressImage"/>
 
                 <Widget type="VBox">
-                    <Widget type="AutoSizedEditBox" skin="NormalText" position="44 8 252 16" align="Left Top" name="SkillNoProgressName">
+                    <Widget type="AutoSizedEditBox" skin="NormalText" position="44 8 0 16" align="Left Top" name="SkillNoProgressName">
                         <Property key="TextAlign" value="Left"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
 
-                    <Widget type="AutoSizedTextBox" skin="SandText" position="44 24 252 16" align="Left Top" name="SkillNoProgressAttribute">
+                    <Widget type="AutoSizedTextBox" skin="SandText" position="44 24 0 16" align="Left Top" name="SkillNoProgressAttribute">
                         <Property key="TextAlign" value="Left"/>
                         <UserString key="HStretch" value="true"/>
                     </Widget>
                 </Widget>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 320 0" align="Left Top" name="SkillNoProgressDescription">
+            <Widget type="Widget" skin="" position="0 0 0 2" align="Left Top" />
+
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 430 0" align="Left Top" name="SkillNoProgressDescription">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
+                <Property key="Spacing" value="28"/>
             </Widget>
         </Widget>
 

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -29,16 +29,33 @@
             </Widget>
         </Widget>
 
-        <!-- Text with centered caption tooltip -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 56" align="Stretch" name="TextWithCenteredCaptionToolTip">
+        <!-- Race tooltip -->
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 56" align="Stretch" name="RaceToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="12"/>
+            <Property key="Spacing" value="8"/>
 
             <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 284 18" align="Left Top" name="CenteredCaption">
                 <Property key="TextAlign" value="Center"/>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 30 330 18" align="Left Top" name="CenteredCaptionText">
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 30 430 18" align="Left Top" name="CenteredCaptionText">
+                <Property key="MultiLine" value="true"/>
+                <Property key="WordWrap" value="true"/>
+                <Property key="TextAlign" value="Left Top"/>
+            </Widget>
+        </Widget>
+
+        <!-- Specialization tooltip -->
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 56" align="Stretch" name="SpecializationToolTip">
+            <Property key="AutoResize" value="true"/>
+            <Property key="Padding" value="12"/>
+
+            <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 140 18" align="Left Top" name="Caption">
+                <Property key="TextAlign" value="Center"/>
+            </Widget>
+
+            <Widget type="AutoSizedEditBox" skin="SandText" position="0 30 140 18" align="Left Top" name="ColumnText">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
@@ -46,15 +63,16 @@
         </Widget>
 
         <!-- Class tooltip -->
-        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 78" align="Stretch" name="ClassToolTip">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 0 78" align="Stretch" name="ClassToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="12"/>
+            <Property key="Spacing" value="8"/>
 
             <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 284 18" align="Left Top" name="ClassName">
                 <Property key="TextAlign" value="Center"/>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 30 320 18" align="Left Top" name="ClassDescription">
+            <Widget type="AutoSizedEditBox" skin="SandText" position="8 30 430 18" align="Left Top" name="ClassDescription">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
@@ -204,15 +222,18 @@
         </Widget>
 
         <!-- Level tooltip -->
-        <Widget type="Widget" skin="HUD_Box_NoTransp" position="0 0 300 58" align="Left Top" name="LevelToolTip">
-            <Widget type="TextBox" skin="NormalText" position="8 8 284 18" align="Left Top HStretch">
+        <Widget type="VBox" skin="HUD_Box_NoTransp" position="0 0 300 58" align="HStretch" name="LevelToolTip">
+            <Property key="AutoResize" value="true"/>
+            <Property key="Padding" value="12"/>
+
+            <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 284 18" align="Left Top">
                 <Property key="Caption" value="#{sLevelProgress}"/>
                 <Property key="TextAlign" value="Center"/>
             </Widget>
 
-            <Widget type="ProgressBar" skin="MW_Progress_Red" position="50 30 200 20" align="HCenter Bottom" name="LevelProgress">
-                <Widget type="TextBox" skin="ProgressText" position="0 0 200 16" align="Stretch" name="LevelProgressText">
-                    <Property key="TextAlign" value="Center"/>
+            <Widget type="ProgressBar" skin="MW_Progress_Red" position="50 30 180 20" align="HCenter Bottom" name="LevelProgress">
+                <Widget type="TextBox" skin="ProgressText" position="0 0 180 20" align="HCenter" name="LevelProgressText">
+                    <Property key="TextAlign" value="HCenter Top"/>
                 </Widget>
             </Widget>
         </Widget>

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -86,7 +86,7 @@
         <!-- Hand-to-hand tooltip -->
         <Widget type="HBox" skin="HUD_Box_NoTransp" position="0 0 300 300" align="Stretch" name="HandToHandToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="6"/>
 
             <Widget type="VBox">
                 <UserString key="VStretch" value="true"/>
@@ -102,9 +102,9 @@
         </Widget>
 
         <!-- Health/Magicka/Fatigue tooltip -->
-        <Widget type="HBox" skin="HUD_Box_NoTransp" position="0 0 300 300" align="Stretch" name="HealthToolTip">
+        <Widget type="HBox" skin="HUD_Box_NoTransp" position="0 0 0 0" align="Stretch" name="HealthToolTip">
             <Property key="AutoResize" value="true"/>
-            <Property key="Padding" value="8"/>
+            <Property key="Padding" value="14"/>
             <Property key="Spacing" value="8"/>
 
             <Widget type="VBox">
@@ -115,7 +115,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="44 8 248 284" align="Left Top" name="HealthDescription">
+            <Widget type="AutoSizedEditBox" skin="SandText" position="44 8 392 0" align="Left Top" name="HealthDescription">
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>


### PR DESCRIPTION
Makes tooltips size close to vanilla game.
Note: text position can be different from vanilla since default font has slightly larger width of some characters.