### PR TITLE
Combat AI improvements [feedback needed]

### DIFF
--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -535,6 +535,10 @@ namespace MWMechanics
         // opponent's weapon range, or not backing up if opponent is also using a ranged weapon
         if (isDistantCombat && distToTarget < rangeAttack / 4)
         {
+            // actor should not back up into water
+            if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(actor), 0.5f))
+                return;
+
             mMovement.mPosition[1] = -1;
         }
     }

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -118,7 +118,19 @@ namespace MWMechanics
         float bonus=0.f;
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow && weapon->mData.mType <= ESM::Weapon::MarksmanThrown)
+        {
+            // Range weapon is useless under water
+            if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(actor), 0.75f))
+                return 0.f;
+
+            if (enemy.isEmpty())
+                return 0.f;
+
+            if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(enemy), 0.75f))
+                return 0.f;
+
             bonus+=1.5f;
+        }
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
         {

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -135,6 +135,9 @@ namespace MWMechanics
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
         {
             rating = (weapon->mData.mChop[0] + weapon->mData.mChop[1]) / 2.f;
+
+            if (weapon->mData.mType >= ESM::Weapon::MarksmanThrown)
+                MWMechanics::resistNormalWeapon(enemy, actor, item, rating);
         }
         else
         {
@@ -145,6 +148,8 @@ namespace MWMechanics
                 rating += weapon->mData.mChop[i];
             }
             rating /= 6.f;
+
+            MWMechanics::resistNormalWeapon(enemy, actor, item, rating);
         }
 
         if (item.getClass().hasItemHealth(item))
@@ -181,6 +186,10 @@ namespace MWMechanics
         int skill = item.getClass().getEquipmentSkill(item);
         if (skill != -1)
             rating *= actor.getClass().getSkill(actor, skill) / 100.f;
+
+        // There is no need to apply bonus if weapon rating == 0
+        if (rating == 0.f)
+            return 0.f;
 
         return rating + bonus;
     }

--- a/apps/openmw/mwmechanics/aicombataction.hpp
+++ b/apps/openmw/mwmechanics/aicombataction.hpp
@@ -101,6 +101,7 @@ namespace MWMechanics
     float rateEffects (const ESM::EffectList& list, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
 
     std::shared_ptr<Action> prepareNextAction (const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
+    float getBestActionRating(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy);
 
     float getDistanceMinusHalfExtents(const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy, bool minusZDist=false);
     float getMaxAttackDistance(const MWWorld::Ptr& actor);

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -16,6 +16,7 @@
 #include "aifollow.hpp"
 #include "aiactivate.hpp"
 #include "aicombat.hpp"
+#include "aicombataction.hpp"
 #include "aipursue.hpp"
 #include "actorutil.hpp"
 
@@ -208,6 +209,8 @@ void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& charac
             float nearestDist = std::numeric_limits<float>::max();
             osg::Vec3f vActorPos = actor.getRefData().getPosition().asVec3();
 
+            float bestRating = 0.f;
+
             for(std::list<AiPackage *>::iterator it = mPackages.begin(); it != mPackages.end();)
             {
                 if ((*it)->getTypeId() != AiPackage::TypeIdCombat) break;
@@ -222,6 +225,8 @@ void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& charac
                 }
                 else
                 {
+                    float rating = MWMechanics::getBestActionRating(actor, target);
+
                     const ESM::Position &targetPos = target.getRefData().getPosition();
 
                     float distTo = (targetPos.asVec3() - vActorPos).length();
@@ -230,10 +235,12 @@ void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& charac
                     if (it == mPackages.begin())
                         distTo = std::max(0.f, distTo - 50.f);
 
-                    if (distTo < nearestDist)
+                    // if a target has higher priority than current target or has same priority but closer
+                    if (rating > bestRating || ((distTo < nearestDist) && rating == bestRating))
                     {
                         nearestDist = distTo;
                         itActualCombat = it;
+                        bestRating = rating;
                     }
                     ++it;
                 }


### PR DESCRIPTION
1. AI will not use range weapons under water
2. AI will take in account enemy normal weapon resistance and silver weapons damage bonus (against werewolves).
3. AI will not use bows/crossbows if best arrow/bolt rating is 0.
4. AI will choose target by best action priority, not only by distance (see [this](https://bugs.openmw.org/issues/3921) feature).
For example, warrior with steel longsword will not attack summoned Golden Saint (100% normal weapons resistance), he will attack another enemies (player-summoner, for example) instead.

Notes: 
1. Strange, but both vanilla and OpenMW engines allow to kill actors with immunity to normal weapons (e.g. ghosts) with bare hands. Should we alter vanilla behaviour or leave the current implementation?
2. If actor can do nothing with all enemies, he will attack nearest enemy with bare hands.

Also I have a question: when I open a PR to fix a not-registered bug, should I create a bugreport too?