### PR TITLE
Ensure jail does not decrease a skill past zero

### DIFF
--- a/apps/openmw/mwgui/jailscreen.cpp
+++ b/apps/openmw/mwgui/jailscreen.cpp
@@ -93,7 +93,7 @@ namespace MWGui
             if (skill == ESM::Skill::Security || skill == ESM::Skill::Sneak)
                 value.setBase(std::min(100, value.getBase()+1));
             else
-                value.setBase(value.getBase()-1);
+                value.setBase(std::max(0, value.getBase()-1));
         }
 
         const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();


### PR DESCRIPTION
This PR fixes a bug where going to jail could decrease a skill below zero as can be seen in [this imgur album.](http://imgur.com/a/PJsZQ)
Previously in OpenMW, if the random skill picked by the jail function was already at 0, the skill would be decreased to -1, causing issues with the "Progress towards skill increase" bar.
In Morrowind, if the random skill picked is already at 0, it simply keeps it at 0, displaying the same message ("Your x skill decreased to 0"). 
This PR brings OpenMW functionality in line with Morrowind functionality.