### PR TITLE
Renaming duplicate horizontalSpacer variable

### DIFF
--- a/files/ui/settingspage.ui
+++ b/files/ui/settingspage.ui
@@ -53,7 +53,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,1">
       <item row="1" column="1">
-       <spacer name="horizontalSpacer">
+       <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -115,7 +115,7 @@
       <item>
        <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,1">
         <item row="2" column="1">
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_3">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>


### PR DESCRIPTION
Fixes issue identified [here](https://github.com/OpenMW/openmw/pull/1349#issuecomment-318932672), which was introduced in #1345