### PR TITLE
Fix dialogue window performance

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -72,6 +72,8 @@ namespace MWGui
         ShowInDialogueMode_Only,
         ShowInDialogueMode_Never
     };
+
+    struct TextColours;
 }
 
 namespace SFO
@@ -361,6 +363,8 @@ namespace MWBase
 
             virtual void removeCell(MWWorld::CellStore* cell) = 0;
             virtual void writeFog(MWWorld::CellStore* cell) = 0;
+
+            virtual const MWGui::TextColours& getTextColours() = 0;
     };
 }
 

--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -35,22 +35,22 @@ struct TypesetBookImpl : TypesetBook
         MyGUI::Colour         mNormalColour;
         InteractiveId mInteractiveId;
 
-        bool match (MyGUI::IFont* tstFont, MyGUI::Colour tstHotColour, MyGUI::Colour tstActiveColour,
-                    MyGUI::Colour tstNormalColour, intptr_t tstInteractiveId)
+        bool match (MyGUI::IFont* tstFont, const MyGUI::Colour& tstHotColour, const MyGUI::Colour& tstActiveColour,
+                    const MyGUI::Colour& tstNormalColour, intptr_t tstInteractiveId)
         {
             return (mFont == tstFont) &&
                    partal_match (tstHotColour, tstActiveColour, tstNormalColour, tstInteractiveId);
         }
 
-        bool match (char const * tstFont, MyGUI::Colour tstHotColour, MyGUI::Colour tstActiveColour,
-                    MyGUI::Colour tstNormalColour, intptr_t tstInteractiveId)
+        bool match (char const * tstFont, const MyGUI::Colour& tstHotColour, const MyGUI::Colour& tstActiveColour,
+                    const MyGUI::Colour& tstNormalColour, intptr_t tstInteractiveId)
         {
             return (mFont->getResourceName ()   == tstFont) &&
                    partal_match (tstHotColour, tstActiveColour, tstNormalColour, tstInteractiveId);
         }
 
-        bool partal_match (MyGUI::Colour tstHotColour, MyGUI::Colour tstActiveColour,
-                           MyGUI::Colour tstNormalColour, intptr_t tstInteractiveId)
+        bool partal_match (const MyGUI::Colour& tstHotColour, const MyGUI::Colour& tstActiveColour,
+                           const MyGUI::Colour& tstNormalColour, intptr_t tstInteractiveId)
         {
             return
                 (mHotColour                  == tstHotColour     ) &&
@@ -261,7 +261,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
     {
     }
 
-    Style * createStyle (char const * fontName, Colour fontColour)
+    Style * createStyle (char const * fontName, const Colour& fontColour)
     {
         if (strcmp(fontName, "") == 0)
             return createStyle(MyGUI::FontManager::getInstance().getDefaultFont().c_str(), fontColour);
@@ -284,7 +284,8 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
         return &style;
     }
 
-    Style* createHotStyle (Style* baseStyle, Colour normalColour, Colour hoverColour, Colour activeColour, InteractiveId id, bool unique)
+    Style* createHotStyle (Style* baseStyle, const Colour& normalColour, const Colour& hoverColour,
+                           const Colour& activeColour, InteractiveId id, bool unique)
     {
         StyleImpl* BaseStyle = static_cast <StyleImpl*> (baseStyle);
 

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -37,6 +37,9 @@ namespace MWGui
         typedef uint8_t const * Utf8Point;
         typedef std::pair <Utf8Point, Utf8Point> Utf8Span;
 
+
+
+
         enum Alignment {
             AlignLeft   = -1,
             AlignCenter = 0,
@@ -53,12 +56,13 @@ namespace MWGui
         static Ptr create (int pageWidth, int pageHeight);
 
         /// Create a simple text style consisting of a font and a text color.
-        virtual Style* createStyle (char const * Font, Colour Colour) = 0;
+        virtual Style* createStyle (char const * Font, const Colour& Colour) = 0;
 
         /// Create a hyper-link style with a user-defined identifier based on an
         /// existing style. The unique flag forces a new instance of this style
         /// to be created even if an existing instance is present.
-        virtual Style* createHotStyle (Style * BaseStyle, Colour NormalColour, Colour HoverColour, Colour ActiveColour, InteractiveId Id, bool Unique = true) = 0;
+        virtual Style* createHotStyle (Style * BaseStyle, const Colour& NormalColour, const Colour& HoverColour,
+                                       const Colour& ActiveColour, InteractiveId Id, bool Unique = true) = 0;
 
         /// Insert a line break into the document. Newline characters in the input
         /// text have the same affect. The margin parameter adds additional space

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -22,18 +22,9 @@
 
 #include "widgets.hpp"
 #include "bookpage.hpp"
+#include "textcolours.hpp"
 
 #include "journalbooks.hpp" // to_utf8_span
-
-namespace
-{
-
-    MyGUI::Colour getDialogueTextColour (const std::string& type)
-    {
-        return MyGUI::Colour::parse(MyGUI::LanguageManager::getInstance().replaceTags("#{fontcolour=" + type + "}"));
-    }
-
-}
 
 namespace MWGui
 {
@@ -116,7 +107,8 @@ namespace MWGui
 
         if (mTitle != "")
         {
-            BookTypesetter::Style* title = typesetter->createStyle("", getDialogueTextColour("header"));
+            const MyGUI::Colour& headerColour = MWBase::Environment::get().getWindowManager()->getTextColours().header;
+            BookTypesetter::Style* title = typesetter->createStyle("", headerColour);
             typesetter->write(title, to_utf8_span(mTitle.c_str()));
             typesetter->sectionBreak();
         }
@@ -159,15 +151,16 @@ namespace MWGui
 
         if (hyperLinks.size() && MWBase::Environment::get().getWindowManager()->getTranslationDataStorage().hasTranslation())
         {
-            BookTypesetter::Style* style = typesetter->createStyle("", getDialogueTextColour("normal"));
+            const TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
+
+            BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal);
             size_t formatted = 0; // points to the first character that is not laid out yet
             for (std::map<Range, intptr_t>::iterator it = hyperLinks.begin(); it != hyperLinks.end(); ++it)
             {
                 intptr_t topicId = it->second;
-                const MyGUI::Colour linkHot(getDialogueTextColour("link_over"));
-                const MyGUI::Colour linkNormal(getDialogueTextColour("link"));
-                const MyGUI::Colour linkActive(getDialogueTextColour("link_pressed"));
-                BookTypesetter::Style* hotStyle = typesetter->createHotStyle (style, linkNormal, linkHot, linkActive, topicId);
+                BookTypesetter::Style* hotStyle = typesetter->createHotStyle (style, textColours.link,
+                                                                              textColours.linkOver, textColours.linkPressed,
+                                                                              topicId);
                 if (formatted < it->first.first)
                     typesetter->write(style, formatted, it->first.first);
                 typesetter->write(hotStyle, it->first.first, it->first.second);
@@ -199,14 +192,13 @@ namespace MWGui
 
     void Response::addTopicLink(BookTypesetter::Ptr typesetter, intptr_t topicId, size_t begin, size_t end) const
     {
-        BookTypesetter::Style* style = typesetter->createStyle("", getDialogueTextColour("normal"));
+        const TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
 
-        const MyGUI::Colour linkHot(getDialogueTextColour("link_over"));
-        const MyGUI::Colour linkNormal(getDialogueTextColour("link"));
-        const MyGUI::Colour linkActive(getDialogueTextColour("link_pressed"));
+        BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal);
+
 
         if (topicId)
-            style = typesetter->createHotStyle (style, linkNormal, linkHot, linkActive, topicId);
+            style = typesetter->createHotStyle (style, textColours.link, textColours.linkOver, textColours.linkPressed, topicId);
         typesetter->write (style, begin, end);
     }
 
@@ -217,7 +209,8 @@ namespace MWGui
 
     void Message::write(BookTypesetter::Ptr typesetter, KeywordSearchT* keywordSearch, std::map<std::string, Link*>& topicLinks) const
     {
-        BookTypesetter::Style* title = typesetter->createStyle("", getDialogueTextColour("notify"));
+        const MyGUI::Colour& textColour = MWBase::Environment::get().getWindowManager()->getTextColours().notify;
+        BookTypesetter::Style* title = typesetter->createStyle("", textColour);
         typesetter->sectionBreak(9);
         typesetter->write(title, to_utf8_span(mText.c_str()));
     }
@@ -300,8 +293,12 @@ namespace MWGui
 
     void DialogueWindow::onWindowResize(MyGUI::Window* _sender)
     {
+        // if the window has only been moved, not resized, we don't need to update
+        if (mCurrentWindowSize == _sender->getSize()) return;
+
         mTopicsList->adjustSize();
         updateHistory();
+        mCurrentWindowSize = _sender->getSize();
     }
 
     void DialogueWindow::onMouseWheel(MyGUI::Widget* _sender, int _rel)
@@ -486,16 +483,15 @@ namespace MWGui
 
         typesetter->sectionBreak(9);
         // choices
-        const MyGUI::Colour linkHot(getDialogueTextColour("answer_over"));
-        const MyGUI::Colour linkNormal(getDialogueTextColour("answer"));
-        const MyGUI::Colour linkActive(getDialogueTextColour("answer_pressed"));
+        const TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
         for (std::vector<std::pair<std::string, int> >::iterator it = mChoices.begin(); it != mChoices.end(); ++it)
         {
             Choice* link = new Choice(it->second);
             mLinks.push_back(link);
 
             typesetter->lineBreak();
-            BookTypesetter::Style* questionStyle = typesetter->createHotStyle(body, linkNormal, linkHot, linkActive,
+            BookTypesetter::Style* questionStyle = typesetter->createHotStyle(body, textColours.answer, textColours.answerOver,
+                                                                              textColours.answerPressed,
                                                                               TypesetBook::InteractiveId(link));
             typesetter->write(questionStyle, to_utf8_span(it->first.c_str()));
         }
@@ -505,7 +501,8 @@ namespace MWGui
             Goodbye* link = new Goodbye();
             mLinks.push_back(link);
             std::string goodbye = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("sGoodbye")->getString();
-            BookTypesetter::Style* questionStyle = typesetter->createHotStyle(body, linkNormal, linkHot, linkActive,
+            BookTypesetter::Style* questionStyle = typesetter->createHotStyle(body, textColours.answer, textColours.answerOver,
+                                                                              textColours.answerPressed,
                                                                               TypesetBook::InteractiveId(link));
             typesetter->lineBreak();
             typesetter->write(questionStyle, to_utf8_span(goodbye.c_str()));

--- a/apps/openmw/mwgui/dialogue.hpp
+++ b/apps/openmw/mwgui/dialogue.hpp
@@ -171,6 +171,8 @@ namespace MWGui
         MyGUI::TextBox*     mDispositionText;
 
         PersuasionDialog mPersuasionDialog;
+
+        MyGUI::IntSize mCurrentWindowSize;
     };
 }
 #endif

--- a/apps/openmw/mwgui/journalbooks.cpp
+++ b/apps/openmw/mwgui/journalbooks.cpp
@@ -2,13 +2,14 @@
 
 #include <MyGUI_LanguageManager.h>
 
+#include "../mwbase/environment.hpp"
+#include "../mwbase/windowmanager.hpp"
+
+#include "textcolours.hpp"
+
+
 namespace
 {
-    MyGUI::Colour getTextColour (const std::string& type)
-    {
-        return MyGUI::Colour::parse(MyGUI::LanguageManager::getInstance().replaceTags("#{fontcolour=" + type + "}"));
-    }
-
     struct AddContent
     {
         MWGui::BookTypesetter::Ptr mTypesetter;
@@ -31,12 +32,10 @@ namespace
         {
             MWGui::BookTypesetter::Style* style = mBodyStyle;
 
-            static const MyGUI::Colour linkHot    (getTextColour("journal_link_over"));
-            static const MyGUI::Colour linkNormal (getTextColour("journal_link"));
-            static const MyGUI::Colour linkActive (getTextColour("journal_link_pressed"));
-
+            const MWGui::TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
             if (topicId)
-                style = mTypesetter->createHotStyle (mBodyStyle, linkNormal, linkHot, linkActive, topicId);
+                style = mTypesetter->createHotStyle (mBodyStyle, textColours.journalLink, textColours.journalLinkOver,
+                                                     textColours.journalLinkPressed, topicId);
 
             mTypesetter->write (style, begin, end);
         }
@@ -233,11 +232,10 @@ book JournalBooks::createTopicIndexBook ()
 
         sprintf (buffer, "( %c )", ch);
 
-        MyGUI::Colour linkHot (getTextColour("journal_topic_over"));
-        MyGUI::Colour linkActive (getTextColour("journal_topic_pressed"));
-        MyGUI::Colour linkNormal (getTextColour("journal_topic"));
-
-        BookTypesetter::Style* style = typesetter->createHotStyle (body, linkNormal, linkHot, linkActive, ch);
+        const MWGui::TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
+        BookTypesetter::Style* style = typesetter->createHotStyle (body, textColours.journalTopic,
+                                                                   textColours.journalTopicOver,
+                                                                   textColours.journalTopicPressed, ch);
 
         if (i == 13)
             typesetter->sectionBreak ();

--- a/apps/openmw/mwgui/textcolours.hpp
+++ b/apps/openmw/mwgui/textcolours.hpp
@@ -1,0 +1,35 @@
+#ifndef MWGUI_TEXTCOLORS_H
+#define MWGUI_TEXTCOLORS_H
+
+#include <MyGUI_Colour.h>
+
+namespace MWGui
+{
+
+    struct TextColours
+    {
+        MyGUI::Colour header;
+        MyGUI::Colour normal;
+        MyGUI::Colour notify;
+
+
+        MyGUI::Colour link;
+        MyGUI::Colour linkOver;
+        MyGUI::Colour linkPressed;
+
+        MyGUI::Colour answer;
+        MyGUI::Colour answerOver;
+        MyGUI::Colour answerPressed;
+
+        MyGUI::Colour journalLink;
+        MyGUI::Colour journalLinkOver;
+        MyGUI::Colour journalLinkPressed;
+
+        MyGUI::Colour journalTopic;
+        MyGUI::Colour journalTopicOver;
+        MyGUI::Colour journalTopicPressed;
+    };
+
+}
+
+#endif

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -113,6 +113,16 @@
 #include "jailscreen.hpp"
 #include "itemchargeview.hpp"
 
+namespace
+{
+
+    MyGUI::Colour getTextColour(const std::string& type)
+    {
+        return MyGUI::Colour::parse(MyGUI::LanguageManager::getInstance().replaceTags("#{fontcolour=" + type + "}"));
+    }
+
+}
+
 namespace MWGui
 {
 
@@ -282,6 +292,27 @@ namespace MWGui
         // Get size info from the Gui object
         int w = MyGUI::RenderManager::getInstance().getViewSize().width;
         int h = MyGUI::RenderManager::getInstance().getViewSize().height;
+
+        mTextColours.header = getTextColour("header");
+        mTextColours.normal = getTextColour("normal");
+        mTextColours.notify = getTextColour("notify");
+
+        mTextColours.link = getTextColour("link");
+        mTextColours.linkOver = getTextColour("link_over");
+        mTextColours.linkPressed = getTextColour("link_pressed");
+
+        mTextColours.answer = getTextColour("answer");
+        mTextColours.answerOver = getTextColour("answer_over");
+        mTextColours.answerPressed = getTextColour("answer_pressed");
+
+        mTextColours.journalLink = getTextColour("journal_link");
+        mTextColours.journalLinkOver = getTextColour("journal_link_over");
+        mTextColours.journalLinkPressed = getTextColour("journal_link_pressed");
+
+        mTextColours.journalTopic = getTextColour("journal_topic");
+        mTextColours.journalTopicOver = getTextColour("journal_topic_over");
+        mTextColours.journalTopicPressed = getTextColour("journal_topic_pressed");
+
 
         mDragAndDrop = new DragAndDrop();
 
@@ -2136,6 +2167,11 @@ namespace MWGui
     void WindowManager::writeFog(MWWorld::CellStore *cell)
     {
         mLocalMapRender->saveFogOfWar(cell);
+    }
+
+    const MWGui::TextColours& WindowManager::getTextColours()
+    {
+        return mTextColours;
     }
 
 }

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -19,6 +19,7 @@
 #include <components/to_utf8/to_utf8.hpp>
 
 #include "mapwindow.hpp"
+#include "textcolours.hpp"
 
 #include <MyGUI_KeyCode.h>
 #include <MyGUI_Types.h>
@@ -391,6 +392,8 @@ namespace MWGui
     void removeCell(MWWorld::CellStore* cell);
     void writeFog(MWWorld::CellStore* cell);
 
+    virtual const MWGui::TextColours& getTextColours();
+
   private:
     const MWWorld::ESMStore* mStore;
     Resource::ResourceSystem* mResourceSystem;
@@ -513,6 +516,8 @@ namespace MWGui
     int mShowOwned;
 
     std::string mVersionDescription;
+
+    MWGui::TextColours mTextColours;
 
     /**
      * Called when MyGUI tries to retrieve a tag's value. Tags must be denoted in #{tag} notation and will be replaced upon setting a user visible text/property.


### PR DESCRIPTION
Fixes [Bug #3126](https://bugs.openmw.org/issues/3126).

There were 2 problems with the dialogue window:

1. MyGUI doesn't seem to have separate events for resizing and moving, so when dragging the window it went through the whole resize routine which recreates the dialogue history etc.. Now it only does that when the size has actually changed.
2. During (re)writing the dialogue history, the text colours were retrieved by letting MyGUI parse a generated string over and over again hundreds of times per frame which caused the majority of the slowdown. The text colours are now cached in MWGui::WindowManager (they can't change at runtime right?) and can be used directly.