### PR TITLE
Use SwimTurnLeft/Right animations correctly

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1874,7 +1874,7 @@ void CharacterController::update(float duration)
                                          : (sneak ? CharState_SneakBack
                                                   : (isrunning ? CharState_RunBack : CharState_WalkBack)));
             }
-            else if(rot.z() != 0.0f && !inwater && !sneak && !(mPtr == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson()))
+            else if(rot.z() != 0.0f && !sneak && !(mPtr == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson()))
             {
                 if(rot.z() > 0.0f)
                     movestate = inwater ? CharState_SwimTurnRight : CharState_TurnRight;


### PR DESCRIPTION
Fixes a bug in PR #1474. Due to wrong "if" statement, these animations were not used.
@scrawl, thanks for spotting that.

Note: If you turn with a very small speed, a player character will be twitchy (due to constant switching between idle and turning animations). Both OpenMW and vanilla Morrowind are affected by this bug. Can we do something with it? Or will we have to treat it as a bug in resource files?