### PR TITLE
Disable transparency for all popup lists

### DIFF
--- a/files/mygui/openmw_resources.xml
+++ b/files/mygui/openmw_resources.xml
@@ -106,24 +106,6 @@
                 <Widget type="TextBox" skin="SandText" position="6 3 71 20" align="Stretch" name="Client">
                     <Property key="TextAlign" value="Left VCenter"/>
                 </Widget>
-                <Widget type="ListBox" skin="MW_PopupList" position="65 38 100 200" style="Popup" layer="Popup" name="List">
-                    <Property key="Visible" value="false"/>
-                </Widget>
-                <Widget type="Button" skin="MW_ArrowDown" position="79 7 14 11" align="Right VCenter" name="Button"/>
-            </Widget>
-        </Widget>
-    </Resource>
-
-    <Resource type="ResourceLayout" name="MW_ComboBoxNoTransp" version="3.2.0">
-        <Widget type="Widget" skin="" position="65 10 100 26" name="Root">
-            <Property key="MaxListLength" value="200"/>
-            <Property key="SmoothShow" value="true"/>
-            <Property key="ModeDrop" value="true"/>
-
-            <Widget type="Widget" skin="MW_Box" position="0 0 100 26" align="Stretch">
-                <Widget type="TextBox" skin="SandText" position="6 3 71 20" align="Stretch" name="Client">
-                    <Property key="TextAlign" value="Left VCenter"/>
-                </Widget>
                 <Widget type="ListBox" skin="MW_PopupListNoTransp" position="65 38 100 200" style="Popup" layer="Popup" name="List">
                     <Property key="Visible" value="false"/>
                 </Widget>

--- a/files/mygui/openmw_savegame_dialog.layout
+++ b/files/mygui/openmw_savegame_dialog.layout
@@ -16,7 +16,7 @@
                 <UserString key="VStretch" value="true"/>
                 <Property key="Spacing" value="8"/>
 
-                <Widget type="ComboBox" skin="MW_ComboBoxNoTransp" position="0 0 200 24" name="SelectCharacter">
+                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 200 24" name="SelectCharacter">
                     <Property key="Caption" value="Select Character"/>
                     <UserString key="HStretch" value="true"/>
                 </Widget>


### PR DESCRIPTION
A change requested by @scrawl [here](https://github.com/OpenMW/openmw/pull/1335).

Note: this change affects popups in settings menu.
