### PR TITLE
Implement a Fisher-Yates shuffle on background music

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -271,7 +271,6 @@ namespace MWSound
         return sound;
     }
 
-
     // Gets the combined volume settings for the given sound type
     float SoundManager::volumeFromType(PlayType type) const
     {
@@ -297,7 +296,6 @@ namespace MWSound
         }
         return volume;
     }
-
 
     void SoundManager::stopMusic()
     {
@@ -367,7 +365,9 @@ namespace MWSound
             }
 
             mMusicFiles[mCurrentPlaylist] = filelist;
-
+            mMusicToPlay.reserve(mMusicToPlay.size() + filelist.size());
+            for(int it = 0; it < filelist.size(); it++)
+                mMusicToPlay.push_back(it);
         }
         else
             filelist = mMusicFiles[mCurrentPlaylist];
@@ -375,15 +375,23 @@ namespace MWSound
         if(filelist.empty())
             return;
 
-        int i = Misc::Rng::rollDice(filelist.size());
-
-        // Don't play the same music track twice in a row
-        if (filelist[i] == mLastPlayedMusic)
+        // Do a Fisher-Yates shuffle
+        if(mMusicFiles.size() == 0)
         {
-            i = (i+1) % filelist.size();
+            mMusicToPlay.reserve(filelist.size());
+            for (int it = 0; it < filelist.size(); it++)
+                mMusicToPlay.push_back(it);
         }
 
-        advanceMusic(filelist[i]);
+        int i = Misc::Rng::rollDice(mMusicToPlay.size());
+
+        // Fix last played music being the same after another shuffle
+        if(filelist[mMusicToPlay[i]] == mLastPlayedMusic)
+            i = (i+1) % mMusicToPlay.size();
+
+        advanceMusic(filelist[mMusicToPlay[i]]);
+        mMusicToPlay[i] = mMusicToPlay.back();
+        mMusicToPlay.pop_back();
     }
 
     bool SoundManager::isMusicPlaying()

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -49,6 +49,7 @@ namespace MWSound
 
         // Caches available music tracks by <playlist name, (sound files) >
         std::map<std::string, std::vector<std::string> > mMusicFiles;
+        std::vector<int> mMusicToPlay; // The list of music files not played yet
         std::string mLastPlayedMusic; // The music file that was last played
 
         float mMasterVolume;


### PR DESCRIPTION
This may fix #4024, which may be a result of the only guard against repetitive music being not letting the same song play twice. The memory overhead is minimal, with a mere 5 extra kb used in a music library with 1300 songs.You may want to squash all commits when merging.