### PR TITLE
Allow to add levelup a description for levels > 20

### DIFF
--- a/apps/openmw/mwgui/levelupdialog.cpp
+++ b/apps/openmw/mwgui/levelupdialog.cpp
@@ -143,10 +143,10 @@ namespace MWGui
         mLevelText->setCaptionWithReplacing("#{sLevelUpMenu1} " + MyGUI::utility::toString(level));
 
         std::string levelupdescription;
-        if(level > 20)
+        levelupdescription=world->getFallback()->getFallbackString("Level_Up_Level"+MyGUI::utility::toString(level));
+
+        if (levelupdescription == "")
             levelupdescription=world->getFallback()->getFallbackString("Level_Up_Default");
-        else
-            levelupdescription=world->getFallback()->getFallbackString("Level_Up_Level"+MyGUI::utility::toString(level));
 
         mLevelDescription->setCaption (levelupdescription);
 


### PR DESCRIPTION
Fixes [bug #4094](https://bugs.openmw.org/issues/4094). A relevant discussion is [here](https://forum.openmw.org/viewtopic.php?f=8&t=4633).

A solution is very simple: try to get a message for a current level first, and use a default message, if that string was not found.