### PR TITLE
Fixes regression in spell school detection (bug #4007)

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -121,6 +121,11 @@ namespace MWMechanics
 
         CreatureStats& stats = actor.getClass().getCreatureStats(actor);
 
+        float castBonus = -stats.getMagicEffects().get(ESM::MagicEffect::Sound).getMagnitude();
+
+        float castChance = calcSpellBaseSuccessChance(spell, actor, effectiveSchool) + castBonus;
+        castChance *= stats.getFatigueTerm();
+
         if (stats.getMagicEffects().get(ESM::MagicEffect::Silence).getMagnitude()&& !godmode)
             return 0;
 
@@ -137,11 +142,6 @@ namespace MWMechanics
         {
             return 100;
         }
-
-        float castBonus = -stats.getMagicEffects().get(ESM::MagicEffect::Sound).getMagnitude();
-
-        float castChance = calcSpellBaseSuccessChance(spell, actor, effectiveSchool) + castBonus;
-        castChance *= stats.getFatigueTerm();
 
         if (!cap)
             return std::max(0.f, castChance);


### PR DESCRIPTION
Fixes [bug #4007](https://bugs.openmw.org/issues/4007). This issue is caused by regression in my #1329 PR (there was return in godmode before spell school was actually determined).