### PR TITLE
Clear player fields upon reload (bug #2639)

### DIFF
--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -276,6 +276,29 @@ namespace MWWorld
         mAutoMove = false;
         mForwardBackward = 0;
         mTeleported = false;
+        mAttackingOrSpell = false;
+        mCurrentCrimeId = -1;
+        mPaidCrimeId = -1;
+        mLastKnownExteriorPosition = osg::Vec3f(0,0,0);
+
+        for (int i=0; i<ESM::Skill::Length; ++i)
+        {
+            mSaveSkills[i].setBase(0);
+            mSaveSkills[i].setModifier(0);
+        }
+
+        for (int i=0; i<ESM::Attribute::Length; ++i)
+        {
+            mSaveAttributes[i].setBase(0);
+            mSaveAttributes[i].setModifier(0);
+        }
+
+        mMarkedPosition.pos[0] = 0;
+        mMarkedPosition.pos[1] = 0;
+        mMarkedPosition.pos[2] = 0;
+        mMarkedPosition.rot[0] = 0;
+        mMarkedPosition.rot[1] = 0;
+        mMarkedPosition.rot[2] = 0;
     }
 
     void Player::write (ESM::ESMWriter& writer, Loading::Listener& progress) const


### PR DESCRIPTION
Should fix [bug #2639](https://bugs.openmw.org/issues/2639), if it still exists.

What's wrong here:
1. We keep mAttackingOrSpell flag between reloads.
2. With mAttackingOrSpell == true an engine treats a player as aiming.
3. This can lead to unintended behaviour, such as animation bugs, accidental spellcasting, etc.

So I suggest just ensure that mAttackingOrSpell will be reset after reload.