### PR TITLE
Fixed quickload with menus open

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -309,6 +309,7 @@ namespace MWWorld
 
         mDoorStates.clear();
 
+        mGoToJail = false;
         mTeleportEnabled = true;
         mLevitationEnabled = true;
 


### PR DESCRIPTION
[Bug #3879](https://bugs.openmw.org/issues/3879)

Summary: Added a check to see if the guiMode was false. 

Testing: Attempted quickloading in various menus and in the situation mentioned. 
