### PR TITLE
Use constant nodeMap during part updating in creature animation

### DIFF
--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -118,7 +118,7 @@ void CreatureWeaponAnimation::updatePart(PartHolderPtr& scene, int slot)
         osg::ref_ptr<osg::Node> node = mResourceSystem->getSceneManager()->getInstance(item.getClass().getModel(item));
 
         const NodeMap& nodeMap = getNodeMap();
-        NodeMap::const_iterator found = getNodeMap().find(Misc::StringUtils::lowerCase(bonename));
+        NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
         if (found == nodeMap.end())
             throw std::runtime_error("Can't find attachment node " + bonename);
         osg::ref_ptr<osg::Node> attached = SceneUtil::attach(node, mObjectRoot, bonename, found->second.get());


### PR DESCRIPTION
Caching nodemaps was added in [this commit](https://github.com/OpenMW/openmw/commit/767eba941fb73f2a31989a99ff09b80d426eb826#diff-b3ea3213353ad543081ad5df6226b915).
Constant nodeMap found with getNodeMap() in npcanimation.cpp [is used](https://github.com/OpenMW/openmw/blob/11c4aed4e568f0b88d5a0d746351fc90c6ddd15e/apps/openmw/mwrender/npcanimation.cpp#L661), yet in creatureanimation.cpp getNodeMap() is used instead in practically the same line in the code, although constant nodeMap is declared immediately before and used immediately after. Doesn't seem to be intentional to me.

It would be nice to also get rid of code duplication but there's a lot of occasions of it in these two files some of which may as well be very much intentional - and I'm definitely not experienced enough.