### PR TITLE
Check actual movement for GetPCRunning and GetPCSneaking [Feedback needed]

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -230,7 +230,7 @@ namespace MWBase
 
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid) = 0;
-            
+
             virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim) = 0;
 
             /// Turn actor into werewolf or normal form.
@@ -243,6 +243,9 @@ namespace MWBase
             virtual void cleanupSummonedCreature(const MWWorld::Ptr& caster, int creatureActorId) = 0;
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count) = 0;
+
+            virtual bool isRunning(const MWWorld::Ptr& ptr) = 0;
+            virtual bool isSneaking(const MWWorld::Ptr& ptr) = 0;
     };
 }
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -802,6 +802,26 @@ namespace MWMechanics
         }
     }
 
+    bool Actors::isRunning(const MWWorld::Ptr& ptr)
+    {
+        PtrActorMap::iterator it = mActors.find(ptr);
+        if (it == mActors.end())
+            return false;
+        CharacterController* ctrl = it->second->getCharacterController();
+
+        return ctrl->isRunning();
+    }
+
+    bool Actors::isSneaking(const MWWorld::Ptr& ptr)
+    {
+        PtrActorMap::iterator it = mActors.find(ptr);
+        if (it == mActors.end())
+            return false;
+        CharacterController* ctrl = it->second->getCharacterController();
+
+        return ctrl->isSneaking();
+    }
+
     void Actors::updateDrowning(const MWWorld::Ptr& ptr, float duration)
     {
         PtrActorMap::iterator it = mActors.find(ptr);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -107,6 +107,9 @@ namespace MWMechanics
             int countDeaths (const std::string& id) const;
             ///< Return the number of deaths for actors with the given ID.
 
+            bool isRunning(const MWWorld::Ptr& ptr);
+            bool isSneaking(const MWWorld::Ptr& ptr);
+
         void forceStateUpdate(const MWWorld::Ptr &ptr);
 
         bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number, bool persist=false);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1650,7 +1650,7 @@ void CharacterController::update(float duration)
                     mSecondsOfSwimming -= 1;
                 }
             }
-            else if(isrunning)
+            else if(isrunning && !sneak)
             {
                 mSecondsOfRunning += duration;
                 while(mSecondsOfRunning > 1)
@@ -1688,7 +1688,7 @@ void CharacterController::update(float duration)
                     else
                         fatigueLoss = fFatigueSwimRunBase + encumbrance * fFatigueSwimRunMult;
                 }
-                if (isrunning)
+                else if (isrunning)
                     fatigueLoss = fFatigueRunBase + encumbrance * fFatigueRunMult;
             }
         }
@@ -2235,6 +2235,18 @@ bool CharacterController::isSneaking() const
             mMovementState == CharState_SneakBack ||
             mMovementState == CharState_SneakLeft ||
             mMovementState == CharState_SneakRight;
+}
+
+bool CharacterController::isRunning() const
+{
+    return mMovementState == CharState_RunForward ||
+            mMovementState == CharState_RunBack ||
+            mMovementState == CharState_RunLeft ||
+            mMovementState == CharState_RunRight ||
+            mMovementState == CharState_SwimRunForward ||
+            mMovementState == CharState_SwimRunBack ||
+            mMovementState == CharState_SwimRunLeft ||
+            mMovementState == CharState_SwimRunRight;
 }
 
 void CharacterController::setAttackingOrSpell(bool attackingOrSpell)

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -266,6 +266,7 @@ public:
     bool isReadyToBlock() const;
     bool isKnockedOut() const;
     bool isSneaking() const;
+    bool isRunning() const;
 
     void setAttackingOrSpell(bool attackingOrSpell);
     void setAIAttackType(const std::string& attackType);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -422,6 +422,16 @@ namespace MWMechanics
         mObjects.update(duration, paused);
     }
 
+    bool MechanicsManager::isRunning(const MWWorld::Ptr& ptr)
+    {
+        return mActors.isRunning(ptr);
+    }
+
+    bool MechanicsManager::isSneaking(const MWWorld::Ptr& ptr)
+    {
+        return mActors.isSneaking(ptr);
+    }
+
     void MechanicsManager::rest(bool sleep)
     {
         mActors.rest(sleep);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -197,7 +197,7 @@ namespace MWMechanics
 
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid);
-            
+
             /// @return is \a ptr allowed to take/use \a cellref or is it a crime?
             virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim);
 
@@ -208,6 +208,8 @@ namespace MWMechanics
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count);
 
+            virtual bool isRunning(const MWWorld::Ptr& ptr);
+            virtual bool isSneaking(const MWWorld::Ptr& ptr);
         private:
             void reportCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
                                       OffenseType type, int arg=0);

--- a/apps/openmw/mwscript/controlextensions.cpp
+++ b/apps/openmw/mwscript/controlextensions.cpp
@@ -9,12 +9,14 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/inputmanager.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/ptr.hpp"
 
 #include "../mwmechanics/npcstats.hpp"
+#include "../mwmechanics/movement.hpp"
 
 #include "interpretercontext.hpp"
 #include "ref.hpp"
@@ -167,7 +169,11 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = MWBase::Environment::get().getWorld ()->getPlayerPtr();
-                    runtime.push (ptr.getClass().getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Run));
+                    const MWWorld::Class &cls = ptr.getClass();
+
+                    bool isRunning = MWBase::Environment::get().getMechanicsManager()->isRunning(ptr);
+
+                    runtime.push (isRunning && cls.getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Run));
                 }
         };
 
@@ -177,8 +183,12 @@ namespace MWScript
 
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
-                    MWWorld::Ptr ptr = MWBase::Environment::get().getWorld ()->getPlayerPtr();
-                    runtime.push (ptr.getClass().getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Sneak));
+                    MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
+                    const MWWorld::Class &cls = ptr.getClass();
+
+                    bool isSneaking = MWBase::Environment::get().getMechanicsManager()->isSneaking(ptr);
+
+                    runtime.push (isSneaking && cls.getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Sneak));
                 }
         };
 


### PR DESCRIPTION
Upstream OpenMW checks only stance for these functions, Morrowind checks also actual moving.

But in upstream OpenMW getStance() can return true for both sneak and running. This behaviour leads to odd bugs. For example, if you sneak with Always run enabled, both PC Athletics and Sneak will be increased (a game treats PC as sneaking and running in the same time).

We have two options:
1) Modify getStance()
2) Use additional checks outside getStance()
Which option would be better?