### PR TITLE
Fix regressions in PR1474

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1892,7 +1892,7 @@ void CharacterController::update(float duration)
             movestate = mMovementState;
         }
 
-        if(!isTurning())
+        if(movestate != CharState_None && !isTurning())
             clearAnimQueue();
 
         if(mAnimQueue.empty() || inwater || sneak)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2123,6 +2123,9 @@ namespace MWWorld
 
     bool World::isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const
     {
+        if (!cell)
+            return false;
+
         if (!(cell->getCell()->hasWater())) {
             return false;
         }


### PR DESCRIPTION
1. Idle animations should be played correctly now (one "if" statement was incorrect).
2. World::isUnderwater() should not crash a game, if a target cell is empty (fixes a new game start).