### PR TITLE
Update alchemy effects after every created potion (#4079)

### DIFF
--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -262,22 +262,16 @@ const ESM::Potion *MWMechanics::Alchemy::getRecord(const ESM::Potion& toFind) co
 
 void MWMechanics::Alchemy::removeIngredients()
 {
-    bool needsUpdate = false;
-
     for (TIngredientsContainer::iterator iter (mIngredients.begin()); iter!=mIngredients.end(); ++iter)
         if (!iter->isEmpty())
         {
             iter->getContainerStore()->remove(*iter, 1, mAlchemist);
 
             if (iter->getRefData().getCount()<1)
-            {
-                needsUpdate = true;
                 *iter = MWWorld::Ptr();
-            }
         }
 
-    if (needsUpdate)
-        updateEffects();
+    updateEffects();
 }
 
 void MWMechanics::Alchemy::addPotion (const std::string& name)

--- a/components/widgets/windowcaption.hpp
+++ b/components/widgets/windowcaption.hpp
@@ -23,6 +23,7 @@ namespace Gui
     private:
         MyGUI::Widget* mLeft;
         MyGUI::Widget* mRight;
+        MyGUI::Widget* mClient;
 
         void align();
     };


### PR DESCRIPTION
Fixes [bug #4079](https://bugs.openmw.org/issues/4079).

A question: should we bother to use needsUpdate or can just update potion effects every time?