### PR TITLE
Restack soulgems when use SoulTrap

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -209,6 +209,9 @@ namespace MWMechanics
             gem->getContainerStore()->unstack(*gem, caster);
             gem->getCellRef().setSoul(mCreature.getCellRef().getRefId());
 
+            // Restack the gem with other gems with the same soul
+            gem->getContainerStore()->restack(*gem);
+
             mTrapped = true;
 
             if (caster == getPlayer())


### PR DESCRIPTION
How we handle soultrap now:
1. Unstack one soulgem.
2. Modify this soulgem via setSoul().

There is a problem: we forget to stack modified soulgem with other gems which have the same soul.
This PR fixes this issue.

Tested with a stack of Greater soulgems ("Misc_SoulGem_Greater") and few Dremoras ("dremora").