### PR TITLE
UI adjustments to prevent parchment scroll from being cut off (fixes #3910)

### DIFF
--- a/files/ui/mainwindow.ui
+++ b/files/ui/mainwindow.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>635</width>
-    <height>575</height>
+    <height>565</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>635</width>
-    <height>535</height>
+    <height>565</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -57,6 +57,18 @@
        <string/>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QStackedWidget" name="pagesWidget"/>
        </item>


### PR DESCRIPTION
I figure that the margin is unnecessary since the parchment scroll PNG has a built in margin. Increased the window size a bit to properly fit the parchment.

This is what is the minimum window size with these changes:

<img width="747" alt="Launcher window with changes" src="https://user-images.githubusercontent.com/6200170/28602976-e260be9a-7186-11e7-8a7a-a18252b47db8.png">

Fixes [#3910](https://bugs.openmw.org/issues/3910)