### PR TITLE
Allow revealing up to 8 magic effects of a potion if the player's Alchemy skill is sufficient and the potion has more than 4 effects

### DIFF
--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -457,7 +457,9 @@ bool MWMechanics::Alchemy::knownEffect(unsigned int potionEffectIndex, const MWW
     static const float fWortChanceValue =
             MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fWortChanceValue")->getFloat();
     return (potionEffectIndex <= 1 && alchemySkill >= fWortChanceValue)
-            || (potionEffectIndex <= 3 && alchemySkill >= fWortChanceValue*2);
+            || (potionEffectIndex <= 3 && alchemySkill >= fWortChanceValue*2)
+            || (potionEffectIndex <= 5 && alchemySkill >= fWortChanceValue*3)
+            || (potionEffectIndex <= 7 && alchemySkill >= fWortChanceValue*4);
 }
 
 MWMechanics::Alchemy::Result MWMechanics::Alchemy::create (const std::string& name)


### PR DESCRIPTION
As per Vladimir Ulisko's note [here](https://bugs.openmw.org/issues/1792).