### PR TITLE
[Editor] Fix region colors

### DIFF
--- a/apps/opencs/model/world/columnimp.hpp
+++ b/apps/opencs/model/world/columnimp.hpp
@@ -692,32 +692,23 @@ namespace CSMWorld
         }
     };
 
-    /// \todo QColor is a GUI class and should not be in model. Need to think of an alternative
-    /// solution.
     template<typename ESXRecordT>
     struct MapColourColumn : public Column<ESXRecordT>
     {
-        /// \todo Replace Display_Integer with something that displays the colour value more directly.
         MapColourColumn()
         : Column<ESXRecordT> (Columns::ColumnId_MapColour, ColumnBase::Display_Colour)
         {}
 
         virtual QVariant get (const Record<ESXRecordT>& record) const
         {
-            int colour = record.get().mMapColor;
-
-            return QColor (colour & 0xff, (colour>>8) & 0xff, (colour>>16) & 0xff);
+            return record.get().mMapColor;
         }
 
         virtual void set (Record<ESXRecordT>& record, const QVariant& data)
         {
-            ESXRecordT record2 = record.get();
-
-            QColor colour = data.value<QColor>();
-
-            record2.mMapColor = (colour.blue() << 16) | (colour.green() << 8) | colour.red();
-
-            record.setModified (record2);
+            ESXRecordT copy = record.get();
+            copy.mMapColor = data.toInt();
+            record.setModified (copy);
         }
 
         virtual bool isEditable() const

--- a/apps/opencs/view/world/colordelegate.cpp
+++ b/apps/opencs/view/world/colordelegate.cpp
@@ -5,29 +5,32 @@
 
 #include "../widget/coloreditor.hpp"
 
-CSVWorld::ColorDelegate::ColorDelegate(CSMWorld::CommandDispatcher *dispatcher, 
-                                       CSMDoc::Document& document, 
+CSVWorld::ColorDelegate::ColorDelegate(CSMWorld::CommandDispatcher *dispatcher,
+                                       CSMDoc::Document& document,
                                        QObject *parent)
     : CommandDelegate(dispatcher, document, parent)
 {}
 
-void CSVWorld::ColorDelegate::paint(QPainter *painter, 
+void CSVWorld::ColorDelegate::paint(QPainter *painter,
                                     const QStyleOptionViewItem &option,
                                     const QModelIndex &index) const
 {
+    int colorInt = index.data().toInt();
+    QColor color(colorInt & 0xff, (colorInt >> 8) & 0xff, (colorInt >> 16) & 0xff);
+
     QRect coloredRect(option.rect.x() + qRound(option.rect.width() / 4.0),
                       option.rect.y() + qRound(option.rect.height() / 4.0),
                       option.rect.width() / 2,
                       option.rect.height() / 2);
     painter->save();
-    painter->fillRect(coloredRect, index.data().value<QColor>());
+    painter->fillRect(coloredRect, color);
     painter->setPen(Qt::black);
     painter->drawRect(coloredRect);
     painter->restore();
 }
 
-CSVWorld::CommandDelegate *CSVWorld::ColorDelegateFactory::makeDelegate(CSMWorld::CommandDispatcher *dispatcher, 
-                                                                        CSMDoc::Document &document, 
+CSVWorld::CommandDelegate *CSVWorld::ColorDelegateFactory::makeDelegate(CSMWorld::CommandDispatcher *dispatcher,
+                                                                        CSMDoc::Document &document,
                                                                         QObject *parent) const
 {
     return new ColorDelegate(dispatcher, document, parent);


### PR DESCRIPTION
This fixes the regression reported in [Bug#4119](https://bugs.openmw.org/issues/4119). I have tested the following:
1. Setting region colors in both the regular table and nested table views
2. Setting the the map color in the Cell nested table, even though it seems to be an unused field. 
3. Setting colors in Preferences->Scripts

Is there anywhere else that uses colors and could be affected?