### PR TITLE
Do not allow player to change weapon/spell during attack or spellcast

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -221,6 +221,7 @@ namespace MWBase
             virtual void keepPlayerAlive() = 0;
 
             virtual bool isReadyToBlock (const MWWorld::Ptr& ptr) const = 0;
+            virtual bool isAttackingOrSpell(const MWWorld::Ptr &ptr) const = 0;
 
             virtual void confiscateStolenItems (const MWWorld::Ptr& player, const MWWorld::Ptr& targetContainer) = 0;
 

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -212,7 +212,10 @@ namespace MWBase
             virtual void setSpellVisibility(bool visible) = 0;
             virtual void setSneakVisibility(bool visible) = 0;
 
-            virtual void activateQuickKey  (int index) = 0;
+            /// activate selected quick key
+            virtual void activateQuickKey (int index) = 0;
+            /// update activated quick key state (if action executing was delayed for some reason)
+            virtual void updateActivatedQuickKey () = 0;
 
             virtual std::string getSelectedSpell() = 0;
             virtual void setSelectedSpell(const std::string& spellId, int successChancePercent) = 0;

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -4,6 +4,7 @@
 #include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 
@@ -372,6 +373,9 @@ namespace MWClass
     {
         if (hasItemHealth(ptr) && ptr.getCellRef().getCharge() == 0)
             return std::make_pair(0, "#{sInventoryMessage1}");
+
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(npc))
+            return std::make_pair(0, "#{sCantEquipWeapWarning}");
 
         std::pair<std::vector<int>, bool> slots_ = ptr.getClass().getEquipmentSlots(ptr);
 

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -29,6 +29,7 @@
 #include "../mwrender/characterpreview.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/creaturestats.hpp"
 
 #include "itemview.hpp"
 #include "inventoryitemmodel.hpp"
@@ -660,9 +661,18 @@ namespace MWGui
 
     void InventoryWindow::cycle(bool next)
     {
+        MWWorld::Ptr player = MWMechanics::getPlayer();
+
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(player))
+            return;
+
+        const MWMechanics::CreatureStats &stats = player.getClass().getCreatureStats(player);
+        if (stats.isParalyzed() || stats.getKnockedDown() || stats.isDead() || stats.getHitRecovery())
+            return;
+
         ItemModel::ModelIndex selected = -1;
         // not using mSortFilterModel as we only need sorting, not filtering
-        SortFilterItemModel model(new InventoryItemModel(MWMechanics::getPlayer()));
+        SortFilterItemModel model(new InventoryItemModel(player));
         model.setSortByType(false);
         model.update();
         if (model.getItemCount() == 0)

--- a/apps/openmw/mwgui/quickkeysmenu.hpp
+++ b/apps/openmw/mwgui/quickkeysmenu.hpp
@@ -36,6 +36,7 @@ namespace MWGui
         void onAssignMagicCancel ();
 
         void activateQuickKey(int index);
+        void updateActivatedQuickKey();
 
         /// @note This enum is serialized, so don't move the items around!
         enum QuickKeyType
@@ -64,7 +65,7 @@ namespace MWGui
         MagicSelectionDialog* mMagicSelectionDialog;
 
         int mSelectedIndex;
-
+        int mActivatedIndex;
 
         void onQuickKeyButtonClicked(MyGUI::Widget* sender);
         void onOkButtonClicked(MyGUI::Widget* sender);

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -9,6 +9,7 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/class.hpp"
@@ -195,6 +196,15 @@ namespace MWGui
 
     void SpellWindow::cycle(bool next)
     {
+        MWWorld::Ptr player = MWMechanics::getPlayer();
+
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(player))
+            return;
+
+        const MWMechanics::CreatureStats &stats = player.getClass().getCreatureStats(player);
+        if (stats.isParalyzed() || stats.getKnockedDown() || stats.isDead() || stats.getHitRecovery())
+            return;
+
         mSpellView->setModel(new SpellModel(MWMechanics::getPlayer()));
 
         SpellModel::ModelIndex selected = 0;

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -518,6 +518,8 @@ namespace MWGui
         cleanupGarbage();
 
         mHud->update();
+
+        updateActivatedQuickKey ();
     }
 
     void WindowManager::updateVisible()
@@ -1526,6 +1528,11 @@ namespace MWGui
     {
         if (mHud)
             mHud->setCrosshairVisible (show && mCrosshairEnabled);
+    }
+
+    void WindowManager::updateActivatedQuickKey ()
+    {
+        mQuickKeysMenu->updateActivatedQuickKey();
     }
 
     void WindowManager::activateQuickKey (int index)

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -241,7 +241,10 @@ namespace MWGui
     virtual void setSpellVisibility(bool visible);
     virtual void setSneakVisibility(bool visible);
 
-    virtual void activateQuickKey  (int index);
+    /// activate selected quick key
+    virtual void activateQuickKey (int index);
+    /// update activated quick key state (if action executing was delayed for some reason)
+    virtual void updateActivatedQuickKey ();
 
     virtual std::string getSelectedSpell() { return mSelectedSpell; }
     virtual void setSelectedSpell(const std::string& spellId, int successChancePercent);

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -20,6 +20,7 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/statemanager.hpp"
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 
 #include "../mwworld/player.hpp"
 #include "../mwworld/class.hpp"
@@ -929,6 +930,9 @@ namespace MWInput
             inventory.getSelectedEnchantItem() == inventory.end())
             return;
 
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(mPlayer->getPlayer()))
+            return;
+
         MWMechanics::DrawState_ state = mPlayer->getDrawState();
         if (state == MWMechanics::DrawState_Weapon || state == MWMechanics::DrawState_Nothing)
             mPlayer->setDrawState(MWMechanics::DrawState_Spell);
@@ -942,6 +946,9 @@ namespace MWInput
 
         // Not allowed before the inventory window is accessible
         if (!mControlSwitch["playerfighting"] || !mControlSwitch["playercontrols"])
+            return;
+
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(mPlayer->getPlayer()))
             return;
 
         MWMechanics::DrawState_ state = mPlayer->getDrawState();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1784,6 +1784,16 @@ namespace MWMechanics
         return it->second->getCharacterController()->isReadyToBlock();
     }
 
+    bool Actors::isAttackingOrSpell(const MWWorld::Ptr& ptr) const
+    {
+        PtrActorMap::const_iterator it = mActors.find(ptr);
+        if (it == mActors.end())
+            return false;
+        CharacterController* ctrl = it->second->getCharacterController();
+
+        return ctrl->isAttackingOrSpell();
+    }
+
     void Actors::fastForwardAi()
     {
         if (!MWBase::Environment::get().getMechanicsManager()->isAIActive())

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -150,6 +150,7 @@ namespace MWMechanics
             void clear(); // Clear death counter
 
             bool isReadyToBlock(const MWWorld::Ptr& ptr) const;
+            bool isAttackingOrSpell(const MWWorld::Ptr& ptr) const;
 
     private:
         PtrActorMap mActors;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2228,6 +2228,12 @@ bool CharacterController::isKnockedOut() const
     return mHitState == CharState_KnockOut;
 }
 
+bool CharacterController::isAttackingOrSpell() const
+{
+    return mUpperBodyState != UpperCharState_Nothing &&
+            mUpperBodyState != UpperCharState_WeapEquiped;
+}
+
 bool CharacterController::isSneaking() const
 {
     return mIdleState == CharState_IdleSneak ||

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -267,6 +267,7 @@ public:
     bool isKnockedOut() const;
     bool isSneaking() const;
     bool isRunning() const;
+    bool isAttackingOrSpell() const;
 
     void setAttackingOrSpell(bool attackingOrSpell);
     void setAIAttackType(const std::string& attackType);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1581,6 +1581,11 @@ namespace MWMechanics
         return mActors.isReadyToBlock(ptr);
     }
 
+    bool MechanicsManager::isAttackingOrSpell(const MWWorld::Ptr &ptr) const
+    {
+        return mActors.isAttackingOrSpell(ptr);
+    }
+
     void MechanicsManager::setWerewolf(const MWWorld::Ptr& actor, bool werewolf)
     {
         MWMechanics::NpcStats& npcStats = actor.getClass().getNpcStats(actor);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -188,6 +188,8 @@ namespace MWMechanics
             virtual void keepPlayerAlive();
 
             virtual bool isReadyToBlock (const MWWorld::Ptr& ptr) const;
+            /// Is \a ptr casting spell or using weapon now?
+            virtual bool isAttackingOrSpell(const MWWorld::Ptr &ptr) const;
 
             virtual void confiscateStolenItems (const MWWorld::Ptr& player, const MWWorld::Ptr& targetContainer);
 


### PR DESCRIPTION
Fixes [bug #2445](https://bugs.openmw.org/issues/2445). 
Also partially fixes [bug #2835](https://bugs.openmw.org/issues/2835) (since you will have to wait until end of switching animation, your movement will be much slower).

As it works:
1) If player attacking someone, or casting spell, or switches between weapons, etc., disable weapon/spell cycling keys and weapon/spell stance toggling keys.
2) If player activates a hotkey during animation, a hotkey action will be delayed until animation ends.
If player activates many hotkeys during animation, only last action will be executed.