### PR TITLE
Use base skill value when calculating rank requirements

### DIFF
--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -380,7 +380,7 @@ bool MWMechanics::NpcStats::hasSkillsForRank (const std::string& factionId, int 
     for (int i=0; i<7; ++i)
     {
         if (faction.mData.mSkills[i] != -1)
-            skills.push_back (static_cast<int> (getSkill (faction.mData.mSkills[i]).getModified()));
+            skills.push_back (static_cast<int> (getSkill (faction.mData.mSkills[i]).getBase()));
     }
 
     if (skills.empty())


### PR DESCRIPTION
Looks like a vanilla game uses base skill value to check requirement for a new rank. Skill bonuses from spells and items are not taken in account.