### PR TITLE
Wizard: Changing "New Installation" to "Retail CD/DVD" for clarity

### DIFF
--- a/apps/wizard/componentselectionpage.cpp
+++ b/apps/wizard/componentselectionpage.cpp
@@ -2,7 +2,6 @@
 
 #include <QDebug>
 #include <QPushButton>
-#include <QAbstractButton>
 #include <QMessageBox>
 
 #include "mainwizard.hpp"
@@ -26,7 +25,7 @@ Wizard::ComponentSelectionPage::ComponentSelectionPage(QWidget *parent) :
 
 void Wizard::ComponentSelectionPage::updateButton(QListWidgetItem*)
 {
-    if (field(QLatin1String("installation.new")).toBool() == true)
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true)
         return; // Morrowind is always checked here
 
     bool unchecked = true;
@@ -60,7 +59,7 @@ void Wizard::ComponentSelectionPage::initializePage()
     QListWidgetItem *tribunalItem = new QListWidgetItem(QLatin1String("Tribunal"));
     QListWidgetItem *bloodmoonItem = new QListWidgetItem(QLatin1String("Bloodmoon"));
 
-    if (field(QLatin1String("installation.new")).toBool() == true)
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true)
     {
         morrowindItem->setFlags((morrowindItem->flags() & ~Qt::ItemIsEnabled) | Qt::ItemIsUserCheckable);
         morrowindItem->setData(Qt::CheckStateRole, Qt::Checked);
@@ -117,7 +116,7 @@ bool Wizard::ComponentSelectionPage::validatePage()
 
 //    qDebug() << components << path << mWizard->mInstallations[path];
 
-    if (field(QLatin1String("installation.new")).toBool() == false) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == false) {
         if (components.contains(QLatin1String("Tribunal")) && !components.contains(QLatin1String("Bloodmoon")))
         {
             if (mWizard->mInstallations[path].hasBloodmoon)

--- a/apps/wizard/conclusionpage.cpp
+++ b/apps/wizard/conclusionpage.cpp
@@ -16,14 +16,14 @@ Wizard::ConclusionPage::ConclusionPage(QWidget *parent) :
 void Wizard::ConclusionPage::initializePage()
 {
     // Write the path to openmw.cfg
-    if (field(QLatin1String("installation.new")).toBool() == true) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true) {
         QString path(field(QLatin1String("installation.path")).toString());
         mWizard->addInstallation(path);
     }
 
     if (!mWizard->mError)
     {
-        if ((field(QLatin1String("installation.new")).toBool() == true)
+        if ((field(QLatin1String("installation.retailDisc")).toBool() == true)
                 || (field(QLatin1String("installation.import-settings")).toBool() == true))
         {
             qDebug() << "IMPORT SETTINGS";
@@ -33,7 +33,7 @@ void Wizard::ConclusionPage::initializePage()
 
     if (!mWizard->mError)
     {
-        if (field(QLatin1String("installation.new")).toBool() == true)
+        if (field(QLatin1String("installation.retailDisc")).toBool() == true)
         {
             textLabel->setText(tr("<html><head/><body><p>The OpenMW Wizard successfully installed Morrowind on your computer.</p> \
                                   <p>Click Finish to close the Wizard.</p></body></html>"));

--- a/apps/wizard/installationpage.cpp
+++ b/apps/wizard/installationpage.cpp
@@ -7,7 +7,6 @@
 #include <QMessageBox>
 
 #include "mainwizard.hpp"
-#include "inisettings.hpp"
 
 Wizard::InstallationPage::InstallationPage(QWidget *parent) :
     QWizardPage(parent)
@@ -76,7 +75,7 @@ void Wizard::InstallationPage::initializePage()
     // That way installing all three components would yield 300%
     // When one component is done the bar will be filled by 33%
 
-    if (field(QLatin1String("installation.new")).toBool() == true) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true) {
         installProgressBar->setMaximum((components.count() * 100));
     } else {
         if (components.contains(QLatin1String("Tribunal"))
@@ -96,7 +95,7 @@ void Wizard::InstallationPage::startInstallation()
     QStringList components(field(QLatin1String("installation.components")).toStringList());
     QString path(field(QLatin1String("installation.path")).toString());
 
-    if (field(QLatin1String("installation.new")).toBool() == true)
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true)
     {
         // Always install Morrowind
         mUnshield->setInstallComponent(Wizard::Component_Morrowind, true);
@@ -227,7 +226,7 @@ bool Wizard::InstallationPage::isComplete() const
 
 int Wizard::InstallationPage::nextId() const
 {
-    if (field(QLatin1String("installation.new")).toBool() == true) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true) {
         return MainWizard::Page_Conclusion;
     } else {
         if (!mWizard->mError) {

--- a/apps/wizard/languageselectionpage.cpp
+++ b/apps/wizard/languageselectionpage.cpp
@@ -30,7 +30,7 @@ void Wizard::LanguageSelectionPage::initializePage()
 
 int Wizard::LanguageSelectionPage::nextId() const
 {
-    if (field(QLatin1String("installation.new")).toBool() == true) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true) {
         return MainWizard::Page_ComponentSelection;
     } else {
         QString path(field(QLatin1String("installation.path")).toString());

--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -3,7 +3,6 @@
 #include <QDebug>
 
 #include <QTime>
-#include <QDateTime>
 #include <QCloseEvent>
 #include <QMessageBox>
 #include <QTextCodec>
@@ -258,7 +257,7 @@ void Wizard::MainWizard::runSettingsImporter()
     QStringList arguments;
 
     // Import plugin selection?
-    if (field(QLatin1String("installation.new")).toBool() == true
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true
             || field(QLatin1String("installation.import-addons")).toBool() == true)
         arguments.append(QLatin1String("--game-files"));
 
@@ -278,7 +277,7 @@ void Wizard::MainWizard::runSettingsImporter()
     // Now the paths
     arguments.append(QLatin1String("--ini"));
 
-    if (field(QLatin1String("installation.new")).toBool() == true) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true) {
         arguments.append(path + QDir::separator() + QLatin1String("Morrowind.ini"));
     } else {
         arguments.append(mInstallations[path].iniPath);

--- a/apps/wizard/methodselectionpage.cpp
+++ b/apps/wizard/methodselectionpage.cpp
@@ -1,5 +1,4 @@
 #include "methodselectionpage.hpp"
-#include <QDebug>
 #include "mainwizard.hpp"
 
 Wizard::MethodSelectionPage::MethodSelectionPage(QWidget *parent) :
@@ -10,16 +9,16 @@ Wizard::MethodSelectionPage::MethodSelectionPage(QWidget *parent) :
     setupUi(this);
 
 #ifndef OPENMW_USE_UNSHIELD
-    newLocationRadioButton->setEnabled(false);
+    retailDiscRadioButton->setEnabled(false);
     existingLocationRadioButton->setChecked(true);
 #endif
 
-    registerField(QLatin1String("installation.new"), newLocationRadioButton);
+    registerField(QLatin1String("installation.retailDisc"), retailDiscRadioButton);
 }
 
 int Wizard::MethodSelectionPage::nextId() const
 {
-    if (field(QLatin1String("installation.new")).toBool() == true) {
+    if (field(QLatin1String("installation.retailDisc")).toBool() == true) {
         return MainWizard::Page_InstallationTarget;
     } else {
         return MainWizard::Page_ExistingInstallation;

--- a/files/ui/wizard/methodselectionpage.ui
+++ b/files/ui/wizard/methodselectionpage.ui
@@ -17,16 +17,16 @@
    <string>Select Installation Method</string>
   </property>
   <property name="subTitle">
-   <string>Select how OpenMW should get the required Morrowind installation files.</string>
+   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select how you would like to install &lt;i&gt;The Elder Scrolls III: Morrowind&lt;/i&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QRadioButton" name="newLocationRadioButton">
+    <widget class="QRadioButton" name="retailDiscRadioButton">
      <property name="styleSheet">
       <string notr="true">font-weight:bold;</string>
      </property>
      <property name="text">
-      <string>Install Morrowind to a new location</string>
+      <string>Retail CD/DVD</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -34,7 +34,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="newLocationLayout">
+    <layout class="QHBoxLayout" name="retailDiscLayout">
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -72,14 +72,14 @@
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
        <property name="buddy">
-        <cstring>newLocationRadioButton</cstring>
+        <cstring>retailDiscRadioButton</cstring>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="newLocationLabel">
+      <widget class="QLabel" name="retailDiscLabel">
        <property name="text">
-        <string>Install Morrowind from a retail disk to a new location for OpenMW to use.</string>
+        <string>Install from a retail disc to a new location.</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -94,7 +94,7 @@
       <string notr="true">font-weight:bold</string>
      </property>
      <property name="text">
-      <string>Select an existing Morrowind installation</string>
+      <string>Existing Installation</string>
      </property>
     </widget>
    </item>
@@ -138,7 +138,7 @@
      <item>
       <widget class="QLabel" name="existingLocationLabel">
        <property name="text">
-        <string>Select an existing Morrowind installation for OpenMW to use.</string>
+        <string>Select an existing installation.</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>


### PR DESCRIPTION
References #3032, since it addresses the last point of that bug report. 

Before this change:

<img width="660" alt="selection installation page before" src="https://user-images.githubusercontent.com/6200170/29106126-b7a0807e-7c98-11e7-9ff5-f4fa7672aaf9.png">

After this change:

<img width="688" alt="select installation page v2" src="https://user-images.githubusercontent.com/6200170/29106130-bd908bf0-7c98-11e7-945f-9c5e6657096e.png">
