### PR TITLE
Print sound init info and preload sound buffer info

### DIFF
--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -594,6 +594,8 @@ bool OpenAL_Output::init(const std::string &devname, const std::string &hrtfname
 {
     deinit();
 
+    std::cout<< "Initializing OpenAL..." <<std::endl;
+
     mDevice = alcOpenDevice(devname.c_str());
     if(!mDevice && !devname.empty())
     {
@@ -612,6 +614,12 @@ bool OpenAL_Output::init(const std::string &devname, const std::string &hrtfname
     if(alcGetError(mDevice) != AL_NO_ERROR || !name)
         name = alcGetString(mDevice, ALC_DEVICE_SPECIFIER);
     std::cout<< "Opened \""<<name<<"\"" <<std::endl;
+
+    ALCint major=0, minor=0;
+    alcGetIntegerv(mDevice, ALC_MAJOR_VERSION, 1, &major);
+    alcGetIntegerv(mDevice, ALC_MINOR_VERSION, 1, &minor);
+    std::cout<< "  ALC Version: "<<major<<"."<<minor<<"\n"<<
+                "  ALC Extensions: "<<alcGetString(mDevice, ALC_EXTENSIONS) <<std::endl;
 
     ALC.EXT_EFX = alcIsExtensionPresent(mDevice, "ALC_EXT_EFX");
     ALC.SOFT_HRTF = alcIsExtensionPresent(mDevice, "ALC_SOFT_HRTF");
@@ -664,6 +672,11 @@ bool OpenAL_Output::init(const std::string &devname, const std::string &hrtfname
         mDevice = nullptr;
         return false;
     }
+
+    std::cout<< "  Vendor: "<<alGetString(AL_VENDOR)<<"\n"<<
+                "  Renderer: "<<alGetString(AL_RENDERER)<<"\n"<<
+                "  Version: "<<alGetString(AL_VERSION)<<"\n"<<
+                "  Extensions: "<<alGetString(AL_EXTENSIONS)<<std::endl;
 
     if(!ALC.SOFT_HRTF)
         std::cout<< "HRTF status unavailable" <<std::endl;

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -66,9 +66,8 @@ namespace MWSound
         virtual std::vector<std::string> enumerateHrtf();
         virtual void setHrtf(const std::string &hrtfname, HrtfMode hrtfmode);
 
-        virtual Sound_Handle loadSound(const std::string &fname);
-        virtual void unloadSound(Sound_Handle data);
-        virtual size_t getSoundDataSize(Sound_Handle data) const;
+        virtual std::pair<Sound_Handle,size_t> loadSound(const std::string &fname);
+        virtual size_t unloadSound(Sound_Handle data);
 
         virtual bool playSound(Sound *sound, Sound_Handle data, float offset);
         virtual bool playSound3D(Sound *sound, Sound_Handle data, float offset);

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -36,9 +36,8 @@ namespace MWSound
         virtual std::vector<std::string> enumerateHrtf() = 0;
         virtual void setHrtf(const std::string &hrtfname, HrtfMode hrtfmode) = 0;
 
-        virtual Sound_Handle loadSound(const std::string &fname) = 0;
-        virtual void unloadSound(Sound_Handle data) = 0;
-        virtual size_t getSoundDataSize(Sound_Handle data) const = 0;
+        virtual std::pair<Sound_Handle,size_t> loadSound(const std::string &fname) = 0;
+        virtual size_t unloadSound(Sound_Handle data) = 0;
 
         virtual bool playSound(Sound *sound, Sound_Handle data, float offset) = 0;
         virtual bool playSound3D(Sound *sound, Sound_Handle data, float offset) = 0;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -215,10 +215,11 @@ namespace MWSound
 
         if(!sfx->mHandle)
         {
-            sfx->mHandle = mOutput->loadSound(sfx->mResourceName);
+            size_t size;
+            std::tie(sfx->mHandle, size) = mOutput->loadSound(sfx->mResourceName);
             if(!sfx->mHandle) return nullptr;
 
-            mBufferCacheSize += mOutput->getSoundDataSize(sfx->mHandle);
+            mBufferCacheSize += size;
             if(mBufferCacheSize > mBufferCacheMax)
             {
                 do {
@@ -229,8 +230,8 @@ namespace MWSound
                     }
                     Sound_Buffer *unused = mUnusedBuffers.back();
 
-                    mBufferCacheSize -= mOutput->getSoundDataSize(unused->mHandle);
-                    mOutput->unloadSound(unused->mHandle);
+                    size = mOutput->unloadSound(unused->mHandle);
+                    mBufferCacheSize -= size;
                     unused->mHandle = 0;
 
                     mUnusedBuffers.pop_back();

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -26,11 +26,7 @@
 #include "sound.hpp"
 
 #include "openal_output.hpp"
-#define SOUND_OUT "OpenAL"
 #include "ffmpeg_decoder.hpp"
-#ifndef SOUND_IN
-#define SOUND_IN "FFmpeg"
-#endif
 
 
 namespace MWSound
@@ -60,6 +56,8 @@ namespace MWSound
         , mUnderwaterSound(nullptr)
         , mNearWaterSound(nullptr)
     {
+        std::cout<< "Initializing sound..." <<std::endl;
+
         mMasterVolume = Settings::Manager::getFloat("master volume", "Sound");
         mMasterVolume = std::min(std::max(mMasterVolume, 0.0f), 1.0f);
         mSFXVolume = Settings::Manager::getFloat("sfx volume", "Sound");
@@ -91,9 +89,6 @@ namespace MWSound
         HrtfMode hrtfmode = hrtfstate < 0 ? HrtfMode::Auto :
                             hrtfstate > 0 ? HrtfMode::Enable : HrtfMode::Disable;
 
-        std::cout << "Sound output: " << SOUND_OUT << std::endl;
-        std::cout << "Sound decoder: " << SOUND_IN << std::endl;
-
         std::vector<std::string> names = mOutput->enumerate();
         std::cout <<"Enumerated output devices:\n";
         std::for_each(names.cbegin(), names.cend(),
@@ -103,15 +98,9 @@ namespace MWSound
         std::cout.flush();
 
         std::string devname = Settings::Manager::getString("device", "Sound");
-        bool inited = mOutput->init(devname, hrtfname, hrtfmode);
-        if(!inited && !devname.empty())
+        if(!mOutput->init(devname, hrtfname, hrtfmode))
         {
-            std::cerr<< "Failed to initialize device \""<<devname<<"\", trying default" <<std::endl;
-            inited = mOutput->init(std::string(), hrtfname, hrtfmode);
-        }
-        if(!inited)
-        {
-            std::cerr<< "Failed to initialize default audio device, sound disabled" <<std::endl;
+            std::cerr<< "Failed to initialize audio output, sound disabled" <<std::endl;
             return;
         }
 


### PR DESCRIPTION
This traces some audio device info to ```std::cout``` about the OpenAL version, extensions, etc, so it's shown what's available. It also preloads all the ```ESM::Sound``` records into ```Sound_Buffer``` objects the first time a sound record is needed (this is just the filename, volume, and distance settings; the actual sound data is still loaded as-needed), which avoids a bit of overhead with first-played sounds (and with GCC's ```__builtin_expect```, can optimize a bit for the common case of the sound buffer record being prepared already). If somehow a new ```ESM::Sound``` record is created and used after the fact, it will still work as it always has.