### PR TITLE
Inherit owner, if an item is in container (regression #4128)

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1012,14 +1012,17 @@ namespace MWMechanics
 
         MWWorld::Ptr victim;
 
+        bool isAllowed = true;
         const MWWorld::CellRef* ownerCellRef = &item.getCellRef();
         if (!container.isEmpty())
         {
             // Inherit the owner of the container
             ownerCellRef = &container.getCellRef();
+            isAllowed = isAllowedToUse(ptr, container, victim);
         }
         else
         {
+            isAllowed = isAllowedToUse(ptr, item, victim);
             if (!item.getCellRef().hasContentFile())
             {
                 // this is a manually placed item, which means it was already stolen
@@ -1027,7 +1030,7 @@ namespace MWMechanics
             }
         }
 
-        if (isAllowedToUse(ptr, item, victim))
+        if (isAllowed)
             return;
 
         Owner owner;


### PR DESCRIPTION
Fixes [bug #4128](https://bugs.openmw.org/issues/4128).
In 0.42 isAllowedToUse() accepted ownerCellRef, in 0.43 accepts a pointer, so if an item is in container, we should provide a container pointer instead of item pointer.