### PR TITLE
Owned crosshair feature improvements [discussion]

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -7,6 +7,8 @@
 #include <set>
 #include <stdint.h>
 
+#include "../mwworld/ptr.hpp"
+
 namespace osg
 {
     class Vec3f;
@@ -231,7 +233,7 @@ namespace MWBase
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid) = 0;
 
-            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim) = 0;
+            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::ConstPtr& item, MWWorld::Ptr& victim) = 0;
 
             /// Turn actor into werewolf or normal form.
             virtual void setWerewolf(const MWWorld::Ptr& actor, bool werewolf) = 0;

--- a/apps/openmw/mwclass/activator.cpp
+++ b/apps/openmw/mwclass/activator.cpp
@@ -51,6 +51,11 @@ namespace MWClass
         return "";
     }
 
+    bool Activator::isActivator() const
+    {
+        return true;
+    }
+
     bool Activator::useAnim() const
     {
         return true;

--- a/apps/openmw/mwclass/activator.hpp
+++ b/apps/openmw/mwclass/activator.hpp
@@ -42,6 +42,8 @@ namespace MWClass
 
             virtual bool useAnim() const;
             ///< Whether or not to use animated variant of model (default false)
+
+            virtual bool isActivator() const;
     };
 }
 

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -76,6 +76,11 @@ namespace MWClass
         }
     }
 
+    bool Door::isDoor() const
+    {
+        return true;
+    }
+
     bool Door::useAnim() const
     {
         return true;

--- a/apps/openmw/mwclass/door.hpp
+++ b/apps/openmw/mwclass/door.hpp
@@ -20,6 +20,8 @@ namespace MWClass
 
             virtual void insertObject(const MWWorld::Ptr& ptr, const std::string& model, MWPhysics::PhysicsSystem& physics) const;
 
+            virtual bool isDoor() const;
+
             virtual bool useAnim() const;
 
             virtual std::string getName (const MWWorld::ConstPtr& ptr) const;

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -359,12 +359,11 @@ namespace MWGui
     {
         if(!mFocusObject.isEmpty())
         {
-            const MWWorld::CellRef& cellref = mFocusObject.getCellRef();
             MWWorld::Ptr ptr = MWMechanics::getPlayer();
             MWWorld::Ptr victim;
             
             MWBase::MechanicsManager* mm = MWBase::Environment::get().getMechanicsManager();
-            bool allowed = mm->isAllowedToUse(ptr, cellref, victim); 
+            bool allowed = mm->isAllowedToUse(ptr, mFocusObject, victim); 
 
             return !allowed;
         }

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -199,7 +199,7 @@ namespace MWMechanics
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid);
 
             /// @return is \a ptr allowed to take/use \a cellref or is it a crime?
-            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::CellRef& cellref, MWWorld::Ptr& victim);
+            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::ConstPtr& item, MWWorld::Ptr& victim);
 
             virtual void setWerewolf(const MWWorld::Ptr& actor, bool werewolf);
             virtual void applyWerewolfAcrobatics(const MWWorld::Ptr& actor);

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -301,11 +301,19 @@ namespace MWWorld
 
             virtual Ptr copyToCell(const ConstPtr &ptr, CellStore &cell, const ESM::Position &pos, int count) const;
 
+            virtual bool isActivator() const {
+                return false;
+            }
+
             virtual bool isActor() const {
                 return false;
             }
 
             virtual bool isNpc() const {
+                return false;
+            }
+
+            virtual bool isDoor() const {
                 return false;
             }
 


### PR DESCRIPTION
This PR is aimed to fix [bug #2789](https://bugs.openmw.org/issues/2789).

Since "owned crosshair" feature does not present in vanilla game, I am not sure about which behaviour we can treat as correct.

Anyway, in vanilla game there are no fines for activating owned doors or activators. What we can do here:
1) Check if an owned door is locked or trapped (unlocking a door is a Trespassing crime).
2) Check if owned activator is a bed, but I do not know how to implement this check properly.

Any ideas?