### PR TITLE
Adjust restock calculations to ignore filled soul gems. (Bug #3684)

### DIFF
--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -156,6 +156,16 @@ int MWWorld::ContainerStore::count(const std::string &id)
     return total;
 }
 
+int MWWorld::ContainerStore::restockCount(const std::string &id)
+{
+    int total=0;
+    for (MWWorld::ContainerStoreIterator iter (begin()); iter!=end(); ++iter)
+        if (Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), id))
+            if (iter->getCellRef().getSoul().empty())
+                total += iter->getRefData().getCount();
+    return total;
+}
+
 MWWorld::ContainerStoreListener* MWWorld::ContainerStore::getContListener() const
 {
     return mListener;
@@ -512,7 +522,7 @@ void MWWorld::ContainerStore::restock (const ESM::InventoryList& items, const MW
     for (std::map<std::pair<std::string, std::string>, int>::iterator it = mLevelledItemMap.begin(); it != mLevelledItemMap.end();)
     {
         int spawnedCount = it->second; //How many items should be in shop originally
-        int itemCount = count(it->first.first); //How many items are there in shop now
+        int itemCount = restockCount(it->first.first); //How many items are there in shop now
         //If something was not sold
         if(itemCount >= spawnedCount)
         {
@@ -578,7 +588,7 @@ void MWWorld::ContainerStore::restock (const ESM::InventoryList& items, const MW
         else
         {
             //Restocking static item - just restock to the max count
-            int currentCount = count(itemOrList);
+            int currentCount = restockCount(itemOrList);
             if (currentCount < std::abs(it->mCount))
                 addInitialItem(itemOrList, owner, -(std::abs(it->mCount) - currentCount), true);
         }

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -162,8 +162,12 @@ namespace MWWorld
             /// If a compatible stack is found, the item's count is added to that stack, then the original is deleted.
             /// @return If the item was stacked, return the stack, otherwise return the old (untouched) item.
 
-            /// @return How many items with refID \a id are in this container?
             int count (const std::string& id);
+            ///< @return How many items with refID \a id are in this container?
+
+            int restockCount (const std::string& id);
+            ///< Item count with restock adjustments (such as ignoring filled soul gems).
+            ///  @return How many items with refID \a id are in this container?
 
             ContainerStoreListener* getContListener() const;
             void setContListener(ContainerStoreListener* listener);


### PR DESCRIPTION
Bug #3684

I've split the count method so that restocking can be fixed without affecting other uses of ContainerStore.count().  Things like getting the player's gold amount wouldn't be affected by putting this in the main count routine, but I'm not familiar with how that would affect scripting functions, and have left the original method unchanged.

Basic testing done with the Fadase Selvayn in Tel Branora / common soul gem case.