### PR TITLE
Allow to play only one copy of given sound at time (bug #3647)

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -579,6 +579,9 @@ namespace MWSound
             if((mode&Play_RemoveAtDistance) && (mListenerPos-objpos).length2() > 2000*2000)
                 return MWBase::SoundPtr();
 
+            // Only one copy of given sound can be played at time on ptr, so stop previous copy
+            stopSound3D(ptr, soundId);
+
             if(!(mode&Play_NoPlayerLocal) && ptr == MWMechanics::getPlayer())
             {
                 sound.reset(new Sound(volume * sfx->mVolume, basevol, pitch, mode|type|Play_2D));


### PR DESCRIPTION
Fixes [bug #3647](https://bugs.openmw.org/issues/3647).

According to @Allofich (in #1145), only one copy of given sound can be played on single object at time. When a new copy is started, a game stops a previous copy.

Note: we have **two** playSound3D functions:
1. Play a sound on given object.
2. Play a sound at given position (e.g. for area spells).
I modified only first one.

Tested with imperial shrines and locked doors.