### PR TITLE
Implement missing swim animations

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -283,12 +283,22 @@ void CharacterController::refreshHitRecoilAnims()
         }
         else if (recovery)
         {
-            std::string anim = chooseRandomGroup("hit");
-            if (mAnimation->hasAnimation(anim))
+            std::string anim = isSwimming ? chooseRandomGroup("swimhit") : chooseRandomGroup("hit");
+            if (isSwimming && mAnimation->hasAnimation(anim))
             {
-                mHitState = CharState_Hit;
+                mHitState = CharState_SwimHit;
                 mCurrentHit = anim;
                 mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::BlendMask_All, true, 1, "start", "stop", 0.0f, 0);
+            }
+            else
+            {
+                anim = chooseRandomGroup("hit");
+                if (mAnimation->hasAnimation(anim))
+                {
+                    mHitState = CharState_Hit;
+                    mCurrentHit = anim;
+                    mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::BlendMask_All, true, 1, "start", "stop", 0.0f, 0);
+                }
             }
         }
         else if (block && mAnimation->hasAnimation("shield"))
@@ -1157,7 +1167,7 @@ bool CharacterController::updateWeaponState()
                             mWeaponType > WeapType_HandToHand && mWeaponType < WeapType_Spell;
 
     if(weaptype != mWeaponType && !isKnockedOut() &&
-        !isKnockedDown() && mHitState != CharState_Hit)
+        !isKnockedDown() && !isRecovery())
     {
         forcestateupdate = true;
 
@@ -2265,6 +2275,12 @@ bool CharacterController::isKnockedOut() const
 {
     return mHitState == CharState_KnockOut ||
             mHitState == CharState_SwimKnockOut;
+}
+
+bool CharacterController::isRecovery() const
+{
+    return mHitState == CharState_Hit ||
+            mHitState == CharState_SwimHit;
 }
 
 bool CharacterController::isAttackingOrSpell() const

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -925,7 +925,7 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
             mPtr.getClass().hit(mPtr, mAttackStrength, ESM::Weapon::AT_Chop);
         else if (groupname == "attack2" || groupname == "swimattack2")
             mPtr.getClass().hit(mPtr, mAttackStrength, ESM::Weapon::AT_Slash);
-        else if (groupname == "attack3" || groupname == "swimattack1")
+        else if (groupname == "attack3" || groupname == "swimattack3")
             mPtr.getClass().hit(mPtr, mAttackStrength, ESM::Weapon::AT_Thrust);
         else
             mPtr.getClass().hit(mPtr, mAttackStrength);

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -97,6 +97,8 @@ enum CharacterState {
     CharState_Death4,
     CharState_Death5,
     CharState_SwimDeath,
+    CharState_SwimDeathKnockDown,
+    CharState_SwimDeathKnockOut,
     CharState_DeathKnockDown,
     CharState_DeathKnockOut,
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -88,6 +88,8 @@ enum CharacterState {
 
     CharState_TurnLeft,
     CharState_TurnRight,
+    CharState_SwimTurnLeft,
+    CharState_SwimTurnRight,
 
     CharState_Jump,
 
@@ -275,6 +277,7 @@ public:
     bool isRecovery() const;
     bool isSneaking() const;
     bool isRunning() const;
+    bool isTurning() const;
     bool isAttackingOrSpell() const;
 
     void setAttackingOrSpell(bool attackingOrSpell);

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -105,6 +105,8 @@ enum CharacterState {
     CharState_Hit,
     CharState_KnockDown,
     CharState_KnockOut,
+    CharState_SwimKnockDown,
+    CharState_SwimKnockOut,
     CharState_Block
 };
 
@@ -267,6 +269,7 @@ public:
     
     bool isAttackPrepairing() const;
     bool isReadyToBlock() const;
+    bool isKnockedDown() const;
     bool isKnockedOut() const;
     bool isSneaking() const;
     bool isRunning() const;

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -103,6 +103,7 @@ enum CharacterState {
     CharState_DeathKnockOut,
 
     CharState_Hit,
+    CharState_SwimHit,
     CharState_KnockDown,
     CharState_KnockOut,
     CharState_SwimKnockDown,
@@ -271,6 +272,7 @@ public:
     bool isReadyToBlock() const;
     bool isKnockedDown() const;
     bool isKnockedOut() const;
+    bool isRecovery() const;
     bool isSneaking() const;
     bool isRunning() const;
     bool isAttackingOrSpell() const;


### PR DESCRIPTION
Should fix [#2704](https://bugs.openmw.org/issues/2704).

A full list of used animations:
SwimAttack1-3
SwimKnockdown
SwimKnockout
SwimTurnLeft
SwimTurnRight
SwimDeathKnockDown
SwimDeathKnockOut
SwimHit

Maybe I missed something, so any feedback would be helpful.
You can test this PR with horkers (BM_Horker) and any NPC (just type "modcurrentfatigue -10000" in console)