### PR TITLE
fixed new clothing replacing old clothing of same value

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -340,7 +340,7 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                     if (old.getTypeName() == typeid(ESM::Clothing).name())
                     {
                         // check value
-                        if (old.getClass().getValue (old) > test.getClass().getValue (test))
+                        if (old.getClass().getValue (old) >= test.getClass().getValue (test))
                             // old clothing was more valuable
                             continue;
                     }


### PR DESCRIPTION
Found on the bug http://bugs.openmw.org/issues/4165.

In original Morrowind, new clothing of the same value wouldn't replace old clothing. Tested with common and expensive clothing by selling to merchants and using the AddItem console command in original Morrowind. 

In OpenMW, before this change, new clothing of the same value would replace old clothing, tested with the same methods used above.