### PR TITLE
Fix openmw-cs regression that I caused

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,8 +329,9 @@ endif ()
 configure_resource_file(${OpenMW_SOURCE_DIR}/files/openmw-cs.cfg
     "${OpenMW_BINARY_DIR}" "openmw-cs.cfg")
 
-configure_resource_file(${OpenMW_SOURCE_DIR}/files/opencs/defaultfilters
-    "${OpenMW_BINARY_DIR}" "resources/defaultfilters" COPYONLY)
+# Needs the copy version because the configure version assumes the end of the file has been reached when a null character is reached and there are no CMake expressions to evaluate.
+copy_resource_file(${OpenMW_SOURCE_DIR}/files/opencs/defaultfilters
+    "${OpenMW_BINARY_DIR}" "resources/defaultfilters")
 
 configure_resource_file(${OpenMW_SOURCE_DIR}/files/gamecontrollerdb.txt
     "${OpenMW_BINARY_DIR}" "gamecontrollerdb.txt")


### PR DESCRIPTION
Apparently, I didn't test my CMake tweaks properly the other day, so what was semantically equivalent to a typo got in and broke file creation from the CS. This fixes that.

This means I've fixed two regressions in under 24 hours. It's a shame that I caused them too, though.