### PR TITLE
Implement a Fisher-Yates shuffle on background music

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -271,7 +271,6 @@ namespace MWSound
         return sound;
     }
 
-
     // Gets the combined volume settings for the given sound type
     float SoundManager::volumeFromType(PlayType type) const
     {
@@ -298,7 +297,6 @@ namespace MWSound
         return volume;
     }
 
-
     void SoundManager::stopMusic()
     {
         if(mMusic)
@@ -311,6 +309,7 @@ namespace MWSound
         if(!mOutput->isInitialized())
             return;
         std::cout <<"Playing "<<filename<< std::endl;
+        mLastPlayedMusic = filename;
         try {
             stopMusic();
 
@@ -375,12 +374,17 @@ namespace MWSound
         if(filelist.empty())
             return;
 
-        //Do a Fisher-Yates shuffle
+        // Do a Fisher-Yates shuffle
         if(mMusicFiles.size() == 0)
             for(int it = 0; it < filelist.size(); it++)
                 mMusicToPlay.push_back(it);
 
         int i = Misc::Rng::rollDice(mMusicToPlay.size());
+
+        // Fix last played music being the same after another shuffle
+        if(filelist[mMusicToPlay[i]] == mLastPlayedMusic)
+            i = (i+1) % mMusicToPlay.size();
+
         advanceMusic(filelist[mMusicToPlay[i]]);
         mMusicToPlay.erase(mMusicToPlay.begin()+i);
     }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -311,7 +311,6 @@ namespace MWSound
         if(!mOutput->isInitialized())
             return;
         std::cout <<"Playing "<<filename<< std::endl;
-        mLastPlayedMusic = filename;
         try {
             stopMusic();
 
@@ -367,7 +366,8 @@ namespace MWSound
             }
 
             mMusicFiles[mCurrentPlaylist] = filelist;
-
+            for(int it = 0; it < filelist.size(); it++)
+                mLastPlayedMusic.push_back(it);
         }
         else
             filelist = mMusicFiles[mCurrentPlaylist];
@@ -375,15 +375,14 @@ namespace MWSound
         if(filelist.empty())
             return;
 
-        int i = Misc::Rng::rollDice(filelist.size());
+        //Do a Fisher-Yates shuffle
+        if(mMusicFiles.size() == 0)
+            for(int it = 0; it < filelist.size(); it++)
+                mLastPlayedMusic.push_back(it);
 
-        // Don't play the same music track twice in a row
-        if (filelist[i] == mLastPlayedMusic)
-        {
-            i = (i+1) % filelist.size();
-        }
-
-        advanceMusic(filelist[i]);
+        int i = Misc::Rng::rollDice(mLastPlayedMusic.size());
+        advanceMusic(filelist[mLastPlayedMusic[i]]);
+        mLastPlayedMusic.erase(mLastPlayedMusic.begin()+i-1);
     }
 
     bool SoundManager::isMusicPlaying()

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -367,7 +367,7 @@ namespace MWSound
 
             mMusicFiles[mCurrentPlaylist] = filelist;
             for(int it = 0; it < filelist.size(); it++)
-                mLastPlayedMusic.push_back(it);
+                mMusicToPlay.push_back(it);
         }
         else
             filelist = mMusicFiles[mCurrentPlaylist];
@@ -378,11 +378,11 @@ namespace MWSound
         //Do a Fisher-Yates shuffle
         if(mMusicFiles.size() == 0)
             for(int it = 0; it < filelist.size(); it++)
-                mLastPlayedMusic.push_back(it);
+                mMusicToPlay.push_back(it);
 
-        int i = Misc::Rng::rollDice(mLastPlayedMusic.size());
-        advanceMusic(filelist[mLastPlayedMusic[i]]);
-        mLastPlayedMusic.erase(mLastPlayedMusic.begin()+i-1);
+        int i = Misc::Rng::rollDice(mMusicToPlay.size());
+        advanceMusic(filelist[mMusicToPlay[i]]);
+        mMusicToPlay.erase(mMusicToPlay.begin()+i);
     }
 
     bool SoundManager::isMusicPlaying()

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -49,7 +49,7 @@ namespace MWSound
 
         // Caches available music tracks by <playlist name, (sound files) >
         std::map<std::string, std::vector<std::string> > mMusicFiles;
-        std::vector<int> mLastPlayedMusic; // The music file that was last played
+        std::vector<int> mMusicToPlay; // The music file that was last played
 
         float mMasterVolume;
         float mSFXVolume;

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -49,7 +49,7 @@ namespace MWSound
 
         // Caches available music tracks by <playlist name, (sound files) >
         std::map<std::string, std::vector<std::string> > mMusicFiles;
-        std::string mLastPlayedMusic; // The music file that was last played
+        std::vector<int> mLastPlayedMusic; // The music file that was last played
 
         float mMasterVolume;
         float mSFXVolume;

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -50,6 +50,7 @@ namespace MWSound
         // Caches available music tracks by <playlist name, (sound files) >
         std::map<std::string, std::vector<std::string> > mMusicFiles;
         std::vector<int> mMusicToPlay; // The music file that was last played
+        std::string mLastPlayedMusic;
 
         float mMasterVolume;
         float mSFXVolume;


### PR DESCRIPTION
This may fix #4024, which may be a result of the only guard against repetitive music being not letting the same song play twice. The memory overhead is minimal, with a mere 5 extra kb used in a music library with 1300 songs.

You may want to squash all commits when merging.