### PR TITLE
Get only text from input fields (alternative implementation)

### DIFF
--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -64,7 +64,7 @@ namespace MWGui
 
     void AlchemyWindow::onCreateButtonClicked(MyGUI::Widget* _sender)
     {
-        MWMechanics::Alchemy::Result result = mAlchemy->create (mNameEdit->getOnlyText());
+        MWMechanics::Alchemy::Result result = mAlchemy->create (mNameEdit->getCaption ());
         MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
 
         switch (result)

--- a/apps/openmw/mwgui/class.cpp
+++ b/apps/openmw/mwgui/class.cpp
@@ -483,7 +483,7 @@ namespace MWGui
 
     std::string CreateClassDialog::getName() const
     {
-        return mEditName->getOnlyText();
+        return mEditName->getCaption();
     }
 
     std::string CreateClassDialog::getDescription() const

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -3,7 +3,6 @@
 #include <iomanip>
 
 #include <MyGUI_Button.h>
-#include <MyGUI_EditBox.h>
 #include <MyGUI_ScrollView.h>
 
 #include <components/widgets/list.hpp>
@@ -313,7 +312,7 @@ namespace MWGui
             return;
         }
 
-        if (mName->getOnlyText().empty())
+        if (mName->getCaption ().empty())
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage10}");
             return;
@@ -337,7 +336,7 @@ namespace MWGui
             return;
         }
 
-        mEnchanting.setNewItemName(mName->getOnlyText());
+        mEnchanting.setNewItemName(mName->getCaption());
         mEnchanting.setEffect(mEffectList);
 
         MWWorld::Ptr player = MWMechanics::getPlayer();

--- a/apps/openmw/mwgui/enchantingdialog.hpp
+++ b/apps/openmw/mwgui/enchantingdialog.hpp
@@ -58,7 +58,7 @@ namespace MWGui
         MyGUI::Button* mTypeButton;
         MyGUI::Button* mBuyButton;
 
-        MyGUI::EditBox* mName;
+        MyGUI::TextBox* mName;
         MyGUI::TextBox* mEnchantmentPoints;
         MyGUI::TextBox* mCastCost;
         MyGUI::TextBox* mCharge;

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -248,7 +248,7 @@ namespace MWGui
                 dialog->eventCancelClicked.clear();
                 return;
             }
-            if (mSaveNameEdit->getOnlyText().empty())
+            if (mSaveNameEdit->getCaption().empty())
             {
                 MWBase::Environment::get().getWindowManager()->messageBox("#{sNotifyMessage65}");
                 return;
@@ -275,7 +275,7 @@ namespace MWGui
 
         if (mSaving)
         {
-            MWBase::Environment::get().getStateManager()->saveGame (mSaveNameEdit->getOnlyText(), mCurrentSlot);
+            MWBase::Environment::get().getStateManager()->saveGame (mSaveNameEdit->getCaption(), mCurrentSlot);
         }
         else
         {

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -373,7 +373,7 @@ namespace MWGui
             return;
         }
 
-        if (mNameEdit->getOnlyText() == "")
+        if (mNameEdit->getCaption () == "")
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage10}");
             return;
@@ -394,7 +394,7 @@ namespace MWGui
             return;
         }
 
-        mSpell.mName = mNameEdit->getOnlyText();
+        mSpell.mName = mNameEdit->getCaption();
 
         int price = MyGUI::utility::parseInt(mPriceLabel->getCaption());
 

--- a/apps/openmw/mwgui/textinput.cpp
+++ b/apps/openmw/mwgui/textinput.cpp
@@ -53,7 +53,7 @@ namespace MWGui
 
     void TextInputDialog::onOkClicked(MyGUI::Widget* _sender)
     {
-        if (mTextEdit->getOnlyText() == "")
+        if (mTextEdit->getCaption() == "")
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage37}");
             MWBase::Environment::get().getWindowManager()->setKeyFocusWidget (mTextEdit);
@@ -69,7 +69,7 @@ namespace MWGui
 
     std::string TextInputDialog::getTextInput() const
     {
-        return mTextEdit->getOnlyText();
+        return mTextEdit->getCaption();
     }
 
     void TextInputDialog::setTextInput(const std::string &text)

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1983,12 +1983,8 @@ namespace MWGui
         char* text=0;
         text = SDL_GetClipboardText();
         if (text)
-        {
-            // MyGUI's clipboard might still have color information, to retain that information, only set the new text
-            // if it actually changed (clipboard inserted by an external application)
-            if (MyGUI::TextIterator::getOnlyText(_data) != text)
-                _data = text;
-        }
+            _data = MyGUI::TextIterator::toTagsString(text);
+
         SDL_free(text);
     }
 


### PR DESCRIPTION
Implement fix on a clipboard level (should work for all widgets now).
Adding '#' symbol to save or item name should work now too.

If this implementation is ok, we can revert my [67d59be](https://github.com/OpenMW/openmw/commit/67d59bead51ce4948c0e0256ee014bdab3bc8b5f) commit.

P.S. I am not sure about comment at lines 1987-1988. Maybe we should change it...