### PR TITLE
[Feedback needed] Add scrollbar to a birth effect lists (bug #4105)

### DIFF
--- a/apps/openmw/mwgui/birth.cpp
+++ b/apps/openmw/mwgui/birth.cpp
@@ -3,6 +3,7 @@
 #include <MyGUI_ListBox.h>
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_Gui.h>
+#include <MyGUI_ScrollView.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -244,6 +245,11 @@ namespace MWGui
                 }
             }
         }
-    }
 
+        // Canvas size must be expressed with VScroll disabled, otherwise MyGUI would expand the scroll area when the scrollbar is hidden
+        mSpellArea->setVisibleVScroll(false);
+        mSpellArea->setCanvasSize(MyGUI::IntSize(mSpellArea->getWidth(), std::max(mSpellArea->getHeight(), coord.top)));
+        mSpellArea->setVisibleVScroll(true);
+        mSpellArea->setViewOffset(MyGUI::IntPoint(0, 0));
+    }
 }

--- a/apps/openmw/mwgui/birth.hpp
+++ b/apps/openmw/mwgui/birth.hpp
@@ -47,7 +47,7 @@ namespace MWGui
         void updateSpells();
 
         MyGUI::ListBox* mBirthList;
-        MyGUI::Widget*  mSpellArea;
+        MyGUI::ScrollView* mSpellArea;
         MyGUI::ImageBox* mBirthImage;
         std::vector<MyGUI::Widget*> mSpellItems;
 

--- a/files/mygui/openmw_chargen_birth.layout
+++ b/files/mygui/openmw_chargen_birth.layout
@@ -11,7 +11,9 @@
         </Widget>
 
         <!-- Spell list -->
-        <Widget type="Widget" skin="" position="8 160 519 178" align="Left Top" name="SpellArea"/>
+        <Widget type="ScrollView" skin="MW_ScrollView" position="8 160 507 170" align="Left Top" name="SpellArea">
+            <Property key="CanvasAlign" value="Left"/>
+        </Widget>>
 
         <!-- Dialog buttons -->
         <Widget type="HBox" position="0 338 511 24">


### PR DESCRIPTION
Fixes [bug #4105](https://bugs.openmw.org/issues/4105).
A scrollbar will be hidden, if a list size is too small.

For now, I do not know how to implement a mouse scroll properly for this list (there are private child widgets in MWSpellEffect).