### PR TITLE
Fixes for building in MSVC

### DIFF
--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -1,5 +1,7 @@
 #include "containeritemmodel.hpp"
 
+#include <algorithm>
+
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
 

--- a/apps/openmw/mwscript/skyextensions.cpp
+++ b/apps/openmw/mwscript/skyextensions.cpp
@@ -1,5 +1,7 @@
 #include "skyextensions.hpp"
 
+#include <algorithm>
+
 #include <components/compiler/extensions.hpp>
 #include <components/compiler/opcodes.hpp>
 

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -4,6 +4,7 @@
 
 #include <stdexcept>
 #include <sstream>
+#include <algorithm>
 
 #include <components/vfs/manager.hpp>
 

--- a/apps/openmw/mwsound/loudness.cpp
+++ b/apps/openmw/mwsound/loudness.cpp
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <limits>
+#include <algorithm>
 
 #include "soundmanagerimp.hpp"
 

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -1,6 +1,8 @@
 #ifndef GAME_SOUND_SOUND_H
 #define GAME_SOUND_SOUND_H
 
+#include <algorithm>
+
 #include "sound_output.hpp"
 
 namespace MWSound

--- a/apps/openmw/mwstate/charactermanager.cpp
+++ b/apps/openmw/mwstate/charactermanager.cpp
@@ -58,7 +58,7 @@ MWState::Character* MWState::CharacterManager::createCharacter(const std::string
     // The character name is user-supplied, so we need to escape the path
     for (std::string::const_iterator it = name.begin(); it != name.end(); ++it)
     {
-        if (std::isalnum(*it)) // Ignores multibyte characters and non alphanumeric characters
+        if (isalnum(*it)) // Ignores multibyte characters and non alphanumeric characters
             stream << *it;
         else
             stream << "_";

--- a/components/files/constrainedfilestream.cpp
+++ b/components/files/constrainedfilestream.cpp
@@ -1,6 +1,7 @@
 #include "constrainedfilestream.hpp"
 
 #include <streambuf>
+#include <algorithm>
 
 #include "lowlevelfile.hpp"
 

--- a/components/sceneutil/controller.cpp
+++ b/components/sceneutil/controller.cpp
@@ -1,5 +1,7 @@
 #include "controller.hpp"
 
+#include <algorithm>
+
 #include "statesetupdater.hpp"
 
 #include <osg/Drawable>


### PR DESCRIPTION
Since the deboosting commits, I haven't been able to compile the source locally on Visual Studio 2015. This PR fixes the compiler issues for me and the CI builds work.

Current master is working in AppVeyor, and no one else has said anything about not compiling (except for uramer in https://github.com/OpenMW/openmw/pull/1320), so I would appreciate it if uramer or anyone building in Visual Studio can confirm they have the same issue.

The compile problems are that "min" and "max" are not members of std, and that std::isalnum expects 2 arguments but only 1 is provided.