### PR TITLE
Fade screen in on a new game start

### DIFF
--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -146,6 +146,9 @@ void MWState::StateManager::newGame (bool bypass)
         MWBase::Environment::get().getWorld()->startNewGame (bypass);
 
         mState = State_Running;
+
+        MWBase::Environment::get().getWindowManager()->fadeScreenOut(0);
+        MWBase::Environment::get().getWindowManager()->fadeScreenIn(1);
     }
     catch (std::exception& e)
     {


### PR DESCRIPTION
Implements a missing case from [Feature #824](https://bugs.openmw.org/issues/824).

And what kind of work should we do to close this feature request?

Also I found a difference in fading behaviour: in vanilla Morrowind screen fades BEFORE location change (loading bar), in OpenMW - AFTER location change.

@scrawl, have we a description about how screen fading should behave?
