### PR TITLE
Get only text from input fields (bug #4025)

### DIFF
--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -64,7 +64,7 @@ namespace MWGui
 
     void AlchemyWindow::onCreateButtonClicked(MyGUI::Widget* _sender)
     {
-        MWMechanics::Alchemy::Result result = mAlchemy->create (mNameEdit->getCaption ());
+        MWMechanics::Alchemy::Result result = mAlchemy->create (mNameEdit->getOnlyText());
         MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
 
         switch (result)

--- a/apps/openmw/mwgui/class.cpp
+++ b/apps/openmw/mwgui/class.cpp
@@ -483,7 +483,7 @@ namespace MWGui
 
     std::string CreateClassDialog::getName() const
     {
-        return mEditName->getCaption();
+        return mEditName->getOnlyText();
     }
 
     std::string CreateClassDialog::getDescription() const

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 
 #include <MyGUI_Button.h>
+#include <MyGUI_EditBox.h>
 #include <MyGUI_ScrollView.h>
 
 #include <components/widgets/list.hpp>
@@ -312,7 +313,7 @@ namespace MWGui
             return;
         }
 
-        if (mName->getCaption ().empty())
+        if (mName->getOnlyText().empty())
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage10}");
             return;
@@ -336,7 +337,7 @@ namespace MWGui
             return;
         }
 
-        mEnchanting.setNewItemName(mName->getCaption());
+        mEnchanting.setNewItemName(mName->getOnlyText());
         mEnchanting.setEffect(mEffectList);
 
         MWWorld::Ptr player = MWMechanics::getPlayer();

--- a/apps/openmw/mwgui/enchantingdialog.hpp
+++ b/apps/openmw/mwgui/enchantingdialog.hpp
@@ -58,7 +58,7 @@ namespace MWGui
         MyGUI::Button* mTypeButton;
         MyGUI::Button* mBuyButton;
 
-        MyGUI::TextBox* mName;
+        MyGUI::EditBox* mName;
         MyGUI::TextBox* mEnchantmentPoints;
         MyGUI::TextBox* mCastCost;
         MyGUI::TextBox* mCharge;

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -248,7 +248,7 @@ namespace MWGui
                 dialog->eventCancelClicked.clear();
                 return;
             }
-            if (mSaveNameEdit->getCaption().empty())
+            if (mSaveNameEdit->getOnlyText().empty())
             {
                 MWBase::Environment::get().getWindowManager()->messageBox("#{sNotifyMessage65}");
                 return;
@@ -275,7 +275,7 @@ namespace MWGui
 
         if (mSaving)
         {
-            MWBase::Environment::get().getStateManager()->saveGame (mSaveNameEdit->getCaption(), mCurrentSlot);
+            MWBase::Environment::get().getStateManager()->saveGame (mSaveNameEdit->getOnlyText(), mCurrentSlot);
         }
         else
         {

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -373,7 +373,7 @@ namespace MWGui
             return;
         }
 
-        if (mNameEdit->getCaption () == "")
+        if (mNameEdit->getOnlyText() == "")
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage10}");
             return;
@@ -394,7 +394,7 @@ namespace MWGui
             return;
         }
 
-        mSpell.mName = mNameEdit->getCaption();
+        mSpell.mName = mNameEdit->getOnlyText();
 
         int price = MyGUI::utility::parseInt(mPriceLabel->getCaption());
 

--- a/apps/openmw/mwgui/textinput.cpp
+++ b/apps/openmw/mwgui/textinput.cpp
@@ -53,7 +53,7 @@ namespace MWGui
 
     void TextInputDialog::onOkClicked(MyGUI::Widget* _sender)
     {
-        if (mTextEdit->getCaption() == "")
+        if (mTextEdit->getOnlyText() == "")
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage37}");
             MWBase::Environment::get().getWindowManager()->setKeyFocusWidget (mTextEdit);
@@ -69,7 +69,7 @@ namespace MWGui
 
     std::string TextInputDialog::getTextInput() const
     {
-        return mTextEdit->getCaption();
+        return mTextEdit->getOnlyText();
     }
 
     void TextInputDialog::setTextInput(const std::string &text)


### PR DESCRIPTION
Fixes [bug #4025](https://bugs.openmw.org/issues/4025).

Now color tags should not be placed in items/spells names.