### PR TITLE
add transport-command

### DIFF
--- a/apps/openmw/mwscript/cellextensions.cpp
+++ b/apps/openmw/mwscript/cellextensions.cpp
@@ -199,6 +199,36 @@ namespace MWScript
                 }
         };
 
+        /// A command to transport the player and all his followers to make nice teleport-rings possible
+        // args: 'cell' x y z orientation
+        class OpTransport : public Interpreter::Opcode0
+        {
+            public:
+
+                virtual void execute (Interpreter::Runtime& runtime)
+                {
+                    std::string cell = runtime.getStringLiteral (runtime[0].mInteger);
+                    runtime.pop();
+
+                    ESM::Position pos;
+                    pos.pos[0] = runtime[0].mFloat;
+                    runtime.pop();
+                    pos.pos[1] = runtime[0].mFloat;
+                    runtime.pop();
+                    pos.pos[2] = runtime[0].mFloat;
+                    runtime.pop();
+                    float zRot = runtime[0].mFloat;
+                    runtime.pop();
+
+                    MWBase::World *world = MWBase::Environment::get().getWorld();
+                    MWWorld::Ptr playerPtr = world->getPlayerPtr();
+                    MWWorld::ActionTeleport(cell, pos, true).execute(playerPtr);
+                    float ax = playerPtr.getRefData().getPosition().rot[0];
+                    float ay = playerPtr.getRefData().getPosition().rot[1];
+                    MWBase::Environment::get().getWorld()->rotateObject(playerPtr,ax,ay,osg::DegreesToRadians(zRot));
+                }
+        };
+
 
         void installOpcodes (Interpreter::Interpreter& interpreter)
         {
@@ -210,6 +240,7 @@ namespace MWScript
             interpreter.installSegment5 (Compiler::Cell::opcodeGetWaterLevel, new OpGetWaterLevel);
             interpreter.installSegment5 (Compiler::Cell::opcodeSetWaterLevel, new OpSetWaterLevel);
             interpreter.installSegment5 (Compiler::Cell::opcodeModWaterLevel, new OpModWaterLevel);
+            interpreter.installSegment5 (Compiler::Cell::opcodeTransport, new OpTransport);
         }
     }
 }

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -92,6 +92,7 @@ namespace Compiler
             extensions.registerInstruction ("coc", "S", opcodeCOC);
             extensions.registerInstruction ("centeroncell", "S", opcodeCOC);
             extensions.registerInstruction ("coe", "ll", opcodeCOE);
+            extensions.registerInstruction ("transport", "Sffff", opcodeTransport);
             extensions.registerInstruction ("centeronexterior", "ll", opcodeCOE);
             extensions.registerInstruction ("setwaterlevel", "f", opcodeSetWaterLevel);
             extensions.registerInstruction ("modwaterlevel", "f", opcodeModWaterLevel);

--- a/components/compiler/opcodes.hpp
+++ b/components/compiler/opcodes.hpp
@@ -77,6 +77,7 @@ namespace Compiler
         const int opcodeCellChanged = 0x2000000;
         const int opcodeCOC = 0x2000026;
         const int opcodeCOE = 0x2000226;
+        const int opcodeTransport = 0x2002226;
         const int opcodeGetInterior = 0x2000131;
         const int opcodeGetPCCell = 0x2000136;
         const int opcodeGetWaterLevel = 0x2000141;


### PR DESCRIPTION
The idea behind this is to provide an alternative to player->positioncell that also teleports any followers.

Having encountered two mods that involve teleport rings which add an NPC so that they can use the travel-command in order to also transport the followers, I came to the following conclusions:

* That approach is a very ugly hack
* A better solution would be to add a command that does that.
* Being able to do that nice would be yet another openmw-only feature that could help to convert people.

The implementation below is the result of a bit of experimenting but seems to do it's intended job reasonably well. One thing that should however be discussed is the opcode that I assigned for thsi command: I was unable to discover any kind of logic behind how they were assigned and therefore just picked something that was free. If I overlooked something there please adjust that part.

Of course I'll be happy to get some feedback on this before you merge it (if you plan to do so).