### PR TITLE
Transparent object markers

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -191,6 +191,7 @@ void CSMPrefs::State::declare()
         setTooltip ("Acceleration factor during drag operations while holding down shift").
         setRange (0.001, 100.0);
     declareDouble ("rotate-factor", "Free rotation factor", 0.007).setPrecision(4).setRange(0.0001, 0.1);
+    declareDouble ("object-marker-alpha", "Object Marker Transparency", 0.5).setPrecision(2).setRange(0,1);
 
     declareCategory ("Tooltips");
     declareBool ("scene", "Show Tooltips in 3D scenes", true);

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -390,7 +390,7 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
 
 void CSVRender::Object::setupCommonMarkerState(osg::ref_ptr<osg::Geometry> geometry)
 {
-    const int RenderBin = osg::StateSet::TRANSPARENT_BIN - 1;
+    const int RenderBin = osg::StateSet::TRANSPARENT_BIN;
 
     osg::ref_ptr<osg::StateSet> state = geometry->getOrCreateStateSet();
     state->setMode(GL_LIGHTING, osg::StateAttribute::OFF);

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -336,6 +336,9 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
     osg::ref_ptr<osg::DrawElementsUShort> primitives = new osg::DrawElementsUShort(osg::PrimitiveSet::TRIANGLES,
         IndexCount);
 
+    // prevent some depth collision issues from overlaps
+    osg::Vec3f offset = getMarkerPosition(0, MarkerShaftWidth/4, 0, axis);
+
     for (size_t i = 0; i < SegmentCount; ++i)
     {
         size_t index = i * VerticesPerSegment;
@@ -346,10 +349,10 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
         float outerX = OuterRadius * std::cos(i * Angle);
         float outerY = OuterRadius * std::sin(i * Angle);
 
-        vertices->at(index++) = getMarkerPosition(innerX, innerY,  MarkerShaftWidth / 2, axis);
-        vertices->at(index++) = getMarkerPosition(innerX, innerY, -MarkerShaftWidth / 2, axis);
-        vertices->at(index++) = getMarkerPosition(outerX, outerY,  MarkerShaftWidth / 2, axis);
-        vertices->at(index++) = getMarkerPosition(outerX, outerY, -MarkerShaftWidth / 2, axis);
+        vertices->at(index++) = getMarkerPosition(innerX, innerY,  MarkerShaftWidth / 2, axis) + offset;
+        vertices->at(index++) = getMarkerPosition(innerX, innerY, -MarkerShaftWidth / 2, axis) + offset;
+        vertices->at(index++) = getMarkerPosition(outerX, outerY,  MarkerShaftWidth / 2, axis) + offset;
+        vertices->at(index++) = getMarkerPosition(outerX, outerY, -MarkerShaftWidth / 2, axis) + offset;
     }
 
     colors->at(0) = osg::Vec4f (
@@ -390,17 +393,11 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
 
 void CSVRender::Object::setupCommonMarkerState(osg::ref_ptr<osg::Geometry> geometry)
 {
-    const int RenderBin = osg::StateSet::TRANSPARENT_BIN;
-
     osg::ref_ptr<osg::StateSet> state = geometry->getOrCreateStateSet();
     state->setMode(GL_LIGHTING, osg::StateAttribute::OFF);
     state->setMode(GL_BLEND, osg::StateAttribute::ON);
 
-    osg::ref_ptr<osg::Depth> depth(new osg::Depth);
-    depth->setWriteMask(false);
-    state->setAttributeAndModes(depth, osg::StateAttribute::ON);
-
-    state->setRenderBinDetails(RenderBin, "RenderBin");
+    state->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
 }
 
 osg::Vec3f CSVRender::Object::getMarkerPosition (float x, float y, float z, int axis)

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -221,7 +221,7 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeMoveOrScaleMarker (int axis)
 
     for (int i=0; i<2; ++i)
     {
-        float length = i ? shaftLength : 0;
+        float length = i ? shaftLength : MarkerShaftWidth;
 
         vertices->push_back (getMarkerPosition (-MarkerShaftWidth/2, -MarkerShaftWidth/2, length, axis));
         vertices->push_back (getMarkerPosition (-MarkerShaftWidth/2, MarkerShaftWidth/2, length, axis));

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -307,11 +307,11 @@ osg::ref_ptr<osg::Node> CSVRender::Object::makeRotateMarker (int axis)
 {
     const float Pi = 3.14159265f;
 
-    const float InnerRadius = mBaseNode->getBound().radius();
+    const float InnerRadius = std::max(MarkerShaftBaseLength, mBaseNode->getBound().radius());
     const float OuterRadius = InnerRadius + MarkerShaftWidth;
 
     const float SegmentDistance = 100.f;
-    const size_t SegmentCount = std::min(64, std::max(8, (int)(OuterRadius * 2 * Pi / SegmentDistance)));
+    const size_t SegmentCount = std::min(64, std::max(24, (int)(OuterRadius * 2 * Pi / SegmentDistance)));
     const size_t VerticesPerSegment = 4;
     const size_t IndicesPerSegment = 24;
 

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -22,6 +22,7 @@
 #include "../../model/world/universalid.hpp"
 #include "../../model/world/commandmacro.hpp"
 #include "../../model/world/cellcoordinates.hpp"
+#include "../../model/prefs/state.hpp"
 
 #include <components/resource/scenemanager.hpp>
 #include <components/sceneutil/lightutil.hpp>
@@ -473,6 +474,7 @@ void CSVRender::Object::setSelected(bool selected)
     else
         mRootNode->addChild(mBaseNode);
 
+    mMarkerTransparency = CSMPrefs::get()["3D Scene Input"]["object-marker-alpha"].toDouble();
     updateMarker();
 }
 

--- a/apps/opencs/view/render/object.hpp
+++ b/apps/opencs/view/render/object.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <osg/ref_ptr>
+#include <osg/Geometry>
 #include <osg/Referenced>
 
 #include <components/esm/defs.hpp>
@@ -96,6 +97,7 @@ namespace CSVRender
             int mOverrideFlags;
             osg::ref_ptr<osg::Node> mMarker[3];
             int mSubMode;
+            float mMarkerTransparency;
 
             /// Not implemented
             Object (const Object&);
@@ -120,6 +122,9 @@ namespace CSVRender
 
             osg::ref_ptr<osg::Node> makeMoveOrScaleMarker (int axis);
             osg::ref_ptr<osg::Node> makeRotateMarker (int axis);
+
+            /// Sets up a stateset with properties common to all marker types.
+            void setupCommonMarkerState(osg::ref_ptr<osg::Geometry> geometry);
 
             osg::Vec3f getMarkerPosition (float x, float y, float z, int axis);
 
@@ -178,6 +183,8 @@ namespace CSVRender
 
             /// Set override scale
             void setScale (float scale);
+
+            void setMarkerTransparency(float value);
 
             /// Apply override changes via command and end edit mode
             void apply (CSMWorld::CommandMacro& commands);

--- a/apps/opencs/view/render/worldspacewidget.hpp
+++ b/apps/opencs/view/render/worldspacewidget.hpp
@@ -65,6 +65,7 @@ namespace CSVRender
             QPoint mToolTipPos;
             bool mShowToolTips;
             int mToolTipDelay;
+            bool mInConstructor;
 
         public:
 


### PR DESCRIPTION
This is a partial implementation for making object markers transparent, as suggested by scrawl in #1438 . The transparency is not yet configurable, since doing so will require some tedious chaining of functions. If people could test this and provide feedback on whether or not transparency is the way to go, it would be greatly appreciated.