### PR TITLE
Minor GUI layout fixes

### DIFF
--- a/files/mygui/openmw_chargen_class.layout
+++ b/files/mygui/openmw_chargen_class.layout
@@ -34,6 +34,7 @@
                 <Widget type="AutoSizedEditBox" skin="HeaderText" position="0 0 166 18" name="FavoriteAttributesT" align="Left Top">
                     <Property key="Caption" value="#{sChooseClassMenu2}"/>
                     <Property key="TextAlign" value="Left Top"/>
+                    <Property key="Static" value="true"/>
                     <UserString key="ToolTipType" value="Layout"/>
                     <UserString key="ToolTipLayout" value="TextToolTip"/>
                     <UserString key="Caption_Text" value="#{sCreateClassMenuHelp2}"/>

--- a/files/mygui/openmw_chargen_class_description.layout
+++ b/files/mygui/openmw_chargen_class_description.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 244 248" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 244 248" align="Center" name="_Main">
 
         <!-- Edit box -->
         <Widget type="Widget" skin="MW_Box" position="8 8 220 192" align="Stretch" name="Client"/>

--- a/files/mygui/openmw_chargen_create_class.layout
+++ b/files/mygui/openmw_chargen_create_class.layout
@@ -33,6 +33,7 @@
                 <Widget type="AutoSizedEditBox" skin="HeaderText" position="0 0 166 18" name="FavoriteAttributesT" align="Left Top">
                     <Property key="Caption" value="#{sChooseClassMenu2}"/>
                     <Property key="TextAlign" value="Left Top"/>
+                    <Property key="Static" value="true"/>
                     <UserString key="ToolTipType" value="Layout"/>
                     <UserString key="ToolTipLayout" value="TextToolTip"/>
                     <UserString key="Caption_Text" value="#{sCreateClassMenuHelp2}"/>

--- a/files/mygui/openmw_edit_note.layout
+++ b/files/mygui/openmw_edit_note.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 336 242" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 336 242" align="Center" name="_Main">
 
         <Widget type="AutoSizedTextBox" skin="SandText" position="13 13 200 16">
             <Property key="Caption" value="#{sEditNote}"/>


### PR DESCRIPTION
1. Fixed a regression in which you can get cursor on FavoriteAttributes label (in class creation/selection menu).
2. Disabled transparency for map note edit field and class description edit field (as in vanilla game).