### PR TITLE
EditEffectDialog fixes

### DIFF
--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -170,11 +170,20 @@ namespace MWGui
         mAreaSlider->setScrollPosition (effect.mArea);
         mDurationSlider->setScrollPosition (effect.mDuration-1);
 
+        if (mEffect.mRange == ESM::RT_Self)
+            mRangeButton->setCaptionWithReplacing ("#{sRangeSelf}");
+        else if (mEffect.mRange == ESM::RT_Target)
+            mRangeButton->setCaptionWithReplacing ("#{sRangeTarget}");
+        else if (mEffect.mRange == ESM::RT_Touch)
+            mRangeButton->setCaptionWithReplacing ("#{sRangeTouch}");
+
         onMagnitudeMinChanged (mMagnitudeMinSlider, effect.mMagnMin-1);
         onMagnitudeMaxChanged (mMagnitudeMinSlider, effect.mMagnMax-1);
         onAreaChanged (mAreaSlider, effect.mArea);
         onDurationChanged (mDurationSlider, effect.mDuration-1);
         eventEffectModified(mEffect);
+
+        updateBoxes();
     }
 
     void EditEffectDialog::setMagicEffect (const ESM::MagicEffect *effect)

--- a/files/mygui/openmw_edit_effect.layout
+++ b/files/mygui/openmw_edit_effect.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 362 310" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 362 310" align="Center" name="_Main">
 
         <Widget type="ImageBox" skin="ImageBox" position="8 12 16 16" name="EffectImage">
         </Widget>


### PR DESCRIPTION
Fixes [#3956](https://bugs.openmw.org/issues/3956), also makes an EditEffectDialog background  non-transparent.