### PR TITLE
AI: Autoequip armor when bound armor spell expires

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -71,7 +71,9 @@ void adjustBoundItem (const std::string& item, bool bound, const MWWorld::Ptr& a
     }
     else
     {
-        actor.getClass().getContainerStore(actor).remove(item, 1, actor);
+        MWWorld::Ptr itemPtr = actor.getClass().getInventoryStore(actor).search(item);
+        if (!itemPtr.isEmpty())
+            actor.getClass().getInventoryStore(actor).remove(itemPtr, 1, actor, true);
     }
 }
 


### PR DESCRIPTION
Just this.

To test a difference between old behaviour and new one, you can add a scroll to any armoured NPC:
`additem sc_lordmhasvengeance 1`