### PR TITLE
Copy PathFinder::mPath back value when pass to MWMechanics::AiPackage…

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -489,7 +489,7 @@ namespace MWMechanics
         float duration, AiWanderStorage& storage, ESM::Position& pos)
     {
         // Is there no destination or are we there yet?
-        if ((!mPathFinder.isPathConstructed()) || pathTo(actor, mPathFinder.getPath().back(), duration, DESTINATION_TOLERANCE))
+        if ((!mPathFinder.isPathConstructed()) || pathTo(actor, ESM::Pathgrid::Point(mPathFinder.getPath().back()), duration, DESTINATION_TOLERANCE))
         {
             stopWalking(actor, storage);
             storage.setState(Wander_ChooseAction);


### PR DESCRIPTION
…::pathTo as dest

May become dangling reference because method may remove all elements from mPath.

Found by clang AddressSanitizer:
```
==26422==ERROR: AddressSanitizer: heap-use-after-free on address 0x60300b50b4d0 at pc 0x55db582b362a bp 0x7fff653fe450 sp 0x7fff653fe448
READ of size 4 at 0x60300b50b4d0 thread T0
    #0 0x55db582b3629 in MWMechanics::PathFinder::MakeOsgVec3(ESM::Pathgrid::Point const&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/pathfinding.hpp:113:56
    #1 0x55db5832192a in MWMechanics::getZAngleToPoint(ESM::Pathgrid::Point const&, ESM::Pathgrid::Point const&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/pathfinding.cpp:98:26
    #2 0x55db582ae189 in MWMechanics::AiPackage::pathTo(MWWorld::Ptr const&, ESM::Pathgrid::Point const&, float, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aipackage.cpp:145:22
    #3 0x55db582e4655 in MWMechanics::AiWander::onWalkingStatePerFrameActions(MWWorld::Ptr const&, float, MWMechanics::AiWanderStorage&, ESM::Position&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:492:51
    #4 0x55db582ddae5 in MWMechanics::AiWander::doPerFrameActionsForState(MWWorld::Ptr const&, float, MWMechanics::AiWanderStorage&, ESM::Position&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:431:17
    #5 0x55db582dd62b in MWMechanics::AiWander::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:225:9
    #6 0x55db582b94a5 in MWMechanics::AiSequence::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aisequence.cpp:264:26
    #7 0x55db583ea76b in MWMechanics::Actors::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwmechanics/actors.cpp:1177:55
    #8 0x55db581ee3b2 in MWMechanics::MechanicsManager::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp:421:17
    #9 0x55db5849125c in OMW::Engine::frame(float) /home/elsid/dev/openmw/apps/openmw/engine.cpp:141:49
    #10 0x55db5849f890 in OMW::Engine::go() /home/elsid/dev/openmw/apps/openmw/engine.cpp:701:9
    #11 0x55db5844f1a7 in main /home/elsid/dev/openmw/apps/openmw/main.cpp:354:21
    #12 0x7f521a9de4c9 in __libc_start_main (/usr/lib/libc.so.6+0x204c9)
    #13 0x55db56f99339 in _start (/home/elsid/dev/openmw/build_clang_asan/openmw+0xbed339)

0x60300b50b4d0 is located 16 bytes inside of 32-byte region [0x60300b50b4c0,0x60300b50b4e0)
freed by thread T0 here:
    #0 0x55db5708da59 in operator delete(void*) (/home/elsid/dev/openmw/build_clang_asan/openmw+0xce1a59)
    #1 0x55db582b3eff in __gnu_cxx::new_allocator<std::_List_node<ESM::Pathgrid::Point> >::deallocate(std::_List_node<ESM::Pathgrid::Point>*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/ext/new_allocator.h:125:2
    #2 0x55db582b3ecf in std::allocator_traits<std::allocator<std::_List_node<ESM::Pathgrid::Point> > >::deallocate(std::allocator<std::_List_node<ESM::Pathgrid::Point> >&, std::_List_node<ESM::Pathgrid::Point>*, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/alloc_traits.h:462:13
    #3 0x55db582b3e23 in std::__cxx11::_List_base<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::_M_put_node(std::_List_node<ESM::Pathgrid::Point>*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:387:9
    #4 0x55db582f6d56 in std::__cxx11::list<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::_M_erase(std::_List_iterator<ESM::Pathgrid::Point>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:1820:2
    #5 0x55db5832581b in std::__cxx11::list<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::pop_front() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:1104:15
    #6 0x55db58324bc6 in MWMechanics::PathFinder::checkPathCompleted(float, float, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/pathfinding.cpp:291:19
    #7 0x55db582ae158 in MWMechanics::AiPackage::pathTo(MWWorld::Ptr const&, ESM::Pathgrid::Point const&, float, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aipackage.cpp:142:38
    #8 0x55db582e4655 in MWMechanics::AiWander::onWalkingStatePerFrameActions(MWWorld::Ptr const&, float, MWMechanics::AiWanderStorage&, ESM::Position&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:492:51
    #9 0x55db582ddae5 in MWMechanics::AiWander::doPerFrameActionsForState(MWWorld::Ptr const&, float, MWMechanics::AiWanderStorage&, ESM::Position&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:431:17
    #10 0x55db582dd62b in MWMechanics::AiWander::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:225:9
    #11 0x55db582b94a5 in MWMechanics::AiSequence::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aisequence.cpp:264:26
    #12 0x55db583ea76b in MWMechanics::Actors::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwmechanics/actors.cpp:1177:55
    #13 0x55db581ee3b2 in MWMechanics::MechanicsManager::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp:421:17
    #14 0x55db5849125c in OMW::Engine::frame(float) /home/elsid/dev/openmw/apps/openmw/engine.cpp:141:49
    #15 0x55db5849f890 in OMW::Engine::go() /home/elsid/dev/openmw/apps/openmw/engine.cpp:701:9
    #16 0x55db5844f1a7 in main /home/elsid/dev/openmw/apps/openmw/main.cpp:354:21
    #17 0x7f521a9de4c9 in __libc_start_main (/usr/lib/libc.so.6+0x204c9)

previously allocated by thread T0 here:
    #0 0x55db5708cd19 in operator new(unsigned long) (/home/elsid/dev/openmw/build_clang_asan/openmw+0xce0d19)
    #1 0x55db582b4a6b in __gnu_cxx::new_allocator<std::_List_node<ESM::Pathgrid::Point> >::allocate(unsigned long, void const*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/ext/new_allocator.h:111:27
    #2 0x55db582b4a0b in std::allocator_traits<std::allocator<std::_List_node<ESM::Pathgrid::Point> > >::allocate(std::allocator<std::_List_node<ESM::Pathgrid::Point> >&, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/alloc_traits.h:436:20
    #3 0x55db582b47ab in std::__cxx11::_List_base<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::_M_get_node() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:383:16
    #4 0x55db582b458c in std::_List_node<ESM::Pathgrid::Point>* std::__cxx11::list<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::_M_create_node<ESM::Pathgrid::Point const&>(ESM::Pathgrid::Point const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:572:21
    #5 0x55db582b4240 in void std::__cxx11::list<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::_M_insert<ESM::Pathgrid::Point const&>(std::_List_iterator<ESM::Pathgrid::Point>, ESM::Pathgrid::Point const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:1801:18
    #6 0x55db582b4096 in std::__cxx11::list<ESM::Pathgrid::Point, std::allocator<ESM::Pathgrid::Point> >::push_back(ESM::Pathgrid::Point const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.1.1/../../../../include/c++/7.1.1/bits/stl_list.h:1118:15
    #7 0x55db582b30ec in MWMechanics::PathFinder::addPointToPath(ESM::Pathgrid::Point const&) /home/elsid/dev/openmw/apps/openmw/mwmechanics/pathfinding.hpp:96:23
    #8 0x55db582e104d in MWMechanics::AiWander::wanderNearStart(MWWorld::Ptr const&, MWMechanics::AiWanderStorage&, int) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:386:29
    #9 0x55db582df377 in MWMechanics::AiWander::reactionTimeActions(MWWorld::Ptr const&, MWMechanics::AiWanderStorage&, MWWorld::CellStore const*&, bool, ESM::Position&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:271:17
    #10 0x55db582dd7bf in MWMechanics::AiWander::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aiwander.cpp:234:20
    #11 0x55db582b94a5 in MWMechanics::AiSequence::execute(MWWorld::Ptr const&, MWMechanics::CharacterController&, MWMechanics::DerivedClassStorage<MWMechanics::AiTemporaryBase>&, float) /home/elsid/dev/openmw/apps/openmw/mwmechanics/aisequence.cpp:264:26
    #12 0x55db583ea76b in MWMechanics::Actors::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwmechanics/actors.cpp:1177:55
    #13 0x55db581ee3b2 in MWMechanics::MechanicsManager::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp:421:17
    #14 0x55db5849125c in OMW::Engine::frame(float) /home/elsid/dev/openmw/apps/openmw/engine.cpp:141:49
    #15 0x55db5849f890 in OMW::Engine::go() /home/elsid/dev/openmw/apps/openmw/engine.cpp:701:9
    #16 0x55db5844f1a7 in main /home/elsid/dev/openmw/apps/openmw/main.cpp:354:21
    #17 0x7f521a9de4c9 in __libc_start_main (/usr/lib/libc.so.6+0x204c9)

SUMMARY: AddressSanitizer: heap-use-after-free /home/elsid/dev/openmw/apps/openmw/mwmechanics/pathfinding.hpp:113:56 in MWMechanics::PathFinder::MakeOsgVec3(ESM::Pathgrid::Point const&)
Shadow bytes around the buggy address:
  0x0c0681699640: fd fd fa fa fd fd fd fa fa fa fd fd fd fd fa fa
  0x0c0681699650: fd fd fd fa fa fa fd fd fd fa fa fa fd fd fd fa
  0x0c0681699660: fa fa fd fd fd fd fa fa fd fd fd fa fa fa fd fd
  0x0c0681699670: fd fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x0c0681699680: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fa
=>0x0c0681699690: fa fa fd fd fd fa fa fa fd fd[fd]fd fa fa fd fd
  0x0c06816996a0: fd fd fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa
  0x0c06816996b0: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fd
  0x0c06816996c0: fa fa fd fd fd fd fa fa fd fd fd fd fa fa fd fd
  0x0c06816996d0: fd fd fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x0c06816996e0: fd fd fd fa fa fa fd fd fd fd fa fa fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
=================================================================

```