### PR TITLE
Disable sound distortion for GUI actions and PlaySound command [discussion]

### DIFF
--- a/apps/openmw/mwscript/soundextensions.cpp
+++ b/apps/openmw/mwscript/soundextensions.cpp
@@ -82,7 +82,7 @@ namespace MWScript
                     std::string sound = runtime.getStringLiteral (runtime[0].mInteger);
                     runtime.pop();
 
-                    MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
+                    MWBase::Environment::get().getSoundManager()->playSound(sound, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_NoEnv);
                 }
         };
 
@@ -101,7 +101,7 @@ namespace MWScript
                     Interpreter::Type_Float pitch = runtime[0].mFloat;
                     runtime.pop();
 
-                    MWBase::Environment::get().getSoundManager()->playSound (sound, volume, pitch);
+                    MWBase::Environment::get().getSoundManager()->playSound(sound, volume, pitch, MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_NoEnv);
                 }
         };
 

--- a/apps/openmw/mwworld/action.cpp
+++ b/apps/openmw/mwworld/action.cpp
@@ -4,6 +4,7 @@
 #include "../mwbase/world.hpp"
 
 #include "../mwbase/soundmanager.hpp"
+#include "../mwbase/windowmanager.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
 
@@ -26,9 +27,18 @@ void MWWorld::Action::execute (const Ptr& actor, bool noSound)
 {
     if(!mSoundId.empty() && !noSound)
     {
+        MWBase::SoundManager::PlayMode envType = MWBase::SoundManager::Play_Normal;
+
+        // Action sounds should not have a distortion in GUI mode
+        // example: take an item or drink a potion underwater
+        if (actor == MWMechanics::getPlayer() && MWBase::Environment::get().getWindowManager()->isGuiMode())
+        {
+            envType = MWBase::SoundManager::Play_NoEnv;
+        }
+
         if(mKeepSound && actor == MWMechanics::getPlayer())
             MWBase::Environment::get().getSoundManager()->playSound(mSoundId, 1.0, 1.0,
-                MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Normal, mSoundOffset
+                MWBase::SoundManager::Play_TypeSfx, envType, mSoundOffset
             );
         else
         {
@@ -37,12 +47,12 @@ void MWWorld::Action::execute (const Ptr& actor, bool noSound)
                 MWBase::Environment::get().getSoundManager()->playSound3D(
                     (local ? actor : mTarget).getRefData().getPosition().asVec3(),
                     mSoundId, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx,
-                    MWBase::SoundManager::Play_Normal, mSoundOffset
+                    envType, mSoundOffset
                 );
             else
                 MWBase::Environment::get().getSoundManager()->playSound3D(local ? actor : mTarget,
                     mSoundId, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx,
-                    MWBase::SoundManager::Play_Normal, mSoundOffset
+                    envType, mSoundOffset
                 );
         }
     }


### PR DESCRIPTION
This PR:
1) Disables sound distortion for PlaySound and PlaySoundVP commands, as in vanilla game.
2) Disables sound distortion for player actions on GUI mode.
To test this you can take an item via Space button and via mouse in GUI mode underwater in Morrowind and see the difference.

Allows to fix bug [#3942](https://bugs.openmw.org/issues/3942).

Differences from vanilla implementation:
1) PlaySound3D-like commands are bugged in vanilla game: if you start a sound via PlaySound3D from console underwater, the sound will not be distorted. But if you close console then, the sound will be distorted.
Should we replicate this behaviour?
2) If you take items from container via "Take all" or "Dispose corpse" buttons in vanilla game, a sound will be distorted. It seems Morrowind disables GUI mode first, and take items last (via take item action analog). OpenMW just moves items in player inventory first, then disables GUI mode.
Should we use distortion here, or it will be better to unify a distortion usage in GUI mode? 