### PR TITLE
standerdise on 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,16 +24,8 @@ if (USE_QT)
     set_property(CACHE DESIRED_QT_VERSION PROPERTY STRINGS 4 5)
 endif()
 
-if (APPLE)
-    # OS X build process relies on this fix: https://github.com/Kitware/CMake/commit/3df5147043d83aa09acd5c9ce31d5c602efb99db
-    cmake_minimum_required(VERSION 3.1.0)
-elseif (USE_QT AND DESIRED_QT_VERSION MATCHES 5)
-    # 2.8.11+ is required to make Qt5 happy and allow linking QtMain on Windows.
-    cmake_minimum_required(VERSION 2.8.11)
-else()
-    # We probably support older versions than this.
-    cmake_minimum_required(VERSION 2.6)
-endif()
+# set the minimum required version across the board
+cmake_minimum_required(VERSION 3.1.0)
 
 project(OpenMW)
 


### PR DESCRIPTION
In reference to https://github.com/OpenMW/openmw/pull/1520

This sets the min version of cmake to 3.1, which is supported by Ubuntu Trusty (cmake3) 14.04

It solves the following problems (by removing them):

```
CMake Warning (dev) in extern/osg-ffmpeg-videoplayer/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osg-ffmpeg-videoplayer/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osgQt/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osgQt/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in components/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in components/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/openmw/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/openmw/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/bsatool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/bsatool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/esmtool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/esmtool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/launcher/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/launcher/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/mwiniimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/mwiniimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/essimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/essimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/opencs/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/opencs/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/wizard/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/wizard/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in components/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in components/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osg-ffmpeg-videoplayer/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osg-ffmpeg-videoplayer/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/oics/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osgQt/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in extern/osgQt/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in components/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in components/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/openmw/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/openmw/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/bsatool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/bsatool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/esmtool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/esmtool/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/launcher/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/launcher/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/mwiniimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/mwiniimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/essimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/essimporter/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/opencs/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/opencs/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/wizard/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in apps/wizard/CMakeLists.txt:
  Policy CMP0043 is not set: Ignore COMPILE_DEFINITIONS_<Config> properties.
  Run "cmake --help-policy CMP0043" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```