### PR TITLE
Fixed encumberance check (bug #3963)

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1673,9 +1673,10 @@ void CharacterController::update(float duration)
         static const float fFatigueSneakBase = gmst.find("fFatigueSneakBase")->getFloat();
         static const float fFatigueSneakMult = gmst.find("fFatigueSneakMult")->getFloat();
 
-        const float encumbrance = cls.getEncumbrance(mPtr) / cls.getCapacity(mPtr);
-        if (encumbrance < 1)
+        if (cls.getEncumbrance(mPtr) <= cls.getCapacity(mPtr))
         {
+            const float encumbrance = cls.getEncumbrance(mPtr) / cls.getCapacity(mPtr);
+
             if (sneak)
                 fatigueLoss = fFatigueSneakBase + encumbrance * fFatigueSneakMult;
             else


### PR DESCRIPTION
Allows to fix [bug #3963](https://bugs.openmw.org/issues/3963).
In all cases when we check for encumberance, we do not use a division.