### PR TITLE
Add style for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
+BreakBeforeBraces: Allman
+ColumnLimit: 0
+DerivePointerAlignment: true
+IndentCaseLabels: true
+IndentWidth: 4
+NamespaceIndentation: All
+SortIncludes: false
+...


### PR DESCRIPTION
Adds a style file for use with clang-format that is a close approximation to the current style throughout the codebase.

[clang-format](http://clang.llvm.org/docs/ClangFormat.html) is a refactoring tool for formatting in a custom style. It is useful because it enables other refactoring tools which are not formatting-aware, such as [clang-tidy](http://clang.llvm.org/extra/clang-tidy/) (which can safely update code to use C++11 idioms).

If this format was applied to the entire repository, there would be 85426 insertions and 87970 deletions across 1546 files. Most of this churn cannot be alleviated with an alternate style due to the following inconsistencies:
1. Namespaces are sometimes not indented.
2. Functions are sometimes spaced before parameters or arguments.
3. Arithmetic and logical operators are sometimes not spaced.

Note this commit doesn't apply the format. Developers could apply the format incrementally or it can be applied across the codebase with:
```bash
find . -iname *.hpp -o -iname *.cpp | xargs clang-format -i
```