### PR TITLE
AiWander: move back only after combat or pursue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 0.45.0
 ------
+
     Bug #2835: Player able to slowly move when overencumbered
+    Bug #3997: Almalexia doesn't pace
     Bug #4221: Characters get stuck in V-shaped terrain
+    Bug #4251: Stationary NPCs do not return to their position after combat
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4327: Missing animations during spell/weapon stance switching
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4429: [Windows] Error on build INSTALL.vcxproj project (debug) with cmake 3.7.2
+    Bug #4432: Guards behaviour is incorrect if they do not have AI packages
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
     Bug #4443: Goodbye option and dialogue choices are not mutually exclusive 
     Feature #4444: Per-group KF-animation files support

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -79,6 +79,9 @@ namespace MWMechanics
             /// Get the target actor the AI is targeted at (not applicable to all AI packages, default return empty Ptr)
             virtual MWWorld::Ptr getTarget() const;
 
+            /// Get the destination point of the AI package (not applicable to all AI packages, default return (0, 0, 0))
+            virtual osg::Vec3f getDestination(const MWWorld::Ptr& actor) const { return osg::Vec3f(0, 0, 0); };
+
             /// Return true if having this AiPackage makes the actor side with the target in fights (default false)
             virtual bool sideWithTarget() const;
 

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -48,7 +48,8 @@ namespace MWMechanics
                 TypeIdPursue = 6,
                 TypeIdAvoidDoor = 7,
                 TypeIdFace = 8,
-                TypeIdBreathe = 9
+                TypeIdBreathe = 9,
+                TypeIdInternalTravel = 10
             };
 
             ///Default constructor

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -308,11 +308,13 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor, boo
     if (isActualAiPackage(package.getTypeId()))
         stopCombat();
 
-    // we should return a wandering actor back after combat or pursuit
-    // the same thing for actors without AI packages
+    // We should return a wandering actor back after combat or pursuit.
+    // The same thing for actors without AI packages.
+    // Also there is no point to stack return packages.
     int currentTypeId = getTypeId();
     int newTypeId = package.getTypeId();
     if (currentTypeId <= MWMechanics::AiPackage::TypeIdWander
+        && !hasPackage(MWMechanics::AiPackage::TypeIdInternalTravel)
         && (newTypeId <= MWMechanics::AiPackage::TypeIdCombat
         || newTypeId == MWMechanics::AiPackage::TypeIdPursue))
     {

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -308,6 +308,29 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor, boo
     if (isActualAiPackage(package.getTypeId()))
         stopCombat();
 
+    // we should return a wandering actor back after combat or pursuit
+    // the same thing for actors without AI packages
+    int currentTypeId = getTypeId();
+    int newTypeId = package.getTypeId();
+    if (currentTypeId <= MWMechanics::AiPackage::TypeIdWander
+        && (newTypeId <= MWMechanics::AiPackage::TypeIdCombat
+        || newTypeId == MWMechanics::AiPackage::TypeIdPursue))
+    {
+        osg::Vec3f dest;
+        if (currentTypeId == MWMechanics::AiPackage::TypeIdWander)
+        {
+            AiPackage* activePackage = getActivePackage();
+            dest = activePackage->getDestination(actor);
+        }
+        else
+        {
+            dest = actor.getRefData().getPosition().asVec3();
+        }
+
+        MWMechanics::AiTravel travelPackage(dest.x(), dest.y(), dest.z(), true);
+        stack(travelPackage, actor, false);
+    }
+
     // remove previous packages if required
     if (cancelOther && package.shouldCancelPreviousAi())
     {

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -184,7 +184,8 @@ bool isActualAiPackage(int packageTypeId)
                    && packageTypeId != AiPackage::TypeIdPursue
                    && packageTypeId != AiPackage::TypeIdAvoidDoor
                    && packageTypeId != AiPackage::TypeIdFace
-                   && packageTypeId != AiPackage::TypeIdBreathe);
+                   && packageTypeId != AiPackage::TypeIdBreathe
+                   && packageTypeId != AiPackage::TypeIdInternalTravel);
 }
 
 void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration)

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -393,6 +393,8 @@ void AiSequence::writeState(ESM::AiSequence::AiSequence &sequence) const
     {
         (*iter)->writeState(sequence);
     }
+
+    sequence.mLastAiPackage = mLastAiPackage;
 }
 
 void AiSequence::readState(const ESM::AiSequence::AiSequence &sequence)
@@ -404,7 +406,7 @@ void AiSequence::readState(const ESM::AiSequence::AiSequence &sequence)
     int count = 0;
     for (std::vector<ESM::AiSequence::AiPackageContainer>::const_iterator it = sequence.mPackages.begin();
          it != sequence.mPackages.end(); ++it)
-    {    
+    {
         if (isActualAiPackage(it->mType))
             count++;
     }
@@ -463,6 +465,8 @@ void AiSequence::readState(const ESM::AiSequence::AiSequence &sequence)
 
         mPackages.push_back(package.release());
     }
+
+    mLastAiPackage = sequence.mLastAiPackage;
 }
 
 void AiSequence::fastForward(const MWWorld::Ptr& actor, AiState& state)

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -298,7 +298,7 @@ void AiSequence::clear()
     mPackages.clear();
 }
 
-void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor)
+void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor, bool cancelOther)
 {
     if (actor == getPlayer())
         throw std::runtime_error("Can't add AI packages to player");
@@ -308,7 +308,7 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor)
         stopCombat();
 
     // remove previous packages if required
-    if (package.shouldCancelPreviousAi())
+    if (cancelOther && package.shouldCancelPreviousAi())
     {
         for(std::list<AiPackage *>::iterator it = mPackages.begin(); it != mPackages.end();)
         {

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -115,7 +115,7 @@ namespace MWMechanics
             ///< Add \a package to the front of the sequence
             /** Suspends current package
                 @param actor The actor that owns this AiSequence **/
-            void stack (const AiPackage& package, const MWWorld::Ptr& actor);
+            void stack (const AiPackage& package, const MWWorld::Ptr& actor, bool cancelOther=true);
 
             /// Return the current active package.
             /** If there is no active package, it will throw an exception **/

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -34,7 +34,7 @@ namespace MWMechanics
     }
 
     AiTravel::AiTravel(const ESM::AiSequence::AiTravel *travel)
-        : mX(travel->mData.mX), mY(travel->mData.mY), mZ(travel->mData.mZ)
+        : mX(travel->mData.mX), mY(travel->mData.mY), mZ(travel->mData.mZ), mHidden(travel->mHidden)
     {
     }
 
@@ -63,7 +63,6 @@ namespace MWMechanics
 
     int AiTravel::getTypeId() const
     {
-        // TODO: store mHidden in the savegame?
         return mHidden ? TypeIdInternalTravel : TypeIdTravel;
     }
 
@@ -83,6 +82,7 @@ namespace MWMechanics
         travel->mData.mX = mX;
         travel->mData.mY = mY;
         travel->mData.mZ = mZ;
+        travel->mHidden = mHidden;
 
         ESM::AiSequence::AiPackageContainer package;
         package.mType = ESM::AiSequence::Ai_Travel;

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -28,15 +28,14 @@ bool isWithinMaxRange(const osg::Vec3f& pos1, const osg::Vec3f& pos2)
 
 namespace MWMechanics
 {
-    AiTravel::AiTravel(float x, float y, float z)
-    : mX(x),mY(y),mZ(z)
+    AiTravel::AiTravel(float x, float y, float z, bool hidden)
+    : mX(x),mY(y),mZ(z),mHidden(hidden)
     {
     }
 
     AiTravel::AiTravel(const ESM::AiSequence::AiTravel *travel)
         : mX(travel->mData.mX), mY(travel->mData.mY), mZ(travel->mData.mZ)
     {
-
     }
 
     AiTravel *MWMechanics::AiTravel::clone() const
@@ -64,7 +63,8 @@ namespace MWMechanics
 
     int AiTravel::getTypeId() const
     {
-        return TypeIdTravel;
+        // TODO: store mHidden in the savegame?
+        return mHidden ? TypeIdInternalTravel : TypeIdTravel;
     }
 
     void AiTravel::fastForward(const MWWorld::Ptr& actor, AiState& state)

--- a/apps/openmw/mwmechanics/aitravel.hpp
+++ b/apps/openmw/mwmechanics/aitravel.hpp
@@ -20,7 +20,7 @@ namespace MWMechanics
     {
         public:
             /// Default constructor
-            AiTravel(float x, float y, float z);
+            AiTravel(float x, float y, float z, bool hidden = false);
             AiTravel(const ESM::AiSequence::AiTravel* travel);
 
             /// Simulates the passing of time
@@ -38,6 +38,8 @@ namespace MWMechanics
             float mX;
             float mY;
             float mZ;
+
+            bool mHidden;
     };
 }
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -335,9 +335,18 @@ namespace MWMechanics
 
     bool AiWander::getRepeat() const
     {
-         return mRepeat;
+        return mRepeat;
     }
 
+    osg::Vec3f AiWander::getDestination(const MWWorld::Ptr& actor) const
+    {
+        if (mHasDestination)
+            return mDestination;
+
+        const ESM::Pathgrid::Point currentPosition = actor.getRefData().getPosition().pos;
+        const osg::Vec3f currentPositionVec3f = osg::Vec3f(currentPosition.mX, currentPosition.mY, currentPosition.mZ);
+        return currentPositionVec3f;
+    }
 
     bool AiWander::isPackageCompleted(const MWWorld::Ptr& actor, AiWanderStorage& storage)
     {
@@ -346,8 +355,8 @@ namespace MWMechanics
             // End package if duration is complete
             if (mRemainingDuration <= 0)
             {
-                    stopWalking(actor, storage);
-                    return true;
+                stopWalking(actor, storage);
+                return true;
             }
         }
         // if get here, not yet completed

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -201,18 +201,7 @@ namespace MWMechanics
             stopWalking(actor, storage);
             currentCell = actor.getCell();
             storage.mPopulateAvailableNodes = true;
-        }
-
-        // Here we should reset an initial position, if a current cell was REALLY changed
-        // We do not store AiStorage in a savegame, so cellChange is not help us in this case
-        // TODO: find a more simple and fast solution, or do not store the mInitialActorPosition at all
-        if (mStoredInitialActorPosition)
-        {
-            int cx,cy;
-            MWBase::Environment::get().getWorld()->positionToIndex(mInitialActorPosition.x(),mInitialActorPosition.y(),cx,cy);
-            MWWorld::CellStore* cell = MWBase::Environment::get().getWorld()->getExterior(cx,cy);
-            if (cell != currentCell)
-                mStoredInitialActorPosition = false;
+            mStoredInitialActorPosition = false;
         }
 
         mRemainingDuration -= ((duration*MWBase::Environment::get().getWorld()->getTimeScaleFactor()) / 3600);

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -85,7 +85,6 @@ namespace MWMechanics
             bool reactionTimeActions(const MWWorld::Ptr& actor, AiWanderStorage& storage,
             const MWWorld::CellStore*& currentCell, bool cellChange, ESM::Position& pos, float duration);
             bool isPackageCompleted(const MWWorld::Ptr& actor, AiWanderStorage& storage);
-            void returnToStartLocation(const MWWorld::Ptr& actor, AiWanderStorage& storage, ESM::Position& pos);
             void wanderNearStart(const MWWorld::Ptr &actor, AiWanderStorage &storage, int wanderDistance);
             bool destinationIsAtWater(const MWWorld::Ptr &actor, const osg::Vec3f& destination);
             bool destinationThroughGround(const osg::Vec3f& startPoint, const osg::Vec3f& destination);

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -47,9 +47,11 @@ namespace MWMechanics
             virtual void writeState(ESM::AiSequence::AiSequence &sequence) const;
 
             virtual void fastForward(const MWWorld::Ptr& actor, AiState& state);
-            
+
             bool getRepeat() const;
-            
+
+            osg::Vec3f getDestination(const MWWorld::Ptr& actor) const;
+
             enum GreetingState {
                 Greet_None,
                 Greet_InProgress,

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1604,26 +1604,6 @@ namespace MWMechanics
         if (aiSequence.isInCombat(target))
             return;
 
-        // we should return a wandering actor back after combat
-        // the same thing for actors without AI packages
-        if (aiSequence.getTypeId() <= MWMechanics::AiPackage::TypeIdWander)
-        {
-            int typeId = aiSequence.getTypeId();
-            osg::Vec3f dest;
-            if (typeId == MWMechanics::AiPackage::TypeIdNone)
-            {
-                dest = ptr.getRefData().getPosition().asVec3();
-            }
-            else if (typeId == MWMechanics::AiPackage::TypeIdWander)
-            {
-                AiPackage* activePackage = aiSequence.getActivePackage();
-                dest = activePackage->getDestination(ptr);
-            }
-
-            MWMechanics::AiTravel travelPackage(dest.x(), dest.y(), dest.z(), true);
-            aiSequence.stack(travelPackage, ptr, false);
-        }
-
         aiSequence.stack(MWMechanics::AiCombat(target), ptr);
         if (target == getPlayer())
         {

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1606,7 +1606,7 @@ namespace MWMechanics
 
         // we should return a wandering actor back after combat
         // the same thing for actors without AI packages
-        if (!aiSequence.isInCombat() && aiSequence.getTypeId() <= MWMechanics::AiPackage::TypeIdWander)
+        if (aiSequence.getTypeId() <= MWMechanics::AiPackage::TypeIdWander)
         {
             int typeId = aiSequence.getTypeId();
             osg::Vec3f dest;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1611,7 +1611,7 @@ namespace MWMechanics
             osg::Vec3f pos = ptr.getRefData().getPosition().asVec3();
 
             MWMechanics::AiTravel travelPackage(pos.x(), pos.y(), pos.z());
-            aiSequence.stack(travelPackage, ptr);
+            aiSequence.stack(travelPackage, ptr, false);
         }
 
         aiSequence.stack(MWMechanics::AiCombat(target), ptr);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1620,7 +1620,7 @@ namespace MWMechanics
                 dest = activePackage->getDestination(ptr);
             }
 
-            MWMechanics::AiTravel travelPackage(dest.x(), dest.y(), dest.z());
+            MWMechanics::AiTravel travelPackage(dest.x(), dest.y(), dest.z(), true);
             aiSequence.stack(travelPackage, ptr, false);
         }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1605,12 +1605,22 @@ namespace MWMechanics
             return;
 
         // we should return a wandering actor back after combat
-        // TODO: only for stationary wander?
-        if (!aiSequence.isInCombat() && aiSequence.getLastRunTypeId() == MWMechanics::AiPackage::TypeIdWander)
+        // the same thing for actors without AI packages
+        if (!aiSequence.isInCombat() && aiSequence.getTypeId() <= MWMechanics::AiPackage::TypeIdWander)
         {
-            osg::Vec3f pos = ptr.getRefData().getPosition().asVec3();
+            int typeId = aiSequence.getTypeId();
+            osg::Vec3f dest;
+            if (typeId == MWMechanics::AiPackage::TypeIdNone)
+            {
+                dest = ptr.getRefData().getPosition().asVec3();
+            }
+            else if (typeId == MWMechanics::AiPackage::TypeIdWander)
+            {
+                AiPackage* activePackage = aiSequence.getActivePackage();
+                dest = activePackage->getDestination(ptr);
+            }
 
-            MWMechanics::AiTravel travelPackage(pos.x(), pos.y(), pos.z());
+            MWMechanics::AiTravel travelPackage(dest.x(), dest.y(), dest.z());
             aiSequence.stack(travelPackage, ptr, false);
         }
 

--- a/components/esm/aisequence.cpp
+++ b/components/esm/aisequence.cpp
@@ -156,6 +156,8 @@ namespace AiSequence
                 break;
             }
         }
+
+        esm.writeHNT ("LAST", mLastAiPackage);
     }
 
     void AiSequence::load(ESMReader &esm)
@@ -223,6 +225,8 @@ namespace AiSequence
                 return;
             }
         }
+
+        esm.getHNOT (mLastAiPackage, "LAST");
     }
 }
 }

--- a/components/esm/aisequence.cpp
+++ b/components/esm/aisequence.cpp
@@ -35,11 +35,13 @@ namespace AiSequence
     void AiTravel::load(ESMReader &esm)
     {
         esm.getHNT (mData, "DATA");
+        esm.getHNOT (mHidden, "HIDD");
     }
 
     void AiTravel::save(ESMWriter &esm) const
     {
         esm.writeHNT ("DATA", mData);
+        esm.writeHNT ("HIDD", mHidden);
     }
 
     void AiEscort::load(ESMReader &esm)

--- a/components/esm/aisequence.hpp
+++ b/components/esm/aisequence.hpp
@@ -148,10 +148,14 @@ namespace ESM
 
     struct AiSequence
     {
-        AiSequence() {}
+        AiSequence()
+        {
+            mLastAiPackage = -1;
+        }
         ~AiSequence();
 
         std::vector<AiPackageContainer> mPackages;
+        int mLastAiPackage;
 
         void load (ESMReader &esm);
         void save (ESMWriter &esm) const;

--- a/components/esm/aisequence.hpp
+++ b/components/esm/aisequence.hpp
@@ -80,6 +80,7 @@ namespace ESM
     struct AiTravel : AiPackage
     {
         AiTravelData mData;
+        bool mHidden;
 
         void load(ESMReader &esm);
         void save(ESMWriter &esm) const;

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -5,7 +5,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 3;
+int ESM::SavedGame::sCurrentFormat = 4;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
Fixes [bug #3997](https://bugs.openmw.org/issues/3997), [bug #4251](https://bugs.openmw.org/issues/4251) and [bug #4432](https://bugs.openmw.org/issues/4432).

A basic idea: when the wandering actor (or actor without AI packages) starts combat or pursuit, I create the AiTravel package with his current position. After combat/pursuit this AiTravel package will return the actor to this position.