### PR TITLE
Character generation layout fixes

### DIFF
--- a/apps/openmw/mwgui/levelupdialog.cpp
+++ b/apps/openmw/mwgui/levelupdialog.cpp
@@ -89,7 +89,7 @@ namespace MWGui
 
     void LevelupDialog::resetCoins()
     {
-        const int coinSpacing = 10;
+        const int coinSpacing = 33;
         int curX = mCoinBox->getWidth()/2 - (coinSpacing*(mCoinCount - 1) + 16*mCoinCount)/2;
         for (unsigned int i=0; i<sMaxCoins; ++i)
         {

--- a/files/mygui/openmw_chargen_class.layout
+++ b/files/mygui/openmw_chargen_class.layout
@@ -27,16 +27,23 @@
             </Widget>
 
             <!-- Favorite Attributes -->
-            <Widget type="TextBox" skin="HeaderText" position="0 41 166 18" name="FavoriteAttributesT" align="Left Top">
-                <Property key="Caption" value="#{sChooseClassMenu2}"/>
-                <Property key="TextAlign" value="Left Top"/>
-                <UserString key="ToolTipType" value="Layout"/>
-                <UserString key="ToolTipLayout" value="TextToolTip"/>
-                <UserString key="Caption_Text" value="#{sCreateClassMenuHelp2}"/>
-            </Widget>
+            <Widget type="VBox" skin="" position="0 39 166 72" align="Stretch">
+                <Property key="Spacing" value="0"/>
 
-            <Widget type="MWAttribute" skin="MW_StatName" position="0 59 166 18" name="FavoriteAttribute0" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatName" position="0 77 166 18" name="FavoriteAttribute1" align="Left Top"/>
+                <!-- Favorite Attributes -->
+                <Widget type="AutoSizedEditBox" skin="HeaderText" position="0 0 166 18" name="FavoriteAttributesT" align="Left Top">
+                    <Property key="Caption" value="#{sChooseClassMenu2}"/>
+                    <Property key="TextAlign" value="Left Top"/>
+                    <UserString key="ToolTipType" value="Layout"/>
+                    <UserString key="ToolTipLayout" value="TextToolTip"/>
+                    <UserString key="Caption_Text" value="#{sCreateClassMenuHelp2}"/>
+                    <Property key="MultiLine" value="true"/>
+                    <Property key="WordWrap" value="true"/>
+                </Widget>
+
+                <Widget type="MWAttribute" skin="MW_StatNameButton" position="0 0 166 18" name="FavoriteAttribute0" align="Left Top"/>
+                <Widget type="MWAttribute" skin="MW_StatNameButton" position="0 0 166 18" name="FavoriteAttribute1" align="Left Top"/>
+             </Widget>
 
             <!-- Major Skills -->
             <Widget type="TextBox" skin="HeaderText" position="166 0 162 18" name="MajorSkillT" align="Left Top">

--- a/files/mygui/openmw_chargen_create_class.layout
+++ b/files/mygui/openmw_chargen_create_class.layout
@@ -26,22 +26,30 @@
                 <Property key="TextAlign" value="Left Top"/>
             </Widget>
 
-            <!-- Favorite Attributes -->
-            <Widget type="TextBox" skin="HeaderText" position="0 41 166 18" name="FavoriteAttributesT" align="Left Top">
-                <Property key="Caption" value="#{sChooseClassMenu2}"/>
-                <Property key="TextAlign" value="Left Top"/>
-                <UserString key="ToolTipType" value="Layout"/>
-                <UserString key="ToolTipLayout" value="TextToolTip"/>
-                <UserString key="Caption_Text" value="#{sCreateClassMenuHelp2}"/>
-            </Widget>
+            <Widget type="VBox" skin="" position="0 41 166 72" align="Stretch">
+                <Property key="Spacing" value="0"/>
 
-            <Widget type="MWAttribute" skin="MW_StatNameButton" position="0 59 166 18" name="FavoriteAttribute0" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButton" position="0 77 166 18" name="FavoriteAttribute1" align="Left Top"/>
+                <!-- Favorite Attributes -->
+                <Widget type="AutoSizedEditBox" skin="HeaderText" position="0 0 166 18" name="FavoriteAttributesT" align="Left Top">
+                    <Property key="Caption" value="#{sChooseClassMenu2}"/>
+                    <Property key="TextAlign" value="Left Top"/>
+                    <UserString key="ToolTipType" value="Layout"/>
+                    <UserString key="ToolTipLayout" value="TextToolTip"/>
+                    <UserString key="Caption_Text" value="#{sCreateClassMenuHelp2}"/>
+                    <Property key="MultiLine" value="true"/>
+                    <Property key="WordWrap" value="true"/>
+                </Widget>
+
+                <Widget type="MWAttribute" skin="MW_StatNameButton" position="0 0 166 18" name="FavoriteAttribute0" align="Left Top"/>
+                <Widget type="MWAttribute" skin="MW_StatNameButton" position="0 0 166 18" name="FavoriteAttribute1" align="Left Top"/>
+             </Widget>
 
             <!-- Major Skills -->
             <Widget type="TextBox" skin="HeaderText" position="166 0 166 18" name="MajorSkillT" align="Left Top">
                 <Property key="Caption" value="#{sChooseClassMenu3}"/>
                 <Property key="TextAlign" value="Left Top"/>
+                <Property key="MultiLine" value="true"/>
+                <Property key="WordWrap" value="true"/>
             </Widget>
 
             <Widget type="MWSkill" skin="MW_StatNameButton" position="166 18 166 18" name="MajorSkill0" align="Left Top"/>

--- a/files/mygui/openmw_chargen_race.layout
+++ b/files/mygui/openmw_chargen_race.layout
@@ -57,7 +57,7 @@
         <Widget type="TextBox" skin="HeaderText" position="261 16 132 18" name="RaceT" align="Left Top">
             <Property key="TextAlign" value="Left Top"/>
         </Widget>
-        <Widget type="ListBox" skin="MW_List" position="264 39 132 161" name="RaceList">
+        <Widget type="ListBox" skin="MW_List" position="264 39 132 150" name="RaceList">
         </Widget>
 
         <!-- Spell powers -->

--- a/files/mygui/openmw_chargen_select_attribute.layout
+++ b/files/mygui/openmw_chargen_select_attribute.layout
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 217 234" align="Center" name="_Main">
-        <Widget type="Widget" skin="" position="14 14 186 203" align="Stretch">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 217 234" align="Center" name="_Main">
+        <Widget type="Widget" skin="" position="14 14 200 203" align="HCenter VStretch">
 
             <!-- Label -->
-            <Widget type="TextBox" skin="HeaderText" position="0 0 186 18" name="LabelT" align="Left Top">
+            <Widget type="TextBox" skin="HeaderText" position="0 0 200 18" name="LabelT" align="HCenter Top">
                 <Property key="Caption" value="#{sAttributesMenu1}"/>
                 <Property key="TextAlign" value="HCenter Top"/>
             </Widget>
 
             <!-- Attribute list -->
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 28 186 18" name="Attribute0" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 46 186 18" name="Attribute1" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 64 186 18" name="Attribute2" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 82 186 18" name="Attribute3" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 100 186 18" name="Attribute4" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 118 186 18" name="Attribute5" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 136 186 18" name="Attribute6" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 154 186 18" name="Attribute7" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 28 200 18" name="Attribute0" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 46 200 18" name="Attribute1" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 64 200 18" name="Attribute2" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 82 200 18" name="Attribute3" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 100 200 18" name="Attribute4" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 118 200 18" name="Attribute5" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 136 200 18" name="Attribute6" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 154 200 18" name="Attribute7" align="Left Top"/>
 
             <!-- Dialog buttons -->
             <Widget type="AutoSizedButton" skin="MW_Button" position="120 180 66 21" name="CancelButton">

--- a/files/mygui/openmw_chargen_select_skill.layout
+++ b/files/mygui/openmw_chargen_select_skill.layout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 477 270" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 477 270" align="Center" name="_Main">
         <Widget type="Widget" skin="" position="17 14 447 239" align="Stretch">
 
             <!-- Label -->

--- a/files/mygui/openmw_chargen_select_specialization.layout
+++ b/files/mygui/openmw_chargen_select_specialization.layout
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
     <!-- correct size is 247 144, adjust when skin is changed to a dialog -->
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 247 144" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 247 144" align="Center" name="_Main">
         <Widget type="Widget" skin="" position="14 14 216 113" align="Stretch">
 
             <!-- Label -->
-            <Widget type="TextBox" skin="HeaderText" position="0 0 216 18" name="LabelT" align="Left Top">
+            <Widget type="TextBox" skin="HeaderText" position="0 0 216 18" name="LabelT" align="Center Top">
                 <Property key="Caption" value="#{sSpecializationMenu1}"/>
-                <Property key="TextAlign" value="Left Top"/>
+                <Property key="TextAlign" value="Center Top"/>
             </Widget>
 
             <!-- Specialization list -->

--- a/files/mygui/openmw_infobox.layout
+++ b/files/mygui/openmw_infobox.layout
@@ -11,6 +11,6 @@
         </Widget>
 
         <!-- Button bar, buttons are created as children -->
-        <Widget type="Widget" skin="" position="72 98 400 150" name="ButtonBar" align="Top HCenter" />
+        <Widget type="Widget" skin="" position="72 98 450 150" name="ButtonBar" align="Top HCenter" />
     </Widget>
 </MyGUI>

--- a/files/mygui/openmw_levelup_dialog.layout
+++ b/files/mygui/openmw_levelup_dialog.layout
@@ -2,7 +2,7 @@
 
 <MyGUI type="Layout">
     <Widget type="VBox" skin="MW_Dialog" layer="Windows" position="0 0 0 0" align="Center" name="_Main">
-        <Property key="Padding" value="12"/>
+        <Property key="Padding" value="10"/>
         <Property key="Spacing" value="8"/>
         <Property key="AutoResize" value="true"/>
 
@@ -22,25 +22,25 @@
             <Property key="Static" value="true"/>
         </Widget>
 
-        <Widget type="Widget" skin="" position="0 0 100 16" name="Coins">
+        <Widget type="Widget" skin="" position="0 0 150 16" name="Coins">
             <UserString key="HStretch" value="true"/>
             <UserString key="VStretch" value="false"/>
         </Widget>
 
-        <Widget type="Widget" skin="" position="0 280 391 100" name="AssignWidget">
+        <Widget type="Widget" skin="" position="0 280 420 84" name="AssignWidget">
             <UserString key="HStretch" value="false"/>
             <UserString key="VStretch" value="false"/>
 
-            <Widget type="TextBox" skin="SandTextVCenter" position="22 0 100 24" name="AttribMultiplier1"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="22 24 100 24" name="AttribMultiplier2"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="22 48 100 24" name="AttribMultiplier3"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="22 72 100 24" name="AttribMultiplier4"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="218 0 100 24" name="AttribMultiplier5"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="218 24 100 24" name="AttribMultiplier6"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="218 48 100 24" name="AttribMultiplier7"/>
-            <Widget type="TextBox" skin="SandTextVCenter" position="218 72 100 24" name="AttribMultiplier8"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="32 0 100 20" name="AttribMultiplier1"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="32 20 100 20" name="AttribMultiplier2"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="32 40 100 20" name="AttribMultiplier3"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="32 60 100 20" name="AttribMultiplier4"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="218 0 100 20" name="AttribMultiplier5"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="218 20 100 20" name="AttribMultiplier6"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="218 40 100 20" name="AttribMultiplier7"/>
+            <Widget type="TextBox" skin="SandTextVCenter" position="218 60 100 20" name="AttribMultiplier8"/>
 
-            <Widget type="HBox" position="42 0 200 24">
+            <Widget type="HBox" position="52 0 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib1">
                     <UserString key="TextPadding" value="0 0"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -54,7 +54,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="42 24 200 24">
+            <Widget type="HBox" position="52 20 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib2">
                     <UserString key="TextPadding" value="0 0"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -68,7 +68,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="42 48 200 24">
+            <Widget type="HBox" position="52 40 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib3">
                     <UserString key="TextPadding" value="0 0"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -82,7 +82,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="42 72 200 24">
+            <Widget type="HBox" position="52 60 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib4">
                     <UserString key="TextPadding" value="0 0"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -97,7 +97,7 @@
             </Widget>
 
 
-            <Widget type="HBox" position="238 0 200 24">
+            <Widget type="HBox" position="238 0 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib5">
                     <UserString key="TextPadding" value="0 0"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -111,7 +111,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="238 24 200 24">
+            <Widget type="HBox" position="238 20 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib6">
                     <UserString key="TextPadding" value="0 0"/>
                     <UserString key="ToolTipType" value="Layout"/>
@@ -125,7 +125,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="238 48 200 24">
+            <Widget type="HBox" position="238 40 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib7">
                 <UserString key="TextPadding" value="0 0"/>
                 <UserString key="ToolTipType" value="Layout"/>
@@ -139,7 +139,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="238 72 200 24">
+            <Widget type="HBox" position="238 60 200 20">
                 <Widget type="AutoSizedButton" skin="SandTextButton" name="Attrib8">
                 <UserString key="TextPadding" value="0 0"/>
                 <UserString key="ToolTipType" value="Layout"/>

--- a/files/mygui/openmw_list.skin.xml
+++ b/files/mygui/openmw_list.skin.xml
@@ -127,7 +127,7 @@
     <Resource type="ResourceSkin" name="MW_List" size="516 516" align="Left Top">
         <Property key="NeedKey" value="true"/>
         <Property key="SkinLine" value="MW_ListLine"/>
-        <Property key="HeightLine" value="20"/>
+        <Property key="HeightLine" value="18"/>
 
         <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>
 
@@ -140,7 +140,7 @@
     <Resource type="ResourceSkin" name="MW_PopupList" size="516 516" align="Left Top">
         <Property key="NeedKey" value="true"/>
         <Property key="SkinLine" value="MW_ListLine"/>
-        <Property key="HeightLine" value="20"/>
+        <Property key="HeightLine" value="18"/>
 
         <Child type="Widget" skin="BlackBG" offset="0 0 516 516" align="Stretch"/>
         <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>


### PR DESCRIPTION
See screenshots: left one - current OpenMW layout, right one - PR layout.

1) [Birthsign menu](http://i.imgur.com/sQX9rlh.png): set list spacing as in Morrowind.
2) [Class creation](http://i.imgur.com/By7y4vv.png): make "Major skills" label multiline as in Morrowind.
3) [enableclassmenu](http://i.imgur.com/UBZy9fi.png) : set size as in Morrowind.
4) [Skill selection menu](http://i.imgur.com/bR2ea42.png): disable transparency.
5) [Specialization select menu](http://i.imgur.com/Zv88YC0.png): disable transparency, centered caption.
6) [Levelup menu](http://i.imgur.com/0O8nhXP.png): set layout close to Morrowind one.