### PR TITLE
Add Visual Studio 2017 support (Feature #3952)

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -215,9 +215,7 @@ fi
 case $VS_VERSION in
 	15|15.0|2017 )
 		GENERATOR="Visual Studio 15 2017"
-		XP_TOOLSET="v140xp"
-		TOOLSET="v140"
-		BOOST_TOOLSET="vc140"
+		TOOLSET="vc140"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
 		MSVC_DISPLAY_YEAR="2017"
@@ -225,9 +223,7 @@ case $VS_VERSION in
 
 	14|14.0|2015 )
 		GENERATOR="Visual Studio 14 2015"
-		XP_TOOLSET="v140_xp"
-		TOOLSET="v140"
-		BOOST_TOOLSET="vc140"
+		TOOLSET="vc140"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
 		MSVC_DISPLAY_YEAR="2015"
@@ -235,9 +231,7 @@ case $VS_VERSION in
 
 	12|12.0|2013 )
 		GENERATOR="Visual Studio 12 2013"
-		XP_TOOLSET="v120_xp"
-		TOOLSET="v120"
-		BOOST_TOOLSET="vc120"
+		TOOLSET="vc120"
 		MSVC_VER="12"
 		MSVC_YEAR="2013"
 		MSVC_DISPLAY_YEAR="2013"
@@ -409,7 +403,7 @@ fi
 
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
 			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.0"
-		add_cmake_opts -DBoost_COMPILER="-${BOOST_TOOLSET}"
+		add_cmake_opts -DBoost_COMPILER="-${TOOLSET}"
 
 		echo Done.
 	else
@@ -421,7 +415,7 @@ fi
 		fi
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
 			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.0"
-		add_cmake_opts -DBoost_COMPILER="-${BOOST_TOOLSET}"
+		add_cmake_opts -DBoost_COMPILER="-${TOOLSET}"
 
 		echo Done.
 	fi

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -75,7 +75,7 @@ Options:
 		Set the build platform, can also be set with environment variable PLATFORM.
 	-u
 		Configure for unity builds.
-	-v <2013/2015>
+	-v <2013/2015/2017>
 		Choose the Visual Studio version to use.
 	-V
 		Run verbosely
@@ -213,20 +213,34 @@ if [ -z $VS_VERSION ]; then
 fi
 
 case $VS_VERSION in
+	15|15.0|2017 )
+		GENERATOR="Visual Studio 15 2017"
+		XP_TOOLSET="v140xp"
+		TOOLSET="v140"
+		BOOST_TOOLSET="vc140"
+		MSVC_VER="14"
+		MSVC_YEAR="2015"
+		MSVC_DISPLAY_YEAR="2017"
+		;;
+
 	14|14.0|2015 )
 		GENERATOR="Visual Studio 14 2015"
 		XP_TOOLSET="v140_xp"
 		TOOLSET="v140"
+		BOOST_TOOLSET="vc140"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
+		MSVC_DISPLAY_YEAR="2015"
 		;;
 
 	12|12.0|2013 )
 		GENERATOR="Visual Studio 12 2013"
 		XP_TOOLSET="v120_xp"
 		TOOLSET="v120"
+		BOOST_TOOLSET="vc120"
 		MSVC_VER="12"
 		MSVC_YEAR="2013"
+		MSVC_DISPLAY_YEAR="2013"
 		;;
 esac
 
@@ -278,7 +292,7 @@ fi
 
 echo
 echo "==================================="
-echo "Starting prebuild on MSVC${MSVC_YEAR} WIN${BITS}"
+echo "Starting prebuild on MSVC${MSVC_DISPLAY_YEAR} WIN${BITS}"
 echo "==================================="
 echo
 
@@ -350,7 +364,7 @@ fi
 cd .. #/..
 
 # Set up dependencies
-BUILD_DIR="MSVC${MSVC_YEAR}_${BITS}"
+BUILD_DIR="MSVC${MSVC_DISPLAY_YEAR}_${BITS}"
 if [ -z $KEEP ]; then
 	echo
 	echo "(Re)Creating build directory."
@@ -395,6 +409,7 @@ fi
 
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
 			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.0"
+		add_cmake_opts -DBoost_COMPILER="-${BOOST_TOOLSET}"
 
 		echo Done.
 	else
@@ -406,6 +421,7 @@ fi
 		fi
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
 			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.0"
+		add_cmake_opts -DBoost_COMPILER="-${BOOST_TOOLSET}"
 
 		echo Done.
 	fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,7 @@ if (WIN32)
         4510 4512 # Unable to generate copy constructor/assignment operator as it's not public in the base
         4706 # Assignment in conditional expression
         4738 # Storing 32-bit float result in memory, possible loss of performance
+        4774 # Format string expected in argument is not a string literal
         4986 # Undocumented warning that occurs in the crtdbg.h file
         4987 # nonstandard extension used (triggered by setjmp.h)
         4996 # Function was declared deprecated


### PR DESCRIPTION
https://bugs.openmw.org/issues/3952
Adds Visual Studio 2017 support to the build script. This uses the same configuration settings as for VS2015 but uses a different generator. I removed the old TOOLSET and XP_TOOLSET variables as they didn't seem to be used anywhere, but they can be added back if they do turn out to be needed.
Should build.msvc.sh be upgraded as well? I'm not sure what its purpose is exactly but it's probably something most users won't need to run.