### PR TITLE
Use an "owned crosshair" feature for items in containers

### DIFF
--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -22,6 +22,7 @@
 #include "itemview.hpp"
 #include "itemwidget.hpp"
 #include "inventoryitemmodel.hpp"
+#include "containeritemmodel.hpp"
 #include "sortfilteritemmodel.hpp"
 #include "pickpocketitemmodel.hpp"
 #include "draganddrop.hpp"
@@ -136,15 +137,22 @@ namespace MWGui
 
         bool loot = mPtr.getClass().isActor() && mPtr.getClass().getCreatureStats(mPtr).isDead();
 
-        if (mPtr.getClass().isNpc() && !loot)
+        if (mPtr.getClass().hasInventoryStore(mPtr))
         {
-            // we are stealing stuff
-            MWWorld::Ptr player = MWMechanics::getPlayer();
-            mModel = new PickpocketItemModel(player, new InventoryItemModel(container),
-                                             !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown());
+            if (mPtr.getClass().isNpc() && !loot)
+            {
+                // we are stealing stuff
+                MWWorld::Ptr player = MWMechanics::getPlayer();
+                mModel = new PickpocketItemModel(player, new InventoryItemModel(container),
+                                                 !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown());
+            }
+            else
+                mModel = new InventoryItemModel(container);
         }
         else
-            mModel = new InventoryItemModel(container);
+        {
+            mModel = new ContainerItemModel(container);
+        }
 
         mDisposeCorpseButton->setVisible(loot);
 

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -6,7 +6,10 @@
 #include "../mwworld/class.hpp"
 
 #include "../mwbase/world.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/environment.hpp"
+
+#include "../mwmechanics/actorutil.hpp"
 
 namespace
 {
@@ -45,6 +48,19 @@ ContainerItemModel::ContainerItemModel(const std::vector<MWWorld::Ptr>& itemSour
 ContainerItemModel::ContainerItemModel (const MWWorld::Ptr& source)
 {
     mItemSources.push_back(source);
+}
+
+bool ContainerItemModel::allowedToUseItems() const
+{
+    if (mItemSources.size() == 0)
+        return true;
+
+    MWWorld::Ptr ptr = MWMechanics::getPlayer();
+    MWWorld::Ptr victim;
+
+    // Check if the player is allowed to use items from opened container
+    MWBase::MechanicsManager* mm = MWBase::Environment::get().getMechanicsManager();
+    return mm->isAllowedToUse(ptr, mItemSources[0], victim);
 }
 
 ItemStack ContainerItemModel::getItem (ModelIndex index)

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -17,6 +17,7 @@ namespace MWGui
 
         ContainerItemModel (const MWWorld::Ptr& source);
 
+        virtual bool allowedToUseItems() const;
         virtual ItemStack getItem (ModelIndex index);
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -119,6 +119,11 @@ namespace MWGui
         return ret;
     }
 
+    bool ItemModel::allowedToUseItems() const
+    {
+        return true;
+    }
+
     bool ItemModel::allowedToInsertItems() const
     {
         return true;
@@ -133,6 +138,11 @@ namespace MWGui
     ProxyItemModel::~ProxyItemModel()
     {
         delete mSourceModel;
+    }
+
+    bool ProxyItemModel::allowedToUseItems() const
+    {
+        return mSourceModel->allowedToUseItems();
     }
 
     MWWorld::Ptr ProxyItemModel::copyItem (const ItemStack& item, size_t count, bool setNewOwner)

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -70,6 +70,9 @@ namespace MWGui
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false) = 0;
         virtual void removeItem (const ItemStack& item, size_t count) = 0;
 
+        /// Is the player allowed to use items from this item model? (default true)
+        virtual bool allowedToUseItems() const;
+
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
 
@@ -85,6 +88,9 @@ namespace MWGui
     public:
         ProxyItemModel();
         virtual ~ProxyItemModel();
+
+        bool allowedToUseItems() const;
+
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual ModelIndex getIndex (ItemStack item);

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -26,6 +26,11 @@ namespace MWGui
         }
     }
 
+    bool PickpocketItemModel::allowedToUseItems() const
+    {
+        return false;
+    }
+
     ItemStack PickpocketItemModel::getItem (ModelIndex index)
     {
         if (index < 0)

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -11,6 +11,8 @@ namespace MWGui
     {
     public:
         PickpocketItemModel (const MWWorld::Ptr& thief, ItemModel* sourceModel, bool hideItems=true);
+
+        virtual bool allowedToUseItems() const;
         virtual ItemStack getItem (ModelIndex index);
         virtual size_t getItemCount();
         virtual void update();

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -159,6 +159,11 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
+    bool SortFilterItemModel::allowedToUseItems() const
+    {
+        return mSourceModel->allowedToUseItems();
+    }
+
     void SortFilterItemModel::addDragItem (const MWWorld::Ptr& dragItem, size_t count)
     {
         mDragItems.push_back(std::make_pair(dragItem, count));

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -15,6 +15,7 @@ namespace MWGui
 
         bool filterAccepts (const ItemStack& item);
 
+        bool allowedToUseItems() const;
         virtual ItemStack getItem (ModelIndex index);
         virtual size_t getItemCount();
 

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -98,10 +98,10 @@ namespace MWGui
 
         MWWorld::Ptr mFocusObject;
 
-        MyGUI::IntSize getToolTipViaPtr (int count, bool image=true);
+        MyGUI::IntSize getToolTipViaPtr (int count, bool image = true, bool isOwned = false);
         ///< @return requested tooltip size
 
-        MyGUI::IntSize createToolTip(const ToolTipInfo& info, bool isFocusObject);
+        MyGUI::IntSize createToolTip(const ToolTipInfo& info, bool isOwned = false);
         ///< @return requested tooltip size
         /// @param isFocusObject Is the object this tooltips originates from mFocusObject?
 

--- a/apps/openmw/mwgui/tradeitemmodel.cpp
+++ b/apps/openmw/mwgui/tradeitemmodel.cpp
@@ -15,6 +15,11 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
+    bool TradeItemModel::allowedToUseItems() const
+    {
+        return true;
+    }
+
     ItemStack TradeItemModel::getItem (ModelIndex index)
     {
         if (index < 0)

--- a/apps/openmw/mwgui/tradeitemmodel.hpp
+++ b/apps/openmw/mwgui/tradeitemmodel.hpp
@@ -15,6 +15,8 @@ namespace MWGui
     public:
         TradeItemModel (ItemModel* sourceModel, const MWWorld::Ptr& merchant);
 
+        bool allowedToUseItems() const;
+
         virtual ItemStack getItem (ModelIndex index);
         virtual size_t getItemCount();
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -842,6 +842,9 @@ namespace MWMechanics
 
     bool MechanicsManager::isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim)
     {
+        if (target.isEmpty())
+            return true;
+
         const MWWorld::CellRef& cellref = target.getCellRef();
         // there is no harm to use unlocked doors
         if (target.getClass().isDoor() && cellref.getLockLevel() <= 0 && ptr.getCellRef().getTrap().empty())


### PR DESCRIPTION
Requested by scrawl in #1482.

If a focused item is in container, we should check if the player can take items from this container, instead of owned common check.

How it works:
1. If the focused item is in container, get ContainerStore for current opened container.
2. Check if the container store is the same, as for focused item.
3. If yes, check isAllowedToUse() for opened container instead of focused item itself.