### PR TITLE
ESS-Importer: Convert ballistic projectiles

### DIFF
--- a/apps/essimporter/CMakeLists.txt
+++ b/apps/essimporter/CMakeLists.txt
@@ -16,6 +16,7 @@ set(ESSIMPORTER_FILES
     importjour.cpp
     importscri.cpp
     importscpt.cpp
+    importproj.cpp
     importercontext.cpp
     converter.cpp
     convertacdt.cpp

--- a/apps/essimporter/converter.hpp
+++ b/apps/essimporter/converter.hpp
@@ -35,6 +35,7 @@
 #include "importques.hpp"
 #include "importjour.hpp"
 #include "importscpt.hpp"
+#include "importproj.h"
 
 #include "convertacdt.hpp"
 #include "convertnpcc.hpp"
@@ -591,6 +592,17 @@ public:
     }
 private:
     std::vector<ESM::GlobalScript> mScripts;
+};
+
+/// Projectile converter
+class ConvertPROJ : public Converter
+{
+public:
+    virtual int getStage() override { return 2; }
+    virtual void read(ESM::ESMReader& esm) override;
+    virtual void write(ESM::ESMWriter& esm) override;
+private:
+    PROJ mProj;
 };
 
 }

--- a/apps/essimporter/importer.cpp
+++ b/apps/essimporter/importer.cpp
@@ -303,6 +303,7 @@ namespace ESSImport
         converters[ESM::REC_QUES] = std::shared_ptr<Converter>(new ConvertQUES());
         converters[recJOUR      ] = std::shared_ptr<Converter>(new ConvertJOUR());
         converters[ESM::REC_SCPT] = std::shared_ptr<Converter>(new ConvertSCPT());
+        converters[ESM::REC_PROJ] = std::shared_ptr<Converter>(new ConvertPROJ());
 
         // TODO:
         // - REGN (weather in certain regions?)
@@ -419,6 +420,19 @@ namespace ESSImport
         }
         context.mPlayer.save(writer);
         writer.endRecord(ESM::REC_PLAY);
+
+        writer.startRecord(ESM::REC_ACTC);
+        writer.writeHNT("COUN", context.mNextActorId);
+        writer.endRecord(ESM::REC_ACTC);
+
+        // Stage 2 requires cell references to be written / actors IDs assigned
+        for (std::map<unsigned int, std::shared_ptr<Converter> >::const_iterator it = converters.begin();
+             it != converters.end(); ++it)
+        {
+            if (it->second->getStage() != 2)
+                continue;
+            it->second->write(writer);
+        }
 
         writer.startRecord (ESM::REC_DIAS);
         context.mDialogueState.save(writer);

--- a/apps/essimporter/importercontext.hpp
+++ b/apps/essimporter/importercontext.hpp
@@ -48,6 +48,9 @@ namespace ESSImport
         std::map<std::pair<int, std::string>, NPCC> mNpcChanges;
         std::map<std::pair<int, std::string>, CNTC> mContainerChanges;
 
+        std::map<std::pair<int, std::string>, int> mActorIdMap;
+        int mNextActorId;
+
         std::map<std::string, ESM::Creature> mCreatures;
         std::map<std::string, ESM::NPC> mNpcs;
 
@@ -56,6 +59,7 @@ namespace ESSImport
             , mMonth(0)
             , mYear(0)
             , mHour(0.f)
+            , mNextActorId(0)
         {
             mPlayer.mAutoMove = 0;
             ESM::CellId playerCellId;
@@ -71,11 +75,17 @@ namespace ESSImport
             mPlayer.mObject.blank();
             mPlayer.mObject.mEnabled = true;
             mPlayer.mObject.mRef.mRefID = "player"; // REFR.mRefID would be PlayerSaveGame
+            mPlayer.mObject.mCreatureStats.mActorId = generateActorId();
 
             mGlobalMapState.mBounds.mMinX = 0;
             mGlobalMapState.mBounds.mMaxX = 0;
             mGlobalMapState.mBounds.mMinY = 0;
             mGlobalMapState.mBounds.mMaxY = 0;
+        }
+
+        int generateActorId()
+        {
+            return mNextActorId++;
         }
     };
 

--- a/apps/essimporter/importercontext.hpp
+++ b/apps/essimporter/importercontext.hpp
@@ -71,7 +71,8 @@ namespace ESSImport
                 = mPlayer.mLastKnownExteriorPosition[2]
                 = 0.0f;
             mPlayer.mHasMark = 0;
-            mPlayer.mCurrentCrimeId = 0; // TODO
+            mPlayer.mCurrentCrimeId = -1; // TODO
+            mPlayer.mPaidCrimeId = -1;
             mPlayer.mObject.blank();
             mPlayer.mObject.mEnabled = true;
             mPlayer.mObject.mRef.mRefID = "player"; // REFR.mRefID would be PlayerSaveGame

--- a/apps/essimporter/importproj.cpp
+++ b/apps/essimporter/importproj.cpp
@@ -1,0 +1,18 @@
+#include "importproj.h"
+
+#include <components/esm/esmreader.hpp>
+
+namespace ESSImport
+{
+
+void ESSImport::PROJ::load(ESM::ESMReader& esm)
+{
+    while (esm.isNextSub("PNAM"))
+    {
+        PNAM pnam;
+        esm.getHT(pnam);
+        mProjectiles.push_back(pnam);
+    }
+}
+
+}

--- a/apps/essimporter/importproj.h
+++ b/apps/essimporter/importproj.h
@@ -1,0 +1,47 @@
+#ifndef OPENMW_ESSIMPORT_IMPORTPROJ_H
+#define OPENMW_ESSIMPORT_IMPORTPROJ_H
+
+#include <vector>
+#include <components/esm/esmcommon.hpp>
+#include <components/esm/util.hpp>
+
+namespace ESM
+{
+    class ESMReader;
+}
+
+namespace ESSImport
+{
+
+struct PROJ
+{
+
+#pragma pack(push)
+#pragma pack(1)
+    struct PNAM // 184 bytes
+    {
+        float mAttackStrength;
+        float mSpeed;
+        unsigned char mUnknown[4*2];
+        float mFlightTime;
+        int mSplmIndex; // reference to a SPLM record (0 for ballistic projectiles)
+        unsigned char mUnknown2[4];
+        ESM::Vector3 mVelocity;
+        ESM::Vector3 mPosition;
+        unsigned char mUnknown3[4*9];
+        ESM::NAME32 mActorId; // indexed refID (with the exception of "PlayerSaveGame")
+        ESM::NAME32 mArrowId;
+        ESM::NAME32 mBowId;
+
+        bool isMagic() const { return mSplmIndex != 0; }
+    };
+#pragma pack(pop)
+
+    std::vector<PNAM> mProjectiles;
+
+    void load(ESM::ESMReader& esm);
+};
+
+}
+
+#endif


### PR DESCRIPTION
Partially implements: https://bugs.openmw.org/issues/2320

This PR implements conversion of ballistic projectiles. Magic projectiles need further investigation - at first sight it looks like we might be missing context for magic effects (though I don't understand why OpenMW must serialize those effects in the first place - aren't they redundant?)

Due to the need for indexedRefId -> actorId conversion, I also had to implement static assignment of actor IDs. Previously, all actor instance records had them set to -1 (which means assign on demand at runtime). I'm surprised we haven't needed to reference concrete actors within converted savefiles until now.

I also ran into a bug where actors wouldn't fight me back after attacking them (the code for calming witnesses always triggered even if I didn't pay a fine). Turned out to be an uninitialized variable problem affecting the converted player record.