### PR TITLE
make Qt5 the default instead of 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
       # FFmpeg
       libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev,
       # Audio & Video
-      libsdl2-dev, libqt4-dev, libopenal-dev,
+      libsdl2-dev, libqt5opengl5-dev, libopenal-dev,
       # The other ones from OpenMW ppa
       libbullet-dev, libswresample-dev, libopenscenegraph-3.4-dev, libmygui-dev
     ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
 endif()
 
 if (USE_QT)
-    set(DESIRED_QT_VERSION 4 CACHE STRING "The QT version OpenMW should use (4 or 5)")
+    set(DESIRED_QT_VERSION 5 CACHE STRING "The QT version OpenMW should use (4 or 5)")
     set_property(CACHE DESIRED_QT_VERSION PROPERTY STRINGS 4 5)
 endif()
 


### PR DESCRIPTION
In reference to https://github.com/OpenMW/openmw/pull/1520

This does not remove Qt4 support, but makes Qt5 default because Ubuntu and Debian are purging Qt4 from future releases. Other distros are following.

The only issue preventing us from removing Qt4 support entirely is a slight performance issue with OpenMW-CS that involves threading. There are possible workarounds, but that is for another PR.