### PR TITLE
Allow distant terrain to be seen when enabled

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -256,6 +256,7 @@ namespace MWRender
         float mNearClip;
         float mFarClip;
         float mViewDistance;
+        bool mDistantFog : 1;
         bool mDistantTerrain : 1;
         bool mFieldOfViewOverridden : 1;
         float mFieldOfViewOverride;

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -106,7 +106,7 @@ namespace MWRender
 
         void configureAmbient(const ESM::Cell* cell);
         void configureFog(const ESM::Cell* cell);
-        void configureFog(float fogDepth, float underwaterFog, const osg::Vec4f& colour);
+        void configureFog(float fogDepth, float underwaterFog, float dlFactor, float dlOffset, const osg::Vec4f& colour);
 
         void addCell(const MWWorld::CellStore* store);
         void removeCell(const MWWorld::CellStore* store);
@@ -241,10 +241,12 @@ namespace MWRender
 
         osg::ref_ptr<StateUpdater> mStateUpdater;
 
-        float mFogDepth;
+        float mLandFogStart;
+        float mLandFogEnd;
+        float mUnderwaterFogStart;
+        float mUnderwaterFogEnd;
         osg::Vec4f mUnderwaterColor;
         float mUnderwaterWeight;
-        float mUnderwaterFog;
         float mUnderwaterIndoorFog;
         osg::Vec4f mFogColor;
 

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -254,7 +254,6 @@ namespace MWRender
         float mNightEyeFactor;
 
         float mNearClip;
-        float mFarClip;
         float mViewDistance;
         bool mDistantFog : 1;
         bool mDistantTerrain : 1;

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -252,9 +252,11 @@ namespace MWRender
         float mNightEyeFactor;
 
         float mNearClip;
+        float mFarClip;
         float mViewDistance;
+        bool mDistantTerrain : 1;
+        bool mFieldOfViewOverridden : 1;
         float mFieldOfViewOverride;
-        bool mFieldOfViewOverridden;
         float mFieldOfView;
         float mFirstPersonFieldOfView;
 

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -65,6 +65,9 @@ namespace MWRender
 
         float mFogDepth;
 
+        float mDLFogFactor;
+        float mDLFogOffset;
+
         float mWindSpeed;
 
         float mCloudSpeed;

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -103,6 +103,8 @@ Weather::Weather(const std::string& name,
                  const Fallback::Map& fallback,
                  float stormWindSpeed,
                  float rainSpeed,
+                 float dlFactor,
+                 float dlOffset,
                  const std::string& particleEffect)
     : mCloudTexture(fallback.getFallbackString("Weather_" + name + "_Cloud_Texture"))
     , mSkyColor(fallback.getFallbackColour("Weather_" + name +"_Sky_Sunrise_Color"),
@@ -129,6 +131,7 @@ Weather::Weather(const std::string& name,
     , mWindSpeed(fallback.getFallbackFloat("Weather_" + name + "_Wind_Speed"))
     , mCloudSpeed(fallback.getFallbackFloat("Weather_" + name + "_Cloud_Speed"))
     , mGlareView(fallback.getFallbackFloat("Weather_" + name + "_Glare_View"))
+    , mDL{dlFactor, dlOffset}
     , mIsStorm(mWindSpeed > stormWindSpeed)
     , mRainSpeed(rainSpeed)
     , mRainFrequency(fallback.getFallbackFloat("Weather_" + name + "_Rain_Entrance_Speed"))
@@ -541,16 +544,18 @@ WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, const Fall
     mTimeSettings.mSunriseTime = mSunriseTime;
 
     mWeatherSettings.reserve(10);
-    addWeather("Clear", fallback); // 0
-    addWeather("Cloudy", fallback); // 1
-    addWeather("Foggy", fallback); // 2
-    addWeather("Overcast", fallback); // 3
-    addWeather("Rain", fallback); // 4
-    addWeather("Thunderstorm", fallback); // 5
-    addWeather("Ashstorm", fallback, "meshes\\ashcloud.nif"); // 6
-    addWeather("Blight", fallback, "meshes\\blightcloud.nif"); // 7
-    addWeather("Snow", fallback, "meshes\\snow.nif"); // 8
-    addWeather("Blizzard", fallback, "meshes\\blizzard.nif"); // 9
+    // These distant land fog factor and offset values are the defaults MGE XE provides. Should be
+    // provided by settings somewhere?
+    addWeather("Clear", fallback, 1.0f, 0.0f); // 0
+    addWeather("Cloudy", fallback, 0.9f, 0.0f); // 1
+    addWeather("Foggy", fallback, 0.2f, 30.0f); // 2
+    addWeather("Overcast", fallback, 0.7f, 0.0f); // 3
+    addWeather("Rain", fallback, 0.5f, 10.0f); // 4
+    addWeather("Thunderstorm", fallback, 0.5f, 20.0f); // 5
+    addWeather("Ashstorm", fallback, 0.2f, 50.0f, "meshes\\ashcloud.nif"); // 6
+    addWeather("Blight", fallback, 0.2f, 60.0f, "meshes\\blightcloud.nif"); // 7
+    addWeather("Snow", fallback, 0.5f, 40.0f, "meshes\\snow.nif"); // 8
+    addWeather("Blizzard", fallback, 0.16f, 70.0f, "meshes\\blizzard.nif"); // 9
 
     Store<ESM::Region>::iterator it = store.get<ESM::Region>().begin();
     for(; it != store.get<ESM::Region>().end(); ++it)
@@ -720,7 +725,8 @@ void WeatherManager::update(float duration, bool paused)
     mRendering.getSkyManager()->setMasserState(mMasser.calculateState(time));
     mRendering.getSkyManager()->setSecundaState(mSecunda.calculateState(time));
 
-    mRendering.configureFog(mResult.mFogDepth, underwaterFog, mResult.mFogColor);
+    mRendering.configureFog(mResult.mFogDepth, underwaterFog, mResult.mDLFogFactor,
+                            mResult.mDLFogOffset/100.0f, mResult.mFogColor);
     mRendering.setAmbientColour(mResult.mAmbientColor);
     mRendering.setSunColour(mResult.mSunColor, mResult.mSunColor * mResult.mGlareView);
 
@@ -866,11 +872,12 @@ void WeatherManager::clear()
 
 inline void WeatherManager::addWeather(const std::string& name,
                                        const Fallback::Map& fallback,
+                                       float dlFactor, float dlOffset,
                                        const std::string& particleEffect)
 {
     static const float fStromWindSpeed = mStore.get<ESM::GameSetting>().find("fStromWindSpeed")->getFloat();
 
-    Weather weather(name, fallback, fStromWindSpeed, mRainSpeed, particleEffect);
+    Weather weather(name, fallback, fStromWindSpeed, mRainSpeed, dlFactor, dlOffset, particleEffect);
 
     mWeatherSettings.push_back(weather);
 }
@@ -1058,6 +1065,8 @@ inline void WeatherManager::calculateResult(const int weatherID, const float gam
     mResult.mNight = (gameHour < mSunriseTime || gameHour > mTimeSettings.mNightStart - 1);
 
     mResult.mFogDepth = current.mLandFogDepth.getValue(gameHour, mTimeSettings);
+    mResult.mDLFogFactor = current.mDL.FogFactor;
+    mResult.mDLFogOffset = current.mDL.FogOffset;
     mResult.mFogColor = current.mFogColor.getValue(gameHour, mTimeSettings);
     mResult.mAmbientColor = current.mAmbientColor.getValue(gameHour, mTimeSettings);
     mResult.mSunColor = current.mSunColor.getValue(gameHour, mTimeSettings);
@@ -1113,6 +1122,8 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
     mResult.mAmbientColor = lerp(current.mAmbientColor, other.mAmbientColor, factor);
     mResult.mSunDiscColor = lerp(current.mSunDiscColor, other.mSunDiscColor, factor);
     mResult.mFogDepth = lerp(current.mFogDepth, other.mFogDepth, factor);
+    mResult.mDLFogFactor = lerp(current.mDLFogFactor, other.mDLFogFactor, factor);
+    mResult.mDLFogOffset = lerp(current.mDLFogOffset, other.mDLFogOffset, factor);
     mResult.mWindSpeed = lerp(current.mWindSpeed, other.mWindSpeed, factor);
     mResult.mCloudSpeed = lerp(current.mCloudSpeed, other.mCloudSpeed, factor);
     mResult.mGlareView = lerp(current.mGlareView, other.mGlareView, factor);

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -131,7 +131,6 @@ Weather::Weather(const std::string& name,
     , mWindSpeed(fallback.getFallbackFloat("Weather_" + name + "_Wind_Speed"))
     , mCloudSpeed(fallback.getFallbackFloat("Weather_" + name + "_Cloud_Speed"))
     , mGlareView(fallback.getFallbackFloat("Weather_" + name + "_Glare_View"))
-    , mDL{dlFactor, dlOffset}
     , mIsStorm(mWindSpeed > stormWindSpeed)
     , mRainSpeed(rainSpeed)
     , mRainFrequency(fallback.getFallbackFloat("Weather_" + name + "_Rain_Entrance_Speed"))
@@ -145,6 +144,8 @@ Weather::Weather(const std::string& name,
     , mFlashDecrement(fallback.getFallbackFloat("Weather_" + name + "_Flash_Decrement"))
     , mFlashBrightness(0.0f)
 {
+    mDL.FogFactor = dlFactor;
+    mDL.FogOffset = dlOffset;
     mThunderSoundID[0] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_0");
     mThunderSoundID[1] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_1");
     mThunderSoundID[2] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_2");

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -73,6 +73,8 @@ namespace MWWorld
                 const Fallback::Map& fallback,
                 float stormWindSpeed,
                 float rainSpeed,
+                float dlFactor,
+                float dlOffset,
                 const std::string& particleEffect);
 
         std::string mCloudTexture;
@@ -101,6 +103,12 @@ namespace MWWorld
         // Value between 0 and 1, defines the strength of the sun glare effect.
         // Also appears to modify how visible the sun, moons, and stars are for various weather effects.
         float mGlareView;
+
+        // Fog factor and offset used with distant land rendering.
+        struct {
+            float FogFactor;
+            float FogOffset;
+        } mDL;
 
         // Sound effect
         // This is used for Blight, Ashstorm and Blizzard (Bloodmoon)
@@ -293,6 +301,7 @@ namespace MWWorld
 
         void addWeather(const std::string& name,
                         const Fallback::Map& fallback,
+                        float dlFactor, float dlOffset,
                         const std::string& particleEffect = "");
 
         void importRegions();

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -25,10 +25,6 @@ small feature culling pixel size = 2.0
 # can dramatically affect performance, see documentation for details.
 viewing distance = 6666.0
 
-# Maximum visible distance for distant terrain. Caution: setting this too high
-# can increase the chance for Z-fighting (flickering artifacts).
-distant viewing distance = 40960
-
 # Camera field of view in degrees (e.g. 30.0 to 110.0).
 # Does not affect the player's hands in the first person camera.
 field of view = 55.0

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -25,6 +25,10 @@ small feature culling pixel size = 2.0
 # can dramatically affect performance, see documentation for details.
 viewing distance = 6666.0
 
+# Maximum visible distance for distant terrain. Caution: setting this too high
+# can increase the chance for Z-fighting (flickering artifacts).
+distant viewing distance = 40960
+
 # Camera field of view in degrees (e.g. 30.0 to 110.0).
 # Does not affect the player's hands in the first person camera.
 field of view = 55.0
@@ -89,6 +93,24 @@ pointers cache size = 40
 
 # If true, use paging and LOD algorithms to display the entire terrain. If false, only display terrain of the loaded cells
 distant terrain = false
+
+[Fog]
+
+# If true, use extended fog parameters for distant terrain not controlled by
+# viewing distance. If false, use the standard fog calculations.
+use distant fog = false
+
+distant land fog start = 16384
+
+distant land fog end = 40960
+
+distant underwater fog start = -4096
+
+distant underwater fog end = 2457.6
+
+distant interior fog start = 0
+
+distant interior fog end = 16384
 
 [Map]
 


### PR DESCRIPTION
Currently when distant terrain is enabled, the viewing distance clips it preventing it from being seen. This automatically extends the view distance when distant terrain is enabled, and also adjusts the fog so that it's not blocked out against the background. The viewing distance option is effectively ignored when distant terrain is enabled, and when distant terrain is disabled everything should still behave like normal.

The fog adjustments are based on MGE XE's default fog parameters when its distant land is enabled. Currently these are not modifiable by users/modders, but it wouldn't be difficult to add a settings.cfg section for the base fog values if it's desirable (the per-weather modifiers would probably need to wait until post-1.0 for omwaddons to specify weather settings). A settings section for these things might be useful anyway for future options to use exponential curves and atmospheric scattering and the like.