### PR TITLE
Split greeting from topic response

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -170,7 +170,7 @@ namespace MWDialogue
                     parseText (info->mResponse);
 
                     MWScript::InterpreterContext interpreterContext(&mActor.getRefData().getLocals(),mActor);
-                    win->addResponse (Interpreter::fixDefinesDialog(info->mResponse, interpreterContext));
+                    win->addResponse (Interpreter::fixDefinesDialog(info->mResponse, interpreterContext), "", false);
                     executeScript (info->mResultScript, mActor);
                     mLastTopic = Misc::StringUtils::lowerCase(it->mId);
 

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -107,23 +107,22 @@ namespace MWGui
 
     // --------------------------------------------------------------------------------------------------
 
-    Response::Response(const std::string &text, const std::string &title)
-        : mTitle(title)
+    Response::Response(const std::string &text, const std::string &title, bool needMargin)
+        : mTitle(title), mNeedMargin(needMargin)
     {
         mText = text;
     }
 
     void Response::write(BookTypesetter::Ptr typesetter, KeywordSearchT* keywordSearch, std::map<std::string, Link*>& topicLinks) const
     {
-        BookTypesetter::Style* title = typesetter->createStyle("", getDialogueTextColour("header"));
+        typesetter->sectionBreak(mNeedMargin ? 9 : 0);
 
         if (mTitle != "")
         {
-            typesetter->sectionBreak(9);
+            BookTypesetter::Style* title = typesetter->createStyle("", getDialogueTextColour("header"));
             typesetter->write(title, to_utf8_span(mTitle.c_str()));
+            typesetter->sectionBreak();
         }
-
-        typesetter->sectionBreak();
 
         typedef std::pair<size_t, size_t> Range;
         std::map<Range, intptr_t> hyperLinks;
@@ -554,7 +553,7 @@ namespace MWGui
         mHistory->setPosition(0, static_cast<int>(pos) * -1);
     }
 
-    void DialogueWindow::addResponse(const std::string &text, const std::string &title)
+    void DialogueWindow::addResponse(const std::string &text, const std::string &title, bool needMargin)
     {
         // This is called from the dialogue manager, so text is
         // case-smashed - thus we have to retrieve the correct case
@@ -573,7 +572,7 @@ namespace MWGui
             }
         }
 
-        mHistoryContents.push_back(new Response(text, realTitle));
+        mHistoryContents.push_back(new Response(text, realTitle, needMargin));
         updateHistory();
     }
 

--- a/apps/openmw/mwgui/dialogue.hpp
+++ b/apps/openmw/mwgui/dialogue.hpp
@@ -82,10 +82,11 @@ namespace MWGui
 
     struct Response : DialogueText
     {
-        Response(const std::string& text, const std::string& title = "");
+        Response(const std::string& text, const std::string& title = "", bool needMargin = true);
         virtual void write (BookTypesetter::Ptr typesetter, KeywordSearchT* keywordSearch, std::map<std::string, Link*>& topicLinks) const;
         void addTopicLink (BookTypesetter::Ptr typesetter, intptr_t topicId, size_t begin, size_t end) const;
         std::string mTitle;
+        bool mNeedMargin;
     };
 
     struct Message : DialogueText
@@ -109,7 +110,7 @@ namespace MWGui
         void startDialogue(MWWorld::Ptr actor, std::string npcName, bool resetHistory);
         void setKeywords(std::list<std::string> keyWord);
 
-        void addResponse (const std::string& text, const std::string& title="");
+        void addResponse (const std::string& text, const std::string& title="", bool needMargin = true);
 
         void addMessageBox(const std::string& text);
 


### PR DESCRIPTION
Fixes a regression in [PR1310](https://github.com/OpenMW/openmw/pull/1310).

The main idea is splitting greating records from response records since Morrowind handles these record types differently.