### PR TITLE
OpenMW-CS: Fix occurrence highlighting preferences panel

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -153,11 +153,11 @@ void CSMPrefs::State::declare()
     declareInt ("error-height", "Initial height of the error panel", 100).
         setRange (100, 10000);
     declareBool ("highlight-occurrences", "Highlight other occurrences of selected names", true);
+    declareColour ("colour-highlight", "Colour of highlighted occurrences", QColor("lightcyan"));
     declareSeparator();
     declareColour ("colour-int", "Highlight Colour: Integer Literals", QColor ("darkmagenta"));
     declareColour ("colour-float", "Highlight Colour: Float Literals", QColor ("magenta"));
     declareColour ("colour-name", "Highlight Colour: Names", QColor ("grey"));
-    declareColour ("colour-highlight", "Highlight Colour: Highlighting", QColor("palegreen"));
     declareColour ("colour-keyword", "Highlight Colour: Keywords", QColor ("red"));
     declareColour ("colour-special", "Highlight Colour: Special Characters", QColor ("darkorange"));
     declareColour ("colour-comment", "Highlight Colour: Comments", QColor ("green"));


### PR DESCRIPTION
When I added the occurrence highlighting feature in [this pull request](https://github.com/OpenMW/openmw/pull/1278), the preferences panel was badly laid out and not implemented very well. This feature moves the background colour setting to be separate from the others, changes the name of the setting, and also changes the colour to look better and not stand out so much.