### PR TITLE
Launcher and wizard ampersand escape support

### DIFF
--- a/components/config/gamesettings.cpp
+++ b/components/config/gamesettings.cpp
@@ -126,6 +126,7 @@ bool Config::GameSettings::readFile(QTextStream &stream, QMap<QString, QString> 
             else
             {
                 // 'data=...' line, so needs processing to deal with ampersands and quotes
+                // The following is based on boost::io::detail::quoted_manip.hpp, but calling those functions did not work as there are too may QStrings involved
                 QChar delim = '\"';
                 QChar escape = '&';
 

--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -75,8 +75,6 @@ void ConfigurationManager::processPaths(Files::PathContainer& dataDirs, bool cre
     for (Files::PathContainer::iterator it = dataDirs.begin(); it != dataDirs.end(); ++it)
     {
         path = it->string();
-        boost::erase_all(path, "\"");
-        *it = boost::filesystem::path(path);
 
         // Check if path contains a token
         if (!path.empty() && *path.begin() == '?')


### PR DESCRIPTION
Before this pull request:

* The launcher wouldn't display .es[pm] files in folders whose path contained an ampersand (and may or may not have deactivated them), even though they would load fine in OpenMW itself.
* The installation wizard would produce an invalid `openmw.cfg` file when selecting an install in a path containing an ampersand character, as discovered by this user: https://forum.openmw.org/viewtopic.php?f=8&t=4676

This PR handles the escaping of quotation marks and ampersands in `data=...` lines more in line with how `boost::program_options` does, meaning the launcher and wizard produce config files which the engine and editor can read correctly and can read these config files correctly themselves.

With this pull request:

* The launcher displays all content files which the engine and editor can actually see, and definitely won't erroneously deactivate any (although I didn't check if it was doing that in the first place anyway).
* The installation wizard produces a valid `openmw.cfg` file when processing an installation with an ampersand in the path.

I'm still salty about the decision to use two different systems to handle interaction with the configuration files, but at least they should have achieved parity now.

I submit this to the mercy of Travis and AppVeyor and hope my offering pleases them more than my last one.