### PR TITLE
fix rain ripple regression (bug #4169)

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -252,6 +252,7 @@ namespace MWRender
         sceneRoot->setName("Scene Root");
 
         mSky.reset(new SkyManager(sceneRoot, resourceSystem->getSceneManager()));
+
         mSky->setCamera(mViewer->getCamera());
         mSky->setRainIntensityUniform(mWater->getRainIntensityUniform());
 

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -416,9 +416,9 @@ Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem
 
     setHeight(mTop);
 
-    updateWaterMaterial();
-
     mRainIntensityUniform = new osg::Uniform("rainIntensity",(float) 0.0);
+
+    updateWaterMaterial();
 }
 
 osg::Uniform *Water::getRainIntensityUniform()
@@ -517,6 +517,7 @@ void Water::createShaderWaterStateSet(osg::Node* node, Reflection* reflection, R
     osg::ref_ptr<osg::Shader> fragmentShader (shaderMgr.getShader("water_fragment.glsl", defineMap, osg::Shader::FRAGMENT));
 
     osg::ref_ptr<osg::Texture2D> normalMap (new osg::Texture2D(readPngImage(mResourcePath + "/shaders/water_nm.png")));
+
     if (normalMap->getImage())
         normalMap->getImage()->flipVertical();
     normalMap->setWrap(osg::Texture::WRAP_S, osg::Texture::REPEAT);
@@ -531,6 +532,7 @@ void Water::createShaderWaterStateSet(osg::Node* node, Reflection* reflection, R
 
     shaderStateset->setTextureAttributeAndModes(0, normalMap, osg::StateAttribute::ON);
     shaderStateset->setTextureAttributeAndModes(1, reflection->getReflectionTexture(), osg::StateAttribute::ON);
+
     if (refraction)
     {
         shaderStateset->setTextureAttributeAndModes(2, refraction->getRefractionTexture(), osg::StateAttribute::ON);
@@ -552,12 +554,12 @@ void Water::createShaderWaterStateSet(osg::Node* node, Reflection* reflection, R
 
     shaderStateset->setMode(GL_CULL_FACE, osg::StateAttribute::OFF);
 
+    shaderStateset->addUniform(mRainIntensityUniform.get());
+
     osg::ref_ptr<osg::Program> program (new osg::Program);
     program->addShader(vertexShader);
     program->addShader(fragmentShader);
     shaderStateset->setAttributeAndModes(program, osg::StateAttribute::ON);
-
-    shaderStateset->addUniform(mRainIntensityUniform);
 
     node->setStateSet(shaderStateset);
     node->setUpdateCallback(NULL);


### PR DESCRIPTION
Fixing regression [#4169](https://bugs.openmw.org/issues/4169) - now I create the rain intensity uniform **before** creating the water stateset. (I also left a minor change of adding the uniform to the stateset before the shader program creation, as other uniforms are handled the same way.) Also here I post my test checklist for the ripples, may be helpful in case there's more problems:

- load (seyda neen, shader on), it's raining
- changeweather "Bitter Coast Region" 0, T for 1 hour
- changeweather "Bitter Coast Region" 4, real-time wait until rain
- coc "Vivec, Telvanni Underworks"
- coc "vivec"
- changeweather "Ascadian Isles Region" 4, T for 1 hour
- coc "Vivec, Telvanni Underworks"
- coc "seyda neen"
- coe 0 20
- changeweather "Bitter Coast Region" 8, T for 1 hour
- coc "seyda neen"
- save, load
- turn water shader off, on, off
- changeweather "Bitter Coast Region" 6, T for 1 hour
- save, exit, run again loading save
- changeweather "Bitter Coast Region" 4, T for 1 hour
- turn water shader on
- save and exit