### PR TITLE
Fix macOS CI

### DIFF
--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -2,10 +2,9 @@
 
 brew update
 
-brew rm cmake || true
-brew rm pkgconfig || true
-brew rm qt5 || true
-brew install cmake pkgconfig $macos_qt_formula
+brew outdated cmake || brew upgrade cmake
+brew outdated pkgconfig || brew upgrade pkgconfig
+brew install $macos_qt_formula
 
 curl https://downloads.openmw.org/osx/dependencies/openmw-deps-c79172d.zip -o ~/openmw-deps.zip
 unzip ~/openmw-deps.zip -d /private/tmp/openmw-deps > /dev/null


### PR DESCRIPTION
Travis has changed the set of preinstalled dependencies and pkgconfig can no longer be removed, switching to the recommended way to upgrade preinstalled dependencies (https://docs.travis-ci.com/user/osx-ci-environment/#A-note-on-upgrading-packages).