### PR TITLE
Escape hash characters in content file names so the loading screen wi…

### DIFF
--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -1,5 +1,7 @@
 #include "loadingscreen.hpp"
 
+#include <boost/algorithm/string/replace.hpp>
+
 #include <osgViewer/Viewer>
 
 #include <osg/Texture2D>
@@ -88,7 +90,8 @@ namespace MWGui
     {
         mImportantLabel = important;
 
-        mLoadingText->setCaptionWithReplacing(label);
+        std::string escaped = boost::replace_all_copy(label, "#", "##");
+        mLoadingText->setCaptionWithReplacing(escaped);
         int padding = mLoadingBox->getWidth() - mLoadingText->getWidth();
         MyGUI::IntSize size(mLoadingText->getTextSize().width+padding, mLoadingBox->getHeight());
         size.width = std::max(300, size.width);

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -1,5 +1,7 @@
 #include "loadingscreen.hpp"
 
+#include <boost/algorithm/string/replace.hpp>
+
 #include <osgViewer/Viewer>
 
 #include <osg/Texture2D>
@@ -8,7 +10,6 @@
 #include <MyGUI_ScrollBar.h>
 #include <MyGUI_Gui.h>
 #include <MyGUI_TextBox.h>
-#include <MyGUI_TextIterator.h>
 
 #include <components/misc/rng.hpp>
 
@@ -89,7 +90,8 @@ namespace MWGui
     {
         mImportantLabel = important;
 
-        mLoadingText->setCaptionWithReplacing(MyGUI::TextIterator::toTagsString(label));
+        std::string escaped = boost::replace_all_copy(label, "#", "##");
+        mLoadingText->setCaptionWithReplacing(escaped);
         int padding = mLoadingBox->getWidth() - mLoadingText->getWidth();
         MyGUI::IntSize size(mLoadingText->getTextSize().width+padding, mLoadingBox->getHeight());
         size.width = std::max(300, size.width);

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -1,7 +1,5 @@
 #include "loadingscreen.hpp"
 
-#include <boost/algorithm/string/replace.hpp>
-
 #include <osgViewer/Viewer>
 
 #include <osg/Texture2D>
@@ -10,6 +8,7 @@
 #include <MyGUI_ScrollBar.h>
 #include <MyGUI_Gui.h>
 #include <MyGUI_TextBox.h>
+#include <MyGUI_TextIterator.h>
 
 #include <components/misc/rng.hpp>
 
@@ -90,8 +89,7 @@ namespace MWGui
     {
         mImportantLabel = important;
 
-        std::string escaped = boost::replace_all_copy(label, "#", "##");
-        mLoadingText->setCaptionWithReplacing(escaped);
+        mLoadingText->setCaptionWithReplacing(MyGUI::TextIterator::toTagsString(label));
         int padding = mLoadingBox->getWidth() - mLoadingText->getWidth();
         MyGUI::IntSize size(mLoadingText->getTextSize().width+padding, mLoadingBox->getHeight());
         size.width = std::max(300, size.width);

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -1,7 +1,5 @@
 #include "loadingscreen.hpp"
 
-#include <boost/algorithm/string/replace.hpp>
-
 #include <osgViewer/Viewer>
 
 #include <osg/Texture2D>
@@ -90,8 +88,7 @@ namespace MWGui
     {
         mImportantLabel = important;
 
-        std::string escaped = boost::replace_all_copy(label, "#", "##");
-        mLoadingText->setCaptionWithReplacing(escaped);
+        mLoadingText->setCaptionWithReplacing(label);
         int padding = mLoadingBox->getWidth() - mLoadingText->getWidth();
         MyGUI::IntSize size(mLoadingText->getTextSize().width+padding, mLoadingBox->getHeight());
         size.width = std::max(300, size.width);

--- a/apps/openmw/mwworld/contentloader.hpp
+++ b/apps/openmw/mwworld/contentloader.hpp
@@ -4,6 +4,7 @@
 #include <iosfwd>
 #include <iostream>
 #include <boost/filesystem/path.hpp>
+#include <MyGUI_TextIterator.h>
 
 #include "components/loadinglistener/loadinglistener.hpp"
 
@@ -24,7 +25,7 @@ struct ContentLoader
     virtual void load(const boost::filesystem::path& filepath, int& index)
     {
       std::cout << "Loading content file " << filepath.string() << std::endl;
-      mListener.setLabel(filepath.string());
+      mListener.setLabel(MyGUI::TextIterator::toTagsString(filepath.string()));
     }
 
     protected:


### PR DESCRIPTION
…ll display them correctly

Since I tweaked the config file loading so content files with a hash in their name could actually be loaded, the loading screen text was interpreting any hash characters as a command to change the text colour. Now they're displayed properly.