### PR TITLE
Update a disposition bar when a dialogue widget is disabled, but visible

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -634,7 +634,7 @@ namespace MWGui
 
     void DialogueWindow::onFrame()
     {
-        if(mMainWidget->getVisible() && mEnabled && mPtr.getTypeName() == typeid(ESM::NPC).name())
+        if(mMainWidget->getVisible() && mPtr.getTypeName() == typeid(ESM::NPC).name())
         {
             int disp = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mPtr);
             mDispositionBar->setProgressRange(100);


### PR DESCRIPTION
Fixes [bug #4076](https://bugs.openmw.org/issues/4076).

Looks like we should update a disposition bar even when dialogue widget is locked (mEnabled == false), but still visible.