### PR TITLE
Do not allow to loot fighting actors during death animation (bug #3528)

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -4,6 +4,7 @@
 
 #include <components/esm/loadcrea.hpp>
 #include <components/esm/creaturestate.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/magiceffects.hpp"
@@ -448,10 +449,27 @@ namespace MWClass
             return action;
         }
 
-        if(getCreatureStats(ptr).isDead())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr, true));
-        if(ptr.getClass().getCreatureStats(ptr).getAiSequence().isInCombat())
+        const MWMechanics::CreatureStats& stats = getCreatureStats(ptr);
+
+        if(stats.isDead())
+        {
+            bool canLoot = Settings::Manager::getBool ("can loot during death animation", "Game");
+
+            // by default user can loot friendly actors during death animation
+            if (canLoot && !stats.getAiSequence().isInCombat())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr, true));
+
+            // otherwise wait until death animation
+            if(stats.isDeathAnimationFinished())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr, true));
+
+            // death animation is not finished, do nothing
+            return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
+        }
+
+        if(stats.getAiSequence().isInCombat())
             return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
+
         return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
     }
 
@@ -558,7 +576,11 @@ namespace MWClass
             return true;
 
         const CreatureCustomData& customData = ptr.getRefData().getCustomData()->asCreatureCustomData();
-        return !customData.mCreatureStats.getAiSequence().isInCombat() || customData.mCreatureStats.isDead();
+
+        if (customData.mCreatureStats.isDead() && customData.mCreatureStats.isDeathAnimationFinished())
+            return true;
+
+        return !customData.mCreatureStats.getAiSequence().isInCombat();
     }
 
     MWGui::ToolTipInfo Creature::getToolTipInfo (const MWWorld::ConstPtr& ptr, int count) const

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -885,6 +885,14 @@ namespace MWClass
         if(stats.getAiSequence().isInCombat())
             return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
 
+        if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak)
+            || ptr.getClass().getCreatureStats(ptr).getKnockedDown())
+            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
+
+        // Can't talk to werewolfs
+        if(ptr.getClass().isNpc() && ptr.getClass().getNpcStats(ptr).isWerewolf())
+            return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
+
         return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
     }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -7,6 +7,7 @@
 #include <components/esm/loadmgef.hpp>
 #include <components/esm/loadnpc.hpp>
 #include <components/esm/npcstate.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -863,16 +864,27 @@ namespace MWClass
             return action;
         }
 
-        if(getCreatureStats(ptr).isDead())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr, true));
-        if(ptr.getClass().getCreatureStats(ptr).getAiSequence().isInCombat())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction("#{sActorInCombat}"));
-        if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak)
-                || ptr.getClass().getCreatureStats(ptr).getKnockedDown())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
-        // Can't talk to werewolfs
-        if(ptr.getClass().isNpc() && ptr.getClass().getNpcStats(ptr).isWerewolf())
+        const MWMechanics::CreatureStats& stats = getCreatureStats(ptr);
+
+        if(stats.isDead())
+        {
+            bool canLoot = Settings::Manager::getBool ("can loot during death animation", "Game");
+
+            // by default user can loot friendly actors during death animation
+            if (canLoot && !stats.getAiSequence().isInCombat())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr, true));
+
+            // otherwise wait until death animation
+            if(stats.isDeathAnimationFinished())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr, true));
+
+            // death animation is not finished, do nothing
             return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
+        }
+
+        if(stats.getAiSequence().isInCombat())
+            return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
+
         return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
     }
 
@@ -1019,7 +1031,11 @@ namespace MWClass
             return true;
 
         const NpcCustomData& customData = ptr.getRefData().getCustomData()->asNpcCustomData();
-        return !customData.mNpcStats.getAiSequence().isInCombat() || customData.mNpcStats.isDead();
+
+        if (customData.mNpcStats.isDead() && customData.mNpcStats.isDeathAnimationFinished())
+            return true;
+
+        return !customData.mNpcStats.getAiSequence().isInCombat();
     }
 
     MWGui::ToolTipInfo Npc::getToolTipInfo (const MWWorld::ConstPtr& ptr, int count) const

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -781,7 +781,7 @@ namespace MWMechanics
             creatureStats.getActiveSpells().visitEffectSources(updateSummonedCreatures);
             if (ptr.getClass().hasInventoryStore(ptr))
                 ptr.getClass().getInventoryStore(ptr).visitEffectSources(updateSummonedCreatures);
-            updateSummonedCreatures.process();
+            updateSummonedCreatures.process(mTimerDisposeSummonsCorpses == 0.f);
         }
     }
 
@@ -1009,7 +1009,9 @@ namespace MWMechanics
         }
     }
 
-    Actors::Actors() {}
+    Actors::Actors() {
+        mTimerDisposeSummonsCorpses = 0.2f; // We should add a delay between summoned creature death and its corpse despawning
+    }
 
     Actors::~Actors()
     {
@@ -1078,6 +1080,7 @@ namespace MWMechanics
             // target lists get updated once every 1.0 sec
             if (timerUpdateAITargets >= 1.0f) timerUpdateAITargets = 0;
             if (timerUpdateHeadTrack >= 0.3f) timerUpdateHeadTrack = 0;
+            if (mTimerDisposeSummonsCorpses >= 0.2f) mTimerDisposeSummonsCorpses = 0;
             if (timerUpdateEquippedLight >= updateEquippedLightInterval) timerUpdateEquippedLight = 0;
 
             MWWorld::Ptr player = getPlayer();
@@ -1182,6 +1185,7 @@ namespace MWMechanics
             timerUpdateAITargets += duration;
             timerUpdateHeadTrack += duration;
             timerUpdateEquippedLight += duration;
+            mTimerDisposeSummonsCorpses += duration;
 
             // Looping magic VFX update
             // Note: we need to do this before any of the animations are updated.

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -150,6 +150,7 @@ namespace MWMechanics
 
     private:
         PtrActorMap mActors;
+        float mTimerDisposeSummonsCorpses;
 
     };
 }

--- a/apps/openmw/mwmechanics/summoning.hpp
+++ b/apps/openmw/mwmechanics/summoning.hpp
@@ -22,7 +22,7 @@ namespace MWMechanics
                             float magnitude, float remainingTime = -1, float totalTime = -1);
 
         /// To call after all effect sources have been visited
-        void process();
+        void process(bool cleanup);
 
     private:
         MWWorld::Ptr mActor;

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -65,6 +65,22 @@ the type of attack is determined by the direction that the character is moving a
 The default value is false.
 This setting can be toggled with the Always Use Best Attack button in the Prefs panel of the Options menu.
 
+can loot during death animation
+-------------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	True
+
+If this setting is true, the player is allowed to loot actors (e.g. summoned creatures) during death animation, if they are not in combat.
+However disposing corpses during death animation is not recommended - death counter may not be incremented, and this behaviour can break quests.
+This is how original Morrowind behaves.
+
+If this setting is false, player has to wait until end of death animation in all cases.
+This case is more safe, but makes using of summoned creatures exploit (looting summoned Dremoras and Golden Saints for expensive weapons) a lot harder.
+
+The default value is true. This setting can only be configured by editing the settings configuration file.
+
 difficulty
 ----------
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -180,6 +180,9 @@ prevent merchant equipping = false
 # or the player. Otherwise they wait for the enemies or the player to do an attack first.
 followers attack on sight = false
 
+# Can loot non-fighting actors during death animation
+can loot during death animation = true
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Allows to fix [bug #3528](https://bugs.openmw.org/issues/3528).

Also adds an option to control lootiong behaviour:
1) True (default) - player can loot only non-fighting actors during death animation (as in vanilla Morrowind).
2) False - player can not loot all actors during death animation.

Tested with normal NPCs, summoned creatures and spriggans.