### PR TITLE
Fix bug #3864

### DIFF
--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -70,6 +70,9 @@ void Objects::insertBegin(const MWWorld::Ptr& ptr)
 
 void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh, bool animated, bool allowLight)
 {
+    if (mObjects.count(ptr))
+        return;
+
     insertBegin(ptr);
 
     osg::ref_ptr<ObjectAnimation> anim (new ObjectAnimation(ptr, mesh, mResourceSystem, animated, allowLight));
@@ -79,6 +82,9 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh, bool
 
 void Objects::insertCreature(const MWWorld::Ptr &ptr, const std::string &mesh, bool weaponsShields)
 {
+    if (mObjects.count(ptr))
+        return;
+
     insertBegin(ptr);
     ptr.getRefData().getBaseNode()->setNodeMask(Mask_Actor);
 
@@ -97,6 +103,9 @@ void Objects::insertCreature(const MWWorld::Ptr &ptr, const std::string &mesh, b
 
 void Objects::insertNPC(const MWWorld::Ptr &ptr)
 {
+    if (mObjects.count(ptr))
+        return;
+
     insertBegin(ptr);
     ptr.getRefData().getBaseNode()->setNodeMask(Mask_Actor);
 


### PR DESCRIPTION
I've made investigation. Basically problem with the accessing destructed object. Here is log:
```
Loading cell -8, 3
NpcAnimation this=0x55c6b91fdac0
static_cast<...>(anim.get())=0x55c6b91fd870 0x55c6b91fdac0 at /home/elsid/dev/openmw/apps/openmw/mwrender/objects.cpp:108
setInvListener this=0x55c6b8cf67b0 mListener=0x55c6b91fdac0
~NpcAnimation this=0x55c6b91fdac0
...
fireEquipmentChangedEvent this=0x55c6b8cf67b0 mListener=0x55c6b91fdac0
Segmentation fault (core dumped)
```
But originally the problem with double [insert](https://github.com/OpenMW/openmw/blob/59b92dc67b99448f9656592818cf89c0ee5431ec/apps/openmw/mwrender/objects.cpp#L108) into Objects:mObjects different values by equal keys. It is the NPC with id "hlaalu guard_outside". First insert performs when cell [respawns](https://github.com/OpenMW/openmw/blob/59b92dc67b99448f9656592818cf89c0ee5431ec/apps/openmw/mwworld/scene.cpp#L293).
```
#2  0x000055a252bc8ddd in MWRender::NpcAnimation::NpcAnimation (this=0x55a267652dd0, ptr=..., parentNode=..., resourceSystem=0x55a257cd6d60, disableSounds=false, viewMode=MWRender::NpcAnimation::VM_Normal, firstPersonFieldOfView=55)
    at /home/elsid/dev/openmw/apps/openmw/mwrender/npcanimation.cpp:292
292	        abort();
(gdb) print mNpc->mId
$1 = "hlaalu guard_outside"
(gdb) bt
#0  0x00007f0c0cef68c0 in raise () at /usr/lib/libc.so.6
#1  0x00007f0c0cef7f72 in abort () at /usr/lib/libc.so.6
#2  0x000055a252bc8ddd in MWRender::NpcAnimation::NpcAnimation(MWWorld::Ptr const&, osg::ref_ptr<osg::Group>, Resource::ResourceSystem*, bool, MWRender::NpcAnimation::ViewMode, float) (this=0x55a267652dd0, ptr=..., parentNode=..., resourceSystem=0x55a257cd6d60, disableSounds=false, viewMode=MWRender::NpcAnimation::VM_Normal, firstPersonFieldOfView=55) at /home/elsid/dev/openmw/apps/openmw/mwrender/npcanimation.cpp:292
#3  0x000055a252b94719 in MWRender::Objects::insertNPC(MWWorld::Ptr const&) (this=0x55a258f6b2b0, ptr=...) at /home/elsid/dev/openmw/apps/openmw/mwrender/objects.cpp:107
#4  0x000055a253583a89 in MWClass::Npc::insertObjectRendering(MWWorld::Ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MWRender::RenderingInterface&) const (this=0x55a255a97a50, ptr=..., model="meshes\\xbase_anim.nif", renderingInterface=...) at /home/elsid/dev/openmw/apps/openmw/mwclass/npc.cpp:414
#5  0x000055a2531f1380 in (anonymous namespace)::addObject(MWWorld::Ptr const&, MWPhysics::PhysicsSystem&, MWRender::RenderingManager&) (ptr=..., physics=..., rendering=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:66
#6  0x000055a2531f97b7 in MWWorld::Scene::addObjectToScene(MWWorld::Ptr const&) (this=0x55a25b37e970, ptr=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:612
#7  0x000055a2531d52af in MWWorld::World::moveObject(MWWorld::Ptr const&, MWWorld::CellStore*, float, float, float, bool) (this=0x55a258f51480, ptr=..., newCell=0x55a25f01d088, x=-61596.75, y=27251.0254, z=486.958862, movePhysics=true)
    at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:1187
#8  0x000055a2531d6070 in MWWorld::World::moveObjectImp(MWWorld::Ptr const&, float, float, float, bool) (this=0x55a258f51480, ptr=..., x=-61596.75, y=27251.0254, z=486.958862, movePhysics=true)
    at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:1254
#9  0x000055a2531d6130 in MWWorld::World::moveObject(MWWorld::Ptr const&, float, float, float) (this=0x55a258f51480, ptr=..., x=-61596.75, y=27251.0254, z=486.958862) at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:1259
#10 0x000055a253593158 in MWClass::Npc::respawn(MWWorld::Ptr const&) const (this=0x55a255a97a50, ptr=...) at /home/elsid/dev/openmw/apps/openmw/mwclass/npc.cpp:1342
#11 0x000055a253236a5b in MWWorld::CellStore::respawn() (this=0x55a25f01d088) at /home/elsid/dev/openmw/apps/openmw/mwworld/cellstore.cpp:994
#12 0x000055a2531f3def in MWWorld::Scene::loadCell(MWWorld::CellStore*, Loading::Listener*, bool) (this=0x55a25b37e970, cell=0x55a25f01d088, loadingListener=0x55a257da1788, respawn=true)
    at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:295
#13 0x000055a2531f569b in MWWorld::Scene::changeCellGrid(int, int, bool) (this=0x55a25b37e970, X=-9, Y=4, changeEvent=true) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:424
#14 0x000055a2531f92dd in MWWorld::Scene::changeToExteriorCell(ESM::Position const&, bool, bool) (this=0x55a25b37e970, position=..., adjustPlayerPos=true, changeEvent=true) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:580
#15 0x000055a2531d27ab in MWWorld::World::changeToExteriorCell(ESM::Position const&, bool, bool) (this=0x55a258f51480, position=..., adjustPlayerPos=true, changeEvent=true) at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:1008
#16 0x000055a2532032ec in MWWorld::ActionTeleport::teleport(MWWorld::Ptr const&) (this=0x55a266eff4a0, actor=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/actionteleport.cpp:44
#17 0x000055a253203095 in MWWorld::ActionTeleport::executeImp(MWWorld::Ptr const&) (this=0x55a266eff4a0, actor=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/actionteleport.cpp:33
#18 0x000055a253202c68 in MWWorld::Action::execute(MWWorld::Ptr const&, bool) (this=0x55a266eff4a0, actor=..., noSound=false) at /home/elsid/dev/openmw/apps/openmw/mwworld/action.cpp:60
#19 0x000055a2531ef844 in MWWorld::World::activate(MWWorld::Ptr const&, MWWorld::Ptr const&) (this=0x55a258f51480, object=..., actor=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:3369
#20 0x000055a253212626 in MWWorld::Player::activate() (this=0x55a25bf36cc0) at /home/elsid/dev/openmw/apps/openmw/mwworld/player.cpp:226
#21 0x000055a252d0042f in MWInput::InputManager::activate() (this=0x55a257cd83d0) at /home/elsid/dev/openmw/apps/openmw/mwinput/inputmanagerimp.cpp:1070
#22 0x000055a252cf5279 in MWInput::InputManager::channelChanged(ICS::Channel*, float, float) (this=0x55a257cd83d0, channel=0x55a257cdb860, currentValue=1, previousValue=0)
    at /home/elsid/dev/openmw/apps/openmw/mwinput/inputmanagerimp.cpp:237
#23 0x000055a25379e5fa in ICS::Channel::notifyListeners(float) (this=0x55a257cdb860, previousValue=0) at /home/elsid/dev/openmw/extern/oics/ICSChannel.cpp:99
#24 0x000055a25379e559 in ICS::Channel::setValue(float) (this=0x55a257cdb860, value=1) at /home/elsid/dev/openmw/extern/oics/ICSChannel.cpp:90
#25 0x000055a25379e820 in ICS::Channel::update() (this=0x55a257cdb860) at /home/elsid/dev/openmw/extern/oics/ICSChannel.cpp:141
#26 0x000055a2537a10b1 in ICS::Control::updateChannels() (this=0x55a257cdeef0) at /home/elsid/dev/openmw/extern/oics/ICSControl.cpp:79
#27 0x000055a2537a0fbe in ICS::Control::setValue(float) (this=0x55a257cdeef0, value=inf) at /home/elsid/dev/openmw/extern/oics/ICSControl.cpp:62
#28 0x000055a2537a136c in ICS::Control::update(float) (this=0x55a257cdeef0, timeSinceLastFrame=0.00773700001) at /home/elsid/dev/openmw/extern/oics/ICSControl.cpp:122
#29 0x000055a2537a877b in ICS::InputControlSystem::update(float) (this=0x55a257cdac40, lTimeSinceLastFrame=0.00773700001) at /home/elsid/dev/openmw/extern/oics/ICSInputControlSystem.cpp:650
#30 0x000055a252cf6322 in MWInput::InputManager::update(float, bool, bool) (this=0x55a257cd83d0, dt=0.00773700001, disableControls=false, disableEvents=false) at /home/elsid/dev/openmw/apps/openmw/mwinput/inputmanagerimp.cpp:380
#31 0x000055a2537809eb in OMW::Engine::frame(float) (this=0x55a255a975c0, frametime=0.00773700001) at /home/elsid/dev/openmw/apps/openmw/engine.cpp:90
#32 0x000055a25378e246 in OMW::Engine::go() (this=0x55a255a975c0) at /home/elsid/dev/openmw/apps/openmw/engine.cpp:701
#33 0x000055a253755ed1 in main(int, char**) (argc=4, argv=0x7ffeaa0e64d8) at /home/elsid/dev/openmw/apps/openmw/main.cpp:354
```
and the second when cell normally [inserts](https://github.com/OpenMW/openmw/blob/59b92dc67b99448f9656592818cf89c0ee5431ec/apps/openmw/mwworld/scene.cpp#L297).
```
#2  0x000056393b5c3bbb in MWRender::Objects::insertNPC(MWWorld::Ptr const&) (this=0x56394206cdd0, ptr=...) at /home/elsid/dev/openmw/apps/openmw/mwrender/objects.cpp:116
#3  0x000056393bfb2661 in MWClass::Npc::insertObjectRendering(MWWorld::Ptr const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MWRender::RenderingInterface&) const (this=0x56393eacba50, ptr=..., model="meshes\\xbase_anim.nif", renderingInterface=...) at /home/elsid/dev/openmw/apps/openmw/mwclass/npc.cpp:414
#4  0x000056393bc20048 in (anonymous namespace)::addObject(MWWorld::Ptr const&, MWPhysics::PhysicsSystem&, MWRender::RenderingManager&) (ptr=..., physics=..., rendering=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:66
#5  0x000056393bc20c07 in (anonymous namespace)::InsertVisitor::insert() (this=0x7ffe4f280760) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:150
#6  0x000056393bc28328 in MWWorld::Scene::insertCell(MWWorld::CellStore&, bool, Loading::Listener*) (this=0x563943780840, cell=..., rescale=true, loadingListener=0x563940d63408) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:601
#7  0x000056393bc22b07 in MWWorld::Scene::loadCell(MWWorld::CellStore*, Loading::Listener*, bool) (this=0x563943780840, cell=0x5639480519c8, loadingListener=0x563940d63408, respawn=true)
    at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:299
#8  0x000056393bc24363 in MWWorld::Scene::changeCellGrid(int, int, bool) (this=0x563943780840, X=-9, Y=4, changeEvent=true) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:424
#9  0x000056393bc27fa5 in MWWorld::Scene::changeToExteriorCell(ESM::Position const&, bool, bool) (this=0x563943780840, position=..., adjustPlayerPos=true, changeEvent=true) at /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:580
#10 0x000056393bc01473 in MWWorld::World::changeToExteriorCell(ESM::Position const&, bool, bool) (this=0x563941f8fe20, position=..., adjustPlayerPos=true, changeEvent=true) at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:1008
#11 0x000056393bc31fb4 in MWWorld::ActionTeleport::teleport(MWWorld::Ptr const&) (this=0x56394dcf08f0, actor=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/actionteleport.cpp:44
#12 0x000056393bc31d5d in MWWorld::ActionTeleport::executeImp(MWWorld::Ptr const&) (this=0x56394dcf08f0, actor=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/actionteleport.cpp:33
#13 0x000056393bc31930 in MWWorld::Action::execute(MWWorld::Ptr const&, bool) (this=0x56394dcf08f0, actor=..., noSound=false) at /home/elsid/dev/openmw/apps/openmw/mwworld/action.cpp:60
#14 0x000056393bc1e50c in MWWorld::World::activate(MWWorld::Ptr const&, MWWorld::Ptr const&) (this=0x563941f8fe20, object=..., actor=...) at /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:3369
#15 0x000056393bc412ee in MWWorld::Player::activate() (this=0x563944fde9d0) at /home/elsid/dev/openmw/apps/openmw/mwworld/player.cpp:226
#16 0x000056393b72f0f7 in MWInput::InputManager::activate() (this=0x563940d0c2d0) at /home/elsid/dev/openmw/apps/openmw/mwinput/inputmanagerimp.cpp:1070
#17 0x000056393b723f41 in MWInput::InputManager::channelChanged(ICS::Channel*, float, float) (this=0x563940d0c2d0, channel=0x563940d0f760, currentValue=1, previousValue=0)
    at /home/elsid/dev/openmw/apps/openmw/mwinput/inputmanagerimp.cpp:237
#18 0x000056393c1cd1d2 in ICS::Channel::notifyListeners(float) (this=0x563940d0f760, previousValue=0) at /home/elsid/dev/openmw/extern/oics/ICSChannel.cpp:99
#19 0x000056393c1cd131 in ICS::Channel::setValue(float) (this=0x563940d0f760, value=1) at /home/elsid/dev/openmw/extern/oics/ICSChannel.cpp:90
#20 0x000056393c1cd3f8 in ICS::Channel::update() (this=0x563940d0f760) at /home/elsid/dev/openmw/extern/oics/ICSChannel.cpp:141
#21 0x000056393c1cfc89 in ICS::Control::updateChannels() (this=0x563940d12df0) at /home/elsid/dev/openmw/extern/oics/ICSControl.cpp:79
#22 0x000056393c1cfb96 in ICS::Control::setValue(float) (this=0x563940d12df0, value=inf) at /home/elsid/dev/openmw/extern/oics/ICSControl.cpp:62
#23 0x000056393c1cff44 in ICS::Control::update(float) (this=0x563940d12df0, timeSinceLastFrame=0.0070679998) at /home/elsid/dev/openmw/extern/oics/ICSControl.cpp:122
#24 0x000056393c1d7353 in ICS::InputControlSystem::update(float) (this=0x563940d0eb40, lTimeSinceLastFrame=0.0070679998) at /home/elsid/dev/openmw/extern/oics/ICSInputControlSystem.cpp:650
#25 0x000056393b724fea in MWInput::InputManager::update(float, bool, bool) (this=0x563940d0c2d0, dt=0.0070679998, disableControls=false, disableEvents=false) at /home/elsid/dev/openmw/apps/openmw/mwinput/inputmanagerimp.cpp:380
#26 0x000056393c1af5c3 in OMW::Engine::frame(float) (this=0x56393eacb5c0, frametime=0.0070679998) at /home/elsid/dev/openmw/apps/openmw/engine.cpp:90
#27 0x000056393c1bce1e in OMW::Engine::go() (this=0x56393eacb5c0) at /home/elsid/dev/openmw/apps/openmw/engine.cpp:701
#28 0x000056393c184aa9 in main(int, char**) (argc=4, argv=0x7ffe4f281e38) at /home/elsid/dev/openmw/apps/openmw/main.cpp:354
```
Looks like logic error. So the solution is to ignore any inserts after first. Commit fix the bug, but it doesn't looks like best solution.
