### PR TITLE
fix rain ripple bug

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -504,6 +504,9 @@ namespace MWRender
             mWater->update(dt);
         }
 
+        if (!mSky->isEnabled() || !mSky->hasRain())
+          clearRainRipples();
+
         mCamera->update(dt, paused);
 
         osg::Vec3f focal, cameraPos;
@@ -803,7 +806,11 @@ namespace MWRender
     {
         mEffectManager->clear();
         mWater->clearRipples();
-        mUniformRainIntensity->set((float) 0.0);  // for interiors
+    }
+
+    void RenderingManager::clearRainRipples()
+    {
+        mUniformRainIntensity->set((float) 0.0);
     }
 
     void RenderingManager::clear()

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -160,6 +160,8 @@ namespace MWRender
         /// Clear all worldspace-specific data
         void notifyWorldSpaceChanged();
 
+        void clearRainRipples();
+
         void update(float dt, bool paused);
 
         Animation* getAnimation(const MWWorld::Ptr& ptr);

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1431,6 +1431,16 @@ int SkyManager::getSecundaPhase() const
     return mSecunda->getPhaseInt();
 }
 
+bool SkyManager::isEnabled()
+{
+    return mEnabled;
+}
+
+bool SkyManager::hasRain()
+{
+    return mRainNode != NULL;
+}
+
 void SkyManager::update(float duration)
 {
     if (!mEnabled) return;

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -138,6 +138,10 @@ namespace MWRender
 
         void sunDisable();
 
+        bool isEnabled();
+
+        bool hasRain();
+
         void setRainSpeed(float speed);
 
         void setStormDirection(const osg::Vec3f& direction);


### PR DESCRIPTION
I'm fixing a bug regarding the rain ripples I recently implemented. I noticed the ripples were sometimes preserved when I teleported with `coc` from a place with rain to a place without rain, so there were ripples but no rain.

Previously I cleared the ripples in `RenderingManager::notifyWorldSpaceChanged()` function as I though it was called anytime a cell was changed, but that wasn't the case. I moved the check inside `RenderingManager::update()`. It checks if the sky manager has actual rain node created and whether the sky manager is enabled (because if you teleport from an exterior cell to an interior one, the rain node remains, only the sky manager gets disabled) - if one of these is false, the ripples are cleared.

I tested this fix by randomly changing weather in Seyda Neen and teleporting over the map (`coc balmora`, `coc "molag mar"`, `coc "seyda neen"`) and into interior cells with water (`coc "Vivec, Telvanni Underworks"`) and back. It seems to work now but better if more people test this.

