### PR TITLE
Bugfix #4155: NPCs don't equip a second ring in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Makefile
 makefile
 build*
 prebuilt
+cmake-build-debug/
 
 ##windows build process
 /deps

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ Makefile
 makefile
 build*
 prebuilt
-cmake-build-debug/
 
 ##windows build process
 /deps
@@ -27,6 +26,7 @@ Doxygen
 .settings
 .directory
 .idea
+cmake-build-*
 files/windows/*.aps
 ## qt-creator
 CMakeLists.txt.user*

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -265,8 +265,6 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
 
     // Autoequip clothing, armor and weapons.
     // Equipping lights is handled in Actors::updateEquippedLight based on environment light.
-
-    // the main loop iterating through all items in inventory
     for (ContainerStoreIterator iter (begin(ContainerStore::Type_Clothing | ContainerStore::Type_Armor)); iter!=end(); ++iter)
     {
         Ptr test = *iter;
@@ -291,8 +289,7 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
         std::pair<std::vector<int>, bool> itemsSlots =
             iter->getClass().getEquipmentSlots (*iter);
 
-        // nested loop for iterating through avialable NPC slots for equipped items
-        // and checking if current item poited by iter can be placed there
+        // checking if current item poited by iter can be equipped
         for (std::vector<int>::const_iterator iter2 (itemsSlots.first.begin());
             iter2!=itemsSlots.first.end(); ++iter2)
         {
@@ -323,7 +320,7 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                     // if left ring is equipped
                     if (*iter2 == Slot_LeftRing)
                     {
-                        // if there is a place for right ring dont swap left leaving right hand empty
+                        // if there is a place for right ring dont swap it
                         if (slots_.at(Slot_RightRing) == end())
                         {
                             continue;

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -266,6 +266,7 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
     // Autoequip clothing, armor and weapons.
     // Equipping lights is handled in Actors::updateEquippedLight based on environment light.
 
+    // the main loop iterating through all items in inventory
     for (ContainerStoreIterator iter (begin(ContainerStore::Type_Clothing | ContainerStore::Type_Armor)); iter!=end(); ++iter)
     {
         Ptr test = *iter;
@@ -290,9 +291,13 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
         std::pair<std::vector<int>, bool> itemsSlots =
             iter->getClass().getEquipmentSlots (*iter);
 
+        // nested loop for iterating through avialable NPC slots for equipped items
+        // and checking if current item poited by iter can be placed there
         for (std::vector<int>::const_iterator iter2 (itemsSlots.first.begin());
             iter2!=itemsSlots.first.end(); ++iter2)
         {
+            // if true then it means slot is equipped already
+            // check if slot may require swapping if current item is more valueable
             if (slots_.at (*iter2)!=end())
             {
                 Ptr old = *slots_.at (*iter2);
@@ -315,8 +320,10 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                 }
                 else if (iter.getType() == ContainerStore::Type_Clothing)
                 {
+                    // if left ring is equipped
                     if (*iter2 == MWWorld::InventoryStore::Slot_LeftRing)
                     {
+                        // if there is a place for right ring dont swap left leaving right hand empty
                         if (slots_.at(MWWorld::InventoryStore::Slot_RightRing) == end())
                         {
                             continue;
@@ -345,6 +352,7 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                 }
             }
 
+            // if we are here it means item can be equipped or swapped
             slots_[*iter2] = iter;
             break;
         }

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -321,12 +321,22 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                 else if (iter.getType() == ContainerStore::Type_Clothing)
                 {
                     // if left ring is equipped
-                    if (*iter2 == MWWorld::InventoryStore::Slot_LeftRing)
+                    if (*iter2 == Slot_LeftRing)
                     {
                         // if there is a place for right ring dont swap left leaving right hand empty
-                        if (slots_.at(MWWorld::InventoryStore::Slot_RightRing) == end())
+                        if (slots_.at(Slot_RightRing) == end())
                         {
                             continue;
+                        }
+                        else // if right ring is equipped too
+                        {
+                            Ptr rightRing = *slots_.at(Slot_RightRing);
+
+                            // we want to swap cheaper ring only if both are equipped
+                            if (rightRing.getClass().getValue(rightRing) < old.getClass().getValue(old))
+                            {
+                                continue;
+                            }
                         }
                     }
 

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -315,6 +315,14 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                 }
                 else if (iter.getType() == ContainerStore::Type_Clothing)
                 {
+                    if (*iter2 == MWWorld::InventoryStore::Slot_LeftRing)
+                    {
+                        if (slots_.at(MWWorld::InventoryStore::Slot_RightRing) == end())
+                        {
+                            continue;
+                        }
+                    }
+
                     if (old.getTypeName() == typeid(ESM::Clothing).name())
                     {
                         // check value


### PR DESCRIPTION
https://bugs.openmw.org/issues/4155
Now NPC will autoequip any second ring if he has a free hand. NPC will also autoequip most expensive rings if has more than two. 