### PR TITLE
[macOS, CI] reenable packaging to make nightlies work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "MegynKyJpyL7XDwdWVEbypQh7CLjqOqOi9lGF97G7Fq0HosVZTmnwjHhmIPZspTP7ES4UbxM3rs/f3ce7sp9JN2ShRJpduD6UEFc8egQXBte9J3obUBIdUxPTRdhnht7VJ+u+pksK1S/Bm1Cs6l0eEluP3vmcaXWMykVQcZsPhY="
    # macOS builds FTP upload password
    - secure: "jQcAaWAdDy0+vlNu4POMX8322HanCOQEUTdpviWTAUjWQTjMa0UTM4+zVVgrtEaHMpBaVYYbTT3Rg5BQ9oG+2SiVLJBQQ2XoMcos/YrjPVT6inB02Gs0vFjP29LdPAQVrB8CkAcfQr6u+Z2C+RqAtwhE09LsBUMXjRDzPAtr1CM="
-   - macos_qt_formula=qt@5.5
+   - macos_qt_formula=qt@5.7
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_script: ./CI/before_script.${TRAVIS_OS_NAME}.sh
 script:
  - cd ./build
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then ${ANALYZE}make -j3; fi
- - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "osx" ]; then make; fi
+ - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "osx" ]; then make package; fi
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then ./openmw_test_suite; fi
  - if [ "$COVERITY_SCAN_BRANCH" != 1 ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then cd .. && ./CI/check_tabs.sh; fi
  - cd "${TRAVIS_BUILD_DIR}"

--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -6,5 +6,5 @@ brew outdated cmake || brew upgrade cmake
 brew outdated pkgconfig || brew upgrade pkgconfig
 brew install $macos_qt_formula
 
-curl http://downloads.openmw.org/osx/dependencies/openmw-deps-c++11.zip -o ~/openmw-deps.zip
+curl https://downloads.openmw.org/osx/dependencies/openmw-deps-eaf8112.zip -o ~/openmw-deps.zip
 unzip ~/openmw-deps.zip -d /private/tmp/openmw-deps > /dev/null


### PR DESCRIPTION
Packaging was disabled in C++11 branch, let's see if it works now.