### PR TITLE
Add showsInInventory() check to the ContainerItemModel

### DIFF
--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -142,6 +142,9 @@ void ContainerItemModel::update()
 
         for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
         {
+            if (!(*it).getClass().showsInInventory(*it))
+                continue;
+
             std::vector<ItemStack>::iterator itemStack = mItems.begin();
             for (; itemStack != mItems.end(); ++itemStack)
             {


### PR DESCRIPTION
For some reason ContainerItemModel do not have this check.

For example, you can add Light item without CanCarry flag, and this light will be shown in the items list.