### PR TITLE
Add an option to use third person animations in first person view (Feature #2666)

### DIFF
--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -1,8 +1,11 @@
 #include "camera.hpp"
 
 #include <osg/Camera>
+#include <osg/PositionAttitudeTransform>
 
 #include <components/sceneutil/positionattitudetransform.hpp>
+
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
@@ -364,10 +367,20 @@ namespace MWRender
     {
         if(isFirstPerson())
         {
-            mAnimation->setViewMode(NpcAnimation::VM_FirstPerson);
             mTrackingNode = mAnimation->getNode("Camera");
             if (!mTrackingNode)
                 mTrackingNode = mAnimation->getNode("Head");
+            if (!Settings::Manager::getBool("use third person animations in first person view","Camera"))
+            {
+                mAnimation->setViewMode(NpcAnimation::VM_FirstPerson);
+            }
+            else
+            {
+                osg::ref_ptr<osg::PositionAttitudeTransform> node2 = new osg::PositionAttitudeTransform;
+                const_cast<osg::Node*>(mTrackingNode.get())->asGroup()->addChild(node2);
+                node2->setPosition(osg::Vec3f(0,-10,0));
+                mTrackingNode = node2;
+            }
             mHeightScale = 1.f;
         }
         else

--- a/docs/source/reference/modding/settings/camera.rst
+++ b/docs/source/reference/modding/settings/camera.rst
@@ -121,3 +121,14 @@ because the Bethesda provided Morrowind assets do not adapt well to large values
 while small values can result in the hands not being visible.
 
 The default value is 55.0. This setting can only be configured by editing the settings configuration file.
+
+use third person animations in first person view
+------------------------------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, first person camera uses third person animations. This results in the body of player character being shown in first person view and added head bobbing, because the camera is attached to the head of the character.
+
+The default value is false. This setting can only be configured by editing the settings configuration file.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -33,6 +33,9 @@ field of view = 55.0
 # Best to leave this at the default since vanilla assets are not complete enough to adapt to high FoV's. Too low FoV would clip the hands off screen.
 first person field of view = 55.0
 
+# Show player character's body and use third person animations in first person camera.
+use third person animations in first person view = false
+
 [Cells]
 
 # Adjacent exterior cells loaded (>0). Caution: this setting can


### PR DESCRIPTION
Implements [feature #2666](https://bugs.openmw.org/issues/2666) based on scrawl's 8 lines. I've added a configuration setting, by default the behavior is (of course) not changed.