### PR TITLE
[discussion] attempt at solving rain/snow moving with player (issue #2698)

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -255,7 +255,7 @@ namespace MWRender
         
         mRootNode->getOrCreateStateSet()->addUniform(mUniformRainIntensity);
 
-        mSky.reset(new SkyManager(sceneRoot, resourceSystem->getSceneManager()));
+        mSky.reset(new SkyManager(sceneRoot, resourceSystem->getSceneManager(), this));
 
         source->setStateSetModes(*mRootNode->getOrCreateStateSet(), osg::StateAttribute::ON);
 

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1502,9 +1502,8 @@ void SkyManager::setEnabled(bool enabled)
 
     mRootNode->setNodeMask(enabled ? Mask_Sky : 0);
 
-if (mRainNode)
-mRainNode->setNodeMask(enabled ? Mask_Sky : 0);
-
+    if (mRainNode)
+        mRainNode->setNodeMask(enabled ? Mask_Sky : 0);
 
     mEnabled = enabled;
 }

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1126,6 +1126,7 @@ SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneMana
     parentNode->addChild(skyroot);
 
     mRootNode = skyroot;
+    mParticleParent = mRootNode->getParent(0);
 
     mEarlyRenderBinRoot = new osg::Group;
     // render before the world is rendered
@@ -1421,7 +1422,7 @@ void SkyManager::createRain()
     mRainNode->addCullCallback(mUnderwaterSwitch);
     mRainNode->setNodeMask(Mask_WeatherParticles);
 
-    mRootNode->getParent(0)->addChild(mRainNode);
+    mParticleParent->addChild(mRainNode);
 }
 
 void SkyManager::destroyRain()
@@ -1429,7 +1430,7 @@ void SkyManager::destroyRain()
     if (!mRainNode)
         return;
 
-    mRootNode->getParent(0)->removeChild(mRainNode);
+    mParticleParent->removeChild(mRainNode);
     mRainNode = NULL;
     mRainParticleSystem = NULL;
     mRainShooter = NULL;
@@ -1501,8 +1502,9 @@ void SkyManager::setEnabled(bool enabled)
 
     mRootNode->setNodeMask(enabled ? Mask_Sky : 0);
 
-    if (mRainNode)
-      mRainNode->setNodeMask(enabled ? Mask_Sky : 0);
+if (mRainNode)
+mRainNode->setNodeMask(enabled ? Mask_Sky : 0);
+
 
     mEnabled = enabled;
 }

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1501,9 +1501,8 @@ void SkyManager::setEnabled(bool enabled)
 
     mRootNode->setNodeMask(enabled ? Mask_Sky : 0);
 
-if (mRainNode)
-mRainNode->setNodeMask(enabled ? Mask_Sky : 0);
-
+    if (mRainNode)
+      mRainNode->setNodeMask(enabled ? Mask_Sky : 0);
 
     mEnabled = enabled;
 }

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -175,6 +175,7 @@ class RenderingManager;
         MWRender::RenderingManager *mRendering;
 
         osg::ref_ptr<osg::Group> mRootNode;
+        osg::ref_ptr<osg::Group> mParticleParent;      ///< parent node of particle systems
         osg::ref_ptr<osg::Group> mEarlyRenderBinRoot;
 
         osg::ref_ptr<osg::PositionAttitudeTransform> mParticleNode;

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -103,12 +103,14 @@ namespace MWRender
         float mMoonAlpha;
     };
 
+class RenderingManager;
+
     ///@brief The SkyManager handles rendering of the sky domes, celestial bodies as well as other objects that need to be rendered
     /// relative to the camera (e.g. weather particle effects)
     class SkyManager
     {
     public:
-        SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneManager);
+        SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneManager, MWRender::RenderingManager *);
         ~SkyManager();
 
         void update(float duration);
@@ -170,6 +172,7 @@ namespace MWRender
         void updateRainParameters();
 
         Resource::SceneManager* mSceneManager;
+        MWRender::RenderingManager *mRendering;
 
         osg::ref_ptr<osg::Group> mRootNode;
         osg::ref_ptr<osg::Group> mEarlyRenderBinRoot;

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -250,6 +250,11 @@ void Emitter::setPlacer(osgParticle::Placer *placer)
     mPlacer = placer;
 }
 
+osgParticle::Placer *Emitter::getPlacer()
+{
+   return  mPlacer;
+}
+
 void Emitter::setCounter(osgParticle::Counter *counter)
 {
     mCounter = counter;

--- a/components/nifosg/particle.hpp
+++ b/components/nifosg/particle.hpp
@@ -226,6 +226,7 @@ namespace NifOsg
         void setShooter(osgParticle::Shooter* shooter);
         void setPlacer(osgParticle::Placer* placer);
         void setCounter(osgParticle::Counter* counter);
+        osgParticle::Placer *getPlacer();
 
     private:
         // NIF Record indices


### PR DESCRIPTION
I've been trying to fix [bug #2698](https://bugs.openmw.org/issues/2698). **Do not merge** this please, there are bugs. I'm posting this to get some feedback.

I've done this:

- Reparented the rain emitter from sky node to its parent, so that the rain drops do not move with the player.
- Created a subclass of `BoxPlacer` (`RainPlacer`) to place particles relatively to camera position.

So now the emitter is always placed at [0,0] in the world and the rain particles are spawned relatively to the camera, but are not parented to it, so they move independently. Questions:

1. Is this a good idea? I had to increase the number of particles greatly in order to cover greater area than just the camera immediate surrounding. Is it OK to parent the rain node outside the sky subtree?
2. Could the emitter stay parented to the sky node, but ignore its position somehow? I am a newbie with OSG and don't know if this could be done. (I tried `emitter->setReferenceFrame(osgParticle::ParticleProcessor::ABSOLUTE_RF)`, didn't work).
3. Any ideas for different approaches?

Also snow is broken now and behaves weirdly, I didn't really look much into the reason yet, but I think it uses a different particle system object to which I'd have to apply the same approach.