### PR TITLE
Fix some issues with pickpocketing (bug #4131)

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -238,7 +238,7 @@ namespace MWBase
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid) = 0;
 
-            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::ConstPtr& item, MWWorld::Ptr& victim) = 0;
+            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim) = 0;
 
             /// Turn actor into werewolf or normal form.
             virtual void setWerewolf(const MWWorld::Ptr& actor, bool werewolf) = 0;

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -470,6 +470,9 @@ namespace MWClass
         if(stats.getAiSequence().isInCombat())
             return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
 
+        if(stats.getKnockedDown())
+            return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
+
         return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
     }
 

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -567,6 +567,12 @@ namespace MWDialogue
             return;
         }
 
+        if (actor.getClass().getCreatureStats(actor).getKnockedDown())
+        {
+            // Unconscious actors can not speak
+            return;
+        }
+
         const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
         const ESM::Dialogue *dial = store.get<ESM::Dialogue>().find(topic);
 

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -136,7 +136,7 @@ namespace MWGui
 
         bool loot = mPtr.getClass().isActor() && mPtr.getClass().getCreatureStats(mPtr).isDead();
 
-        if (mPtr.getTypeName() == typeid(ESM::NPC).name() && !loot)
+        if (mPtr.getClass().isNpc() && !loot)
         {
             // we are stealing stuff
             MWWorld::Ptr player = MWMechanics::getPlayer();
@@ -271,9 +271,8 @@ namespace MWGui
             MWMechanics::Pickpocket pickpocket(player, mPtr);
             if (pickpocket.pick(item.mBase, count))
             {
-                int value = item.mBase.getClass().getValue(item.mBase) * count;
                 MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                            player, mPtr, MWBase::MechanicsManager::OT_Theft, value, true);
+                            player, mPtr, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
                 MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
                 mPickpocketDetected = true;
                 return false;

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -325,7 +325,7 @@ namespace MWGui
         }
     }
 
-    void ToolTips::setFocusObject(const MWWorld::ConstPtr& focus)
+    void ToolTips::setFocusObject(const MWWorld::Ptr& focus)
     {
         mFocusObject = focus;
 

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -59,7 +59,7 @@ namespace MWGui
 
         void setDelay(float delay);
 
-        void setFocusObject(const MWWorld::ConstPtr& focus);
+        void setFocusObject(const MWWorld::Ptr& focus);
         void setFocusObjectScreenCoords(float min_x, float min_y, float max_x, float max_y);
         ///< set the screen-space position of the tooltip for focused object
 
@@ -96,7 +96,7 @@ namespace MWGui
     private:
         MyGUI::Widget* mDynamicToolTipBox;
 
-        MWWorld::ConstPtr mFocusObject;
+        MWWorld::Ptr mFocusObject;
 
         MyGUI::IntSize getToolTipViaPtr (int count, bool image=true);
         ///< @return requested tooltip size

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1573,7 +1573,7 @@ namespace MWGui
 
         mMessageBoxManager->clear();
 
-        mToolTips->setFocusObject(MWWorld::ConstPtr());
+        mToolTips->setFocusObject(MWWorld::Ptr());
 
         mSelectedSpell.clear();
         mCustomMarkers.clear();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1232,13 +1232,17 @@ namespace MWMechanics
                             float sqrHeadTrackDistance = std::numeric_limits<float>::max();
                             MWWorld::Ptr headTrackTarget;
 
-                            for(PtrActorMap::iterator it(mActors.begin()); it != mActors.end(); ++it)
+                            // Unconsious actor can not track target
+                            if (!iter->first.getClass().getCreatureStats(iter->first).getKnockedDown())
                             {
-                                if (it->first == iter->first)
-                                    continue;
-                                updateHeadTracking(iter->first, it->first, headTrackTarget, sqrHeadTrackDistance);
+                                for(PtrActorMap::iterator it(mActors.begin()); it != mActors.end(); ++it)
+                                {
+                                    if (it->first == iter->first)
+                                        continue;
+                                    updateHeadTracking(iter->first, it->first, headTrackTarget, sqrHeadTrackDistance);
+                                }
+                                iter->second->getCharacterController()->setHeadTrackTarget(headTrackTarget);
                             }
-                            iter->second->getCharacterController()->setHeadTrackTarget(headTrackTarget);
                         }
 
                         if (iter->first.getClass().isNpc() && iter->first != player)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -856,6 +856,9 @@ namespace MWMechanics
             if (target.getClass().getCreatureStats(target).isDead())
                 return true;
 
+            if (target.getClass().getCreatureStats(target).getAiSequence().isInCombat())
+                return true;
+
             // check if a player tries to pickpocket a target NPC
             if(ptr.getClass().getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Sneak)
                 || target.getClass().getCreatureStats(target).getKnockedDown())

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1097,6 +1097,10 @@ namespace MWMechanics
             if (it->getClass().getCreatureStats(*it).isDead())
                 continue;
 
+            // Unconsious actor can not report about crime
+            if (it->getClass().getCreatureStats(*it).getKnockedDown())
+                continue;
+
             if ((*it == victim && victimAware)
                     || (MWBase::Environment::get().getWorld()->getLOS(player, *it) && awarenessCheck(player, *it) )
                     // Murder crime can be reported even if no one saw it (hearing is enough, I guess).
@@ -1208,10 +1212,14 @@ namespace MWMechanics
         // Tell everyone (including the original reporter) in alarm range
         for (std::vector<MWWorld::Ptr>::iterator it = neighbors.begin(); it != neighbors.end(); ++it)
         {
-            if (   *it == player
+            if (*it == player
                 || !it->getClass().isNpc() || it->getClass().getCreatureStats(*it).isDead()) continue;
 
             if (it->getClass().getCreatureStats(*it).getAiSequence().isInCombat(victim))
+                continue;
+
+            // Unconsious actor can not report about crime and should not become hostile
+            if (it->getClass().getCreatureStats(*it).getKnockedDown())
                 continue;
 
             // Player's followers should not attack player, or try to arrest him

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -204,8 +204,8 @@ namespace MWMechanics
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid);
 
-            /// @return is \a ptr allowed to take/use \a cellref or is it a crime?
-            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::ConstPtr& item, MWWorld::Ptr& victim);
+            /// @return is \a ptr allowed to take/use \a target or is it a crime?
+            virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim);
 
             virtual void setWerewolf(const MWWorld::Ptr& actor, bool werewolf);
             virtual void applyWerewolfAcrobatics(const MWWorld::Ptr& actor);


### PR DESCRIPTION
A summary of changes:
1. If you try to steal an item and pickpocked failed, a OT_Pickpocket crime with iCrimePickPocket bounty will be reported.
2. Unconscious targets will not report about crimes, speak (e.g. if you attack them) and track heads (all as in vanilla game).
3. If you take an item from unconscious target, it will be considered as a OT_Theft crime.
4. If a crime was reported by someone else, unconscious actors do not become hostile.
5. "Owned crosshair" feature now takes in account, if interacting with actor will be considered as a crime (when you are in the stealth mode, or the target NPC in unconscious)

Notes:
1. An issue, referenced by scrawl in #1482 still exists.
2. As I understood, a "Theft" crime means that a player actually got an item, and "Pickpocket" means only attempt to steal something from victim's inventory.

Any feedback or additional testing would be helphul.
