### PR TITLE
[discussion] Improve hotkey usage for 'close container' and 'take all items' actions

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -196,6 +196,8 @@ namespace MWBase
             ///< show extra info in item tooltips (owner, script)
 
             virtual bool getFullHelp() const = 0;
+            virtual void closeContainer() const = 0;
+            virtual void takeAllItemsFromContainer() const = 0;
 
             virtual void setActiveMap(int x, int y, bool interior) = 0;
             ///< set the indices of the map texture that should be used

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -46,7 +46,6 @@ namespace MWGui
 
         mDisposeCorpseButton->eventMouseButtonClick += MyGUI::newDelegate(this, &ContainerWindow::onDisposeCorpseButtonClicked);
         mCloseButton->eventMouseButtonClick += MyGUI::newDelegate(this, &ContainerWindow::onCloseButtonClicked);
-        mCloseButton->eventKeyButtonPressed += MyGUI::newDelegate(this, &ContainerWindow::onKeyPressed);
         mTakeButton->eventMouseButtonClick += MyGUI::newDelegate(this, &ContainerWindow::onTakeAllButtonClicked);
 
         setCoord(200,0,600,300);
@@ -156,14 +155,6 @@ namespace MWGui
         setTitle(container.getClass().getName(container));
     }
 
-    void ContainerWindow::onKeyPressed(MyGUI::Widget *_sender, MyGUI::KeyCode _key, MyGUI::Char _char)
-    {
-        if (_key == MyGUI::KeyCode::Space)
-            onCloseButtonClicked(mCloseButton);
-        if (_key == MyGUI::KeyCode::Return || _key == MyGUI::KeyCode::NumpadEnter)
-            onTakeAllButtonClicked(mTakeButton);
-    }
-
     void ContainerWindow::resetReference()
     {
         ReferenceInterface::resetReference();
@@ -251,6 +242,11 @@ namespace MWGui
 
             mPtr = MWWorld::Ptr();
         }
+    }
+
+    void ContainerWindow::takeAll()
+    {
+        onTakeAllButtonClicked(mTakeButton);
     }
 
     void ContainerWindow::onReferenceUnavailable()

--- a/apps/openmw/mwgui/container.hpp
+++ b/apps/openmw/mwgui/container.hpp
@@ -34,6 +34,7 @@ namespace MWGui
         ContainerWindow(DragAndDrop* dragAndDrop);
 
         void openContainer(const MWWorld::Ptr& container, bool loot=false);
+        virtual void takeAll();
         virtual void close();
 
         virtual void resetReference();

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1143,6 +1143,16 @@ namespace MWGui
         return mToolTips->getFullHelp();
     }
 
+    void WindowManager::closeContainer() const
+    {
+        mContainerWindow->exit();
+    }
+
+    void WindowManager::takeAllItemsFromContainer() const
+    {
+        mContainerWindow->takeAll();
+    }
+
     void WindowManager::setWeaponVisibility(bool visible)
     {
         mHud->setWeapVisible (visible);

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -226,6 +226,8 @@ namespace MWGui
     virtual bool toggleFogOfWar();
     virtual bool toggleFullHelp(); ///< show extra info in item tooltips (owner, script)
     virtual bool getFullHelp() const;
+    virtual void closeContainer() const;
+    virtual void takeAllItemsFromContainer() const;
 
     virtual void setActiveMap(int x, int y, bool interior);
     ///< set the indices of the map texture that should be used

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -162,12 +162,11 @@ namespace MWInput
 
     void InputManager::setPlayerControlsEnabled(bool enabled)
     {
-        int nPlayerChannels = 18;
-        int playerChannels[] = {A_Activate, A_AutoMove, A_AlwaysRun, A_ToggleWeapon,
+        int nPlayerChannels = 16;
+        int playerChannels[] = {A_AutoMove, A_AlwaysRun, A_Use, A_Journal,
                                 A_ToggleSpell, A_Rest, A_QuickKey1, A_QuickKey2,
                                 A_QuickKey3, A_QuickKey4, A_QuickKey5, A_QuickKey6,
-                                A_QuickKey7, A_QuickKey8, A_QuickKey9, A_QuickKey10,
-                                A_Use, A_Journal};
+                                A_QuickKey7, A_QuickKey8, A_QuickKey9, A_QuickKey10};
 
         for(int i = 0; i < nPlayerChannels; i++) {
             int pc = playerChannels[i];
@@ -234,8 +233,12 @@ namespace MWInput
                 break;
             case A_Activate:
                 resetIdleTime();
-                if (!MWBase::Environment::get().getWindowManager()->isGuiMode())
-                    activate();
+                if (MWBase::Environment::get().getWindowManager()->getMode() == MWGui::GM_Container)
+                {
+                    MWBase::Environment::get().getWindowManager()->closeContainer();
+                    break;
+                }
+                activate();
                 break;
             case A_Journal:
                 toggleJournal ();
@@ -247,6 +250,11 @@ namespace MWInput
                 toggleWalking ();
                 break;
             case A_ToggleWeapon:
+                if (MWBase::Environment::get().getWindowManager()->getMode() == MWGui::GM_Container)
+                {
+                    MWBase::Environment::get().getWindowManager()->takeAllItemsFromContainer();
+                    break;
+                }
                 toggleWeapon ();
                 break;
             case A_Rest:
@@ -1078,7 +1086,10 @@ namespace MWInput
 
     void InputManager::activate()
     {
-        if (mControlSwitch["playercontrols"])
+        if (!mControlSwitch["playercontrols"])
+            return;
+
+        if (!MWBase::Environment::get().getWindowManager()->isGuiMode())
             mPlayer->activate();
     }
 


### PR DESCRIPTION
This is a proof of concept for now.

Allows to fix [bug #1555](https://bugs.openmw.org/issues/1555), [bug #4016](https://bugs.openmw.org/issues/4016), and partially implements [feature #4092](https://bugs.openmw.org/issues/4092).

A summary of changes:
1. Use Activate button instead of hardcoded Spacebar to close a container window.
2. Use ToggleWeapon button instead of hardcoded Enter to take all items from the container window.
3. Resolve these actions in InputManager, so actions, assigned to Spacebar and Enter, should not be triggered now.

Questions:
1. I had to modify setPlayerControlsEnabled(). Have we a better option?
2. Have we a better button to use instead of ToggleWeapon to take all items?
3. If you loot a corpse, should "take all" action also dispose it?