### PR TITLE
Prevent GUI sounds distortion

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -351,6 +351,8 @@ namespace MWBase
             /// Cycle to next or previous weapon
             virtual void cycleWeapon(bool next) = 0;
 
+            virtual void playSound(const std::string& soundId, float volume = 1.f, float pitch = 1.f) = 0;
+
             // In WindowManager for now since there isn't a VFS singleton
             virtual std::string correctIconPath(const std::string& path) = 0;
             virtual std::string correctBookartPath(const std::string& path, int width, int height) = 0;

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -4,7 +4,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 
 #include "../mwmechanics/magiceffects.hpp"
@@ -66,26 +65,27 @@ namespace MWGui
     void AlchemyWindow::onCreateButtonClicked(MyGUI::Widget* _sender)
     {
         MWMechanics::Alchemy::Result result = mAlchemy->create (mNameEdit->getCaption ());
+        MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
 
         switch (result)
         {
         case MWMechanics::Alchemy::Result_NoName:
-            MWBase::Environment::get().getWindowManager()->messageBox("#{sNotifyMessage37}");
+            winMgr->messageBox("#{sNotifyMessage37}");
             break;
         case MWMechanics::Alchemy::Result_NoMortarAndPestle:
-            MWBase::Environment::get().getWindowManager()->messageBox("#{sNotifyMessage45}");
+            winMgr->messageBox("#{sNotifyMessage45}");
             break;
         case MWMechanics::Alchemy::Result_LessThanTwoIngredients:
-            MWBase::Environment::get().getWindowManager()->messageBox("#{sNotifyMessage6a}");
+            winMgr->messageBox("#{sNotifyMessage6a}");
             break;
         case MWMechanics::Alchemy::Result_Success:
-            MWBase::Environment::get().getWindowManager()->messageBox("#{sPotionSuccess}");
-            MWBase::Environment::get().getSoundManager()->playSound("potion success", 1.f, 1.f);
+            winMgr->messageBox("#{sPotionSuccess}");
+            winMgr->playSound("potion success");
             break;
         case MWMechanics::Alchemy::Result_NoEffects:
         case MWMechanics::Alchemy::Result_RandomFailure:
-            MWBase::Environment::get().getWindowManager()->messageBox("#{sNotifyMessage8}");
-            MWBase::Environment::get().getSoundManager()->playSound("potion fail", 1.f, 1.f);
+            winMgr->messageBox("#{sNotifyMessage8}");
+            winMgr->playSound("potion fail");
             break;
         }
 
@@ -151,7 +151,7 @@ namespace MWGui
             update();
 
             std::string sound = item.getClass().getUpSoundId(item);
-            MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+            MWBase::Environment::get().getWindowManager()->playSound(sound);
         }
     }
 

--- a/apps/openmw/mwgui/bookwindow.cpp
+++ b/apps/openmw/mwgui/bookwindow.cpp
@@ -6,7 +6,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
@@ -82,7 +81,7 @@ namespace MWGui
         clearPages();
         mCurrentPage = 0;
 
-        MWBase::Environment::get().getSoundManager()->playSound ("book open", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("book open");
 
         MWWorld::LiveCellRef<ESM::Book> *ref = mBook.get<ESM::Book>();
 
@@ -98,7 +97,7 @@ namespace MWGui
     void BookWindow::exit()
     {
         // no 3d sounds because the object could be in a container.
-        MWBase::Environment::get().getSoundManager()->playSound ("book close", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("book close");
 
         MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Book);
     }
@@ -122,7 +121,7 @@ namespace MWGui
 
     void BookWindow::onTakeButtonClicked (MyGUI::Widget* sender)
     {
-        MWBase::Environment::get().getSoundManager()->playSound("Item Book Up", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("Item Book Up");
 
         MWWorld::ActionTake take(mBook);
         take.execute (MWMechanics::getPlayer());
@@ -195,7 +194,7 @@ namespace MWGui
     {
         if ((mCurrentPage+1)*2 < mPages.size())
         {
-            MWBase::Environment::get().getSoundManager()->playSound ("book page2", 1.0, 1.0);
+            MWBase::Environment::get().getWindowManager()->playSound("book page2");
 
             ++mCurrentPage;
 
@@ -206,7 +205,7 @@ namespace MWGui
     {
         if (mCurrentPage > 0)
         {
-            MWBase::Environment::get().getSoundManager()->playSound ("book page", 1.0, 1.0);
+            MWBase::Environment::get().getWindowManager()->playSound("book page");
 
             --mCurrentPage;
 

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -5,7 +5,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
@@ -224,7 +223,7 @@ namespace MWGui
                     // play the sound of the first object
                     MWWorld::Ptr item = mModel->getItem(i).mBase;
                     std::string sound = item.getClass().getUpSoundId(item);
-                    MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+                    MWBase::Environment::get().getWindowManager()->playSound(sound);
                 }
 
                 const ItemStack& item = mModel->getItem(i);

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -11,7 +11,6 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 
 #include "../mwworld/class.hpp"
@@ -228,21 +227,21 @@ namespace MWGui
     void Choice::activated()
     {
 
-        MWBase::Environment::get().getSoundManager()->playSound("Menu Click", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("Menu Click");
         MWBase::Environment::get().getDialogueManager()->questionAnswered(mChoiceId);
     }
 
     void Topic::activated()
     {
 
-        MWBase::Environment::get().getSoundManager()->playSound("Menu Click", 1.f, 1.f);
+        MWBase::Environment::get().getWindowManager()->playSound("Menu Click");
         MWBase::Environment::get().getDialogueManager()->keywordSelected(Misc::StringUtils::lowerCase(mTopicId));
     }
 
     void Goodbye::activated()
     {
 
-        MWBase::Environment::get().getSoundManager()->playSound("Menu Click", 1.f, 1.f);
+        MWBase::Environment::get().getWindowManager()->playSound("Menu Click");
         MWBase::Environment::get().getDialogueManager()->goodbyeSelected();
     }
 

--- a/apps/openmw/mwgui/draganddrop.cpp
+++ b/apps/openmw/mwgui/draganddrop.cpp
@@ -5,7 +5,6 @@
 
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/environment.hpp"
-#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/class.hpp"
 
@@ -64,7 +63,7 @@ void DragAndDrop::startDrag (int index, SortFilterItemModel* sortModel, ItemMode
     }
 
     std::string sound = mItem.mBase.getClass().getUpSoundId(mItem.mBase);
-    MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+    MWBase::Environment::get().getWindowManager()->playSound (sound);
 
     if (mSourceSortModel)
     {
@@ -94,7 +93,7 @@ void DragAndDrop::startDrag (int index, SortFilterItemModel* sortModel, ItemMode
 void DragAndDrop::drop(ItemModel *targetModel, ItemView *targetView)
 {
     std::string sound = mItem.mBase.getClass().getDownSoundId(mItem.mBase);
-    MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+    MWBase::Environment::get().getWindowManager()->playSound(sound);
 
     // We can't drop a conjured item to the ground; the target container should always be the source container
     if (mItem.mFlags & ItemStack::Flag_Bound && targetModel != mSourceModel)

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -8,7 +8,6 @@
 #include <components/widgets/list.hpp>
 #include <components/settings/settings.hpp>
 
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwworld/class.hpp"
@@ -237,7 +236,7 @@ namespace MWGui
         mItemSelectionDialog->setVisible(false);
 
         setItem(item);
-        MWBase::Environment::get().getSoundManager()->playSound(item.getClass().getDownSoundId(item), 1, 1);
+        MWBase::Environment::get().getWindowManager()->playSound(item.getClass().getDownSoundId(item));
         mEnchanting.nextCastStyle();
         updateLabels();
     }
@@ -259,7 +258,7 @@ namespace MWGui
         }
 
         setSoulGem(item);
-        MWBase::Environment::get().getSoundManager()->playSound(item.getClass().getDownSoundId(item), 1, 1);
+        MWBase::Environment::get().getWindowManager()->playSound(item.getClass().getDownSoundId(item));
         updateLabels();
     }
 
@@ -374,12 +373,12 @@ namespace MWGui
 
         if(result==1)
         {
-            MWBase::Environment::get().getSoundManager()->playSound("enchant success", 1.f, 1.f);
+            MWBase::Environment::get().getWindowManager()->playSound("enchant success");
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sEnchantmentMenu12}");
         }
         else
         {
-            MWBase::Environment::get().getSoundManager()->playSound("enchant fail", 1.f, 1.f);
+            MWBase::Environment::get().getWindowManager()->playSound("enchant fail");
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage34}");
         }
 

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -18,7 +18,6 @@
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/scriptmanager.hpp"
@@ -239,7 +238,7 @@ namespace MWGui
             // Can't give conjured items to a merchant
             if (item.mFlags & ItemStack::Flag_Bound)
             {
-                MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+                MWBase::Environment::get().getWindowManager()->playSound(sound);
                 MWBase::Environment::get().getWindowManager()->messageBox("#{sBarterDialog9}");
                 return;
             }
@@ -248,7 +247,7 @@ namespace MWGui
             int services = MWBase::Environment::get().getWindowManager()->getTradeWindow()->getMerchantServices();
             if (!object.getClass().canSell(object, services))
             {
-                MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+                MWBase::Environment::get().getWindowManager()->playSound(sound);
                 MWBase::Environment::get().getWindowManager()->
                         messageBox("#{sBarterDialog4}");
                 return;
@@ -322,7 +321,7 @@ namespace MWGui
         ensureSelectedItemUnequipped(count);
         const ItemStack& item = mTradeModel->getItem(mSelectedItem);
         std::string sound = item.mBase.getClass().getDownSoundId(item.mBase);
-        MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound(sound);
 
         if (item.mType == ItemStack::Type_Barter)
         {

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -14,7 +14,6 @@
 #include <components/widgets/list.hpp>
 
 #include "../mwbase/environment.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/journal.hpp"
 
@@ -516,8 +515,9 @@ namespace
 
         void notifyClose(MyGUI::Widget* _sender)
         {
-            MWBase::Environment::get().getSoundManager()->playSound ("book close", 1.0, 1.0);
-            MWBase::Environment::get().getWindowManager ()->popGuiMode ();
+            MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
+            winMgr->playSound("book close");
+            winMgr->popGuiMode();
         }
 
         void notifyMouseWheel(MyGUI::Widget* sender, int rel)

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -10,7 +10,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/statemanager.hpp"
 
@@ -76,23 +75,25 @@ namespace MWGui
 
     void MainMenu::onButtonClicked(MyGUI::Widget *sender)
     {
+        MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
+
         std::string name = *sender->getUserData<std::string>();
-        MWBase::Environment::get().getSoundManager()->playSound("Menu Click", 1.f, 1.f);
+        winMgr->playSound("Menu Click");
         if (name == "return")
         {
-            MWBase::Environment::get().getWindowManager ()->removeGuiMode (GM_MainMenu);
+            winMgr->removeGuiMode (GM_MainMenu);
         }
         else if (name == "options")
-            MWBase::Environment::get().getWindowManager ()->pushGuiMode (GM_Settings);
+            winMgr->pushGuiMode (GM_Settings);
         else if (name == "credits")
-            MWBase::Environment::get().getWindowManager()->playVideo("mw_credits.bik", true);
+            winMgr->playVideo("mw_credits.bik", true);
         else if (name == "exitgame")
         {
             if (MWBase::Environment::get().getStateManager()->getState() == MWBase::StateManager::State_NoGame)
                 onExitConfirmed();
             else
             {
-                ConfirmationDialog* dialog = MWBase::Environment::get().getWindowManager()->getConfirmationDialog();
+                ConfirmationDialog* dialog = winMgr->getConfirmationDialog();
                 dialog->askForConfirmation("#{sMessage2}");
                 dialog->eventOkClicked.clear();
                 dialog->eventOkClicked += MyGUI::newDelegate(this, &MainMenu::onExitConfirmed);
@@ -105,7 +106,7 @@ namespace MWGui
                 onNewGameConfirmed();
             else
             {
-                ConfirmationDialog* dialog = MWBase::Environment::get().getWindowManager()->getConfirmationDialog();
+                ConfirmationDialog* dialog = winMgr->getConfirmationDialog();
                 dialog->askForConfirmation("#{sNotifyMessage54}");
                 dialog->eventOkClicked.clear();
                 dialog->eventOkClicked += MyGUI::newDelegate(this, &MainMenu::onNewGameConfirmed);

--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -10,7 +10,6 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/actorutil.hpp"
@@ -138,8 +137,7 @@ void MerchantRepair::onRepairButtonClick(MyGUI::Widget *sender)
 
     player.getClass().getContainerStore(player).restack(item);
 
-    MWBase::Environment::get().getSoundManager()->playSound("Repair",1,1);
-
+    MWBase::Environment::get().getWindowManager()->playSound("Repair");
 
     player.getClass().getContainerStore(player).remove(MWWorld::ContainerStore::sGoldId, price, player);
 

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -12,7 +12,6 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
@@ -130,7 +129,7 @@ void Recharge::onItemSelected(MWWorld::Ptr item)
     mGemIcon->setUserString ("ToolTipType", "ItemPtr");
     mGemIcon->setUserData(item);
 
-    MWBase::Environment::get().getSoundManager()->playSound(item.getClass().getDownSoundId(item), 1, 1);
+    MWBase::Environment::get().getWindowManager()->playSound(item.getClass().getDownSoundId(item));
     updateView();
 }
 
@@ -175,7 +174,7 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
         item.getCellRef().setEnchantmentCharge(
             std::min(item.getCellRef().getEnchantmentCharge() + restored, static_cast<float>(enchantment->mData.mCharge)));
 
-        MWBase::Environment::get().getSoundManager()->playSound("Enchant Success",1,1);
+        MWBase::Environment::get().getWindowManager()->playSound("Enchant Success");
 
         player.getClass().getContainerStore(player).restack(item);
 
@@ -183,7 +182,7 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
     }
     else
     {
-        MWBase::Environment::get().getSoundManager()->playSound("Enchant Fail",1,1);
+        MWBase::Environment::get().getWindowManager()->playSound("Enchant Fail");
     }
 
     gem.getContainerStore()->remove(gem, 1, player);

--- a/apps/openmw/mwgui/repair.cpp
+++ b/apps/openmw/mwgui/repair.cpp
@@ -11,7 +11,6 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
 
@@ -66,7 +65,7 @@ void Repair::exit()
 
 void Repair::startRepairItem(const MWWorld::Ptr &item)
 {
-    MWBase::Environment::get().getSoundManager()->playSound("Item Repair Up",1,1);
+    MWBase::Environment::get().getWindowManager()->playSound("Item Repair Up");
 
     mRepair.setTool(item);
 
@@ -135,7 +134,7 @@ void Repair::onItemSelected(MWWorld::Ptr item)
 
     mRepair.setTool(item);
 
-    MWBase::Environment::get().getSoundManager()->playSound(item.getClass().getDownSoundId(item), 1, 1);
+    MWBase::Environment::get().getWindowManager()->playSound(item.getClass().getDownSoundId(item));
     updateRepairView();
 }
 

--- a/apps/openmw/mwgui/scrollwindow.cpp
+++ b/apps/openmw/mwgui/scrollwindow.cpp
@@ -7,7 +7,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
@@ -53,7 +52,7 @@ namespace MWGui
     void ScrollWindow::openScroll (MWWorld::Ptr scroll, bool showTakeButton)
     {
         // no 3d sounds because the object could be in a container.
-        MWBase::Environment::get().getSoundManager()->playSound ("scroll", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("scroll");
 
         mScroll = scroll;
 
@@ -78,7 +77,7 @@ namespace MWGui
 
     void ScrollWindow::exit()
     {
-        MWBase::Environment::get().getSoundManager()->playSound ("scroll", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("scroll");
 
         MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Scroll);
     }
@@ -102,7 +101,7 @@ namespace MWGui
 
     void ScrollWindow::onTakeButtonClicked (MyGUI::Widget* _sender)
     {
-        MWBase::Environment::get().getSoundManager()->playSound("Item Book Up", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("Item Book Up");
 
         MWWorld::ActionTake take(mScroll);
         take.execute (MWMechanics::getPlayer());

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -6,7 +6,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
@@ -146,7 +145,7 @@ namespace MWGui
 
         startSpellBuying(mPtr);
 
-        MWBase::Environment::get().getSoundManager()->playSound ("Item Gold Up", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound("Item Gold Up");
     }
 
     void SpellBuyingWindow::onCancelButtonClicked(MyGUI::Widget* _sender)

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -7,7 +7,6 @@
 #include <components/widgets/list.hpp>
 
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -396,7 +395,7 @@ namespace MWGui
         MWMechanics::CreatureStats& npcStats = mPtr.getClass().getCreatureStats(mPtr);
         npcStats.setGoldPool(npcStats.getGoldPool() + price);
 
-        MWBase::Environment::get().getSoundManager()->playSound ("Mysticism Hit", 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound ("Mysticism Hit");
 
         const ESM::Spell* spell = MWBase::Environment::get().getWorld()->createRecord(mSpell);
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -10,7 +10,6 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
@@ -211,7 +210,7 @@ namespace MWGui
     {
         const ItemStack& item = mTradeModel->getItem(mItemToSell);
         std::string sound = item.mBase.getClass().getDownSoundId(item.mBase);
-        MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+        MWBase::Environment::get().getWindowManager()->playSound(sound);
 
         TradeItemModel* playerTradeModel = MWBase::Environment::get().getWindowManager()->getInventoryWindow()->getTradeModel();
 
@@ -356,9 +355,7 @@ namespace MWGui
         MWBase::Environment::get().getWindowManager()->getDialogueWindow()->addResponse(
             MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("sBarterDialog5")->getString());
 
-        std::string sound = "Item Gold Up";
-        MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
-
+        MWBase::Environment::get().getWindowManager()->playSound("Item Gold Up");
         MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Barter);
     }
 

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -8,7 +8,6 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 
 #include "../mwmechanics/creaturestats.hpp"
@@ -158,7 +157,7 @@ namespace MWGui
 
         if (!mPtr.getCell()->isExterior())
             // Interior cell -> mages guild transport
-            MWBase::Environment::get().getSoundManager()->playSound("mysticism cast", 1, 1);
+            MWBase::Environment::get().getWindowManager()->playSound("mysticism cast");
 
         player.getClass().getContainerStore(player).remove(MWWorld::ContainerStore::sGoldId, price, player);
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -856,7 +856,7 @@ namespace MWGui
                 mRepair->exit();
                 break;
             case GM_Journal:
-                MWBase::Environment::get().getSoundManager()->playSound ("book close", 1.0, 1.0);
+                playSound("book close");
                 removeGuiMode(GM_Journal); //Simple way to remove it
                 break;
             default:
@@ -1974,6 +1974,11 @@ namespace MWGui
     {
         if (!isGuiMode())
             mInventoryWindow->cycle(next);
+    }
+
+    void WindowManager::playSound(const std::string& soundId, float volume, float pitch)
+    {
+        MWBase::Environment::get().getSoundManager()->playSound(soundId, volume, pitch, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_NoEnv);
     }
 
     void WindowManager::setConsoleSelectedObject(const MWWorld::Ptr &object)

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -380,6 +380,8 @@ namespace MWGui
     /// Cycle to next or previous weapon
     virtual void cycleWeapon(bool next);
 
+    virtual void playSound(const std::string& soundId, float volume = 1.f, float pitch = 1.f);
+
     // In WindowManager for now since there isn't a VFS singleton
     virtual std::string correctIconPath(const std::string& path);
     virtual std::string correctBookartPath(const std::string& path, int width, int height);

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -18,7 +18,6 @@
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/statemanager.hpp"
 #include "../mwbase/environment.hpp"
 
@@ -715,7 +714,7 @@ namespace MWInput
                 MyGUI::Button* b = MyGUI::InputManager::getInstance ().getMouseFocusWidget ()->castType<MyGUI::Button>(false);
                 if (b && b->getEnabled() && id == SDL_BUTTON_LEFT)
                 {
-                    MWBase::Environment::get().getSoundManager ()->playSound ("Menu Click", 1.f, 1.f);
+                    MWBase::Environment::get().getWindowManager()->playSound("Menu Click");
                 }
             }
         }
@@ -810,7 +809,7 @@ namespace MWInput
                     MyGUI::Button* b = MyGUI::InputManager::getInstance ().getMouseFocusWidget ()->castType<MyGUI::Button>(false);
                     if (b && b->getEnabled())
                     {
-                        MWBase::Environment::get().getSoundManager ()->playSound ("Menu Click", 1.f, 1.f);
+                        MWBase::Environment::get().getWindowManager()->playSound("Menu Click");
                     }
                 }
             }
@@ -1025,12 +1024,12 @@ namespace MWInput
         if(MWBase::Environment::get().getWindowManager()->getMode() != MWGui::GM_Journal
                 && MWBase::Environment::get().getWindowManager ()->getJournalAllowed())
         {
-            MWBase::Environment::get().getSoundManager()->playSound ("book open", 1.0, 1.0);
+            MWBase::Environment::get().getWindowManager()->playSound ("book open");
             MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Journal);
         }
         else if(MWBase::Environment::get().getWindowManager()->containsMode(MWGui::GM_Journal))
         {
-            MWBase::Environment::get().getSoundManager()->playSound ("book close", 1.0, 1.0);
+            MWBase::Environment::get().getWindowManager()->playSound ("book close");
             MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Journal);
         }
     }

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -15,7 +15,6 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 
 MWMechanics::NpcStats::NpcStats()
     : mDisposition (0)
@@ -254,7 +253,7 @@ void MWMechanics::NpcStats::increaseSkill(int skillIndex, const ESM::Class &clas
 
     // Play sound & skill progress notification
     /// \todo check if character is the player, if levelling is ever implemented for NPCs
-    MWBase::Environment::get().getSoundManager ()->playSound ("skillraise", 1, 1);
+    MWBase::Environment::get().getWindowManager()->playSound("skillraise");
 
     std::stringstream message;
     message << boost::format(MWBase::Environment::get().getWindowManager ()->getGameSettingString ("sNotifyMessage39", ""))

--- a/apps/openmw/mwmechanics/repair.cpp
+++ b/apps/openmw/mwmechanics/repair.cpp
@@ -8,7 +8,6 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
@@ -71,12 +70,12 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
         // increase skill
         player.getClass().skillUsageSucceeded(player, ESM::Skill::Armorer, 0);
 
-        MWBase::Environment::get().getSoundManager()->playSound("Repair",1,1);
+        MWBase::Environment::get().getWindowManager()->playSound("Repair");
         MWBase::Environment::get().getWindowManager()->messageBox("#{sRepairSuccess}");
     }
     else
     {
-        MWBase::Environment::get().getSoundManager()->playSound("Repair Fail",1,1);
+        MWBase::Environment::get().getWindowManager()->playSound("Repair Fail");
         MWBase::Environment::get().getWindowManager()->messageBox("#{sRepairFailed}");
     }
 
@@ -100,7 +99,7 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
             {
                 mTool = *iter;
 
-                MWBase::Environment::get().getSoundManager()->playSound("Item Repair Up",1,1);
+                MWBase::Environment::get().getWindowManager()->playSound("Item Repair Up");
 
                 break;
             }


### PR DESCRIPTION
This PR adds a playSound() function to WindowManager, similar to playVideo() one.
This function uses Play_NoEnv mode and played sounds will not be distorted underwater.
Allow to partially fix [#3942](https://bugs.openmw.org/issues/3942).

As alternative solution, we can change default mode for playSound() in SoundManager from Play_Normal to Play_NoEnv.

Or we can just use both solutions.

Note: we also have at least two cases to fix:
1) Sound played by console commands without position (such as "PlaySound", "PlayLoopSound") should not be distorted.
2) Action sound (equip item, drink potion, etc.) should not be distorted too.