### PR TITLE
Combat AI: use WhenUsed enchantments [Feedback needed]

### DIFF
--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -71,6 +71,8 @@ namespace MWMechanics
     {
         const ESM::Enchantment* enchantment = MWBase::Environment::get().getWorld()->getStore().get<ESM::Enchantment>().find(mItem->getClass().getEnchantment(*mItem));
         int types = getRangeTypes(enchantment->mEffects);
+
+        isRanged = (types & RangeTypes::Target) | (types & RangeTypes::Self);
         return suggestCombatRange(types);
     }
 

--- a/apps/openmw/mwmechanics/aicombataction.hpp
+++ b/apps/openmw/mwmechanics/aicombataction.hpp
@@ -54,7 +54,7 @@ namespace MWMechanics
         virtual float getCombatRange (bool& isRanged) const;
 
         /// Since this action has no animation, apply a small cool down for using it
-        virtual float getActionCooldown() { return 1.f; }
+        virtual float getActionCooldown() { return 0.75f; }
     };
 
     class ActionPotion : public Action
@@ -68,7 +68,7 @@ namespace MWMechanics
         virtual bool isAttackingOrSpell() const { return false; }
 
         /// Since this action has no animation, apply a small cool down for using it
-        virtual float getActionCooldown() { return 1.f; }
+        virtual float getActionCooldown() { return 0.75f; }
     };
 
     class ActionWeapon : public Action

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -46,6 +46,26 @@ namespace
         }
         return toCure;
     }
+
+    float getSpellDuration (const MWWorld::Ptr& actor, const std::string& spellId)
+    {
+        float duration = 0;
+        const MWMechanics::ActiveSpells& activeSpells = actor.getClass().getCreatureStats(actor).getActiveSpells();
+        for (MWMechanics::ActiveSpells::TIterator it = activeSpells.begin(); it != activeSpells.end(); ++it)
+        {
+            if (it->first != spellId)
+                continue;
+
+            const MWMechanics::ActiveSpells::ActiveSpellParams& params = it->second;
+            for (std::vector<MWMechanics::ActiveSpells::ActiveEffect>::const_iterator effectIt = params.mEffects.begin();
+                effectIt != params.mEffects.end(); ++effectIt)
+            {
+                if (effectIt->mDuration > duration)
+                    duration = effectIt->mDuration;
+            }
+        }
+        return duration;
+    }
 }
 
 namespace MWMechanics
@@ -114,15 +134,39 @@ namespace MWMechanics
 
         const ESM::Enchantment* enchantment = MWBase::Environment::get().getWorld()->getStore().get<ESM::Enchantment>().find(ptr.getClass().getEnchantment(ptr));
 
+        // Spells don't stack, so early out if the spell is still active on the target
+        int types = getRangeTypes(enchantment->mEffects);
+        if ((types & Self) && actor.getClass().getCreatureStats(actor).getActiveSpells().isSpellActive(ptr.getCellRef().getRefId()))
+            return 0.f;
+
+        if (types & (Touch|Target) && getSpellDuration(enemy, ptr.getCellRef().getRefId()) > 3)
+            return 0.f;
+
         if (enchantment->mData.mType == ESM::Enchantment::CastOnce)
         {
             return rateEffects(enchantment->mEffects, actor, enemy);
         }
-        else
+        else if (enchantment->mData.mType == ESM::Enchantment::WhenUsed)
         {
-            //if (!ptr.getClass().canBeEquipped(ptr, actor))
-            return 0.f;
+            MWWorld::InventoryStore& store = actor.getClass().getInventoryStore(actor);
+
+            // Creatures can not wear armor/clothing, so allow creatures to use non-equipped items, 
+            if (actor.getClass().isNpc() && !store.isEquipped(ptr))
+                return 0.f;
+
+            int castCost = getEffectiveEnchantmentCastCost(static_cast<float>(enchantment->mData.mCost), actor);
+
+            if (ptr.getCellRef().getEnchantmentCharge() != -1
+               && ptr.getCellRef().getEnchantmentCharge() < castCost)
+                return 0.f;
+
+            float rating = rateEffects(enchantment->mEffects, actor, enemy);
+
+            rating *= 2; // prefer rechargable magic items over spells
+            return rating;
         }
+
+        return 0.f;
     }
 
     float rateEffect(const ESM::ENAMstruct &effect, const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy)


### PR DESCRIPTION
Implements [feature #3953](https://bugs.openmw.org/issues/3953).

Known issues:
1. Some creatures still can not use magic items (e.g. Dagoth creatures can not use Six House amulets).

2. When actors use magic item (e.g. "ring of fireballs"), sometimes they change a stance for a half-second or so after cast, as if an item was added or removed from actor's inventory.
**FIXED**

3. When actors use items with combat enchantments (e.g. "ring of fireballs"), they will spam enchantments until a used item will be runned out of charges. This is ok from logic side, but do not look good since ActionEnchantedItem has no animation.
Maybe just allow to use only full-charged offensive items? It is similar how to vanilla Morrowind behaves.

4. A delay between casts is longer than in vanilla - OpenMW does not take in account that ActionEnchantedItem has no animation, so a round duration is shorter than with spells.
**FIXED**

Tested with:
1) Furius Acilius with his "demon katana".
2) A Golden saint with added "first barrier belt" and "ring of fireballs".
3) Dagoth Vaner - he can not use any magic items yet.

Any feedback would be greatly appreciated.