### PR TITLE
Do not artificially limit viewing angle when on preview mode

### DIFF
--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -294,6 +294,12 @@ namespace MWRender
         const float epsilon = 0.000001f;
         float limit = osg::PI_2 - epsilon;
 
+        // Apply a slightly stricter limit in preview mode so that
+        // it would not be possible to zoom in from below and look inside
+        // the player.
+        if (mPreviewMode && angle >= 0 && mPreviewCam.offset <= 100.f)
+                limit *= std::max(0.5f, mPreviewCam.offset / 100.f);
+
         if(angle > limit)
             angle = limit;
         else if(angle < -limit)

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -293,8 +293,6 @@ namespace MWRender
     {
         const float epsilon = 0.000001f;
         float limit = osg::PI_2 - epsilon;
-        if(mPreviewMode)
-            limit /= 2;
 
         if(angle > limit)
             angle = limit;


### PR DESCRIPTION
On third person view there is no angle limit on pitch, and thus there is more freedom from which point of view player can be seen.  However, when tab-key is held pressed (so that it is possible to see the player from the front, for example), there is a technical limit on the angle on pitch. I fail to see a technical reason for this, this change makes the angle limit behaviour on third person view and "preview mode" equivalent.