### PR TITLE
Do not allow to equip a replacement, when take all items from a dead corpse

### DIFF
--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -1,5 +1,10 @@
 #include "inventoryitemmodel.hpp"
 
+#include <sstream>
+
+#include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/npcstats.hpp"
+
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
@@ -45,16 +50,33 @@ MWWorld::Ptr InventoryItemModel::copyItem (const ItemStack& item, size_t count, 
     return *mActor.getClass().getContainerStore(mActor).add(item.mBase, count, mActor, setNewOwner);
 }
 
-
 void InventoryItemModel::removeItem (const ItemStack& item, size_t count)
 {
-    MWWorld::ContainerStore& store = mActor.getClass().getContainerStore(mActor);
-    int removed = store.remove(item.mBase, count, mActor);
+    int removed = 0;
+    // Re-equipping makes sense only if a target has inventory
+    if (mActor.getClass().hasInventoryStore(mActor))
+    {
+        MWWorld::InventoryStore& store = mActor.getClass().getInventoryStore(mActor);
+        removed = store.remove(item.mBase, count, mActor, true);
+    }
+    else
+    {
+        MWWorld::ContainerStore& store = mActor.getClass().getContainerStore(mActor);
+        removed = store.remove(item.mBase, count, mActor);
+    }
+
+    std::stringstream error;
 
     if (removed == 0)
-        throw std::runtime_error("Item to remove not found in container store");
+    {
+        error << "Item '" << item.mBase.getCellRef().getRefId() << "' was not found in container store to remove";
+        throw std::runtime_error(error.str());
+    }
     else if (removed < static_cast<int>(count))
-        throw std::runtime_error("Not enough items in the stack to remove");
+    {
+        error << "Not enough items '" << item.mBase.getCellRef().getRefId() << "' in the stack to remove (" << static_cast<int>(count) << " requested, " << removed << " found)";
+        throw std::runtime_error(error.str());
+    }
 }
 
 MWWorld::Ptr InventoryItemModel::moveItem(const ItemStack &item, size_t count, ItemModel *otherModel)

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -143,8 +143,7 @@ namespace MWScript
                         if (::Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), item))
                             itemName = iter->getClass().getName(*iter);
 
-                    // Actors should not equip a replacement when items are removed with RemoveItem
-                    int numRemoved = store.remove(item, count, ptr, false);
+                    int numRemoved = store.remove(item, count, ptr);
 
                     // Spawn a messagebox (only for items removed from player's inventory)
                     if ((numRemoved > 0)

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -408,13 +408,13 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::addNewStack (const Cons
     return it;
 }
 
-int MWWorld::ContainerStore::remove(const std::string& itemId, int count, const Ptr& actor, bool equipReplacement)
+int MWWorld::ContainerStore::remove(const std::string& itemId, int count, const Ptr& actor)
 {
     int toRemove = count;
 
     for (ContainerStoreIterator iter(begin()); iter != end() && toRemove > 0; ++iter)
         if (Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), itemId))
-            toRemove -= remove(*iter, toRemove, actor, equipReplacement);
+            toRemove -= remove(*iter, toRemove, actor);
 
     flagAsModified();
 
@@ -422,7 +422,7 @@ int MWWorld::ContainerStore::remove(const std::string& itemId, int count, const 
     return count - toRemove;
 }
 
-int MWWorld::ContainerStore::remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement)
+int MWWorld::ContainerStore::remove(const Ptr& item, int count, const Ptr& actor)
 {
     assert(this == item.getContainerStore());
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -142,12 +142,12 @@ namespace MWWorld
             ContainerStoreIterator add(const std::string& id, int count, const Ptr& actorPtr);
             ///< Utility to construct a ManualRef and call add(ptr, count, actorPtr, true)
 
-            int remove(const std::string& itemId, int count, const Ptr& actor, bool equipReplacement = true);
+            int remove(const std::string& itemId, int count, const Ptr& actor);
             ///< Remove \a count item(s) designated by \a itemId from this container.
             ///
             /// @return the number of items actually removed
 
-            virtual int remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement = true);
+            virtual int remove(const Ptr& item, int count, const Ptr& actor);
             ///< Remove \a count item(s) designated by \a item from this inventory.
             ///
             /// @return the number of items actually removed

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -654,6 +654,11 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::getSelectedEnchantItem(
     return mSelectedEnchantItem;
 }
 
+int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor)
+{
+    return remove(item, count, actor, false);
+}
+
 int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement)
 {
     int retCount = ContainerStore::remove(item, count, actor);

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -177,7 +177,8 @@ namespace MWWorld
             virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2) const;
             ///< @return true if the two specified objects can stack with each other
 
-            virtual int remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement = true);
+            virtual int remove(const Ptr& item, int count, const Ptr& actor);
+            virtual int remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement);
             ///< Remove \a count item(s) designated by \a item from this inventory.
             ///
             /// @return the number of items actually removed


### PR DESCRIPTION
Fixes [bug #4095](https://bugs.openmw.org/issues/4095).

Equipping in this case is useless - you will take all items anyway.
Also this PR makes exceptions in InventoryItemModel::removeItem() a bit more informative.