### PR TITLE
Fix a 'Good Beast' companion window

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -391,8 +391,8 @@ namespace MWGui
             // No greetings found. The dialogue window should not be shown.
             // If this is a companion, we must show the companion window directly (used by BM_bear_be_unique).
             MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Dialogue);
-            if (isCompanion())
-                MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Companion, mPtr);
+            if (isCompanion(actor))
+                MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Companion, actor);
             return;
         }
 
@@ -698,8 +698,13 @@ namespace MWGui
 
     bool DialogueWindow::isCompanion()
     {
-        return !mPtr.getClass().getScript(mPtr).empty()
-                && mPtr.getRefData().getLocals().getIntVar(mPtr.getClass().getScript(mPtr), "companion");
+        return isCompanion(mPtr);
+    }
+
+    bool DialogueWindow::isCompanion(const MWWorld::Ptr& actor)
+    {
+        return !actor.getClass().getScript(actor).empty()
+                && actor.getRefData().getLocals().getIntVar(actor.getClass().getScript(actor), "companion");
     }
 
     void DialogueWindow::onPersuadeResult(const std::string &title, const std::string &text)

--- a/apps/openmw/mwgui/dialogue.hpp
+++ b/apps/openmw/mwgui/dialogue.hpp
@@ -133,6 +133,7 @@ namespace MWGui
     protected:
         void updateTopics();
         void updateTopicsPane();
+        bool isCompanion(const MWWorld::Ptr& actor);
         bool isCompanion();
 
         void onPersuadeResult(const std::string& title, const std::string& text);


### PR DESCRIPTION
The "The Ritual of Beasts" Bloodmoon quest is broken in the master branch: you can not remove the arrow from the beast (no companion window appears).
There is an error in the console output:
`
Error in framelistener: Cannot get class of an empty object
`
That's because we call pushGuiMode(MWGui::GM_Companion) with the old pointer.
Steps to reproduce:
1. Execute console commands:
`set riekkilled to 5`
`player->placeatme BM_bear_be_UNIQUE 1 128 0`
2. Try to talk with the beast