### PR TITLE
Combat AI: allow only one summoned creature at time

### DIFF
--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -496,6 +496,15 @@ namespace MWMechanics
             break;
         }
 
+        // Allow only one summoned creature at time
+        if (isSummoningEffect(effect.mEffectID))
+        {
+            MWMechanics::CreatureStats& creatureStats = actor.getClass().getCreatureStats(actor);
+
+            if (!creatureStats.getSummonedCreatureMap().empty())
+                return 0.f;
+        }
+
         const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effect.mEffectID);
 
         // Underwater casting not possible


### PR DESCRIPTION
This is how vanilla Morrowind behaves.
With this PR combat AI will cast only one summon spell at time.
With vanilla assets it means AI will summon only one strongest creature at time, allowed by caster magicka level and Conjuration skill.

If we do not want to replicate this behaviour, we should think about some reasonable cap (two or three creatures, for example).

Note: for now in OpenMW actor can spend all his magicka to summon many creatures (if he knows many summon spells). Summoning spells have a high magicka cost and priority, so such spamming can be considered as magicka wasting.