### PR TITLE
Stopping the thread in the wizard that prevented it to stop correctly

### DIFF
--- a/apps/wizard/unshield/unshieldworker.cpp
+++ b/apps/wizard/unshield/unshieldworker.cpp
@@ -46,6 +46,7 @@ Wizard::UnshieldWorker::~UnshieldWorker()
 void Wizard::UnshieldWorker::stopWorker()
 {
     mStopped = true;
+    mWait.wakeOne();
 }
 
 void Wizard::UnshieldWorker::setInstallComponent(Wizard::Component component, bool install)
@@ -448,6 +449,10 @@ bool Wizard::UnshieldWorker::setupComponent(Component component)
             QReadLocker readLock(&mLock);
             emit requestFileDialog(component);
             mWait.wait(&mLock);
+            if(mStopped) {
+                qDebug() << "We are asked to stop !!";
+                break;
+            }
             disk.setPath(getDiskPath());
         } else {
             disk.setPath(getDiskPath());


### PR DESCRIPTION
Correcting this one : https://bugs.openmw.org/issues/3908

The problem was that the thread couldn't stop because of a wait in unshieldworker.cpp

I had 2 solutions : 
1. Put a timeout in the mThread->wait() call.
2. Wake the waiter and add a condition around the code that handle the file search to break and stop.

I chose the second solution. Do you think it's judicious ?

