### PR TITLE
Editor: Fix wrong folder name

### DIFF
--- a/apps/opencs/model/world/resourcesmanager.cpp
+++ b/apps/opencs/model/world/resourcesmanager.cpp
@@ -31,7 +31,7 @@ void CSMWorld::ResourcesManager::setVFS(const VFS::Manager *vfs)
     addResources (Resources (vfs, "music", UniversalId::Type_Music));
     addResources (Resources (vfs, "sound", UniversalId::Type_SoundRes));
     addResources (Resources (vfs, "textures", UniversalId::Type_Texture));
-    addResources (Resources (vfs, "videos", UniversalId::Type_Video));
+    addResources (Resources (vfs, "video", UniversalId::Type_Video));
 }
 
 const VFS::Manager* CSMWorld::ResourcesManager::getVFS() const


### PR DESCRIPTION
Videos are in the "video" folder and not in the "videos" folder for me. Seems strange that this wasn't noticed for so long. Did the folder name change at some point?