### PR TITLE
AiWander: reset spawn position, if an actor was moved to another cell

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -200,6 +200,7 @@ namespace MWMechanics
             stopWalking(actor, storage);
             currentCell = actor.getCell();
             storage.mPopulateAvailableNodes = true;
+            mStoredInitialActorPosition = false;
         }
 
         mRemainingDuration -= ((duration*MWBase::Environment::get().getWorld()->getTimeScaleFactor()) / 3600);


### PR DESCRIPTION
Fixes [bug #4010](https://bugs.openmw.org/issues/4010).

When we move a wandering actor (with 0 wandering distance) via colsole, he will try to return to his last saved position, even if he was moved to another cell.

There is a [cellChange](https://github.com/OpenMW/openmw/blob/master/apps/openmw/mwmechanics/aiwander.cpp#L289) check, but cellChange == true only in a first package execution after cell change.

So if the actor cell was changed, we should reset last saved position.