### PR TITLE
Reverse pickpocketing

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -238,6 +238,7 @@ namespace MWBase
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid) = 0;
 
+            virtual bool isBoundItem(const MWWorld::Ptr& item) = 0;
             virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim) = 0;
 
             /// Turn actor into werewolf or normal form.

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -250,6 +250,7 @@ namespace MWBase
             virtual void cleanupSummonedCreature(const MWWorld::Ptr& caster, int creatureActorId) = 0;
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count) = 0;
+            virtual void modifyStolenItemsCount(const MWWorld::Ptr &item, int count, const MWWorld::Ptr& victim) = 0;
 
             virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr) = 0;
             virtual bool isRunning(const MWWorld::Ptr& ptr) = 0;

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -100,46 +100,10 @@ namespace MWGui
 
     void ContainerWindow::dropItem()
     {
-        if (mPtr.getTypeName() == typeid(ESM::Container).name())
-        {
-            // check container organic flag
-            MWWorld::LiveCellRef<ESM::Container>* ref = mPtr.get<ESM::Container>();
-            if (ref->mBase->mFlags & ESM::Container::Organic)
-            {
-                MWBase::Environment::get().getWindowManager()->
-                    messageBox("#{sContentsMessage2}");
-                return;
-            }
+        bool success = mModel->onDropItem(mDragAndDrop->mItem.mBase, mDragAndDrop->mDraggedCount);
 
-            // check that we don't exceed container capacity
-            MWWorld::Ptr item = mDragAndDrop->mItem.mBase;
-            float weight = item.getClass().getWeight(item) * mDragAndDrop->mDraggedCount;
-            if (mPtr.getClass().getCapacity(mPtr) < mPtr.getClass().getEncumbrance(mPtr) + weight)
-            {
-                MWBase::Environment::get().getWindowManager()->messageBox("#{sContentsMessage3}");
-                return;
-            }
-        }
-
-        // reverse pickpocketing
-        if (dynamic_cast<PickpocketItemModel*>(mModel)
-                && !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown())
-        {
-            MWWorld::Ptr player = MWMechanics::getPlayer();
-            MWMechanics::Pickpocket pickpocket(player, mPtr);
-            if (pickpocket.pick(mDragAndDrop->mItem.mBase, mDragAndDrop->mDraggedCount))
-            {
-                MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                            player, mPtr, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
-                MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
-                mPickpocketDetected = true;
-                return;
-            }
-            else
-                player.getClass().skillUsageSucceeded(player, ESM::Skill::Sneak, 1);
-        }
-
-        mDragAndDrop->drop(mModel, mItemView);
+        if (success)
+            mDragAndDrop->drop(mModel, mItemView);
     }
 
     void ContainerWindow::onBackgroundSelected()

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -121,6 +121,24 @@ namespace MWGui
             }
         }
 
+        // reverse pickpocketing
+        if (dynamic_cast<PickpocketItemModel*>(mModel)
+                && !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown())
+        {
+            MWWorld::Ptr player = MWMechanics::getPlayer();
+            MWMechanics::Pickpocket pickpocket(player, mPtr);
+            if (pickpocket.pick(mDragAndDrop->mItem.mBase, mDragAndDrop->mDraggedCount))
+            {
+                MWBase::Environment::get().getMechanicsManager()->commitCrime(
+                            player, mPtr, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
+                MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
+                mPickpocketDetected = true;
+                return;
+            }
+            else
+                player.getClass().skillUsageSucceeded(player, ESM::Skill::Sneak, 1);
+        }
+
         mDragAndDrop->drop(mModel, mItemView);
     }
 

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -8,13 +8,13 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
-#include "../mwmechanics/actorutil.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
 
 #include "../mwmechanics/pickpocket.hpp"
 #include "../mwmechanics/creaturestats.hpp"
+#include "../mwmechanics/actorutil.hpp"
 
 #include "countdialog.hpp"
 #include "inventorywindow.hpp"
@@ -159,10 +159,9 @@ namespace MWGui
         {
             if (mPtr.getClass().isNpc() && !loot)
             {
-                // we are stealing stuff
-                MWWorld::Ptr player = MWMechanics::getPlayer();
-                mModel = new PickpocketItemModel(player, new InventoryItemModel(container),
-                                                 !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown());
+            // we are stealing stuff
+            mModel = new PickpocketItemModel(mPtr, new InventoryItemModel(container),
+                                             !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown());
             }
             else
                 mModel = new InventoryItemModel(container);
@@ -289,32 +288,8 @@ namespace MWGui
 
     bool ContainerWindow::onTakeItem(const ItemStack &item, int count)
     {
-        MWWorld::Ptr player = MWMechanics::getPlayer();
-        // TODO: move to ItemModels
-        if (dynamic_cast<PickpocketItemModel*>(mModel)
-                && !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown())
-        {
-            MWMechanics::Pickpocket pickpocket(player, mPtr);
-            if (pickpocket.pick(item.mBase, count))
-            {
-                MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                            player, mPtr, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
-                MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
-                mPickpocketDetected = true;
-                return false;
-            }
-            else
-                player.getClass().skillUsageSucceeded(player, ESM::Skill::Sneak, 1);
-        }
-        else
-        {
-            // Looting a dead corpse is considered OK
-            if (mPtr.getClass().isActor() && mPtr.getClass().getCreatureStats(mPtr).isDead())
-                return true;
-            else
-                MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item.mBase, mPtr, count);
-        }
-        return true;
+        // TODO: mPickpocketDetected = true;
+        return mModel->onTakeItem(item.mBase, count);
     }
 
 }

--- a/apps/openmw/mwgui/container.hpp
+++ b/apps/openmw/mwgui/container.hpp
@@ -44,8 +44,6 @@ namespace MWGui
     private:
         DragAndDrop* mDragAndDrop;
 
-        bool mPickpocketDetected;
-
         MWGui::ItemView* mItemView;
         SortFilterItemModel* mSortModel;
         ItemModel* mModel;

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -2,12 +2,15 @@
 
 #include <algorithm>
 
+#include "../mwmechanics/creaturestats.hpp"
+#include "../mwmechanics/actorutil.hpp"
+
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
 
@@ -181,6 +184,23 @@ void ContainerItemModel::update()
             mItems.push_back(newItem);
         }
     }
+}
+
+bool ContainerItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+{
+    if (mItemSources.empty())
+        return false;
+
+    MWWorld::Ptr target = mItemSources[0];
+
+    // Looting a dead corpse is considered OK
+    if (target.getClass().isActor() && target.getClass().getCreatureStats(target).isDead())
+        return true;
+    
+    MWWorld::Ptr player = MWMechanics::getPlayer();
+    MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, target, count);
+
+    return true;
 }
 
 }

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -186,7 +186,7 @@ void ContainerItemModel::update()
         }
     }
 }
-bool ContainerItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+bool ContainerItemModel::onDropItem(const MWWorld::Ptr &item, int count)
 {
     if (mItemSources.empty())
         return false;
@@ -216,7 +216,7 @@ bool ContainerItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
     return true;
 }
 
-bool ContainerItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+bool ContainerItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
 {
     if (mItemSources.empty())
         return false;

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -19,8 +19,8 @@ namespace MWGui
 
         virtual bool allowedToUseItems() const;
 
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         virtual ItemStack getItem (ModelIndex index);
         virtual ModelIndex getIndex (ItemStack item);

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -26,6 +26,7 @@ namespace MWGui
         virtual void removeItem (const ItemStack& item, size_t count);
 
         virtual void update();
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         std::vector<MWWorld::Ptr> mItemSources;

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -18,6 +18,10 @@ namespace MWGui
         ContainerItemModel (const MWWorld::Ptr& source);
 
         virtual bool allowedToUseItems() const;
+
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
         virtual ItemStack getItem (ModelIndex index);
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
@@ -26,7 +30,6 @@ namespace MWGui
         virtual void removeItem (const ItemStack& item, size_t count);
 
         virtual void update();
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         std::vector<MWWorld::Ptr> mItemSources;

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -119,7 +119,7 @@ void InventoryItemModel::update()
     }
 }
 
-bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
 {
     // Looting a dead corpse is considered OK
     if (mActor.getClass().isActor() && mActor.getClass().getCreatureStats(mActor).isDead())

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -9,6 +9,9 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
 
+#include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+
 namespace MWGui
 {
 
@@ -114,6 +117,18 @@ void InventoryItemModel::update()
 
         mItems.push_back(newItem);
     }
+}
+
+bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+{
+    // Looting a dead corpse is considered OK
+    if (mActor.getClass().isActor() && mActor.getClass().getCreatureStats(mActor).isDead())
+        return true;
+    
+    MWWorld::Ptr player = MWMechanics::getPlayer();
+    MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, mActor, count);
+
+    return true;
 }
 
 }

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -124,7 +124,7 @@ bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     // Looting a dead corpse is considered OK
     if (mActor.getClass().isActor() && mActor.getClass().getCreatureStats(mActor).isDead())
         return true;
-    
+
     MWWorld::Ptr player = MWMechanics::getPlayer();
     MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, mActor, count);
 

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -15,6 +15,8 @@ namespace MWGui
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
 
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
 
@@ -22,7 +24,6 @@ namespace MWGui
         virtual MWWorld::Ptr moveItem (const ItemStack& item, size_t count, ItemModel* otherModel);
 
         virtual void update();
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     protected:
         MWWorld::Ptr mActor;

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -22,6 +22,7 @@ namespace MWGui
         virtual MWWorld::Ptr moveItem (const ItemStack& item, size_t count, ItemModel* otherModel);
 
         virtual void update();
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     protected:
         MWWorld::Ptr mActor;

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -15,7 +15,7 @@ namespace MWGui
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
 
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -129,7 +129,12 @@ namespace MWGui
         return true;
     }
 
-    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    {
+        return true;
+    }
+
+    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
         return true;
     }
@@ -203,7 +208,12 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
-    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    bool ProxyItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    {
+        return mSourceModel->onDropItem (item, count);
+    }
+
+    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
         return mSourceModel->onTakeItem (item, count);
     }

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -129,12 +129,12 @@ namespace MWGui
         return true;
     }
 
-    bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
         return true;
     }
 
-    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
     {
         return true;
     }
@@ -208,13 +208,18 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
-    bool ProxyItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    void ProxyItemModel::onClose()
     {
-        return mSourceModel->onDropItem (item, count);
+        mSourceModel->onClose();
     }
 
-    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool ProxyItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
-        return mSourceModel->onTakeItem (item, count);
+        return mSourceModel->onDropItem(item, count);
+    }
+
+    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem(item, count);
     }
 }

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -129,6 +129,11 @@ namespace MWGui
         return true;
     }
 
+    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return true;
+    }
+
 
     ProxyItemModel::ProxyItemModel()
         : mSourceModel(NULL)
@@ -198,4 +203,8 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
+    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem (item, count);
+    }
 }

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -9,6 +9,7 @@
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 
 namespace MWGui
 {
@@ -23,38 +24,7 @@ namespace MWGui
         if (base.getClass().getEnchantment(base) != "")
             mFlags |= Flag_Enchanted;
 
-        static std::set<std::string> boundItemIDCache;
-
-        // If this is empty then we haven't executed the GMST cache logic yet; or there isn't any sMagicBound* GMST's for some reason
-        if (boundItemIDCache.empty())
-        {
-            // Build a list of known bound item ID's
-            const MWWorld::Store<ESM::GameSetting> &gameSettings = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
-
-            for (MWWorld::Store<ESM::GameSetting>::iterator currentIteration = gameSettings.begin(); currentIteration != gameSettings.end(); ++currentIteration)
-            {
-                const ESM::GameSetting &currentSetting = *currentIteration;
-                std::string currentGMSTID = currentSetting.mId;
-                Misc::StringUtils::lowerCaseInPlace(currentGMSTID);
-
-                // Don't bother checking this GMST if it's not a sMagicBound* one.
-                const std::string& toFind = "smagicbound";
-                if (currentGMSTID.compare(0, toFind.length(), toFind) != 0)
-                    continue;
-
-                // All sMagicBound* GMST's should be of type string
-                std::string currentGMSTValue = currentSetting.getString();
-                Misc::StringUtils::lowerCaseInPlace(currentGMSTValue);
-
-                boundItemIDCache.insert(currentGMSTValue);
-            }
-        }
-
-        // Perform bound item check and assign the Flag_Bound bit if it passes
-        std::string tempItemID = base.getCellRef().getRefId();
-        Misc::StringUtils::lowerCaseInPlace(tempItemID);
-
-        if (boundItemIDCache.count(tempItemID) != 0)
+        if (MWBase::Environment::get().getMechanicsManager()->isBoundItem(base))
             mFlags |= Flag_Bound;
     }
 

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -75,7 +75,8 @@ namespace MWGui
 
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     private:
         ItemModel(const ItemModel&);
@@ -92,10 +93,12 @@ namespace MWGui
 
         bool allowedToUseItems() const;
 
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual ModelIndex getIndex (ItemStack item);
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         /// @note Takes ownership of the passed pointer.
         void setSourceModel(ItemModel* sourceModel);

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -75,6 +75,7 @@ namespace MWGui
 
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         ItemModel(const ItemModel&);
@@ -94,6 +95,7 @@ namespace MWGui
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual ModelIndex getIndex (ItemStack item);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         /// @note Takes ownership of the passed pointer.
         void setSourceModel(ItemModel* sourceModel);

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -75,8 +75,11 @@ namespace MWGui
 
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual void onClose()
+        {
+        }
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         ItemModel(const ItemModel&);
@@ -93,8 +96,9 @@ namespace MWGui
 
         bool allowedToUseItems() const;
 
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual void onClose();
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -17,7 +17,7 @@ namespace MWGui
 {
 
     PickpocketItemModel::PickpocketItemModel(const MWWorld::Ptr& actor, ItemModel *sourceModel, bool hideItems)
-        : mActor(actor)
+        : mActor(actor), mPickpocketDetected(false)
     {
         MWWorld::Ptr player = MWMechanics::getPlayer();
         mSourceModel = sourceModel;
@@ -84,33 +84,44 @@ namespace MWGui
         return true;
     }
 
-    bool PickpocketItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    void PickpocketItemModel::onClose()
+    {
+        // Make sure we were actually closed, rather than just temporarily hidden (e.g. console or main menu opened)
+        if (MWBase::Environment::get().getWindowManager()->containsMode(GM_Container)
+        // If it was already detected while taking an item, no need to check now
+                || mPickpocketDetected)
+            return;
+
+        MWWorld::Ptr player = MWMechanics::getPlayer();
+        MWMechanics::Pickpocket pickpocket(player, mActor);
+        if (pickpocket.finish())
+        {
+            MWBase::Environment::get().getMechanicsManager()->commitCrime(
+                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
+            MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
+            mPickpocketDetected = true;
+        }
+    }
+
+    bool PickpocketItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
         if (mActor.getClass().getCreatureStats(mActor).getKnockedDown())
             return true;
 
         // reverse pickpocketing
-        MWWorld::Ptr player = MWMechanics::getPlayer();
-        MWMechanics::Pickpocket pickpocket(player, mActor);
-        if (pickpocket.pick(item, count))
-        {
-            MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
-            MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
-            //mPickpocketDetected = true;
-            return false;
-        }
-        else
-            player.getClass().skillUsageSucceeded(player, ESM::Skill::Sneak, 1);
-
-        return true;
+        return stealItem(item, count);
     }
 
-    bool PickpocketItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool PickpocketItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
     {
         if (mActor.getClass().getCreatureStats(mActor).getKnockedDown())
             return mSourceModel->onTakeItem(item, count);
 
+        return stealItem(item, count);
+    }
+
+    bool PickpocketItemModel::stealItem(const MWWorld::Ptr &item, int count)
+    {
         MWWorld::Ptr player = MWMechanics::getPlayer();
         MWMechanics::Pickpocket pickpocket(player, mActor);
         if (pickpocket.pick(item, count))
@@ -118,6 +129,7 @@ namespace MWGui
             MWBase::Environment::get().getMechanicsManager()->commitCrime(
                         player, mActor, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
             MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
+            mPickpocketDetected = true;
             return false;
         }
         else

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -2,6 +2,7 @@
 
 #include <components/misc/rng.hpp>
 #include <components/esm/loadskil.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwmechanics/actorutil.hpp"
 #include "../mwmechanics/creaturestats.hpp"
@@ -34,6 +35,8 @@ namespace MWGui
                     mHiddenItems.push_back(mSourceModel->getItem(i));
             }
         }
+
+        mAdvanced = Settings::Manager::getBool("advanced pickpocketing", "Game");
     }
 
     bool PickpocketItemModel::allowedToUseItems() const
@@ -93,7 +96,7 @@ namespace MWGui
             return;
 
         MWWorld::Ptr player = MWMechanics::getPlayer();
-        MWMechanics::Pickpocket pickpocket(player, mActor);
+        MWMechanics::Pickpocket pickpocket(player, mActor, mAdvanced);
         if (pickpocket.finish())
         {
             MWBase::Environment::get().getMechanicsManager()->commitCrime(
@@ -105,6 +108,9 @@ namespace MWGui
 
     bool PickpocketItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
+        if (!mAdvanced)
+            return false;
+
         // check that we don't exceed inventory encumberance
         float weight = item.getClass().getWeight(item) * count;
         if (mActor.getClass().getCapacity(mActor) < mActor.getClass().getEncumbrance(mActor) + weight)
@@ -131,7 +137,7 @@ namespace MWGui
     bool PickpocketItemModel::stealItem(const MWWorld::Ptr &item, int count)
     {
         MWWorld::Ptr player = MWMechanics::getPlayer();
-        MWMechanics::Pickpocket pickpocket(player, mActor);
+        MWMechanics::Pickpocket pickpocket(player, mActor, mAdvanced);
         if (pickpocket.pick(item, count))
         {
             MWBase::Environment::get().getMechanicsManager()->commitCrime(

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -71,8 +71,7 @@ namespace MWGui
 
     bool PickpocketItemModel::allowedToInsertItems() const
     {
-        // don't allow "reverse pickpocket" (yet)
-        return false;
+        return true;
     }
 
 }

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -126,6 +126,13 @@ namespace MWGui
             return false;
         }
 
+        // a player can not get rid of bound item
+        if (MWBase::Environment::get().getMechanicsManager()->isBoundItem(item))
+        {
+            MWBase::Environment::get().getWindowManager()->messageBox("#{sBarterDialog12}");
+            return false;
+        }
+
         if (mActor.getClass().getCreatureStats(mActor).getKnockedDown())
             return true;
 

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -3,15 +3,24 @@
 #include <components/misc/rng.hpp>
 #include <components/esm/loadskil.hpp>
 
+#include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/pickpocket.hpp"
+
 #include "../mwworld/class.hpp"
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/windowmanager.hpp"
 
 namespace MWGui
 {
 
-    PickpocketItemModel::PickpocketItemModel(const MWWorld::Ptr& thief, ItemModel *sourceModel, bool hideItems)
+    PickpocketItemModel::PickpocketItemModel(const MWWorld::Ptr& actor, ItemModel *sourceModel, bool hideItems)
+        : mActor(actor)
     {
+        MWWorld::Ptr player = MWMechanics::getPlayer();
         mSourceModel = sourceModel;
-        int chance = thief.getClass().getSkill(thief, ESM::Skill::Sneak);
+        int chance = player.getClass().getSkill(player, ESM::Skill::Sneak);
 
         mSourceModel->update();
 
@@ -74,4 +83,20 @@ namespace MWGui
         return true;
     }
 
+    bool PickpocketItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    {
+        MWWorld::Ptr player = MWMechanics::getPlayer();
+        MWMechanics::Pickpocket pickpocket(player, mActor);
+        if (pickpocket.pick(item, count))
+        {
+            MWBase::Environment::get().getMechanicsManager()->commitCrime(
+                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
+            MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
+            return false;
+        }
+        else
+            player.getClass().skillUsageSucceeded(player, ESM::Skill::Sneak, 1);
+
+        return true;
+    }
 }

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -105,6 +105,14 @@ namespace MWGui
 
     bool PickpocketItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
+        // check that we don't exceed inventory encumberance
+        float weight = item.getClass().getWeight(item) * count;
+        if (mActor.getClass().getCapacity(mActor) < mActor.getClass().getEncumbrance(mActor) + weight)
+        {
+            MWBase::Environment::get().getWindowManager()->messageBox("#{sContentsMessage3}");
+            return false;
+        }
+
         if (mActor.getClass().getCreatureStats(mActor).getKnockedDown())
             return true;
 

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -18,6 +18,7 @@ namespace MWGui
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
         virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     protected:

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -18,11 +18,14 @@ namespace MWGui
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual void onClose();
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     protected:
         MWWorld::Ptr mActor;
+        bool mPickpocketDetected;
+        bool stealItem(const MWWorld::Ptr &item, int count);
 
     private:
         std::vector<ItemStack> mHiddenItems;

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -18,6 +18,10 @@ namespace MWGui
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
+    protected:
+        MWWorld::Ptr mActor;
 
     private:
         std::vector<ItemStack> mHiddenItems;

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -24,6 +24,7 @@ namespace MWGui
 
     protected:
         MWWorld::Ptr mActor;
+        bool mAdvanced;
         bool mPickpocketDetected;
         bool stealItem(const MWWorld::Ptr &item, int count);
 

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -15,6 +15,7 @@ namespace MWGui
         virtual bool allowedToUseItems() const;
         virtual ItemStack getItem (ModelIndex index);
         virtual size_t getItemCount();
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=true);
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -311,4 +311,8 @@ namespace MWGui
         std::sort(mItems.begin(), mItems.end(), cmp);
     }
 
+    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem (item, count);
+    }
 }

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -311,7 +311,12 @@ namespace MWGui
         std::sort(mItems.begin(), mItems.end(), cmp);
     }
 
-    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    bool SortFilterItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    {
+        return mSourceModel->onDropItem (item, count);
+    }
+
+    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
         return mSourceModel->onTakeItem (item, count);
     }

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -311,13 +311,18 @@ namespace MWGui
         std::sort(mItems.begin(), mItems.end(), cmp);
     }
 
-    bool SortFilterItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    void SortFilterItemModel::onClose()
     {
-        return mSourceModel->onDropItem (item, count);
+        mSourceModel->onClose();
     }
 
-    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool SortFilterItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
-        return mSourceModel->onTakeItem (item, count);
+        return mSourceModel->onDropItem(item, count);
+    }
+
+    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem(item, count);
     }
 }

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -29,6 +29,8 @@ namespace MWGui
         /// Use ItemStack::Type for sorting?
         void setSortByType(bool sort) { mSortByType = sort; }
 
+        bool onTakeItem(const MWWorld::Ptr &item, int count);
+
         static const int Category_Weapon = (1<<1);
         static const int Category_Apparel = (1<<2);
         static const int Category_Misc = (1<<3);

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -29,7 +29,8 @@ namespace MWGui
         /// Use ItemStack::Type for sorting?
         void setSortByType(bool sort) { mSortByType = sort; }
 
-        bool onTakeItem(const MWWorld::Ptr &item, int count);
+        bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
         static const int Category_Weapon = (1<<1);
         static const int Category_Apparel = (1<<2);

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -29,8 +29,9 @@ namespace MWGui
         /// Use ItemStack::Type for sorting?
         void setSortByType(bool sort) { mSortByType = sort; }
 
-        bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        void onClose();
+        bool onDropItem(const MWWorld::Ptr &item, int count);
+        bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         static const int Category_Weapon = (1<<1);
         static const int Category_Apparel = (1<<2);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -993,6 +993,33 @@ namespace MWMechanics
         commitCrime(player, victim, OT_Theft, item.getClass().getValue(item) * toRemove);
     }
 
+    void MechanicsManager::modifyStolenItemsCount(const MWWorld::Ptr &item, int count, const MWWorld::Ptr& victim)
+    {
+        const std::string itemId = Misc::StringUtils::lowerCase(item.getCellRef().getRefId());
+
+        if (Misc::StringUtils::ciEqual(itemId, MWWorld::ContainerStore::sGoldId))
+            return;
+
+        Owner owner;
+        owner.first = victim.getCellRef().getRefId();
+        owner.second = false;
+
+        Misc::StringUtils::lowerCaseInPlace(owner.first);
+
+        mStolenItems[itemId][owner] += count;
+        if (mStolenItems[itemId][owner] <= 0)
+        {
+            // erase owner from stolen items owners
+            StolenItemsMap::iterator it = mStolenItems.find(itemId);
+            if (it == mStolenItems.end())
+                return;
+            OwnerMap& owners = it->second;
+            OwnerMap::iterator ownersIt = owners.find(owner);
+            if (ownersIt != owners.end())
+                owners.erase(ownersIt);
+        }
+    }
+
     void MechanicsManager::confiscateStolenItems(const MWWorld::Ptr &player, const MWWorld::Ptr &targetContainer)
     {
         MWWorld::ContainerStore& store = player.getClass().getContainerStore(player);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -204,6 +204,8 @@ namespace MWMechanics
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid);
 
+            virtual bool isBoundItem(const MWWorld::Ptr& item);
+
             /// @return is \a ptr allowed to take/use \a target or is it a crime?
             virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -213,6 +213,7 @@ namespace MWMechanics
             virtual void cleanupSummonedCreature(const MWWorld::Ptr& caster, int creatureActorId);
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count);
+            virtual void modifyStolenItemsCount(const MWWorld::Ptr &item, int count, const MWWorld::Ptr& victim);
 
             virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr);
             virtual bool isRunning(const MWWorld::Ptr& ptr);

--- a/apps/openmw/mwmechanics/pickpocket.cpp
+++ b/apps/openmw/mwmechanics/pickpocket.cpp
@@ -13,9 +13,10 @@
 namespace MWMechanics
 {
 
-    Pickpocket::Pickpocket(const MWWorld::Ptr &thief, const MWWorld::Ptr &victim)
+    Pickpocket::Pickpocket(const MWWorld::Ptr &thief, const MWWorld::Ptr &victim, bool isAdvanced)
         : mThief(thief)
         , mVictim(victim)
+        , mAdvanced(isAdvanced)
     {
     }
 
@@ -55,7 +56,11 @@ namespace MWMechanics
 
     bool Pickpocket::pick(MWWorld::Ptr item, int count)
     {
-        float stackValue = static_cast<float>(item.getClass().getValue(item) * count);
+        float stackValue = 0.f;
+        if (mAdvanced)
+            stackValue = static_cast<float>(item.getClass().getWeight(item) * count * 3);
+        else
+            stackValue = static_cast<float>(item.getClass().getValue(item) * count);
         float fPickPocketMod = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
                 .find("fPickPocketMod")->getFloat();
         float valueTerm = 10 * fPickPocketMod * stackValue;

--- a/apps/openmw/mwmechanics/pickpocket.hpp
+++ b/apps/openmw/mwmechanics/pickpocket.hpp
@@ -9,7 +9,7 @@ namespace MWMechanics
     class Pickpocket
     {
     public:
-        Pickpocket (const MWWorld::Ptr& thief, const MWWorld::Ptr& victim);
+        Pickpocket (const MWWorld::Ptr& thief, const MWWorld::Ptr& victim, bool isAdvanced = false);
 
         /// Steal some items
         /// @return Was the thief detected?
@@ -23,6 +23,7 @@ namespace MWMechanics
         float getChanceModifier(const MWWorld::Ptr& ptr, float add=0);
         MWWorld::Ptr mThief;
         MWWorld::Ptr mVictim;
+        bool mAdvanced;
     };
 
 }

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -51,6 +51,18 @@ Whether or not the chance of success will be displayed in the enchanting menu.
 
 The default value is false. This setting can only be configured by editing the settings configuration file.
 
+advanced pickpocketing
+----------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, the engine will use the the weight of an item instead of the value to calculate the chance of successful pickpocketing.
+Also the "reverse pickpocketing" will be allowed in this case.
+
+The default value is false. This setting can only be configured by editing the settings configuration file.
+
 best attack
 -----------
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -151,6 +151,9 @@ crosshair = true
 
 [Game]
 
+# Enable advanced pickpocketing mechanics
+advanced pickpocketing = false
+
 # Color crosshair and tool tip when object is owned by an NPC. (O is
 # no color, 1 is tool tip only, 2 is crosshair only, and 3 is both).
 show owned = 0


### PR DESCRIPTION
This PR is aimed to implement [feature #1336](https://bugs.openmw.org/issues/1336).

I have a lot of questions:
1. Can this feature be implemented before 1.0?
2. Should a victim use autoequipping if a player places clothing/armor to the victim's inventory?
3. Can we merge this feature with pickpocketing mechanics fix and use it as "advanced pickpocketing" config option?
4. Should we decrement a count of stolen items, if a player previously stole "reversed" item from the same victim?
5. Should the player be able to "overburden" victim by reverse pickpocketing?

A relevant forum discussion is [here](https://forum.openmw.org/viewtopic.php?f=6&t=4477).