### PR TITLE
Fixed escaping @ in boost program options filter

### DIFF
--- a/components/files/escape.cpp
+++ b/components/files/escape.cpp
@@ -1,6 +1,6 @@
 #include "escape.hpp"
 
-#include <boost/algorithm/string/replace.hpp>
+#include <components/misc/stringops.hpp>
 
 namespace Files
 {
@@ -8,7 +8,7 @@ namespace Files
     const int escape_hash_filter::sEscapeIdentifier = 'a';
     const int escape_hash_filter::sHashIdentifier = 'h';
 
-    escape_hash_filter::escape_hash_filter() : mNext(), mPrevious(), mSeenNonWhitespace(false), mFinishLine(false)
+    escape_hash_filter::escape_hash_filter() : mSeenNonWhitespace(false), mFinishLine(false)
     {
     }
 
@@ -26,9 +26,14 @@ namespace Files
 
     std::string EscapeHashString::processString(const std::string & str)
     {
-        std::string temp = boost::replace_all_copy<std::string>(str, std::string() + (char)escape_hash_filter::sEscape + (char)escape_hash_filter::sHashIdentifier, "#");
-        auto format = std::string(1, (char)escape_hash_filter::sEscape);
-        boost::replace_all(temp, std::string() + (char)escape_hash_filter::sEscape + (char)escape_hash_filter::sEscapeIdentifier, format);
+        std::string temp = str;
+
+        static const char hash[] = { escape_hash_filter::sEscape,  escape_hash_filter::sHashIdentifier };
+        Misc::StringUtils::replaceAll(temp, hash, "#", 2, 1);
+
+        static const char escape[] = { escape_hash_filter::sEscape,  escape_hash_filter::sEscapeIdentifier };
+        Misc::StringUtils::replaceAll(temp, escape, "@", 2, 1);
+
         return temp;
     }
 

--- a/components/files/escape.cpp
+++ b/components/files/escape.cpp
@@ -27,7 +27,8 @@ namespace Files
     std::string EscapeHashString::processString(const std::string & str)
     {
         std::string temp = boost::replace_all_copy<std::string>(str, std::string() + (char)escape_hash_filter::sEscape + (char)escape_hash_filter::sHashIdentifier, "#");
-        boost::replace_all(temp, std::string() + (char)escape_hash_filter::sEscape + (char)escape_hash_filter::sEscapeIdentifier, std::string((char)escape_hash_filter::sEscape, 1));
+        auto format = std::string(1, (char)escape_hash_filter::sEscape);
+        boost::replace_all(temp, std::string() + (char)escape_hash_filter::sEscape + (char)escape_hash_filter::sEscapeIdentifier, format);
         return temp;
     }
 

--- a/components/files/escape.hpp
+++ b/components/files/escape.hpp
@@ -30,7 +30,6 @@ namespace Files
 
     private:
         std::queue<int> mNext;
-        int mPrevious;
 
         bool mSeenNonWhitespace;
         bool mFinishLine;
@@ -42,11 +41,9 @@ namespace Files
         if (mNext.empty())
         {
             int character = boost::iostreams::get(src);
-            bool record = true;
             if (character == boost::iostreams::WOULD_BLOCK)
             {
                 mNext.push(character);
-                record = false;
             }
             else if (character == EOF)
             {
@@ -82,12 +79,6 @@ namespace Files
             {
                 mNext.push(sEscape);
                 mNext.push(sEscapeIdentifier);
-                record = false;
-            }
-            else if (mPrevious == sEscape)
-            {
-                mNext.push(sEscape);
-                mNext.push(sEscapeIdentifier);
             }
             else
             {
@@ -95,8 +86,6 @@ namespace Files
             }
             if (!mSeenNonWhitespace && !isspace(character))
                 mSeenNonWhitespace = true;
-            if (record)
-                mPrevious = character;
         }
         int retval = mNext.front();
         mNext.pop();

--- a/components/files/escape.hpp
+++ b/components/files/escape.hpp
@@ -78,6 +78,12 @@ namespace Files
                     mFinishLine = true;
                 }
             }
+            else if (character == sEscape)
+            {
+                mNext.push(sEscape);
+                mNext.push(sEscapeIdentifier);
+                record = false;
+            }
             else if (mPrevious == sEscape)
             {
                 mNext.push(sEscape);

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -145,26 +145,26 @@ public:
      * @param str The string to operate on.
      * @param what The string to replace.
      * @param with The replacement string.
-     * @param what_len The length of the string to replace.
-     * @param with_len The length of the replacement string.
+     * @param whatLen The length of the string to replace.
+     * @param withLen The length of the replacement string.
      *
      * @return A reference to the string passed in @p str.
      */
     static std::string &replaceAll(std::string &str, const char *what, const char *with,
-                                   std::size_t what_len=std::string::npos, std::size_t with_len=std::string::npos)
+                                   std::size_t whatLen=std::string::npos, std::size_t withLen=std::string::npos)
     {
-        if (what_len == std::string::npos)
-            what_len = strlen(what);
+        if (whatLen == std::string::npos)
+            whatLen = strlen(what);
 
-        if (with_len == std::string::npos)
-            with_len = strlen(with);
+        if (withLen == std::string::npos)
+            withLen = strlen(with);
 
         std::size_t found;
         std::size_t offset = 0;
-        while((found = str.find(what, offset, what_len)) != std::string::npos)
+        while((found = str.find(what, offset, whatLen)) != std::string::npos)
         {
-              str.replace(found, what_len, with, with_len);
-              offset = found + with_len;
+              str.replace(found, whatLen, with, withLen);
+              offset = found + withLen;
         }
         return str;
     }

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -2,6 +2,7 @@
 #define MISC_STRINGOPS_H
 
 #include <cctype>
+#include <cstring>
 #include <string>
 #include <algorithm>
 
@@ -137,6 +138,35 @@ public:
         }
 
         return notFound;
+    }
+
+    /** @brief Replaces all occurrences of a string in another string.
+     *
+     * @param str The string to operate on.
+     * @param what The string to replace.
+     * @param with The replacement string.
+     * @param what_len The length of the string to replace.
+     * @param with_len The length of the replacement string.
+     *
+     * @return A reference to the string passed in @p str.
+     */
+    static std::string &replaceAll(std::string &str, const char *what, const char *with,
+                                   std::size_t what_len=std::string::npos, std::size_t with_len=std::string::npos)
+    {
+        if (what_len == std::string::npos)
+            what_len = strlen(what);
+
+        if (with_len == std::string::npos)
+            with_len = strlen(with);
+
+        std::size_t found;
+        std::size_t offset = 0;
+        while((found = str.find(what, offset, what_len)) != std::string::npos)
+        {
+              str.replace(found, what_len, with, with_len);
+              offset = found + with_len;
+        }
+        return str;
     }
 };
 


### PR DESCRIPTION
Resolves [bug 4189](http://bugs.openmw.org/issues/4189) Openmw Doesn't Accept @ in names of BSAs, ESP/ESMs, Textures, Meshes, Ect.

Fixed handling of @ characters in escape_hash_filter::get(), fixed parameter mixup in EscapeHashString::processString(). 

The mod loads with the fix.