### PR TITLE
Spell Ctrl instead of Ctl in OpenMW-CS shortcuts

### DIFF
--- a/apps/opencs/model/prefs/shortcutmanager.cpp
+++ b/apps/opencs/model/prefs/shortcutmanager.cpp
@@ -132,7 +132,7 @@ namespace CSMPrefs
                     if (mods && i == 0)
                     {
                         if (mods & Qt::ControlModifier)
-                            result.append("Ctl+");
+                            result.append("Ctrl+");
                         if (mods & Qt::ShiftModifier)
                             result.append("Shift+");
                         if (mods & Qt::AltModifier)
@@ -196,7 +196,7 @@ namespace CSMPrefs
 
             std::string name = value.substr(start, end - start);
 
-            if (name == "Ctl")
+            if (name == "Ctrl")
             {
                 mods |= Qt::ControlModifier;
             }


### PR DESCRIPTION
I'm not sure why did Aesylwinn use Ctl, since Ctrl is much more common contraction for Control key. I doubt that "Ctl+whatever" may confuse users, but IMO that looks odd.