### PR TITLE
Editor: Fix pathgrid segfault

### DIFF
--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -275,12 +275,14 @@ bool CSVRender::Cell::referenceAdded (const QModelIndex& parent, int start, int 
 
 void CSVRender::Cell::pathgridModified()
 {
-    mPathgrid->recreateGeometry();
+    if (mPathgrid)
+        mPathgrid->recreateGeometry();
 }
 
 void CSVRender::Cell::pathgridRemoved()
 {
-    mPathgrid->removeGeometry();
+    if (mPathgrid)
+        mPathgrid->removeGeometry();
 }
 
 void CSVRender::Cell::reloadAssets()
@@ -320,7 +322,7 @@ void CSVRender::Cell::setSelection (int elementMask, Selection mode)
             iter->second->setSelected (selected);
         }
     }
-    if (elementMask & Mask_Pathgrid)
+    if (mPathgrid && elementMask & Mask_Pathgrid)
     {
         // Only one pathgrid may be selected, so some operations will only have an effect
         // if the pathgrid is already focused
@@ -420,7 +422,7 @@ std::vector<osg::ref_ptr<CSVRender::TagBase> > CSVRender::Cell::getSelection (un
             iter!=mObjects.end(); ++iter)
             if (iter->second->getSelected())
                 result.push_back (iter->second->getTag());
-    if (elementMask & Mask_Pathgrid)
+    if (mPathgrid && elementMask & Mask_Pathgrid)
         if (mPathgrid->isSelected())
             result.push_back(mPathgrid->getTag());
 
@@ -457,6 +459,6 @@ void CSVRender::Cell::reset (unsigned int elementMask)
         for (std::map<std::string, Object *>::const_iterator iter (mObjects.begin());
             iter!=mObjects.end(); ++iter)
             iter->second->reset();
-    if (elementMask & Mask_Pathgrid)
+    if (mPathgrid && elementMask & Mask_Pathgrid)
         mPathgrid->resetIndicators();
 }

--- a/apps/opencs/view/render/pathgridmode.cpp
+++ b/apps/opencs/view/render/pathgridmode.cpp
@@ -72,12 +72,15 @@ namespace CSVRender
         }
         else if (Cell* cell = getWorldspaceWidget().getCell (hitResult.worldPos))
         {
-            // Add node
-            QUndoStack& undoStack = getWorldspaceWidget().getDocument().getUndoStack();
-            QString description = "Add node";
+            if (cell->getPathgrid())
+            {
+                // Add node
+                QUndoStack& undoStack = getWorldspaceWidget().getDocument().getUndoStack();
+                QString description = "Add node";
 
-            CSMWorld::CommandMacro macro(undoStack, description);
-            cell->getPathgrid()->applyPoint(macro, hitResult.worldPos);
+                CSMWorld::CommandMacro macro(undoStack, description);
+                cell->getPathgrid()->applyPoint(macro, hitResult.worldPos);
+            }
         }
     }
 
@@ -205,7 +208,7 @@ namespace CSVRender
             WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
 
             Cell* cell = getWorldspaceWidget().getCell(hit.worldPos);
-            if (cell)
+            if (cell && cell->getPathgrid())
             {
                 PathgridTag* tag = 0;
                 if (hit.tag && (tag = dynamic_cast<PathgridTag*>(hit.tag.get())) && tag->getPathgrid()->getId() == mEdgeId)


### PR DESCRIPTION
Looks like an oversight was made when the pathgrid mode was developed. This should fix some of the the crashing mentioned in #1414 . I tested changing edit modes and adding pathgrid nodes when the cell is deleted.