### PR TITLE
Enable transparency for interactive messageboxes and tooltips in game mode

### DIFF
--- a/apps/openmw/mwgui/messagebox.cpp
+++ b/apps/openmw/mwgui/messagebox.cpp
@@ -196,7 +196,7 @@ namespace MWGui
 
 
     InteractiveMessageBox::InteractiveMessageBox(MessageBoxManager& parMessageBoxManager, const std::string& message, const std::vector<std::string>& buttons)
-        : WindowModal("openmw_interactive_messagebox.layout")
+        : WindowModal(MWBase::Environment::get().getWindowManager()->isGuiMode() ? "openmw_interactive_messagebox_notransp.layout" : "openmw_interactive_messagebox.layout")
       , mMessageBoxManager(parMessageBoxManager)
       , mButtonPressed(-1)
     {

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -378,17 +378,11 @@ namespace MWGui
     {
         mDynamicToolTipBox->setVisible(true);
         
-        if(mShowOwned == 1 || mShowOwned == 3)
-        {
-            if(isFocusObject && checkOwned())
-            {
-                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_Owned");
-            }
-            else
-            {
-                mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp");
-            }
-        }
+        // TODO: apply alpha to "owned" background
+        if((mShowOwned == 1 || mShowOwned == 3) && isFocusObject && checkOwned())
+            mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_Owned");
+        else
+            mDynamicToolTipBox->changeWidgetSkin(MWBase::Environment::get().getWindowManager()->isGuiMode() ? "HUD_Box_NoTransp" : "HUD_Box");
 
         std::string caption = info.caption;
         std::string image = info.icon;

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -378,9 +378,8 @@ namespace MWGui
     {
         mDynamicToolTipBox->setVisible(true);
         
-        // TODO: apply alpha to "owned" background
         if((mShowOwned == 1 || mShowOwned == 3) && isFocusObject && checkOwned())
-            mDynamicToolTipBox->changeWidgetSkin("HUD_Box_NoTransp_Owned");
+            mDynamicToolTipBox->changeWidgetSkin(MWBase::Environment::get().getWindowManager()->isGuiMode() ? "HUD_Box_NoTransp_Owned" : "HUD_Box_Owned");
         else
             mDynamicToolTipBox->changeWidgetSkin(MWBase::Environment::get().getWindowManager()->isGuiMode() ? "HUD_Box_NoTransp" : "HUD_Box");
 

--- a/files/mygui/CMakeLists.txt
+++ b/files/mygui/CMakeLists.txt
@@ -38,6 +38,7 @@ set(MYGUI_FILES
     openmw_hud.layout
     openmw_infobox.layout
     openmw_interactive_messagebox.layout
+    openmw_interactive_messagebox_notransp.layout
     openmw_inventory_window.layout
     openmw_journal.layout
     openmw_journal.skin.xml

--- a/files/mygui/openmw_hud_box.skin.xml
+++ b/files/mygui/openmw_hud_box.skin.xml
@@ -36,6 +36,18 @@
 
         <!-- The interior of the box -->
 
+        <Child type="Widget" skin="DialogBG_NoTransp_Owned" offset="0 0 40 40" align="Stretch" name="Client"/>
+
+        <!-- Borders -->
+
+        <Child type="Widget" skin="MW_Box" offset="0 0 40 40" align="Left Stretch" name="Client"/>
+
+    </Resource>
+
+    <Resource type="ResourceSkin" name="HUD_Box_Owned" size="40 40">
+
+        <!-- The interior of the box -->
+
         <Child type="Widget" skin="DialogBG_Owned" offset="0 0 40 40" align="Stretch" name="Client"/>
 
         <!-- Borders -->

--- a/files/mygui/openmw_interactive_messagebox_notransp.layout
+++ b/files/mygui/openmw_interactive_messagebox_notransp.layout
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<MyGUI type="Layout">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="MessageBox" position="0 0 500 400" align="Center" name="_Main">
+        <Widget type="EditBox" skin="MW_TextEditClient" position="10 10 490 20" align="Left Top Stretch" name="message">
+            <Property key="FontName" value="Default"/>
+            <Property key="TextAlign" value="Center"/>
+            <Property key="Static" value="true"/>
+            <Property key="WordWrap" value="true"/>
+            <Property key="MultiLine" value="1"/>
+            <Property key="VisibleVScroll" value="1"/>
+        </Widget>
+        <Widget type="Widget" skin="" position="0 0 500 400" align="Stretch" name="buttons">
+        </Widget>
+    </Widget>
+</MyGUI>

--- a/files/mygui/openmw_persuasion_dialog.layout
+++ b/files/mygui/openmw_persuasion_dialog.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 220 192" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 220 192" align="Center" name="_Main">
 
         <Widget type="TextBox" skin="NormalText" position="0 4 220 24">
             <Property key="Caption" value="#{sPersuasionMenuTitle}"/>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -158,8 +158,15 @@
     </Resource>
     
     <!-- Defines a owned background -->
-    <Resource type="ResourceSkin" name="DialogBG_Owned" size="8 8" texture="white">
+    <Resource type="ResourceSkin" name="DialogBG_NoTransp_Owned" size="8 8" texture="white">
         <Property key="Colour" value="#{setting=GUI,color background owned}"/> 
+        <BasisSkin type="MainSkin" offset="0 0 8 8">
+            <State name="normal" offset="0 0 8 8"/>
+        </BasisSkin>
+    </Resource>
+
+    <Resource type="ResourceSkin" name="DialogBG_Owned" size="8 8" texture="transparent">
+        <Property key="Colour" value="#{setting=GUI,color background owned}"/>
         <BasisSkin type="MainSkin" offset="0 0 8 8">
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>


### PR DESCRIPTION
In vanilla game tooltips and most of messageboxes do not have transparency only in GUI mode. 
This behaviour makes sense: in GUI mode these widgets can be placed over other widgets.