### PR TITLE
Display negative values on fatigue progress bars

### DIFF
--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -179,29 +179,33 @@ namespace MWGui
 
     void HUD::setValue(const std::string& id, const MWMechanics::DynamicStat<float>& value)
     {
-        int current = std::max(0, static_cast<int>(value.getCurrent()));
+        int current = static_cast<int>(value.getCurrent());
         int modified = static_cast<int>(value.getModified());
+
+        // Fatigue can be negative
+        if (id != "FBar")
+            current = std::max(0, current);
 
         MyGUI::Widget* w;
         std::string valStr = MyGUI::utility::toString(current) + " / " + MyGUI::utility::toString(modified);
         if (id == "HBar")
         {
-            mHealth->setProgressRange(modified);
-            mHealth->setProgressPosition(current);
+            mHealth->setProgressRange(std::max(0, modified));
+            mHealth->setProgressPosition(std::max(0, current));
             getWidget(w, "HealthFrame");
             w->setUserString("Caption_HealthDescription", "#{sHealthDesc}\n" + valStr);
         }
         else if (id == "MBar")
         {
-            mMagicka->setProgressRange (modified);
-            mMagicka->setProgressPosition (current);
+            mMagicka->setProgressRange(std::max(0, modified));
+            mMagicka->setProgressPosition(std::max(0, current));
             getWidget(w, "MagickaFrame");
             w->setUserString("Caption_HealthDescription", "#{sMagDesc}\n" + valStr);
         }
         else if (id == "FBar")
         {
-            mStamina->setProgressRange (modified);
-            mStamina->setProgressPosition (current);
+            mStamina->setProgressRange(std::max(0, modified));
+            mStamina->setProgressPosition(std::max(0, current));
             getWidget(w, "FatigueFrame");
             w->setUserString("Caption_HealthDescription", "#{sFatDesc}\n" + valStr);
         }

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -180,7 +180,7 @@ namespace MWGui
 
     void ReviewDialog::setFatigue(const MWMechanics::DynamicStat<float>& value)
     {
-        int current = std::max(0, static_cast<int>(value.getCurrent()));
+        int current = static_cast<int>(value.getCurrent());
         int modified = static_cast<int>(value.getModified());
 
         mFatigue->setValue(current, modified);

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -102,12 +102,13 @@ namespace MWGui
     {
         MyGUI::ProgressBar* pt;
         getWidget(pt, name);
-        pt->setProgressRange(max);
-        pt->setProgressPosition(val);
 
         std::stringstream out;
         out << val << "/" << max;
         setText(tname, out.str().c_str());
+
+        pt->setProgressRange(std::max(0, max));
+        pt->setProgressPosition(std::max(0, val));
     }
 
     void StatsWindow::setPlayerName(const std::string& playerName)
@@ -147,8 +148,12 @@ namespace MWGui
 
     void StatsWindow::setValue (const std::string& id, const MWMechanics::DynamicStat<float>& value)
     {
-        int current = std::max(0, static_cast<int>(value.getCurrent()));
+        int current = static_cast<int>(value.getCurrent());
         int modified = static_cast<int>(value.getModified());
+
+        // Fatigue can be negative
+        if (id != "FBar")
+            current = std::max(0, current);
 
         setBar (id, id + "T", current, modified);
 

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -502,10 +502,9 @@ namespace MWGui
 
             if (mBarWidget)
             {
-                mBarWidget->setProgressRange(mMax);
-                mBarWidget->setProgressPosition(mValue);
+                mBarWidget->setProgressRange(std::max(0, mMax));
+                mBarWidget->setProgressPosition(std::max(0, mValue));
             }
-
 
             if (mBarTextWidget)
             {


### PR DESCRIPTION
Vanilla Morrowind shows negative fatigue values on scroll bars, in OpenMW minimum value is 0.
Now it matches vanilla behaviour.