### PR TITLE
Do not show empty journal entries (fixes #3891)

### DIFF
--- a/apps/openmw/mwdialogue/journalimp.cpp
+++ b/apps/openmw/mwdialogue/journalimp.cpp
@@ -85,13 +85,15 @@ namespace MWDialogue
 
         StampedJournalEntry entry = StampedJournalEntry::makeFromQuest (id, index, actor);
 
-        mJournal.push_back (entry);
-
         Quest& quest = getQuest (id);
-
         quest.addEntry (entry); // we are doing slicing on purpose here
 
-        MWBase::Environment::get().getWindowManager()->messageBox ("#{sJournalEntry}");
+        // there is no need to show empty entries in journal
+        if (!entry.getText().empty())
+        {
+            mJournal.push_back (entry);
+            MWBase::Environment::get().getWindowManager()->messageBox ("#{sJournalEntry}");
+        }
     }
 
     void Journal::setJournalIndex (const std::string& id, int index)


### PR DESCRIPTION
Fixes bug [#3891](https://bugs.openmw.org/issues/3891).

Note: Morrowind does not show a message when empty entry is added in dialogue, but shows the message in other cases (a bug, maybe?).

In this PR OpenMW does not show the message in all cases (since empty message is not shown in the journal anyway).

Another options:
1. Does not show empty entries in journal but inform about quest status changes in all cases.
2. Does not show empty entries in journal but inform about quest status changes if game in non-dialogue mode (vanilla behaviour).