### PR TITLE
Fix assert with empty setting value

### DIFF
--- a/components/config/gamesettings.cpp
+++ b/components/config/gamesettings.cpp
@@ -63,7 +63,7 @@ void Config::GameSettings::validatePaths()
 
     // Do the same for data-local
     QString local = mSettings.value(QString("data-local"));
-    if (local.at(0) == QChar('\"'))
+    if (local.length() && local.at(0) == QChar('\"'))
     {
         local.remove(0, 1);
         local.chop(1);


### PR DESCRIPTION
Local value could be empty, so it's important to check it size before read first char.