### PR TITLE
Add policy on original engine "fixes"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,25 @@ Furthermore, we advise to:
 * Feel free to submit incomplete pull requests. Even if the work can not be merged yet, pull requests are a great place to collect early feedback. Just make sure to mark it as *[Incomplete]* or *[Do not merge yet]* in the title.
 * If you plan on contributing often, please read the [Developer Reference](https://wiki.openmw.org/index.php?title=Developer_Reference) on our wiki, especially the [Policies and Standards](https://wiki.openmw.org/index.php?title=Policies_and_Standards).
 * Make sure each of your changes has a clear objective. Unnecessary changes may lead to merge conflicts, clutter the commit history and slow down review. Code formatting 'fixes' should be avoided, unless you were already changing that particular line anyway.
+
+Policy on original engine "fixes"
+=============================
+
+From time to time you may be tempted to "fix" what you think was a "bug" in the original game engine.
+
+Unfortunately, the definition of what is a "bug" is not so clear. Consider that your "bug" is actually a feature unless proven otherwise:
+
+* We have no way of knowing what the original developers really intended (short of asking them, good luck with that).
+* What may seem like an illogical mechanic can actually be part of an attempt to balance the game. 
+* Many people will actually <i>like</i> these "bugs" because that is what they remember the game for.
+* Exploits may be part of the fun of an open-world game - they reward knowledge with power. There are too many of them to plug them all, anyway.
+
+OpenMW, in its default configuration, is meant to be a faithful reimplementation of Morrowind, minus things like crash bugs, stability issues and design errors. However, we try to avoid touching anything that affects the core gameplay, the balancing of the game or introduces incompatibilities with existing mod content.
+
+That said, we may sometimes evaluate such issues on an individual basis. Common exceptions to the above would be:
+
+* Issues so glaring that they would severely limit the capabilities of the engine in the future (for example, the scripting engine not being allowed to access objects in remote cells)
+* Bugs where the intent is very obvious, and that have little to no balancing impact (e.g. the bug were being tired made it easier to repair items, instead of harder)
+* Bugs that were fixed in an official patch for Morrowind
+
+In the future, we may offer additional settings to turn each "bug" or exploit on/off, or allow modders to do so by means of scripting. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Furthermore, we advise to:
 * If you plan on contributing often, please read the [Developer Reference](https://wiki.openmw.org/index.php?title=Developer_Reference) on our wiki, especially the [Policies and Standards](https://wiki.openmw.org/index.php?title=Policies_and_Standards).
 * Make sure each of your changes has a clear objective. Unnecessary changes may lead to merge conflicts, clutter the commit history and slow down review. Code formatting 'fixes' should be avoided, unless you were already changing that particular line anyway.
 
-Policy on original engine "fixes"
-=============================
+Guidelines for original engine "fixes"
+=================================
 
 From time to time you may be tempted to "fix" what you think was a "bug" in the original game engine.
 
@@ -52,6 +52,4 @@ That said, we may sometimes evaluate such issues on an individual basis. Common 
 
 * Issues so glaring that they would severely limit the capabilities of the engine in the future (for example, the scripting engine not being allowed to access objects in remote cells)
 * Bugs where the intent is very obvious, and that have little to no balancing impact (e.g. the bug were being tired made it easier to repair items, instead of harder)
-* Bugs that were fixed in an official patch for Morrowind
-
-In the future, we may offer additional settings to turn each "bug" or exploit on/off, or allow modders to do so by means of scripting. 
+* Bugs that were fixed in an official patch for Morrowind 


### PR DESCRIPTION
Since the topic came up again on #1350, I figured to write down this policy. It is what I gathered from many discussions in the past and some "bugs" that we had fixed then later reverted when complaints came in. Do we all agree on this?