### PR TITLE
[macOS, CI] Use most recent dependencies

### DIFF
--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -6,5 +6,5 @@ brew outdated cmake || brew upgrade cmake
 brew outdated pkgconfig || brew upgrade pkgconfig
 brew install $macos_qt_formula
 
-curl https://downloads.openmw.org/osx/dependencies/openmw-deps-eaf8112.zip -o ~/openmw-deps.zip
+curl https://downloads.openmw.org/osx/dependencies/openmw-deps-5e144e2.zip -o ~/openmw-deps.zip
 unzip ~/openmw-deps.zip -d /private/tmp/openmw-deps > /dev/null


### PR DESCRIPTION
Includes a fix for https://bugs.openmw.org/issues/3904.