### PR TITLE
Editor: Fix handling of cell color field

### DIFF
--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -327,7 +327,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, const ResourcesManager& resourc
     mCells.getNestableColumn(index)->addColumn(
         new NestedChildColumn (Columns::ColumnId_WaterLevel, ColumnBase::Display_Float));
     mCells.getNestableColumn(index)->addColumn(
-        new NestedChildColumn (Columns::ColumnId_MapColor, ColumnBase::Display_Integer));
+        new NestedChildColumn (Columns::ColumnId_MapColor, ColumnBase::Display_Colour));
 
     mEnchantments.addColumn (new StringIdColumn<ESM::Enchantment>);
     mEnchantments.addColumn (new RecordStateColumn<ESM::Enchantment>);

--- a/apps/opencs/view/widget/coloreditor.cpp
+++ b/apps/opencs/view/widget/coloreditor.cpp
@@ -64,6 +64,11 @@ QColor CSVWidget::ColorEditor::color() const
     return mColor;
 }
 
+int CSVWidget::ColorEditor::colorInt() const
+{
+    return (mColor.blue() << 16) | (mColor.green() << 8) | (mColor.red());
+}
+
 void CSVWidget::ColorEditor::setColor(const QColor &color)
 {
     mColor = color;

--- a/apps/opencs/view/widget/coloreditor.cpp
+++ b/apps/opencs/view/widget/coloreditor.cpp
@@ -10,9 +10,20 @@
 
 #include "colorpickerpopup.hpp"
 
-CSVWidget::ColorEditor::ColorEditor(const QColor &color, QWidget *parent, bool popupOnStart)
+CSVWidget::ColorEditor::ColorEditor(const QColor &color, QWidget *parent, const bool popupOnStart)
+    : ColorEditor(parent, popupOnStart)
+{
+    setColor(color);
+}
+
+CSVWidget::ColorEditor::ColorEditor(const int colorInt, QWidget *parent, const bool popupOnStart)
+    : ColorEditor(parent, popupOnStart)
+{
+    setColor(colorInt);
+}
+
+CSVWidget::ColorEditor::ColorEditor(QWidget *parent, const bool popupOnStart)
     : QPushButton(parent),
-      mColor(color),
       mColorPicker(new ColorPickerPopup(this)),
       mPopupOnStart(popupOnStart)
 {
@@ -57,6 +68,14 @@ void CSVWidget::ColorEditor::setColor(const QColor &color)
 {
     mColor = color;
     update();
+}
+
+void CSVWidget::ColorEditor::setColor(const int colorInt)
+{
+    // Color RGB values are stored in given integer.
+    // First byte is red, second byte is green, third byte is blue.
+    QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
+    setColor(color);
 }
 
 void CSVWidget::ColorEditor::showPicker()

--- a/apps/opencs/view/widget/coloreditor.hpp
+++ b/apps/opencs/view/widget/coloreditor.hpp
@@ -22,14 +22,22 @@ namespace CSVWidget
             QPoint calculatePopupPosition();
 
         public:
-            ColorEditor(const QColor &color, QWidget *parent = 0, bool popupOnStart = false);
+            ColorEditor(const QColor &color, QWidget *parent = 0, const bool popupOnStart = false);
+            ColorEditor(const int colorInt, QWidget *parent = 0, const bool popupOnStart = false);
 
             QColor color() const;
             void setColor(const QColor &color);
 
+            /// \brief Set color using given int value.
+            /// \param colorInt RGB color value encoded as an integer.
+            void setColor(const int colorInt);
+
         protected:
             virtual void paintEvent(QPaintEvent *event);
             virtual void showEvent(QShowEvent *event);
+
+        private:
+            ColorEditor(QWidget *parent = 0, const bool popupOnStart = false);
 
         private slots:
             void showPicker();

--- a/apps/opencs/view/widget/coloreditor.hpp
+++ b/apps/opencs/view/widget/coloreditor.hpp
@@ -26,6 +26,10 @@ namespace CSVWidget
             ColorEditor(const int colorInt, QWidget *parent = 0, const bool popupOnStart = false);
 
             QColor color() const;
+
+            /// \return Color RGB value encoded in an int.
+            int colorInt() const;
+
             void setColor(const QColor &color);
 
             /// \brief Set color using given int value.

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -181,9 +181,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
     // (the third parameter of ColorEditor's constructor)
     else if (display == CSMWorld::ColumnBase::Display_Colour)
     {
-        int colorInt = index.data().toInt();
-        QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
-        return new CSVWidget::ColorEditor(color, parent, true);
+        return new CSVWidget::ColorEditor(index.data().toInt(), parent, true);
     }
     return createEditor (parent, option, index, display);
 }
@@ -207,9 +205,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
     {
         case CSMWorld::ColumnBase::Display_Colour:
         {
-            int colorInt = variant.toInt();
-            QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
-            return new CSVWidget::ColorEditor(color, parent);
+            return new CSVWidget::ColorEditor(variant.toInt(), parent);
         }
         case CSMWorld::ColumnBase::Display_Integer:
         {
@@ -322,9 +318,7 @@ void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelInde
     CSVWidget::ColorEditor *colorEditor = qobject_cast<CSVWidget::ColorEditor *>(editor);
     if (colorEditor != NULL)
     {
-        int colorInt = variant.toInt();
-        QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
-        colorEditor->setColor(color);
+        colorEditor->setColor(variant.toInt());
         return;
     }
 

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -133,8 +133,7 @@ void CSVWorld::CommandDelegate::setModelDataImp (QWidget *editor, QAbstractItemM
     CSVWidget::ColorEditor *colorEditor = qobject_cast<CSVWidget::ColorEditor *>(editor);
     if (colorEditor != NULL)
     {
-        QColor color = colorEditor->color();
-        variant = (color.blue() << 16) | (color.green() << 8) | (color.red());
+        variant = colorEditor->colorInt();
     }
     else
     {

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -127,22 +127,24 @@ void CSVWorld::CommandDelegate::setModelDataImp (QWidget *editor, QAbstractItemM
     if (!mCommandDispatcher)
         return;
 
-    QVariant new_;
-    // Color columns use a custom editor, so we need explicitly extract a data from it
+    QVariant variant;
+
+    // Color columns use a custom editor, so we need to fetch selected color from it.
     CSVWidget::ColorEditor *colorEditor = qobject_cast<CSVWidget::ColorEditor *>(editor);
     if (colorEditor != NULL)
     {
-        new_ = colorEditor->color();
+        QColor color = colorEditor->color();
+        variant = (color.blue() << 16) | (color.green() << 8) | (color.red());
     }
     else
     {
         NastyTableModelHack hack (*model);
         QStyledItemDelegate::setModelData (editor, &hack, index);
-        new_ = hack.getData();
+        variant = hack.getData();
     }
 
-    if ((model->data (index)!=new_) && (model->flags(index) & Qt::ItemIsEditable))
-        mCommandDispatcher->executeModify (model, index, new_);
+    if ((model->data (index)!=variant) && (model->flags(index) & Qt::ItemIsEditable))
+        mCommandDispatcher->executeModify (model, index, variant);
 }
 
 CSVWorld::CommandDelegate::CommandDelegate (CSMWorld::CommandDispatcher *commandDispatcher,
@@ -179,7 +181,9 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
     // (the third parameter of ColorEditor's constructor)
     else if (display == CSMWorld::ColumnBase::Display_Colour)
     {
-        return new CSVWidget::ColorEditor(index.data().value<QColor>(), parent, true);
+        int colorInt = index.data().toInt();
+        QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
+        return new CSVWidget::ColorEditor(color, parent, true);
     }
     return createEditor (parent, option, index, display);
 }
@@ -202,9 +206,11 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
     switch (display)
     {
         case CSMWorld::ColumnBase::Display_Colour:
-
-            return new CSVWidget::ColorEditor(index.data().value<QColor>(), parent);
-
+        {
+            int colorInt = variant.toInt();
+            QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
+            return new CSVWidget::ColorEditor(color, parent);
+        }
         case CSMWorld::ColumnBase::Display_Integer:
         {
             DialogueSpinBox *sb = new DialogueSpinBox(parent);
@@ -291,13 +297,13 @@ void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelInde
 
 void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelIndex& index, bool tryDisplay) const
 {
-    QVariant v = index.data(Qt::EditRole);
+    QVariant variant = index.data(Qt::EditRole);
     if (tryDisplay)
     {
-        if (!v.isValid())
+        if (!variant.isValid())
         {
-            v = index.data(Qt::DisplayRole);
-            if (!v.isValid())
+            variant = index.data(Qt::DisplayRole);
+            if (!variant.isValid())
             {
                 return;
             }
@@ -305,7 +311,7 @@ void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelInde
         QPlainTextEdit* plainTextEdit = qobject_cast<QPlainTextEdit*>(editor);
         if(plainTextEdit) //for some reason it is easier to brake the loop here
         {
-            if(plainTextEdit->toPlainText() == v.toString())
+            if (plainTextEdit->toPlainText() == variant.toString())
             {
                 return;
             }
@@ -316,23 +322,27 @@ void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelInde
     CSVWidget::ColorEditor *colorEditor = qobject_cast<CSVWidget::ColorEditor *>(editor);
     if (colorEditor != NULL)
     {
-        colorEditor->setColor(index.data().value<QColor>());
+        int colorInt = variant.toInt();
+        QColor color = QColor(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
+        colorEditor->setColor(color);
         return;
     }
 
     QByteArray n = editor->metaObject()->userProperty().name();
 
-    if (n == "dateTime") {
+    if (n == "dateTime")
+    {
         if (editor->inherits("QTimeEdit"))
             n = "time";
         else if (editor->inherits("QDateEdit"))
             n = "date";
     }
 
-    if (!n.isEmpty()) {
-        if (!v.isValid())
-            v = QVariant(editor->property(n).userType(), (const void *)0);
-        editor->setProperty(n, v);
+    if (!n.isEmpty())
+    {
+        if (!variant.isValid())
+            variant = QVariant(editor->property(n).userType(), (const void *)0);
+        editor->setProperty(n, variant);
     }
 
 }


### PR DESCRIPTION
This fixes the cell colour field issue mentioned in [bug 3148](https://bugs.openmw.org/issues/3148).

The conversion from QColor to QVariant to int and vice versa was broken. This PR switches back to using a colour field and explicitly performs the conversion between types.