### PR TITLE
Editor: New project files for new projects

### DIFF
--- a/apps/opencs/model/doc/document.cpp
+++ b/apps/opencs/model/doc/document.cpp
@@ -288,7 +288,7 @@ CSMDoc::Document::Document (const Files::ConfigurationManager& configuration,
     if (mContentFiles.empty())
         throw std::runtime_error ("Empty content file sequence");
 
-    if (!boost::filesystem::exists (mProjectPath))
+    if (mNew || !boost::filesystem::exists (mProjectPath))
     {
         boost::filesystem::path customFiltersPath (configuration.getUserDataPath());
         customFiltersPath /= "defaultfilters";


### PR DESCRIPTION
Instead of reusing an old project file that may be broken, new projects should instead create their own. This is related to one of the issues found in #1501 .