### PR TITLE
Wait a few seconds before getting up (fixes #3884)

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -248,15 +248,14 @@ void CharacterController::refreshHitRecoilAnims()
     bool knockdown = mPtr.getClass().getCreatureStats(mPtr).getKnockedDown();
     bool block = mPtr.getClass().getCreatureStats(mPtr).getBlock();
     bool isSwimming = MWBase::Environment::get().getWorld()->isSwimming(mPtr);
-    MWWorld::TimeStamp currentTime = MWBase::Environment::get().getWorld()->getTimeStamp();
-    float timeScale = MWBase::Environment::get().getWorld()->getTimeScaleFactor();
     if(mHitState == CharState_None)
     {
         if ((mPtr.getClass().getCreatureStats(mPtr).getFatigue().getCurrent() < 0
                 || mPtr.getClass().getCreatureStats(mPtr).getFatigue().getBase() == 0)
                 && mAnimation->hasAnimation("knockout"))
         {
-            mKnockoutTime = MWBase::Environment::get().getWorld()->getTimeStamp();
+            mTimeToWake = time(NULL);
+            mTimeToWake += rand() % 2 + 1; // Wake up after 1 to 3 seconds
             if (isSwimming && mAnimation->hasAnimation("swimknockout"))
             {
                 mHitState = CharState_SwimKnockOut;
@@ -342,7 +341,7 @@ void CharacterController::refreshHitRecoilAnims()
         mHitState = CharState_None;
     }
     else if (isKnockedOut() && mPtr.getClass().getCreatureStats(mPtr).getFatigue().getCurrent() > 0 
-            && (currentTime - mKnockoutTime) > 3*timeScale/3600) //Wait 3 seconds before getting up
+            && time(NULL) > mTimeToWake)
     {
         mHitState = isSwimming ? CharState_SwimKnockDown : CharState_KnockDown;
         mAnimation->disable(mCurrentHit);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -255,7 +255,7 @@ void CharacterController::refreshHitRecoilAnims()
                 && mAnimation->hasAnimation("knockout"))
         {
             mTimeToWake = time(NULL);
-            mTimeToWake += rand() % 2 + 1; // Wake up after 1 to 3 seconds
+            mTimeToWake += (int)( (float)rand() / (float)RAND_MAX * 2) + 1; // Wake up after 1 to 3 seconds
             if (isSwimming && mAnimation->hasAnimation("swimknockout"))
             {
                 mHitState = CharState_SwimKnockOut;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -248,12 +248,15 @@ void CharacterController::refreshHitRecoilAnims()
     bool knockdown = mPtr.getClass().getCreatureStats(mPtr).getKnockedDown();
     bool block = mPtr.getClass().getCreatureStats(mPtr).getBlock();
     bool isSwimming = MWBase::Environment::get().getWorld()->isSwimming(mPtr);
+    MWWorld::TimeStamp currentTime = MWBase::Environment::get().getWorld()->getTimeStamp();
+    float timeScale = MWBase::Environment::get().getWorld()->getTimeScaleFactor();
     if(mHitState == CharState_None)
     {
         if ((mPtr.getClass().getCreatureStats(mPtr).getFatigue().getCurrent() < 0
                 || mPtr.getClass().getCreatureStats(mPtr).getFatigue().getBase() == 0)
                 && mAnimation->hasAnimation("knockout"))
         {
+            mKnockoutTime = MWBase::Environment::get().getWorld()->getTimeStamp();
             if (isSwimming && mAnimation->hasAnimation("swimknockout"))
             {
                 mHitState = CharState_SwimKnockOut;
@@ -338,7 +341,8 @@ void CharacterController::refreshHitRecoilAnims()
             mPtr.getClass().getCreatureStats(mPtr).setBlock(false);
         mHitState = CharState_None;
     }
-    else if (isKnockedOut() && mPtr.getClass().getCreatureStats(mPtr).getFatigue().getCurrent() > 0)
+    else if (isKnockedOut() && mPtr.getClass().getCreatureStats(mPtr).getFatigue().getCurrent() > 0 
+            && (currentTime - mKnockoutTime) > 3*timeScale/3600) //Wait 3 seconds before getting up
     {
         mHitState = isSwimming ? CharState_SwimKnockDown : CharState_KnockDown;
         mAnimation->disable(mCurrentHit);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -242,11 +242,6 @@ std::string CharacterController::chooseRandomGroup (const std::string& prefix, i
     return prefix + toString(roll);
 }
 
-void CharacterController::updateKnockoutTimer(float duration)
-{
-    mTimeUntilWake -= duration;
-}
-
 void CharacterController::refreshHitRecoilAnims()
 {
     bool recovery = mPtr.getClass().getCreatureStats(mPtr).getHitRecovery();
@@ -766,6 +761,7 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
     , mSecondsOfRunning(0)
     , mTurnAnimationThreshold(0)
     , mAttackingOrSpell(false)
+    , mTimeUntilWake(0.f)
 {
     if(!mAnimation)
         return;
@@ -1637,7 +1633,7 @@ void CharacterController::update(float duration)
     updateMagicEffects();
         
     if (isKnockedOut())
-        updateKnockoutTimer(duration);
+        mTimeUntilWake -= duration;
 
     bool godmode = mPtr == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState();
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -20,6 +20,7 @@
 #include "character.hpp"
 
 #include <iostream>
+#include <random>
 
 #include <components/misc/rng.hpp>
 
@@ -254,8 +255,11 @@ void CharacterController::refreshHitRecoilAnims()
                 || mPtr.getClass().getCreatureStats(mPtr).getFatigue().getBase() == 0)
                 && mAnimation->hasAnimation("knockout"))
         {
+            std::random_device r;
+            std::mt19937 gen(r());
+            std::uniform_int_distribution<int> dist(1, 3);
             mTimeToWake = time(NULL);
-            mTimeToWake += (int)( (float)rand() / (float)RAND_MAX * 2) + 1; // Wake up after 1 to 3 seconds
+            mTimeToWake += dist(gen); // Wake up after 1 to 3 seconds
             if (isSwimming && mAnimation->hasAnimation("swimknockout"))
             {
                 mHitState = CharState_SwimKnockOut;

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -7,6 +7,7 @@
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/containerstore.hpp"
+#include "../mwworld/timestamp.hpp"
 
 #include "../mwrender/animation.hpp"
 
@@ -195,6 +196,8 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     // counted for skill increase
     float mSecondsOfSwimming;
     float mSecondsOfRunning;
+
+    MWWorld::TimeStamp mKnockoutTime;
 
     MWWorld::ConstPtr mHeadTrackTarget;
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -7,7 +7,6 @@
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/containerstore.hpp"
-#include "../mwworld/timestamp.hpp"
 
 #include "../mwrender/animation.hpp"
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -226,8 +226,6 @@ class CharacterController : public MWRender::Animation::TextKeyListener
 
     void updateMagicEffects();
 
-    void updateKnockoutTimer(float duration);
-
     void playDeath(float startpoint, CharacterState death);
     CharacterState chooseRandomDeathState() const;
     void playRandomDeath(float startpoint = 0.0f);

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -196,7 +196,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     float mSecondsOfSwimming;
     float mSecondsOfRunning;
 
-    time_t mTimeToWake;
+    float mTimeUntilWake;
 
     MWWorld::ConstPtr mHeadTrackTarget;
 
@@ -225,6 +225,8 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     void updateHeadTracking(float duration);
 
     void updateMagicEffects();
+
+    void updateKnockoutTimer(float duration);
 
     void playDeath(float startpoint, CharacterState death);
     CharacterState chooseRandomDeathState() const;

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -197,7 +197,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     float mSecondsOfSwimming;
     float mSecondsOfRunning;
 
-    MWWorld::TimeStamp mKnockoutTime;
+    time_t mTimeToWake;
 
     MWWorld::ConstPtr mHeadTrackTarget;
 


### PR DESCRIPTION
When characters are knocked down, they wait a few seconds before getting up, even if their fatigue raises above 0. Gives the knockdown animation time to finish.