### PR TITLE
Add an EditorConfig file to force compatible editors to use the correct indentation style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*.cpp]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.hpp]
+indent_style = space
+indent_size = 4
+insert_final_newline = true


### PR DESCRIPTION
A bunch of IDEs and Text editors now support EditorConfig either natively or via a plugin. Adding this file should force all those programs to use the correct indentation style when people are working on OpenMW, even if the default setting is something else.

More information is here: http://editorconfig.org/