### PR TITLE
make move/rotate/scale-marker-width proportional to object-radius

### DIFF
--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -30,10 +30,7 @@
 #include "mask.hpp"
 
 
-const float CSVRender::Object::MarkerShaftWidth = 30;
 const float CSVRender::Object::MarkerShaftBaseLength = 70;
-const float CSVRender::Object::MarkerHeadWidth = 50;
-const float CSVRender::Object::MarkerHeadLength = 50;
 
 
 namespace
@@ -215,6 +212,10 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeMoveOrScaleMarker (int axis)
 
     float shaftLength = MarkerShaftBaseLength + mBaseNode->getBound().radius();
 
+    const float MarkerShaftWidth = mBaseNode->getBound().radius() * 0.05;
+    const float MarkerHeadWidth = MarkerShaftWidth * (5.0 / 3.0);
+    const float MarkerHeadLength = MarkerHeadWidth * 1.5;
+
     // shaft
     osg::Vec3Array *vertices = new osg::Vec3Array;
 
@@ -305,6 +306,7 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
 {
     const float Pi = 3.14159265f;
 
+    const float MarkerShaftWidth = mBaseNode->getBound().radius() * 0.05;
     const float InnerRadius = mBaseNode->getBound().radius();
     const float OuterRadius = InnerRadius + MarkerShaftWidth;
 

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -210,9 +210,10 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeMoveOrScaleMarker (int axis)
 {
     osg::ref_ptr<osg::Geometry> geometry (new osg::Geometry);
 
-    float shaftLength = MarkerShaftBaseLength + mBaseNode->getBound().radius();
+    const float ObjectRadius = mBaseNode->getBound().radius();
 
-    const float MarkerShaftWidth = mBaseNode->getBound().radius() * 0.05;
+    const float shaftLength = MarkerShaftBaseLength + ObjectRadius;
+    const float MarkerShaftWidth = ObjectRadius * 0.05;
     const float MarkerHeadWidth = MarkerShaftWidth * (5.0 / 3.0);
     const float MarkerHeadLength = MarkerHeadWidth * 1.5;
 
@@ -306,8 +307,9 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
 {
     const float Pi = 3.14159265f;
 
-    const float MarkerShaftWidth = mBaseNode->getBound().radius() * 0.05;
-    const float InnerRadius = mBaseNode->getBound().radius();
+    const float ObjectRadius = mBaseNode->getBound().radius();
+    const float MarkerShaftWidth = ObjectRadius * 0.05;
+    const float InnerRadius = ObjectRadius;
     const float OuterRadius = InnerRadius + MarkerShaftWidth;
 
     const float SegmentDistance = 100.f;

--- a/apps/opencs/view/render/object.hpp
+++ b/apps/opencs/view/render/object.hpp
@@ -76,10 +76,7 @@ namespace CSVRender
 
         private:
 
-            static const float MarkerShaftWidth;
             static const float MarkerShaftBaseLength;
-            static const float MarkerHeadWidth;
-            static const float MarkerHeadLength;
 
             CSMWorld::Data& mData;
             std::string mReferenceId;


### PR DESCRIPTION
This makes the width of the edit-markers in the opencs-object-mode proportional to the radius of the object (width = 0.05 * radius). The motivation behind this change is that the markers used to completely hide small objects so that moving and especially rotating them became pretty much guesswork. The same is even true for selecting them: Place ten candles in a row and try to select them in any order but front to back.

With this change all those things become easy by having the markers very small for very small objects, so that those are not obscured, but still very thick for huge objects.

Things to consider:

* Provide seperate markers for move and scale so that it is obvious which is active
* set minimum width or disable the current minimum length for the move/scale-arrows
* possibly a different scale-factor, though the current one seems to work fine.