### PR TITLE
Mark worldimp functions as override to stop distracting Travis CI war…

### DIFF
--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -137,7 +137,7 @@ namespace MWWorld
             MWWorld::Ptr getFacedObject(float maxDistance, bool ignorePlayer=true);
 
     public: // FIXME
-            void removeContainerScripts(const Ptr& reference);
+            void removeContainerScripts(const Ptr& reference) override;
     private:
             void addContainerScripts(const Ptr& reference, CellStore* cell);
             void PCDropped (const Ptr& item);
@@ -191,362 +191,362 @@ namespace MWWorld
 
             virtual ~World();
 
-            virtual void startNewGame (bool bypass);
+            virtual void startNewGame (bool bypass) override;
             ///< \param bypass Bypass regular game start.
 
-            virtual void clear();
+            virtual void clear() override;
 
-            virtual int countSavedGameRecords() const;
-            virtual int countSavedGameCells() const;
+            virtual int countSavedGameRecords() const override;
+            virtual int countSavedGameCells() const override;
 
-            virtual void write (ESM::ESMWriter& writer, Loading::Listener& progress) const;
+            virtual void write (ESM::ESMWriter& writer, Loading::Listener& progress) const override;
 
             virtual void readRecord (ESM::ESMReader& reader, uint32_t type,
-                const std::map<int, int>& contentFileMap);
+                const std::map<int, int>& contentFileMap) override;
 
-            virtual CellStore *getExterior (int x, int y);
+            virtual CellStore *getExterior (int x, int y) override;
 
-            virtual CellStore *getInterior (const std::string& name);
+            virtual CellStore *getInterior (const std::string& name) override;
 
-            virtual CellStore *getCell (const ESM::CellId& id);
+            virtual CellStore *getCell (const ESM::CellId& id) override;
 
             //switch to POV before showing player's death animation
-            virtual void useDeathCamera();
+            virtual void useDeathCamera() override;
 
-            virtual void setWaterHeight(const float height);
+            virtual void setWaterHeight(const float height) override;
 
-            virtual bool toggleWater();
-            virtual bool toggleWorld();
+            virtual bool toggleWater() override;
+            virtual bool toggleWorld() override;
 
-            virtual void adjustSky();
+            virtual void adjustSky() override;
 
-            virtual const Fallback::Map *getFallback() const;
+            virtual const Fallback::Map *getFallback() const override;
 
-            virtual Player& getPlayer();
-            virtual MWWorld::Ptr getPlayerPtr();
+            virtual Player& getPlayer() override;
+            virtual MWWorld::Ptr getPlayerPtr() override;
 
-            virtual const MWWorld::ESMStore& getStore() const;
+            virtual const MWWorld::ESMStore& getStore() const override;
 
             virtual std::vector<ESM::ESMReader>& getEsmReader();
 
-            virtual LocalScripts& getLocalScripts();
+            virtual LocalScripts& getLocalScripts() override;
 
-            virtual bool hasCellChanged() const;
+            virtual bool hasCellChanged() const override;
             ///< Has the set of active cells changed, since the last frame?
 
-            virtual bool isCellExterior() const;
+            virtual bool isCellExterior() const override;
 
-            virtual bool isCellQuasiExterior() const;
+            virtual bool isCellQuasiExterior() const override;
 
-            virtual osg::Vec2f getNorthVector (const CellStore* cell);
+            virtual osg::Vec2f getNorthVector (const CellStore* cell) override;
             ///< get north vector for given interior cell
 
-            virtual void getDoorMarkers (MWWorld::CellStore* cell, std::vector<DoorMarker>& out);
+            virtual void getDoorMarkers (MWWorld::CellStore* cell, std::vector<DoorMarker>& out) override;
             ///< get a list of teleport door markers for a given cell, to be displayed on the local map
 
-            virtual void setGlobalInt (const std::string& name, int value);
+            virtual void setGlobalInt (const std::string& name, int value) override;
             ///< Set value independently from real type.
 
-            virtual void setGlobalFloat (const std::string& name, float value);
+            virtual void setGlobalFloat (const std::string& name, float value) override;
             ///< Set value independently from real type.
 
-            virtual int getGlobalInt (const std::string& name) const;
+            virtual int getGlobalInt (const std::string& name) const override;
             ///< Get value independently from real type.
 
-            virtual float getGlobalFloat (const std::string& name) const;
+            virtual float getGlobalFloat (const std::string& name) const override;
             ///< Get value independently from real type.
 
-            virtual char getGlobalVariableType (const std::string& name) const;
+            virtual char getGlobalVariableType (const std::string& name) const override;
             ///< Return ' ', if there is no global variable with this name.
 
-            virtual std::string getCellName (const MWWorld::CellStore *cell = 0) const;
+            virtual std::string getCellName (const MWWorld::CellStore *cell = 0) const override;
             ///< Return name of the cell.
             ///
             /// \note If cell==0, the cell the player is currently in will be used instead to
             /// generate a name.
 
-            virtual void removeRefScript (MWWorld::RefData *ref);
+            virtual void removeRefScript (MWWorld::RefData *ref) override;
             //< Remove the script attached to ref from mLocalScripts
 
-            virtual Ptr getPtr (const std::string& name, bool activeOnly);
+            virtual Ptr getPtr (const std::string& name, bool activeOnly) override;
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            virtual Ptr searchPtr (const std::string& name, bool activeOnly);
+            virtual Ptr searchPtr (const std::string& name, bool activeOnly) override;
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            virtual Ptr searchPtrViaActorId (int actorId);
+            virtual Ptr searchPtrViaActorId (int actorId) override;
             ///< Search is limited to the active cells.
 
-            virtual MWWorld::Ptr findContainer (const MWWorld::ConstPtr& ptr);
+            virtual MWWorld::Ptr findContainer (const MWWorld::ConstPtr& ptr) override;
             ///< Return a pointer to a liveCellRef which contains \a ptr.
             /// \note Search is limited to the active cells.
 
-            virtual void adjustPosition (const Ptr& ptr, bool force);
+            virtual void adjustPosition (const Ptr& ptr, bool force) override;
             ///< Adjust position after load to be on ground. Must be called after model load.
             /// @param force do this even if the ptr is flying
 
-            virtual void fixPosition (const Ptr& actor);
+            virtual void fixPosition (const Ptr& actor) override;
             ///< Attempt to fix position so that the Ptr is no longer inside collision geometry.
 
-            virtual void enable (const Ptr& ptr);
+            virtual void enable (const Ptr& ptr) override;
 
-            virtual void disable (const Ptr& ptr);
+            virtual void disable (const Ptr& ptr) override;
 
-            virtual void advanceTime (double hours, bool incremental = false);
+            virtual void advanceTime (double hours, bool incremental = false) override;
             ///< Advance in-game time.
 
-            virtual void setHour (double hour);
+            virtual void setHour (double hour) override;
             ///< Set in-game time hour.
 
-            virtual void setMonth (int month);
+            virtual void setMonth (int month) override;
             ///< Set in-game time month.
 
-            virtual void setDay (int day);
+            virtual void setDay (int day) override;
             ///< Set in-game time day.
 
-            virtual int getDay() const;
-            virtual int getMonth() const;
-            virtual int getYear() const;
+            virtual int getDay() const override;
+            virtual int getMonth() const override;
+            virtual int getYear() const override;
 
-            virtual std::string getMonthName (int month = -1) const;
+            virtual std::string getMonthName (int month = -1) const override;
             ///< Return name of month (-1: current month)
 
-            virtual TimeStamp getTimeStamp() const;
+            virtual TimeStamp getTimeStamp() const override;
             ///< Return current in-game time stamp.
 
-            virtual bool toggleSky();
+            virtual bool toggleSky() override;
             ///< \return Resulting mode
 
-            virtual void changeWeather (const std::string& region, const unsigned int id);
+            virtual void changeWeather (const std::string& region, const unsigned int id) override;
 
-            virtual int getCurrentWeather() const;
+            virtual int getCurrentWeather() const override;
 
-            virtual int getMasserPhase() const;
+            virtual int getMasserPhase() const override;
 
-            virtual int getSecundaPhase() const;
+            virtual int getSecundaPhase() const override;
 
-            virtual void setMoonColour (bool red);
+            virtual void setMoonColour (bool red) override;
 
-            virtual void modRegion(const std::string &regionid, const std::vector<char> &chances);
+            virtual void modRegion(const std::string &regionid, const std::vector<char> &chances) override;
 
-            virtual float getTimeScaleFactor() const;
+            virtual float getTimeScaleFactor() const override;
 
-            virtual void changeToInteriorCell (const std::string& cellName, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true);
+            virtual void changeToInteriorCell (const std::string& cellName, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true) override;
             ///< Move to interior cell.
             ///< @param changeEvent If false, do not trigger cell change flag or detect worldspace changes
 
-            virtual void changeToExteriorCell (const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true);
+            virtual void changeToExteriorCell (const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true) override;
             ///< Move to exterior cell.
             ///< @param changeEvent If false, do not trigger cell change flag or detect worldspace changes
 
-            virtual void changeToCell (const ESM::CellId& cellId, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent=true);
+            virtual void changeToCell (const ESM::CellId& cellId, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent=true) override;
             ///< @param changeEvent If false, do not trigger cell change flag or detect worldspace changes
 
-            virtual const ESM::Cell *getExterior (const std::string& cellName) const;
+            virtual const ESM::Cell *getExterior (const std::string& cellName) const override;
             ///< Return a cell matching the given name or a 0-pointer, if there is no such cell.
 
-            virtual void markCellAsUnchanged();
+            virtual void markCellAsUnchanged() override;
 
-            virtual MWWorld::Ptr getFacedObject();
+            virtual MWWorld::Ptr getFacedObject() override;
             ///< Return pointer to the object the player is looking at, if it is within activation range
 
-            virtual float getDistanceToFacedObject();
+            virtual float getDistanceToFacedObject() override;
 
             /// Returns a pointer to the object the provided object would hit (if within the
             /// specified distance), and the point where the hit occurs. This will attempt to
             /// use the "Head" node as a basis.
-            virtual std::pair<MWWorld::Ptr,osg::Vec3f> getHitContact(const MWWorld::ConstPtr &ptr, float distance, std::vector<MWWorld::Ptr> &targets);
+            virtual std::pair<MWWorld::Ptr,osg::Vec3f> getHitContact(const MWWorld::ConstPtr &ptr, float distance, std::vector<MWWorld::Ptr> &targets) override;
 
             /// @note No-op for items in containers. Use ContainerStore::removeItem instead.
-            virtual void deleteObject (const Ptr& ptr);
+            virtual void deleteObject (const Ptr& ptr) override;
 
-            virtual void undeleteObject (const Ptr& ptr);
+            virtual void undeleteObject (const Ptr& ptr) override;
 
-            virtual MWWorld::Ptr moveObject (const Ptr& ptr, float x, float y, float z);
+            virtual MWWorld::Ptr moveObject (const Ptr& ptr, float x, float y, float z) override;
             ///< @return an updated Ptr in case the Ptr's cell changes
 
-            virtual MWWorld::Ptr moveObject (const Ptr& ptr, CellStore* newCell, float x, float y, float z, bool movePhysics=true);
+            virtual MWWorld::Ptr moveObject (const Ptr& ptr, CellStore* newCell, float x, float y, float z, bool movePhysics=true) override;
             ///< @return an updated Ptr
 
-            virtual void scaleObject (const Ptr& ptr, float scale);
+            virtual void scaleObject (const Ptr& ptr, float scale) override;
 
             /// World rotates object, uses radians
             /// @note Rotations via this method use a different rotation order than the initial rotations in the CS. This
             /// could be considered a bug, but is needed for MW compatibility.
             /// \param adjust indicates rotation should be set or adjusted
-            virtual void rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust = false);
+            virtual void rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust = false) override;
 
-            virtual MWWorld::Ptr placeObject(const MWWorld::ConstPtr& ptr, MWWorld::CellStore* cell, ESM::Position pos);
+            virtual MWWorld::Ptr placeObject(const MWWorld::ConstPtr& ptr, MWWorld::CellStore* cell, ESM::Position pos) override;
             ///< Place an object. Makes a copy of the Ptr.
 
-            virtual MWWorld::Ptr safePlaceObject (const MWWorld::ConstPtr& ptr, const MWWorld::ConstPtr& referenceObject, MWWorld::CellStore* referenceCell, int direction, float distance);
+            virtual MWWorld::Ptr safePlaceObject (const MWWorld::ConstPtr& ptr, const MWWorld::ConstPtr& referenceObject, MWWorld::CellStore* referenceCell, int direction, float distance) override;
             ///< Place an object in a safe place next to \a referenceObject. \a direction and \a distance specify the wanted placement
             /// relative to \a referenceObject (but the object may be placed somewhere else if the wanted location is obstructed).
 
-            virtual float getMaxActivationDistance();
+            virtual float getMaxActivationDistance() override;
 
             virtual void indexToPosition (int cellX, int cellY, float &x, float &y, bool centre = false)
-                const;
+                const override;
             ///< Convert cell numbers to position.
 
-            virtual void positionToIndex (float x, float y, int &cellX, int &cellY) const;
+            virtual void positionToIndex (float x, float y, int &cellX, int &cellY) const override;
             ///< Convert position to cell numbers
 
-            virtual void queueMovement(const Ptr &ptr, const osg::Vec3f &velocity);
+            virtual void queueMovement(const Ptr &ptr, const osg::Vec3f &velocity) override;
             ///< Queues movement for \a ptr (in local space), to be applied in the next call to
             /// doPhysics.
 
-            virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2);
+            virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
             ///< cast a Ray and return true if there is an object in the ray path.
 
-            virtual bool toggleCollisionMode();
+            virtual bool toggleCollisionMode() override;
             ///< Toggle collision mode for player. If disabled player object should ignore
             /// collisions and gravity.
             ///< \return Resulting mode
 
-            virtual bool toggleRenderMode (MWRender::RenderMode mode);
+            virtual bool toggleRenderMode (MWRender::RenderMode mode) override;
             ///< Toggle a render mode.
             ///< \return Resulting mode
 
-            virtual const ESM::Potion *createRecord (const ESM::Potion& record);
+            virtual const ESM::Potion *createRecord (const ESM::Potion& record) override;
             ///< Create a new record (of type potion) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Spell *createRecord (const ESM::Spell& record);
+            virtual const ESM::Spell *createRecord (const ESM::Spell& record) override;
             ///< Create a new record (of type spell) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Class *createRecord (const ESM::Class& record);
+            virtual const ESM::Class *createRecord (const ESM::Class& record) override;
             ///< Create a new record (of type class) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Cell *createRecord (const ESM::Cell& record);
+            virtual const ESM::Cell *createRecord (const ESM::Cell& record) override;
             ///< Create a new record (of type cell) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::NPC *createRecord(const ESM::NPC &record);
+            virtual const ESM::NPC *createRecord(const ESM::NPC &record) override;
             ///< Create a new record (of type npc) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Armor *createRecord (const ESM::Armor& record);
+            virtual const ESM::Armor *createRecord (const ESM::Armor& record) override;
             ///< Create a new record (of type armor) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Weapon *createRecord (const ESM::Weapon& record);
+            virtual const ESM::Weapon *createRecord (const ESM::Weapon& record) override;
             ///< Create a new record (of type weapon) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Clothing *createRecord (const ESM::Clothing& record);
+            virtual const ESM::Clothing *createRecord (const ESM::Clothing& record) override;
             ///< Create a new record (of type clothing) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Enchantment *createRecord (const ESM::Enchantment& record);
+            virtual const ESM::Enchantment *createRecord (const ESM::Enchantment& record) override;
             ///< Create a new record (of type enchantment) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Book *createRecord (const ESM::Book& record);
+            virtual const ESM::Book *createRecord (const ESM::Book& record) override;
             ///< Create a new record (of type book) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::CreatureLevList *createOverrideRecord (const ESM::CreatureLevList& record);
+            virtual const ESM::CreatureLevList *createOverrideRecord (const ESM::CreatureLevList& record) override;
             ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
             /// \return pointer to created record
 
-            virtual const ESM::ItemLevList *createOverrideRecord (const ESM::ItemLevList& record);
+            virtual const ESM::ItemLevList *createOverrideRecord (const ESM::ItemLevList& record) override;
             ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
             /// \return pointer to created record
 
-            virtual void update (float duration, bool paused);
+            virtual void update (float duration, bool paused) override;
 
-            virtual void updateWindowManager ();
+            virtual void updateWindowManager () override;
 
-            virtual MWWorld::Ptr placeObject (const MWWorld::ConstPtr& object, float cursorX, float cursorY, int amount);
+            virtual MWWorld::Ptr placeObject (const MWWorld::ConstPtr& object, float cursorX, float cursorY, int amount) override;
             ///< copy and place an object into the gameworld at the specified cursor position
             /// @param object
             /// @param cursor X (relative 0-1)
             /// @param cursor Y (relative 0-1)
             /// @param number of objects to place
 
-            virtual MWWorld::Ptr dropObjectOnGround (const MWWorld::Ptr& actor, const MWWorld::ConstPtr& object, int amount);
+            virtual MWWorld::Ptr dropObjectOnGround (const MWWorld::Ptr& actor, const MWWorld::ConstPtr& object, int amount) override;
             ///< copy and place an object into the gameworld at the given actor's position
             /// @param actor giving the dropped object position
             /// @param object
             /// @param number of objects to place
 
-            virtual bool canPlaceObject(float cursorX, float cursorY);
+            virtual bool canPlaceObject(float cursorX, float cursorY) override;
             ///< @return true if it is possible to place on object at specified cursor location
 
-            virtual void processChangedSettings(const Settings::CategorySettingVector& settings);
+            virtual void processChangedSettings(const Settings::CategorySettingVector& settings) override;
 
-            virtual bool isFlying(const MWWorld::Ptr &ptr) const;
-            virtual bool isSlowFalling(const MWWorld::Ptr &ptr) const;
+            virtual bool isFlying(const MWWorld::Ptr &ptr) const override;
+            virtual bool isSlowFalling(const MWWorld::Ptr &ptr) const override;
             ///Is the head of the creature underwater?
-            virtual bool isSubmerged(const MWWorld::ConstPtr &object) const;
-            virtual bool isSwimming(const MWWorld::ConstPtr &object) const;
-            virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const;
-            virtual bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const;
-            virtual bool isWading(const MWWorld::ConstPtr &object) const;
-            virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const;
-            virtual bool isOnGround(const MWWorld::Ptr &ptr) const;
+            virtual bool isSubmerged(const MWWorld::ConstPtr &object) const override;
+            virtual bool isSwimming(const MWWorld::ConstPtr &object) const override;
+            virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const override;
+            virtual bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const override;
+            virtual bool isWading(const MWWorld::ConstPtr &object) const override;
+            virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const override;
+            virtual bool isOnGround(const MWWorld::Ptr &ptr) const override;
 
-            virtual osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const;
+            virtual osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const override;
 
-            virtual void togglePOV();
+            virtual void togglePOV() override;
 
-            virtual bool isFirstPerson() const;
+            virtual bool isFirstPerson() const override;
 
-            virtual void togglePreviewMode(bool enable);
+            virtual void togglePreviewMode(bool enable) override;
 
-            virtual bool toggleVanityMode(bool enable);
+            virtual bool toggleVanityMode(bool enable) override;
 
-            virtual void allowVanityMode(bool allow);
+            virtual void allowVanityMode(bool allow) override;
 
-            virtual void togglePlayerLooking(bool enable);
+            virtual void togglePlayerLooking(bool enable) override;
 
-            virtual void changeVanityModeScale(float factor);
+            virtual void changeVanityModeScale(float factor) override;
 
-            virtual bool vanityRotateCamera(float * rot);
-            virtual void setCameraDistance(float dist, bool adjust = false, bool override = true);
+            virtual bool vanityRotateCamera(float * rot) override;
+            virtual void setCameraDistance(float dist, bool adjust = false, bool override = true) override;
 
-            virtual void setupPlayer();
-            virtual void renderPlayer();
+            virtual void setupPlayer() override;
+            virtual void renderPlayer() override;
 
             /// open or close a non-teleport door (depending on current state)
-            virtual void activateDoor(const MWWorld::Ptr& door);
+            virtual void activateDoor(const MWWorld::Ptr& door) override;
 
             /// update movement state of a non-teleport door as specified
             /// @param state see MWClass::setDoorState
             /// @note throws an exception when invoked on a teleport door
-            virtual void activateDoor(const MWWorld::Ptr& door, int state);
+            virtual void activateDoor(const MWWorld::Ptr& door, int state) override;
 
-            virtual bool getPlayerStandingOn (const MWWorld::ConstPtr& object); ///< @return true if the player is standing on \a object
-            virtual bool getActorStandingOn (const MWWorld::ConstPtr& object); ///< @return true if any actor is standing on \a object
-            virtual bool getPlayerCollidingWith(const MWWorld::ConstPtr& object); ///< @return true if the player is colliding with \a object
-            virtual bool getActorCollidingWith (const MWWorld::ConstPtr& object); ///< @return true if any actor is colliding with \a object
-            virtual void hurtStandingActors (const MWWorld::ConstPtr& object, float dmgPerSecond);
+            virtual bool getPlayerStandingOn (const MWWorld::ConstPtr& object) override; ///< @return true if the player is standing on \a object
+            virtual bool getActorStandingOn (const MWWorld::ConstPtr& object) override; ///< @return true if any actor is standing on \a object
+            virtual bool getPlayerCollidingWith(const MWWorld::ConstPtr& object) override; ///< @return true if the player is colliding with \a object
+            virtual bool getActorCollidingWith (const MWWorld::ConstPtr& object) override; ///< @return true if any actor is colliding with \a object
+            virtual void hurtStandingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
             ///< Apply a health difference to any actors standing on \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
-            virtual void hurtCollidingActors (const MWWorld::ConstPtr& object, float dmgPerSecond);
+            virtual void hurtCollidingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
             ///< Apply a health difference to any actors colliding with \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
 
-            virtual float getWindSpeed();
+            virtual float getWindSpeed() override;
 
-            virtual void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out);
+            virtual void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all containers in active cells owned by this Npc
-            virtual void getItemsOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out);
+            virtual void getItemsOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all items in active cells owned by this Npc
 
-            virtual bool getLOS(const MWWorld::ConstPtr& actor,const MWWorld::ConstPtr& targetActor);
+            virtual bool getLOS(const MWWorld::ConstPtr& actor,const MWWorld::ConstPtr& targetActor) override;
             ///< get Line of Sight (morrowind stupid implementation)
 
-            virtual float getDistToNearestRayHit(const osg::Vec3f& from, const osg::Vec3f& dir, float maxDist, bool includeWater = false);
+            virtual float getDistToNearestRayHit(const osg::Vec3f& from, const osg::Vec3f& dir, float maxDist, bool includeWater = false) override;
 
-            virtual void enableActorCollision(const MWWorld::Ptr& actor, bool enable);
+            virtual void enableActorCollision(const MWWorld::Ptr& actor, bool enable) override;
 
-            virtual int canRest();
+            virtual int canRest() override;
             ///< check if the player is allowed to rest \n
             /// 0 - yes \n
             /// 1 - only waiting \n
@@ -554,132 +554,132 @@ namespace MWWorld
             /// 3 - enemies are nearby (not implemented)
 
             /// \todo Probably shouldn't be here
-            virtual MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr);
-            virtual const MWRender::Animation* getAnimation(const MWWorld::ConstPtr &ptr) const;
-            virtual void reattachPlayerCamera();
+            virtual MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;
+            virtual const MWRender::Animation* getAnimation(const MWWorld::ConstPtr &ptr) const override;
+            virtual void reattachPlayerCamera() override;
 
             /// \todo this does not belong here
-            virtual void screenshot (osg::Image* image, int w, int h);
+            virtual void screenshot (osg::Image* image, int w, int h) override;
 
             /// Find center of exterior cell above land surface
             /// \return false if exterior with given name not exists, true otherwise
-            virtual bool findExteriorPosition(const std::string &name, ESM::Position &pos);
+            virtual bool findExteriorPosition(const std::string &name, ESM::Position &pos) override;
 
             /// Find position in interior cell near door entrance
             /// \return false if interior with given name not exists, true otherwise
-            virtual bool findInteriorPosition(const std::string &name, ESM::Position &pos);
+            virtual bool findInteriorPosition(const std::string &name, ESM::Position &pos) override;
 
             /// Enables or disables use of teleport spell effects (recall, intervention, etc).
-            virtual void enableTeleporting(bool enable);
+            virtual void enableTeleporting(bool enable) override;
 
             /// Returns true if teleport spell effects are allowed.
-            virtual bool isTeleportingEnabled() const;
+            virtual bool isTeleportingEnabled() const override;
 
             /// Enables or disables use of levitation spell effect.
-            virtual void enableLevitation(bool enable);
+            virtual void enableLevitation(bool enable) override;
 
             /// Returns true if levitation spell effect is allowed.
-            virtual bool isLevitationEnabled() const;
+            virtual bool isLevitationEnabled() const override;
 
-            virtual bool getGodModeState();
+            virtual bool getGodModeState() override;
 
-            virtual bool toggleGodMode();
+            virtual bool toggleGodMode() override;
 
-            virtual bool toggleScripts();
-            virtual bool getScriptsEnabled() const;
+            virtual bool toggleScripts() override;
+            virtual bool getScriptsEnabled() const override;
 
             /**
              * @brief startSpellCast attempt to start casting a spell. Might fail immediately if conditions are not met.
              * @param actor
              * @return true if the spell can be casted (i.e. the animation should start)
              */
-            virtual bool startSpellCast (const MWWorld::Ptr& actor);
+            virtual bool startSpellCast (const MWWorld::Ptr& actor) override;
 
             /**
              * @brief Cast the actual spell, should be called mid-animation
              * @param actor
              */
-            virtual void castSpell (const MWWorld::Ptr& actor);
+            virtual void castSpell (const MWWorld::Ptr& actor) override;
 
             virtual void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) override;
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
-                                           const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength);
+                                           const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength) override;
 
 
-            virtual const std::vector<std::string>& getContentFiles() const;
+            virtual const std::vector<std::string>& getContentFiles() const override;
 
-            virtual void breakInvisibility (const MWWorld::Ptr& actor);
+            virtual void breakInvisibility (const MWWorld::Ptr& actor) override;
             // Are we in an exterior or pseudo-exterior cell and it's night?
-            virtual bool isDark() const;
+            virtual bool isDark() const override;
 
-            virtual bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result);
+            virtual bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) override;
 
             /// Teleports \a ptr to the closest reference of \a id (e.g. DivineMarker, PrisonMarker, TempleMarker)
             /// @note id must be lower case
             virtual void teleportToClosestMarker (const MWWorld::Ptr& ptr,
-                                                  const std::string& id);
+                                                  const std::string& id) override;
 
             /// List all references (filtered by \a type) detected by \a ptr. The range
             /// is determined by the current magnitude of the "Detect X" magic effect belonging to \a type.
             /// @note This also works for references in containers.
             virtual void listDetectedReferences (const MWWorld::Ptr& ptr, std::vector<MWWorld::Ptr>& out,
-                                                  DetectionType type);
+                                                  DetectionType type) override;
 
             /// Update the value of some globals according to the world state, which may be used by dialogue entries.
             /// This should be called when initiating a dialogue.
-            virtual void updateDialogueGlobals();
+            virtual void updateDialogueGlobals() override;
 
             /// Moves all stolen items from \a ptr to the closest evidence chest.
-            virtual void confiscateStolenItems(const MWWorld::Ptr& ptr);
+            virtual void confiscateStolenItems(const MWWorld::Ptr& ptr) override;
 
-            virtual void goToJail ();
+            virtual void goToJail () override;
 
             /// Spawn a random creature from a levelled list next to the player
-            virtual void spawnRandomCreature(const std::string& creatureList);
+            virtual void spawnRandomCreature(const std::string& creatureList) override;
 
             /// Spawn a blood effect for \a ptr at \a worldPosition
-            virtual void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition);
+            virtual void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
 
-            virtual void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos);
+            virtual void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) override;
 
             virtual void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster, const MWWorld::Ptr& ignore,
                                       ESM::RangeType rangeType, const std::string& id, const std::string& sourceName,
-                                      const bool fromProjectile=false);
+                                      const bool fromProjectile=false) override;
 
-            virtual void activate (const MWWorld::Ptr& object, const MWWorld::Ptr& actor);
+            virtual void activate (const MWWorld::Ptr& object, const MWWorld::Ptr& actor) override;
 
             /// @see MWWorld::WeatherManager::isInStorm
-            virtual bool isInStorm() const;
+            virtual bool isInStorm() const override;
 
             /// @see MWWorld::WeatherManager::getStormDirection
-            virtual osg::Vec3f getStormDirection() const;
+            virtual osg::Vec3f getStormDirection() const override;
 
             /// Resets all actors in the current active cells to their original location within that cell.
-            virtual void resetActors();
+            virtual void resetActors() override;
 
-            virtual bool isWalkingOnWater (const MWWorld::ConstPtr& actor) const;
+            virtual bool isWalkingOnWater (const MWWorld::ConstPtr& actor) const override;
 
             /// Return a vector aiming the actor's weapon towards a target.
             /// @note The length of the vector is the distance between actor and target.
-            virtual osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target);
+            virtual osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
             /// Return the distance between actor's weapon and target's collision box.
-            virtual float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target);
+            virtual float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
-            virtual bool isPlayerInJail() const;
+            virtual bool isPlayerInJail() const override;
 
             /// Return terrain height at \a worldPos position.
-            virtual float getTerrainHeightAt(const osg::Vec3f& worldPos) const;
+            virtual float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;
 
             /// Return physical or rendering half extents of the given actor.
-            virtual osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const;
+            virtual osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const override;
 
             /// Export scene graph to a file and return the filename.
             /// \param ptr object to export scene graph for (if empty, export entire scene graph)
-            virtual std::string exportSceneGraph(const MWWorld::Ptr& ptr);
+            virtual std::string exportSceneGraph(const MWWorld::Ptr& ptr) override;
 
             /// Preload VFX associated with this effect list
-            virtual void preloadEffects(const ESM::EffectList* effectList);
+            virtual void preloadEffects(const ESM::EffectList* effectList) override;
     };
 }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -227,7 +227,7 @@ namespace MWWorld
 
             virtual const MWWorld::ESMStore& getStore() const override;
 
-            virtual std::vector<ESM::ESMReader>& getEsmReader();
+            virtual std::vector<ESM::ESMReader>& getEsmReader() override;
 
             virtual LocalScripts& getLocalScripts() override;
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -528,25 +528,25 @@ namespace MWWorld
             void hurtStandingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
             ///< Apply a health difference to any actors standing on \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
-             void hurtCollidingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
+            void hurtCollidingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
             ///< Apply a health difference to any actors colliding with \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
 
-             float getWindSpeed() override;
+            float getWindSpeed() override;
 
-             void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
+            void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all containers in active cells owned by this Npc
-             void getItemsOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
+            void getItemsOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all items in active cells owned by this Npc
 
-             bool getLOS(const MWWorld::ConstPtr& actor,const MWWorld::ConstPtr& targetActor) override;
+            bool getLOS(const MWWorld::ConstPtr& actor,const MWWorld::ConstPtr& targetActor) override;
             ///< get Line of Sight (morrowind stupid implementation)
 
-             float getDistToNearestRayHit(const osg::Vec3f& from, const osg::Vec3f& dir, float maxDist, bool includeWater = false) override;
+            float getDistToNearestRayHit(const osg::Vec3f& from, const osg::Vec3f& dir, float maxDist, bool includeWater = false) override;
 
-             void enableActorCollision(const MWWorld::Ptr& actor, bool enable) override;
+            void enableActorCollision(const MWWorld::Ptr& actor, bool enable) override;
 
-             int canRest() override;
+            int canRest() override;
             ///< check if the player is allowed to rest \n
             /// 0 - yes \n
             /// 1 - only waiting \n
@@ -554,132 +554,132 @@ namespace MWWorld
             /// 3 - enemies are nearby (not implemented)
 
             /// \todo Probably shouldn't be here
-             MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;
-             const MWRender::Animation* getAnimation(const MWWorld::ConstPtr &ptr) const override;
-             void reattachPlayerCamera() override;
+            MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;
+            const MWRender::Animation* getAnimation(const MWWorld::ConstPtr &ptr) const override;
+            void reattachPlayerCamera() override;
 
             /// \todo this does not belong here
-             void screenshot (osg::Image* image, int w, int h) override;
+            void screenshot (osg::Image* image, int w, int h) override;
 
             /// Find center of exterior cell above land surface
             /// \return false if exterior with given name not exists, true otherwise
-             bool findExteriorPosition(const std::string &name, ESM::Position &pos) override;
+            bool findExteriorPosition(const std::string &name, ESM::Position &pos) override;
 
             /// Find position in interior cell near door entrance
             /// \return false if interior with given name not exists, true otherwise
-             bool findInteriorPosition(const std::string &name, ESM::Position &pos) override;
+            bool findInteriorPosition(const std::string &name, ESM::Position &pos) override;
 
             /// Enables or disables use of teleport spell effects (recall, intervention, etc).
-             void enableTeleporting(bool enable) override;
+            void enableTeleporting(bool enable) override;
 
             /// Returns true if teleport spell effects are allowed.
-             bool isTeleportingEnabled() const override;
+            bool isTeleportingEnabled() const override;
 
             /// Enables or disables use of levitation spell effect.
-             void enableLevitation(bool enable) override;
+            void enableLevitation(bool enable) override;
 
             /// Returns true if levitation spell effect is allowed.
-             bool isLevitationEnabled() const override;
+            bool isLevitationEnabled() const override;
 
-             bool getGodModeState() override;
+            bool getGodModeState() override;
 
-             bool toggleGodMode() override;
+            bool toggleGodMode() override;
 
-             bool toggleScripts() override;
-             bool getScriptsEnabled() const override;
+            bool toggleScripts() override;
+            bool getScriptsEnabled() const override;
 
             /**
              * @brief startSpellCast attempt to start casting a spell. Might fail immediately if conditions are not met.
              * @param actor
              * @return true if the spell can be casted (i.e. the animation should start)
              */
-             bool startSpellCast (const MWWorld::Ptr& actor) override;
+            bool startSpellCast (const MWWorld::Ptr& actor) override;
 
             /**
              * @brief Cast the actual spell, should be called mid-animation
              * @param actor
              */
-             void castSpell (const MWWorld::Ptr& actor) override;
+            void castSpell (const MWWorld::Ptr& actor) override;
 
-             void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) override;
-             void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
+            void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) override;
+            void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
                                            const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength) override;
 
 
-             const std::vector<std::string>& getContentFiles() const override;
+            const std::vector<std::string>& getContentFiles() const override;
 
-             void breakInvisibility (const MWWorld::Ptr& actor) override;
+            void breakInvisibility (const MWWorld::Ptr& actor) override;
             // Are we in an exterior or pseudo-exterior cell and it's night?
-             bool isDark() const override;
+            bool isDark() const override;
 
-             bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) override;
+            bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) override;
 
             /// Teleports \a ptr to the closest reference of \a id (e.g. DivineMarker, PrisonMarker, TempleMarker)
             /// @note id must be lower case
-             void teleportToClosestMarker (const MWWorld::Ptr& ptr,
+            void teleportToClosestMarker (const MWWorld::Ptr& ptr,
                                                   const std::string& id) override;
 
             /// List all references (filtered by \a type) detected by \a ptr. The range
             /// is determined by the current magnitude of the "Detect X" magic effect belonging to \a type.
             /// @note This also works for references in containers.
-             void listDetectedReferences (const MWWorld::Ptr& ptr, std::vector<MWWorld::Ptr>& out,
+            void listDetectedReferences (const MWWorld::Ptr& ptr, std::vector<MWWorld::Ptr>& out,
                                                   DetectionType type) override;
 
             /// Update the value of some globals according to the world state, which may be used by dialogue entries.
             /// This should be called when initiating a dialogue.
-             void updateDialogueGlobals() override;
+            void updateDialogueGlobals() override;
 
             /// Moves all stolen items from \a ptr to the closest evidence chest.
-             void confiscateStolenItems(const MWWorld::Ptr& ptr) override;
+            void confiscateStolenItems(const MWWorld::Ptr& ptr) override;
 
-             void goToJail () override;
+            void goToJail () override;
 
             /// Spawn a random creature from a levelled list next to the player
              void spawnRandomCreature(const std::string& creatureList) override;
 
             /// Spawn a blood effect for \a ptr at \a worldPosition
-             void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
+            void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
 
-             void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) override;
+            void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) override;
 
-             void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster, const MWWorld::Ptr& ignore,
+            void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster, const MWWorld::Ptr& ignore,
                                       ESM::RangeType rangeType, const std::string& id, const std::string& sourceName,
                                       const bool fromProjectile=false) override;
 
-             void activate (const MWWorld::Ptr& object, const MWWorld::Ptr& actor) override;
+            void activate (const MWWorld::Ptr& object, const MWWorld::Ptr& actor) override;
 
             /// @see MWWorld::WeatherManager::isInStorm
-             bool isInStorm() const override;
+            bool isInStorm() const override;
 
             /// @see MWWorld::WeatherManager::getStormDirection
-             osg::Vec3f getStormDirection() const override;
+            osg::Vec3f getStormDirection() const override;
 
             /// Resets all actors in the current active cells to their original location within that cell.
-             void resetActors() override;
+            void resetActors() override;
 
-             bool isWalkingOnWater (const MWWorld::ConstPtr& actor) const override;
+            bool isWalkingOnWater (const MWWorld::ConstPtr& actor) const override;
 
             /// Return a vector aiming the actor's weapon towards a target.
             /// @note The length of the vector is the distance between actor and target.
              osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
             /// Return the distance between actor's weapon and target's collision box.
-             float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
+            float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
-             bool isPlayerInJail() const override;
+            bool isPlayerInJail() const override;
 
             /// Return terrain height at \a worldPos position.
-             float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;
+            float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;
 
             /// Return physical or rendering half extents of the given actor.
-             osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const override;
+            osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const override;
 
             /// Export scene graph to a file and return the filename.
             /// \param ptr object to export scene graph for (if empty, export entire scene graph)
-             std::string exportSceneGraph(const MWWorld::Ptr& ptr) override;
+            std::string exportSceneGraph(const MWWorld::Ptr& ptr) override;
 
             /// Preload VFX associated with this effect list
-             void preloadEffects(const ESM::EffectList* effectList) override;
+            void preloadEffects(const ESM::EffectList* effectList) override;
     };
 }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -69,7 +69,7 @@ namespace MWWorld
 
     /// \brief The game world and its visual representation
 
-    class World : public MWBase::World
+    class World final: public MWBase::World
     {
             Resource::ResourceSystem* mResourceSystem;
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -191,362 +191,362 @@ namespace MWWorld
 
             virtual ~World();
 
-            virtual void startNewGame (bool bypass) override;
+            void startNewGame (bool bypass) override;
             ///< \param bypass Bypass regular game start.
 
-            virtual void clear() override;
+            void clear() override;
 
-            virtual int countSavedGameRecords() const override;
-            virtual int countSavedGameCells() const override;
+            int countSavedGameRecords() const override;
+            int countSavedGameCells() const override;
 
-            virtual void write (ESM::ESMWriter& writer, Loading::Listener& progress) const override;
+            void write (ESM::ESMWriter& writer, Loading::Listener& progress) const override;
 
-            virtual void readRecord (ESM::ESMReader& reader, uint32_t type,
+            void readRecord (ESM::ESMReader& reader, uint32_t type,
                 const std::map<int, int>& contentFileMap) override;
 
-            virtual CellStore *getExterior (int x, int y) override;
+            CellStore *getExterior (int x, int y) override;
 
-            virtual CellStore *getInterior (const std::string& name) override;
+            CellStore *getInterior (const std::string& name) override;
 
-            virtual CellStore *getCell (const ESM::CellId& id) override;
+            CellStore *getCell (const ESM::CellId& id) override;
 
             //switch to POV before showing player's death animation
-            virtual void useDeathCamera() override;
+            void useDeathCamera() override;
 
-            virtual void setWaterHeight(const float height) override;
+            void setWaterHeight(const float height) override;
 
-            virtual bool toggleWater() override;
-            virtual bool toggleWorld() override;
+            bool toggleWater() override;
+            bool toggleWorld() override;
 
-            virtual void adjustSky() override;
+            void adjustSky() override;
 
-            virtual const Fallback::Map *getFallback() const override;
+            const Fallback::Map *getFallback() const override;
 
-            virtual Player& getPlayer() override;
-            virtual MWWorld::Ptr getPlayerPtr() override;
+            Player& getPlayer() override;
+            MWWorld::Ptr getPlayerPtr() override;
 
-            virtual const MWWorld::ESMStore& getStore() const override;
+            const MWWorld::ESMStore& getStore() const override;
 
-            virtual std::vector<ESM::ESMReader>& getEsmReader() override;
+            std::vector<ESM::ESMReader>& getEsmReader() override;
 
-            virtual LocalScripts& getLocalScripts() override;
+            LocalScripts& getLocalScripts() override;
 
-            virtual bool hasCellChanged() const override;
+            bool hasCellChanged() const override;
             ///< Has the set of active cells changed, since the last frame?
 
-            virtual bool isCellExterior() const override;
+            bool isCellExterior() const override;
 
-            virtual bool isCellQuasiExterior() const override;
+            bool isCellQuasiExterior() const override;
 
-            virtual osg::Vec2f getNorthVector (const CellStore* cell) override;
+            osg::Vec2f getNorthVector (const CellStore* cell) override;
             ///< get north vector for given interior cell
 
-            virtual void getDoorMarkers (MWWorld::CellStore* cell, std::vector<DoorMarker>& out) override;
+            void getDoorMarkers (MWWorld::CellStore* cell, std::vector<DoorMarker>& out) override;
             ///< get a list of teleport door markers for a given cell, to be displayed on the local map
 
-            virtual void setGlobalInt (const std::string& name, int value) override;
+            void setGlobalInt (const std::string& name, int value) override;
             ///< Set value independently from real type.
 
-            virtual void setGlobalFloat (const std::string& name, float value) override;
+            void setGlobalFloat (const std::string& name, float value) override;
             ///< Set value independently from real type.
 
-            virtual int getGlobalInt (const std::string& name) const override;
+            int getGlobalInt (const std::string& name) const override;
             ///< Get value independently from real type.
 
-            virtual float getGlobalFloat (const std::string& name) const override;
+            float getGlobalFloat (const std::string& name) const override;
             ///< Get value independently from real type.
 
-            virtual char getGlobalVariableType (const std::string& name) const override;
+            char getGlobalVariableType (const std::string& name) const override;
             ///< Return ' ', if there is no global variable with this name.
 
-            virtual std::string getCellName (const MWWorld::CellStore *cell = 0) const override;
+            std::string getCellName (const MWWorld::CellStore *cell = 0) const override;
             ///< Return name of the cell.
             ///
             /// \note If cell==0, the cell the player is currently in will be used instead to
             /// generate a name.
 
-            virtual void removeRefScript (MWWorld::RefData *ref) override;
+            void removeRefScript (MWWorld::RefData *ref) override;
             //< Remove the script attached to ref from mLocalScripts
 
-            virtual Ptr getPtr (const std::string& name, bool activeOnly) override;
+            Ptr getPtr (const std::string& name, bool activeOnly) override;
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            virtual Ptr searchPtr (const std::string& name, bool activeOnly) override;
+            Ptr searchPtr (const std::string& name, bool activeOnly) override;
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            virtual Ptr searchPtrViaActorId (int actorId) override;
+            Ptr searchPtrViaActorId (int actorId) override;
             ///< Search is limited to the active cells.
 
-            virtual MWWorld::Ptr findContainer (const MWWorld::ConstPtr& ptr) override;
+            MWWorld::Ptr findContainer (const MWWorld::ConstPtr& ptr) override;
             ///< Return a pointer to a liveCellRef which contains \a ptr.
             /// \note Search is limited to the active cells.
 
-            virtual void adjustPosition (const Ptr& ptr, bool force) override;
+            void adjustPosition (const Ptr& ptr, bool force) override;
             ///< Adjust position after load to be on ground. Must be called after model load.
             /// @param force do this even if the ptr is flying
 
-            virtual void fixPosition (const Ptr& actor) override;
+            void fixPosition (const Ptr& actor) override;
             ///< Attempt to fix position so that the Ptr is no longer inside collision geometry.
 
-            virtual void enable (const Ptr& ptr) override;
+            void enable (const Ptr& ptr) override;
 
-            virtual void disable (const Ptr& ptr) override;
+            void disable (const Ptr& ptr) override;
 
-            virtual void advanceTime (double hours, bool incremental = false) override;
+            void advanceTime (double hours, bool incremental = false) override;
             ///< Advance in-game time.
 
-            virtual void setHour (double hour) override;
+            void setHour (double hour) override;
             ///< Set in-game time hour.
 
-            virtual void setMonth (int month) override;
+            void setMonth (int month) override;
             ///< Set in-game time month.
 
-            virtual void setDay (int day) override;
+            void setDay (int day) override;
             ///< Set in-game time day.
 
-            virtual int getDay() const override;
-            virtual int getMonth() const override;
-            virtual int getYear() const override;
+            int getDay() const override;
+            int getMonth() const override;
+            int getYear() const override;
 
-            virtual std::string getMonthName (int month = -1) const override;
+            std::string getMonthName (int month = -1) const override;
             ///< Return name of month (-1: current month)
 
-            virtual TimeStamp getTimeStamp() const override;
+            TimeStamp getTimeStamp() const override;
             ///< Return current in-game time stamp.
 
-            virtual bool toggleSky() override;
+            bool toggleSky() override;
             ///< \return Resulting mode
 
-            virtual void changeWeather (const std::string& region, const unsigned int id) override;
+            void changeWeather (const std::string& region, const unsigned int id) override;
 
-            virtual int getCurrentWeather() const override;
+            int getCurrentWeather() const override;
 
-            virtual int getMasserPhase() const override;
+            int getMasserPhase() const override;
 
-            virtual int getSecundaPhase() const override;
+            int getSecundaPhase() const override;
 
-            virtual void setMoonColour (bool red) override;
+            void setMoonColour (bool red) override;
 
-            virtual void modRegion(const std::string &regionid, const std::vector<char> &chances) override;
+            void modRegion(const std::string &regionid, const std::vector<char> &chances) override;
 
-            virtual float getTimeScaleFactor() const override;
+            float getTimeScaleFactor() const override;
 
-            virtual void changeToInteriorCell (const std::string& cellName, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true) override;
+            void changeToInteriorCell (const std::string& cellName, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true) override;
             ///< Move to interior cell.
             ///< @param changeEvent If false, do not trigger cell change flag or detect worldspace changes
 
-            virtual void changeToExteriorCell (const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true) override;
+            void changeToExteriorCell (const ESM::Position& position, bool adjustPlayerPos, bool changeEvent = true) override;
             ///< Move to exterior cell.
             ///< @param changeEvent If false, do not trigger cell change flag or detect worldspace changes
 
-            virtual void changeToCell (const ESM::CellId& cellId, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent=true) override;
+            void changeToCell (const ESM::CellId& cellId, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent=true) override;
             ///< @param changeEvent If false, do not trigger cell change flag or detect worldspace changes
 
-            virtual const ESM::Cell *getExterior (const std::string& cellName) const override;
+            const ESM::Cell *getExterior (const std::string& cellName) const override;
             ///< Return a cell matching the given name or a 0-pointer, if there is no such cell.
 
-            virtual void markCellAsUnchanged() override;
+            void markCellAsUnchanged() override;
 
-            virtual MWWorld::Ptr getFacedObject() override;
+            MWWorld::Ptr getFacedObject() override;
             ///< Return pointer to the object the player is looking at, if it is within activation range
 
-            virtual float getDistanceToFacedObject() override;
+            float getDistanceToFacedObject() override;
 
             /// Returns a pointer to the object the provided object would hit (if within the
             /// specified distance), and the point where the hit occurs. This will attempt to
             /// use the "Head" node as a basis.
-            virtual std::pair<MWWorld::Ptr,osg::Vec3f> getHitContact(const MWWorld::ConstPtr &ptr, float distance, std::vector<MWWorld::Ptr> &targets) override;
+            std::pair<MWWorld::Ptr,osg::Vec3f> getHitContact(const MWWorld::ConstPtr &ptr, float distance, std::vector<MWWorld::Ptr> &targets) override;
 
             /// @note No-op for items in containers. Use ContainerStore::removeItem instead.
-            virtual void deleteObject (const Ptr& ptr) override;
+            void deleteObject (const Ptr& ptr) override;
 
-            virtual void undeleteObject (const Ptr& ptr) override;
+            void undeleteObject (const Ptr& ptr) override;
 
-            virtual MWWorld::Ptr moveObject (const Ptr& ptr, float x, float y, float z) override;
+            MWWorld::Ptr moveObject (const Ptr& ptr, float x, float y, float z) override;
             ///< @return an updated Ptr in case the Ptr's cell changes
 
-            virtual MWWorld::Ptr moveObject (const Ptr& ptr, CellStore* newCell, float x, float y, float z, bool movePhysics=true) override;
+            MWWorld::Ptr moveObject (const Ptr& ptr, CellStore* newCell, float x, float y, float z, bool movePhysics=true) override;
             ///< @return an updated Ptr
 
-            virtual void scaleObject (const Ptr& ptr, float scale) override;
+            void scaleObject (const Ptr& ptr, float scale) override;
 
             /// World rotates object, uses radians
             /// @note Rotations via this method use a different rotation order than the initial rotations in the CS. This
             /// could be considered a bug, but is needed for MW compatibility.
             /// \param adjust indicates rotation should be set or adjusted
-            virtual void rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust = false) override;
+            void rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust = false) override;
 
-            virtual MWWorld::Ptr placeObject(const MWWorld::ConstPtr& ptr, MWWorld::CellStore* cell, ESM::Position pos) override;
+            MWWorld::Ptr placeObject(const MWWorld::ConstPtr& ptr, MWWorld::CellStore* cell, ESM::Position pos) override;
             ///< Place an object. Makes a copy of the Ptr.
 
-            virtual MWWorld::Ptr safePlaceObject (const MWWorld::ConstPtr& ptr, const MWWorld::ConstPtr& referenceObject, MWWorld::CellStore* referenceCell, int direction, float distance) override;
+            MWWorld::Ptr safePlaceObject (const MWWorld::ConstPtr& ptr, const MWWorld::ConstPtr& referenceObject, MWWorld::CellStore* referenceCell, int direction, float distance) override;
             ///< Place an object in a safe place next to \a referenceObject. \a direction and \a distance specify the wanted placement
             /// relative to \a referenceObject (but the object may be placed somewhere else if the wanted location is obstructed).
 
-            virtual float getMaxActivationDistance() override;
+            float getMaxActivationDistance() override;
 
-            virtual void indexToPosition (int cellX, int cellY, float &x, float &y, bool centre = false)
+            void indexToPosition (int cellX, int cellY, float &x, float &y, bool centre = false)
                 const override;
             ///< Convert cell numbers to position.
 
-            virtual void positionToIndex (float x, float y, int &cellX, int &cellY) const override;
+            void positionToIndex (float x, float y, int &cellX, int &cellY) const override;
             ///< Convert position to cell numbers
 
-            virtual void queueMovement(const Ptr &ptr, const osg::Vec3f &velocity) override;
+            void queueMovement(const Ptr &ptr, const osg::Vec3f &velocity) override;
             ///< Queues movement for \a ptr (in local space), to be applied in the next call to
             /// doPhysics.
 
-            virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
+            bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
             ///< cast a Ray and return true if there is an object in the ray path.
 
-            virtual bool toggleCollisionMode() override;
+            bool toggleCollisionMode() override;
             ///< Toggle collision mode for player. If disabled player object should ignore
             /// collisions and gravity.
             ///< \return Resulting mode
 
-            virtual bool toggleRenderMode (MWRender::RenderMode mode) override;
+            bool toggleRenderMode (MWRender::RenderMode mode) override;
             ///< Toggle a render mode.
             ///< \return Resulting mode
 
-            virtual const ESM::Potion *createRecord (const ESM::Potion& record) override;
+            const ESM::Potion *createRecord (const ESM::Potion& record) override;
             ///< Create a new record (of type potion) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Spell *createRecord (const ESM::Spell& record) override;
+            const ESM::Spell *createRecord (const ESM::Spell& record) override;
             ///< Create a new record (of type spell) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Class *createRecord (const ESM::Class& record) override;
+            const ESM::Class *createRecord (const ESM::Class& record) override;
             ///< Create a new record (of type class) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Cell *createRecord (const ESM::Cell& record) override;
+            const ESM::Cell *createRecord (const ESM::Cell& record) override;
             ///< Create a new record (of type cell) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::NPC *createRecord(const ESM::NPC &record) override;
+            const ESM::NPC *createRecord(const ESM::NPC &record) override;
             ///< Create a new record (of type npc) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Armor *createRecord (const ESM::Armor& record) override;
+            const ESM::Armor *createRecord (const ESM::Armor& record) override;
             ///< Create a new record (of type armor) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Weapon *createRecord (const ESM::Weapon& record) override;
+            const ESM::Weapon *createRecord (const ESM::Weapon& record) override;
             ///< Create a new record (of type weapon) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Clothing *createRecord (const ESM::Clothing& record) override;
+            const ESM::Clothing *createRecord (const ESM::Clothing& record) override;
             ///< Create a new record (of type clothing) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Enchantment *createRecord (const ESM::Enchantment& record) override;
+            const ESM::Enchantment *createRecord (const ESM::Enchantment& record) override;
             ///< Create a new record (of type enchantment) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::Book *createRecord (const ESM::Book& record) override;
+            const ESM::Book *createRecord (const ESM::Book& record) override;
             ///< Create a new record (of type book) in the ESM store.
             /// \return pointer to created record
 
-            virtual const ESM::CreatureLevList *createOverrideRecord (const ESM::CreatureLevList& record) override;
+            const ESM::CreatureLevList *createOverrideRecord (const ESM::CreatureLevList& record) override;
             ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
             /// \return pointer to created record
 
-            virtual const ESM::ItemLevList *createOverrideRecord (const ESM::ItemLevList& record) override;
+            const ESM::ItemLevList *createOverrideRecord (const ESM::ItemLevList& record) override;
             ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
             /// \return pointer to created record
 
-            virtual void update (float duration, bool paused) override;
+            void update (float duration, bool paused) override;
 
-            virtual void updateWindowManager () override;
+            void updateWindowManager () override;
 
-            virtual MWWorld::Ptr placeObject (const MWWorld::ConstPtr& object, float cursorX, float cursorY, int amount) override;
+            MWWorld::Ptr placeObject (const MWWorld::ConstPtr& object, float cursorX, float cursorY, int amount) override;
             ///< copy and place an object into the gameworld at the specified cursor position
             /// @param object
             /// @param cursor X (relative 0-1)
             /// @param cursor Y (relative 0-1)
             /// @param number of objects to place
 
-            virtual MWWorld::Ptr dropObjectOnGround (const MWWorld::Ptr& actor, const MWWorld::ConstPtr& object, int amount) override;
+            MWWorld::Ptr dropObjectOnGround (const MWWorld::Ptr& actor, const MWWorld::ConstPtr& object, int amount) override;
             ///< copy and place an object into the gameworld at the given actor's position
             /// @param actor giving the dropped object position
             /// @param object
             /// @param number of objects to place
 
-            virtual bool canPlaceObject(float cursorX, float cursorY) override;
+            bool canPlaceObject(float cursorX, float cursorY) override;
             ///< @return true if it is possible to place on object at specified cursor location
 
-            virtual void processChangedSettings(const Settings::CategorySettingVector& settings) override;
+            void processChangedSettings(const Settings::CategorySettingVector& settings) override;
 
-            virtual bool isFlying(const MWWorld::Ptr &ptr) const override;
-            virtual bool isSlowFalling(const MWWorld::Ptr &ptr) const override;
+            bool isFlying(const MWWorld::Ptr &ptr) const override;
+            bool isSlowFalling(const MWWorld::Ptr &ptr) const override;
             ///Is the head of the creature underwater?
-            virtual bool isSubmerged(const MWWorld::ConstPtr &object) const override;
-            virtual bool isSwimming(const MWWorld::ConstPtr &object) const override;
-            virtual bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const override;
-            virtual bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const override;
-            virtual bool isWading(const MWWorld::ConstPtr &object) const override;
-            virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const override;
-            virtual bool isOnGround(const MWWorld::Ptr &ptr) const override;
+            bool isSubmerged(const MWWorld::ConstPtr &object) const override;
+            bool isSwimming(const MWWorld::ConstPtr &object) const override;
+            bool isUnderwater(const MWWorld::CellStore* cell, const osg::Vec3f &pos) const override;
+            bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const override;
+            bool isWading(const MWWorld::ConstPtr &object) const override;
+            bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const override;
+            bool isOnGround(const MWWorld::Ptr &ptr) const override;
 
-            virtual osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const override;
+            osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const override;
 
-            virtual void togglePOV() override;
+            void togglePOV() override;
 
-            virtual bool isFirstPerson() const override;
+            bool isFirstPerson() const override;
 
-            virtual void togglePreviewMode(bool enable) override;
+            void togglePreviewMode(bool enable) override;
 
-            virtual bool toggleVanityMode(bool enable) override;
+            bool toggleVanityMode(bool enable) override;
 
-            virtual void allowVanityMode(bool allow) override;
+            void allowVanityMode(bool allow) override;
 
-            virtual void togglePlayerLooking(bool enable) override;
+            void togglePlayerLooking(bool enable) override;
 
-            virtual void changeVanityModeScale(float factor) override;
+            void changeVanityModeScale(float factor) override;
 
-            virtual bool vanityRotateCamera(float * rot) override;
-            virtual void setCameraDistance(float dist, bool adjust = false, bool override = true) override;
+            bool vanityRotateCamera(float * rot) override;
+            void setCameraDistance(float dist, bool adjust = false, bool override = true) override;
 
-            virtual void setupPlayer() override;
-            virtual void renderPlayer() override;
+            void setupPlayer() override;
+            void renderPlayer() override;
 
             /// open or close a non-teleport door (depending on current state)
-            virtual void activateDoor(const MWWorld::Ptr& door) override;
+            void activateDoor(const MWWorld::Ptr& door) override;
 
             /// update movement state of a non-teleport door as specified
             /// @param state see MWClass::setDoorState
             /// @note throws an exception when invoked on a teleport door
-            virtual void activateDoor(const MWWorld::Ptr& door, int state) override;
+            void activateDoor(const MWWorld::Ptr& door, int state) override;
 
-            virtual bool getPlayerStandingOn (const MWWorld::ConstPtr& object) override; ///< @return true if the player is standing on \a object
-            virtual bool getActorStandingOn (const MWWorld::ConstPtr& object) override; ///< @return true if any actor is standing on \a object
-            virtual bool getPlayerCollidingWith(const MWWorld::ConstPtr& object) override; ///< @return true if the player is colliding with \a object
-            virtual bool getActorCollidingWith (const MWWorld::ConstPtr& object) override; ///< @return true if any actor is colliding with \a object
-            virtual void hurtStandingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
+            bool getPlayerStandingOn (const MWWorld::ConstPtr& object) override; ///< @return true if the player is standing on \a object
+            bool getActorStandingOn (const MWWorld::ConstPtr& object) override; ///< @return true if any actor is standing on \a object
+            bool getPlayerCollidingWith(const MWWorld::ConstPtr& object) override; ///< @return true if the player is colliding with \a object
+            bool getActorCollidingWith (const MWWorld::ConstPtr& object) override; ///< @return true if any actor is colliding with \a object
+            void hurtStandingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
             ///< Apply a health difference to any actors standing on \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
-            virtual void hurtCollidingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
+             void hurtCollidingActors (const MWWorld::ConstPtr& object, float dmgPerSecond) override;
             ///< Apply a health difference to any actors colliding with \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
 
-            virtual float getWindSpeed() override;
+             float getWindSpeed() override;
 
-            virtual void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
+             void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all containers in active cells owned by this Npc
-            virtual void getItemsOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
+             void getItemsOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all items in active cells owned by this Npc
 
-            virtual bool getLOS(const MWWorld::ConstPtr& actor,const MWWorld::ConstPtr& targetActor) override;
+             bool getLOS(const MWWorld::ConstPtr& actor,const MWWorld::ConstPtr& targetActor) override;
             ///< get Line of Sight (morrowind stupid implementation)
 
-            virtual float getDistToNearestRayHit(const osg::Vec3f& from, const osg::Vec3f& dir, float maxDist, bool includeWater = false) override;
+             float getDistToNearestRayHit(const osg::Vec3f& from, const osg::Vec3f& dir, float maxDist, bool includeWater = false) override;
 
-            virtual void enableActorCollision(const MWWorld::Ptr& actor, bool enable) override;
+             void enableActorCollision(const MWWorld::Ptr& actor, bool enable) override;
 
-            virtual int canRest() override;
+             int canRest() override;
             ///< check if the player is allowed to rest \n
             /// 0 - yes \n
             /// 1 - only waiting \n
@@ -554,132 +554,132 @@ namespace MWWorld
             /// 3 - enemies are nearby (not implemented)
 
             /// \todo Probably shouldn't be here
-            virtual MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;
-            virtual const MWRender::Animation* getAnimation(const MWWorld::ConstPtr &ptr) const override;
-            virtual void reattachPlayerCamera() override;
+             MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;
+             const MWRender::Animation* getAnimation(const MWWorld::ConstPtr &ptr) const override;
+             void reattachPlayerCamera() override;
 
             /// \todo this does not belong here
-            virtual void screenshot (osg::Image* image, int w, int h) override;
+             void screenshot (osg::Image* image, int w, int h) override;
 
             /// Find center of exterior cell above land surface
             /// \return false if exterior with given name not exists, true otherwise
-            virtual bool findExteriorPosition(const std::string &name, ESM::Position &pos) override;
+             bool findExteriorPosition(const std::string &name, ESM::Position &pos) override;
 
             /// Find position in interior cell near door entrance
             /// \return false if interior with given name not exists, true otherwise
-            virtual bool findInteriorPosition(const std::string &name, ESM::Position &pos) override;
+             bool findInteriorPosition(const std::string &name, ESM::Position &pos) override;
 
             /// Enables or disables use of teleport spell effects (recall, intervention, etc).
-            virtual void enableTeleporting(bool enable) override;
+             void enableTeleporting(bool enable) override;
 
             /// Returns true if teleport spell effects are allowed.
-            virtual bool isTeleportingEnabled() const override;
+             bool isTeleportingEnabled() const override;
 
             /// Enables or disables use of levitation spell effect.
-            virtual void enableLevitation(bool enable) override;
+             void enableLevitation(bool enable) override;
 
             /// Returns true if levitation spell effect is allowed.
-            virtual bool isLevitationEnabled() const override;
+             bool isLevitationEnabled() const override;
 
-            virtual bool getGodModeState() override;
+             bool getGodModeState() override;
 
-            virtual bool toggleGodMode() override;
+             bool toggleGodMode() override;
 
-            virtual bool toggleScripts() override;
-            virtual bool getScriptsEnabled() const override;
+             bool toggleScripts() override;
+             bool getScriptsEnabled() const override;
 
             /**
              * @brief startSpellCast attempt to start casting a spell. Might fail immediately if conditions are not met.
              * @param actor
              * @return true if the spell can be casted (i.e. the animation should start)
              */
-            virtual bool startSpellCast (const MWWorld::Ptr& actor) override;
+             bool startSpellCast (const MWWorld::Ptr& actor) override;
 
             /**
              * @brief Cast the actual spell, should be called mid-animation
              * @param actor
              */
-            virtual void castSpell (const MWWorld::Ptr& actor) override;
+             void castSpell (const MWWorld::Ptr& actor) override;
 
-            virtual void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) override;
-            virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
+             void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) override;
+             void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
                                            const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength) override;
 
 
-            virtual const std::vector<std::string>& getContentFiles() const override;
+             const std::vector<std::string>& getContentFiles() const override;
 
-            virtual void breakInvisibility (const MWWorld::Ptr& actor) override;
+             void breakInvisibility (const MWWorld::Ptr& actor) override;
             // Are we in an exterior or pseudo-exterior cell and it's night?
-            virtual bool isDark() const override;
+             bool isDark() const override;
 
-            virtual bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) override;
+             bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) override;
 
             /// Teleports \a ptr to the closest reference of \a id (e.g. DivineMarker, PrisonMarker, TempleMarker)
             /// @note id must be lower case
-            virtual void teleportToClosestMarker (const MWWorld::Ptr& ptr,
+             void teleportToClosestMarker (const MWWorld::Ptr& ptr,
                                                   const std::string& id) override;
 
             /// List all references (filtered by \a type) detected by \a ptr. The range
             /// is determined by the current magnitude of the "Detect X" magic effect belonging to \a type.
             /// @note This also works for references in containers.
-            virtual void listDetectedReferences (const MWWorld::Ptr& ptr, std::vector<MWWorld::Ptr>& out,
+             void listDetectedReferences (const MWWorld::Ptr& ptr, std::vector<MWWorld::Ptr>& out,
                                                   DetectionType type) override;
 
             /// Update the value of some globals according to the world state, which may be used by dialogue entries.
             /// This should be called when initiating a dialogue.
-            virtual void updateDialogueGlobals() override;
+             void updateDialogueGlobals() override;
 
             /// Moves all stolen items from \a ptr to the closest evidence chest.
-            virtual void confiscateStolenItems(const MWWorld::Ptr& ptr) override;
+             void confiscateStolenItems(const MWWorld::Ptr& ptr) override;
 
-            virtual void goToJail () override;
+             void goToJail () override;
 
             /// Spawn a random creature from a levelled list next to the player
-            virtual void spawnRandomCreature(const std::string& creatureList) override;
+             void spawnRandomCreature(const std::string& creatureList) override;
 
             /// Spawn a blood effect for \a ptr at \a worldPosition
-            virtual void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
+             void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
 
-            virtual void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) override;
+             void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) override;
 
-            virtual void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster, const MWWorld::Ptr& ignore,
+             void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster, const MWWorld::Ptr& ignore,
                                       ESM::RangeType rangeType, const std::string& id, const std::string& sourceName,
                                       const bool fromProjectile=false) override;
 
-            virtual void activate (const MWWorld::Ptr& object, const MWWorld::Ptr& actor) override;
+             void activate (const MWWorld::Ptr& object, const MWWorld::Ptr& actor) override;
 
             /// @see MWWorld::WeatherManager::isInStorm
-            virtual bool isInStorm() const override;
+             bool isInStorm() const override;
 
             /// @see MWWorld::WeatherManager::getStormDirection
-            virtual osg::Vec3f getStormDirection() const override;
+             osg::Vec3f getStormDirection() const override;
 
             /// Resets all actors in the current active cells to their original location within that cell.
-            virtual void resetActors() override;
+             void resetActors() override;
 
-            virtual bool isWalkingOnWater (const MWWorld::ConstPtr& actor) const override;
+             bool isWalkingOnWater (const MWWorld::ConstPtr& actor) const override;
 
             /// Return a vector aiming the actor's weapon towards a target.
             /// @note The length of the vector is the distance between actor and target.
-            virtual osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
+             osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
             /// Return the distance between actor's weapon and target's collision box.
-            virtual float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
+             float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
-            virtual bool isPlayerInJail() const override;
+             bool isPlayerInJail() const override;
 
             /// Return terrain height at \a worldPos position.
-            virtual float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;
+             float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;
 
             /// Return physical or rendering half extents of the given actor.
-            virtual osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const override;
+             osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor, bool rendering=false) const override;
 
             /// Export scene graph to a file and return the filename.
             /// \param ptr object to export scene graph for (if empty, export entire scene graph)
-            virtual std::string exportSceneGraph(const MWWorld::Ptr& ptr) override;
+             std::string exportSceneGraph(const MWWorld::Ptr& ptr) override;
 
             /// Preload VFX associated with this effect list
-            virtual void preloadEffects(const ESM::EffectList* effectList) override;
+             void preloadEffects(const ESM::EffectList* effectList) override;
     };
 }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -635,7 +635,7 @@ namespace MWWorld
             void goToJail () override;
 
             /// Spawn a random creature from a levelled list next to the player
-             void spawnRandomCreature(const std::string& creatureList) override;
+            void spawnRandomCreature(const std::string& creatureList) override;
 
             /// Spawn a blood effect for \a ptr at \a worldPosition
             void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
@@ -661,7 +661,7 @@ namespace MWWorld
 
             /// Return a vector aiming the actor's weapon towards a target.
             /// @note The length of the vector is the distance between actor and target.
-             osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
+            osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
             /// Return the distance between actor's weapon and target's collision box.
             float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;


### PR DESCRIPTION
…nings and prevent future typos or other issues that the override keyword was added to prevent.

I think only the OSX Travis builds emitted these warnings, but they were annoying me.

Alternatively, we could turn off the warning, but there's a reason the warning was implemented in the first place.