### PR TITLE
Launcher: Move Morrowind Content Language label to section header

### DIFF
--- a/files/ui/settingspage.ui
+++ b/files/ui/settingspage.ui
@@ -17,20 +17,10 @@
    <item>
     <widget class="QGroupBox" name="generalGroup">
      <property name="title">
-      <string>General</string>
+      <string>Morrowind Content Language</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="languageLabel">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The language of the original Morrowind installation files (used for the character encoding)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Morrowind content language:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
        <widget class="QComboBox" name="languageComboBox">
         <property name="minimumSize">
          <size>
@@ -39,6 +29,19 @@
          </size>
         </property>
        </widget>
+      </item>
+      <item row="0" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Fixes [#3909](https://bugs.openmw.org/issues/3909). Since there was only one element in the "General" section, I figured it would make sense to just make the whole section for the Morrowind language.