### PR TITLE
Implement ExtraSpell magic effect

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -536,6 +536,13 @@ namespace MWMechanics
 
                         appliedLastingEffects.push_back(effect);
 
+                        // Unequip all items, if a spell with the ExtraSpell effect was casted
+                        if (effectIt->mEffectID == ESM::MagicEffect::ExtraSpell && target.getClass().hasInventoryStore(target))
+                        {
+                            MWWorld::InventoryStore& store = target.getClass().getInventoryStore(target);
+                            store.unequipAll(target);
+                        }
+
                         // Command spells should have their effect, including taking the target out of combat, each time the spell successfully affects the target
                         if (((effectIt->mEffectID == ESM::MagicEffect::CommandHumanoid && target.getClass().isNpc())
                         || (effectIt->mEffectID == ESM::MagicEffect::CommandCreature && target.getTypeName() == typeid(ESM::Creature).name()))

--- a/components/esm/loadmgef.cpp
+++ b/components/esm/loadmgef.cpp
@@ -380,6 +380,7 @@ static std::map<short,std::string> genNameMap()
     names[131] ="sEffectBoundGloves";
     names[128] ="sEffectBoundHelm";
     names[125] ="sEffectBoundLongbow";
+    names[126] ="sEffectExtraSpell";
     names[121] ="sEffectBoundLongsword";
     names[122] ="sEffectBoundMace";
     names[130] ="sEffectBoundShield";


### PR DESCRIPTION
Partially implements [feature #2906](https://bugs.openmw.org/issues/2906).
Some mods can use this effect.

Note: I do not know how to implement the autoequipping after spell expiration fo now.