### PR TITLE
Pause game when minimised on Windows (Bug #3943)

### DIFF
--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -221,10 +221,12 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
             case SDL_WINDOWEVENT_CLOSE:
                 break;
             case SDL_WINDOWEVENT_SHOWN:
+            case SDL_WINDOWEVENT_RESTORED:
                 if (mWindowListener)
                     mWindowListener->windowVisibilityChange(true);
                 break;
             case SDL_WINDOWEVENT_HIDDEN:
+            case SDL_WINDOWEVENT_MINIMIZED:
                 if (mWindowListener)
                     mWindowListener->windowVisibilityChange(false);
                 break;


### PR DESCRIPTION
https://bugs.openmw.org/issues/3943
SDL doesn't send SHOWN or HIDDEN events on Windows, but it does send RESTORED and MINIMIZED events. Checking for those events means that the game now pauses as intended when the window is minimised.