### PR TITLE
Do not make target reference unavailable on cell change

### DIFF
--- a/apps/openmw/mwgui/referenceinterface.cpp
+++ b/apps/openmw/mwgui/referenceinterface.cpp
@@ -20,9 +20,8 @@ namespace MWGui
     {
         MWWorld::CellStore* playerCell = MWMechanics::getPlayer().getCell();
 
-        // check if player has changed cell, or count of the reference has become 0
-        if ((playerCell != mCurrentPlayerCell && mCurrentPlayerCell != NULL)
-             || (!mPtr.isEmpty() && mPtr.getRefData().getCount() == 0))
+        // check if count of the reference has become 0
+        if (!mPtr.isEmpty() && mPtr.getRefData().getCount() == 0)
         {
             if (!mPtr.isEmpty())
             {


### PR DESCRIPTION
In vanilla game if you select a target in console window and change player cell, implicit reference is still active.
In OpenMW implicit reference in this case is unavailable.

With this PR it works as in vanilla game.
Also allows to fix [bug #3898](https://bugs.openmw.org/issues/3898) and [bug #4004](https://bugs.openmw.org/issues/4004).