### PR TITLE
Make combat AI to do not cast target spells under water

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -383,6 +383,7 @@ namespace MWBase
             ///Is the head of the creature underwater?
             virtual bool isSubmerged(const MWWorld::ConstPtr &object) const = 0;
             virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const = 0;
+            virtual bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const = 0;
             virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const = 0;
             virtual bool isOnGround(const MWWorld::Ptr &ptr) const = 0;
 

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -545,6 +545,13 @@ namespace MWMechanics
 
         const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effect.mEffectID);
 
+        // Underwater casting not possible
+        if (effect.mRange == ESM::RT_Target)
+        {
+            if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(actor), 0.75f))
+                return 0;
+        }
+
         rating *= magicEffect->mData.mBaseCost;
 
         if (magicEffect->mData.mFlags & ESM::MagicEffect::Harmful)

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -549,7 +549,13 @@ namespace MWMechanics
         if (effect.mRange == ESM::RT_Target)
         {
             if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(actor), 0.75f))
-                return 0;
+                return 0.f;
+
+            if (enemy.isEmpty())
+                return 0.f;
+
+            if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(enemy), 0.75f))
+                return 0.f;
         }
 
         rating *= magicEffect->mData.mBaseCost;

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -168,9 +168,6 @@ namespace MWWorld
 
             float mDistanceToFacedObject;
 
-            bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const;
-            ///< helper function for implementing isSwimming(), isSubmerged(), isWading()
-
             bool mTeleportEnabled;
             bool mLevitationEnabled;
             bool mGoToJail;
@@ -490,6 +487,7 @@ namespace MWWorld
             virtual bool isSubmerged(const MWWorld::ConstPtr &object) const;
             virtual bool isSwimming(const MWWorld::ConstPtr &object) const;
             virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const;
+            virtual bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const;
             virtual bool isWading(const MWWorld::ConstPtr &object) const;
             virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const;
             virtual bool isOnGround(const MWWorld::Ptr &ptr) const;


### PR DESCRIPTION
In current implementation NPCs try to use target spells underwater and spells obviously fail. Fixed.

Also sorry for offtoping, but see [this](https://github.com/OpenMW/openmw/blob/openmw-42/apps/openmw/mwmechanics/aicombataction.cpp#L828) line. Why are we check mArea when we should check mRange? Backward compatibility or a bug? Also getMaxAttackDistance() is affected.