### PR TITLE
Add VS2017 aps files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Doxygen
 .settings
 .directory
 .idea
+files/windows/*.aps
 ## qt-creator
 CMakeLists.txt.user*
 


### PR DESCRIPTION
VS2017 now creates APS files when loading OpenMW. This adds them to the gitignore file to prevent them being accidentally committed.