### PR TITLE
[Incomplete] #2229 Pathfinding based on any angle A* and physics system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ addons:
     packages: [
       # Dev
       cmake, clang-3.6, libunshield-dev, libtinyxml-dev,
-      # Tests
-      libgtest-dev, google-mock,
       # Boost
       libboost-filesystem-dev, libboost-program-options-dev, libboost-system-dev,
       # FFmpeg

--- a/CI/before_install.linux.sh
+++ b/CI/before_install.linux.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/sh -ex
 sudo ln -s /usr/bin/clang-3.6 /usr/local/bin/clang
 sudo ln -s /usr/bin/clang++-3.6 /usr/local/bin/clang++
 
-# build libgtest & libgtest_main
-sudo mkdir /usr/src/gtest/build
-cd /usr/src/gtest/build
-sudo cmake .. -DBUILD_SHARED_LIBS=1
-sudo make -j4
-sudo ln -s /usr/src/gtest/build/libgtest.so /usr/lib/libgtest.so
-sudo ln -s /usr/src/gtest/build/libgtest_main.so /usr/lib/libgtest_main.so
+# build libgtest, libgtest_main, libgmock, libgmock_main
+git clone https://github.com/google/googletest.git
+mkdir googletest/build
+cd googletest/build
+cmake ..
+make -j$(nproc)
+sudo make install

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -72,7 +72,7 @@ add_openmw_dir (mwworld
     )
 
 add_openmw_dir (mwphysics
-    physicssystem trace collisiontype actor convert
+    physicssystem trace collisiontype actor convert closestcollision
     )
 
 add_openmw_dir (mwclass

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -86,6 +86,7 @@ add_openmw_dir (mwmechanics
     aiescort aiactivate aicombat repair enchanting pathfinding pathgrid security spellsuccess spellcasting
     disease pickpocket levelledlist combat steering obstacle autocalcspell difficultyscaling aicombataction actor summoning
     character actors objects aistate coordinateconverter trading aiface weaponpriority spellpriority
+    findoptimalpath
     )
 
 add_openmw_dir (mwstate

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -71,6 +71,11 @@ namespace Fallback
     class Map;
 }
 
+namespace MWPhysics
+{
+    class PhysicsSystem;
+}
+
 namespace MWBase
 {
     /// \brief Interface for the World (implemented in MWWorld)
@@ -574,6 +579,8 @@ namespace MWBase
 
             /// Preload VFX associated with this effect list
             virtual void preloadEffects(const ESM::EffectList* effectList) = 0;
+
+            virtual MWPhysics::PhysicsSystem& getPhysicsSystem() const = 0;
     };
 }
 

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -79,7 +79,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const ESM::Pathgr
 {
     mTimer += duration; //Update timer
 
-    ESM::Position pos = actor.getRefData().getPosition(); //position of the actor
+    const ESM::Position pos = actor.getRefData().getPosition(); //position of the actor
 
     /// Stops the actor when it gets too close to a unloaded cell
     //... At current time, this test is unnecessary. AI shuts down when actor is more than 7168
@@ -92,14 +92,14 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const ESM::Pathgr
     }
 
     // handle path building and shortcutting
-    ESM::Pathgrid::Point start = pos.pos;
+    const ESM::Pathgrid::Point start = pos.pos;
 
-    float distToTarget = distance(start, dest);
-    bool isDestReached = (distToTarget <= destTolerance);
+    const float distToTarget = distance(start, dest);
+    const bool isDestReached = (distToTarget <= destTolerance);
 
     if (!isDestReached && mTimer > AI_REACTION_TIME)
     {
-        bool wasShortcutting = mIsShortcutting;
+        const bool wasShortcutting = mIsShortcutting;
         bool destInLOS = false;
 
         const MWWorld::Class& actorClass = actor.getClass();

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -14,18 +14,48 @@
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 
+#include "../mwphysics/physicssystem.hpp"
+#include "../mwphysics/actor.hpp"
+#include "../mwphysics/convert.hpp"
+
 #include "pathgrid.hpp"
 #include "creaturestats.hpp"
 #include "movement.hpp"
 #include "steering.hpp"
 #include "actorutil.hpp"
 #include "coordinateconverter.hpp"
+#include "findoptimalpath.hpp"
 
 #include <osg/Quat>
 
+#include <LinearMath/btVector3.h>
+#include <BulletCollision/CollisionDispatch/btCollisionObject.h>
+#include <BulletCollision/CollisionShapes/btCollisionShape.h>
+#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
+
+#include <osg/Timer>
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+
+inline std::ostream& operator <<(std::ostream& stream, const btVector3& value) {
+    return stream << std::setprecision(std::numeric_limits<btScalar>::digits)
+        << "(" << value.x() << ", " << value.y() << ", " << value.z() << ")";
+}
+
+template <class T>
+inline std::ostream& operator <<(std::ostream& stream, const std::vector<T>& value) {
+    stream << "{";
+    for (const auto& v : value) {
+        stream << v << ", ";
+    }
+    return stream << "}";
+}
+
 MWMechanics::AiPackage::~AiPackage() {}
 
-MWMechanics::AiPackage::AiPackage() : 
+MWMechanics::AiPackage::AiPackage() :
     mTimer(AI_REACTION_TIME + 1.0f), // to force initial pathbuild
     mRotateOnTheRunChecks(0),
     mIsShortcutting(false),
@@ -117,22 +147,25 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const ESM::Pathgr
         {
             if (wasShortcutting || doesPathNeedRecalc(dest, actor.getCell())) // if need to rebuild path
             {
-                mPathFinder.buildSyncedPath(start, dest, actor.getCell(), getPathGridGraph(actor.getCell()));
-                mRotateOnTheRunChecks = 3;
-
-                // give priority to go directly on target if there is minimal opportunity
-                if (destInLOS && mPathFinder.getPath().size() > 1)
+                if (!buildOptimalPath(dest, actor))
                 {
-                    // get point just before dest
-                    std::list<ESM::Pathgrid::Point>::const_iterator pPointBeforeDest = mPathFinder.getPath().end();
-                    --pPointBeforeDest;
-                    --pPointBeforeDest;
+                    mPathFinder.buildSyncedPath(start, dest, actor.getCell(), getPathGridGraph(actor.getCell()));
+                    mRotateOnTheRunChecks = 3;
 
-                    // if start point is closer to the target then last point of path (excluding target itself) then go straight on the target
-                    if (distance(start, dest) <= distance(dest, *pPointBeforeDest))
+                    // give priority to go directly on target if there is minimal opportunity
+                    if (destInLOS && mPathFinder.getPath().size() > 1)
                     {
-                        mPathFinder.clearPath();
-                        mPathFinder.addPointToPath(dest);
+                        // get point just before dest
+                        std::list<ESM::Pathgrid::Point>::const_iterator pPointBeforeDest = mPathFinder.getPath().end();
+                        --pPointBeforeDest;
+                        --pPointBeforeDest;
+
+                        // if start point is closer to the target then last point of path (excluding target itself) then go straight on the target
+                        if (distance(start, dest) <= distance(dest, *pPointBeforeDest))
+                        {
+                            mPathFinder.clearPath();
+                            mPathFinder.addPointToPath(dest);
+                        }
                     }
                 }
             }
@@ -359,7 +392,7 @@ bool MWMechanics::AiPackage::isReachableRotatingOnTheRun(const MWWorld::Ptr& act
     osg::Vec3f radiusDir = dir ^ osg::Z_AXIS; // radius is perpendicular to a tangent
     radiusDir.normalize();
     radiusDir *= radius;
-    
+
     // pick up the nearest center candidate
     osg::Vec3f dest_ = PathFinder::MakeOsgVec3(dest);
     osg::Vec3f pos = actor.getRefData().getPosition().asVec3();
@@ -372,4 +405,33 @@ bool MWMechanics::AiPackage::isReachableRotatingOnTheRun(const MWWorld::Ptr& act
     // if pathpoint is reachable for the actor rotating on the run:
     // no points of actor's circle should be farther from the center than destination point
     return (radius <= distToDest);
+}
+
+bool MWMechanics::AiPackage::buildOptimalPath(const ESM::Pathgrid::Point& endPoint, const MWWorld::Ptr& actor)
+{
+    const auto& physics = MWBase::Environment::get().getWorld()->getPhysicsSystem();
+    const auto object = physics.getActor(actor)->getCollisionObject();
+    const auto source = object->getWorldTransform().getOrigin() + btVector3(0, 0, 0.5);
+    const auto halfExtents = MWPhysics::toBullet(physics.getActor(actor)->getHalfExtents());
+    const auto halfExtentZ = halfExtents.z();
+    const auto target = btVector3(endPoint.mX, endPoint.mY, endPoint.mZ + halfExtentZ);
+
+    FindOptimalPathConfig config;
+    config.mActorHalfExtents = halfExtents;
+    config.mMaxDepth = 10;
+    config.mMaxIterations = 100;
+
+    const auto path = findOptimalPath(physics.getCollisionWorld(), *object, source, target, config);
+
+    if (path.mPoints.empty())
+        return false;
+
+    mPathFinder.clearPath();
+    for (const auto point : path.mPoints)
+    {
+        const float coordinates[] = {point.x(), point.y(), point.z()};
+        mPathFinder.addPointToPath(ESM::Pathgrid::Point(coordinates));
+    }
+
+    return true;
 }

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -122,6 +122,8 @@ namespace MWMechanics
 
             const PathgridGraph& getPathGridGraph(const MWWorld::CellStore* cell);
 
+            bool buildOptimalPath(const ESM::Pathgrid::Point& endPoint, const MWWorld::Ptr& actor);
+
             // TODO: all this does not belong here, move into temporary storage
             PathFinder mPathFinder;
             ObstacleCheck mObstacleCheck;

--- a/apps/openmw/mwmechanics/findoptimalpath.cpp
+++ b/apps/openmw/mwmechanics/findoptimalpath.cpp
@@ -1,0 +1,17 @@
+#include "findoptimalpath.hpp"
+#include "findoptimalpath/algorithm.hpp"
+#include "findoptimalpath/any_angle_visitor.hpp"
+
+namespace MWMechanics
+{
+    OptimalPath findOptimalPath(btCollisionWorld& collisionWorld, const btCollisionObject& actor,
+            const btVector3& initial, const btVector3& goal, const FindOptimalPathConfig& config)
+    {
+        using FindOptimalPath::AnyAngleVisitor;
+        using FindOptimalPath::Algorithm;
+        using FindOptimalPath::HasNearCollisionFilter;
+        using Visitor = AnyAngleVisitor<HasNearCollisionFilter>;
+        Visitor visitor(collisionWorld, actor, initial, goal, config, HasNearCollisionFilter(config));
+        return Algorithm<Visitor>(config, visitor).perform();
+    }
+}

--- a/apps/openmw/mwmechanics/findoptimalpath.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath.hpp
@@ -1,0 +1,38 @@
+#ifndef OPENMW_MECHANICS_COLLISIONPATHFINDER_H
+#define OPENMW_MECHANICS_COLLISIONPATHFINDER_H
+
+#include <LinearMath/btVector3.h>
+
+#include <vector>
+#include <limits>
+
+class btCollisionWorld;
+class btCollisionObject;
+
+namespace MWMechanics
+{
+    struct FindOptimalPathConfig
+    {
+        bool mAllowFly = false;
+        btVector3 mActorHalfExtents {1, 1, 1};
+        std::size_t mMaxIterations = std::numeric_limits<std::size_t>::max();
+        std::size_t mMaxDepth = std::numeric_limits<std::size_t>::max();
+        btScalar mHasNearCollisionFilterFactor = 0.33f;
+        btScalar mHasNearCollisionFilterReduceFactor = 0.5;
+        btScalar mHorizontalMarginFactor = 2;
+        btScalar mSpaceScailingFactor = 16;
+    };
+
+    struct OptimalPath
+    {
+        bool mReachMaxIterations;
+        std::size_t mIterations;
+        std::vector<btVector3> mPoints;
+    };
+
+    OptimalPath findOptimalPath(btCollisionWorld& collisionWorld, const btCollisionObject& actor,
+            const btVector3& initial, const btVector3& goal, const FindOptimalPathConfig& config);
+
+} // MWMechanics
+
+#endif // OPENMW_MECHANICS_COLLISIONPATHFINDER_H

--- a/apps/openmw/mwmechanics/findoptimalpath/algorithm.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath/algorithm.hpp
@@ -1,0 +1,269 @@
+#ifndef OPENMW_MWMECHANICS_FINDOPTIMALPATH_ALGORITHM_H
+#define OPENMW_MWMECHANICS_FINDOPTIMALPATH_ALGORITHM_H
+
+#include "open_set.hpp"
+#include "debug.hpp"
+#include "common.hpp"
+
+#include <map>
+#include <sstream>
+#include <unordered_set>
+#include <set>
+
+namespace MWMechanics
+{
+    namespace FindOptimalPath
+    {
+        using MWMechanics::FindOptimalPathConfig;
+        using MWMechanics::OptimalPath;
+
+        class ClosedSet
+        {
+        public:
+            void insert(const Transition& transition)
+            {
+                mTransitions.insert({transition.mSourceInt, transition.mDestinationInt});
+            }
+
+            bool contains(const Transition& transition) const
+            {
+                return mTransitions.count({transition.mSourceInt, transition.mDestinationInt}) > 0;
+            }
+
+            void clear()
+            {
+                mTransitions.clear();
+            }
+
+        private:
+            std::set<std::pair<PointInt, PointInt>> mTransitions;
+        };
+
+        template <class Visitor>
+        class Algorithm
+        {
+        public:
+            Algorithm(const FindOptimalPathConfig& config, Visitor& visitor)
+                : mConfig(config)
+                , mVisitor(visitor)
+            {
+            }
+
+            OptimalPath perform()
+            {
+                mOpenSet.clear();
+                mCosts.clear();
+                mCameFrom.clear();
+
+                const auto initial = mVisitor.makeInitialTransition();
+
+                JSON_LOG << withType(initial, "initial") << '\n';
+
+                mCosts.insert({initial.mSourceInt, 0});
+                push(initial);
+
+                std::size_t iterations = 0;
+                Transition final = initial;
+
+                while (true)
+                {
+                    if (mOpenSet.empty())
+                    {
+                        mOpenSet = mVisitor.getMore();
+
+                        DEBUG_LOG << "more " << mOpenSet.size() << '\n';
+
+                        if (mOpenSet.empty())
+                        {
+                            break;
+                        }
+                    }
+
+                    const Transition transition = mOpenSet.top();
+                    DEBUG_LOG << "pop"
+                        << " " << transition
+                        << " distance: " << transition.mSource.distance(initial.mDestination)
+                        << " iterations: " << iterations
+                        << '\n';
+                    JSON_LOG << withType(transition, "pop") << '\n';
+
+                    if (transition.mSource != initial.mSource && !mCameFrom.count(transition.mSource))
+                    {
+                        throw std::logic_error("Dangling transition");
+                    }
+
+                    if (transition.mSource.distance(initial.mDestination) <= mVisitor.getMaxDistance())
+                    {
+                        final = transition;
+                        DEBUG_LOG << "reach goal\n";
+                        break;
+                    }
+
+                    const auto distanceDifference = final.mSource.distance(initial.mDestination)
+                            - transition.mSource.distance(initial.mDestination);
+                    if (distanceDifference >= btScalar(0.5))
+                    {
+                        final = transition;
+                    }
+
+                    if (iterations++ >= mConfig.mMaxIterations)
+                    {
+                        DEBUG_LOG << "max iterations\n";
+                        break;
+                    }
+
+                    mOpenSet.pop();
+                    mClosedSet.insert(transition);
+
+                    if (transition.mDepth >= mConfig.mMaxDepth)
+                    {
+                        DEBUG_LOG << "max depth\n";
+                        continue;
+                    }
+
+                    for (const auto& newTransition : mVisitor.apply(transition))
+                    {
+                        if (newTransition.mState != Transition::State::Traced
+                            && newTransition.mState != Transition::State::SubTraced)
+                        {
+                            push(newTransition);
+                            continue;
+                        }
+                        if (const auto applyResult = applyTransition(newTransition, initial.mSource, initial.mDestination))
+                        {
+                            if (newTransition.mState == Transition::State::Traced)
+                            {
+                                push(applyResult.get());
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                JSON_LOG << withType(final, "final") << '\n';
+                DEBUG_LOG << "final"
+                    << " " << final
+                    << " distance: " << final.mSource.distance(initial.mDestination)
+                    << " iterations: " << iterations
+                    << '\n';
+
+                return OptimalPath {iterations > mConfig.mMaxIterations, iterations,
+                        reconstructPath(initial.mSource, final.mSource, mCameFrom)};
+            }
+
+        private:
+            enum class CheckCollision
+            {
+                NotFound,
+                Found,
+                Undefined,
+            };
+
+            const FindOptimalPathConfig& mConfig;
+            Visitor& mVisitor;
+            const btScalar mHorizontalMargin = std::max(mConfig.mActorHalfExtents.x(), mConfig.mActorHalfExtents.y())
+                    * mConfig.mHorizontalMarginFactor;
+
+            OpenSet mOpenSet;
+            ClosedSet mClosedSet;
+            std::map<PointInt, btScalar> mCosts;
+            std::map<btVector3, btVector3, PointLess> mCameFrom;
+            std::unordered_set<const btCollisionObject*> mOutput;
+
+            boost::optional<Transition> applyTransition(const Transition& transition, const btVector3& initial, const btVector3& goal)
+            {
+                if (transition.mSource != initial && !mCameFrom.count(transition.mSource))
+                {
+                    DEBUG_LOG << "ignore apply " << transition << " reason: no path to source\n";
+                    return boost::none;
+                }
+
+                const auto otherCost = mCosts.find(transition.mDestinationInt);
+                const auto cost = getTentativeCost(transition.mCost, transition.mSource, transition.mDestination);
+
+                if (otherCost == mCosts.end())
+                {
+                    mCosts.insert({transition.mDestinationInt, cost});
+                }
+                else if (otherCost->second > cost)
+                {
+                    otherCost->second = cost;
+                }
+                else
+                {
+                    DEBUG_LOG << "ignore apply " << transition << " reason: expensive cost\n";
+                    return boost::none;
+                }
+
+                {
+                    const auto direction = (transition.mDestination - transition.mSource).normalized();
+                    DEBUG_LOG << "apply"
+                        << " " << transition
+                        << " depth: " << transition.mDepth
+                        << " angle: " << direction.dot(btVector3(direction.x(), direction.y(), 0))
+                        << '\n';
+                }
+                JSON_LOG << withType(transition, "apply") << '\n';
+
+                mCameFrom[transition.mDestination] = transition.mSource;
+
+                return Transition {
+                    mVisitor.getNextTransitionId(),
+                    transition.mId,
+                    mVisitor.getPriority(cost, transition.mDestination, goal),
+                    cost,
+                    transition.mDepth + 1,
+                    transition.mDestination,
+                    goal,
+                    transition.mDestinationInt,
+                    mVisitor.makePointInt(goal),
+                    Transition::State::Proposed,
+                };
+            }
+
+            std::vector<btVector3> reconstructPath(const btVector3& source, const btVector3& final,
+                    const std::map<btVector3, btVector3, PointLess>& cameFrom) const
+            {
+                std::vector<btVector3> result;
+                result.reserve(cameFrom.size());
+                auto position = final;
+                while (position != source)
+                {
+                    result.push_back(position);
+                    try
+                    {
+                        position = cameFrom.at(position);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        std::ostringstream stream;
+                        stream << "Path is broken: position "
+                            << std::setprecision(std::numeric_limits<btScalar>::digits)
+                            << "(" << position.x() << ", " << position.y() << ", " << position.z() << ")"
+                            << " not found";
+                        throw std::logic_error(stream.str());
+                    }
+                }
+                std::reverse(result.begin(), result.end());
+                return result;
+            }
+
+            void push(const Transition& transition)
+            {
+                if (!mClosedSet.contains(transition))
+                {
+                    mOpenSet.push(transition);
+                }
+                else
+                {
+                    DEBUG_LOG << "ignore push " << transition << " reason: already in closed" << '\n';
+                }
+            }
+        };
+    }
+}
+
+#endif // OPENMW_MWMECHANICS_FINDOPTIMALPATH_ALGORITHM_H

--- a/apps/openmw/mwmechanics/findoptimalpath/any_angle_visitor.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath/any_angle_visitor.hpp
@@ -1,0 +1,514 @@
+#ifndef OPENMW_MWMECHANICS_FINDOPTIMALPATH_ANY_ANGLE_VISITOR_H
+#define OPENMW_MWMECHANICS_FINDOPTIMALPATH_ANY_ANGLE_VISITOR_H
+
+#include "open_set.hpp"
+#include "get_neighbors.hpp"
+#include "debug.hpp"
+#include "common.hpp"
+
+#include "../../mwphysics/closestcollision.hpp"
+
+#include <queue>
+#include <unordered_set>
+
+namespace MWMechanics
+{
+    namespace FindOptimalPath
+    {
+        struct EmptyFilter
+        {
+            bool shouldFilter(const Transition&) const { return false; }
+            void addTransitionCollision(const Transition&, const Collision&) const {}
+            void reset() const {}
+        };
+
+        template <typename Filter = EmptyFilter>
+        class AnyAngleVisitor
+        {
+        public:
+            AnyAngleVisitor(btCollisionWorld& collisionWorld, const btCollisionObject& actor,
+                            const btVector3& initial, const btVector3& goal, const FindOptimalPathConfig& config,
+                            Filter filter = Filter())
+                : mCollisionWorld(collisionWorld)
+                , mActor(actor)
+                , mInitial(initial)
+                , mGoal(goal)
+                , mConfig(config)
+                , mFilter(filter)
+            {
+            }
+
+            std::vector<Transition> apply(const Transition& transition)
+            {
+                std::queue<Transition> transitions({transition});
+                std::vector<Transition> result;
+
+                while (!transitions.empty())
+                {
+                    const auto transition = transitions.front();
+                    transitions.pop();
+                    if (mFilter.shouldFilter(transition))
+                    {
+                        DEBUG_LOG << "filter\n";
+                        mFiltered.push(transition);
+                        continue;
+                    }
+                    for (const auto& newTransition : handleTransition(transition))
+                    {
+                        if (newTransition.mState == Transition::State::Proposed
+                                || newTransition.mState == Transition::State::SubTraced
+                                || newTransition.mState == Transition::State::Traced)
+                        {
+                            result.push_back(newTransition);
+                        }
+                        else
+                        {
+                            transitions.push(newTransition);
+                        }
+                    }
+                }
+
+                return result;
+            }
+
+            Transition makeInitialTransition()
+            {
+                return Transition {
+                    getNextTransitionId(),
+                    0,
+                    getPriority(mInitial),
+                    0,
+                    0,
+                    mInitial,
+                    mGoal,
+                    mInitialInt,
+                    mGoalInt,
+                    Transition::State::Proposed,
+                };
+            }
+
+            btScalar getPriority(const btVector3& position) const
+            {
+                return position.distance(mGoal);
+            }
+
+            btScalar getPriority(btScalar tentativeCost, const btVector3& destination) const
+            {
+                return tentativeCost + destination.distance(mGoal);
+            }
+
+            btScalar getPriority(btScalar cost, const btVector3& source, const btVector3& destination) const
+            {
+                return getPriority(getTentativeCost(cost, source, destination), destination);
+            }
+
+            int getNextTransitionId()
+            {
+                return ++mTransitionCounter;
+            }
+
+            PointInt makePointInt(const btVector3& position) const
+            {
+                const auto denominator = getDenominator(position);
+                return PointInt(mToLocal(position) / denominator) * denominator;
+            }
+
+            btScalar getMaxDistance() const
+            {
+                return mMaxDistance;
+            }
+
+            OpenSet getMore()
+            {
+                mFilter.reset();
+                return std::move(mFiltered);
+            }
+
+        private:
+            enum class CheckCollision
+            {
+                NotFound,
+                Found,
+                Undefined,
+            };
+
+            btCollisionWorld& mCollisionWorld;
+            const btCollisionObject& mActor;
+            const btVector3& mInitial;
+            const btVector3& mGoal;
+            const FindOptimalPathConfig& mConfig;
+            Filter mFilter;
+            const btVector3 mGoalAtInitialZ {mGoal.x(), mGoal.y(), mInitial.z()};
+            const btVector3 mDirectionToGoal = (mGoal - mInitial).normalized();
+            const btTransform mToLocal {btQuaternion(btVector3(0, 0, 1), normalizeAngle(std::atan2(mDirectionToGoal.y(), mDirectionToGoal.x()))), mGoalAtInitialZ};
+            const PointInt mInitialInt = makePointInt(mInitial);
+            const PointInt mGoalInt = makePointInt(mGoal);
+            const btScalar mMaxStep = mInitial.distance(mGoal);
+            const btScalar mHorizontalMargin = std::max(mConfig.mActorHalfExtents.x(), mConfig.mActorHalfExtents.y()) * mConfig.mHorizontalMarginFactor;
+            const btScalar mVerticalMargin = mConfig.mActorHalfExtents.z() + 1;
+            const btVector3 mToGround {0, 0, -5e2};
+            OpenSet mFiltered;
+
+            int mTransitionCounter = 0;
+            btScalar mMaxDistance = 1;
+            std::unordered_set<const btCollisionObject*> mOutput;
+
+            std::vector<Transition> handleTransition(const Transition& transition)
+            {
+                switch (transition.mState)
+                {
+                    case Transition::State::Proposed:
+                        return onTransitionProposed(transition);
+                    case Transition::State::WithoutCollisions:
+                        return onTransitionWithoutCollisions(transition);
+                    case Transition::State::WithGroundedDestination:
+                        return onTransitionWithGroundedDestination(transition);
+                    case Transition::State::SubTraced:
+                    case Transition::State::Traced:
+                        return {transition};
+                }
+
+                throw std::invalid_argument("Unhandled Transition::State: " + std::to_string(int(transition.mState)));
+            }
+
+            std::vector<Transition> onTransitionProposed(const Transition& transition)
+            {
+                if (const auto collision = getClosestCollisionWithStepUp(transition.mSource, transition.mDestination))
+                {
+                    return handleCollision(collision.get(), transition);
+                }
+
+                return {withNextState(transition)};
+            }
+
+            std::vector<Transition> onTransitionWithoutCollisions(const Transition& transition)
+            {
+                const auto groundedDestination = groundDestination(transition);
+
+                if (groundedDestination.mType == GroundedDestination::Type::Undefined)
+                {
+                    return {};
+                }
+
+                if (groundedDestination.mType == GroundedDestination::Type::Defined)
+                {
+                    return {
+                        Transition {
+                            transition.mId,
+                            transition.mParentId,
+                            getPriority(transition.mCost, transition.mSource, groundedDestination.mPosition),
+                            transition.mCost,
+                            transition.mDepth,
+                            transition.mSource,
+                            groundedDestination.mPosition,
+                            transition.mSourceInt,
+                            makePointInt(groundedDestination.mPosition),
+                            Transition::State::WithGroundedDestination,
+                        }
+                    };
+                }
+
+                return {withNextState(transition)};
+            }
+
+            std::vector<Transition> onTransitionWithGroundedDestination(const Transition& transition)
+            {
+                return trace(transition);
+            }
+
+            std::vector<Transition> handleCollision(const Collision& collision, const Transition& transition)
+            {
+                if (mOutput.insert(collision.mObject).second)
+                {
+                    JSON_LOG << withType(*collision.mObject) << '\n';
+                }
+
+                JSON_LOG << withType(collision) << '\n';
+                DEBUG_LOG << "collision"
+                    << " point: " << collision.mPoint
+                    << " normal: " << collision.mNormal
+                    << " end: " << collision.mEnd
+                    << " fraction: " << collision.mFraction
+                    << " distance: " << getDistance(transition, collision.mPoint, mConfig.mActorHalfExtents.z())
+                    << " shape: " << BroadphaseNativeTypes(collision.mObject->getCollisionShape()->getShapeType())
+#ifdef OUTPUT_COLLISION_OBJECTS
+                    << " ptr: " << collision.mObject->getCollisionShape()
+#endif
+                    << '\n';
+
+                mFilter.addTransitionCollision(transition, collision);
+
+                if (transition.mDestination == mGoal)
+                {
+                    btCollisionObject actorCopy = mActor;
+                    actorCopy.setWorldTransform(btTransform(btMatrix3x3::getIdentity(), mGoal));
+                    ContactResultCallback contactResultCallback;
+                    contactResultCallback.m_collisionFilterGroup = actorCopy.getBroadphaseHandle()->m_collisionFilterGroup;
+                    contactResultCallback.m_collisionFilterMask = actorCopy.getBroadphaseHandle()->m_collisionFilterMask;
+                    auto objectCopy = *collision.mObject;
+                    mCollisionWorld.contactPairTest(&actorCopy, &objectCopy, contactResultCallback);
+
+                    if (contactResultCallback.mFound)
+                    {
+                        mMaxDistance = mGoal.distance(collision.mEnd) + btScalar(1);
+                        DEBUG_LOG << "occupied max_distance: " << mMaxDistance << '\n';
+                        const auto shift = (transition.mDestination - transition.mSource).normalized() * btScalar(0.1);
+                        const auto destination = collision.mEnd - shift;
+                        const auto newTransition = withNewDestination(transition, destination, true);
+                        return newTransition ? std::vector<Transition>({newTransition.get()}) : std::vector<Transition>();
+                    }
+                }
+
+                std::vector<Transition> result;
+                for (const std::pair<btVector3, bool>& destination : getNeighbors(transition, collision))
+                {
+                    if (const auto newTransition = withNewDestination(transition, destination.first, destination.second))
+                    {
+                        result.push_back(newTransition.get());
+                    }
+                }
+                return result;
+            }
+
+            GetNeighbors::Candidates getNeighbors(const Transition& transition, const Collision& collision) const
+            {
+                const auto minStep = btScalar(std::sqrt(2)) * getDenominator(collision.mEnd);
+                return GetNeighbors(transition.mSource, transition.mDestination, mGoal, collision, minStep,
+                                    mMaxStep, mHorizontalMargin, mVerticalMargin, mConfig.mAllowFly).perform();
+            }
+
+            GroundedDestination groundDestination(const Transition& transition)
+            {
+                if (mConfig.mAllowFly)
+                {
+                    return GroundedDestination {GroundedDestination::Type::Same, btVector3()};
+                }
+
+                const auto ground = getClosestCollision(transition.mDestination, transition.mDestination + mToGround);
+
+                if (!ground)
+                {
+                    DEBUG_LOG << "ground is too far\n";
+                    return GroundedDestination {GroundedDestination::Type::Undefined, btVector3()};
+                }
+
+                DEBUG_LOG << "collision ground"
+                    << " point: " << ground->mPoint
+                    << " normal: " << ground->mNormal
+                    << " end: " << ground->mEnd
+                    << " fraction: " << ground->mFraction
+                    << " distance: " << getDistance(transition, ground->mPoint, mConfig.mActorHalfExtents.z())
+                    << " shape: " << BroadphaseNativeTypes(ground->mObject->getCollisionShape()->getShapeType())
+#ifdef OUTPUT_COLLISION_OBJECTS
+                    << " ptr: " << ground->mObject->getCollisionShape()
+#endif
+                    << '\n';
+
+                if (!isWalkableSlope(ground->mNormal))
+                {
+                    DEBUG_LOG << "ground slope is too steep\n";
+                    return GroundedDestination {GroundedDestination::Type::Undefined, btVector3()};
+                }
+
+                const auto groundedDestination = ground->mEnd + btVector3(0, 0, 1);
+
+                if (groundedDestination.z() >= transition.mDestination.z())
+                {
+                    return GroundedDestination {GroundedDestination::Type::Same, btVector3()};
+                }
+                DEBUG_LOG << "ground " << transition.mDestination << " => " << groundedDestination << ", normal: " << ground->mNormal << '\n';
+
+                if (groundedDestination == transition.mSource)
+                {
+                    DEBUG_LOG << "zero transition\n";
+                    return GroundedDestination {GroundedDestination::Type::Undefined, btVector3()};
+                }
+
+                return GroundedDestination {GroundedDestination::Type::Defined, groundedDestination};
+            }
+
+            std::vector<Transition> trace(const Transition& transition)
+            {
+                if (mConfig.mAllowFly)
+                {
+                    return {withNextState(transition)};
+                }
+
+                const auto path = transition.mDestination - transition.mSource;
+                const auto length = path.length();
+                const btScalar step = mConfig.mActorHalfExtents.x();
+
+                if (length <= step)
+                {
+                    return {withNextState(transition)};
+                }
+
+                const auto count = std::ceil(length / step);
+                Transition sub = transition;
+
+                DEBUG_LOG << "trace path " << transition << " count: " << count << '\n';
+
+                std::vector<Transition> result;
+
+                for (long i = 0; i < count; ++i)
+                {
+                    sub.mParentId = sub.mId;
+                    sub.mId = getNextTransitionId();
+
+                    if (i < count - 1)
+                    {
+                        sub.mDestination = transition.mSource + path * btScalar(i + 1) / btScalar(count);
+                        sub.mDestinationInt = makePointInt(sub.mDestination);
+                        sub.mState = Transition::State::Proposed;
+                        DEBUG_LOG << "trace " << i << " " << sub << '\n';
+                        const auto groundedDestination = groundDestination(sub);
+                        if (groundedDestination.mType == GroundedDestination::Type::Undefined)
+                        {
+                            break;
+                        }
+                        if (groundedDestination.mType == GroundedDestination::Type::Defined)
+                        {
+                            sub.mDestination = groundedDestination.mPosition;
+                            sub.mDestinationInt = makePointInt(sub.mDestination);
+                            sub.mPriority = getPriority(sub.mCost, sub.mSource, sub.mDestination);
+                        }
+                    }
+                    else
+                    {
+                        sub.mDestination = transition.mDestination;
+                        sub.mDestinationInt = makePointInt(sub.mDestination);
+                        sub.mPriority = getPriority(transition.mCost, sub.mSource, sub.mDestination);
+                        DEBUG_LOG << "trace " << i << " " << sub << '\n';
+                    }
+
+                    JSON_LOG << withType(sub, "trace") << '\n';
+
+                    if (const auto collision = getClosestCollisionWithStepUp(sub.mSource, sub.mDestination))
+                    {
+                        DEBUG_LOG << "trace path end reason: found collision\n";
+                        for (const auto newTransition : handleCollision(collision.get(), sub))
+                        {
+                             result.push_back(newTransition);
+                        }
+                        break;
+                    }
+
+                    sub.mState = (i == count - 1) ? Transition::State::Traced : Transition::State::SubTraced;
+
+                    result.push_back(sub);
+
+                    sub.mCost = getTentativeCost(sub.mCost, sub.mSource, sub.mDestination);
+                    sub.mSource = sub.mDestination;
+                    sub.mSourceInt = sub.mDestinationInt;
+                    sub.mPriority = getPriority(sub.mCost, sub.mSource, sub.mDestination);
+                }
+
+                DEBUG_LOG << "trace finished" << '\n';
+
+                return result;
+            }
+
+            boost::optional<Transition> withNewDestination(const Transition& transition, const btVector3& destination, bool withoutCollision)
+            {
+                if (transition.mSource.distance(destination) <= btScalar(1))
+                {
+                    DEBUG_LOG << "ignore add " << transition << " new destination: " << destination << " reason: zero transition" << '\n';
+                    return boost::none;
+                }
+
+                const auto destinationInt = makePointInt(destination);
+
+                if (transition.mSourceInt == destinationInt)
+                {
+                    DEBUG_LOG << "ignore add " << transition << " reason: zero int transition" << '\n';
+                    return boost::none;
+                }
+
+                const auto tentativeCost = getTentativeCost(transition.mCost, transition.mSource, destination);
+
+                return Transition {
+                    getNextTransitionId(),
+                    transition.mId,
+                    getPriority(tentativeCost, destination),
+                    transition.mCost,
+                    transition.mDepth,
+                    transition.mSource,
+                    destination,
+                    transition.mSourceInt,
+                    makePointInt(destination),
+                    withoutCollision ? Transition::State::WithoutCollisions : Transition::State::Proposed,
+                };
+            }
+
+            btScalar getDenominator(const btVector3& position) const
+            {
+                const auto distance = btScalar(mConfig.mSpaceScailingFactor) * position.distance(mGoal);
+                return distance > btScalar(2) ? std::log2(distance) : btScalar(1);
+            }
+
+            boost::optional<Collision> getClosestCollision(const btVector3& source, const btVector3& destination)
+            {
+                return MWPhysics::getClosestCollision(mActor, source, destination, mCollisionWorld);
+            }
+
+            boost::optional<Collision> getClosestCollisionWithStepUp(const btVector3& source, const btVector3& destination)
+            {
+                return MWPhysics::getClosestCollisionWithStepUp(mActor, source, destination, mCollisionWorld);
+            }
+        };
+
+        class HasNearCollisionFilter
+        {
+        public:
+            HasNearCollisionFilter(const FindOptimalPathConfig& config)
+                : mConfig(&config)
+                , mNearCollisionMaxDistance(mConfig->mHasNearCollisionFilterFactor
+                    * std::min({mConfig->mActorHalfExtents.x(), mConfig->mActorHalfExtents.y(), mConfig->mActorHalfExtents.z()}))
+            {
+            }
+
+            bool shouldFilter(const Transition& transition) const
+            {
+                if (transition.mState != Transition::State::Proposed)
+                {
+                    return false;
+                }
+
+                const auto isNearCollisionPoint = [&] (const TransitionCollision& v)
+                {
+                    return getDistance(transition, v.collision.mPoint, mConfig->mActorHalfExtents.z()) <= mNearCollisionMaxDistance;
+                };
+                const auto it = std::find_if(mCollisions.begin(), mCollisions.end(), isNearCollisionPoint);
+
+                if (it != mCollisions.end())
+                {
+                    DEBUG_LOG << "found near collision point " << it->collision.mPoint
+                        << " distance: " << getDistance(transition, it->collision.mPoint, mConfig->mActorHalfExtents.z())
+                        << " max_distance: " << mNearCollisionMaxDistance
+                        << '\n';
+                    return true;
+                }
+
+                return false;
+            }
+
+            void addTransitionCollision(const Transition& transition, const Collision& collision)
+            {
+                mCollisions.push_back(TransitionCollision {collision, transition});
+            }
+
+            void reset()
+            {
+                mCollisions.clear();
+                mNearCollisionMaxDistance *= mConfig->mHasNearCollisionFilterReduceFactor;
+            }
+
+        private:
+            const FindOptimalPathConfig* mConfig;
+            btScalar mNearCollisionMaxDistance;
+            std::vector<TransitionCollision> mCollisions;
+        };
+    }
+}
+
+#endif // OPENMW_MWMECHANICS_FINDOPTIMALPATH_ANY_ANGLE_VISITOR_H

--- a/apps/openmw/mwmechanics/findoptimalpath/common.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath/common.hpp
@@ -1,0 +1,383 @@
+#ifndef OPENMW_MWMECHANICS_FINDOPTIMALPATH_COMMON_HPP
+#define OPENMW_MWMECHANICS_FINDOPTIMALPATH_COMMON_HPP
+
+#include "../findoptimalpath.hpp"
+
+#include "../../mwphysics/collisiontype.hpp"
+#include "../../mwphysics/closestcollision.hpp"
+
+#include <BulletCollision/CollisionShapes/btConcaveShape.h>
+
+#include <osg/Math>
+
+#include <array>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+
+namespace MWMechanics
+{
+    namespace FindOptimalPath
+    {
+        using MWPhysics::Collision;
+
+        inline std::pair<btVector3, btVector3> getTangentPoints(btScalar radius, const btVector3& position, const btVector3& source)
+        {
+            const auto hypot = position.distance(source);
+            const auto far_cathetus = radius;
+            if (hypot <= far_cathetus)
+            {
+                throw std::logic_error("hypot < far_cathetus: " + std::to_string(hypot) + " < " + std::to_string(far_cathetus));
+            }
+            const auto near_cathetus = std::sqrt((hypot * hypot) - (far_cathetus * far_cathetus));
+            const auto sin = far_cathetus / hypot;
+            const auto angle = std::asin(sin);
+            const auto toCircle = (position - source).normalized();
+            const auto toLeftTangent = source + toCircle.rotate(btVector3(0, 0, 1), angle) * near_cathetus;
+            const auto toRightTangent = source + toCircle.rotate(btVector3(0, 0, 1), -angle) * near_cathetus;
+            return {toLeftTangent, toRightTangent};
+        }
+
+        enum class AabbSide
+        {
+            X = 0,
+            Y = 1,
+            Z = 2,
+        };
+
+        inline AabbSide getAabbSide(const btVector3& normal)
+        {
+            std::array<btScalar, 3> values {{normal.x(), normal.y(), normal.z()}};
+            for (auto& v : values)
+            {
+                v = std::abs(v);
+            }
+            return AabbSide(std::max_element(values.begin(), values.end()) - values.begin());
+        }
+
+        static const auto maxSlopeCos = std::cos(osg::DegreesToRadians(btScalar(60)));
+
+        inline bool isWalkableSlope(btScalar cos)
+        {
+            return cos > maxSlopeCos;
+        }
+
+        inline bool isWalkableSlope(const btVector3& normal)
+        {
+            return isWalkableSlope(normal.z());
+        }
+
+        static const auto minSlopeCos = -std::cos(osg::DegreesToRadians(btScalar(80)));
+
+        inline bool isRoof(btScalar cos)
+        {
+            return cos < minSlopeCos;
+        }
+
+        inline bool isRoof(const btVector3& normal)
+        {
+            return isRoof(normal.z());
+        }
+
+        inline btVector3 projectToPlane(const btVector3& point, const btVector3& normal)
+        {
+            return point - point.dot(normal) * normal;
+        }
+
+        class LessByDistanceTo
+        {
+        public:
+            LessByDistanceTo(const btVector3& point)
+                : mPoint(point) {}
+
+            bool operator ()(const btVector3& lhs, const btVector3& rhs) const
+            {
+                return lhs.distance(mPoint) < rhs.distance(mPoint);
+            }
+
+        private:
+            const btVector3& mPoint;
+        };
+
+        class GetCentroid : public btTriangleCallback
+        {
+        public:
+            btVector3 perform(const btConcaveShape& shape, const btVector3& aabbMin, const btVector3& aabbMax)
+            {
+                mCount = 0;
+                mSum = btVector3(0, 0, 0);
+                shape.processAllTriangles(this, aabbMin, aabbMax);
+                return mSum / btScalar(mCount);
+            }
+
+        private:
+            std::size_t mCount = 0;
+            btVector3 mSum;
+
+            void processTriangle(btVector3* triangle, int, int) override final
+            {
+                for (std::size_t i = 0; i < 3; ++i) {
+                    mSum += triangle[i];
+                }
+                ++mCount;
+            }
+        };
+
+        class GetFarestPoint : public btTriangleCallback
+        {
+        public:
+            GetFarestPoint(const btVector3& point)
+                : mPoint(point) {}
+
+            const btVector3& perform(const btConcaveShape& shape, const btVector3& aabbMin, const btVector3& aabbMax)
+            {
+                mFarest = mPoint;
+                shape.processAllTriangles(this, aabbMin, aabbMax);
+                return mFarest;
+            }
+
+        private:
+            const btVector3& mPoint;
+            btVector3 mFarest;
+
+            void processTriangle(btVector3* triangle, int, int) override final
+            {
+                const LessByDistanceTo less(mPoint);
+                const auto localFarest = std::max_element(triangle, triangle + 3, less);
+                if (!less(*localFarest, mFarest))
+                {
+                    mFarest = *localFarest;
+                }
+            }
+        };
+
+        inline btScalar normalizeAngle(btScalar value)
+        {
+            if (value > osg::PI)
+            {
+                return value - std::round(value * btScalar(0.5) * btScalar(1 / osg::PI)) * btScalar(2) * btScalar(osg::PI);
+            }
+            if (value < -osg::PI)
+            {
+                return value + std::round(std::abs(value) * btScalar(0.5) * btScalar(1 / osg::PI)) * btScalar(2) * btScalar(osg::PI);
+            }
+            return value;
+        }
+
+        class PointInt
+        {
+        public:
+            PointInt(const btVector3& value)
+                : mX(std::lround(value.x()))
+                , mY(std::lround(value.y()))
+                , mZ(std::lround(value.z()))
+            {
+            }
+
+            PointInt(long x, long y, long z)
+                : mX(x)
+                , mY(y)
+                , mZ(z)
+            {
+            }
+
+            long x() const { return mX; }
+            long y() const { return mY; }
+            long z() const { return mZ; }
+
+            bool operator ==(const PointInt& other) const
+            {
+                return mX == other.mX && mY == other.mY && mZ == other.mZ;
+            }
+
+            bool operator !=(const PointInt& other) const
+            {
+                return !(*this == other);
+            }
+
+            bool operator <(const PointInt& other) const
+            {
+                return std::make_tuple(mX, mY, mZ) < std::make_tuple(other.mX, other.mY, other.mZ);
+            }
+
+            friend PointInt operator *(const PointInt& lhs, long rhs)
+            {
+                return PointInt(lhs.mX * rhs, lhs.mY * rhs, lhs.mZ * rhs);
+            }
+
+        private:
+            long mX;
+            long mY;
+            long mZ;
+        };
+
+        struct Transition
+        {
+            enum class State
+            {
+                Proposed,
+                WithoutCollisions,
+                WithGroundedDestination,
+                SubTraced,
+                Traced,
+            };
+
+            int mId;
+            int mParentId;
+            btScalar mPriority;
+            btScalar mCost;
+            std::size_t mDepth;
+            btVector3 mSource;
+            btVector3 mDestination;
+            PointInt mSourceInt;
+            PointInt mDestinationInt;
+            State mState;
+        };
+
+        struct PointLess
+        {
+            template <class T>
+            bool operator ()(const T& lhs, const T& rhs) const
+            {
+                return std::make_tuple(lhs.x(), lhs.y(), lhs.z()) < std::make_tuple(rhs.x(), rhs.y(), rhs.z());
+            }
+        };
+
+        struct PointPairLess
+        {
+            template <class T>
+            bool operator ()(const std::pair<T, T>& lhs, const std::pair<T, T>& rhs) const
+            {
+                return PointLess()(lhs.first, rhs.first)
+                        || (!PointLess()(rhs.first, lhs.first) && PointLess()(lhs.second, rhs.second));
+            }
+        };
+
+        struct ContactResultCallback : public btCollisionWorld::ContactResultCallback
+        {
+            bool mFound = false;
+
+            btScalar addSingleResult(btManifoldPoint& cp,
+                    const btCollisionObjectWrapper* /*col0Wrap*/, int /*partId0*/, int /*index0*/,
+                    const btCollisionObjectWrapper* /*col1Wrap*/, int /*partId1*/, int /*index1*/) override
+            {
+                mFound = cp.getDistance() <= btScalar(0);
+                return btScalar(0);
+            }
+        };
+
+        inline btScalar getDistanceToLine(const btVector3& begin, const btVector3& end, const btVector3& point)
+        {
+            if (begin == end) {
+                return begin.distance(point);
+            }
+            return (point - begin).cross(point - end).length() / begin.distance(end);
+        }
+
+        inline btScalar getCathetusLength(btScalar hypotenuse, btScalar cathetus)
+        {
+            return std::sqrt(hypotenuse * hypotenuse - cathetus * cathetus);
+        }
+
+        inline btScalar getDistanceToLineSegment(const btVector3& begin, const btVector3& end, const btVector3& point)
+        {
+            const auto length = begin.distance(end);
+            const auto distanceToBegin = point.distance(begin);
+            const auto distanceToEnd = point.distance(end);
+            const auto distance = getDistanceToLine(begin, end, point);
+            const auto beginCathetus = getCathetusLength(distanceToBegin, distance);
+            const auto endCathetus = getCathetusLength(distanceToEnd, distance);
+            return std::abs(beginCathetus + endCathetus - length) <= 1e-3
+                ? distance
+                : std::min(distanceToBegin, distanceToEnd);
+        }
+
+        inline btScalar getDistance(const Transition& transition, const btVector3& point, btScalar halfExtentZ)
+        {
+            const auto distanceToLineSegment = getDistanceToLineSegment(transition.mSource, transition.mDestination, point);
+            const auto distanceToVerticalAxis = getDistanceToLineSegment(
+                btVector3(transition.mSource.x(), transition.mSource.y(), 0),
+                btVector3(transition.mDestination.x(), transition.mDestination.y(), 0),
+                btVector3(point.x(), point.y(), 0));
+            const auto verticalAxisHeight = getCathetusLength(distanceToLineSegment, distanceToVerticalAxis);
+            return verticalAxisHeight <= halfExtentZ
+                ? distanceToVerticalAxis
+                : std::hypot(distanceToVerticalAxis, verticalAxisHeight - halfExtentZ);
+        }
+
+        struct GreaterByPriorityAndLessById
+        {
+            bool operator ()(const Transition& lhs, const Transition& rhs) const
+            {
+                return std::make_pair(lhs.mPriority, -lhs.mId) > std::make_pair(rhs.mPriority, -rhs.mId);
+            }
+        };
+
+        struct LessByPriorityAndId
+        {
+            bool operator ()(const Transition& lhs, const Transition& rhs) const
+            {
+                return std::make_pair(lhs.mPriority, lhs.mId) < std::make_pair(rhs.mPriority, rhs.mId);
+            }
+        };
+
+        struct GroundedDestination
+        {
+            enum class Type
+            {
+                Same,
+                Undefined,
+                Defined,
+            };
+
+            Type mType;
+            btVector3 mPosition;
+        };
+
+        struct TransitionCollision
+        {
+            Collision collision;
+            Transition transition;
+        };
+
+        inline btScalar getTentativeCost(btScalar cost, const btVector3& source, const btVector3& destination)
+        {
+            return cost + source.distance(destination);
+        }
+
+        inline Transition::State getNextState(Transition::State value)
+        {
+            switch (value)
+            {
+                case Transition::State::Proposed:
+                    return Transition::State::WithoutCollisions;
+                case Transition::State::WithoutCollisions:
+                    return Transition::State::WithGroundedDestination;
+                case Transition::State::WithGroundedDestination:
+                    return Transition::State::Traced;
+                case Transition::State::SubTraced:
+                    throw std::invalid_argument("Transition::State::SubTraced is last Transition::State");
+                case Transition::State::Traced:
+                    throw std::invalid_argument("Transition::State::Traced is last Transition::State");
+            }
+
+            throw std::invalid_argument("Unhandled Transition::State: " + std::to_string(int(value)));
+        }
+
+        inline Transition withNextState(const Transition& transition)
+        {
+            auto result = transition;
+            result.mState = getNextState(transition.mState);
+            return result;
+        }
+
+        inline Transition withTracedState(const Transition& transition)
+        {
+            auto result = transition;
+            result.mState = Transition::State::Traced;
+            return result;
+        }
+    }
+}
+
+#endif // OPENMW_MWMECHANICS_FINDOPTIMALPATH_COMMON_HPP

--- a/apps/openmw/mwmechanics/findoptimalpath/debug.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath/debug.hpp
@@ -1,0 +1,339 @@
+#ifndef OPENMW_MWMECHANICS_FINDOPTIMALPATH_DEBUG_H
+#define OPENMW_MWMECHANICS_FINDOPTIMALPATH_DEBUG_H
+
+#include "common.hpp"
+
+#include <BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h>
+
+#ifdef FIND_OPTIMAL_PATH_JSON
+#include <extern/nlohmann/json.hpp>
+#endif
+
+#include <iomanip>
+#include <iostream>
+
+namespace MWMechanics
+{
+    namespace FindOptimalPath
+    {
+        using MWPhysics::Collision;
+
+        struct DevNull
+        {
+            static DevNull& instance()
+            {
+                static DevNull value;
+                return value;
+            }
+        };
+
+        template <class T>
+        DevNull& operator <<(DevNull& stream, const T&)
+        {
+            return stream;
+        }
+
+#ifdef FIND_OPTIMAL_PATH_DEBUG_OUTPUT
+#define DEBUG_LOG std::cout
+#else
+#define DEBUG_LOG DevNull::instance()
+#endif
+
+#ifdef FIND_OPTIMAL_PATH_JSON
+#define JSON_LOG std::cerr
+#else
+#define JSON_LOG DevNull::instance()
+#endif
+
+#ifdef FIND_OPTIMAL_PATH_DEBUG_OUTPUT
+        inline std::ostream& operator <<(std::ostream& stream, const btVector3& value)
+        {
+            return stream
+                << std::setprecision(std::numeric_limits<btScalar>::digits)
+                << "(" << value.x() << ", " << value.y() << ", " << value.z() << ")";
+        }
+
+        inline std::ostream& operator <<(std::ostream& stream, const btMatrix3x3& value)
+        {
+            stream << "btMatrix3x3 {\n";
+            for (int i = 0; i < 3; ++i) {
+                const auto& row = value.getRow(i);
+                stream << row.x() << ", " << row.y() << ", " << row.z() << ",\n";
+            }
+            return stream << "}";
+        }
+
+        inline std::ostream& operator <<(std::ostream& stream, const btTransform& value)
+        {
+            return stream
+                << std::setprecision(std::numeric_limits<btScalar>::digits)
+                << "btTransform {\n" << value.getBasis() << ",\n" << value.getOrigin() << "\n}";
+        }
+#endif
+
+#if defined(FIND_OPTIMAL_PATH_DEBUG_OUTPUT) || defined(FIND_OPTIMAL_PATH_JSON)
+        inline std::ostream& operator <<(std::ostream& stream, BroadphaseNativeTypes value)
+        {
+            switch (value)
+            {
+#ifndef SHAPE_NAME
+#define SHAPE_NAME(name) case name: return stream << #name;
+                SHAPE_NAME(BOX_SHAPE_PROXYTYPE)
+                SHAPE_NAME(TRIANGLE_SHAPE_PROXYTYPE)
+                SHAPE_NAME(TETRAHEDRAL_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CONVEX_TRIANGLEMESH_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CONVEX_HULL_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CONVEX_POINT_CLOUD_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CUSTOM_POLYHEDRAL_SHAPE_TYPE)
+                SHAPE_NAME(IMPLICIT_CONVEX_SHAPES_START_HERE)
+                SHAPE_NAME(SPHERE_SHAPE_PROXYTYPE)
+                SHAPE_NAME(MULTI_SPHERE_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CAPSULE_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CONE_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CONVEX_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CYLINDER_SHAPE_PROXYTYPE)
+                SHAPE_NAME(UNIFORM_SCALING_SHAPE_PROXYTYPE)
+                SHAPE_NAME(MINKOWSKI_SUM_SHAPE_PROXYTYPE)
+                SHAPE_NAME(MINKOWSKI_DIFFERENCE_SHAPE_PROXYTYPE)
+                SHAPE_NAME(BOX_2D_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CONVEX_2D_SHAPE_PROXYTYPE)
+                SHAPE_NAME(CUSTOM_CONVEX_SHAPE_TYPE)
+                SHAPE_NAME(CONCAVE_SHAPES_START_HERE)
+                SHAPE_NAME(TRIANGLE_MESH_SHAPE_PROXYTYPE)
+                SHAPE_NAME(SCALED_TRIANGLE_MESH_SHAPE_PROXYTYPE)
+                SHAPE_NAME(FAST_CONCAVE_MESH_PROXYTYPE)
+                SHAPE_NAME(TERRAIN_SHAPE_PROXYTYPE)
+                SHAPE_NAME(GIMPACT_SHAPE_PROXYTYPE)
+                SHAPE_NAME(MULTIMATERIAL_TRIANGLE_MESH_PROXYTYPE)
+                SHAPE_NAME(EMPTY_SHAPE_PROXYTYPE)
+                SHAPE_NAME(STATIC_PLANE_PROXYTYPE)
+                SHAPE_NAME(CUSTOM_CONCAVE_SHAPE_TYPE)
+                SHAPE_NAME(CONCAVE_SHAPES_END_HERE)
+                SHAPE_NAME(COMPOUND_SHAPE_PROXYTYPE)
+                SHAPE_NAME(SOFTBODY_SHAPE_PROXYTYPE)
+                SHAPE_NAME(HFFLUID_SHAPE_PROXYTYPE)
+                SHAPE_NAME(HFFLUID_BUOYANT_CONVEX_SHAPE_PROXYTYPE)
+                SHAPE_NAME(INVALID_SHAPE_PROXYTYPE)
+                SHAPE_NAME(MAX_BROADPHASE_COLLISION_TYPES)
+#undef SHAPE_NAME
+#endif
+                default:
+                    return stream << "undefined(" << int(value) << ")";
+            }
+        }
+#endif
+
+#ifdef FIND_OPTIMAL_PATH_DEBUG_OUTPUT
+        inline std::ostream& operator <<(std::ostream& stream, AabbSide value)
+        {
+            switch (value)
+            {
+                case AabbSide::X:
+                    return stream << 'X';
+                case AabbSide::Y:
+                    return stream << 'Y';
+                case AabbSide::Z:
+                    return stream << 'Z';
+                default:
+                    return stream << int(value);
+            }
+        }
+#endif
+
+#if defined(FIND_OPTIMAL_PATH_DEBUG_OUTPUT) || defined(FIND_OPTIMAL_PATH_JSON)
+        inline std::ostream& operator <<(std::ostream& stream, Transition::State value)
+        {
+            switch (value)
+            {
+                case Transition::State::Proposed:
+                    return stream << "Proposed";
+                case Transition::State::WithGroundedDestination:
+                    return stream << "WithGroundedDestination";
+                case Transition::State::WithoutCollisions:
+                    return stream << "WithoutCollisions";
+                case Transition::State::SubTraced:
+                    return stream << "SubTraced";
+                case Transition::State::Traced:
+                    return stream << "Traced";
+            }
+
+            throw std::invalid_argument("Unhandled Transition::State: " + std::to_string(int(value)));
+        }
+#endif
+
+        inline std::ostream& operator <<(std::ostream& stream, const PointInt& value)
+        {
+            return stream << "(" << value.x() << ", " << value.y() << ", " << value.z() << ")";
+        }
+
+#ifdef FIND_OPTIMAL_PATH_DEBUG_OUTPUT
+        inline std::ostream& operator <<(std::ostream& stream, const Transition& value)
+        {
+            return stream
+                << value.mId << "~" << value.mParentId
+                << " " << value.mSource << " -> " << value.mDestination
+                << " [" << value.mSourceInt << " -> " << value.mDestinationInt << "]"
+                << " length: " << value.mSource.distance(value.mDestination)
+                << " cost: " << value.mCost
+                << " priority: " << value.mPriority
+                << " depth: " << value.mDepth
+                << " state: " << value.mState;
+        }
+#endif
+
+#ifdef FIND_OPTIMAL_PATH_JSON
+        inline nlohmann::json toJson(const btVector3& value)
+        {
+            nlohmann::json result;
+            result["x"] = value.x();
+            result["y"] = value.y();
+            result["z"] = value.z();
+            return result;
+        }
+
+        inline nlohmann::json withType(const btVector3& value, const std::string& type)
+        {
+            nlohmann::json result;
+            result["type"] = type;
+            result["position"] = toJson(value);
+            return result;
+        }
+
+        inline nlohmann::json toJson(const PointInt& value)
+        {
+            nlohmann::json result;
+            result["x"] = value.x();
+            result["y"] = value.y();
+            result["z"] = value.z();
+            return result;
+        }
+
+        inline nlohmann::json toJson(Transition::State value)
+        {
+            std::ostringstream stream;
+            stream << value;
+            return stream.str();
+        }
+
+        inline nlohmann::json toJson(const Transition& value)
+        {
+            nlohmann::json result;
+            result["id"] = value.mId;
+            result["parent_id"] = value.mParentId;
+            result["priority"] = value.mPriority;
+            result["cost"] = value.mCost;
+            result["depth"] = value.mDepth;
+            result["source"] = toJson(value.mSource);
+            result["destination"] = toJson(value.mDestination);
+            result["source_int"] = toJson(value.mSourceInt);
+            result["destination_int"] = toJson(value.mDestinationInt);
+            result["state"] = toJson(value.mState);
+            return result;
+        }
+
+        inline nlohmann::json withType(const Transition& value, const std::string& type)
+        {
+            nlohmann::json result;
+            result["type"] = type;
+            result["transition"] = toJson(value);
+            return result;
+        }
+
+        inline nlohmann::json toJson(const Collision& value)
+        {
+            nlohmann::json result;
+            result["point"] = toJson(value.mPoint);
+            result["normal"] = toJson(value.mNormal);
+            result["end"] = toJson(value.mEnd);
+            std::ostringstream ptr;
+            ptr << value.mObject;
+            result["object"]["ptr"] = ptr.str();
+            return result;
+        }
+
+        inline nlohmann::json withType(const Collision& value)
+        {
+            nlohmann::json result;
+            result["collision"] = toJson(value);
+            return result;
+        }
+
+        inline nlohmann::json toJson(const btScaledBvhTriangleMeshShape& shape, const btTransform& transform)
+        {
+            nlohmann::json result;
+            nlohmann::json triangles;
+            struct Callback : btTriangleCallback
+            {
+                nlohmann::json& triangles;
+                const btTransform& transform;
+
+                Callback(nlohmann::json& triangles, const btTransform& transform)
+                    : triangles(triangles), transform(transform) {}
+
+                void processTriangle(btVector3* triangle, int, int) override final
+                {
+                    triangles.push_back({toJson(transform(triangle[0])),
+                                         toJson(transform(triangle[1])),
+                                         toJson(transform(triangle[2]))});
+                }
+            } callback(triangles, transform);
+            btVector3 aabbMin;
+            btVector3 aabbMax;
+            shape.getAabb(btTransform::getIdentity(), aabbMin, aabbMax);
+            shape.processAllTriangles(&callback, aabbMin, aabbMax);
+            result["triangles"] = triangles;
+            return result;
+        }
+
+        inline nlohmann::json toJson(const btCollisionShape* shape, const btTransform& transform)
+        {
+            nlohmann::json result;
+            btVector3 aabbMin;
+            btVector3 aabbMax;
+            shape->getAabb(transform, aabbMin, aabbMax);
+            result["aabb"]["min"] = toJson(aabbMin);
+            result["aabb"]["max"] = toJson(aabbMax);
+            std::ostringstream type;
+            type << BroadphaseNativeTypes(shape->getShapeType());
+            result["type"] = type.str();
+            if (shape->getShapeType() == SCALED_TRIANGLE_MESH_SHAPE_PROXYTYPE)
+            {
+                result["data"] = toJson(*static_cast<const btScaledBvhTriangleMeshShape*>(shape), transform);
+            }
+            return result;
+        }
+
+        inline nlohmann::json toJson(const btCollisionObject& object)
+        {
+            nlohmann::json result;
+            std::ostringstream ptr;
+            ptr << &object;
+            result["ptr"] = ptr.str();
+            result["origin"] = toJson(object.getWorldTransform().getOrigin());
+            result["shape"] = toJson(object.getCollisionShape(), object.getWorldTransform());
+            return result;
+        }
+
+        inline nlohmann::json withType(const btCollisionObject& value)
+        {
+            nlohmann::json result;
+            result["object"] = toJson(value);
+            return result;
+        }
+#else
+        template <class ... T>
+        int withType(T&& ...)
+        {
+            return 0;
+        }
+
+        template <class ... T>
+        int toJson(T&& ...)
+        {
+            return 0;
+        }
+#endif
+    }
+}
+
+#endif // OPENMW_MWMECHANICS_FINDOPTIMALPATH_DEBUG_H

--- a/apps/openmw/mwmechanics/findoptimalpath/get_neighbors.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath/get_neighbors.hpp
@@ -1,0 +1,298 @@
+#ifndef OPENMW_MWMECHANICS_FINDOPTIMALPATH_GETNEIGHBORS_H
+#define OPENMW_MWMECHANICS_FINDOPTIMALPATH_GETNEIGHBORS_H
+
+#include "debug.hpp"
+#include "common.hpp"
+
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionShapes/btCapsuleShape.h>
+#include <BulletCollision/CollisionShapes/btCompoundShape.h>
+#include <BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h>
+#include <BulletCollision/CollisionShapes/btSphereShape.h>
+#include <BulletCollision/CollisionShapes/btStaticPlaneShape.h>
+
+#include <sstream>
+
+namespace MWMechanics
+{
+    namespace FindOptimalPath
+    {
+        class GetNeighbors
+        {
+        public:
+            using Candidates = std::vector<std::pair<btVector3, bool>>;
+
+            GetNeighbors(
+                    const btVector3& source,
+                    const btVector3& destination,
+                    const btVector3& goal,
+                    const Collision& collision,
+                    btScalar minStep,
+                    btScalar maxStep,
+                    btScalar horizontalMargin,
+                    btScalar verticalMargin,
+                    bool allowFly)
+                : mSource(source)
+                , mDestination(destination)
+                , mGoal(goal)
+                , mCollision(collision)
+                , mMinStep(minStep)
+                , mMaxStep(maxStep)
+                , mHorizontalMargin(horizontalMargin)
+                , mVerticalMargin(verticalMargin)
+                , mAllowFly(allowFly)
+                , mDirection((mDestination - mSource).normalized())
+            {
+            }
+
+            Candidates perform() const
+            {
+                return getShapeCandidates(mCollision.mObject->getCollisionShape(), mCollision.mObject->getWorldTransform());
+            }
+
+        private:
+            const btVector3& mSource;
+            const btVector3& mDestination;
+            const btVector3& mGoal;
+            const Collision& mCollision;
+            const btScalar mMinStep;
+            const btScalar mMaxStep;
+            const btScalar mHorizontalMargin;
+            const btScalar mVerticalMargin;
+            const bool mAllowFly;
+            const btVector3 mDirection;
+
+            Candidates getShapeCandidates(const btCollisionShape* shape, const btTransform& transform) const
+            {
+                if (shape->isCompound())
+                {
+                    return getCompoundShapeCandidates(*static_cast<const btCompoundShape*>(shape), transform);
+                }
+                else if (shape->getShapeType() == SPHERE_SHAPE_PROXYTYPE)
+                {
+                    return getShapeWithRadiusCandidates(*static_cast<const btSphereShape*>(shape), transform);
+                }
+                else if (shape->getShapeType() == CAPSULE_SHAPE_PROXYTYPE && static_cast<const btCapsuleShape*>(shape)->getUpAxis() == 2)
+                {
+                    return getShapeWithRadiusCandidates(*static_cast<const btCapsuleShapeZ*>(shape), transform);
+                }
+                else if (shape->getShapeType() == TERRAIN_SHAPE_PROXYTYPE)
+                {
+                    return getHeightfieldTerrainShapeCandidates(*static_cast<const btHeightfieldTerrainShape*>(shape), transform);
+                }
+                else if (shape->getShapeType() == BOX_SHAPE_PROXYTYPE)
+                {
+                    return getSingleShapeCandidates(*static_cast<const btBoxShape*>(shape), transform);
+                }
+                else if (shape->getShapeType() == STATIC_PLANE_PROXYTYPE)
+                {
+                    return getStaticPlaneShapeCandidates(*static_cast<const btStaticPlaneShape*>(shape), transform);
+                }
+                else if (shape->isConcave())
+                {
+                    return getSingleShapeCandidates(*static_cast<const btConcaveShape*>(shape), transform);
+                }
+                else
+                {
+                    std::ostringstream stream;
+                    stream << "GetNeighbors::getSingleShapeCandidates is not implemented for shape type: " << shape->getShapeType();
+                    throw std::logic_error(stream.str());
+                }
+            }
+
+            Candidates getCompoundShapeCandidates(const btCompoundShape& shape, const btTransform& transform) const {
+                Candidates result;
+                // TODO: select one
+                for (int i = 0, num = shape.getNumChildShapes(); i < num; ++i)
+                {
+                    const auto sub = getShapeCandidates(shape.getChildShape(i), transform * shape.getChildTransform(i));
+                    std::copy(sub.begin(), sub.end(), std::back_inserter(result));
+                }
+                return result;
+            }
+
+            template <class ShapeWithRadius>
+            Candidates getShapeWithRadiusCandidates(const ShapeWithRadius& shape, const btTransform& transform) const
+            {
+                return getTangentPointsCandidates(transform.getOrigin(), shape.getRadius());
+            }
+
+            btVector3 adjustDestination(const btVector3& destination) const
+            {
+                const auto toDestination = destination - mSource;
+                const auto increaseFactor = mMinStep / toDestination.norm();
+                return mSource + toDestination * (btScalar(1) + increaseFactor);
+            }
+
+            Candidates getHeightfieldTerrainShapeCandidates(const btHeightfieldTerrainShape& shape, const btTransform& transform) const
+            {
+                const auto length = std::min(mMaxStep, std::max(mMinStep, btScalar(2) * mHorizontalMargin));
+                return getSingleShapeCandidatesImpl(shape, transform, length);
+            }
+
+            Candidates getStaticPlaneShapeCandidates(const btStaticPlaneShape& shape, const btTransform& transform) const
+            {
+                return getSingleShapeCandidatesImpl(shape, transform, mMinStep);
+            }
+
+            template <class Shape>
+            Candidates getSingleShapeCandidates(const Shape& shape, const btTransform& transform) const
+            {
+                btVector3 aabbMin;
+                btVector3 aabbMax;
+                shape.getAabb(btTransform::getIdentity(), aabbMin, aabbMax);
+                const auto aabbSide = getAabbSide(transform.invXform(mCollision.mNormal));
+                switch (aabbSide)
+                {
+                    case AabbSide::X:
+                        return getSingleShapeCandidatesImpl(
+                            shape, transform,
+                            limitLength(std::min(aabbMax.y() - aabbMin.y(), aabbMax.z() - aabbMin.z()) * btScalar(0.5))
+                        );
+                    case AabbSide::Y:
+                        return getSingleShapeCandidatesImpl(
+                            shape, transform,
+                            limitLength(std::min(aabbMax.x() - aabbMin.x(), aabbMax.z() - aabbMin.z()) * btScalar(0.5))
+                        );
+                    case AabbSide::Z:
+                        return getSingleShapeCandidatesImpl(
+                            shape, transform,
+                            limitLength(std::min(aabbMax.x() - aabbMin.x(), aabbMax.y() - aabbMin.y()) * btScalar(0.5))
+                        );
+                }
+
+                throw std::logic_error("Unhandled AabbSide type " + std::to_string(int(aabbSide)));
+            }
+
+            template <class Shape>
+            Candidates getSingleShapeCandidatesImpl(const Shape& shape, const btTransform& transform, btScalar length) const
+            {
+                assert(length > std::numeric_limits<btScalar>::epsilon());
+    #ifdef FIND_OPTIMAL_PATH_DEBUG_OUTPUT
+                DEBUG_LOG << std::boolalpha << "walkable: " << isWalkableSlope(mCollision.mNormal)
+                    << " roof: " << isRoof(mCollision.mNormal)
+                    << " z: " << mCollision.mNormal.z() << '\n';
+    #endif
+                const auto base = mCollision.mEnd + mCollision.mNormal;
+                btVector3 projectedUp;
+                btVector3 projectedLeft;
+                const btVector3 z(0, 0, 1);
+                if (std::abs(mDirection.z()) <= std::abs(mDirection.y()))
+                {
+                    const auto left = z.cross(mDirection);
+                    const auto up = mDirection.cross(left);
+                    if (up.dot(mCollision.mNormal) <= left.dot(mCollision.mNormal))
+                    {
+                        projectedUp = projectToPlane(up, mCollision.mNormal).normalized();
+                        projectedLeft = mCollision.mNormal.cross(projectedUp);
+                    }
+                    else
+                    {
+                        projectedLeft = projectToPlane(left, mCollision.mNormal).normalized();
+                        projectedUp = projectedLeft.cross(mCollision.mNormal);
+                    }
+                }
+                else
+                {
+                    const btVector3 y(0, 1, 0);
+                    const auto up = mDirection.cross(y);
+                    const auto left = up.cross(mDirection);
+                    if (up.dot(mCollision.mNormal) <= left.dot(mCollision.mNormal))
+                    {
+                        projectedUp = projectToPlane(up, mCollision.mNormal).normalized();
+                        projectedLeft = projectedUp.cross(mCollision.mNormal);
+                    }
+                    else
+                    {
+                        projectedLeft = projectToPlane(left, mCollision.mNormal).normalized();
+                        projectedUp = projectedLeft.cross(mCollision.mNormal);
+                    }
+                }
+
+                if (projectedUp.dot(z) < projectedLeft.dot(z))
+                {
+                    std::swap(projectedUp, projectedLeft);
+                }
+
+                Candidates result;
+
+                if (mAllowFly || isWalkableSlope(mCollision.mNormal) || isRoof(mCollision.mNormal))
+                {
+                    DEBUG_LOG << "above: " << projectedUp << " length: " << length << '\n';
+                    projectedUp *= length;
+                    result.push_back({base + projectedUp, false});
+                    result.push_back({base - projectedUp, false});
+                    if (!mAllowFly) {
+                        return result;
+                    }
+                }
+
+                result.push_back({base, true});
+
+                DEBUG_LOG << "front: " << projectedLeft << " length: " << length << '\n';
+                projectedLeft *= length;
+
+                if (std::abs(mCollision.mNormal.dot((mGoal - mCollision.mEnd).normalized())) < btScalar(0.1))
+                {
+                    const auto left = base + projectedLeft;
+                    const auto right = base + projectedLeft;
+                    result.push_back({left.distance(mGoal) < right.distance(mGoal) ? left : right, false});
+                    const auto tangent = getTangentPointsCandidates(shape, transform);
+                    std::copy(tangent.begin(), tangent.end(), std::back_inserter(result));
+                } else {
+                    result.push_back({base + projectedLeft, false});
+                    result.push_back({base - projectedLeft, false});
+                }
+
+                return result;
+            }
+
+            Candidates getTangentPointsCandidates(const btBoxShape& shape, const btTransform& transform) const
+            {
+                btVector3 aabbMin;
+                btVector3 aabbMax;
+                shape.getAabb(transform, aabbMin, aabbMax);
+                const auto center = (aabbMin + aabbMax) * btScalar(0.5);
+                const auto radius = std::min((aabbMax - aabbMin).length() * btScalar(0.5), center.distance(mSource) - mHorizontalMargin);
+                return getTangentPointsCandidates(center, radius);
+            }
+
+            Candidates getTangentPointsCandidates(const btConcaveShape& shape, const btTransform& transform) const
+            {
+                btVector3 aabbMin;
+                btVector3 aabbMax;
+                shape.getAabb(btTransform::getIdentity(), aabbMin, aabbMax);
+                const auto center = GetCentroid().perform(shape, aabbMin, aabbMax);
+                const auto farest = GetFarestPoint(center).perform(shape, aabbMin, aabbMax);
+                const auto transformedCenter = transform(center);
+                const auto radius = std::min(center.distance(farest), transformedCenter.distance(mSource) - mHorizontalMargin);
+                return getTangentPointsCandidates(transformedCenter, radius);
+            }
+
+            Candidates getTangentPointsCandidates(const btVector3& center, btScalar radius) const
+            {
+                if (mSource.distance(center) - radius <= btScalar(1))
+                {
+                    return {};
+                }
+                const auto tangentPoints = getTangentPoints(radius, center, mSource);
+                const auto getCandidate = [&] (const btVector3& tangent)
+                {
+                    const auto result = tangent + mHorizontalMargin * (tangent - center).normalized();
+                    return btVector3(result.x(), result.y(), mCollision.mEnd.z());
+                };
+                return {
+                    {adjustDestination(getCandidate(tangentPoints.first)), false},
+                    {adjustDestination(getCandidate(tangentPoints.second)), false},
+                };
+            }
+
+            btScalar limitLength(btScalar value) const
+            {
+                return std::max(mMinStep, std::min(mMaxStep, value));
+            }
+        };
+    }
+}
+
+#endif // OPENMW_MWMECHANICS_FINDOPTIMALPATH_GETNEIGHBORS_H

--- a/apps/openmw/mwmechanics/findoptimalpath/open_set.hpp
+++ b/apps/openmw/mwmechanics/findoptimalpath/open_set.hpp
@@ -1,0 +1,76 @@
+#ifndef OPENMW_MWMECHANICS_FINDOPTIMALPATH_OPENSET_H
+#define OPENMW_MWMECHANICS_FINDOPTIMALPATH_OPENSET_H
+
+#include "debug.hpp"
+
+#include <map>
+#include <set>
+
+namespace MWMechanics
+{
+    namespace FindOptimalPath
+    {
+        class OpenSet
+        {
+        public:
+            void push(const Transition& transition)
+            {
+                const auto pushed = mPushed.find({transition.mSourceInt, transition.mDestinationInt});
+                if (pushed != mPushed.end())
+                {
+                    if (pushed->second->mPriority <= transition.mPriority)
+                    {
+                        DEBUG_LOG << "ignore " << transition << " reason: already pushed with not greater priority" << '\n';
+                        return;
+                    }
+                    DEBUG_LOG << "repush " << transition << '\n';
+                    JSON_LOG << withType(transition, "repush") << '\n';
+                    mTransitions.erase(pushed->second);
+                    pushed->second = mTransitions.insert(transition).first;
+                }
+                else
+                {
+                    DEBUG_LOG << "push " << transition << '\n';
+                    JSON_LOG << withType(transition, "push") << '\n';
+                    const auto it = mTransitions.insert(transition).first;
+                    mPushed.insert({{transition.mSourceInt, transition.mDestinationInt}, it});
+                }
+            }
+
+            const Transition& top() const
+            {
+                return *mTransitions.begin();
+            }
+
+            void pop()
+            {
+                mPushed.erase({mTransitions.begin()->mSourceInt, mTransitions.begin()->mDestinationInt});
+                mTransitions.erase(mTransitions.begin());
+            }
+
+            bool empty() const
+            {
+                return mTransitions.empty();
+            }
+
+            void clear()
+            {
+                mTransitions.clear();
+                mPushed.clear();
+            }
+
+            std::size_t size() const
+            {
+                return mTransitions.size();
+            }
+
+        private:
+            using Transitions = std::set<Transition, LessByPriorityAndId>;
+
+            Transitions mTransitions;
+            std::map<std::pair<PointInt, PointInt>, Transitions::const_iterator> mPushed;
+        };
+    }
+}
+
+#endif // OPENMW_MWMECHANICS_FINDOPTIMALPATH_OPENSET_H

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -205,17 +205,6 @@ namespace MWMechanics
             endPointInLocalCoords,
                 startNode);
 
-        // if it's shorter for actor to travel from start to end, than to travel from either
-        // start or end to nearest pathgrid point, just travel from start to end.
-        float startToEndLength2 = (endPointInLocalCoords - startPointInLocalCoords).length2();
-        float endTolastNodeLength2 = DistanceSquared(mPathgrid->mPoints[endNode.first], endPointInLocalCoords);
-        float startTo1stNodeLength2 = DistanceSquared(mPathgrid->mPoints[startNode], startPointInLocalCoords);
-        if ((startToEndLength2 < startTo1stNodeLength2) || (startToEndLength2 < endTolastNodeLength2))
-        {
-            mPath.push_back(endPoint);
-            return;
-        }
-
         // AiWander has logic that depends on whether a path was created,
         // deleting allowed nodes if not.  Hence a path needs to be created
         // even if the start and the end points are the same.

--- a/apps/openmw/mwphysics/closestcollision.cpp
+++ b/apps/openmw/mwphysics/closestcollision.cpp
@@ -4,6 +4,10 @@
 #include <BulletCollision/CollisionShapes/btCapsuleShape.h>
 #include <BulletCollision/CollisionShapes/btConvexShape.h>
 
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
 namespace MWPhysics
 {
     static btVector3 getEnd(const btVector3& source, const btVector3& path, btScalar fraction)
@@ -44,6 +48,22 @@ namespace MWPhysics
         return ClosestConvexResultCallback::addSingleResult(convexResult, normalInWorldSpace);
     }
 
+    CollisionWithObjectCallback::CollisionWithObjectCallback(const btCollisionObject& object)
+      : btCollisionWorld::ClosestConvexResultCallback(btVector3(0, 0, 0), btVector3(0, 0, 0))
+      , mObject(&object)
+    {
+    }
+
+    btScalar CollisionWithObjectCallback::addSingleResult(btCollisionWorld::LocalConvexResult& convexResult, bool normalInWorldSpace)
+    {
+        if (convexResult.m_hitCollisionObject != mObject)
+        {
+            return btScalar(1);
+        }
+
+        return ClosestConvexResultCallback::addSingleResult(convexResult, normalInWorldSpace);
+    }
+
     boost::optional<Collision> getClosestCollision(const btCollisionObject& actorObject,
             const btVector3& source, const btVector3& destination, const btCollisionWorld& collisionWorld,
             int excludeFilterMask)
@@ -70,6 +90,106 @@ namespace MWPhysics
                 callback.m_hitNormalWorld,
                 callback.m_hitPointWorld,
                 getEnd(source, destination - source, callback.m_closestHitFraction),
+            };
+        }
+
+        return boost::none;
+    }
+
+    static const btScalar stepSizeUp = 2;
+
+    static btCapsuleShapeZ makeReducedByHeightShape(const btCapsuleShapeZ& shape)
+    {
+        btCapsuleShapeZ result(shape.getRadius(), std::max(btScalar(0), btScalar(2) * shape.getHalfHeight() - stepSizeUp));
+        result.setMargin(shape.getMargin());
+        return result;
+    }
+
+    static btBoxShape makeReducedByHeightShape(const btBoxShape& shape)
+    {
+        const auto halfExtents = shape.getHalfExtentsWithoutMargin();
+        btBoxShape result(btVector3(halfExtents.x(), halfExtents.y(), halfExtents.z() - stepSizeUp * btScalar(0.5)));
+        result.setMargin(shape.getMargin());
+        return result;
+    }
+
+    boost::optional<Collision> getClosestCollisionWithStepUp(const btCollisionObject& actorObject,
+            const btVector3& source, const btVector3& destination, const btCollisionWorld& collisionWorld)
+    {
+        const auto shape = actorObject.getCollisionShape();
+
+        if (!shape->isConvex())
+        {
+            throw std::invalid_argument("Actor shape is not convex");
+        }
+
+        const auto path = destination - source;
+
+        ClosestNotMeConvexResultCallback reducedShapeCallback(&actorObject, -path, btScalar(0));
+        reducedShapeCallback.m_collisionFilterGroup = actorObject.getBroadphaseHandle()->m_collisionFilterGroup;
+        reducedShapeCallback.m_collisionFilterMask = actorObject.getBroadphaseHandle()->m_collisionFilterMask;
+
+        const auto direction = path.normalized();
+        const auto angle = btVector3(1, 0, 0).dot(direction);
+        const btMatrix3x3 rotation(btQuaternion(btVector3(0, 0, 1), angle));
+
+        if (shape->getShapeType() == CAPSULE_SHAPE_PROXYTYPE && static_cast<const btCapsuleShape*>(shape)->getUpAxis() == 2)
+        {
+            const auto casted = static_cast<const btCapsuleShapeZ*>(shape);
+            const auto reducedShape = makeReducedByHeightShape(*casted);
+            const auto z = casted->getHalfHeight() - reducedShape.getHalfHeight();
+            const auto shift = rotation * btVector3(0, 0, z);
+            const btTransform from(rotation, source + shift);
+            const btTransform to(rotation, destination + shift);
+
+            collisionWorld.convexSweepTest(&reducedShape, from, to, reducedShapeCallback);
+        }
+        else if (shape->getShapeType() == BOX_SHAPE_PROXYTYPE)
+        {
+            const auto casted = static_cast<const btBoxShape*>(shape);
+            const auto reducedShape = makeReducedByHeightShape(*casted);
+            const auto z = casted->getHalfExtentsWithoutMargin().z() - reducedShape.getHalfExtentsWithoutMargin().z();
+            const auto shift = rotation * btVector3(0, 0, z);
+            const btTransform from(rotation, source + shift);
+            const btTransform to(rotation, destination + shift);
+
+            collisionWorld.convexSweepTest(&reducedShape, from, to, reducedShapeCallback);
+        }
+        else
+        {
+            throw std::logic_error(std::string("Shape reducing is not implemented for ") + shape->getName());
+        }
+
+        if (reducedShapeCallback.hasHit())
+        {
+            const btTransform from(rotation, source);
+            const btTransform to(rotation, destination);
+
+            CollisionWithObjectCallback fullShapeCallback(*reducedShapeCallback.m_hitCollisionObject);
+            fullShapeCallback.m_collisionFilterGroup = actorObject.getBroadphaseHandle()->m_collisionFilterGroup;
+            fullShapeCallback.m_collisionFilterMask = actorObject.getBroadphaseHandle()->m_collisionFilterMask;
+
+            collisionWorld.convexSweepTest(static_cast<const btConvexShape*>(shape), from, to, fullShapeCallback);
+
+            if (fullShapeCallback.hasHit())
+            {
+                return Collision
+                {
+                    fullShapeCallback.m_hitCollisionObject,
+                    fullShapeCallback.m_closestHitFraction,
+                    fullShapeCallback.m_hitNormalWorld,
+                    fullShapeCallback.m_hitPointWorld,
+                    getEnd(source, path, fullShapeCallback.m_closestHitFraction),
+                };
+            }
+
+            return Collision
+            {
+                reducedShapeCallback.m_hitCollisionObject,
+                reducedShapeCallback.m_closestHitFraction,
+                reducedShapeCallback.m_hitNormalWorld,
+                reducedShapeCallback.m_hitPointWorld,
+                getEnd(source, path, reducedShapeCallback.m_closestHitFraction),
             };
         }
 

--- a/apps/openmw/mwphysics/closestcollision.cpp
+++ b/apps/openmw/mwphysics/closestcollision.cpp
@@ -1,0 +1,78 @@
+#include "closestcollision.hpp"
+
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionShapes/btCapsuleShape.h>
+#include <BulletCollision/CollisionShapes/btConvexShape.h>
+
+namespace MWPhysics
+{
+    static btVector3 getEnd(const btVector3& source, const btVector3& path, btScalar fraction)
+    {
+        return source + path * fraction;
+    }
+
+    ClosestNotMeConvexResultCallback::ClosestNotMeConvexResultCallback(const btCollisionObject *me, const btVector3 &up, btScalar minSlopeDot)
+      : btCollisionWorld::ClosestConvexResultCallback(btVector3(0, 0, 0), btVector3(0, 0, 0)),
+        mMe(me), mUp(up), mMinSlopeDot(minSlopeDot)
+    {
+    }
+
+    btScalar ClosestNotMeConvexResultCallback::addSingleResult(btCollisionWorld::LocalConvexResult& convexResult, bool normalInWorldSpace)
+    {
+        if (convexResult.m_hitCollisionObject == mMe)
+        {
+            return btScalar(1);
+        }
+
+        btVector3 hitNormalWorld;
+        if (normalInWorldSpace)
+        {
+            hitNormalWorld = convexResult.m_hitNormalLocal;
+        }
+        else
+        {
+            // need to transform normal into worldspace
+            hitNormalWorld = convexResult.m_hitCollisionObject->getWorldTransform().getBasis() * convexResult.m_hitNormalLocal;
+        }
+
+        const btScalar dotUp = mUp.dot(hitNormalWorld);
+        if (dotUp < mMinSlopeDot)
+        {
+            return btScalar(1);
+        }
+
+        return ClosestConvexResultCallback::addSingleResult(convexResult, normalInWorldSpace);
+    }
+
+    boost::optional<Collision> getClosestCollision(const btCollisionObject& actorObject,
+            const btVector3& source, const btVector3& destination, const btCollisionWorld& collisionWorld,
+            int excludeFilterMask)
+    {
+        const btTransform& actorTransform = actorObject.getWorldTransform();
+        const btTransform from(actorTransform.getBasis(), source);
+        const btTransform to(actorTransform.getBasis(), destination);
+
+        ClosestNotMeConvexResultCallback callback(&actorObject, source - destination, btScalar(0));
+        // Inherit the actor's collision group and mask
+        callback.m_collisionFilterGroup = actorObject.getBroadphaseHandle()->m_collisionFilterGroup;
+        callback.m_collisionFilterMask = actorObject.getBroadphaseHandle()->m_collisionFilterMask & ~excludeFilterMask;
+
+        const btCollisionShape* shape = actorObject.getCollisionShape();
+        assert(shape->isConvex());
+        collisionWorld.convexSweepTest(static_cast<const btConvexShape*>(shape), from, to, callback);
+
+        if (callback.hasHit())
+        {
+            return Collision
+            {
+                callback.m_hitCollisionObject,
+                callback.m_closestHitFraction,
+                callback.m_hitNormalWorld,
+                callback.m_hitPointWorld,
+                getEnd(source, destination - source, callback.m_closestHitFraction),
+            };
+        }
+
+        return boost::none;
+    }
+}

--- a/apps/openmw/mwphysics/closestcollision.hpp
+++ b/apps/openmw/mwphysics/closestcollision.hpp
@@ -1,0 +1,39 @@
+#ifndef OPENMW_MWPHYSICS_CLOSESTCOLLISION_H
+#define OPENMW_MWPHYSICS_CLOSESTCOLLISION_H
+
+#include <boost/optional.hpp>
+#include <LinearMath/btVector3.h>
+#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
+
+class btCollisionObject;
+
+namespace MWPhysics
+{
+    struct Collision
+    {
+        const btCollisionObject* mObject;
+        btScalar mFraction;
+        btVector3 mNormal;
+        btVector3 mPoint;
+        btVector3 mEnd;
+    };
+
+    class ClosestNotMeConvexResultCallback : public btCollisionWorld::ClosestConvexResultCallback
+    {
+    public:
+        ClosestNotMeConvexResultCallback(const btCollisionObject *me, const btVector3 &up, btScalar minSlopeDot);
+
+        virtual btScalar addSingleResult(btCollisionWorld::LocalConvexResult& convexResult, bool normalInWorldSpace);
+
+    private:
+        const btCollisionObject* mMe;
+        const btVector3 mUp;
+        const btScalar mMinSlopeDot;
+    };
+
+    boost::optional<Collision> getClosestCollision(const btCollisionObject& actorObject,
+            const btVector3& source, const btVector3& destination, const btCollisionWorld& collisionWorld,
+            int excludeFilterMask = 0);
+}
+
+#endif

--- a/apps/openmw/mwphysics/closestcollision.hpp
+++ b/apps/openmw/mwphysics/closestcollision.hpp
@@ -34,6 +34,20 @@ namespace MWPhysics
     boost::optional<Collision> getClosestCollision(const btCollisionObject& actorObject,
             const btVector3& source, const btVector3& destination, const btCollisionWorld& collisionWorld,
             int excludeFilterMask = 0);
+
+    class CollisionWithObjectCallback : public btCollisionWorld::ClosestConvexResultCallback
+    {
+    public:
+        CollisionWithObjectCallback(const btCollisionObject& object);
+
+        virtual btScalar addSingleResult(btCollisionWorld::LocalConvexResult& convexResult, bool normalInWorldSpace);
+
+    private:
+        const btCollisionObject* mObject;
+    };
+
+    boost::optional<Collision> getClosestCollisionWithStepUp(const btCollisionObject& actorObject,
+            const btVector3& source, const btVector3& destination, const btCollisionWorld& collisionWorld);
 }
 
 #endif

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1546,4 +1546,9 @@ namespace MWPhysics
         mCollisionWorld->addCollisionObject(mWaterCollisionObject.get(), CollisionType_Water,
                                                     CollisionType_Actor);
     }
+
+    btCollisionWorld& PhysicsSystem::getCollisionWorld() const
+    {
+        return *mCollisionWorld;
+    }
 }

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -170,6 +170,8 @@ namespace MWPhysics
 
             bool isOnSolidGround (const MWWorld::Ptr& actor) const;
 
+            btCollisionWorld& getCollisionWorld() const;
+
         private:
 
             void updateWater();

--- a/apps/openmw/mwphysics/trace.cpp
+++ b/apps/openmw/mwphysics/trace.cpp
@@ -1,84 +1,22 @@
 #include "trace.h"
 
-#include <map>
-
-#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
-#include <BulletCollision/CollisionShapes/btConvexShape.h>
-
 #include "collisiontype.hpp"
 #include "actor.hpp"
 #include "convert.hpp"
+#include "closestcollision.hpp"
 
 namespace MWPhysics
 {
 
-class ClosestNotMeConvexResultCallback : public btCollisionWorld::ClosestConvexResultCallback
-{
-public:
-    ClosestNotMeConvexResultCallback(const btCollisionObject *me, const btVector3 &up, btScalar minSlopeDot)
-      : btCollisionWorld::ClosestConvexResultCallback(btVector3(0.0, 0.0, 0.0), btVector3(0.0, 0.0, 0.0)),
-        mMe(me), mUp(up), mMinSlopeDot(minSlopeDot)
-    {
-    }
-
-    virtual btScalar addSingleResult(btCollisionWorld::LocalConvexResult& convexResult,bool normalInWorldSpace)
-    {
-        if(convexResult.m_hitCollisionObject == mMe)
-            return btScalar( 1 );
-
-        btVector3 hitNormalWorld;
-        if(normalInWorldSpace)
-            hitNormalWorld = convexResult.m_hitNormalLocal;
-        else
-        {
-            ///need to transform normal into worldspace
-            hitNormalWorld = convexResult.m_hitCollisionObject->getWorldTransform().getBasis()*convexResult.m_hitNormalLocal;
-        }
-
-        btScalar dotUp = mUp.dot(hitNormalWorld);
-        if(dotUp < mMinSlopeDot)
-            return btScalar(1);
-
-        return ClosestConvexResultCallback::addSingleResult(convexResult, normalInWorldSpace);
-    }
-
-protected:
-    const btCollisionObject *mMe;
-    const btVector3 mUp;
-    const btScalar mMinSlopeDot;
-};
-
-
 void ActorTracer::doTrace(const btCollisionObject *actor, const osg::Vec3f& start, const osg::Vec3f& end, const btCollisionWorld* world)
 {
-    const btVector3 btstart = toBullet(start);
-    const btVector3 btend = toBullet(end);
-
-    const btTransform &trans = actor->getWorldTransform();
-    btTransform from(trans);
-    btTransform to(trans);
-    from.setOrigin(btstart);
-    to.setOrigin(btend);
-
-    ClosestNotMeConvexResultCallback newTraceCallback(actor, btstart-btend, btScalar(0.0));
-    // Inherit the actor's collision group and mask
-    newTraceCallback.m_collisionFilterGroup = actor->getBroadphaseHandle()->m_collisionFilterGroup;
-    newTraceCallback.m_collisionFilterMask = actor->getBroadphaseHandle()->m_collisionFilterMask;
-
-    const btCollisionShape *shape = actor->getCollisionShape();
-    assert(shape->isConvex());
-    world->convexSweepTest(static_cast<const btConvexShape*>(shape),
-                                               from, to, newTraceCallback);
-
-    // Copy the hit data over to our trace results struct:
-    if(newTraceCallback.hasHit())
+    if (const auto collision = getClosestCollision(*actor, toBullet(start), toBullet(end), *world))
     {
-        const btVector3& tracehitnormal = newTraceCallback.m_hitNormalWorld;
-        mFraction = newTraceCallback.m_closestHitFraction;
-        mPlaneNormal = osg::Vec3f(tracehitnormal.x(), tracehitnormal.y(), tracehitnormal.z());
-        mEndPos = (end-start)*mFraction + start;
-        mHitPoint = toOsg(newTraceCallback.m_hitPointWorld);
-        mHitObject = newTraceCallback.m_hitCollisionObject;
+        mFraction = collision->mFraction;
+        mPlaneNormal = toOsg(collision->mNormal);
+        mEndPos = toOsg(collision->mEnd);
+        mHitPoint = toOsg(collision->mPoint);
+        mHitObject = collision->mObject;
     }
     else
     {
@@ -92,26 +30,11 @@ void ActorTracer::doTrace(const btCollisionObject *actor, const osg::Vec3f& star
 
 void ActorTracer::findGround(const Actor* actor, const osg::Vec3f& start, const osg::Vec3f& end, const btCollisionWorld* world)
 {
-    const btVector3 btstart(start.x(), start.y(), start.z());
-    const btVector3 btend(end.x(), end.y(), end.z());
-
-    const btTransform &trans = actor->getCollisionObject()->getWorldTransform();
-    btTransform from(trans.getBasis(), btstart);
-    btTransform to(trans.getBasis(), btend);
-
-    ClosestNotMeConvexResultCallback newTraceCallback(actor->getCollisionObject(), btstart-btend, btScalar(0.0));
-    // Inherit the actor's collision group and mask
-    newTraceCallback.m_collisionFilterGroup = actor->getCollisionObject()->getBroadphaseHandle()->m_collisionFilterGroup;
-    newTraceCallback.m_collisionFilterMask = actor->getCollisionObject()->getBroadphaseHandle()->m_collisionFilterMask;
-    newTraceCallback.m_collisionFilterMask &= ~CollisionType_Actor;
-
-    world->convexSweepTest(actor->getConvexShape(), from, to, newTraceCallback);
-    if(newTraceCallback.hasHit())
+    if (const auto collision = getClosestCollision(*actor->getCollisionObject(), toBullet(start), toBullet(end), *world, CollisionType_Actor))
     {
-        const btVector3& tracehitnormal = newTraceCallback.m_hitNormalWorld;
-        mFraction = newTraceCallback.m_closestHitFraction;
-        mPlaneNormal = osg::Vec3f(tracehitnormal.x(), tracehitnormal.y(), tracehitnormal.z());
-        mEndPos = (end-start)*mFraction + start;
+        mFraction = collision->mFraction;
+        mPlaneNormal = toOsg(collision->mNormal);
+        mEndPos = toOsg(collision->mEnd);
     }
     else
     {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3485,4 +3485,8 @@ namespace MWWorld
         }
     }
 
+    MWPhysics::PhysicsSystem& World::getPhysicsSystem() const
+    {
+        return *mPhysics;
+    }
 }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -679,6 +679,8 @@ namespace MWWorld
 
             /// Preload VFX associated with this effect list
             void preloadEffects(const ESM::EffectList* effectList) override;
+
+            MWPhysics::PhysicsSystem& getPhysicsSystem() const override;
     };
 }
 

--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(GTest REQUIRED)
 
 if (GTEST_FOUND)
-    include_directories(${GTEST_INCLUDE_DIRS})
+    include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 
     file(GLOB UNITTEST_SRC_FILES
         ../openmw/mwworld/store.cpp

--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -1,29 +1,25 @@
 find_package(GTest REQUIRED)
 
-if (GTEST_FOUND)
-    include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
+include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
 
-    file(GLOB UNITTEST_SRC_FILES
-        ../openmw/mwworld/store.cpp
-        ../openmw/mwworld/esmstore.cpp
-        mwworld/test_store.cpp
+file(GLOB UNITTEST_SRC_FILES
+    ../openmw/mwworld/store.cpp
+    ../openmw/mwworld/esmstore.cpp
+    mwworld/test_store.cpp
 
-        mwdialogue/test_keywordsearch.cpp
+    mwdialogue/test_keywordsearch.cpp
 
-        esm/test_fixed_string.cpp
+    esm/test_fixed_string.cpp
 
-        misc/test_stringops.cpp
-    )
+    misc/test_stringops.cpp
+)
 
-    source_group(apps\\openmw_test_suite FILES openmw_test_suite.cpp ${UNITTEST_SRC_FILES})
+source_group(apps\\openmw_test_suite FILES openmw_test_suite.cpp ${UNITTEST_SRC_FILES})
 
-    openmw_add_executable(openmw_test_suite openmw_test_suite.cpp ${UNITTEST_SRC_FILES})
+openmw_add_executable(openmw_test_suite openmw_test_suite.cpp ${UNITTEST_SRC_FILES})
 
-    target_link_libraries(openmw_test_suite ${GTEST_BOTH_LIBRARIES} components)
-    # Fix for not visible pthreads functions for linker with glibc 2.15
-    if (UNIX AND NOT APPLE)
-        target_link_libraries(openmw_test_suite ${CMAKE_THREAD_LIBS_INIT})
-    endif()
+target_link_libraries(openmw_test_suite ${GTEST_BOTH_LIBRARIES} components)
+# Fix for not visible pthreads functions for linker with glibc 2.15
+if (UNIX AND NOT APPLE)
+    target_link_libraries(openmw_test_suite ${CMAKE_THREAD_LIBS_INIT})
 endif()
-
-

--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_package(GTest REQUIRED)
+find_package(GMock REQUIRED)
 
 include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
+include_directories(SYSTEM ${GMOCK_INCLUDE_DIRS})
 
 file(GLOB UNITTEST_SRC_FILES
     ../openmw/mwworld/store.cpp
@@ -18,7 +20,7 @@ source_group(apps\\openmw_test_suite FILES openmw_test_suite.cpp ${UNITTEST_SRC_
 
 openmw_add_executable(openmw_test_suite openmw_test_suite.cpp ${UNITTEST_SRC_FILES})
 
-target_link_libraries(openmw_test_suite ${GTEST_BOTH_LIBRARIES} components)
+target_link_libraries(openmw_test_suite ${GMOCK_BOTH_LIBRARIES} components)
 # Fix for not visible pthreads functions for linker with glibc 2.15
 if (UNIX AND NOT APPLE)
     target_link_libraries(openmw_test_suite ${CMAKE_THREAD_LIBS_INIT})

--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -14,6 +14,13 @@ file(GLOB UNITTEST_SRC_FILES
     esm/test_fixed_string.cpp
 
     misc/test_stringops.cpp
+
+    ../openmw/mwmechanics/findoptimalpath.cpp
+    ../openmw/mwphysics/closestcollision.cpp
+    mwmechanics/findoptimalpath/testscenarios.cpp
+    mwmechanics/findoptimalpath/testrandom.cpp
+    mwmechanics/findoptimalpath/testgetneighbors.cpp
+    mwmechanics/findoptimalpath/testcommon.cpp
 )
 
 source_group(apps\\openmw_test_suite FILES openmw_test_suite.cpp ${UNITTEST_SRC_FILES})

--- a/apps/openmw_test_suite/mwmechanics/findoptimalpath/collisionobjects.hpp
+++ b/apps/openmw_test_suite/mwmechanics/findoptimalpath/collisionobjects.hpp
@@ -1,0 +1,876 @@
+#ifndef OPENMW_TEST_SUITE_MWMECHANICS_COLLISIONOBJECTS_HPP
+#define OPENMW_TEST_SUITE_MWMECHANICS_COLLISIONOBJECTS_HPP
+
+#include <BulletCollision/BroadphaseCollision/btDbvtBroadphase.h>
+#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
+#include <BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.h>
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionShapes/btCapsuleShape.h>
+#include <BulletCollision/CollisionShapes/btCompoundShape.h>
+#include <BulletCollision/CollisionShapes/btConcaveShape.h>
+#include <BulletCollision/CollisionShapes/btConvexShape.h>
+#include <BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h>
+#include <BulletCollision/CollisionShapes/btPolyhedralConvexShape.h>
+#include <BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h>
+#include <BulletCollision/CollisionShapes/btSphereShape.h>
+#include <BulletCollision/CollisionShapes/btStaticPlaneShape.h>
+#include <BulletCollision/CollisionShapes/btTriangleMesh.h>
+
+#include <osg/Math>
+
+#include <array>
+#include <vector>
+#include <algorithm>
+
+namespace
+{
+    template <class T>
+    void init(T& value)
+    {
+        value.object.setCollisionShape(&value.shape);
+        value.object.setWorldTransform(value.transform);
+        value.object.setCollisionFlags(value.flags);
+    }
+
+    btTriangleMesh makeTriangleMesh(const std::vector<std::vector<btVector3>>& triangles)
+    {
+        btTriangleMesh shape(false);
+        for (const auto& triangle : triangles)
+        {
+            shape.addTriangle(triangle[0], triangle[1], triangle[2]);
+        }
+        return shape;
+    }
+
+    struct Actor
+    {
+        const btVector3 halfExtents {29.27999496459961, 28.479997634887695, 66.5};
+        const btVector3 origin {0, 0, halfExtents.z() + btScalar(1)};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btCapsuleShapeZ shape {halfExtents.x(), 2 * halfExtents.z() - 2 * halfExtents.x()};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_KINEMATIC_OBJECT;
+        btCollisionObject object;
+
+        Actor() { init(*this); }
+    };
+
+    struct Floor
+    {
+        const btVector3 origin {0, 0, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, 0, 1), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Floor() { init(*this); }
+    };
+
+    template <int x, int y, int z, int radius = 250>
+    struct Sphere
+    {
+        const btVector3 origin {x, y, z};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btSphereShape shape {radius};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Sphere() { init(*this); }
+    };
+
+    struct Capsule
+    {
+        const btVector3 halfExtents {29.27999496459961, 28.479997634887695, 66.5};
+        const btVector3 origin {400, 0, halfExtents.z() + btScalar(1)};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btCapsuleShapeZ shape {halfExtents.x(), 2 * halfExtents.z() - 2 * halfExtents.x()};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Capsule() { init(*this); }
+    };
+
+    template <int x, int y, int z>
+    struct Box
+    {
+        const btVector3 origin {x, y, z};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(100, 100, 100)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Box() { init(*this); }
+    };
+
+    struct Compound
+    {
+        struct Right
+        {
+            const btVector3 origin {0, 250, 0};
+            const btTransform transform {btMatrix3x3::getIdentity(), origin};
+            btBoxShape shape {btVector3(50, 200, 100)};
+        } right;
+
+        struct Top
+        {
+            const btVector3 origin {0, 0, 150};
+            const btTransform transform {btMatrix3x3::getIdentity(), origin};
+            btBoxShape shape {btVector3(50, 450, 50)};
+        } top;
+
+        struct Left
+        {
+            const btVector3 origin {0, -250, 0};
+            const btTransform transform {btMatrix3x3::getIdentity(), origin};
+            btBoxShape shape {btVector3(50, 200, 100)};
+        } left;
+
+        const btVector3 origin {400, 100, 100};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btCompoundShape shape;
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Compound()
+        {
+            shape.addChildShape(right.transform, &right.shape);
+            shape.addChildShape(top.transform, &top.shape);
+            shape.addChildShape(left.transform, &left.shape);
+            shape.recalculateLocalAabb();
+            init(*this);
+        }
+    };
+
+    struct Stair
+    {
+        const btVector3 origin {400, 0, -5};
+        const btTransform transform {btMatrix3x3(btQuaternion(btVector3(0, 1, 0), btScalar(osg::PI_4))), origin};
+        btBoxShape shape {btVector3(10, 1000, 10)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Stair() { init(*this); }
+    };
+
+    struct LeftWall
+    {
+        const btVector3 origin {0, -1000, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, 1, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        LeftWall() { init(*this); }
+    };
+
+    struct RightWall
+    {
+        const btVector3 origin {0, 1000, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, -1, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        RightWall() { init(*this); }
+    };
+
+    struct Roof
+    {
+        const btVector3 origin {0, 0, 1000};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, 0, -1), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Roof() { init(*this); }
+    };
+
+    struct FirstPlatform
+    {
+        const btVector3 origin {0, 0, -100};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(100, 100, 100)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        FirstPlatform() { init(*this); }
+    };
+
+    struct SecondLoweredPlatform
+    {
+        const btVector3 origin {200, 0, -200};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(100, 100, 100)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        SecondLoweredPlatform() { init(*this); }
+    };
+
+    struct ThirdPlatform
+    {
+        const btVector3 origin {400, 0, -100};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(100, 100, 100)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        ThirdPlatform() { init(*this); }
+    };
+
+    struct Slope
+    {
+        const btScalar angle = osg::DegreesToRadians(btScalar(48));
+        const btVector3 origin {400, 0, 200 * std::sin(angle)};
+        const btTransform transform {btMatrix3x3(btQuaternion(btVector3(0, 1, 0), -angle)), origin};
+        btBoxShape shape {btVector3(200, 100, 1)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Slope() { init(*this); }
+    };
+
+    struct ElevatedPlatform
+    {
+        const btScalar angle = osg::DegreesToRadians(btScalar(48));
+        const btVector3 origin {600 + 200 * std::cos(angle), 0, 400 * std::sin(angle)};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(200, 100, 1)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        ElevatedPlatform() { init(*this); }
+    };
+
+    struct SteepSlope
+    {
+        const btScalar angle = osg::DegreesToRadians(btScalar(80));
+        const btVector3 origin {400, 0, 200 * std::sin(angle)};
+        const btTransform transform {btMatrix3x3(btQuaternion(btVector3(0, 1, 0), -angle)), origin};
+        btBoxShape shape {btVector3(200, 100, 1)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        SteepSlope() { init(*this); }
+    };
+
+    struct UnreachableElevatedPlatform
+    {
+        const btScalar angle = osg::DegreesToRadians(btScalar(50));
+        const btVector3 origin {600 + 200 * std::cos(angle), 0, 400 * std::sin(angle)};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(200, 100, 1)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        UnreachableElevatedPlatform() { init(*this); }
+    };
+
+    struct EllispoidY
+    {
+        const btVector3 origin {400, 0, 50};
+        const btTransform transform {btMatrix3x3::getIdentity().scaled(btVector3(1, 2, 1)), origin};
+        btSphereShape shape {50};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        EllispoidY() { init(*this); }
+    };
+
+    struct TurnBackWall
+    {
+        const btVector3 origin {-1000, 0, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(1, 0, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        TurnBackWall() { init(*this); }
+    };
+
+    struct TurnFrontWall
+    {
+        const btVector3 origin {0, 0, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(-1, 0, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        TurnFrontWall() { init(*this); }
+    };
+
+    struct TurnLeftWall
+    {
+        const btVector3 origin {0, 0, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, -1, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        TurnLeftWall() { init(*this); }
+    };
+
+    struct TurnRightWall
+    {
+        const btVector3 origin {0, -1000, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, 1, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        TurnRightWall() { init(*this); }
+    };
+
+    struct TurnInside
+    {
+        const btVector3 origin {-1000, -1000, 500};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(940, 940, 500)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        TurnInside() { init(*this); }
+    };
+
+    struct UTurnInsideWall
+    {
+        const btVector3 origin {-1000, -60, 500};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btBoxShape shape {btVector3(940, 1, 500)};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        UTurnInsideWall() { init(*this); }
+    };
+
+    struct UTurnRightWall
+    {
+        const btVector3 origin {0, -121, 0};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        btStaticPlaneShape shape {btVector3(0, 1, 0), 0};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        UTurnRightWall() { init(*this); }
+    };
+
+    struct Mesh
+    {
+        const std::vector<std::vector<btVector3>> triangles {{
+            {btVector3(-114.477508544921875, -146.597381591796875, -21.62689971923828125), btVector3(-73.4812164306640625, -143.31243896484375, 1.9177703857421875), btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625)},
+            {btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625), btVector3(-167.7228240966796875, -48.69559478759765625, -21.62689971923828125), btVector3(-114.477508544921875, -146.597381591796875, -21.62689971923828125)},
+            {btVector3(-73.4812164306640625, -143.31243896484375, 1.9177703857421875), btVector3(-13.20505523681640625, -65.31792449951171875, 44.1930084228515625), btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625)},
+            {btVector3(-9.643306732177734375, 19.6725254058837890625, 67.32411956787109375), btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625), btVector3(-13.20505523681640625, -65.31792449951171875, 44.1930084228515625)},
+            {btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875), btVector3(233.0417938232421875, -0.644420623779296875, 9.42864227294921875), btVector3(146.439453125, 85.5523834228515625, 9.42864227294921875)},
+            {btVector3(146.439453125, 85.5523834228515625, 9.42864227294921875), btVector3(111.245361328125, 75.8625946044921875, 83.74178314208984375), btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875)},
+            {btVector3(-167.7228240966796875, -48.69559478759765625, -21.62689971923828125), btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625), btVector3(-193.2003021240234375, 119.9915008544921875, 28.84505462646484375)},
+            {btVector3(-193.2003021240234375, 119.9915008544921875, 28.84505462646484375), btVector3(-225.829345703125, 83.18597412109375, -21.62689971923828125), btVector3(-167.7228240966796875, -48.69559478759765625, -21.62689971923828125)},
+            {btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625), btVector3(-9.643306732177734375, 19.6725254058837890625, 67.32411956787109375), btVector3(-143.5372314453125, 132.8759613037109375, 36.259674072265625)},
+            {btVector3(-143.5372314453125, 132.8759613037109375, 36.259674072265625), btVector3(-193.2003021240234375, 119.9915008544921875, 28.84505462646484375), btVector3(-44.60581207275390625, 4.470401763916015625, 62.26615142822265625)},
+            {btVector3(111.245361328125, 75.8625946044921875, 83.74178314208984375), btVector3(146.439453125, 85.5523834228515625, 9.42864227294921875), btVector3(82.9957733154296875, 146.936798095703125, 9.42864227294921875)},
+            {btVector3(82.9957733154296875, 146.936798095703125, 9.42864227294921875), btVector3(76.13427734375, 108.4758453369140625, 79.62641143798828125), btVector3(111.245361328125, 75.8625946044921875, 83.74178314208984375)},
+            {btVector3(-114.477508544921875, -150.4773712158203125, -59.69403839111328125), btVector3(-64.3871917724609375, -165.521484375, -59.69403839111328125), btVector3(-73.4812164306640625, -143.31243896484375, 1.9177703857421875)},
+            {btVector3(-73.4812164306640625, -143.31243896484375, 1.9177703857421875), btVector3(-114.477508544921875, -146.597381591796875, -21.62689971923828125), btVector3(-114.477508544921875, -150.4773712158203125, -59.69403839111328125)},
+            {btVector3(-64.3871917724609375, -165.521484375, -59.69403839111328125), btVector3(5.43251800537109375, -90.4968414306640625, -59.69403839111328125), btVector3(-73.4812164306640625, -143.31243896484375, 1.9177703857421875)},
+            {btVector3(-13.20505523681640625, -65.31792449951171875, 44.1930084228515625), btVector3(-73.4812164306640625, -143.31243896484375, 1.9177703857421875), btVector3(5.43251800537109375, -90.4968414306640625, -59.69403839111328125)},
+            {btVector3(204.1771240234375, -67.90195465087890625, -59.69403839111328125), btVector3(233.0417938232421875, -0.644435882568359375, -59.69403839111328125), btVector3(233.0417938232421875, -0.644420623779296875, 9.42864227294921875)},
+            {btVector3(233.0417938232421875, -0.644420623779296875, 9.42864227294921875), btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875), btVector3(204.1771240234375, -67.90195465087890625, -59.69403839111328125)},
+            {btVector3(233.0417938232421875, -0.644435882568359375, -59.69403839111328125), btVector3(146.439453125, 85.5523681640625, -59.69403839111328125), btVector3(146.439453125, 85.5523834228515625, 9.42864227294921875)},
+            {btVector3(146.439453125, 85.5523834228515625, 9.42864227294921875), btVector3(233.0417938232421875, -0.644420623779296875, 9.42864227294921875), btVector3(233.0417938232421875, -0.644435882568359375, -59.69403839111328125)},
+            {btVector3(146.439453125, 85.5523681640625, -59.69403839111328125), btVector3(82.99576568603515625, 146.9367828369140625, -59.69403839111328125), btVector3(82.9957733154296875, 146.936798095703125, 9.42864227294921875)},
+            {btVector3(82.9957733154296875, 146.936798095703125, 9.42864227294921875), btVector3(146.439453125, 85.5523834228515625, 9.42864227294921875), btVector3(146.439453125, 85.5523681640625, -59.69403839111328125)},
+            {btVector3(82.99576568603515625, 146.9367828369140625, -59.69403839111328125), btVector3(-9.458038330078125, 134.382843017578125, -59.69403839111328125), btVector3(76.13427734375, 108.4758453369140625, 79.62641143798828125)},
+            {btVector3(76.13427734375, 108.4758453369140625, 79.62641143798828125), btVector3(82.9957733154296875, 146.936798095703125, 9.42864227294921875), btVector3(82.99576568603515625, 146.9367828369140625, -59.69403839111328125)},
+            {btVector3(-9.458038330078125, 134.382843017578125, -59.69403839111328125), btVector3(-59.33648681640625, 164.923309326171875, -59.69403839111328125), btVector3(-44.1344451904296875, 129.96099853515625, 49.08777618408203125)},
+            {btVector3(-44.1344451904296875, 129.96099853515625, 49.08777618408203125), btVector3(76.13427734375, 108.4758453369140625, 79.62641143798828125), btVector3(-9.458038330078125, 134.382843017578125, -59.69403839111328125)},
+            {btVector3(-206.0509033203125, 139.53753662109375, -59.69403839111328125), btVector3(-225.829345703125, 83.1859588623046875, -59.69403839111328125), btVector3(-225.829345703125, 83.18597412109375, -21.62689971923828125)},
+            {btVector3(-225.829345703125, 83.18597412109375, -21.62689971923828125), btVector3(-193.2003021240234375, 119.9915008544921875, 28.84505462646484375), btVector3(-206.0509033203125, 139.53753662109375, -59.69403839111328125)},
+            {btVector3(-225.829345703125, 83.1859588623046875, -59.69403839111328125), btVector3(-167.7228240966796875, -48.695587158203125, -59.69403839111328125), btVector3(-167.7228240966796875, -48.69559478759765625, -21.62689971923828125)},
+            {btVector3(-167.7228240966796875, -48.69559478759765625, -21.62689971923828125), btVector3(-225.829345703125, 83.18597412109375, -21.62689971923828125), btVector3(-225.829345703125, 83.1859588623046875, -59.69403839111328125)},
+            {btVector3(-167.7228240966796875, -48.695587158203125, -59.69403839111328125), btVector3(-114.477508544921875, -150.4773712158203125, -59.69403839111328125), btVector3(-114.477508544921875, -146.597381591796875, -21.62689971923828125)},
+            {btVector3(-114.477508544921875, -146.597381591796875, -21.62689971923828125), btVector3(-167.7228240966796875, -48.69559478759765625, -21.62689971923828125), btVector3(-167.7228240966796875, -48.695587158203125, -59.69403839111328125)},
+            {btVector3(78.02291107177734375, -56.20673370361328125, 59.3943634033203125), btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875), btVector3(36.38812255859375, 49.786357879638671875, 98.27130889892578125)},
+            {btVector3(111.245361328125, 75.8625946044921875, 83.74178314208984375), btVector3(36.38812255859375, 49.786357879638671875, 98.27130889892578125), btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875)},
+            {btVector3(36.38812255859375, 49.786357879638671875, 98.27130889892578125), btVector3(111.245361328125, 75.8625946044921875, 83.74178314208984375), btVector3(76.13427734375, 108.4758453369140625, 79.62641143798828125)},
+            {btVector3(76.13427734375, 108.4758453369140625, 79.62641143798828125), btVector3(-44.1344451904296875, 129.96099853515625, 49.08777618408203125), btVector3(36.38812255859375, 49.786357879638671875, 98.27130889892578125)},
+            {btVector3(75.41629791259765625, -74.87143707275390625, -59.69403839111328125), btVector3(204.1771240234375, -67.90195465087890625, -59.69403839111328125), btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875)},
+            {btVector3(166.892181396484375, -62.2358245849609375, 54.0697479248046875), btVector3(78.02291107177734375, -56.20673370361328125, 59.3943634033203125), btVector3(75.41629791259765625, -74.87143707275390625, -59.69403839111328125)},
+            {btVector3(-59.33648681640625, 164.923309326171875, -59.69403839111328125), btVector3(-136.2525482177734375, 162.112640380859375, -59.69403839111328125), btVector3(-143.5372314453125, 132.8759613037109375, 36.259674072265625)},
+            {btVector3(-143.5372314453125, 132.8759613037109375, 36.259674072265625), btVector3(-44.1344451904296875, 129.96099853515625, 49.08777618408203125), btVector3(-59.33648681640625, 164.923309326171875, -59.69403839111328125)},
+            {btVector3(-13.20505523681640625, -65.31792449951171875, 44.1930084228515625), btVector3(78.02291107177734375, -56.20673370361328125, 59.3943634033203125), btVector3(-9.643306732177734375, 19.6725254058837890625, 67.32411956787109375)},
+            {btVector3(36.38812255859375, 49.786357879638671875, 98.27130889892578125), btVector3(-9.643306732177734375, 19.6725254058837890625, 67.32411956787109375), btVector3(78.02291107177734375, -56.20673370361328125, 59.3943634033203125)},
+            {btVector3(-9.643306732177734375, 19.6725254058837890625, 67.32411956787109375), btVector3(36.38812255859375, 49.786357879638671875, 98.27130889892578125), btVector3(-44.1344451904296875, 129.96099853515625, 49.08777618408203125)},
+            {btVector3(-44.1344451904296875, 129.96099853515625, 49.08777618408203125), btVector3(-143.5372314453125, 132.8759613037109375, 36.259674072265625), btVector3(-9.643306732177734375, 19.6725254058837890625, 67.32411956787109375)},
+            {btVector3(5.43251800537109375, -90.4968414306640625, -59.69403839111328125), btVector3(75.41629791259765625, -74.87143707275390625, -59.69403839111328125), btVector3(78.02291107177734375, -56.20673370361328125, 59.3943634033203125)},
+            {btVector3(78.02291107177734375, -56.20673370361328125, 59.3943634033203125), btVector3(-13.20505523681640625, -65.31792449951171875, 44.1930084228515625), btVector3(5.43251800537109375, -90.4968414306640625, -59.69403839111328125)},
+            {btVector3(-136.2525482177734375, 162.112640380859375, -59.69403839111328125), btVector3(-206.0509033203125, 139.53753662109375, -59.69403839111328125), btVector3(-193.2003021240234375, 119.9915008544921875, 28.84505462646484375)},
+            {btVector3(-193.2003021240234375, 119.9915008544921875, 28.84505462646484375), btVector3(-143.5372314453125, 132.8759613037109375, 36.259674072265625), btVector3(-136.2525482177734375, 162.112640380859375, -59.69403839111328125)},
+        }};
+        const btVector3 origin {56358.9140625, -49133.828125, 520.4376220703125};
+        const btTransform transform {
+            btMatrix3x3 {
+                0.01159584522247314453125, 0.93638515472412109375, -0.350782603025436401367188,
+                -0.9893035888671875, 0.06175744533538818359375, 0.132152974605560302734375,
+                0.145409524440765380859375, 0.34549808502197265625, 0.92708528041839599609375,
+            },
+            origin,
+        };
+        btTriangleMesh mesh = makeTriangleMesh(triangles);
+        btBvhTriangleMeshShape child {&mesh, true};
+        const btVector3 scaling {1.610000133514404296875, 1.610000133514404296875, 1.610000133514404296875};
+        btScaledBvhTriangleMeshShape shape {&child, scaling};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Mesh() { init(*this); }
+    };
+
+    struct Mesh2
+    {
+        const std::vector<std::vector<btVector3>> triangles {{
+            {btVector3(-245.40185546875, -107.0033111572265625, -87.27094268798828125), btVector3(-129.9500274658203125, -63.68837738037109375, -18.95238494873046875), btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875)},
+            {btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875), btVector3(-266.35302734375, -37.80367279052734375, -87.27094268798828125), btVector3(-245.40185546875, -107.0033111572265625, -87.27094268798828125)},
+            {btVector3(-129.9500274658203125, -63.68837738037109375, -18.95238494873046875), btVector3(-63.398223876953125, -44.517730712890625, -12.27741241455078125), btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875)},
+            {btVector3(-34.71561431884765625, 29.562168121337890625, 29.39096832275390625), btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875), btVector3(-63.398223876953125, -44.517730712890625, -12.27741241455078125)},
+            {btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125), btVector3(206.46435546875, -138.4351654052734375, -56.21540069580078125), btVector3(308.36669921875, -15.01595306396484375, -56.21540069580078125)},
+            {btVector3(308.36669921875, -15.01595306396484375, -56.21540069580078125), btVector3(159.370941162109375, 29.562164306640625, 30.56577301025390625), btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125)},
+            {btVector3(-266.35302734375, -37.80367279052734375, -87.27094268798828125), btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875), btVector3(-159.6646575927734375, 129.527557373046875, -38.45085906982421875)},
+            {btVector3(-159.6646575927734375, 129.527557373046875, -38.45085906982421875), btVector3(-168.52783203125, 159.794952392578125, -87.27094268798828125), btVector3(-266.35302734375, -37.80367279052734375, -87.27094268798828125)},
+            {btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875), btVector3(-34.71561431884765625, 29.562168121337890625, 29.39096832275390625), btVector3(-34.715610504150390625, 128.923736572265625, -11.595306396484375)},
+            {btVector3(-34.715610504150390625, 128.923736572265625, -11.595306396484375), btVector3(-159.6646575927734375, 129.527557373046875, -38.45085906982421875), btVector3(-72.8401641845703125, 29.562168121337890625, 24.33300018310546875)},
+            {btVector3(159.370941162109375, 29.562164306640625, 30.56577301025390625), btVector3(308.36669921875, -15.01595306396484375, -56.21540069580078125), btVector3(197.0830078125, 132.9785003662109375, -56.21540069580078125)},
+            {btVector3(197.0830078125, 132.9785003662109375, -56.21540069580078125), btVector3(159.370941162109375, 128.923736572265625, 7.59090423583984375), btVector3(159.370941162109375, 29.562164306640625, 30.56577301025390625)},
+            {btVector3(-245.40185546875, -107.003326416015625, -154.53173828125), btVector3(-129.9500274658203125, -117.751556396484375, -154.53173828125), btVector3(-129.9500274658203125, -63.68837738037109375, -18.95238494873046875)},
+            {btVector3(-129.9500274658203125, -63.68837738037109375, -18.95238494873046875), btVector3(-245.40185546875, -107.0033111572265625, -87.27094268798828125), btVector3(-245.40185546875, -107.003326416015625, -154.53173828125)},
+            {btVector3(-129.9500274658203125, -117.751556396484375, -154.53173828125), btVector3(-64.82010650634765625, -77.481231689453125, -154.53173828125), btVector3(-129.9500274658203125, -63.68837738037109375, -18.95238494873046875)},
+            {btVector3(-63.398223876953125, -44.517730712890625, -12.27741241455078125), btVector3(-129.9500274658203125, -63.68837738037109375, -18.95238494873046875), btVector3(-64.82010650634765625, -77.481231689453125, -154.53173828125)},
+            {btVector3(121.647796630859375, -138.4351806640625, -154.53173828125), btVector3(206.46435546875, -138.4351806640625, -154.53173828125), btVector3(206.46435546875, -138.4351654052734375, -56.21540069580078125)},
+            {btVector3(206.46435546875, -138.4351654052734375, -56.21540069580078125), btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125), btVector3(121.647796630859375, -138.4351806640625, -154.53173828125)},
+            {btVector3(206.46435546875, -138.4351806640625, -154.53173828125), btVector3(308.36669921875, -15.015960693359375, -154.53173828125), btVector3(308.36669921875, -15.01595306396484375, -56.21540069580078125)},
+            {btVector3(308.36669921875, -15.01595306396484375, -56.21540069580078125), btVector3(206.46435546875, -138.4351654052734375, -56.21540069580078125), btVector3(206.46435546875, -138.4351806640625, -154.53173828125)},
+            {btVector3(308.36669921875, -15.015960693359375, -154.53173828125), btVector3(197.0830078125, 132.978485107421875, -154.53173828125), btVector3(197.0830078125, 132.9785003662109375, -56.21540069580078125)},
+            {btVector3(197.0830078125, 132.9785003662109375, -56.21540069580078125), btVector3(308.36669921875, -15.01595306396484375, -56.21540069580078125), btVector3(308.36669921875, -15.015960693359375, -154.53173828125)},
+            {btVector3(197.0830078125, 132.978485107421875, -154.53173828125), btVector3(46.318695068359375, 169.0604095458984375, -154.53173828125), btVector3(159.370941162109375, 128.923736572265625, 7.59090423583984375)},
+            {btVector3(159.370941162109375, 128.923736572265625, 7.59090423583984375), btVector3(197.0830078125, 132.9785003662109375, -56.21540069580078125), btVector3(197.0830078125, 132.978485107421875, -154.53173828125)},
+            {btVector3(46.318695068359375, 169.0604095458984375, -154.53173828125), btVector3(9.7556304931640625, 169.2423248291015625, -154.53173828125), btVector3(9.75562953948974609375, 128.923736572265625, -9.7012939453125)},
+            {btVector3(9.75562953948974609375, 128.923736572265625, -9.7012939453125), btVector3(159.370941162109375, 128.923736572265625, 7.59090423583984375), btVector3(46.318695068359375, 169.0604095458984375, -154.53173828125)},
+            {btVector3(-72.8401641845703125, 169.4899444580078125, -154.53173828125), btVector3(-168.52783203125, 159.7949371337890625, -154.53173828125), btVector3(-168.52783203125, 159.794952392578125, -87.27094268798828125)},
+            {btVector3(-168.52783203125, 159.794952392578125, -87.27094268798828125), btVector3(-159.6646575927734375, 129.527557373046875, -38.45085906982421875), btVector3(-72.8401641845703125, 169.4899444580078125, -154.53173828125)},
+            {btVector3(-168.52783203125, 159.7949371337890625, -154.53173828125), btVector3(-266.35302734375, -37.803680419921875, -154.53173828125), btVector3(-266.35302734375, -37.80367279052734375, -87.27094268798828125)},
+            {btVector3(-266.35302734375, -37.80367279052734375, -87.27094268798828125), btVector3(-168.52783203125, 159.794952392578125, -87.27094268798828125), btVector3(-168.52783203125, 159.7949371337890625, -154.53173828125)},
+            {btVector3(-266.35302734375, -37.803680419921875, -154.53173828125), btVector3(-245.40185546875, -107.003326416015625, -154.53173828125), btVector3(-245.40185546875, -107.0033111572265625, -87.27094268798828125)},
+            {btVector3(-245.40185546875, -107.0033111572265625, -87.27094268798828125), btVector3(-266.35302734375, -37.80367279052734375, -87.27094268798828125), btVector3(-266.35302734375, -37.803680419921875, -154.53173828125)},
+            {btVector3(18.284912109375, -69.66729736328125, -10.55902862548828125), btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125), btVector3(18.28491973876953125, 29.5621662139892578125, 34.42610931396484375)},
+            {btVector3(159.370941162109375, 29.562164306640625, 30.56577301025390625), btVector3(18.28491973876953125, 29.5621662139892578125, 34.42610931396484375), btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125)},
+            {btVector3(18.28491973876953125, 29.5621662139892578125, 34.42610931396484375), btVector3(159.370941162109375, 29.562164306640625, 30.56577301025390625), btVector3(159.370941162109375, 128.923736572265625, 7.59090423583984375)},
+            {btVector3(159.370941162109375, 128.923736572265625, 7.59090423583984375), btVector3(9.75562953948974609375, 128.923736572265625, -9.7012939453125), btVector3(18.28491973876953125, 29.5621662139892578125, 34.42610931396484375)},
+            {btVector3(60.518802642822265625, -143.243988037109375, -154.53173828125), btVector3(121.647796630859375, -138.4351806640625, -154.53173828125), btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125)},
+            {btVector3(159.370941162109375, -72.2315673828125, -9.82831573486328125), btVector3(18.284912109375, -69.66729736328125, -10.55902862548828125), btVector3(60.518802642822265625, -143.243988037109375, -154.53173828125)},
+            {btVector3(9.7556304931640625, 169.2423248291015625, -154.53173828125), btVector3(-34.71561431884765625, 169.3756561279296875, -154.53173828125), btVector3(-34.715610504150390625, 128.923736572265625, -11.595306396484375)},
+            {btVector3(-34.715610504150390625, 128.923736572265625, -11.595306396484375), btVector3(9.75562953948974609375, 128.923736572265625, -9.7012939453125), btVector3(9.7556304931640625, 169.2423248291015625, -154.53173828125)},
+            {btVector3(-63.398223876953125, -44.517730712890625, -12.27741241455078125), btVector3(18.284912109375, -69.66729736328125, -10.55902862548828125), btVector3(-34.71561431884765625, 29.562168121337890625, 29.39096832275390625)},
+            {btVector3(18.28491973876953125, 29.5621662139892578125, 34.42610931396484375), btVector3(-34.71561431884765625, 29.562168121337890625, 29.39096832275390625), btVector3(18.284912109375, -69.66729736328125, -10.55902862548828125)},
+            {btVector3(-34.71561431884765625, 29.562168121337890625, 29.39096832275390625), btVector3(18.28491973876953125, 29.5621662139892578125, 34.42610931396484375), btVector3(9.75562953948974609375, 128.923736572265625, -9.7012939453125)},
+            {btVector3(9.75562953948974609375, 128.923736572265625, -9.7012939453125), btVector3(-34.715610504150390625, 128.923736572265625, -11.595306396484375), btVector3(-34.71561431884765625, 29.562168121337890625, 29.39096832275390625)},
+            {btVector3(-64.82010650634765625, -77.481231689453125, -154.53173828125), btVector3(60.518802642822265625, -143.243988037109375, -154.53173828125), btVector3(18.284912109375, -69.66729736328125, -10.55902862548828125)},
+            {btVector3(18.284912109375, -69.66729736328125, -10.55902862548828125), btVector3(-63.398223876953125, -44.517730712890625, -12.27741241455078125), btVector3(-64.82010650634765625, -77.481231689453125, -154.53173828125)},
+            {btVector3(-34.71561431884765625, 169.3756561279296875, -154.53173828125), btVector3(-72.8401641845703125, 169.4899444580078125, -154.53173828125), btVector3(-159.6646575927734375, 129.527557373046875, -38.45085906982421875)},
+            {btVector3(-159.6646575927734375, 129.527557373046875, -38.45085906982421875), btVector3(-34.715610504150390625, 128.923736572265625, -11.595306396484375), btVector3(-34.71561431884765625, 169.3756561279296875, -154.53173828125)},
+        }};
+        const btVector3 origin {55885.75, -49099.9296875, 576.158203125};
+        const btTransform transform {
+            btMatrix3x3 {
+                -0.1230890750885009765625, -0.947373807430267333984375, 0.295519769191741943359375,
+                0.990511953830718994140625, -0.09894287586212158203125, 0.0953752323985099792480469,
+                -0.0611164346337318420410156, 0.304455488920211791992188, 0.950563848018646240234375,
+            },
+            origin,
+        };
+        btTriangleMesh mesh = makeTriangleMesh(triangles);
+        btBvhTriangleMeshShape child {&mesh, true};
+        const btVector3 scaling {1.32000005245208740234375, 1.32000005245208740234375, 1.32000005245208740234375};
+        btScaledBvhTriangleMeshShape shape {&child, scaling};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Mesh2() { init(*this); }
+    };
+
+    struct HeightField
+    {
+        static const int heightStickWidth = 65;
+        static const int heightStickLength = 65;
+        const std::array<btScalar, heightStickWidth * heightStickLength> heightfieldData {{
+            1080, 1024, 944, 856, 760, 672, 560, 448, 336, 232, 144, 72, 8, -40, -80, -128, -160, -184, -184, -176, -144, -80, 0, 96, 192, 288, 384, 496, 632, 760, 864, 936, 984, 1000, 1024, 1048, 1072, 1120, 1184, 1192, 1208, 1216, 1232, 1248, 1272, 1304, 1360, 1384, 1408, 1424, 1440, 1448, 1456, 1456, 1456, 1456, 1456, 1440, 1352, 1360, 1400, 1616, 1768, 1928, 2072,
+            992, 936, 848, 752, 648, 528, 416, 304, 208, 128, 64, 16, -32, -72, -112, -144, -176, -192, -200, -168, -120, -56, 40, 136, 232, 328, 432, 552, 688, 824, 928, 1008, 1048, 1056, 1080, 1096, 1112, 1136, 1184, 1208, 1208, 1224, 1240, 1264, 1296, 1320, 1352, 1376, 1392, 1384, 1384, 1384, 1384, 1392, 1392, 1392, 1352, 1352, 1352, 1352, 1400, 1536, 1736, 1920, 2080,
+            912, 848, 768, 664, 544, 408, 296, 184, 96, 32, -8, -40, -72, -104, -136, -168, -200, -200, -192, -160, -104, -32, 72, 176, 272, 368, 472, 600, 744, 872, 976, 1048, 1096, 1120, 1136, 1152, 1152, 1160, 1176, 1184, 1192, 1208, 1216, 1256, 1288, 1312, 1336, 1360, 1368, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1368, 1512, 1728, 1920, 2088,
+            832, 768, 680, 576, 448, 320, 200, 96, 16, -32, -64, -88, -112, -128, -152, -176, -200, -200, -192, -160, -120, -16, 104, 216, 328, 376, 488, 648, 792, 912, 1016, 1088, 1128, 1152, 1176, 1184, 1184, 1176, 1176, 1176, 1184, 1192, 1208, 1232, 1256, 1280, 1312, 1336, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1368, 1400, 1552, 1736, 1968, 2104,
+            760, 680, 592, 488, 376, 240, 128, 24, -48, -88, -112, -128, -136, -152, -160, -168, -168, -160, -144, -104, -56, 40, 152, 272, 352, 424, 568, 704, 840, 968, 1072, 1144, 1176, 1192, 1176, 1184, 1184, 1184, 1184, 1184, 1184, 1192, 1200, 1216, 1248, 1272, 1304, 1344, 1352, 1352, 1352, 1352, 1352, 1352, 1352, 1344, 1352, 1352, 1352, 1376, 1416, 1584, 1792, 1968, 2136,
+            696, 584, 504, 408, 288, 168, 56, -32, -104, -144, -160, -168, -168, -168, -160, -144, -120, -104, -72, -32, 8, 104, 216, 344, 408, 504, 640, 776, 872, 984, 1080, 1152, 1184, 1200, 1184, 1176, 1184, 1184, 1184, 1184, 1184, 1184, 1184, 1208, 1240, 1272, 1312, 1352, 1344, 1352, 1352, 1352, 1352, 1344, 1344, 1344, 1344, 1344, 1352, 1376, 1448, 1592, 1800, 2000, 2144,
+            592, 480, 400, 312, 208, 104, 0, -88, -152, -192, -200, -200, -192, -176, -144, -104, -64, -32, 8, 48, 104, 184, 288, 400, 456, 544, 704, 792, 896, 992, 1080, 1144, 1176, 1208, 1184, 1176, 1176, 1184, 1184, 1184, 1184, 1184, 1184, 1208, 1240, 1272, 1328, 1360, 1360, 1352, 1352, 1352, 1352, 1344, 1344, 1344, 1344, 1344, 1352, 1392, 1464, 1584, 1792, 2000, 2152,
+            488, 400, 320, 232, 144, 48, -40, -136, -192, -224, -240, -232, -208, -168, -120, -64, -8, 32, 80, 128, 184, 264, 352, 440, 520, 632, 744, 832, 904, 984, 1064, 1120, 1160, 1184, 1184, 1176, 1176, 1184, 1184, 1184, 1184, 1184, 1184, 1208, 1240, 1296, 1352, 1408, 1408, 1368, 1336, 1336, 1328, 1336, 1344, 1336, 1336, 1336, 1360, 1392, 1464, 1592, 1776, 1984, 2168,
+            408, 328, 248, 168, 96, 24, -64, -152, -232, -264, -272, -264, -232, -176, -104, -32, 32, 80, 128, 184, 248, 320, 408, 488, 568, 672, 752, 840, 912, 984, 1056, 1112, 1144, 1176, 1176, 1176, 1176, 1184, 1184, 1184, 1184, 1184, 1192, 1208, 1240, 1288, 1376, 1472, 1448, 1392, 1336, 1328, 1328, 1328, 1336, 1328, 1328, 1328, 1336, 1376, 1456, 1584, 1768, 1960, 2144,
+            336, 264, 192, 128, 72, 0, -88, -176, -256, -304, -312, -304, -256, -192, -112, -24, 48, 112, 168, 224, 288, 368, 440, 512, 592, 688, 760, 840, 912, 992, 1056, 1120, 1152, 1168, 1176, 1176, 1184, 1184, 1184, 1184, 1176, 1184, 1192, 1208, 1232, 1272, 1360, 1440, 1456, 1408, 1336, 1328, 1328, 1328, 1312, 1312, 1312, 1320, 1320, 1360, 1472, 1592, 1752, 1936, 2120,
+            272, 208, 152, 112, 56, -16, -112, -200, -280, -344, -360, -336, -288, -216, -120, -24, 56, 128, 184, 256, 320, 392, 464, 528, 600, 680, 760, 840, 920, 984, 1048, 1120, 1152, 1168, 1176, 1184, 1184, 1176, 1184, 1176, 1176, 1184, 1192, 1208, 1224, 1248, 1304, 1368, 1400, 1360, 1328, 1320, 1320, 1296, 1288, 1296, 1304, 1312, 1320, 1368, 1472, 1600, 1744, 1904, 2064,
+            216, 160, 120, 88, 40, -40, -136, -224, -312, -376, -384, -368, -320, -240, -136, -32, 56, 128, 192, 264, 328, 400, 464, 528, 584, 656, 744, 832, 904, 984, 1056, 1112, 1144, 1168, 1176, 1176, 1176, 1176, 1176, 1176, 1176, 1184, 1184, 1200, 1216, 1232, 1240, 1296, 1360, 1336, 1320, 1304, 1296, 1288, 1288, 1296, 1296, 1312, 1352, 1408, 1496, 1608, 1736, 1872, 1992,
+            152, 120, 96, 72, 24, -56, -160, -264, -336, -392, -400, -376, -328, -248, -144, -40, 56, 128, 192, 256, 336, 408, 472, 528, 560, 624, 720, 816, 912, 1000, 1072, 1120, 1152, 1176, 1184, 1184, 1184, 1176, 1176, 1168, 1168, 1176, 1176, 1184, 1200, 1208, 1224, 1272, 1312, 1352, 1312, 1272, 1280, 1288, 1288, 1288, 1296, 1296, 1336, 1408, 1496, 1608, 1720, 1832, 1920,
+            112, 88, 72, 56, 0, -88, -184, -296, -376, -392, -400, -376, -336, -256, -160, -48, 72, 144, 192, 240, 320, 392, 488, 520, 528, 576, 704, 816, 920, 1016, 1088, 1136, 1160, 1176, 1184, 1184, 1176, 1176, 1176, 1168, 1160, 1168, 1168, 1176, 1184, 1192, 1208, 1240, 1272, 1288, 1272, 1248, 1256, 1272, 1296, 1288, 1288, 1296, 1312, 1392, 1488, 1592, 1696, 1792, 1872,
+            80, 72, 48, 16, -24, -120, -216, -312, -384, -400, -400, -392, -352, -280, -176, -48, 64, 136, 176, 208, 288, 376, 440, 480, 512, 568, 704, 824, 936, 1032, 1096, 1144, 1168, 1184, 1184, 1184, 1168, 1168, 1160, 1160, 1160, 1160, 1160, 1168, 1176, 1184, 1192, 1200, 1224, 1240, 1224, 1224, 1232, 1264, 1264, 1272, 1280, 1288, 1288, 1368, 1464, 1568, 1664, 1760, 1832,
+            64, 48, 24, -16, -80, -160, -240, -320, -376, -392, -392, -376, -344, -280, -184, -80, 24, 104, 176, 200, 264, 344, 408, 464, 520, 592, 712, 848, 944, 1032, 1104, 1160, 1184, 1200, 1184, 1168, 1160, 1152, 1152, 1152, 1152, 1152, 1152, 1160, 1168, 1176, 1184, 1184, 1192, 1192, 1192, 1192, 1200, 1240, 1256, 1256, 1256, 1256, 1264, 1336, 1432, 1536, 1640, 1720, 1792,
+            40, 24, -8, -64, -120, -192, -264, -328, -376, -384, -376, -368, -336, -272, -192, -96, 0, 72, 152, 216, 264, 336, 400, 464, 544, 648, 768, 864, 952, 1048, 1136, 1192, 1216, 1216, 1200, 1176, 1160, 1152, 1144, 1144, 1136, 1136, 1144, 1152, 1160, 1168, 1176, 1176, 1184, 1184, 1184, 1192, 1200, 1208, 1232, 1240, 1232, 1200, 1224, 1296, 1400, 1504, 1592, 1680, 1752,
+            0, -24, -64, -112, -168, -224, -288, -336, -376, -376, -376, -352, -312, -256, -176, -104, -8, 88, 168, 240, 304, 360, 416, 472, 584, 688, 800, 896, 960, 1032, 1144, 1208, 1232, 1232, 1216, 1200, 1176, 1152, 1136, 1128, 1128, 1128, 1136, 1144, 1152, 1160, 1168, 1168, 1176, 1184, 1184, 1184, 1184, 1200, 1200, 1200, 1192, 1200, 1216, 1272, 1344, 1464, 1552, 1648, 1712,
+            -48, -88, -128, -176, -224, -272, -320, -368, -384, -384, -376, -344, -296, -232, -144, -64, 32, 120, 208, 288, 352, 408, 456, 512, 608, 720, 824, 904, 944, 1064, 1152, 1216, 1248, 1256, 1240, 1216, 1184, 1152, 1120, 1112, 1120, 1120, 1120, 1128, 1144, 1144, 1152, 1168, 1168, 1176, 1184, 1184, 1184, 1192, 1192, 1192, 1192, 1192, 1192, 1232, 1312, 1408, 1504, 1600, 1664,
+            -120, -152, -192, -232, -272, -320, -352, -384, -392, -392, -368, -312, -248, -184, -104, -16, 72, 160, 256, 336, 400, 448, 488, 536, 624, 728, 832, 904, 944, 1080, 1184, 1248, 1272, 1304, 1256, 1216, 1176, 1128, 1104, 1088, 1096, 1104, 1104, 1112, 1128, 1136, 1144, 1160, 1168, 1176, 1184, 1184, 1184, 1192, 1200, 1200, 1200, 1192, 1192, 1192, 1264, 1352, 1448, 1536, 1608,
+            -184, -208, -240, -280, -312, -344, -376, -392, -400, -392, -352, -288, -208, -144, -64, 24, 112, 200, 288, 368, 432, 472, 512, 552, 632, 728, 816, 880, 944, 1056, 1152, 1224, 1272, 1264, 1272, 1216, 1160, 1104, 1072, 1056, 1056, 1056, 1072, 1080, 1104, 1120, 1136, 1152, 1168, 1176, 1192, 1192, 1192, 1200, 1208, 1208, 1208, 1200, 1192, 1192, 1192, 1304, 1392, 1472, 1560,
+            -232, -256, -288, -320, -344, -368, -384, -400, -400, -384, -336, -264, -184, -112, -32, 56, 136, 224, 304, 376, 440, 480, 520, 560, 616, 696, 768, 840, 920, 1008, 1088, 1152, 1200, 1216, 1200, 1168, 1112, 1056, 1024, 1008, 1008, 1008, 1016, 1048, 1080, 1104, 1120, 1136, 1168, 1168, 1184, 1184, 1192, 1200, 1208, 1216, 1208, 1200, 1192, 1192, 1216, 1264, 1328, 1400, 1472,
+            -272, -288, -320, -344, -368, -392, -400, -400, -400, -376, -328, -256, -184, -96, -16, 72, 152, 240, 304, 376, 424, 464, 512, 552, 600, 664, 736, 808, 888, 968, 1040, 1096, 1128, 1152, 1144, 1112, 1064, 1000, 960, 944, 976, 952, 944, 976, 1048, 1080, 1136, 1144, 1144, 1152, 1160, 1176, 1184, 1192, 1200, 1208, 1200, 1192, 1192, 1192, 1192, 1232, 1280, 1328, 1384,
+            -296, -312, -344, -368, -392, -408, -416, -408, -400, -376, -328, -256, -176, -96, -8, 80, 168, 240, 296, 352, 400, 440, 488, 520, 568, 624, 696, 776, 864, 936, 1008, 1056, 1080, 1088, 1080, 1056, 1016, 952, 920, 880, 888, 872, 872, 920, 976, 1024, 1112, 1136, 1120, 1128, 1128, 1136, 1152, 1168, 1192, 1184, 1192, 1184, 1192, 1192, 1192, 1216, 1240, 1272, 1312,
+            -312, -328, -360, -392, -424, -432, -432, -424, -400, -376, -336, -272, -192, -112, -16, 80, 160, 224, 272, 320, 360, 400, 448, 496, 536, 592, 664, 752, 840, 928, 992, 1032, 1048, 1048, 1040, 1008, 968, 920, 880, 880, 880, 872, 880, 888, 936, 976, 1008, 1112, 1088, 1088, 1096, 1104, 1120, 1144, 1160, 1176, 1184, 1184, 1192, 1192, 1192, 1200, 1216, 1232, 1264,
+            -336, -352, -384, -424, -440, -456, -448, -432, -408, -384, -352, -296, -224, -136, -40, 56, 136, 200, 240, 280, 312, 360, 408, 456, 512, 568, 648, 728, 824, 920, 984, 1024, 1032, 1024, 1000, 968, 920, 888, 880, 888, 880, 880, 880, 880, 912, 944, 976, 1008, 1040, 1072, 1064, 1072, 1064, 1056, 1024, 1160, 1184, 1184, 1192, 1192, 1192, 1192, 1200, 1216, 1232,
+            -360, -376, -408, -440, -464, -472, -456, -440, -416, -392, -368, -320, -248, -168, -72, 16, 104, 160, 200, 232, 264, 304, 368, 432, 496, 560, 632, 712, 792, 872, 952, 992, 1008, 1016, 984, 936, 880, 880, 880, 880, 880, 880, 880, 880, 880, 904, 928, 960, 992, 1024, 1064, 1040, 1024, 1040, 1064, 1104, 1168, 1192, 1192, 1192, 1192, 1192, 1192, 1200, 1216,
+            -376, -400, -424, -456, -472, -472, -464, -448, -400, -400, -384, -344, -288, -208, -112, -16, 72, 144, 168, 192, 224, 272, 344, 416, 480, 552, 616, 680, 752, 824, 880, 936, 960, 992, 960, 936, 904, 888, 880, 880, 880, 880, 880, 880, 880, 880, 888, 904, 936, 952, 952, 968, 992, 1016, 1040, 1056, 1096, 1088, 1192, 1192, 1192, 1192, 1192, 1192, 1208,
+            -384, -400, -424, -448, -464, -464, -448, -432, -392, -384, -376, -360, -304, -240, -160, -72, 16, 88, 120, 152, 192, 248, 328, 400, 472, 536, 600, 656, 712, 760, 808, 864, 896, 920, 944, 912, 904, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 896, 904, 944, 952, 960, 1016, 1048, 1056, 1064, 1088, 1144, 1176, 1192, 1192, 1192, 1192, 1192,
+            -376, -392, -408, -424, -432, -432, -432, -408, -376, -368, -376, -360, -312, -256, -192, -112, -40, 32, 80, 128, 176, 232, 312, 392, 464, 528, 576, 624, 656, 688, 720, 760, 832, 848, 864, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 872, 864, 864, 888, 936, 976, 1032, 1040, 1040, 1048, 1064, 1072, 1144, 1192, 1192, 1192, 1192, 1192,
+            -352, -360, -376, -392, -400, -400, -400, -384, -368, -360, -352, -336, -312, -264, -208, -136, -64, 0, 56, 112, 160, 232, 304, 376, 440, 496, 544, 568, 592, 608, 624, 640, 672, 728, 784, 824, 856, 880, 880, 880, 888, 880, 880, 880, 880, 880, 880, 872, 864, 864, 864, 864, 880, 880, 952, 1000, 1024, 1040, 1064, 1112, 1136, 1184, 1184, 1184, 1200,
+            -312, -312, -320, -344, -360, -368, -368, -360, -352, -344, -336, -328, -304, -264, -216, -152, -88, -16, 40, 104, 160, 224, 288, 344, 400, 448, 480, 504, 520, 528, 520, 520, 544, 592, 680, 752, 816, 880, 880, 888, 888, 880, 880, 880, 880, 880, 880, 872, 864, 864, 864, 872, 872, 880, 880, 1016, 992, 1016, 1040, 1056, 1088, 1112, 1128, 1160, 1168,
+            -272, -264, -280, -288, -328, -344, -352, -344, -336, -328, -320, -312, -296, -272, -224, -176, -104, -40, 32, 88, 152, 216, 256, 304, 344, 384, 408, 424, 440, 440, 424, 400, 400, 472, 560, 672, 768, 864, 880, 896, 920, 912, 888, 880, 880, 880, 880, 880, 880, 872, 872, 872, 880, 880, 880, 880, 1000, 992, 1016, 1032, 1040, 1048, 1064, 1080, 1120,
+            -232, -216, -232, -288, -320, -336, -344, -336, -328, -320, -320, -312, -296, -280, -248, -200, -144, -72, 0, 56, 120, 176, 208, 248, 280, 304, 328, 344, 352, 352, 344, 328, 312, 360, 472, 592, 704, 824, 880, 920, 936, 928, 904, 888, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 976, 968, 976, 1000, 1024, 1032, 1048, 1080,
+            -208, -216, -240, -288, -328, -344, -344, -336, -320, -312, -304, -312, -304, -296, -272, -240, -192, -128, -56, 0, 56, 112, 160, 176, 200, 224, 240, 256, 264, 264, 264, 264, 264, 304, 392, 512, 632, 760, 856, 928, 952, 952, 928, 904, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 888, 928, 952, 984, 1024, 1024, 1080,
+            -192, -224, -264, -312, -344, -360, -352, -336, -320, -312, -304, -312, -320, -312, -304, -280, -248, -200, -136, -72, -24, 24, 64, 104, 128, 144, 152, 176, 184, 192, 192, 208, 224, 272, 344, 456, 584, 696, 800, 880, 920, 936, 920, 904, 880, 872, 872, 872, 872, 872, 880, 880, 880, 880, 880, 880, 880, 880, 880, 880, 920, 960, 1008, 1048, 1104,
+            -184, -232, -288, -336, -376, -400, -376, -352, -328, -312, -320, -320, -328, -336, -336, -328, -312, -280, -232, -176, -120, -72, -24, 16, 48, 48, 64, 80, 96, 104, 120, 152, 192, 240, 320, 416, 544, 640, 728, 776, 832, 864, 872, 872, 880, 880, 872, 872, 872, 872, 880, 880, 880, 880, 880, 880, 880, 872, 880, 880, 904, 952, 1016, 1056, 1104,
+            -176, -248, -312, -368, -408, -424, -400, -368, -336, -328, -320, -328, -344, -360, -376, -376, -376, -360, -336, -296, -248, -192, -152, -104, -72, -64, -40, 0, 32, 48, 64, 104, 160, 200, 256, 400, 488, 560, 648, 712, 736, 768, 800, 832, 856, 864, 848, 856, 864, 872, 880, 880, 880, 880, 880, 872, 872, 872, 872, 880, 896, 936, 1000, 1048, 1096,
+            -168, -256, -336, -392, -432, -440, -424, -392, -352, -336, -328, -336, -352, -376, -408, -424, -432, -432, -424, -400, -360, -320, -272, -232, -184, -152, -112, -64, -24, 8, 32, 40, 112, 192, 224, 304, 392, 464, 528, 592, 632, 672, 712, 728, 760, 808, 824, 840, 864, 880, 888, 880, 888, 880, 880, 872, 872, 872, 872, 880, 896, 936, 1024, 1040, 1072,
+            -152, -256, -352, -416, -456, -472, -456, -408, -360, -336, -320, -328, -360, -392, -424, -456, -472, -480, -488, -480, -456, -424, -384, -344, -288, -224, -168, -104, -56, -16, 40, 96, 144, 184, 208, 224, 288, 360, 440, 480, 496, 552, 584, 632, 680, 712, 784, 816, 864, 912, 896, 888, 880, 872, 872, 872, 872, 864, 864, 864, 888, 936, 1008, 1008, 1040,
+            -144, -272, -352, -424, -464, -472, -456, -424, -360, -328, -312, -328, -360, -392, -432, -464, -496, -520, -544, -552, -544, -528, -488, -432, -368, -288, -208, -128, -56, 8, 72, 144, 160, 184, 192, 192, 192, 232, 216, 216, 256, 296, 400, 520, 576, 656, 720, 768, 808, 880, 888, 880, 888, 872, 872, 864, 856, 840, 832, 832, 864, 904, 944, 976, 1008,
+            -120, -256, -352, -424, -456, -472, -448, -408, -352, -320, -304, -320, -352, -384, -424, -472, -504, -536, -560, -584, -600, -592, -568, -512, -440, -352, -240, -136, -40, 40, 112, 160, 160, 168, 176, 176, 168, 168, 208, 192, 176, 184, 312, 392, 472, 552, 624, 648, 672, 744, 840, 848, 832, 872, 872, 832, 808, 792, 784, 784, 808, 848, 888, 936, 984,
+            -88, -240, -352, -432, -472, -472, -440, -384, -328, -296, -288, -312, -336, -376, -424, -464, -504, -536, -568, -600, -632, -640, -616, -560, -496, -408, -272, -144, -24, 96, 152, 152, 168, 176, 176, 176, 160, 168, 168, 168, 168, 168, 232, 296, 392, 432, 496, 464, 480, 624, 680, 744, 768, 800, 800, 784, 760, 744, 728, 728, 728, 768, 832, 896, 968,
+            -64, -208, -328, -408, -448, -456, -416, -360, -304, -280, -280, -296, -328, -368, -408, -448, -496, -528, -568, -608, -632, -648, -640, -600, -536, -432, -312, -160, -24, 104, 160, 160, 168, 176, 184, 176, 176, 168, 168, 168, 160, 160, 160, 240, 328, 336, 336, 400, 432, 528, 704, 720, 704, 728, 728, 712, 688, 672, 672, 656, 648, 704, 784, 864, 952,
+            -8, -176, -280, -368, -416, -416, -384, -336, -288, -248, -256, -280, -312, -352, -392, -432, -472, -520, -560, -592, -624, -648, -648, -616, -560, -464, -344, -192, -40, 104, 136, 160, 168, 176, 184, 184, 184, 176, 176, 168, 168, 168, 168, 208, 272, 360, 456, 520, 552, 584, 616, 640, 640, 664, 656, 640, 624, 616, 608, 600, 592, 632, 744, 848, 952,
+            88, -120, -224, -312, -368, -376, -352, -304, -264, -232, -240, -272, -296, -336, -368, -408, -456, -496, -536, -576, -608, -632, -640, -624, -576, -488, -368, -216, -64, 104, 160, 160, 168, 168, 176, 176, 184, 184, 176, 168, 176, 176, 176, 192, 240, 328, 416, 512, 528, 528, 544, 560, 576, 592, 592, 536, 576, 576, 560, 552, 544, 600, 712, 824, 944,
+            192, -8, -168, -272, -344, -352, -320, -280, -248, -224, -232, -264, -288, -320, -352, -384, -424, -464, -504, -544, -584, -616, -632, -624, -584, -504, -392, -240, -64, 96, 160, 160, 160, 160, 168, 168, 176, 168, 176, 168, 176, 192, 176, 168, 240, 320, 392, 480, 528, 528, 528, 528, 520, 528, 528, 544, 528, 528, 528, 528, 536, 600, 696, 816, 944,
+            296, 112, -72, -192, -272, -304, -288, -256, -240, -232, -232, -248, -280, -304, -336, -368, -400, -432, -472, -512, -552, -584, -608, -608, -584, -512, -400, -248, -80, 104, 160, 160, 160, 160, 160, 160, 160, 160, 160, 168, 176, 176, 176, 168, 232, 312, 384, 464, 496, 528, 528, 528, 528, 520, 528, 528, 528, 528, 528, 528, 544, 576, 672, 792, 928,
+            376, 224, 56, -120, -256, -256, -248, -240, -232, -224, -232, -240, -264, -288, -312, -344, -368, -400, -432, -472, -512, -544, -576, -584, -568, -496, -392, -240, -56, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 168, 168, 168, 160, 224, 304, 376, 440, 488, 528, 528, 528, 528, 528, 528, 528, 528, 528, 528, 528, 544, 568, 648, 776, 912,
+            472, 368, 192, 24, -120, -224, -216, -216, -216, -224, -232, -240, -264, -280, -304, -320, -344, -368, -392, -424, -464, -496, -528, -544, -528, -480, -376, -224, -48, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 224, 288, 360, 424, 488, 528, 528, 528, 528, 528, 528, 528, 528, 528, 528, 528, 544, 560, 640, 760, 896,
+            528, 448, 296, 136, -8, -120, -168, -192, -200, -208, -224, -248, -264, -280, -296, -320, -320, -336, -352, -384, -408, -440, -472, -488, -480, -432, -328, -176, 8, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 216, 280, 336, 408, 520, 528, 528, 528, 528, 528, 528, 528, 528, 528, 528, 528, 536, 568, 624, 752, 896,
+            568, 504, 368, 224, 80, -16, -96, -144, -168, -192, -216, -248, -272, -288, -304, -312, -312, -320, -328, -328, -344, -368, -392, -408, -400, -352, -248, -96, 24, 128, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 160, 200, 256, 320, 392, 520, 528, 528, 528, 528, 520, 520, 520, 520, 520, 528, 528, 536, 552, 656, 776, 912,
+            584, 520, 408, 280, 152, 40, -16, -72, -128, -176, -216, -248, -280, -296, -312, -312, -312, -304, -296, -280, -272, -280, -304, -320, -312, -304, -192, -56, 32, 160, 160, 160, 160, 160, 160, 160, 168, 168, 168, 168, 168, 168, 160, 160, 176, 232, 312, 424, 472, 512, 520, 528, 528, 512, 512, 512, 520, 520, 528, 528, 544, 592, 704, 824, 960,
+            616, 544, 440, 328, 200, 72, 32, 16, -80, -152, -208, -256, -288, -312, -328, -328, -312, -296, -264, -232, -200, -192, -192, -200, -200, -168, -104, -8, 72, 144, 160, 160, 160, 168, 168, 168, 168, 168, 168, 168, 168, 168, 168, 168, 184, 240, 328, 408, 480, 536, 552, 560, 536, 504, 496, 496, 504, 512, 528, 528, 568, 656, 768, 888, 1024,
+            632, 568, 472, 360, 232, 88, 56, 40, -48, -136, -216, -272, -312, -336, -344, -344, -320, -288, -240, -192, -128, -104, -96, -96, -88, -64, -32, 16, 72, 96, 152, 176, 184, 176, 176, 168, 168, 168, 168, 168, 168, 176, 176, 176, 192, 248, 336, 424, 496, 552, 568, 592, 560, 520, 488, 488, 496, 512, 528, 576, 648, 744, 856, 976, 1120,
+            648, 584, 496, 376, 232, 96, 40, 40, -40, -136, -224, -288, -328, -360, -368, -360, -328, -280, -216, -152, -72, -40, -16, 0, 16, 16, 32, 56, 112, 40, 136, 224, 224, 200, 176, 168, 168, 168, 168, 168, 176, 176, 184, 176, 176, 264, 368, 456, 512, 560, 584, 584, 560, 528, 480, 488, 496, 528, 552, 608, 728, 832, 944, 1064, 1200,
+            656, 600, 504, 376, 232, 88, 40, 32, -32, -152, -248, -312, -360, -384, -392, -376, -336, -280, -200, -112, -8, 40, 64, 96, 96, 128, 168, 200, 176, 152, 296, 296, 296, 256, 224, 176, 168, 176, 168, 168, 168, 184, 176, 184, 200, 296, 400, 488, 544, 576, 592, 584, 552, 520, 472, 480, 496, 536, 600, 704, 816, 920, 1016, 1136, 1272,
+            664, 600, 496, 368, 200, 56, 24, -16, -80, -192, -280, -344, -384, -408, -416, -392, -352, -280, -192, -88, 16, 72, 136, 136, 176, 232, 296, 328, 344, 360, 480, 432, 368, 336, 288, 224, 184, 184, 176, 168, 176, 176, 184, 192, 224, 344, 448, 512, 560, 592, 600, 584, 544, 496, 472, 480, 504, 552, 616, 744, 880, 984, 1080, 1200, 1328,
+            664, 592, 472, 336, 176, 32, 0, -64, -136, -240, -328, -376, -416, -432, -440, -416, -360, -280, -184, -72, 56, 112, 168, 192, 248, 328, 392, 424, 480, 488, 528, 456, 448, 416, 352, 264, 208, 192, 184, 176, 176, 176, 200, 256, 328, 416, 496, 560, 584, 608, 608, 584, 536, 488, 472, 480, 512, 560, 632, 784, 904, 1024, 1136, 1240, 1360,
+            648, 568, 472, 304, 128, 16, -48, -128, -200, -304, -376, -416, -448, -472, -472, -440, -392, -304, -184, -64, 56, 128, 168, 232, 304, 384, 448, 480, 520, 520, 544, 528, 512, 456, 416, 320, 232, 184, 176, 176, 176, 192, 240, 320, 408, 488, 568, 584, 608, 616, 608, 576, 528, 480, 456, 464, 504, 552, 656, 800, 944, 1040, 1152, 1256, 1376,
+            632, 536, 424, 248, 80, -48, -120, -184, -264, -352, -416, -456, -480, -496, -496, -464, -408, -320, -192, -72, 56, 128, 184, 264, 352, 424, 472, 496, 520, 520, 528, 528, 520, 480, 416, 304, 232, 192, 184, 176, 184, 200, 264, 360, 456, 536, 592, 624, 632, 632, 624, 576, 520, 480, 464, 456, 496, 568, 648, 792, 936, 1032, 1136, 1256, 1384,
+            600, 488, 360, 184, 24, -96, -192, -240, -320, -408, -456, -480, -504, -512, -504, -472, -416, -328, -208, -80, 48, 136, 192, 304, 400, 464, 496, 512, 520, 528, 536, 536, 528, 448, 344, 248, 192, 168, 168, 176, 184, 216, 312, 408, 504, 576, 632, 664, 672, 656, 624, 576, 520, 488, 464, 464, 504, 552, 656, 776, 896, 1016, 1112, 1232, 1376,
+            560, 440, 296, 120, -32, -144, -232, -288, -376, -432, -480, -504, -520, -520, -504, -472, -416, -328, -216, -88, 48, 168, 256, 360, 456, 536, 536, 536, 520, 528, 544, 552, 520, 416, 312, 264, 168, 160, 160, 160, 184, 264, 352, 456, 544, 616, 672, 704, 704, 688, 640, 584, 536, 488, 472, 472, 504, 552, 648, 752, 856, 968, 1080, 1208, 1360,
+            520, 392, 240, 64, -80, -208, -288, -328, -408, -464, -504, -520, -528, -528, -504, -472, -416, -328, -216, -88, 64, 216, 432, 432, 512, 536, 536, 528, 528, 528, 544, 552, 512, 424, 344, 280, 232, 168, 168, 160, 192, 304, 400, 496, 584, 648, 696, 720, 720, 696, 656, 592, 536, 488, 472, 480, 504, 544, 632, 728, 824, 928, 1048, 1184, 1328,
+            504, 360, 200, 24, -120, -248, -336, -384, -440, -488, -512, -536, -536, -528, -504, -464, -408, -320, -216, -96, 80, 256, 416, 408, 512, 528, 528, 528, 528, 528, 544, 536, 512, 448, 376, 320, 272, 208, 160, 176, 240, 352, 440, 528, 608, 672, 712, 720, 712, 688, 640, 584, 536, 488, 464, 472, 496, 544, 616, 704, 800, 904, 1016, 1152, 1296,
+        }};
+        const btScalar heightScale = 1;
+        const btScalar minHeight;
+        const btScalar maxHeight;
+        const int upAxis = 2;
+        const PHY_ScalarType heightDataType = PHY_FLOAT;
+        const bool flipQuadEdges = false;
+        btHeightfieldTerrainShape shape;
+        const btVector3 origin {53248, -53248, 760};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        const btVector3 scaling {128, 128, 1};
+        btCollisionObject object;
+
+        HeightField()
+            : minHeight(*std::min_element(heightfieldData.begin(), heightfieldData.end())),
+              maxHeight(*std::max_element(heightfieldData.begin(), heightfieldData.end())),
+              shape(btHeightfieldTerrainShape{
+                  heightStickWidth,
+                  heightStickLength,
+                  heightfieldData.data(),
+                  heightScale,
+                  minHeight,
+                  maxHeight,
+                  upAxis,
+                  heightDataType,
+                  flipQuadEdges
+              })
+        {
+            shape.setLocalScaling(scaling);
+            init(*this);
+        }
+    };
+
+    struct HeightField2
+    {
+        static const int heightStickWidth = 65;
+        static const int heightStickLength = 65;
+        const std::array<btScalar, heightStickWidth * heightStickLength> heightfieldData {{
+            504, 360, 200, 24, -120, -248, -336, -384, -440, -488, -512, -536, -536, -528, -504, -464, -408, -320, -216, -96, 80, 256, 416, 408, 512, 528, 528, 528, 528, 528, 544, 536, 512, 448, 376, 320, 272, 208, 160, 176, 240, 352, 440, 528, 608, 672, 712, 720, 712, 688, 640, 584, 536, 488, 464, 472, 496, 544, 616, 704, 800, 904, 1016, 1152, 1296,
+            504, 344, 176, 16, -136, -272, -312, -408, -456, -496, -520, -536, -544, -536, -504, -472, -416, -320, -224, -104, 80, 256, 440, 432, 504, 536, 528, 528, 536, 536, 544, 544, 528, 488, 440, 392, 344, 304, 272, 272, 344, 424, 496, 576, 640, 688, 704, 712, 688, 656, 616, 568, 512, 472, 456, 464, 488, 528, 600, 688, 784, 880, 992, 1120, 1256,
+            504, 336, 176, 24, -104, -216, -328, -424, -456, -496, -528, -536, -536, -528, -496, -448, -392, -304, -200, -112, 56, 208, 384, 480, 488, 536, 528, 536, 552, 552, 552, 552, 552, 528, 496, 464, 440, 416, 392, 408, 456, 520, 576, 632, 672, 688, 704, 688, 656, 616, 576, 528, 480, 448, 440, 448, 480, 528, 592, 680, 776, 872, 976, 1088, 1224,
+            504, 352, 216, 104, 8, -120, -296, -424, -448, -488, -512, -528, -528, -504, -480, -432, -352, -264, -168, -56, 72, 192, 312, 392, 504, 536, 536, 536, 552, 560, 552, 560, 568, 552, 560, 520, 512, 512, 544, 560, 576, 624, 648, 672, 688, 688, 680, 648, 608, 568, 528, 480, 440, 424, 424, 440, 472, 528, 600, 688, 784, 872, 968, 1072, 1192,
+            528, 400, 280, 192, 128, 40, -128, -296, -408, -440, -480, -496, -496, -480, -448, -392, -312, -208, -96, 32, 112, 200, 296, 400, 496, 536, 528, 536, 544, 544, 544, 544, 552, 552, 552, 544, 552, 576, 616, 656, 696, 680, 704, 712, 704, 696, 664, 616, 568, 520, 472, 440, 416, 408, 416, 432, 472, 536, 616, 704, 800, 888, 976, 1064, 1176,
+            560, 448, 344, 296, 256, 144, 48, -176, -304, -400, -448, -472, -472, -456, -416, -360, -272, -160, -32, 104, 160, 224, 312, 408, 512, 544, 528, 528, 528, 528, 528, 536, 536, 536, 536, 536, 560, 608, 656, 704, 728, 728, 728, 728, 712, 680, 640, 584, 528, 480, 416, 416, 400, 400, 416, 440, 480, 544, 632, 720, 824, 920, 1000, 1088, 1192,
+            616, 504, 440, 384, 328, 256, 136, -32, -192, -328, -400, -440, -440, -424, -392, -320, -224, -104, 16, 128, 176, 240, 320, 400, 504, 520, 528, 528, 528, 528, 528, 528, 528, 528, 536, 544, 568, 608, 664, 712, 736, 728, 728, 720, 696, 664, 624, 568, 520, 472, 440, 408, 400, 400, 416, 448, 496, 568, 648, 744, 848, 952, 1048, 1136, 1240,
+            688, 592, 520, 464, 408, 336, 232, 72, -96, -248, -352, -400, -416, -400, -360, -296, -192, -72, 32, 112, 176, 240, 312, 392, 456, 536, 528, 528, 528, 528, 528, 528, 536, 536, 536, 536, 560, 600, 648, 680, 704, 704, 696, 688, 672, 648, 616, 576, 528, 480, 440, 416, 400, 408, 424, 464, 512, 584, 672, 776, 888, 1008, 1112, 1208, 1296,
+            760, 672, 600, 536, 472, 400, 296, 144, -40, -200, -328, -392, -408, -392, -344, -272, -168, -40, 48, 120, 184, 248, 312, 376, 440, 496, 520, 528, 528, 528, 528, 536, 536, 536, 536, 536, 544, 584, 624, 656, 672, 672, 664, 664, 656, 640, 608, 576, 536, 480, 440, 424, 416, 416, 448, 480, 536, 608, 704, 808, 928, 1056, 1168, 1264, 1344,
+            808, 720, 656, 584, 512, 424, 320, 168, -16, -184, -312, -376, -392, -384, -336, -264, -160, -32, 64, 128, 184, 240, 288, 344, 400, 480, 512, 536, 536, 536, 536, 536, 536, 536, 536, 536, 544, 568, 600, 624, 632, 632, 640, 640, 640, 624, 600, 576, 528, 472, 440, 424, 424, 440, 464, 512, 568, 640, 728, 832, 952, 1072, 1192, 1296, 1392,
+            808, 744, 680, 600, 520, 416, 296, 136, -48, -208, -320, -376, -392, -384, -336, -272, -168, -32, 56, 128, 176, 216, 248, 288, 336, 400, 448, 472, 480, 536, 536, 512, 536, 544, 536, 536, 544, 552, 568, 584, 592, 600, 616, 624, 624, 616, 592, 560, 504, 464, 440, 432, 432, 456, 488, 536, 600, 672, 752, 856, 976, 1096, 1216, 1320, 1424,
+            816, 736, 672, 592, 496, 392, 248, 72, -104, -248, -360, -400, -416, -400, -360, -288, -200, -72, 24, 96, 144, 176, 208, 232, 256, 280, 320, 312, 328, 384, 360, 432, 400, 480, 496, 536, 512, 520, 520, 520, 544, 568, 592, 608, 608, 592, 568, 528, 480, 456, 440, 440, 448, 472, 512, 560, 624, 696, 784, 880, 992, 1112, 1232, 1344, 1456,
+            784, 712, 632, 544, 448, 320, 160, -24, -184, -304, -400, -424, -432, -408, -368, -312, -232, -128, -24, 48, 88, 128, 152, 176, 184, 184, 184, 192, 184, 192, 128, 96, 128, 296, 416, 408, 464, 432, 432, 456, 488, 528, 560, 584, 584, 552, 528, 488, 456, 440, 440, 440, 456, 488, 528, 584, 656, 728, 808, 904, 1016, 1136, 1256, 1368, 1480,
+            744, 664, 576, 480, 368, 224, 48, -112, -248, -352, -440, -456, -448, -432, -392, -344, -272, -176, -88, -16, 32, 56, 72, 80, 88, 96, 96, 96, 88, 72, 56, 80, 64, 88, 232, 296, 312, 320, 344, 376, 424, 472, 512, 536, 544, 512, 480, 456, 440, 432, 432, 448, 464, 504, 552, 608, 688, 760, 840, 928, 1040, 1160, 1280, 1392, 1512,
+            688, 608, 520, 416, 288, 136, -32, -176, -296, -400, -440, -456, -456, -440, -416, -368, -296, -216, -128, -64, -24, -8, 0, 8, 8, 8, 16, 24, 24, 24, 24, 24, 56, 80, 128, 184, 208, 216, 256, 304, 360, 416, 456, 480, 480, 472, 440, 424, 424, 424, 432, 456, 480, 520, 568, 640, 720, 800, 872, 968, 1072, 1192, 1312, 1432, 1552,
+            632, 552, 464, 368, 248, 56, -104, -248, -360, -408, -440, -448, -448, -432, -408, -368, -304, -232, -152, -104, -72, -56, -48, -48, -48, -56, -48, -40, -24, -8, 16, 32, 24, 40, 72, 104, 128, 144, 176, 232, 296, 352, 400, 424, 424, 416, 408, 408, 416, 424, 440, 464, 496, 536, 592, 664, 744, 824, 912, 1008, 1112, 1240, 1360, 1488, 1616,
+            592, 504, 408, 304, 176, -8, -152, -280, -360, -424, -432, -432, -424, -408, -384, -352, -296, -224, -160, -112, -88, -80, -80, -88, -88, -96, -88, -80, -72, -56, -32, -24, -8, 0, 24, 48, 64, 64, 128, 176, 248, 304, 352, 376, 384, 384, 392, 400, 416, 432, 456, 480, 512, 560, 616, 688, 776, 864, 960, 1056, 1168, 1288, 1416, 1552, 1696,
+            568, 480, 376, 256, 128, -40, -192, -312, -376, -408, -416, -416, -400, -376, -344, -304, -256, -200, -144, -104, -88, -80, -88, -96, -96, -104, -104, -104, -96, -80, -64, -56, -48, -32, -16, 8, 40, 88, 144, 192, 240, 272, 320, 344, 360, 368, 384, 400, 424, 448, 472, 504, 544, 592, 656, 736, 816, 912, 1000, 1104, 1216, 1344, 1480, 1632, 1784,
+            552, 464, 344, 248, 120, -96, -216, -320, -384, -408, -392, -376, -344, -312, -272, -248, -184, -136, -96, -64, -56, -56, -56, -72, -80, -104, -104, -104, -96, -88, -80, -72, -56, -48, -32, 0, 48, 112, 168, 224, 264, 280, 312, 336, 352, 368, 392, 416, 440, 472, 496, 536, 576, 632, 712, 784, 872, 960, 1056, 1160, 1272, 1400, 1552, 1704, 1872,
+            568, 464, 352, 248, 72, -112, -240, -336, -384, -392, -360, -320, -264, -208, -160, -120, -72, -40, -16, 0, 16, 16, 0, -16, -32, -64, -72, -80, -72, -72, -64, -64, -56, -40, -16, 24, 80, 152, 224, 264, 280, 304, 328, 344, 368, 384, 408, 432, 464, 496, 528, 576, 632, 696, 768, 848, 928, 1016, 1104, 1208, 1328, 1456, 1608, 1776, 1952,
+            544, 448, 344, 224, 32, -128, -280, -384, -392, -368, -328, -256, -176, -96, -24, 40, 64, 72, 80, 96, 104, 104, 88, 64, 32, 0, -16, -24, -24, -24, -24, -40, -32, 16, 40, 80, 144, 200, 280, 296, 320, 336, 352, 368, 384, 408, 432, 456, 488, 520, 568, 616, 680, 752, 832, 912, 984, 1064, 1152, 1248, 1376, 1512, 1664, 1840, 2016,
+            544, 456, 320, 176, 0, -160, -288, -384, -384, -336, -264, -168, -64, 40, 168, 224, 216, 184, 184, 192, 200, 192, 168, 144, 120, 88, 72, 56, 48, 40, 24, 48, 64, 96, 128, 168, 216, 272, 312, 336, 360, 376, 392, 400, 416, 432, 456, 488, 512, 552, 608, 672, 744, 824, 904, 976, 1048, 1120, 1208, 1312, 1424, 1568, 1728, 1896, 2080,
+            544, 440, 296, 112, -56, -192, -296, -368, -368, -320, -216, -72, 56, 184, 280, 320, 304, 280, 272, 288, 296, 288, 264, 240, 216, 184, 168, 152, 136, 128, 136, 144, 168, 192, 224, 256, 296, 328, 368, 384, 400, 408, 424, 432, 448, 464, 488, 520, 552, 600, 664, 744, 824, 904, 976, 1040, 1112, 1184, 1272, 1376, 1496, 1624, 1776, 1952, 2136,
+            520, 400, 240, 40, -120, -240, -312, -352, -344, -272, -120, 40, 184, 280, 384, 424, 408, 360, 336, 344, 352, 352, 344, 328, 312, 288, 256, 240, 224, 224, 232, 240, 264, 288, 312, 336, 360, 392, 416, 432, 440, 448, 456, 464, 480, 504, 528, 560, 608, 664, 744, 824, 904, 984, 1048, 1120, 1184, 1264, 1344, 1448, 1568, 1704, 1848, 2008, 2192,
+            504, 328, 128, -56, -184, -288, -352, -360, -328, -200, -40, 128, 272, 392, 496, 528, 504, 448, 416, 408, 408, 408, 400, 392, 376, 352, 336, 320, 312, 304, 312, 328, 344, 368, 392, 408, 424, 448, 464, 472, 472, 480, 488, 496, 512, 536, 576, 616, 672, 744, 832, 920, 1000, 1064, 1128, 1192, 1264, 1344, 1432, 1536, 1656, 1784, 1928, 2080, 2248,
+            416, 216, 16, -152, -272, -320, -360, -352, -288, -160, 32, 256, 344, 480, 568, 576, 560, 504, 464, 456, 440, 440, 440, 440, 424, 416, 400, 392, 384, 392, 392, 400, 416, 432, 440, 456, 472, 488, 504, 504, 504, 504, 512, 520, 544, 584, 640, 696, 768, 848, 936, 1016, 1088, 1152, 1208, 1280, 1352, 1432, 1528, 1624, 1736, 1864, 2000, 2152, 2304,
+            312, 104, -72, -192, -296, -360, -384, -360, -296, -168, 72, 248, 400, 520, 576, 568, 576, 536, 512, 496, 480, 480, 472, 464, 464, 464, 456, 456, 456, 464, 464, 464, 472, 480, 496, 504, 512, 528, 544, 544, 536, 536, 536, 552, 576, 640, 712, 792, 872, 960, 1032, 1104, 1168, 1232, 1296, 1360, 1440, 1528, 1616, 1720, 1832, 1952, 2080, 2224, 2376,
+            224, -8, -120, -232, -320, -376, -384, -352, -272, -152, 88, 280, 432, 536, 560, 592, 600, 600, 576, 552, 528, 504, 496, 496, 496, 504, 512, 512, 512, 520, 528, 528, 528, 536, 536, 544, 560, 576, 576, 584, 576, 576, 576, 592, 632, 712, 800, 896, 992, 1064, 1128, 1184, 1240, 1304, 1376, 1448, 1536, 1624, 1712, 1816, 1920, 2032, 2160, 2296, 2440,
+            168, -56, -152, -256, -344, -384, -392, -352, -272, -104, 96, 296, 432, 512, 584, 640, 672, 680, 656, 624, 584, 560, 544, 536, 536, 536, 552, 560, 568, 576, 584, 584, 584, 584, 584, 592, 600, 616, 616, 624, 624, 624, 632, 656, 712, 784, 896, 1008, 1096, 1152, 1200, 1248, 1312, 1384, 1456, 1544, 1632, 1720, 1816, 1912, 2008, 2120, 2240, 2376, 2520,
+            160, -16, -160, -272, -352, -392, -392, -352, -280, -160, 96, 280, 424, 520, 616, 704, 760, 776, 752, 704, 656, 616, 584, 576, 576, 584, 592, 608, 616, 624, 632, 632, 624, 624, 632, 632, 648, 656, 664, 672, 680, 696, 712, 752, 808, 896, 1000, 1104, 1168, 1216, 1264, 1312, 1384, 1456, 1544, 1640, 1728, 1824, 1912, 2000, 2096, 2200, 2328, 2464, 2608,
+            176, -32, -152, -272, -344, -384, -384, -352, -280, -160, 72, 264, 408, 536, 656, 760, 840, 872, 848, 792, 736, 688, 648, 640, 640, 648, 656, 672, 680, 680, 680, 680, 680, 680, 680, 688, 704, 712, 728, 744, 760, 776, 808, 856, 920, 984, 1096, 1176, 1224, 1272, 1320, 1384, 1456, 1536, 1632, 1728, 1824, 1920, 2000, 2088, 2176, 2288, 2416, 2560, 2704,
+            208, 0, -136, -248, -328, -368, -368, -336, -272, -160, 72, 272, 400, 544, 680, 808, 904, 944, 928, 880, 824, 776, 736, 720, 720, 728, 744, 744, 752, 752, 744, 736, 736, 736, 744, 752, 768, 784, 808, 832, 864, 912, 960, 1016, 1064, 1136, 1200, 1248, 1288, 1336, 1384, 1456, 1528, 1616, 1720, 1816, 1912, 2000, 2096, 2168, 2256, 2368, 2504, 2656, 2784,
+            240, 40, -144, -224, -296, -336, -336, -304, -296, -136, 72, 256, 400, 552, 696, 824, 928, 984, 984, 936, 904, 864, 840, 832, 824, 832, 840, 840, 840, 832, 824, 808, 808, 816, 824, 840, 856, 872, 896, 928, 984, 1040, 1120, 1184, 1216, 1256, 1296, 1336, 1368, 1416, 1464, 1528, 1600, 1696, 1792, 1888, 1984, 2088, 2160, 2240, 2336, 2448, 2592, 2728, 2872,
+            264, 64, -96, -216, -288, -328, -320, -280, -200, -96, 112, 272, 416, 560, 696, 824, 920, 992, 1016, 1008, 976, 960, 944, 936, 936, 944, 952, 952, 944, 928, 912, 904, 888, 904, 928, 944, 960, 984, 1008, 1048, 1112, 1192, 1272, 1304, 1336, 1368, 1400, 1432, 1464, 1496, 1544, 1600, 1672, 1760, 1848, 1944, 2048, 2144, 2224, 2304, 2392, 2528, 2672, 2824, 2936,
+            272, 80, -80, -200, -272, -296, -280, -224, -128, -8, 168, 320, 456, 576, 696, 808, 904, 976, 1024, 1048, 1048, 1048, 1048, 1048, 1048, 1056, 1064, 1064, 1056, 1040, 1024, 1008, 1000, 1008, 1024, 1056, 1080, 1096, 1120, 1160, 1232, 1320, 1368, 1400, 1440, 1480, 1504, 1528, 1560, 1584, 1616, 1664, 1728, 1816, 1904, 2000, 2104, 2200, 2288, 2344, 2440, 2600, 2760, 2896, 3024,
+            248, 64, -88, -192, -248, -272, -240, -168, -72, 56, 232, 392, 504, 608, 704, 800, 888, 968, 1032, 1080, 1104, 1128, 1136, 1144, 1152, 1160, 1168, 1176, 1168, 1160, 1144, 1128, 1120, 1112, 1144, 1192, 1232, 1256, 1264, 1304, 1360, 1408, 1448, 1488, 1536, 1568, 1600, 1624, 1648, 1664, 1688, 1720, 1768, 1840, 1920, 2008, 2112, 2208, 2296, 2384, 2520, 2696, 2848, 3000, 3096,
+            200, 24, -112, -200, -240, -248, -208, -128, -16, 120, 304, 456, 552, 640, 720, 800, 880, 968, 1056, 1128, 1176, 1192, 1216, 1232, 1240, 1256, 1264, 1272, 1288, 1272, 1264, 1248, 1240, 1256, 1288, 1328, 1360, 1400, 1392, 1416, 1464, 1480, 1520, 1568, 1616, 1648, 1680, 1712, 1728, 1736, 1752, 1768, 1800, 1856, 1928, 2016, 2120, 2224, 2336, 2472, 2640, 2800, 2960, 3072, 3152,
+            136, -24, -144, -208, -248, -232, -176, -88, 32, 176, 360, 496, 584, 672, 744, 816, 896, 984, 1072, 1152, 1208, 1248, 1280, 1304, 1320, 1336, 1352, 1368, 1376, 1376, 1368, 1360, 1360, 1368, 1400, 1456, 1496, 1504, 1480, 1496, 1520, 1544, 1576, 1624, 1680, 1712, 1752, 1784, 1800, 1800, 1808, 1816, 1832, 1864, 1944, 2040, 2160, 2288, 2440, 2600, 2776, 2936, 3072, 3168, 3240,
+            80, -72, -176, -240, -256, -232, -160, -56, 80, 224, 400, 528, 632, 720, 784, 848, 928, 1016, 1104, 1176, 1240, 1280, 1320, 1344, 1368, 1384, 1416, 1440, 1456, 1464, 1464, 1456, 1456, 1464, 1480, 1528, 1536, 1536, 1536, 1544, 1560, 1584, 1624, 1672, 1720, 1768, 1808, 1840, 1856, 1856, 1856, 1856, 1872, 1888, 1952, 2048, 2200, 2368, 2552, 2752, 2928, 3104, 3240, 3304, 3328,
+            16, -128, -232, -280, -280, -240, -152, -24, 120, 296, 440, 600, 720, 776, 840, 904, 968, 1048, 1136, 1208, 1272, 1328, 1360, 1384, 1408, 1440, 1464, 1496, 1520, 1536, 1544, 1536, 1536, 1536, 1560, 1544, 1544, 1544, 1560, 1576, 1592, 1616, 1656, 1704, 1760, 1800, 1848, 1880, 1896, 1904, 1904, 1912, 1920, 1944, 2008, 2120, 2280, 2480, 2728, 2936, 3072, 3224, 3344, 3440, 3464,
+            -48, -192, -280, -320, -312, -248, -144, 0, 160, 344, 528, 680, 808, 856, 904, 952, 1016, 1088, 1176, 1256, 1328, 1376, 1408, 1432, 1456, 1488, 1512, 1552, 1576, 1600, 1608, 1608, 1592, 1576, 1568, 1544, 1544, 1552, 1568, 1592, 1616, 1640, 1672, 1720, 1776, 1824, 1872, 1904, 1928, 1944, 1952, 1960, 1976, 2008, 2080, 2200, 2368, 2584, 2816, 3032, 3216, 3352, 3488, 3552, 3616,
+            -120, -248, -328, -352, -328, -256, -136, 16, 192, 400, 592, 752, 880, 952, 992, 1032, 1072, 1144, 1224, 1304, 1376, 1432, 1472, 1496, 1512, 1536, 1568, 1600, 1632, 1648, 1656, 1656, 1632, 1608, 1576, 1544, 1536, 1552, 1576, 1600, 1624, 1648, 1680, 1728, 1776, 1832, 1880, 1920, 1952, 1976, 2000, 2016, 2048, 2080, 2152, 2272, 2456, 2672, 2904, 3120, 3288, 3424, 3536, 3592, 3656,
+            -192, -304, -368, -384, -352, -264, -136, 32, 224, 456, 640, 800, 936, 1032, 1088, 1112, 1152, 1208, 1288, 1368, 1440, 1496, 1544, 1568, 1584, 1600, 1616, 1640, 1672, 1696, 1696, 1688, 1656, 1616, 1584, 1552, 1544, 1560, 1584, 1608, 1632, 1648, 1680, 1720, 1776, 1832, 1888, 1936, 1976, 2016, 2048, 2080, 2120, 2160, 2232, 2368, 2552, 2760, 2984, 3200, 3360, 3480, 3576, 3624, 3680,
+            -272, -360, -408, -408, -368, -272, -136, 40, 240, 488, 688, 840, 968, 1112, 1168, 1192, 1216, 1280, 1352, 1424, 1504, 1568, 1608, 1632, 1648, 1656, 1672, 1688, 1712, 1728, 1728, 1704, 1664, 1632, 1584, 1560, 1552, 1568, 1592, 1616, 1632, 1648, 1672, 1712, 1768, 1832, 1896, 1952, 2008, 2064, 2112, 2160, 2200, 2256, 2336, 2488, 2664, 2872, 3080, 3264, 3416, 3528, 3616, 3656, 3704,
+            -336, -416, -448, -440, -384, -280, -136, 48, 248, 480, 664, 832, 976, 1096, 1168, 1232, 1288, 1344, 1416, 1488, 1568, 1640, 1680, 1704, 1712, 1720, 1720, 1728, 1744, 1760, 1760, 1728, 1680, 1624, 1584, 1560, 1560, 1568, 1600, 1624, 1640, 1656, 1664, 1704, 1760, 1824, 1896, 1976, 2056, 2128, 2192, 2248, 2296, 2368, 2480, 2616, 2792, 2992, 3192, 3360, 3496, 3592, 3656, 3696, 3736,
+            -384, -464, -496, -480, -416, -304, -152, 40, 248, 480, 648, 808, 960, 1072, 1168, 1256, 1320, 1376, 1456, 1536, 1640, 1712, 1752, 1760, 1776, 1776, 1784, 1784, 1784, 1776, 1768, 1728, 1664, 1608, 1576, 1560, 1552, 1568, 1600, 1632, 1664, 1680, 1688, 1696, 1760, 1832, 1920, 2016, 2120, 2216, 2296, 2344, 2408, 2504, 2608, 2752, 2928, 3128, 3320, 3488, 3600, 3672, 3712, 3744, 3776,
+            -424, -496, -528, -512, -432, -320, -160, 0, 248, 432, 616, 776, 928, 1048, 1160, 1264, 1328, 1400, 1472, 1568, 1680, 1752, 1784, 1816, 1832, 1856, 1856, 1856, 1832, 1800, 1760, 1704, 1640, 1600, 1568, 1544, 1544, 1560, 1592, 1632, 1672, 1704, 1728, 1728, 1752, 1824, 1952, 2088, 2216, 2344, 2432, 2488, 2552, 2632, 2744, 2896, 3080, 3280, 3472, 3616, 3712, 3760, 3784, 3800, 3832,
+            -456, -544, -576, -552, -472, -344, -184, 0, 208, 400, 576, 744, 904, 1040, 1160, 1256, 1336, 1416, 1488, 1568, 1672, 1752, 1816, 1864, 1912, 1944, 1960, 1944, 1912, 1864, 1800, 1720, 1648, 1568, 1552, 1528, 1512, 1536, 1584, 1640, 1696, 1728, 1752, 1768, 1816, 1920, 2064, 2208, 2352, 2496, 2592, 2640, 2680, 2760, 2880, 3032, 3224, 3424, 3608, 3752, 3824, 3848, 3848, 3848, 3872,
+            -448, -536, -568, -552, -472, -344, -184, 0, 184, 360, 552, 736, 896, 1048, 1176, 1280, 1368, 1448, 1512, 1568, 1640, 1760, 1864, 1952, 2024, 2072, 2088, 2080, 2024, 1952, 1864, 1760, 1656, 1576, 1536, 1520, 1528, 1552, 1584, 1648, 1696, 1736, 1768, 1816, 1904, 2040, 2192, 2336, 2472, 2616, 2688, 2744, 2800, 2880, 2992, 3152, 3336, 3544, 3720, 3856, 3912, 3920, 3888, 3872, 3896,
+            -448, -496, -560, -536, -464, -336, -192, 0, 184, 336, 552, 744, 920, 1080, 1224, 1336, 1440, 1520, 1576, 1632, 1688, 1824, 1936, 2048, 2136, 2200, 2216, 2200, 2144, 2056, 1952, 1840, 1728, 1592, 1560, 1568, 1584, 1608, 1624, 1680, 1720, 1776, 1824, 1904, 2032, 2176, 2328, 2464, 2592, 2704, 2792, 2848, 2904, 2976, 3088, 3240, 3424, 3616, 3792, 3904, 3952, 3936, 3904, 3880, 3888,
+            -368, -464, -496, -496, -472, -344, -176, 16, 192, 392, 592, 800, 984, 1160, 1304, 1432, 1536, 1616, 1672, 1744, 1824, 1928, 2040, 2144, 2256, 2312, 2336, 2312, 2248, 2152, 2040, 1928, 1816, 1712, 1656, 1656, 1672, 1656, 1704, 1760, 1800, 1872, 1944, 2040, 2168, 2312, 2456, 2584, 2704, 2832, 2920, 2984, 2984, 3040, 3152, 3296, 3472, 3648, 3800, 3904, 3936, 3912, 3880, 3856, 3864,
+            -320, -408, -456, -456, -432, -304, -144, 40, 232, 440, 656, 872, 1080, 1256, 1416, 1560, 1672, 1744, 1808, 1880, 1960, 2048, 2152, 2248, 2352, 2408, 2432, 2400, 2336, 2240, 2120, 2008, 1896, 1808, 1744, 1760, 1720, 1752, 1816, 1880, 1928, 2000, 2088, 2192, 2312, 2448, 2576, 2688, 2792, 2896, 2968, 3016, 3024, 3080, 3176, 3312, 3472, 3632, 3760, 3848, 3872, 3856, 3824, 3808, 3816,
+            -280, -368, -408, -416, -384, -264, -104, 80, 280, 496, 720, 944, 1168, 1360, 1520, 1672, 1792, 1888, 1952, 2024, 2096, 2168, 2256, 2336, 2424, 2480, 2488, 2464, 2392, 2304, 2192, 2080, 1976, 1872, 1784, 1768, 1824, 1888, 1960, 2024, 2088, 2168, 2256, 2360, 2464, 2576, 2688, 2784, 2888, 2960, 3008, 3032, 3048, 3088, 3176, 3288, 3424, 3568, 3680, 3752, 3776, 3768, 3744, 3736, 3744,
+            -248, -328, -376, -376, -352, -232, -64, 128, 328, 544, 776, 1024, 1256, 1472, 1648, 1800, 1936, 2016, 2104, 2160, 2216, 2280, 2344, 2408, 2480, 2520, 2504, 2496, 2440, 2352, 2248, 2144, 2056, 1968, 1880, 1928, 1976, 2040, 2104, 2192, 2264, 2352, 2440, 2536, 2632, 2720, 2816, 2896, 2968, 3016, 3040, 3048, 3032, 3080, 3152, 3248, 3360, 3472, 3576, 3640, 3664, 3664, 3656, 3656, 3656,
+            -232, -312, -344, -352, -320, -176, -16, 168, 368, 592, 824, 1072, 1312, 1528, 1712, 1888, 2040, 2128, 2216, 2280, 2336, 2384, 2424, 2464, 2504, 2528, 2528, 2504, 2456, 2392, 2304, 2224, 2152, 2080, 2048, 2088, 2128, 2184, 2248, 2328, 2416, 2512, 2616, 2712, 2800, 2880, 2952, 3024, 3072, 3104, 3104, 3088, 3064, 3048, 3128, 3200, 3288, 3384, 3464, 3528, 3560, 3568, 3568, 3568, 3592,
+            -240, -304, -336, -328, -272, -144, 16, 208, 408, 632, 864, 1112, 1352, 1584, 1784, 1952, 2112, 2232, 2336, 2408, 2472, 2480, 2496, 2520, 2536, 2544, 2544, 2520, 2480, 2432, 2368, 2312, 2264, 2216, 2224, 2248, 2272, 2312, 2376, 2448, 2544, 2648, 2760, 2872, 2960, 3040, 3104, 3160, 3200, 3208, 3200, 3160, 3120, 3088, 3080, 3160, 3224, 3296, 3368, 3432, 3464, 3480, 3480, 3488, 3520,
+            -248, -304, -328, -304, -248, -136, 48, 240, 448, 672, 904, 1144, 1384, 1624, 1824, 2000, 2160, 2296, 2392, 2472, 2528, 2536, 2544, 2552, 2560, 2568, 2560, 2544, 2520, 2488, 2448, 2408, 2376, 2368, 2368, 2376, 2408, 2424, 2472, 2552, 2656, 2776, 2904, 3024, 3120, 3192, 3232, 3272, 3304, 3304, 3280, 3224, 3176, 3136, 3112, 3120, 3160, 3200, 3304, 3360, 3384, 3400, 3408, 3416, 3440,
+            -256, -296, -304, -288, -224, -112, 64, 264, 480, 712, 944, 1192, 1432, 1664, 1864, 2056, 2232, 2376, 2480, 2536, 2584, 2568, 2576, 2584, 2584, 2584, 2584, 2576, 2560, 2544, 2520, 2512, 2496, 2480, 2504, 2496, 2488, 2496, 2544, 2624, 2728, 2848, 2976, 3088, 3192, 3272, 3336, 3384, 3368, 3360, 3328, 3280, 3232, 3184, 3144, 3104, 3152, 3192, 3248, 3296, 3320, 3336, 3344, 3336, 3328,
+            -256, -288, -296, -264, -200, -80, 80, 296, 520, 752, 992, 1232, 1472, 1696, 1896, 2072, 2240, 2376, 2480, 2536, 2576, 2592, 2592, 2592, 2600, 2608, 2608, 2608, 2600, 2608, 2592, 2576, 2560, 2568, 2552, 2536, 2528, 2544, 2592, 2672, 2768, 2888, 3016, 3128, 3232, 3312, 3376, 3408, 3432, 3416, 3376, 3320, 3288, 3240, 3176, 3128, 3192, 3208, 3248, 3272, 3288, 3288, 3272, 3232, 3200,
+            -264, -272, -264, -232, -152, -48, 104, 328, 560, 800, 1040, 1288, 1512, 1712, 1912, 2072, 2232, 2368, 2472, 2536, 2584, 2592, 2600, 2600, 2616, 2624, 2632, 2648, 2640, 2640, 2632, 2608, 2608, 2584, 2560, 2552, 2560, 2584, 2624, 2688, 2792, 2912, 3032, 3144, 3240, 3328, 3384, 3408, 3432, 3432, 3432, 3392, 3328, 3264, 3200, 3224, 3216, 3232, 3256, 3272, 3264, 3240, 3192, 3136, 3088,
+            -264, -256, -240, -208, -128, -24, 168, 376, 608, 848, 1088, 1320, 1536, 1744, 1920, 2088, 2240, 2376, 2456, 2520, 2568, 2584, 2592, 2608, 2624, 2632, 2640, 2656, 2664, 2648, 2672, 2648, 2600, 2584, 2568, 2576, 2592, 2608, 2632, 2696, 2792, 2912, 3024, 3136, 3248, 3336, 3392, 3416, 3440, 3464, 3456, 3424, 3344, 3280, 3208, 3240, 3240, 3248, 3272, 3280, 3248, 3192, 3128, 3056, 3008,
+            -264, -240, -208, -160, -64, 48, 216, 432, 656, 888, 1128, 1352, 1592, 1768, 1920, 2080, 2224, 2344, 2440, 2504, 2544, 2576, 2592, 2608, 2624, 2632, 2648, 2648, 2656, 2656, 2648, 2624, 2600, 2592, 2576, 2584, 2592, 2616, 2640, 2696, 2784, 2880, 2992, 3112, 3224, 3320, 3384, 3432, 3464, 3472, 3456, 3384, 3320, 3248, 3176, 3240, 3240, 3264, 3288, 3312, 3256, 3160, 3080, 3024, 2992,
+            -264, -224, -176, -96, 0, 128, 296, 496, 704, 920, 1136, 1344, 1560, 1752, 1920, 2072, 2216, 2336, 2432, 2488, 2536, 2576, 2600, 2616, 2632, 2640, 2648, 2648, 2648, 2640, 2624, 2600, 2584, 2584, 2576, 2584, 2600, 2624, 2656, 2704, 2760, 2832, 2928, 3040, 3152, 3256, 3336, 3408, 3456, 3456, 3416, 3352, 3296, 3216, 3184, 3192, 3224, 3248, 3272, 3344, 3240, 3136, 3056, 3000, 2976,
+            -256, -208, -144, -56, 56, 192, 360, 552, 744, 944, 1144, 1336, 1528, 1704, 1872, 2040, 2184, 2296, 2408, 2488, 2536, 2584, 2624, 2640, 2656, 2656, 2656, 2648, 2640, 2624, 2608, 2584, 2560, 2560, 2584, 2600, 2608, 2632, 2664, 2704, 2744, 2800, 2864, 2944, 3048, 3160, 3256, 3368, 3448, 3472, 3432, 3368, 3272, 3208, 3184, 3184, 3240, 3288, 3328, 3336, 3248, 3112, 3032, 2968, 2960,
+            -248, -184, -104, 0, 120, 256, 408, 592, 776, 960, 1136, 1312, 1496, 1664, 1824, 1984, 2128, 2264, 2368, 2464, 2536, 2592, 2640, 2672, 2688, 2688, 2672, 2648, 2632, 2608, 2584, 2560, 2544, 2560, 2592, 2616, 2608, 2656, 2680, 2704, 2728, 2760, 2800, 2864, 2960, 3072, 3184, 3304, 3400, 3416, 3360, 3296, 3232, 3176, 3168, 3184, 3232, 3272, 3304, 3296, 3184, 3088, 3000, 2952, 2944,
+        }};
+        const btScalar heightScale = 1;
+        const btScalar minHeight;
+        const btScalar maxHeight;
+        const int upAxis = 2;
+        const PHY_ScalarType heightDataType = PHY_FLOAT;
+        const bool flipQuadEdges = false;
+        btHeightfieldTerrainShape shape;
+        const btVector3 origin {53248, -45056, 1688};
+        const btTransform transform {btMatrix3x3::getIdentity(), origin};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        const btVector3 scaling {128, 128, 1};
+        btCollisionObject object;
+
+        HeightField2()
+            : minHeight(*std::min_element(heightfieldData.begin(), heightfieldData.end())),
+              maxHeight(*std::max_element(heightfieldData.begin(), heightfieldData.end())),
+              shape(btHeightfieldTerrainShape{
+                  heightStickWidth,
+                  heightStickLength,
+                  heightfieldData.data(),
+                  heightScale,
+                  minHeight,
+                  maxHeight,
+                  upAxis,
+                  heightDataType,
+                  flipQuadEdges
+              })
+        {
+            shape.setLocalScaling(scaling);
+            init(*this);
+        }
+    };
+
+    struct Player
+    {
+        const btVector3 halfExtents {29.279994964599609375, 28.4799976348876953125, 66.5};
+        const btVector3 origin {56607.9765625, -49244.609375, 726.5640869140625};
+        const btTransform transform {
+            btMatrix3x3(
+                0.2631151676177978515625, -0.964764416217803955078125, -0,
+                0.964764416217803955078125, 0.2631151676177978515625, 0,
+                0, -0, 1
+            ),
+            origin
+        };
+        btCapsuleShapeZ shape {halfExtents.x(), 2 * halfExtents.z() - 2 * halfExtents.x()};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_KINEMATIC_OBJECT;
+        btCollisionObject object;
+
+        Player() { init(*this); }
+    };
+
+    struct Mesh3
+    {
+        const std::vector<std::vector<btVector3>> triangles {{
+            {btVector3(3.165980815887451171875, -13.70164394378662109375, -89.81629180908203125), btVector3(3.6294574737548828125, 19.6229343414306640625, -0.18219268321990966796875), btVector3(9.03495025634765625, 16.5020732879638671875, -0.182192966341972351074219)},
+            {btVector3(3.165980815887451171875, -13.70164394378662109375, -89.81629180908203125), btVector3(-7.08998012542724609375, -7.78036403656005859375, -89.81629180908203125), btVector3(3.6294574737548828125, 19.6229343414306640625, -0.18219268321990966796875)},
+            {btVector3(-7.08998012542724609375, -7.78036403656005859375, -89.81629180908203125), btVector3(3.6294574737548828125, 13.38121128082275390625, -0.182193234562873840332031), btVector3(3.6294574737548828125, 19.6229343414306640625, -0.18219268321990966796875)},
+            {btVector3(-7.08998012542724609375, -7.78036403656005859375, -89.81629180908203125), btVector3(-7.0899791717529296875, -19.6229267120361328125, -89.81629180908203125), btVector3(3.6294574737548828125, 13.38121128082275390625, -0.182193234562873840332031)},
+            {btVector3(-7.0899791717529296875, -19.6229267120361328125, -89.81629180908203125), btVector3(9.03495025634765625, 16.5020732879638671875, -0.182192966341972351074219), btVector3(3.6294574737548828125, 13.38121128082275390625, -0.182193234562873840332031)},
+            {btVector3(-7.0899791717529296875, -19.6229267120361328125, -89.81629180908203125), btVector3(3.165980815887451171875, -13.70164394378662109375, -89.81629180908203125), btVector3(9.03495025634765625, 16.5020732879638671875, -0.182192966341972351074219)},
+            {btVector3(-5.458113193511962890625, 4.863862514495849609375, 89.8333587646484375), btVector3(-7.778857707977294921875, 6.2037448883056640625, 89.8333587646484375), btVector3(-9.03495025634765625, 4.7086391448974609375, 89.81629180908203125)},
+            {btVector3(-7.778857707977294921875, 6.2037448883056640625, 89.8333587646484375), btVector3(-7.778858184814453125, 3.5239799022674560546875, 89.8333587646484375), btVector3(-9.03495025634765625, 4.7086391448974609375, 89.81629180908203125)},
+            {btVector3(-7.778858184814453125, 3.5239799022674560546875, 89.8333587646484375), btVector3(-5.458113193511962890625, 4.863862514495849609375, 89.8333587646484375), btVector3(-9.03495025634765625, 4.7086391448974609375, 89.81629180908203125)},
+            {btVector3(-5.458113193511962890625, 4.863862514495849609375, 89.8333587646484375), btVector3(3.6294574737548828125, 19.6229343414306640625, -0.18219268321990966796875), btVector3(-7.778857707977294921875, 6.2037448883056640625, 89.8333587646484375)},
+            {btVector3(9.03495025634765625, 16.5020732879638671875, -0.182192966341972351074219), btVector3(3.6294574737548828125, 19.6229343414306640625, -0.18219268321990966796875), btVector3(-5.458113193511962890625, 4.863862514495849609375, 89.8333587646484375)},
+            {btVector3(-7.778857707977294921875, 6.2037448883056640625, 89.8333587646484375), btVector3(3.6294574737548828125, 13.38121128082275390625, -0.182193234562873840332031), btVector3(-7.778858184814453125, 3.5239799022674560546875, 89.8333587646484375)},
+            {btVector3(3.6294574737548828125, 19.6229343414306640625, -0.18219268321990966796875), btVector3(3.6294574737548828125, 13.38121128082275390625, -0.182193234562873840332031), btVector3(-7.778857707977294921875, 6.2037448883056640625, 89.8333587646484375)},
+            {btVector3(-7.778858184814453125, 3.5239799022674560546875, 89.8333587646484375), btVector3(9.03495025634765625, 16.5020732879638671875, -0.182192966341972351074219), btVector3(-5.458113193511962890625, 4.863862514495849609375, 89.8333587646484375)},
+            {btVector3(3.6294574737548828125, 13.38121128082275390625, -0.182193234562873840332031), btVector3(9.03495025634765625, 16.5020732879638671875, -0.182192966341972351074219), btVector3(-7.778858184814453125, 3.5239799022674560546875, 89.8333587646484375)},
+        }};
+        const btVector3 origin {55718.6875, -48041.33203125, 495.931671142578125};
+        const btTransform transform {
+            btMatrix3x3 {
+                0.825336039066314697265625, -0.56464183330535888671875, -0,
+                0.56464183330535888671875, 0.825336039066314697265625, 0,
+                0, -0, 1
+            },
+            origin,
+        };
+        btTriangleMesh mesh = makeTriangleMesh(triangles);
+        btBvhTriangleMeshShape child {&mesh, true};
+        const btVector3 scaling {1, 1, 1};
+        btScaledBvhTriangleMeshShape shape {&child, scaling};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Mesh3() { init(*this); }
+    };
+
+    struct Mesh4
+    {
+        const std::vector<std::vector<btVector3>> triangles {{
+            {btVector3(127.2141571044921875, -144.489776611328125, -67.22026824951171875), btVector3(127.2141571044921875, -144.489776611328125, -9.3186511993408203125), btVector3(-14.818561553955078125, -114.1361236572265625, 9.71700382232666015625)},
+            {btVector3(-14.818561553955078125, -114.1361236572265625, 9.71700382232666015625), btVector3(-14.818546295166015625, -114.1361083984375, -72.82059478759765625), btVector3(127.2141571044921875, -144.489776611328125, -67.22026824951171875)},
+            {btVector3(231.712982177734375, 112.0338134765625, -81.81510162353515625), btVector3(94.68686676025390625, 186.737396240234375, -87.415435791015625), btVector3(94.68686676025390625, 186.737396240234375, -6.17350006103515625)},
+            {btVector3(94.68686676025390625, 186.737396240234375, -6.17350006103515625), btVector3(231.7129669189453125, 112.033782958984375, -20.698131561279296875), btVector3(231.712982177734375, 112.0338134765625, -81.81510162353515625)},
+            {btVector3(127.2141571044921875, -144.489776611328125, -67.22026824951171875), btVector3(-14.818546295166015625, -114.1361083984375, -72.82059478759765625), btVector3(94.68686676025390625, 186.737396240234375, -87.415435791015625)},
+            {btVector3(94.68686676025390625, 186.737396240234375, -87.415435791015625), btVector3(231.712982177734375, 112.0338134765625, -81.81510162353515625), btVector3(127.2141571044921875, -144.489776611328125, -67.22026824951171875)},
+            {btVector3(-14.818561553955078125, -114.1361236572265625, 9.71700382232666015625), btVector3(127.2141571044921875, -144.489776611328125, -9.3186511993408203125), btVector3(231.7129669189453125, 112.033782958984375, -20.698131561279296875)},
+            {btVector3(231.7129669189453125, 112.033782958984375, -20.698131561279296875), btVector3(94.68686676025390625, 186.737396240234375, -6.17350006103515625), btVector3(-14.818561553955078125, -114.1361236572265625, 9.71700382232666015625)},
+            {btVector3(127.2141571044921875, -144.489776611328125, -9.3186511993408203125), btVector3(127.2141571044921875, -144.489776611328125, -67.22026824951171875), btVector3(231.712982177734375, 112.0338134765625, -81.81510162353515625)},
+            {btVector3(231.712982177734375, 112.0338134765625, -81.81510162353515625), btVector3(231.7129669189453125, 112.033782958984375, -20.698131561279296875), btVector3(127.2141571044921875, -144.489776611328125, -9.3186511993408203125)},
+            {btVector3(261.976165771484375, -247.282928466796875, -199.272430419921875), btVector3(261.97613525390625, -247.28289794921875, -69.9124908447265625), btVector3(26.63442230224609375, -285.659881591796875, -71.75213623046875)},
+            {btVector3(26.63442230224609375, -285.659881591796875, -71.75213623046875), btVector3(58.30145263671875, -285.659881591796875, -239.4290618896484375), btVector3(261.976165771484375, -247.282928466796875, -199.272430419921875)},
+            {btVector3(252.56353759765625, 91.8106536865234375, -199.2724151611328125), btVector3(24.5088253021240234375, 107.3464813232421875, -239.429046630859375), btVector3(-7.1582050323486328125, 107.34649658203125, -73.49704742431640625)},
+            {btVector3(-7.1582050323486328125, 107.34649658203125, -73.49704742431640625), btVector3(252.5635223388671875, 91.8106231689453125, -75.74108123779296875), btVector3(252.56353759765625, 91.8106536865234375, -199.2724151611328125)},
+            {btVector3(261.976165771484375, -247.282928466796875, -199.272430419921875), btVector3(58.30145263671875, -285.659881591796875, -239.4290618896484375), btVector3(24.5088253021240234375, 107.3464813232421875, -239.429046630859375)},
+            {btVector3(24.5088253021240234375, 107.3464813232421875, -239.429046630859375), btVector3(252.56353759765625, 91.8106536865234375, -199.2724151611328125), btVector3(261.976165771484375, -247.282928466796875, -199.272430419921875)},
+            {btVector3(26.63442230224609375, -285.659881591796875, -71.75213623046875), btVector3(261.97613525390625, -247.28289794921875, -69.9124908447265625), btVector3(252.5635223388671875, 91.8106231689453125, -75.74108123779296875)},
+            {btVector3(252.5635223388671875, 91.8106231689453125, -75.74108123779296875), btVector3(-7.1582050323486328125, 107.34649658203125, -73.49704742431640625), btVector3(26.63442230224609375, -285.659881591796875, -71.75213623046875)},
+            {btVector3(261.97613525390625, -247.28289794921875, -69.9124908447265625), btVector3(261.976165771484375, -247.282928466796875, -199.272430419921875), btVector3(252.56353759765625, 91.8106536865234375, -199.2724151611328125)},
+            {btVector3(252.56353759765625, 91.8106536865234375, -199.2724151611328125), btVector3(252.5635223388671875, 91.8106231689453125, -75.74108123779296875), btVector3(261.97613525390625, -247.28289794921875, -69.9124908447265625)},
+            {btVector3(70.37933349609375, -321.66650390625, -22.208202362060546875), btVector3(70.3793182373046875, -310.325531005859375, 49.395694732666015625), btVector3(-153.392242431640625, -336.590118408203125, 76.0716400146484375)},
+            {btVector3(-153.392242431640625, -336.590118408203125, 76.0716400146484375), btVector3(-153.392242431640625, -352.286041259765625, -23.028697967529296875), btVector3(70.37933349609375, -321.66650390625, -22.208202362060546875)},
+            {btVector3(70.379302978515625, -172.317138671875, -45.86280059814453125), btVector3(-187.1848602294921875, -157.8486328125, -53.8245697021484375), btVector3(-187.18487548828125, -142.152679443359375, 45.275787353515625)},
+            {btVector3(-187.18487548828125, -142.152679443359375, 45.275787353515625), btVector3(70.3793182373046875, -160.976226806640625, 25.7410869598388671875), btVector3(70.379302978515625, -172.317138671875, -45.86280059814453125)},
+            {btVector3(70.37933349609375, -321.66650390625, -22.208202362060546875), btVector3(-153.392242431640625, -352.286041259765625, -23.028697967529296875), btVector3(-187.1848602294921875, -157.8486328125, -53.8245697021484375)},
+            {btVector3(-187.1848602294921875, -157.8486328125, -53.8245697021484375), btVector3(70.379302978515625, -172.317138671875, -45.86280059814453125), btVector3(70.37933349609375, -321.66650390625, -22.208202362060546875)},
+            {btVector3(-153.392242431640625, -336.590118408203125, 76.0716400146484375), btVector3(70.3793182373046875, -310.325531005859375, 49.395694732666015625), btVector3(70.3793182373046875, -160.976226806640625, 25.7410869598388671875)},
+            {btVector3(70.3793182373046875, -160.976226806640625, 25.7410869598388671875), btVector3(-187.18487548828125, -142.152679443359375, 45.275787353515625), btVector3(-153.392242431640625, -336.590118408203125, 76.0716400146484375)},
+            {btVector3(70.3793182373046875, -310.325531005859375, 49.395694732666015625), btVector3(70.37933349609375, -321.66650390625, -22.208202362060546875), btVector3(70.379302978515625, -172.317138671875, -45.86280059814453125)},
+            {btVector3(70.379302978515625, -172.317138671875, -45.86280059814453125), btVector3(70.3793182373046875, -160.976226806640625, 25.7410869598388671875), btVector3(70.3793182373046875, -310.325531005859375, 49.395694732666015625)},
+            {btVector3(-87.05802154541015625, -80.8120880126953125, 129.385986328125), btVector3(-87.05803680419921875, -80.8120880126953125, 226.8372650146484375), btVector3(-228.86474609375, -98.93280029296875, 242.0215301513671875)},
+            {btVector3(-228.86474609375, -98.93280029296875, 242.0215301513671875), btVector3(-228.86474609375, -98.93280029296875, 123.78565216064453125), btVector3(-87.05802154541015625, -80.8120880126953125, 129.385986328125)},
+            {btVector3(-87.05805206298828125, 105.68819427490234375, 129.3860015869140625), btVector3(-262.657379150390625, 114.700714111328125, 123.78565216064453125), btVector3(-262.657379150390625, 114.7007293701171875, 242.02154541015625)},
+            {btVector3(-262.657379150390625, 114.7007293701171875, 242.02154541015625), btVector3(-87.05806732177734375, 105.68820953369140625, 226.8372802734375), btVector3(-87.05805206298828125, 105.68819427490234375, 129.3860015869140625)},
+            {btVector3(-87.05802154541015625, -80.8120880126953125, 129.385986328125), btVector3(-228.86474609375, -98.93280029296875, 123.78565216064453125), btVector3(-262.657379150390625, 114.700714111328125, 123.78565216064453125)},
+            {btVector3(-262.657379150390625, 114.700714111328125, 123.78565216064453125), btVector3(-87.05805206298828125, 105.68819427490234375, 129.3860015869140625), btVector3(-87.05802154541015625, -80.8120880126953125, 129.385986328125)},
+            {btVector3(-228.86474609375, -98.93280029296875, 242.0215301513671875), btVector3(-87.05803680419921875, -80.8120880126953125, 226.8372650146484375), btVector3(-87.05806732177734375, 105.68820953369140625, 226.8372802734375)},
+            {btVector3(-87.05806732177734375, 105.68820953369140625, 226.8372802734375), btVector3(-262.657379150390625, 114.7007293701171875, 242.02154541015625), btVector3(-228.86474609375, -98.93280029296875, 242.0215301513671875)},
+            {btVector3(-87.05803680419921875, -80.8120880126953125, 226.8372650146484375), btVector3(-87.05802154541015625, -80.8120880126953125, 129.385986328125), btVector3(-87.05805206298828125, 105.68819427490234375, 129.3860015869140625)},
+            {btVector3(-87.05805206298828125, 105.68819427490234375, 129.3860015869140625), btVector3(-87.05806732177734375, 105.68820953369140625, 226.8372802734375), btVector3(-87.05803680419921875, -80.8120880126953125, 226.8372650146484375)},
+            {btVector3(19.9618892669677734375, -232.823455810546875, 9.30895233154296875), btVector3(19.9618740081787109375, -232.823455810546875, 61.761646270751953125), btVector3(-130.46112060546875, -253.700408935546875, 76.80644989013671875)},
+            {btVector3(-130.46112060546875, -253.700408935546875, 76.80644989013671875), btVector3(-125.48846435546875, -253.700408935546875, -4.35540771484375), btVector3(19.9618892669677734375, -232.823455810546875, 9.30895233154296875)},
+            {btVector3(19.9618701934814453125, 47.853260040283203125, 80.03176116943359375), btVector3(-159.2810821533203125, 47.96441650390625, 74.431396484375), btVector3(-164.2537384033203125, 27.0286102294921875, 154.099822998046875)},
+            {btVector3(-164.2537384033203125, 27.0286102294921875, 154.099822998046875), btVector3(19.9618625640869140625, 25.65235137939453125, 133.169219970703125), btVector3(19.9618701934814453125, 47.853260040283203125, 80.03176116943359375)},
+            {btVector3(19.9618892669677734375, -232.823455810546875, 9.30895233154296875), btVector3(-125.48846435546875, -253.700408935546875, -4.35540771484375), btVector3(-159.2810821533203125, 47.96441650390625, 74.431396484375)},
+            {btVector3(-159.2810821533203125, 47.96441650390625, 74.431396484375), btVector3(19.9618701934814453125, 47.853260040283203125, 80.03176116943359375), btVector3(19.9618892669677734375, -232.823455810546875, 9.30895233154296875)},
+            {btVector3(-130.46112060546875, -253.700408935546875, 76.80644989013671875), btVector3(19.9618740081787109375, -232.823455810546875, 61.761646270751953125), btVector3(19.9618625640869140625, 25.65235137939453125, 133.169219970703125)},
+            {btVector3(19.9618625640869140625, 25.65235137939453125, 133.169219970703125), btVector3(-164.2537384033203125, 27.0286102294921875, 154.099822998046875), btVector3(-130.46112060546875, -253.700408935546875, 76.80644989013671875)},
+            {btVector3(19.9618740081787109375, -232.823455810546875, 61.761646270751953125), btVector3(19.9618892669677734375, -232.823455810546875, 9.30895233154296875), btVector3(19.9618701934814453125, 47.853260040283203125, 80.03176116943359375)},
+            {btVector3(19.9618701934814453125, 47.853260040283203125, 80.03176116943359375), btVector3(19.9618625640869140625, 25.65235137939453125, 133.169219970703125), btVector3(19.9618740081787109375, -232.823455810546875, 61.761646270751953125)},
+            {btVector3(111.757293701171875, 46.82357025146484375, -23.50151824951171875), btVector3(111.75730133056640625, 46.82360076904296875, 41.27971649169921875), btVector3(-120.8619232177734375, 26.180267333984375, 59.787322998046875)},
+            {btVector3(-120.8619232177734375, 26.180267333984375, 59.787322998046875), btVector3(-120.8619232177734375, 26.180267333984375, -29.10186004638671875), btVector3(111.757293701171875, 46.82357025146484375, -23.50151824951171875)},
+            {btVector3(97.6928253173828125, 218.0892333984375, -23.50151824951171875), btVector3(-154.6544952392578125, 233.6251220703125, -29.10186004638671875), btVector3(-154.654510498046875, 233.6251220703125, 59.78733062744140625)},
+            {btVector3(-154.654510498046875, 233.6251220703125, 59.78733062744140625), btVector3(97.69283294677734375, 218.0892486572265625, 41.27972412109375), btVector3(97.6928253173828125, 218.0892333984375, -23.50151824951171875)},
+            {btVector3(111.757293701171875, 46.82357025146484375, -23.50151824951171875), btVector3(-120.8619232177734375, 26.180267333984375, -29.10186004638671875), btVector3(-154.6544952392578125, 233.6251220703125, -29.10186004638671875)},
+            {btVector3(-154.6544952392578125, 233.6251220703125, -29.10186004638671875), btVector3(97.6928253173828125, 218.0892333984375, -23.50151824951171875), btVector3(111.757293701171875, 46.82357025146484375, -23.50151824951171875)},
+            {btVector3(-120.8619232177734375, 26.180267333984375, 59.787322998046875), btVector3(111.75730133056640625, 46.82360076904296875, 41.27971649169921875), btVector3(97.69283294677734375, 218.0892486572265625, 41.27972412109375)},
+            {btVector3(97.69283294677734375, 218.0892486572265625, 41.27972412109375), btVector3(-154.654510498046875, 233.6251220703125, 59.78733062744140625), btVector3(-120.8619232177734375, 26.180267333984375, 59.787322998046875)},
+            {btVector3(111.75730133056640625, 46.82360076904296875, 41.27971649169921875), btVector3(111.757293701171875, 46.82357025146484375, -23.50151824951171875), btVector3(97.6928253173828125, 218.0892333984375, -23.50151824951171875)},
+            {btVector3(97.6928253173828125, 218.0892333984375, -23.50151824951171875), btVector3(97.69283294677734375, 218.0892486572265625, 41.27972412109375), btVector3(111.75730133056640625, 46.82360076904296875, 41.27971649169921875)},
+            {btVector3(162.4515228271484375, 169.8447265625, -74.99315643310546875), btVector3(162.4515228271484375, 186.15289306640625, -18.56806182861328125), btVector3(-58.764862060546875, 171.739044189453125, 17.144008636474609375)},
+            {btVector3(-58.764862060546875, 171.739044189453125, 17.144008636474609375), btVector3(-58.764862060546875, 139.24249267578125, -73.67574310302734375), btVector3(162.4515228271484375, 169.8447265625, -74.99315643310546875)},
+            {btVector3(153.033050537109375, 317.18017578125, -104.923583984375), btVector3(-92.5574798583984375, 331.058074951171875, -113.87520599365234375), btVector3(-92.5574951171875, 363.554595947265625, -35.65110015869140625)},
+            {btVector3(-92.5574951171875, 363.554595947265625, -35.65110015869140625), btVector3(153.0330657958984375, 333.48834228515625, -52.58312225341796875), btVector3(153.033050537109375, 317.18017578125, -104.923583984375)},
+            {btVector3(162.4515228271484375, 169.8447265625, -74.99315643310546875), btVector3(-58.764862060546875, 139.24249267578125, -73.67574310302734375), btVector3(-92.5574798583984375, 331.058074951171875, -113.87520599365234375)},
+            {btVector3(-92.5574798583984375, 331.058074951171875, -113.87520599365234375), btVector3(153.033050537109375, 317.18017578125, -104.923583984375), btVector3(162.4515228271484375, 169.8447265625, -74.99315643310546875)},
+            {btVector3(-58.764862060546875, 171.739044189453125, 17.144008636474609375), btVector3(162.4515228271484375, 186.15289306640625, -18.56806182861328125), btVector3(153.0330657958984375, 333.48834228515625, -52.58312225341796875)},
+            {btVector3(153.0330657958984375, 333.48834228515625, -52.58312225341796875), btVector3(-92.5574951171875, 363.554595947265625, -35.65110015869140625), btVector3(-58.764862060546875, 171.739044189453125, 17.144008636474609375)},
+            {btVector3(162.4515228271484375, 186.15289306640625, -18.56806182861328125), btVector3(162.4515228271484375, 169.8447265625, -74.99315643310546875), btVector3(153.033050537109375, 317.18017578125, -104.923583984375)},
+            {btVector3(153.033050537109375, 317.18017578125, -104.923583984375), btVector3(153.0330657958984375, 333.48834228515625, -52.58312225341796875), btVector3(162.4515228271484375, 186.15289306640625, -18.56806182861328125)},
+        }};
+        const btVector3 origin {55537.421875, -47893.875, 430.579010009765625};
+        const btTransform transform {
+            btMatrix3x3 {
+                0.848353207111358642578125, -0.358678400516510009765625, -0.389418423175811767578125,
+                0.310398101806640625, 0.93282854557037353515625, -0.182986229658126831054688,
+                0.4288938045501708984375, 0.0343622341752052307128906, 0.9027011394500732421875
+            },
+            origin,
+        };
+        btTriangleMesh mesh = makeTriangleMesh(triangles);
+        btBvhTriangleMeshShape child {&mesh, true};
+        const btVector3 scaling {1, 1, 1};
+        btScaledBvhTriangleMeshShape shape {&child, scaling};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_STATIC_OBJECT;
+        btCollisionObject object;
+
+        Mesh4() { init(*this); }
+    };
+
+    struct Player2
+    {
+        const btVector3 halfExtents {29.279994964599609375, 28.4799976348876953125, 66.5};
+        const btVector3 origin {55193.90625, -48007.45703125, 636.29437255859375};
+        const btTransform transform {
+            btMatrix3x3(
+                0.002278387546539306640625, 0.9999973773956298828125, 0,
+                -0.9999973773956298828125, 0.002278387546539306640625, -0,
+                -0, 0, 1
+            ),
+            origin
+        };
+        btCapsuleShapeZ shape {halfExtents.x(), 2 * halfExtents.z() - 2 * halfExtents.x()};
+        const btCollisionObject::CollisionFlags flags = btCollisionObject::CF_KINEMATIC_OBJECT;
+        btCollisionObject object;
+
+        Player2() { init(*this); }
+    };
+}
+
+#endif // OPENMW_TEST_SUITE_MWMECHANICS_COLLISIONOBJECTS_HPP

--- a/apps/openmw_test_suite/mwmechanics/findoptimalpath/matchers.hpp
+++ b/apps/openmw_test_suite/mwmechanics/findoptimalpath/matchers.hpp
@@ -1,0 +1,57 @@
+#ifndef OPENMW_TEST_SUITE_MWMECHANICS_MATCHERS_HPP
+#define OPENMW_TEST_SUITE_MWMECHANICS_MATCHERS_HPP
+
+#include "apps/openmw/mwphysics/closestcollision.hpp"
+
+#include <LinearMath/btVector3.h>
+
+#include <gmock/gmock.h>
+
+namespace
+{
+
+    using MWPhysics::getClosestCollision;
+
+    MATCHER_P2(IsNearTo, other, notFarThan, "")
+    {
+        const auto distance = arg.distance(other);
+        *result_listener << "is too far from " << other << ", distance is " << distance;
+        return distance <= notFarThan;
+    }
+
+    MATCHER_P2(IsFarFrom, other, notCloseThan, "")
+    {
+        const auto distance = arg.distance(other);
+        *result_listener << "is too close to " << other << ", distance is " << distance;
+        return distance > notCloseThan;
+    }
+
+    MATCHER_P(IsOnGround, test, "")
+    {
+        const auto difference = test->getDistanceToGround(arg) - test->actor.halfExtents.z();
+        *result_listener << "is lifted above ground by " << difference;
+        return difference <= btScalar(2);
+    }
+
+    using Transition = std::pair<btVector3, btVector3>;
+
+    MATCHER_P(MedianPointIsOnGround, test, "")
+    {
+        const auto median = btScalar(0.5) * (arg.first + arg.second);
+        const auto difference = test->getDistanceToGround(median) - test->actor.halfExtents.z();
+        *result_listener << "median " << median << " is lifted above ground by " << difference;
+        return difference <= btScalar(2);
+    }
+
+    MATCHER_P(IsClear, test, "")
+    {
+        if (const auto collision = getClosestCollision(test->actor.object, arg.first, arg.second, test->collisionWorld)) {
+            *result_listener << "transition is not clear, hit at " << collision->mEnd;
+            return false;
+        }
+        return true;
+    }
+
+}
+
+#endif // OPENMW_TEST_SUITE_MWMECHANICS_MATCHERS_HPP

--- a/apps/openmw_test_suite/mwmechanics/findoptimalpath/testcommon.cpp
+++ b/apps/openmw_test_suite/mwmechanics/findoptimalpath/testcommon.cpp
@@ -1,0 +1,30 @@
+#include "apps/openmw/mwmechanics/findoptimalpath/common.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+    using namespace testing;
+    using namespace MWMechanics;
+
+    using MWMechanics::FindOptimalPath::isWalkableSlope;
+
+    struct IsWalkableSlope : Test {};
+
+    TEST(IsWalkableSlope, with_cos)
+    {
+        EXPECT_TRUE(isWalkableSlope(btScalar(1)));
+        EXPECT_TRUE(isWalkableSlope(btScalar(0.5) + std::numeric_limits<btScalar>::epsilon()));
+        EXPECT_TRUE(isWalkableSlope(btScalar(0.5)));
+        EXPECT_FALSE(isWalkableSlope(btScalar(0.5) - std::numeric_limits<btScalar>::epsilon()));
+        EXPECT_FALSE(isWalkableSlope(btScalar(0)));
+    }
+
+    TEST(IsWalkableSlope, with_vector)
+    {
+        EXPECT_TRUE(isWalkableSlope(btVector3(0, 0, 1)));
+        EXPECT_FALSE(isWalkableSlope(btVector3(1, 0, 0)));
+    }
+
+}

--- a/apps/openmw_test_suite/mwmechanics/findoptimalpath/testgetneighbors.cpp
+++ b/apps/openmw_test_suite/mwmechanics/findoptimalpath/testgetneighbors.cpp
@@ -1,0 +1,330 @@
+#include "collisionobjects.hpp"
+
+#include "apps/openmw/mwmechanics/findoptimalpath/get_neighbors.hpp"
+
+#include <BulletCollision/CollisionShapes/btStaticPlaneShape.h>
+
+#include <gtest/gtest.h>
+
+inline std::ostream& operator <<(std::ostream& stream, const btVector3& value)
+{
+    return stream << std::setprecision(std::numeric_limits<btScalar>::digits)
+        << "(" << value.x() << ", " << value.y() << ", " << value.z() << ")";
+}
+
+namespace
+{
+
+    using namespace testing;
+    using namespace MWMechanics;
+
+    using MWMechanics::FindOptimalPath::GetNeighbors;
+    using MWPhysics::Collision;
+
+    struct GetNeightborsTest : Test
+    {
+        btScalar minStep = std::numeric_limits<btScalar>::min();
+        btScalar maxStep = std::numeric_limits<btScalar>::max();
+        btScalar horizontalMargin = 1;
+        btScalar verticalMargin = 1;
+        bool allowFly = false;
+
+        Sphere<400, 0, 125> sphere;
+        Capsule capsule;
+        Box<400, 0, 100> box;
+        Floor floor;
+        Stair stair;
+        HeightField heightField;
+    };
+
+    TEST_F(GetNeightborsTest, with_sphere)
+    {
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &sphere.object;
+        collision.mFraction = 0.338400036096572875976562;
+        collision.mNormal = btVector3(-0.99736011028289794921875, 0, -0.0726152881979942321777344);
+        collision.mPoint = btVector3(150.660003662109375, 0, 106.8461761474609375);
+        collision.mEnd = btVector3(121.45731353759765625, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(246.2955474853515625, 195.2046966552734375, 67.5), false},
+            {btVector3(246.2955474853515625, -195.2046966552734375, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_sphere_when_allow_fly)
+    {
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &sphere.object;
+        collision.mFraction = 0.338400036096572875976562;
+        collision.mNormal = btVector3(-0.99736011028289794921875, 0, -0.0726152881979942321777344);
+        collision.mPoint = btVector3(150.660003662109375, 0, 106.8461761474609375);
+        collision.mEnd = btVector3(121.45731353759765625, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly = true);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(246.2955474853515625, 195.2046966552734375, 67.5), false},
+            {btVector3(246.2955474853515625, -195.2046966552734375, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_capsule)
+    {
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &capsule.object;
+        collision.mFraction = 0.4268000125885009765625;
+        collision.mNormal = btVector3(-1, 0, 0);
+        collision.mPoint = btVector3(370.720001220703125, 0, 104.720001220703125);
+        collision.mEnd = btVector3(341.44000244140625, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(397.783477783203125, 30.198760986328125, 67.5), false},
+            {btVector3(397.783477783203125, -30.198760986328125, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_capsule_when_allow_fly)
+    {
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &capsule.object;
+        collision.mFraction = 0.4268000125885009765625;
+        collision.mNormal = btVector3(-1, 0, 0);
+        collision.mPoint = btVector3(370.720001220703125, 0, 104.720001220703125);
+        collision.mEnd = btVector3(341.44000244140625, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly = true);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(397.783477783203125, 30.198760986328125, 67.5), false},
+            {btVector3(397.783477783203125, -30.198760986328125, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_box_by_x_when_allow_fly)
+    {
+        const btVector3 source {0, 0, 100};
+        const btVector3 destination {800, 0, 100};
+        const btVector3 goal {800, 0, 100};
+        Collision collision;
+        collision.mObject = &box.object;
+        collision.mFraction = 0.33840000629425048828125;
+        collision.mNormal = btVector3(-1, 0, 0);
+        collision.mPoint = btVector3(300, 0, 100);
+        collision.mEnd = btVector3(270.720001220703125, 0, 100);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly = true);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(269.720001220703125, 0, 200), false},
+            {btVector3(269.720001220703125, 0, 0), false},
+            {btVector3(269.720001220703125, 0, 100), true},
+            {btVector3(269.720001220703125, 100, 100), false},
+            {btVector3(269.720001220703125, -100, 100), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_box_by_y_when_allow_fly)
+    {
+        const btVector3 source {400, -400, 100};
+        const btVector3 destination {400, 400, 100};
+        const btVector3 goal {400, 400, 100};
+        Collision collision;
+        collision.mObject = &box.object;
+        collision.mFraction = 0.33840000629425048828125;
+        collision.mNormal = btVector3(0, -1, 0);
+        collision.mPoint = btVector3(400, -100, 100);
+        collision.mEnd = btVector3(400, -129.279998779296875, 100);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly = true);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(400, -130.279998779296875, 200), false},
+            {btVector3(400, -130.279998779296875, 0), false},
+            {btVector3(400, -130.279998779296875, 100), true},
+            {btVector3(300, -130.279998779296875, 100), false},
+            {btVector3(500, -130.279998779296875, 100), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_box_by_z_when_allow_fly)
+    {
+        const btVector3 source {400, 0, -300};
+        const btVector3 destination {400, 0, 500};
+        const btVector3 goal {800, 0, 100};
+        Collision collision;
+        collision.mObject = &box.object;
+        collision.mFraction = 0.29187500476837158203125;
+        collision.mNormal = btVector3(0, 0, -1);
+        collision.mPoint = btVector3(400, 0, 0);
+        collision.mEnd = btVector3(400, 0, -66.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly = true);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(300, 0, -67.5), false},
+            {btVector3(500, 0, -67.5), false},
+            {btVector3(400, 0, -67.5), true},
+            {btVector3(400, -100, -67.5), false},
+            {btVector3(400, 100, -67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_box_where_front_has_x_normal)
+    {
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &box.object;
+        collision.mFraction = 0.338400036096572875976562;
+        collision.mNormal = btVector3(-1, 0, 0);
+        collision.mPoint = btVector3(300, 0, 76.3179779052734375);
+        collision.mEnd = btVector3(270.72003173828125, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(269.72003173828125, 0, 67.5), true},
+            {btVector3(269.72003173828125, 100, 67.5), false},
+            {btVector3(269.72003173828125, -100, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_box_where_front_has_y_normal)
+    {
+        box.object.setWorldTransform(btTransform(btQuaternion(btVector3(0, 0, 1), btScalar(osg::PI_2)), box.origin));
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &box.object;
+        collision.mFraction = 0.338400036096572875976562;
+        collision.mNormal = btVector3(-1, 0, 0);
+        collision.mPoint = btVector3(300, 0, 76.3179779052734375);
+        collision.mEnd = btVector3(270.72003173828125, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(269.72003173828125, 0, 67.5), true},
+            {btVector3(269.72003173828125, 100, 67.5), false},
+            {btVector3(269.72003173828125, -100, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_box_where_front_has_z_normal)
+    {
+        box.object.setWorldTransform(btTransform(btQuaternion(btVector3(0, 1, 0), btScalar(osg::PI_2)), box.origin));
+        const btVector3 source {0, 0, 67.5};
+        const btVector3 destination {800, 0, 67.5};
+        const btVector3 goal {800, 0, 67.5};
+        Collision collision;
+        collision.mObject = &box.object;
+        collision.mFraction = 0.338400036096572875976562;
+        collision.mNormal = btVector3(-1, 0, 0);
+        collision.mPoint = btVector3(300, 0, 76.3179779052734375);
+        collision.mEnd = btVector3(270.72003173828125, 0, 67.5);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(269.72003173828125, 0, 67.5), true},
+            {btVector3(269.72003173828125, 100, 67.5), false},
+            {btVector3(269.72003173828125, -100, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_plane)
+    {
+        const btVector3 source {0, 0, 66.51000213623046875};
+        const btVector3 destination {365.31549072265625, 0, 54.498546600341796875};
+        const btVector3 goal {800, 0, 66.51000213623046875};
+        Collision collision;
+        collision.mObject = &floor.object;
+        collision.mFraction = 0.000832716410513967275619507;
+        collision.mNormal = btVector3(0, 0, 1);
+        collision.mPoint = btVector3(0.304204195737838745117188, 0, 0);
+        collision.mEnd = btVector3(0.304204195737838745117188, 0, 66.5);
+
+        minStep = 1;
+        maxStep = 800;
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(1.3042042255401611328125, 0, 67.5), false},
+            {btVector3(-0.6957957744598388671875, 0, 67.5), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_stair)
+    {
+        const btVector3 source {0, 0, 66.51000213623046875};
+        const btVector3 destination {365.31549072265625, 0, 54.498546600341796875};
+        const btVector3 goal {800, 0, 66.51000213623046875};
+        Collision collision;
+        collision.mObject = &stair.object;
+        collision.mFraction = 0.473426431417465209960938;
+        collision.mNormal = btVector3(-0.707106769084930419921875, 0, 0.7071068286895751953125);
+        collision.mPoint = btVector3(399.44451904296875, 0, 8.586639404296875);
+        collision.mEnd = btVector3(378.74114990234375, 0, 66.51000213623046875);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(385.105133056640625, 0, 74.288177490234375), false},
+            {btVector3(370.962982177734375, 0, 60.1460418701171875), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+    TEST_F(GetNeightborsTest, with_height_field)
+    {
+        const btVector3 source {0, 0, 1};
+        const btVector3 destination {10, 0, 1};
+        const btVector3 goal {1, 0, 1};
+        Collision collision;
+        collision.mObject = &heightField.object;
+        collision.mFraction = 0;
+        collision.mNormal = btVector3(0, 0, 1);
+        collision.mPoint = btVector3(0, 0, 0);
+        collision.mEnd = btVector3(0, 0, 1);
+
+        const GetNeighbors getNeighbors(source, destination, goal, collision, minStep, maxStep, horizontalMargin, verticalMargin, allowFly);
+        const auto result = getNeighbors.perform();
+        const std::vector<std::pair<btVector3, bool>> expected({
+            {btVector3(2, 0, 2), false},
+            {btVector3(-2, 0, 2), false},
+        });
+        EXPECT_EQ(result, expected);
+    }
+
+}

--- a/apps/openmw_test_suite/mwmechanics/findoptimalpath/testrandom.cpp
+++ b/apps/openmw_test_suite/mwmechanics/findoptimalpath/testrandom.cpp
@@ -1,0 +1,320 @@
+#include "collisionobjects.hpp"
+#include "matchers.hpp"
+
+#include "apps/openmw/mwmechanics/findoptimalpath.hpp"
+
+#include "apps/openmw/mwphysics/closestcollision.hpp"
+
+#include <BulletCollision/BroadphaseCollision/btDbvtBroadphase.h>
+#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
+#include <BulletCollision/CollisionDispatch/btDefaultCollisionConfiguration.h>
+#include <BulletCollision/CollisionShapes/btBoxShape.h>
+#include <BulletCollision/CollisionShapes/btCapsuleShape.h>
+#include <BulletCollision/CollisionShapes/btCompoundShape.h>
+#include <BulletCollision/CollisionShapes/btConcaveShape.h>
+#include <BulletCollision/CollisionShapes/btConvexShape.h>
+#include <BulletCollision/CollisionShapes/btPolyhedralConvexShape.h>
+#include <BulletCollision/CollisionShapes/btSphereShape.h>
+#include <BulletCollision/CollisionShapes/btStaticPlaneShape.h>
+#include <BulletCollision/CollisionShapes/btScaledBvhTriangleMeshShape.h>
+#include <BulletCollision/CollisionShapes/btTriangleMesh.h>
+#include <BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h>
+
+#include <osg/Math>
+
+#include <boost/optional.hpp>
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <random>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#ifdef FIND_OPTIMAL_PATH_JSON
+#include <extern/nlohmann/json.hpp>
+#endif
+
+inline std::ostream& operator <<(std::ostream& stream, const btVector3& value)
+{
+    return stream << std::setprecision(std::numeric_limits<btScalar>::digits)
+        << "(" << value.x() << ", " << value.y() << ", " << value.z() << ")";
+}
+
+namespace
+{
+
+    using namespace testing;
+    using namespace MWMechanics;
+    using MWPhysics::getClosestCollision;
+
+    struct FindOptimalPathWithRandomGeneratedWorldTest : Test
+    {
+        Floor floor;
+        Actor actor;
+        btDefaultCollisionConfiguration collisionConfiguration;
+        btCollisionDispatcher dispatcher {&collisionConfiguration};
+        btDbvtBroadphase broadphase;
+        btCollisionWorld collisionWorld {&dispatcher, &broadphase, &collisionConfiguration};
+        FindOptimalPathConfig config;
+
+        FindOptimalPathWithRandomGeneratedWorldTest()
+        {
+            config.mAllowFly = false;
+            config.mActorHalfExtents = actor.halfExtents;
+            config.mMaxDepth = std::numeric_limits<std::size_t>::max();
+            config.mMaxIterations = std::numeric_limits<std::size_t>::max();
+            config.mHasNearCollisionFilterFactor = 0.33f;
+            config.mHasNearCollisionFilterReduceFactor = 0.5f;
+            config.mHorizontalMarginFactor = 2;
+
+            collisionWorld.addCollisionObject(&actor.object);
+            collisionWorld.addCollisionObject(&floor.object);
+            collisionWorld.updateAabbs();
+        }
+
+        btScalar getDistanceToGround(const btVector3& point) const
+        {
+            if (const auto collision = getClosestCollision(actor.object, point, point - btVector3(0, 0, 1e5), collisionWorld))
+            {
+                return point.distance(collision->mPoint);
+            }
+            else
+            {
+                return std::numeric_limits<btScalar>::max();
+            }
+        }
+
+        void assertThatAllPathIsOnGround(btVector3 initial, const std::vector<btVector3>& points)
+        {
+            ASSERT_THAT(initial, IsOnGround(this));
+            for (const auto& point : points)
+            {
+                ASSERT_THAT(point, IsOnGround(this));
+//s                ASSERT_THAT(Transition(initial, point), MedianPointIsOnGround(this));
+                initial = point;
+            }
+        }
+
+        void assertThatNoCollisionsOnThePath(btVector3 initial, const std::vector<btVector3>& points)
+        {
+            for (const auto& point : points)
+            {
+                ASSERT_THAT(Transition(initial, point), IsClear(this));
+                initial = point;
+            }
+        }
+
+        btVector3 onGround(const btVector3& point)
+        {
+            const auto collision = getClosestCollision(actor.object, point, point - btVector3(0, 0, 1e5), collisionWorld);
+            return collision ? collision->mEnd + btVector3(0, 0, 1e-2f) : point;
+        }
+    };
+
+    TEST_F(FindOptimalPathWithRandomGeneratedWorldTest, with_floor_and_random_spheres)
+    {
+        const btVector3 initial = onGround(actor.origin - btVector3(200, 0, 0));
+        const btVector3 goal = onGround(actor.origin + btVector3(2000, 0, 0));
+
+        std::mt19937_64 device(0);
+        std::uniform_real_distribution<btScalar> uniform(0, 1);
+        std::exponential_distribution<btScalar> exponential(1);
+        std::vector<std::unique_ptr<btCollisionShape>> shapes;
+        std::vector<std::unique_ptr<btCollisionObject>> objects;
+        for (std::size_t i = 0; i < 700; ++i)
+        {
+            const auto x = btScalar(4000) * uniform(device);
+            const auto y = btScalar(10000) * (uniform(device) - btScalar(0.5));
+            const auto radius = std::min(btScalar(3) * actor.halfExtents.z(), actor.halfExtents.z() * (btScalar(0.5) + exponential(device)));
+            std::unique_ptr<btCollisionShape> shape(new btSphereShape(radius));
+            shapes.push_back(std::move(shape));
+            std::unique_ptr<btCollisionObject> object(new btCollisionObject);
+            object->setCollisionShape(shapes.back().get());
+            object->setWorldTransform(btTransform(btMatrix3x3::getIdentity(), btVector3(x, y, actor.halfExtents.z())));
+            object->setCollisionFlags(btCollisionObject::CF_STATIC_OBJECT);
+            objects.push_back(std::move(object));
+            collisionWorld.addCollisionObject(objects.back().get());
+        }
+        collisionWorld.updateAabbs();
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+
+        for (const auto& object : objects)
+        {
+            collisionWorld.removeCollisionObject(object.get());
+        }
+    }
+
+    TEST_F(FindOptimalPathWithRandomGeneratedWorldTest, with_floor_and_random_boxes)
+    {
+        const btVector3 initial = onGround(actor.origin - btVector3(200, 0, 0));
+        const btVector3 goal = onGround(actor.origin + btVector3(2000, 0, 0));
+
+        std::mt19937_64 device(100);
+        std::uniform_real_distribution<btScalar> uniform(0, 1);
+        std::exponential_distribution<btScalar> exponential(1);
+        std::vector<std::unique_ptr<btCollisionShape>> shapes;
+        std::vector<std::unique_ptr<btCollisionObject>> objects;
+        for (std::size_t i = 0; i < 500; ++i)
+        {
+            const auto x = btScalar(4000) * uniform(device);
+            const auto y = btScalar(10000) * (uniform(device) - btScalar(0.5));
+            const auto halfExtent = std::min(btScalar(3) * actor.halfExtents.z(), actor.halfExtents.z() * (btScalar(0.5) + exponential(device)));
+            std::unique_ptr<btCollisionShape> shape(new btBoxShape(btVector3(halfExtent, halfExtent, halfExtent)));
+            shapes.push_back(std::move(shape));
+            std::unique_ptr<btCollisionObject> object(new btCollisionObject);
+            object->setCollisionShape(shapes.back().get());
+            object->setWorldTransform(btTransform(btMatrix3x3::getIdentity(), btVector3(x, y, actor.halfExtents.z())));
+            object->setCollisionFlags(btCollisionObject::CF_STATIC_OBJECT);
+            objects.push_back(std::move(object));
+            collisionWorld.addCollisionObject(objects.back().get());
+        }
+        collisionWorld.updateAabbs();
+
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+
+        for (const auto& object : objects)
+        {
+            collisionWorld.removeCollisionObject(object.get());
+        }
+    }
+
+    TEST_F(FindOptimalPathWithRandomGeneratedWorldTest, with_random_height_field)
+    {
+        const btScalar maxAllowedHeight = 32;
+
+        std::mt19937_64 device(100);
+        std::uniform_real_distribution<btScalar> uniform(0, maxAllowedHeight);
+
+        const std::size_t heightStickWidth = 65;
+        const std::size_t heightStickLength = 65;
+        std::vector<btScalar> heightfieldData;
+        std::generate_n(std::back_inserter(heightfieldData), heightStickWidth * heightStickLength,
+                        [&] { return uniform(device); });
+        const btScalar heightScale = 1;
+        const btScalar minHeight = *std::min_element(heightfieldData.begin(), heightfieldData.end());
+        const btScalar maxHeight = *std::max_element(heightfieldData.begin(), heightfieldData.end());
+        const int upAxis = 2;
+        const PHY_ScalarType heightDataType = PHY_FLOAT;
+        const bool flipQuadEdges = false;
+        btHeightfieldTerrainShape shape(
+            heightStickWidth,
+            heightStickLength,
+            heightfieldData.data(),
+            heightScale,
+            minHeight,
+            maxHeight,
+            upAxis,
+            heightDataType,
+            flipQuadEdges
+        );
+        btCollisionObject object;
+        shape.setLocalScaling(btVector3(128, 128, 1));
+        object.setCollisionShape(&shape);
+        object.setWorldTransform(btTransform(btMatrix3x3::getIdentity(), btVector3(0, 0, 0)));
+        object.setCollisionFlags(btCollisionObject::CF_STATIC_OBJECT);
+        collisionWorld.addCollisionObject(&object);
+        collisionWorld.updateAabbs();
+
+        const btVector3 initial = onGround(btVector3(-2000, 0, maxAllowedHeight + 100));
+        const btVector3 goal = onGround(btVector3(2000, 0, maxAllowedHeight + 100));
+
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+
+        collisionWorld.removeCollisionObject(&object);
+    }
+
+    TEST_F(FindOptimalPathWithRandomGeneratedWorldTest, with_random_height_field_and_random_boxes)
+    {
+        const btScalar maxAllowedHeight = 32;
+
+        std::mt19937_64 device(100);
+        std::uniform_real_distribution<btScalar> uniform(0, 1);
+        std::exponential_distribution<btScalar> exponential(1);
+        std::vector<std::unique_ptr<btCollisionShape>> shapes;
+        std::vector<std::unique_ptr<btCollisionObject>> objects;
+        for (std::size_t i = 0; i < 100; ++i)
+        {
+            const auto x = btScalar(3600) * (uniform(device) - btScalar(0.5));
+            const auto y = btScalar(10000) * (uniform(device) - btScalar(0.5));
+            const auto halfExtent = std::min(btScalar(3) * actor.halfExtents.z(), actor.halfExtents.z() * (btScalar(0.5) + exponential(device)));
+            std::unique_ptr<btCollisionShape> shape(new btBoxShape(btVector3(halfExtent, halfExtent, halfExtent)));
+            shapes.push_back(std::move(shape));
+            std::unique_ptr<btCollisionObject> object(new btCollisionObject);
+            object->setCollisionShape(shapes.back().get());
+            const auto position = onGround(btVector3(x, y, maxAllowedHeight) + btVector3(0, 0, actor.halfExtents.z()));
+            object->setWorldTransform(btTransform(btMatrix3x3::getIdentity(), position));
+            object->setCollisionFlags(btCollisionObject::CF_STATIC_OBJECT);
+            objects.push_back(std::move(object));
+            collisionWorld.addCollisionObject(objects.back().get());
+        }
+
+        uniform = std::uniform_real_distribution<btScalar>(0, maxAllowedHeight);
+
+        const std::size_t heightStickWidth = 65;
+        const std::size_t heightStickLength = 65;
+        std::vector<btScalar> heightfieldData;
+        std::generate_n(std::back_inserter(heightfieldData), heightStickWidth * heightStickLength,
+                        [&] { return uniform(device); });
+
+        const btScalar heightScale = 1;
+        const btScalar minHeight = *std::min_element(heightfieldData.begin(), heightfieldData.end());
+        const btScalar maxHeight = *std::max_element(heightfieldData.begin(), heightfieldData.end());
+        const int upAxis = 2;
+        const PHY_ScalarType heightDataType = PHY_FLOAT;
+        const bool flipQuadEdges = false;
+        btHeightfieldTerrainShape shape(
+            heightStickWidth,
+            heightStickLength,
+            heightfieldData.data(),
+            heightScale,
+            minHeight,
+            maxHeight,
+            upAxis,
+            heightDataType,
+            flipQuadEdges
+        );
+        btCollisionObject object;
+        shape.setLocalScaling(btVector3(128, 128, 1));
+        object.setCollisionShape(&shape);
+        object.setWorldTransform(btTransform(btMatrix3x3::getIdentity(), btVector3(0, 0, 0)));
+        object.setCollisionFlags(btCollisionObject::CF_STATIC_OBJECT);
+        collisionWorld.addCollisionObject(&object);
+        collisionWorld.updateAabbs();
+
+        const btVector3 initial = onGround(btVector3(-2000, 0, maxAllowedHeight + 100));
+        const btVector3 goal = onGround(btVector3(2000, 0, maxAllowedHeight + 100));
+
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+
+        for (const auto& object : objects)
+        {
+            collisionWorld.removeCollisionObject(object.get());
+        }
+        collisionWorld.removeCollisionObject(&object);
+    }
+
+}

--- a/apps/openmw_test_suite/mwmechanics/findoptimalpath/testscenarios.cpp
+++ b/apps/openmw_test_suite/mwmechanics/findoptimalpath/testscenarios.cpp
@@ -1,0 +1,699 @@
+#include "collisionobjects.hpp"
+#include "matchers.hpp"
+
+#include "apps/openmw/mwmechanics/findoptimalpath.hpp"
+
+#include "apps/openmw/mwphysics/closestcollision.hpp"
+
+#include <osg/Math>
+
+#include <boost/optional.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <iostream>
+#include <iomanip>
+#include <random>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#ifdef FIND_OPTIMAL_PATH_JSON
+#include <extern/nlohmann/json.hpp>
+#endif
+
+inline std::ostream& operator <<(std::ostream& stream, const btVector3& value)
+{
+    return stream << std::setprecision(std::numeric_limits<btScalar>::digits)
+        << "(" << value.x() << ", " << value.y() << ", " << value.z() << ")";
+}
+
+namespace
+{
+
+    using namespace testing;
+    using namespace MWMechanics;
+    using MWPhysics::getClosestCollision;
+
+    struct FindOptimalPathScenariosTest : Test
+    {
+        Sphere<400, 0, 125> sphere;
+        Sphere<100, 300, 125> sphere2;
+        Sphere<100, -300, 125> sphere3;
+        Capsule capsule;
+        Box<400, 0, 100> box;
+        Box<200, 200, 100> box2;
+        Box<200, -200, 100> box3;
+        Compound compound;
+        Floor floor;
+        Stair stair;
+        LeftWall leftWall;
+        RightWall rightWall;
+        Roof roof;
+        Sphere<44, -144, 67, 20> sphereAtLeftTangent;
+        Sphere<44, 144, 67, 20> sphereAtRightTangent;
+        FirstPlatform firstPlatform;
+        SecondLoweredPlatform secondLoweredPlatform;
+        ThirdPlatform thirdPlatform;
+        Slope slope;
+        ElevatedPlatform elevatedPlatform;
+        SteepSlope steepSlope;
+        UnreachableElevatedPlatform unreachableElevatedPlatform;
+        EllispoidY ellispoidY;
+        TurnBackWall turnBackWall;
+        TurnFrontWall turnFrontWall;
+        TurnLeftWall turnLeftWall;
+        TurnRightWall turnRightWall;
+        TurnInside turnInside;
+        UTurnInsideWall uTurnInsideWall;
+        UTurnRightWall uTurnRightWall;
+        Mesh mesh;
+        Mesh2 mesh2;
+        HeightField heightField;
+        HeightField2 heightField2;
+        Player player;
+        Mesh3 mesh3;
+        Mesh4 mesh4;
+        Player2 player2;
+        Actor actor;
+        btDefaultCollisionConfiguration collisionConfiguration;
+        btCollisionDispatcher dispatcher {&collisionConfiguration};
+        btDbvtBroadphase broadphase;
+        btCollisionWorld collisionWorld {&dispatcher, &broadphase, &collisionConfiguration};
+        FindOptimalPathConfig config;
+
+        FindOptimalPathScenariosTest()
+        {
+            config.mAllowFly = false;
+            config.mActorHalfExtents = actor.halfExtents;
+            config.mMaxDepth = std::numeric_limits<std::size_t>::max();
+            config.mMaxIterations = std::numeric_limits<std::size_t>::max();
+            config.mHasNearCollisionFilterFactor = 0.33f;
+            config.mHasNearCollisionFilterReduceFactor = 0.5f;
+            config.mHorizontalMarginFactor = 2;
+
+            collisionWorld.addCollisionObject(&actor.object);
+        }
+
+        btScalar getDistanceToGround(const btVector3& point) const
+        {
+            if (const auto collision = getClosestCollision(actor.object, point, point - btVector3(0, 0, 1e5), collisionWorld))
+            {
+                return point.distance(collision->mPoint);
+            }
+            else
+            {
+                return std::numeric_limits<btScalar>::max();
+            }
+        }
+
+        void assertThatAllPathIsOnGround(btVector3 initial, const std::vector<btVector3>& points)
+        {
+            ASSERT_THAT(initial, IsOnGround(this));
+            for (const auto& point : points)
+            {
+                ASSERT_THAT(point, IsOnGround(this));
+//                ASSERT_THAT(Transition(initial, point), MedianPointIsOnGround(this));
+                initial = point;
+            }
+        }
+
+        void assertThatNoCollisionsOnThePath(btVector3 initial, const std::vector<btVector3>& points)
+        {
+            for (const auto& point : points)
+            {
+                ASSERT_THAT(Transition(initial, point), IsClear(this));
+                initial = point;
+            }
+        }
+
+        btVector3 onGround(const btVector3& point)
+        {
+            const auto collision = getClosestCollision(actor.object, point, point - btVector3(0, 0, 1e5), collisionWorld);
+            return collision ? collision->mEnd + btVector3(0, 0, 1e-2f) : point;
+        }
+    };
+
+    inline btScalar length(btVector3 initial, const std::vector<btVector3>& points)
+    {
+        return std::accumulate(points.begin(), points.end(), btScalar(0),
+            [&] (btScalar s, const btVector3& v) {
+                const auto r = s + initial.distance(v);
+                initial = v;
+                return r;
+            });
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, without_objects)
+    {
+        config.mAllowFly = true;
+        config.mMaxDepth = 1;
+        config.mMaxIterations = 1;
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 800, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor)
+    {
+        config.mMaxDepth = 1;
+        config.mMaxIterations = 1;
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 800, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_left_and_right_walls)
+    {
+        config.mMaxDepth = 1;
+        config.mMaxIterations = 1;
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&leftWall.object);
+        collisionWorld.addCollisionObject(&rightWall.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 800, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_roof)
+    {
+        config.mMaxDepth = 1;
+        config.mMaxIterations = 1;
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&roof.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 800, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_roof_and_left_and_right_walls)
+    {
+        config.mMaxDepth = 1;
+        config.mMaxIterations = 1;
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&roof.object);
+        collisionWorld.addCollisionObject(&leftWall.object);
+        collisionWorld.addCollisionObject(&rightWall.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 800, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_sphere_on_the_way)
+    {
+        config.mAllowFly = true;
+        collisionWorld.addCollisionObject(&sphere.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1045, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_sphere_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&sphere.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1045, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_three_spheres_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&sphere.object);
+        collisionWorld.addCollisionObject(&sphere2.object);
+        collisionWorld.addCollisionObject(&sphere3.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1805, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_sphere_on_the_way_and_spheres_at_tangents_to_first)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&sphere.object);
+        collisionWorld.addCollisionObject(&sphereAtLeftTangent.object);
+        collisionWorld.addCollisionObject(&sphereAtRightTangent.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin - btVector3(200, 0, 0);
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1228, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_capsule_on_the_way)
+    {
+        config.mAllowFly = true;
+        collisionWorld.addCollisionObject(&capsule.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 821, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_capsule_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&capsule.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 821, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_box_by_x_on_the_way)
+    {
+        config.mAllowFly = true;
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = box.origin - btVector3(400, 0, 0);
+        const btVector3 goal = box.origin + btVector3(400, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 959, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_box_by_y_on_the_way)
+    {
+        config.mAllowFly = true;
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = box.origin - btVector3(0, 400, 0);
+        const btVector3 goal = box.origin + btVector3(0, 400, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 959, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_box_by_z_on_the_way)
+    {
+        config.mAllowFly = true;
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = box.origin - btVector3(0, 0, 400);
+        const btVector3 goal = box.origin + btVector3(0, 0, 400);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 974, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_box_where_front_has_x_normal_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 959, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_box_where_front_has_y_normal_on_the_way)
+    {
+        box.object.setWorldTransform(btTransform(btQuaternion(btVector3(0, 0, 1), btScalar(osg::PI_2)), box.origin));
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 959, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_box_where_front_has_z_normal_on_the_way)
+    {
+        box.object.setWorldTransform(btTransform(btQuaternion(btVector3(0, 1, 0), btScalar(osg::PI_2)), box.origin));
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = actor.origin;
+        const btVector3 goal = actor.origin + btVector3(800, 0, 0);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 959, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_three_boxes_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&box.object);
+        collisionWorld.addCollisionObject(&box2.object);
+        collisionWorld.addCollisionObject(&box3.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1220, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_stair_on_the_floor)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&stair.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 802, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_compound_of_three_box_collision_objects_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&compound.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 865, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_sequence_of_three_platforms_where_second_is_lowered)
+    {
+        collisionWorld.addCollisionObject(&firstPlatform.object);
+        collisionWorld.addCollisionObject(&secondLoweredPlatform.object);
+        collisionWorld.addCollisionObject(&thirdPlatform.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(400, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsFarFrom(goal, 197));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_slope_to_the_elevated_platform)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&slope.object);
+        collisionWorld.addCollisionObject(&elevatedPlatform.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const auto z = elevatedPlatform.origin.z() + elevatedPlatform.shape.getHalfExtentsWithMargin().z();
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, z));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 928, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_steep_slope_to_the_unreachable_elevated_platform)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&steepSlope.object);
+        collisionWorld.addCollisionObject(&unreachableElevatedPlatform.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const auto z = unreachableElevatedPlatform.origin.z()
+                + unreachableElevatedPlatform.shape.getHalfExtentsWithMargin().z();
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, z));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_TRUE(result.mPoints.empty());
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_ellipsoid_on_the_way)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&ellispoidY.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(actor.origin + btVector3(800, 0, 0));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 831, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_floor_and_capsule_goal_occupier)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&capsule.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(actor.origin);
+        const btVector3 goal = onGround(capsule.origin);
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, capsule.halfExtents.x() + actor.halfExtents.x() + 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 341, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_turn)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&roof.object);
+        collisionWorld.addCollisionObject(&turnBackWall.object);
+        collisionWorld.addCollisionObject(&turnFrontWall.object);
+        collisionWorld.addCollisionObject(&turnLeftWall.object);
+        collisionWorld.addCollisionObject(&turnRightWall.object);
+        collisionWorld.addCollisionObject(&turnInside.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(btVector3(-30, -970, actor.origin.z()));
+        const btVector3 goal = onGround(btVector3(-970, -30, actor.origin.z()));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, capsule.halfExtents.x() + actor.halfExtents.x() + 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1880, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, DISABLED_with_uturn)
+    {
+        collisionWorld.addCollisionObject(&floor.object);
+        collisionWorld.addCollisionObject(&roof.object);
+        collisionWorld.addCollisionObject(&turnBackWall.object);
+        collisionWorld.addCollisionObject(&turnFrontWall.object);
+        collisionWorld.addCollisionObject(&turnLeftWall.object);
+        collisionWorld.addCollisionObject(&uTurnRightWall.object);
+        collisionWorld.addCollisionObject(&uTurnInsideWall.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial = onGround(btVector3(-970, -30, actor.origin.z()));
+        const btVector3 goal = onGround(btVector3(-970, -91, actor.origin.z()));
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, capsule.halfExtents.x() + actor.halfExtents.x() + 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1801, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_mesh)
+    {
+        config.mAllowFly = true;
+        collisionWorld.addCollisionObject(&mesh.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial {56210.8125, -49236.421875, 549.3701171875};
+        const btVector3 goal {56607, -49244, 726.5};
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 619, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_height_field)
+    {
+        collisionWorld.addCollisionObject(&heightField.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial {56210.8125, -49236.421875, 549.3701171875};
+        const btVector3 goal {56607, -49244, 726.5};
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 441, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_mesh_and_height_fields)
+    {
+        collisionWorld.addCollisionObject(&heightField.object);
+        collisionWorld.addCollisionObject(&heightField2.object);
+        collisionWorld.addCollisionObject(&mesh.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial {56210.8125, -49236.421875, 549.3701171875};
+        const btVector3 goal {56607, -49244, 726.5};
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 938, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_meshes_and_height_fields)
+    {
+        collisionWorld.addCollisionObject(&heightField.object);
+        collisionWorld.addCollisionObject(&heightField2.object);
+        collisionWorld.addCollisionObject(&mesh.object);
+        collisionWorld.addCollisionObject(&mesh2.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial {56210.8125, -49236.421875, 549.3701171875};
+        const btVector3 goal {56607, -49244, 726.5};
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 1));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 938, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_meshes_and_height_fields_and_player)
+    {
+        collisionWorld.addCollisionObject(&heightField.object);
+        collisionWorld.addCollisionObject(&heightField2.object);
+        collisionWorld.addCollisionObject(&mesh.object);
+        collisionWorld.addCollisionObject(&mesh2.object);
+        collisionWorld.addCollisionObject(&player.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial {56210.8125, -49236.421875, 549.3701171875};
+        const btVector3 goal {56607, -49244, 726.5};
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 62));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 878, 0.5);
+    }
+
+    TEST_F(FindOptimalPathScenariosTest, with_meshes_and_height_fields_and_player_2)
+    {
+        collisionWorld.addCollisionObject(&heightField2.object);
+        collisionWorld.addCollisionObject(&mesh3.object);
+        collisionWorld.addCollisionObject(&mesh4.object);
+        collisionWorld.addCollisionObject(&player2.object);
+        collisionWorld.updateAabbs();
+        const btVector3 initial {55736.3125, -47998.01953125, 492.180938720703125};
+        const btVector3 goal {55193, -48007, 635.5};
+        const auto result = findOptimalPath(collisionWorld, actor.object, initial, goal, config);
+        ASSERT_FALSE(result.mReachMaxIterations);
+        ASSERT_FALSE(result.mPoints.empty());
+        ASSERT_THAT(result.mPoints.back(), IsNearTo(goal, 62));
+        assertThatAllPathIsOnGround(initial, result.mPoints);
+//        assertThatNoCollisionsOnThePath(initial, result.mPoints);
+        EXPECT_NEAR(length(initial, result.mPoints), 1046, 0.5);
+    }
+
+}

--- a/cmake/FindGMock.cmake
+++ b/cmake/FindGMock.cmake
@@ -1,0 +1,129 @@
+# Locate the Google C++ Mocking Framework.
+# (This file is almost an identical copy of the original FindGTest.cmake file,
+#  feel free to use it as it is or modify it for your own needs.)
+#
+#
+# Defines the following variables:
+#
+#   GMOCK_FOUND - Found the Google Testing framework
+#   GMOCK_INCLUDE_DIRS - Include directories
+#
+# Also defines the library variables below as normal
+# variables. These contain debug/optimized keywords when
+# a debugging library is found.
+#
+#   GMOCK_BOTH_LIBRARIES - Both libgmock & libgmock-main
+#   GMOCK_LIBRARIES - libgmock
+#   GMOCK_MAIN_LIBRARIES - libgmock-main
+#
+# Accepts the following variables as input:
+#
+#   GMOCK_ROOT - (as a CMake or environment variable)
+#                The root directory of the gmock install prefix
+#
+#   GMOCK_MSVC_SEARCH - If compiling with MSVC, this variable can be set to
+#                       "MD" or "MT" to enable searching a gmock build tree
+#                       (defaults: "MD")
+#
+#-----------------------
+# Example Usage:
+#
+#    find_package(GMock REQUIRED)
+#    include_directories(${GMOCK_INCLUDE_DIRS})
+#
+#    add_executable(foo foo.cc)
+#    target_link_libraries(foo ${GMOCK_BOTH_LIBRARIES})
+#
+#=============================================================================
+# This file is released under the MIT licence:
+#
+# Copyright (c) 2011 Matej Svec
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#=============================================================================
+
+
+function(_gmock_append_debugs _endvar _library)
+if(${_library} AND ${_library}_DEBUG)
+  set(_output optimized ${${_library}} debug ${${_library}_DEBUG})
+else()
+  set(_output ${${_library}})
+endif()
+set(${_endvar} ${_output} PARENT_SCOPE)
+endfunction()
+
+function(_gmock_find_library _name)
+find_library(${_name}
+  NAMES ${ARGN}
+  HINTS
+    $ENV{GMOCK_ROOT}
+    ${GMOCK_ROOT}
+  PATH_SUFFIXES ${_gmock_libpath_suffixes}
+)
+mark_as_advanced(${_name})
+endfunction()
+
+
+if(NOT DEFINED GMOCK_MSVC_SEARCH)
+set(GMOCK_MSVC_SEARCH MD)
+endif()
+
+set(_gmock_libpath_suffixes lib)
+if(MSVC)
+if(GMOCK_MSVC_SEARCH STREQUAL "MD")
+  list(APPEND _gmock_libpath_suffixes
+    msvc/gmock-md/Debug
+    msvc/gmock-md/Release)
+elseif(GMOCK_MSVC_SEARCH STREQUAL "MT")
+  list(APPEND _gmock_libpath_suffixes
+    msvc/gmock/Debug
+    msvc/gmock/Release)
+endif()
+endif()
+
+find_path(GMOCK_INCLUDE_DIR gmock/gmock.h
+HINTS
+  $ENV{GMOCK_ROOT}/include
+  ${GMOCK_ROOT}/include
+)
+mark_as_advanced(GMOCK_INCLUDE_DIR)
+
+if(MSVC AND GMOCK_MSVC_SEARCH STREQUAL "MD")
+# The provided /MD project files for Google Mock add -md suffixes to the
+# library names.
+_gmock_find_library(GMOCK_LIBRARY            gmock-md  gmock)
+_gmock_find_library(GMOCK_LIBRARY_DEBUG      gmock-mdd gmockd)
+_gmock_find_library(GMOCK_MAIN_LIBRARY       gmock_main-md  gmock_main)
+_gmock_find_library(GMOCK_MAIN_LIBRARY_DEBUG gmock_main-mdd gmock_maind)
+else()
+_gmock_find_library(GMOCK_LIBRARY            gmock)
+_gmock_find_library(GMOCK_LIBRARY_DEBUG      gmockd)
+_gmock_find_library(GMOCK_MAIN_LIBRARY       gmock_main)
+_gmock_find_library(GMOCK_MAIN_LIBRARY_DEBUG gmock_maind)
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GMock DEFAULT_MSG GMOCK_LIBRARY GMOCK_INCLUDE_DIR GMOCK_MAIN_LIBRARY)
+
+if(GMOCK_FOUND)
+set(GMOCK_INCLUDE_DIRS ${GMOCK_INCLUDE_DIR})
+_gmock_append_debugs(GMOCK_LIBRARIES      GMOCK_LIBRARY)
+_gmock_append_debugs(GMOCK_MAIN_LIBRARIES GMOCK_MAIN_LIBRARY)
+set(GMOCK_BOTH_LIBRARIES ${GMOCK_LIBRARIES} ${GMOCK_MAIN_LIBRARIES})
+endif()


### PR DESCRIPTION
The idea is to use any angle **A*** to generate transitions graph on the fly by adding new points based on collisions with world objects. To check collisions **Bullet** is used. The chain of transitions without collisions leads from initial point to goal. The number of iterations (to handle one transition) and depth of search (length of the transitions chain) are limited. New algorithm doesn't replace old. Shortcutting is still working, and if path is not found old pathfinder uses. There are functional tests with specific scenario, tests with randomly generating environment and unit tests for some functions.

TODO:
* Improve performance (reduce the number of collision checks)
* Find path around holes
* ???