### PR TITLE
Editor: Orbit Camera Fix

### DIFF
--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -393,6 +393,7 @@ void SceneWidget::selectNavigationMode (const std::string& mode)
         mCurrentCamControl->setCamera(NULL);
         mCurrentCamControl = mOrbitCamControl;
         mOrbitCamControl->setCamera(getCamera());
+        mOrbitCamControl->reset();
     }
 }
 


### PR DESCRIPTION
This is a fix for [bug#3709](https://bugs.openmw.org/issues/3709). This change causes the orbit camera to recalculate its position and center point whenever the user switches to the orbit camera.