### PR TITLE
Do not replace an equpped ring of the same value

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -330,10 +330,8 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
                             Ptr rightRing = *slots_.at(Slot_RightRing);
 
                             // we want to swap cheaper ring only if both are equipped
-                            if (rightRing.getClass().getValue(rightRing) < old.getClass().getValue(old))
-                            {
+                            if (old.getClass().getValue (old) >= rightRing.getClass().getValue (rightRing))
                                 continue;
-                            }
                         }
                     }
 


### PR DESCRIPTION
Related to #1512 (a fix for [bug #4165](https://bugs.openmw.org/issues/4165)).

This bug is mostly fixed, but we forgot about recently added separate check for rings.

