### PR TITLE
[macOS] Fixes accidental loading of plugins from system-wide Qt install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "MegynKyJpyL7XDwdWVEbypQh7CLjqOqOi9lGF97G7Fq0HosVZTmnwjHhmIPZspTP7ES4UbxM3rs/f3ce7sp9JN2ShRJpduD6UEFc8egQXBte9J3obUBIdUxPTRdhnht7VJ+u+pksK1S/Bm1Cs6l0eEluP3vmcaXWMykVQcZsPhY="
    # macOS builds FTP upload password
    - secure: "jQcAaWAdDy0+vlNu4POMX8322HanCOQEUTdpviWTAUjWQTjMa0UTM4+zVVgrtEaHMpBaVYYbTT3Rg5BQ9oG+2SiVLJBQQ2XoMcos/YrjPVT6inB02Gs0vFjP29LdPAQVrB8CkAcfQr6u+Z2C+RqAtwhE09LsBUMXjRDzPAtr1CM="
-   - macos_qt_formula=qt@5.7
+   - macos_qt_formula=qt
 addons:
   apt:
     sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,7 +800,6 @@ if (OPENMW_OSX_DEPLOYMENT AND APPLE AND DESIRED_QT_VERSION MATCHES 5)
             endif()
         endfunction()
 
-        cmake_policy(SET CMP0009 OLD)
         fixup_bundle(\"${INSTALLED_OPENMW_APP}\" \"${PLUGINS}\" \"\")
         fixup_bundle(\"${INSTALLED_OPENCS_APP}\" \"${OPENCS_PLUGINS}\" \"\")
         " COMPONENT Runtime)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,17 +718,19 @@ if (WIN32)
 endif()
 
 # Apple bundling
-if (APPLE AND DESIRED_QT_VERSION MATCHES 5)
+if (OPENMW_OSX_DEPLOYMENT AND APPLE AND DESIRED_QT_VERSION MATCHES 5)
     get_property(QT_COCOA_PLUGIN_PATH TARGET Qt5::QCocoaIntegrationPlugin PROPERTY LOCATION_RELEASE)
     get_filename_component(QT_COCOA_PLUGIN_DIR "${QT_COCOA_PLUGIN_PATH}" DIRECTORY)
     get_filename_component(QT_COCOA_PLUGIN_GROUP "${QT_COCOA_PLUGIN_DIR}" NAME)
     get_filename_component(QT_COCOA_PLUGIN_NAME "${QT_COCOA_PLUGIN_PATH}" NAME)
-    configure_file("${QT_COCOA_PLUGIN_PATH}" "${APP_BUNDLE_DIR}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}" COPYONLY)
+    configure_file("${QT_COCOA_PLUGIN_PATH}" "${APP_BUNDLE_DIR}/Contents/PlugIns/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}" COPYONLY)
+    configure_file("${OpenMW_SOURCE_DIR}/files/mac/qt.conf" "${APP_BUNDLE_DIR}/Contents/Resources/qt.conf" COPYONLY)
 
     if (BUILD_OPENCS)
       get_property(OPENCS_BUNDLE_NAME_TMP TARGET openmw-cs PROPERTY OUTPUT_NAME)
       set(OPENCS_BUNDLE_NAME "${OPENCS_BUNDLE_NAME_TMP}.app")
-      configure_file("${QT_COCOA_PLUGIN_PATH}" "${OPENCS_BUNDLE_NAME}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}" COPYONLY)
+      configure_file("${QT_COCOA_PLUGIN_PATH}" "${OPENCS_BUNDLE_NAME}/Contents/PlugIns/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}" COPYONLY)
+      configure_file("${OpenMW_SOURCE_DIR}/files/mac/qt.conf" "${OPENCS_BUNDLE_NAME}/Contents/Resources/qt.conf" COPYONLY)
     endif ()
 
     install(DIRECTORY "${APP_BUNDLE_DIR}" USE_SOURCE_PERMISSIONS DESTINATION "." COMPONENT Runtime)
@@ -787,8 +789,8 @@ if (APPLE AND DESIRED_QT_VERSION MATCHES 5)
     install_plugins_for_bundle("${APP_BUNDLE_NAME}" PLUGINS)
     install_plugins_for_bundle("${OPENCS_BUNDLE_NAME}" OPENCS_PLUGINS)
 
-    set(PLUGINS ${PLUGINS} "${INSTALLED_OPENMW_APP}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}")
-    set(OPENCS_PLUGINS ${OPENCS_PLUGINS} "${INSTALLED_OPENCS_APP}/Contents/MacOS/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}")
+    set(PLUGINS ${PLUGINS} "${INSTALLED_OPENMW_APP}/Contents/PlugIns/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}")
+    set(OPENCS_PLUGINS ${OPENCS_PLUGINS} "${INSTALLED_OPENCS_APP}/Contents/PlugIns/${QT_COCOA_PLUGIN_GROUP}/${QT_COCOA_PLUGIN_NAME}")
 
     install(CODE "
         function(gp_item_default_embedded_path_override item  default_embedded_path_var)
@@ -803,7 +805,7 @@ if (APPLE AND DESIRED_QT_VERSION MATCHES 5)
         fixup_bundle(\"${INSTALLED_OPENCS_APP}\" \"${OPENCS_PLUGINS}\" \"\")
         " COMPONENT Runtime)
     include(CPack)
-endif (APPLE AND DESIRED_QT_VERSION MATCHES 5)
+endif ()
 
 # Doxygen Target -- simply run 'make doc' or 'make doc_pages'
 # output directory for 'make doc'       is "${OpenMW_BINARY_DIR}/docs/Doxygen"

--- a/files/mac/qt.conf
+++ b/files/mac/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Plugins = PlugIns


### PR DESCRIPTION
I was too eager to remove the workaround in 014a2fc0e924b9229e8da812eddf85b883cd8a8e. Actually, config-based solution seems cleaner. Respective Qt documentation: http://doc.qt.io/qt-5/qt-conf.html.

Also, moves Qt plugins from Contents/MacOS to Contents/PlugIns for consistency.

Also, removes legacy CMake policy use and bumps Qt version used on CI.