### PR TITLE
Do not allow to use journal in a main menu

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1022,6 +1022,7 @@ namespace MWInput
             return;
 
         if(MWBase::Environment::get().getWindowManager()->getMode() != MWGui::GM_Journal
+                && MWBase::Environment::get().getWindowManager()->getMode() != MWGui::GM_MainMenu
                 && MWBase::Environment::get().getWindowManager ()->getJournalAllowed())
         {
             MWBase::Environment::get().getWindowManager()->playSound ("book open");


### PR DESCRIPTION
Fixes [bug #3991](https://bugs.openmw.org/issues/3991).

Note: in vanilla game you can not open a journal from some other windows (e.g. book, trade), but IMO OpenMW behaviour is better.