### PR TITLE
Improved shuffle

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -60,6 +60,7 @@ Programmers
     Gašper Sedej
     gugus/gus
     Hallfaer Tuilinn
+    Haoda Wang (h313)
     hristoast
     Internecine
     Jacob Essex (Yacoby)    

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -367,10 +367,6 @@ namespace MWSound
             }
 
             mMusicFiles[mCurrentPlaylist] = filelist;
-
-            // Build mMusicToPlay for this playlist
-            tracklist.resize(filelist.size());
-            std::iota(tracklist.begin(), tracklist.end(), 0);
         }
         else
             filelist = mMusicFiles[mCurrentPlaylist];

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <algorithm>
 #include <map>
+#include <numeric>
 
 #include <osg/Matrixf>
 
@@ -347,6 +348,7 @@ namespace MWSound
     void SoundManager::startRandomTitle()
     {
         std::vector<std::string> filelist;
+        auto &tracklist = mMusicToPlay[mCurrentPlaylist];
         if (mMusicFiles.find(mCurrentPlaylist) == mMusicFiles.end())
         {
             const std::map<std::string, VFS::File*>& index = mVFS->getIndex();
@@ -367,11 +369,8 @@ namespace MWSound
             mMusicFiles[mCurrentPlaylist] = filelist;
 
             // Build mMusicToPlay for this playlist
-            std::vector<int> temp;
-            temp.reserve(filelist.size());
-            for(int it = 0; it < filelist.size(); it++)
-                temp.push_back(it);
-            mMusicToPlay.insert(std::make_pair(mCurrentPlaylist, temp));
+            tracklist.resize(filelist.size());
+            std::iota(tracklist.begin(), tracklist.end(), 0);
         }
         else
             filelist = mMusicFiles[mCurrentPlaylist];
@@ -380,15 +379,13 @@ namespace MWSound
             return;
 
         // Do a Fisher-Yates shuffle
-        std::vector<int>& tracklist = mMusicToPlay[mCurrentPlaylist];
         int i = Misc::Rng::rollDice(tracklist.size());
 
         // Repopulate if playlist is empty
         if(tracklist.empty())
         {
-            tracklist.reserve(filelist.size());
-            for (int it = 0; it < filelist.size(); it++)
-                tracklist.push_back(it);
+            tracklist.resize(filelist.size());
+            std::iota(tracklist.begin(), tracklist.end(), 0);
         }
 
         // Reshuffle if last played music is the same after a repopulation

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -379,7 +379,6 @@ namespace MWSound
             return;
 
         // Do a Fisher-Yates shuffle
-        int i = Misc::Rng::rollDice(tracklist.size());
 
         // Repopulate if playlist is empty
         if(tracklist.empty())
@@ -387,6 +386,8 @@ namespace MWSound
             tracklist.resize(filelist.size());
             std::iota(tracklist.begin(), tracklist.end(), 0);
         }
+
+        int i = Misc::Rng::rollDice(tracklist.size());
 
         // Reshuffle if last played music is the same after a repopulation
         if(filelist[tracklist[i]] == mLastPlayedMusic)

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <deque>
 #include <map>
+#include <unordered_map>
 
 #include <components/settings/settings.hpp>
 
@@ -49,6 +50,7 @@ namespace MWSound
 
         // Caches available music tracks by <playlist name, (sound files) >
         std::map<std::string, std::vector<std::string> > mMusicFiles;
+        std::unordered_map<std::string, std::vector<int>> mMusicToPlay; // A list with music files not yet played
         std::string mLastPlayedMusic; // The music file that was last played
 
         float mMasterVolume;


### PR DESCRIPTION
Changes from previous commit #1401 :

- Use a `std::map` so that each playlist will have unique values
- Fixed the `mMusicToPlay` growing larger each time `startRandomTitle()` was called
- Documentation

I tested entering and going out of combat and did not encounter any crashes.