### PR TITLE
Regression fixes

### DIFF
--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -191,8 +191,7 @@ namespace MWGui
                 else if (type == "ItemPtr")
                 {
                     mFocusObject = *focus->getUserData<MWWorld::Ptr>();
-                    bool isAllowedToUse = checkOwned();
-                    tooltipSize = getToolTipViaPtr(mFocusObject.getRefData().getCount(), false, !isAllowedToUse);
+                    tooltipSize = getToolTipViaPtr(mFocusObject.getRefData().getCount(), false, checkOwned());
                 }
                 else if (type == "ItemModelIndex")
                 {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -70,11 +70,7 @@ void adjustBoundItem (const std::string& item, bool bound, const MWWorld::Ptr& a
         }
     }
     else
-    {
-        MWWorld::Ptr itemPtr = actor.getClass().getInventoryStore(actor).search(item);
-        if (!itemPtr.isEmpty())
-            actor.getClass().getInventoryStore(actor).remove(itemPtr, 1, actor, true);
-    }
+        actor.getClass().getInventoryStore(actor).remove(item, 1, actor, true);
 }
 
 class CheckActorCommanded : public MWMechanics::EffectSourceVisitor

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -654,9 +654,28 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::getSelectedEnchantItem(
     return mSelectedEnchantItem;
 }
 
+int MWWorld::InventoryStore::remove(const std::string& itemId, int count, const Ptr& actor)
+{
+    return remove(itemId, count, actor, false);
+}
+
 int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor)
 {
     return remove(item, count, actor, false);
+}
+
+int MWWorld::InventoryStore::remove(const std::string& itemId, int count, const Ptr& actor, bool equipReplacement)
+{
+    int toRemove = count;
+
+    for (ContainerStoreIterator iter(begin()); iter != end() && toRemove > 0; ++iter)
+        if (Misc::StringUtils::ciEqual(iter->getCellRef().getRefId(), itemId))
+            toRemove -= remove(*iter, toRemove, actor, equipReplacement);
+
+    flagAsModified();
+
+    // number of removed items
+    return count - toRemove;
 }
 
 int MWWorld::InventoryStore::remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement)

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -177,6 +177,9 @@ namespace MWWorld
             virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2) const;
             ///< @return true if the two specified objects can stack with each other
 
+            virtual int remove(const std::string& itemId, int count, const Ptr& actor);
+            virtual int remove(const std::string& itemId, int count, const Ptr& actor, bool equipReplacement);
+
             virtual int remove(const Ptr& item, int count, const Ptr& actor);
             virtual int remove(const Ptr& item, int count, const Ptr& actor, bool equipReplacement);
             ///< Remove \a count item(s) designated by \a item from this inventory.


### PR DESCRIPTION
1. Fixes [bug #4146](https://bugs.openmw.org/issues/4146).
2. An engine displays magic items in the player's spellwindow as owned. Fixed.