### PR TITLE
Display large  journal entries correctly

### DIFF
--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -435,9 +435,15 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
             }
             else
             {
+                // The section won't completely fit on the current page. Finish the current page and start a new one.
+                mBook->mPages.push_back (Page (curPageStart, curPageStop));
+
+                curPageStart = i->mRect.top;
+                curPageStop = i->mRect.bottom;
+
                 //split section
                 int sectionHeightLeft = sectionHeight;
-                while (sectionHeightLeft > mPageHeight)
+                while (sectionHeightLeft >= mPageHeight)
                 {
                     // Adjust to the top of the first line that does not fit on the current page anymore
                     int splitPos = curPageStop;


### PR DESCRIPTION
A problem occurs with "Town_Sadrith 6" entry (at least in russain translation), for example.

It seems our current pagination implementation fails to split a large journal entry (near 512 symbols - one page), if a previous page was not empty (end of the entry will be cut off).

We can modify loop condition to avoid this issue.
Also we should start large entry rendering from new page.