### PR TITLE
Disable AiPursue package for player's followers

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1152,7 +1152,19 @@ namespace MWMechanics
                 it->getClass().getNpcStats(*it).setCrimeId(id);
 
                 if (!it->getClass().getCreatureStats(*it).getAiSequence().hasPackage(AiPackage::TypeIdPursue))
+                {
+                    // Player's followers should not try to arrest player
+                    if (it->getClass().getCreatureStats(*it).getAiSequence().hasPackage(AiPackage::TypeIdFollow))
+                    {
+                        std::set<MWWorld::Ptr> playerFollowers;
+                        getActorsSidingWith(player, playerFollowers);
+
+                        if (playerFollowers.find(*it) != playerFollowers.end())
+                            continue;
+                    }
+
                     it->getClass().getCreatureStats(*it).getAiSequence().stack(AiPursue(player), *it);
+                }
             }
             else
             {


### PR DESCRIPTION
Related to [bug #3863](https://bugs.openmw.org/issues/3863).

If you have a Guard follower in vanilla game, he will not report about your crimes, and wll not try to arrest you if your crime was reported by someone else.
In OpenMW a Guard follower do not report about your crimes, but still tries to arrest you if the crime was reported by someone else. 
Now a Guard followers behave how any other followers.