### PR TITLE
AiWander: add offset when forwarding only if destination is occupied

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -191,6 +191,9 @@ namespace MWBase
             virtual void getObjectsInRange (const osg::Vec3f& position, float radius, std::vector<MWWorld::Ptr>& objects) = 0;
             virtual void getActorsInRange(const osg::Vec3f &position, float radius, std::vector<MWWorld::Ptr> &objects) = 0;
 
+            /// Check if there are actors in selected range
+            virtual bool isAnyActorInRange(const osg::Vec3f &position, float radius) = 0;
+
             ///Returns the list of actors which are siding with the given actor in fights
             /**ie AiFollow or AiEscort is active and the target is the actor **/
             virtual std::list<MWWorld::Ptr> getActorsSidingWith(const MWWorld::Ptr& actor) = 0;

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1621,6 +1621,17 @@ namespace MWMechanics
         }
     }
 
+    bool Actors::isAnyObjectInRange(const osg::Vec3f& position, float radius)
+    {
+        for (PtrActorMap::iterator iter = mActors.begin(); iter != mActors.end(); ++iter)
+        {
+            if ((iter->first.getRefData().getPosition().asVec3() - position).length2() <= radius*radius)
+                return true;
+        }
+
+        return false;
+    }
+
     std::list<MWWorld::Ptr> Actors::getActorsSidingWith(const MWWorld::Ptr& actor)
     {
         std::list<MWWorld::Ptr> list;

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -115,14 +115,16 @@ namespace MWMechanics
             bool isRunning(const MWWorld::Ptr& ptr);
             bool isSneaking(const MWWorld::Ptr& ptr);
 
-        void forceStateUpdate(const MWWorld::Ptr &ptr);
+            void forceStateUpdate(const MWWorld::Ptr &ptr);
 
-        bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number, bool persist=false);
-        void skipAnimation(const MWWorld::Ptr& ptr);
-        bool checkAnimationPlaying(const MWWorld::Ptr& ptr, const std::string& groupName);
-        void persistAnimationStates();
+            bool playAnimationGroup(const MWWorld::Ptr& ptr, const std::string& groupName, int mode, int number, bool persist=false);
+            void skipAnimation(const MWWorld::Ptr& ptr);
+            bool checkAnimationPlaying(const MWWorld::Ptr& ptr, const std::string& groupName);
+            void persistAnimationStates();
 
             void getObjectsInRange(const osg::Vec3f& position, float radius, std::vector<MWWorld::Ptr>& out);
+
+            bool isAnyObjectInRange(const osg::Vec3f& position, float radius);
 
             void cleanupSummonedCreature (CreatureStats& casterStats, int creatureActorId);
 

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -104,6 +104,8 @@ namespace MWMechanics
             bool mHasDestination;
             osg::Vec3f mDestination;
 
+            void getNeighbouringNodes(ESM::Pathgrid::Point dest, const MWWorld::CellStore* currentCell, ESM::Pathgrid::PointList& points);
+
             void getAllowedNodes(const MWWorld::Ptr& actor, const ESM::Cell* cell, AiWanderStorage& storage);
 
             void trimAllowedNodes(std::vector<ESM::Pathgrid::Point>& nodes, const PathFinder& pathfinder);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1529,6 +1529,11 @@ namespace MWMechanics
         mActors.getObjectsInRange(position, radius, objects);
     }
 
+    bool MechanicsManager::isAnyActorInRange(const osg::Vec3f &position, float radius)
+    {
+        return mActors.isAnyObjectInRange(position, radius);
+    }
+
     std::list<MWWorld::Ptr> MechanicsManager::getActorsSidingWith(const MWWorld::Ptr& actor)
     {
         return mActors.getActorsSidingWith(actor);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -158,6 +158,9 @@ namespace MWMechanics
             virtual void getObjectsInRange (const osg::Vec3f& position, float radius, std::vector<MWWorld::Ptr>& objects);
             virtual void getActorsInRange(const osg::Vec3f &position, float radius, std::vector<MWWorld::Ptr> &objects);
 
+            /// Check if there are actors in selected range
+            virtual bool isAnyActorInRange(const osg::Vec3f &position, float radius);
+
             virtual std::list<MWWorld::Ptr> getActorsSidingWith(const MWWorld::Ptr& actor);
             virtual std::list<MWWorld::Ptr> getActorsFollowing(const MWWorld::Ptr& actor);
             virtual std::list<int> getActorsFollowingIndices(const MWWorld::Ptr& actor);

--- a/apps/openmw/mwmechanics/pathgrid.cpp
+++ b/apps/openmw/mwmechanics/pathgrid.cpp
@@ -214,6 +214,16 @@ namespace MWMechanics
         return (mGraph[start].componentId == mGraph[end].componentId);
     }
 
+    void PathgridGraph::getNeighbouringPoints(const int index, ESM::Pathgrid::PointList &nodes) const
+    {
+        for(int i = 0; i < static_cast<int> (mGraph[index].edges.size()); i++)
+        {
+            int neighbourIndex = mGraph[index].edges[i].index;
+            if (neighbourIndex != index)
+                nodes.push_back(mPathgrid->mPoints[neighbourIndex]);
+        }
+    }
+
     /*
      * NOTE: Based on buildPath2(), please check git history if interested
      *       Should consider using a 3rd party library version (e.g. boost)

--- a/apps/openmw/mwmechanics/pathgrid.hpp
+++ b/apps/openmw/mwmechanics/pathgrid.hpp
@@ -28,6 +28,9 @@ namespace MWMechanics
             // from start point) both start and end are pathgrid point indexes
             bool isPointConnected(const int start, const int end) const;
 
+            // get neighbouring nodes for index node and put them to "nodes" vector
+            void getNeighbouringPoints(const int index, ESM::Pathgrid::PointList &nodes) const;
+
             // the input parameters are pathgrid point indexes
             // the output list is in local (internal cells) or world (external
             // cells) coordinates

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -942,6 +942,11 @@ namespace MWWorld
         return mPathgridGraph.isPointConnected(start, end);
     }
 
+    void CellStore::getNeighbouringPoints(const int index, ESM::Pathgrid::PointList &nodes) const
+    {
+        return mPathgridGraph.getNeighbouringPoints(index, nodes);
+    }
+
     std::list<ESM::Pathgrid::Point> CellStore::aStarSearch(const int start, const int end) const
     {
         return mPathgridGraph.aStarSearch(start, end);

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -377,6 +377,7 @@ namespace MWWorld
             ///< Check mLastRespawn and respawn references if necessary. This is a no-op if the cell is not loaded.
 
             bool isPointConnected(const int start, const int end) const;
+            void getNeighbouringPoints(const int index, ESM::Pathgrid::PointList &nodes) const;
 
             std::list<ESM::Pathgrid::Point> aStarSearch(const int start, const int end) const;
 


### PR DESCRIPTION
This PR is aimed to fix [#3638](https://bugs.openmw.org/issues/3638), but IMO we need a discussion first.

A solution, applied in this PR, is a quite simple: just add an offset only if destination pathgrid is already occupied by another actor.

Also we can use a more complex, but more safe solution: iterate over all allowed pathgrids, and find a free one. If there are no such pathgrids, just leave wandering actor in place (uploaded [here](https://github.com/akortunov/openmw/tree/forwardingfix2)). This solution allows to avoid moving actor to random position.

Which option would be better?