### PR TITLE
Minor animation fixes

### DIFF
--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -82,9 +82,6 @@ namespace MWBase
             ///< Play a soundifle
             /// \param filename name of a sound file in "Music/" in the data directory.
 
-            virtual void startRandomTitle() = 0;
-            ///< Starts a random track from the current playlist
-
             virtual bool isMusicPlaying() = 0;
             ///< Returns true if music is playing
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -793,7 +793,7 @@ namespace MWRender
               // We have to ignore extra garbage at the end.
               // The Scrib's idle3 animation has "Idle3: Stop." instead of "Idle3: Stop".
               // Why, just why? :(
-              && (stopkey->second.size() < stoptag.size() || stopkey->second.substr(0,stoptag.size()) != stoptag))
+              && (stopkey->second.size() < stoptag.size() || stopkey->second.compare(0,stoptag.size(), stoptag) != 0))
             ++stopkey;
         if(stopkey == keys.rend())
             return false;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -757,8 +757,6 @@ namespace MWRender
                 break;
             }
         }
-        if(iter == mAnimSources.rend())
-            std::cerr<< "Failed to find animation "<<groupname<<" for "<<mPtr.getCellRef().getRefId() <<std::endl;
 
         resetActiveGroups();
     }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -391,11 +391,6 @@ namespace MWSound
         mMusic->setFadeout(0.5f);
     }
 
-    void SoundManager::streamMusic(const std::string& filename)
-    {
-        advanceMusic("Music/"+filename);
-    }
-
     void SoundManager::startRandomTitle()
     {
         std::vector<std::string> filelist;
@@ -444,6 +439,12 @@ namespace MWSound
         advanceMusic(filelist[tracklist[i]]);
         tracklist[i] = tracklist.back();
         tracklist.pop_back();
+    }
+
+
+    void SoundManager::streamMusic(const std::string& filename)
+    {
+        advanceMusic("Music/"+filename);
     }
 
     bool SoundManager::isMusicPlaying()

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -127,6 +127,7 @@ namespace MWSound
 
         void streamMusicFull(const std::string& filename);
         void advanceMusic(const std::string& filename);
+        void startRandomTitle();
 
         void updateSounds(float duration);
         void updateRegionSound(float duration);
@@ -156,9 +157,6 @@ namespace MWSound
         virtual void streamMusic(const std::string& filename);
         ///< Play a soundifle
         /// \param filename name of a sound file in "Music/" in the data directory.
-
-        virtual void startRandomTitle();
-        ///< Starts a random track from the current playlist
 
         virtual bool isMusicPlaying();
         ///< Returns true if music is playing

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -141,11 +141,11 @@ namespace Resource
         void setUnRefImageDataAfterApply(bool unref);
 
         /// @see ResourceManager::updateCache
-        virtual void updateCache(double referenceTime);
+        void updateCache(double referenceTime) override;
 
-        virtual void clearCache();
+        void clearCache() override;
 
-        virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) const;
+        void reportStats(unsigned int frameNumber, osg::Stats* stats) const override;
 
     private:
 

--- a/components/terrain/chunkmanager.hpp
+++ b/components/terrain/chunkmanager.hpp
@@ -32,9 +32,9 @@ namespace Terrain
 
         osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& center, int lod, unsigned int lodFlags);
 
-        virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) const;
+        void reportStats(unsigned int frameNumber, osg::Stats* stats) const override;
 
-        virtual void clearCache();
+        void clearCache() override;
 
         void releaseGLObjects(osg::State* state) override;
 


### PR DESCRIPTION
This cleans up a bunch of spam some creatures can cause (modded ones especially). Often they're missing certain idle animations that the character controller will randomly try to play (I had envisioned making it build and keep a list of available animations and pick randomly from there, rather than assuming idle-idle9 can always be tried).

This also fixes some warnings that Clang was throwing about virtual function overrides not being marked as override.