### PR TITLE
OpenMW-CS: Fix preferences pane width

### DIFF
--- a/apps/opencs/view/prefs/dialogue.cpp
+++ b/apps/opencs/view/prefs/dialogue.cpp
@@ -24,7 +24,7 @@ void CSVPrefs::Dialogue::buildCategorySelector (QSplitter *main)
 
     main->addWidget (list);
 
-    QFontMetrics metrics (QApplication::font());
+    QFontMetrics metrics (QApplication::font(list));
 
     int maxWidth = 1;
 


### PR DESCRIPTION
Fixes bug [#4107](https://bugs.openmw.org/issues/4107) caused by wrong font being checked for width.