### PR TITLE
[Feedback needed] Stance switching changes, part II

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -247,6 +247,7 @@ namespace MWBase
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count) = 0;
 
+            virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr) = 0;
             virtual bool isRunning(const MWWorld::Ptr& ptr) = 0;
             virtual bool isSneaking(const MWWorld::Ptr& ptr) = 0;
     };

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -3,6 +3,7 @@
 #include <components/esm/loadlock.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 
@@ -153,6 +154,16 @@ namespace MWClass
         const MWWorld::LiveCellRef<ESM::Lockpick> *ref = ptr.get<ESM::Lockpick>();
 
         return MWWorld::Ptr(cell.insert(ref), &cell);
+    }
+
+    std::pair<int, std::string> Lockpick::canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const
+    {
+        // Do not allow equip tools from inventory during attack
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(npc)
+            && MWBase::Environment::get().getWindowManager()->isGuiMode())
+            return std::make_pair(0, "#{sCantEquipWeapWarning}");
+
+        return std::make_pair(1, "");
     }
 
     bool Lockpick::canSell (const MWWorld::ConstPtr& item, int npcServices) const

--- a/apps/openmw/mwclass/lockpick.hpp
+++ b/apps/openmw/mwclass/lockpick.hpp
@@ -51,6 +51,8 @@ namespace MWClass
             virtual std::string getInventoryIcon (const MWWorld::ConstPtr& ptr) const;
             ///< Return name of inventory icon.
 
+            virtual std::pair<int, std::string> canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const;
+
             virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
                 const;
             ///< Generate action for using via inventory menu

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -3,6 +3,7 @@
 #include <components/esm/loadprob.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 
@@ -153,6 +154,16 @@ namespace MWClass
         const MWWorld::LiveCellRef<ESM::Probe> *ref = ptr.get<ESM::Probe>();
 
         return MWWorld::Ptr(cell.insert(ref), &cell);
+    }
+
+    std::pair<int, std::string> Probe::canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const
+    {
+        // Do not allow equip tools from inventory during attack
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(npc)
+            && MWBase::Environment::get().getWindowManager()->isGuiMode())
+            return std::make_pair(0, "#{sCantEquipWeapWarning}");
+
+        return std::make_pair(1, "");
     }
 
     bool Probe::canSell (const MWWorld::ConstPtr& item, int npcServices) const

--- a/apps/openmw/mwclass/probe.hpp
+++ b/apps/openmw/mwclass/probe.hpp
@@ -51,6 +51,8 @@ namespace MWClass
             virtual std::string getInventoryIcon (const MWWorld::ConstPtr& ptr) const;
             ///< Return name of inventory icon.
 
+            virtual std::pair<int, std::string> canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const;
+
             virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
                 const;
             ///< Generate action for using via inventory menu

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -374,7 +374,9 @@ namespace MWClass
         if (hasItemHealth(ptr) && ptr.getCellRef().getCharge() == 0)
             return std::make_pair(0, "#{sInventoryMessage1}");
 
-        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(npc))
+        // Do not allow equip weapons from inventory during attack
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(npc)
+            && MWBase::Environment::get().getWindowManager()->isGuiMode())
             return std::make_pair(0, "#{sCantEquipWeapWarning}");
 
         std::pair<std::vector<int>, bool> slots_ = ptr.getClass().getEquipmentSlots(ptr);

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -255,6 +255,19 @@ namespace MWGui
             }
         }
 
+        // If we unequip weapon during attack, it can lead to unexpected behaviour
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(mPtr))
+        {
+            bool isWeapon = item.mBase.getTypeName() == typeid(ESM::Weapon).name();
+            MWWorld::InventoryStore& invStore = mPtr.getClass().getInventoryStore(mPtr);
+
+            if (isWeapon && invStore.isEquipped(item.mBase))
+            {
+                MWBase::Environment::get().getWindowManager()->messageBox("#{sCantEquipWeapWarning}");
+                return;
+            }
+        }
+
         if (count > 1 && !shift)
         {
             CountDialog* dialog = MWBase::Environment::get().getWindowManager()->getCountDialog();

--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -344,16 +344,17 @@ namespace MWGui
         {
             MWWorld::Ptr item = *button->getUserData<MWWorld::Ptr>();
             bool isWeapon = item.getTypeName() == typeid(ESM::Weapon).name();
+            bool isTool = item.getTypeName() == typeid(ESM::Probe).name() || item.getTypeName() == typeid(ESM::Lockpick).name();
 
             // delay weapon switching if player is busy
-            if (isDelayNeeded && isWeapon)
+            if (isDelayNeeded && (isWeapon || isTool))
             {
                 mActivatedIndex = index;
                 return;
             }
 
             // disable weapon switching if player is dead or paralyzed
-            if (isReturnNeeded && isWeapon)
+            if (isReturnNeeded && (isWeapon || isTool))
             {
                 return;
             }

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -948,7 +948,11 @@ namespace MWInput
         if (!mControlSwitch["playerfighting"] || !mControlSwitch["playercontrols"])
             return;
 
-        if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(mPlayer->getPlayer()))
+        // We want to interrupt animation only if attack is prepairing, but still is not triggered
+        // Otherwise we will get a "speedshooting" exploit, when player can skip reload animation by hitting "Toggle Weapon" key twice
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackPrepairing(mPlayer->getPlayer()))
+            mPlayer->setAttackingOrSpell(false);
+        else if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(mPlayer->getPlayer()))
             return;
 
         MWMechanics::DrawState_ state = mPlayer->getDrawState();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -802,6 +802,16 @@ namespace MWMechanics
         }
     }
 
+    bool Actors::isAttackPrepairing(const MWWorld::Ptr& ptr)
+    {
+        PtrActorMap::iterator it = mActors.find(ptr);
+        if (it == mActors.end())
+            return false;
+        CharacterController* ctrl = it->second->getCharacterController();
+
+        return ctrl->isAttackPrepairing();
+    }
+
     bool Actors::isRunning(const MWWorld::Ptr& ptr)
     {
         PtrActorMap::iterator it = mActors.find(ptr);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -107,6 +107,7 @@ namespace MWMechanics
             int countDeaths (const std::string& id) const;
             ///< Return the number of deaths for actors with the given ID.
 
+            bool isAttackPrepairing(const MWWorld::Ptr& ptr);
             bool isRunning(const MWWorld::Ptr& ptr);
             bool isSneaking(const MWWorld::Ptr& ptr);
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2218,6 +2218,12 @@ void CharacterController::setAttackTypeBasedOnMovement()
         mAttackType = "chop";
 }
 
+bool CharacterController::isAttackPrepairing() const
+{
+    return mUpperBodyState == UpperCharState_StartToMinAttack ||
+            mUpperBodyState == UpperCharState_MinAttackToMaxAttack;
+}
+
 bool CharacterController::isReadyToBlock() const
 {
     return updateCarriedLeftVisible(mWeaponType);

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -263,6 +263,7 @@ public:
 
     void forceStateUpdate();
     
+    bool isAttackPrepairing() const;
     bool isReadyToBlock() const;
     bool isKnockedOut() const;
     bool isSneaking() const;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -423,6 +423,11 @@ namespace MWMechanics
         mObjects.update(duration, paused);
     }
 
+    bool MechanicsManager::isAttackPrepairing(const MWWorld::Ptr& ptr)
+    {
+        return mActors.isAttackPrepairing(ptr);
+    }
+
     bool MechanicsManager::isRunning(const MWWorld::Ptr& ptr)
     {
         return mActors.isRunning(ptr);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -210,8 +210,10 @@ namespace MWMechanics
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count);
 
+            virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr);
             virtual bool isRunning(const MWWorld::Ptr& ptr);
             virtual bool isSneaking(const MWWorld::Ptr& ptr);
+
         private:
             void reportCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
                                       OffenseType type, int arg=0);

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -23,6 +23,7 @@
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 #include "../mwworld/class.hpp"
+#include "../mwworld/player.hpp"
 
 #include "../mwmechanics/npcstats.hpp"
 #include "../mwmechanics/actorutil.hpp"
@@ -919,6 +920,9 @@ void NpcAnimation::showWeapons(bool showWeapon)
     else
     {
         removeIndividualPart(ESM::PRT_Weapon);
+        // If we remove/hide weapon from player, we should reset attack animation as well
+        if (mPtr == MWMechanics::getPlayer())
+            MWBase::Environment::get().getWorld()->getPlayer().setAttackingOrSpell(false);
     }
 }
 


### PR DESCRIPTION
This is a continue of #1405.
But I am not sure if we will fix a new behaviour or revert it.

This PR is for the first case for now.
Summary of changes was made:
1. Fixed regression - [bug #4050](https://bugs.openmw.org/issues/4050)
2. Player is allowed to interrupt attack by using Toggle Weapon key, but only when Attack button is pressed, and actual attack is not triggered yet (starting the down-swing, or releasing the arrow), as Chris Robinson suggested in [bug #4051](https://bugs.openmw.org/issues/4051) thread.
3. Do not allow to equip probes and lockpicks during attack 
4. Do not allow to unequip weapons via inventory during attack
5. Reset player attack animation when unequip weapon or tool from inventory.

Note: to implement spellcast interrupting, we should check if a "start" key from "spellcast" animation group is played somehow.