### PR TITLE
GUI fixes

### DIFF
--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -370,7 +370,8 @@ namespace MWGui
         mCancelButton->eventMouseButtonClick += MyGUI::newDelegate(mParent, &QuickKeysMenu::onCancelButtonClicked);
 
 
-        int maxWidth = mItemButton->getTextSize ().width + 24;
+        int maxWidth = mLabel->getTextSize ().width + 24;
+        maxWidth = std::max(maxWidth, mItemButton->getTextSize ().width + 24);
         maxWidth = std::max(maxWidth, mMagicButton->getTextSize ().width + 24);
         maxWidth = std::max(maxWidth, mUnassignButton->getTextSize ().width + 24);
         maxWidth = std::max(maxWidth, mCancelButton->getTextSize ().width + 24);

--- a/apps/openmw/mwgui/spellview.cpp
+++ b/apps/openmw/mwgui/spellview.cpp
@@ -96,9 +96,9 @@ namespace MWGui
                 if (spell.mType == Spell::Type_Power)
                     addGroup("#{sPowers}", "");
                 else if (spell.mType == Spell::Type_Spell)
-                    addGroup("#{sSpells}", "#{sCostChance}");
+                    addGroup("#{sSpells}", mShowCostColumn ? "#{sCostChance}" : "");
                 else
-                    addGroup("#{sMagicItem}", "#{sCostCharge}");
+                    addGroup("#{sMagicItem}", mShowCostColumn ? "#{sCostCharge}" : "");
                 curType = spell.mType;
             }
 

--- a/files/mygui/openmw_list.skin.xml
+++ b/files/mygui/openmw_list.skin.xml
@@ -150,6 +150,19 @@
         <Child type="Widget" skin="" offset="3 3 493 509" align="Stretch" name="Client"/>
     </Resource>
 
+    <Resource type="ResourceSkin" name="MW_PopupListNoTransp" size="516 516" align="Left Top">
+        <Property key="NeedKey" value="true"/>
+        <Property key="SkinLine" value="MW_ListLine"/>
+        <Property key="HeightLine" value="18"/>
+
+        <Child type="Widget" skin="FullBlackBG" offset="0 0 516 516" align="Stretch"/>
+        <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>
+
+        <Child type="MWScrollBar" skin="MW_VScroll" offset="498 3 14 509" align="Right VStretch" name="VScroll"/>
+
+        <Child type="Widget" skin="" offset="3 3 493 509" align="Stretch" name="Client"/>
+    </Resource>
+
     <Resource type="ResourceSkin" name="MW_ItemView" size="516 516" align="Left Top">
         <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>
 

--- a/files/mygui/openmw_magicselection_dialog.layout
+++ b/files/mygui/openmw_magicselection_dialog.layout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" position="0 0 330 370" layer="Windows" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" position="0 0 330 370" layer="Windows" align="Center" name="_Main">
 
         <Widget type="TextBox" skin="SandText" position="8 8 292 24">
             <Property key="Caption" value="#{sMagicSelectTitle}"/>

--- a/files/mygui/openmw_quickkeys_menu_assign.layout
+++ b/files/mygui/openmw_quickkeys_menu_assign.layout
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" position="0 0 16 154" layer="Windows" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" position="0 0 16 154" layer="Windows" name="_Main">
 
         <Widget type="TextBox" skin="SandText" position="8 8 0 18" name="Label">
             <Property key="Caption" value="#{sQuickMenu1}"/>

--- a/files/mygui/openmw_resources.xml
+++ b/files/mygui/openmw_resources.xml
@@ -114,6 +114,24 @@
         </Widget>
     </Resource>
 
+    <Resource type="ResourceLayout" name="MW_ComboBoxNoTransp" version="3.2.0">
+        <Widget type="Widget" skin="" position="65 10 100 26" name="Root">
+            <Property key="MaxListLength" value="200"/>
+            <Property key="SmoothShow" value="true"/>
+            <Property key="ModeDrop" value="true"/>
+
+            <Widget type="Widget" skin="MW_Box" position="0 0 100 26" align="Stretch">
+                <Widget type="TextBox" skin="SandText" position="6 3 71 20" align="Stretch" name="Client">
+                    <Property key="TextAlign" value="Left VCenter"/>
+                </Widget>
+                <Widget type="ListBox" skin="MW_PopupListNoTransp" position="65 38 100 200" style="Popup" layer="Popup" name="List">
+                    <Property key="Visible" value="false"/>
+                </Widget>
+                <Widget type="Button" skin="MW_ArrowDown" position="79 7 14 11" align="Right VCenter" name="Button"/>
+            </Widget>
+        </Widget>
+    </Resource>
+
     <Resource type="ResourceLayout" name="MW_ItemIcon" version="3.2.0">
         <Widget type="Widget" skin="" position="0 0 42 42" name="Root">
             <Widget type="ImageBox" skin="ImageBox" position="0 0 42 42" align="Stretch" name="Frame">

--- a/files/mygui/openmw_savegame_dialog.layout
+++ b/files/mygui/openmw_savegame_dialog.layout
@@ -16,7 +16,7 @@
                 <UserString key="VStretch" value="true"/>
                 <Property key="Spacing" value="8"/>
 
-                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 200 24" name="SelectCharacter">
+                <Widget type="ComboBox" skin="MW_ComboBoxNoTransp" position="0 0 200 24" name="SelectCharacter">
                     <Property key="Caption" value="Select Character"/>
                     <UserString key="HStretch" value="true"/>
                 </Widget>


### PR DESCRIPTION
1) Fixes quick keys menu width calculation and make it non-transparent ([screenshot](http://i.imgur.com/P4PPVSr.jpg))
2) Removes "Cost/Change" and "Cost/Charge" labels from quick key magic selection dialog and make it non-tranparent ([screenshot](http://i.imgur.com/TMRD4bi.jpg))
3) Makes character selection popup in game load menu non-transparent ([screenshot](http://i.imgur.com/z1smMFQ.jpg)).