### PR TITLE
[Testing needed] Item models reworking

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -238,6 +238,7 @@ namespace MWBase
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid) = 0;
 
+            virtual bool isBoundItem(const MWWorld::Ptr& item) = 0;
             virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim) = 0;
 
             /// Turn actor into werewolf or normal form.

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -140,7 +140,7 @@ namespace MWBase
             /// Utility to check if taking this item is illegal and calling commitCrime if so
             /// @param container The container the item is in; may be empty for an item in the world
             virtual void itemTaken (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item, const MWWorld::Ptr& container,
-                                    int count) = 0;
+                                    int count, bool alarm = true) = 0;
             /// Utility to check if opening (i.e. unlocking) this object is illegal and calling commitCrime if so
             virtual void objectOpened (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item) = 0;
             /// Attempt sleeping in a bed. If this is illegal, call commitCrime.
@@ -250,7 +250,6 @@ namespace MWBase
             virtual void cleanupSummonedCreature(const MWWorld::Ptr& caster, int creatureActorId) = 0;
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count) = 0;
-
             virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr) = 0;
             virtual bool isRunning(const MWWorld::Ptr& ptr) = 0;
             virtual bool isSneaking(const MWWorld::Ptr& ptr) = 0;

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -100,28 +100,10 @@ namespace MWGui
 
     void ContainerWindow::dropItem()
     {
-        if (mPtr.getTypeName() == typeid(ESM::Container).name())
-        {
-            // check container organic flag
-            MWWorld::LiveCellRef<ESM::Container>* ref = mPtr.get<ESM::Container>();
-            if (ref->mBase->mFlags & ESM::Container::Organic)
-            {
-                MWBase::Environment::get().getWindowManager()->
-                    messageBox("#{sContentsMessage2}");
-                return;
-            }
+        bool success = mModel->onDropItem(mDragAndDrop->mItem.mBase, mDragAndDrop->mDraggedCount);
 
-            // check that we don't exceed container capacity
-            MWWorld::Ptr item = mDragAndDrop->mItem.mBase;
-            float weight = item.getClass().getWeight(item) * mDragAndDrop->mDraggedCount;
-            if (mPtr.getClass().getCapacity(mPtr) < mPtr.getClass().getEncumbrance(mPtr) + weight)
-            {
-                MWBase::Environment::get().getWindowManager()->messageBox("#{sContentsMessage3}");
-                return;
-            }
-        }
-
-        mDragAndDrop->drop(mModel, mItemView);
+        if (success)
+            mDragAndDrop->drop(mModel, mItemView);
     }
 
     void ContainerWindow::onBackgroundSelected()

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -8,13 +8,13 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
-#include "../mwmechanics/actorutil.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
 
 #include "../mwmechanics/pickpocket.hpp"
 #include "../mwmechanics/creaturestats.hpp"
+#include "../mwmechanics/actorutil.hpp"
 
 #include "countdialog.hpp"
 #include "inventorywindow.hpp"
@@ -142,8 +142,7 @@ namespace MWGui
             if (mPtr.getClass().isNpc() && !loot)
             {
                 // we are stealing stuff
-                MWWorld::Ptr player = MWMechanics::getPlayer();
-                mModel = new PickpocketItemModel(player, new InventoryItemModel(container),
+                mModel = new PickpocketItemModel(mPtr, new InventoryItemModel(container),
                                                  !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown());
             }
             else
@@ -271,32 +270,8 @@ namespace MWGui
 
     bool ContainerWindow::onTakeItem(const ItemStack &item, int count)
     {
-        MWWorld::Ptr player = MWMechanics::getPlayer();
-        // TODO: move to ItemModels
-        if (dynamic_cast<PickpocketItemModel*>(mModel)
-                && !mPtr.getClass().getCreatureStats(mPtr).getKnockedDown())
-        {
-            MWMechanics::Pickpocket pickpocket(player, mPtr);
-            if (pickpocket.pick(item.mBase, count))
-            {
-                MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                            player, mPtr, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
-                MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
-                mPickpocketDetected = true;
-                return false;
-            }
-            else
-                player.getClass().skillUsageSucceeded(player, ESM::Skill::Sneak, 1);
-        }
-        else
-        {
-            // Looting a dead corpse is considered OK
-            if (mPtr.getClass().isActor() && mPtr.getClass().getCreatureStats(mPtr).isDead())
-                return true;
-            else
-                MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item.mBase, mPtr, count);
-        }
-        return true;
+        // TODO: mPickpocketDetected = true;
+        return mModel->onTakeItem(item.mBase, count);
     }
 
 }

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -52,10 +52,9 @@ namespace MWGui
 
     void ContainerWindow::onItemSelected(int index)
     {
-        if (mDragAndDrop->mIsOnDragAndDrop)
+        if (mDragAndDrop->mIsOnDragAndDrop && mModel)
         {
-            if (mModel && mModel->allowedToInsertItems())
-                dropItem();
+            dropItem();
             return;
         }
 
@@ -105,7 +104,7 @@ namespace MWGui
 
     void ContainerWindow::onBackgroundSelected()
     {
-        if (mDragAndDrop->mIsOnDragAndDrop && mModel && mModel->allowedToInsertItems())
+        if (mDragAndDrop->mIsOnDragAndDrop && mModel)
             dropItem();
     }
 

--- a/apps/openmw/mwgui/container.hpp
+++ b/apps/openmw/mwgui/container.hpp
@@ -44,8 +44,6 @@ namespace MWGui
     private:
         DragAndDrop* mDragAndDrop;
 
-        bool mPickpocketDetected;
-
         MWGui::ItemView* mItemView;
         SortFilterItemModel* mSortModel;
         ItemModel* mModel;

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -2,12 +2,15 @@
 
 #include <algorithm>
 
+#include "../mwmechanics/creaturestats.hpp"
+#include "../mwmechanics/actorutil.hpp"
+
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
 
@@ -181,6 +184,23 @@ void ContainerItemModel::update()
             mItems.push_back(newItem);
         }
     }
+}
+
+bool ContainerItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+{
+    if (mItemSources.empty())
+        return false;
+
+    MWWorld::Ptr target = mItemSources[0];
+
+    // Looting a dead corpse is considered OK
+    if (target.getClass().isActor() && target.getClass().getCreatureStats(target).isDead())
+        return true;
+    
+    MWWorld::Ptr player = MWMechanics::getPlayer();
+    MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, target, count);
+
+    return true;
 }
 
 }

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -186,7 +186,7 @@ void ContainerItemModel::update()
         }
     }
 }
-bool ContainerItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+bool ContainerItemModel::onDropItem(const MWWorld::Ptr &item, int count)
 {
     if (mItemSources.empty())
         return false;
@@ -216,7 +216,7 @@ bool ContainerItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
     return true;
 }
 
-bool ContainerItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+bool ContainerItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
 {
     if (mItemSources.empty())
         return false;

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -19,8 +19,8 @@ namespace MWGui
 
         virtual bool allowedToUseItems() const;
 
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         virtual ItemStack getItem (ModelIndex index);
         virtual ModelIndex getIndex (ItemStack item);

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -26,6 +26,7 @@ namespace MWGui
         virtual void removeItem (const ItemStack& item, size_t count);
 
         virtual void update();
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         std::vector<MWWorld::Ptr> mItemSources;

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -18,6 +18,10 @@ namespace MWGui
         ContainerItemModel (const MWWorld::Ptr& source);
 
         virtual bool allowedToUseItems() const;
+
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
         virtual ItemStack getItem (ModelIndex index);
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
@@ -26,7 +30,6 @@ namespace MWGui
         virtual void removeItem (const ItemStack& item, size_t count);
 
         virtual void update();
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         std::vector<MWWorld::Ptr> mItemSources;

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -119,7 +119,7 @@ void InventoryItemModel::update()
     }
 }
 
-bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
 {
     // Looting a dead corpse is considered OK
     if (mActor.getClass().isActor() && mActor.getClass().getCreatureStats(mActor).isDead())

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -9,6 +9,9 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/inventorystore.hpp"
 
+#include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+
 namespace MWGui
 {
 
@@ -114,6 +117,18 @@ void InventoryItemModel::update()
 
         mItems.push_back(newItem);
     }
+}
+
+bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+{
+    // Looting a dead corpse is considered OK
+    if (mActor.getClass().isActor() && mActor.getClass().getCreatureStats(mActor).isDead())
+        return true;
+    
+    MWWorld::Ptr player = MWMechanics::getPlayer();
+    MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, mActor, count);
+
+    return true;
 }
 
 }

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -124,7 +124,7 @@ bool InventoryItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     // Looting a dead corpse is considered OK
     if (mActor.getClass().isActor() && mActor.getClass().getCreatureStats(mActor).isDead())
         return true;
-    
+
     MWWorld::Ptr player = MWMechanics::getPlayer();
     MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, mActor, count);
 

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -15,6 +15,8 @@ namespace MWGui
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
 
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
 
@@ -22,7 +24,6 @@ namespace MWGui
         virtual MWWorld::Ptr moveItem (const ItemStack& item, size_t count, ItemModel* otherModel);
 
         virtual void update();
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     protected:
         MWWorld::Ptr mActor;

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -22,6 +22,7 @@ namespace MWGui
         virtual MWWorld::Ptr moveItem (const ItemStack& item, size_t count, ItemModel* otherModel);
 
         virtual void update();
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     protected:
         MWWorld::Ptr mActor;

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -15,7 +15,7 @@ namespace MWGui
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
 
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -129,7 +129,12 @@ namespace MWGui
         return true;
     }
 
-    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    {
+        return true;
+    }
+
+    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
         return true;
     }
@@ -203,7 +208,12 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
-    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    bool ProxyItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    {
+        return mSourceModel->onDropItem (item, count);
+    }
+
+    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
         return mSourceModel->onTakeItem (item, count);
     }

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -129,12 +129,12 @@ namespace MWGui
         return true;
     }
 
-    bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
         return true;
     }
 
-    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
     {
         return true;
     }
@@ -208,13 +208,18 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
-    bool ProxyItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    void ProxyItemModel::onClose()
     {
-        return mSourceModel->onDropItem (item, count);
+        mSourceModel->onClose();
     }
 
-    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool ProxyItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
-        return mSourceModel->onTakeItem (item, count);
+        return mSourceModel->onDropItem(item, count);
+    }
+
+    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem(item, count);
     }
 }

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -129,6 +129,11 @@ namespace MWGui
         return true;
     }
 
+    bool ItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return true;
+    }
+
 
     ProxyItemModel::ProxyItemModel()
         : mSourceModel(NULL)
@@ -198,4 +203,8 @@ namespace MWGui
         mSourceModel = sourceModel;
     }
 
+    bool ProxyItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem (item, count);
+    }
 }

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -94,11 +94,6 @@ namespace MWGui
         return true;
     }
 
-    bool ItemModel::allowedToInsertItems() const
-    {
-        return true;
-    }
-
     bool ItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
         return true;

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -9,6 +9,7 @@
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 
 namespace MWGui
 {
@@ -23,38 +24,7 @@ namespace MWGui
         if (base.getClass().getEnchantment(base) != "")
             mFlags |= Flag_Enchanted;
 
-        static std::set<std::string> boundItemIDCache;
-
-        // If this is empty then we haven't executed the GMST cache logic yet; or there isn't any sMagicBound* GMST's for some reason
-        if (boundItemIDCache.empty())
-        {
-            // Build a list of known bound item ID's
-            const MWWorld::Store<ESM::GameSetting> &gameSettings = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
-
-            for (MWWorld::Store<ESM::GameSetting>::iterator currentIteration = gameSettings.begin(); currentIteration != gameSettings.end(); ++currentIteration)
-            {
-                const ESM::GameSetting &currentSetting = *currentIteration;
-                std::string currentGMSTID = currentSetting.mId;
-                Misc::StringUtils::lowerCaseInPlace(currentGMSTID);
-
-                // Don't bother checking this GMST if it's not a sMagicBound* one.
-                const std::string& toFind = "smagicbound";
-                if (currentGMSTID.compare(0, toFind.length(), toFind) != 0)
-                    continue;
-
-                // All sMagicBound* GMST's should be of type string
-                std::string currentGMSTValue = currentSetting.getString();
-                Misc::StringUtils::lowerCaseInPlace(currentGMSTValue);
-
-                boundItemIDCache.insert(currentGMSTValue);
-            }
-        }
-
-        // Perform bound item check and assign the Flag_Bound bit if it passes
-        std::string tempItemID = base.getCellRef().getRefId();
-        Misc::StringUtils::lowerCaseInPlace(tempItemID);
-
-        if (boundItemIDCache.count(tempItemID) != 0)
+        if (MWBase::Environment::get().getMechanicsManager()->isBoundItem(base))
             mFlags |= Flag_Bound;
     }
 

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -75,7 +75,8 @@ namespace MWGui
 
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     private:
         ItemModel(const ItemModel&);
@@ -92,10 +93,12 @@ namespace MWGui
 
         bool allowedToUseItems() const;
 
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual ModelIndex getIndex (ItemStack item);
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         /// @note Takes ownership of the passed pointer.
         void setSourceModel(ItemModel* sourceModel);

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -75,6 +75,7 @@ namespace MWGui
 
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         ItemModel(const ItemModel&);
@@ -94,6 +95,7 @@ namespace MWGui
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual ModelIndex getIndex (ItemStack item);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         /// @note Takes ownership of the passed pointer.
         void setSourceModel(ItemModel* sourceModel);

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -75,8 +75,11 @@ namespace MWGui
 
         /// Is the player allowed to insert items into this model? (default true)
         virtual bool allowedToInsertItems() const;
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual void onClose()
+        {
+        }
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     private:
         ItemModel(const ItemModel&);
@@ -93,8 +96,9 @@ namespace MWGui
 
         bool allowedToUseItems() const;
 
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual void onClose();
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool setNewOwner=false);
         virtual void removeItem (const ItemStack& item, size_t count);

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -72,9 +72,6 @@ namespace MWGui
 
         /// Is the player allowed to use items from this item model? (default true)
         virtual bool allowedToUseItems() const;
-
-        /// Is the player allowed to insert items into this model? (default true)
-        virtual bool allowedToInsertItems() const;
         virtual void onClose()
         {
         }

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -79,12 +79,6 @@ namespace MWGui
         ProxyItemModel::removeItem(item, count);
     }
 
-    bool PickpocketItemModel::allowedToInsertItems() const
-    {
-        // don't allow "reverse pickpocket" (it will be handled by scripts after 1.0)
-        return false;
-    }
-
     bool PickpocketItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
         // don't allow "reverse pickpocket" (it will be handled by scripts after 1.0)

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -7,6 +7,7 @@
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/pickpocket.hpp"
 
+#include "../mwworld/containerstore.hpp"
 #include "../mwworld/class.hpp"
 
 #include "../mwbase/environment.hpp"
@@ -76,7 +77,6 @@ namespace MWGui
     void PickpocketItemModel::removeItem (const ItemStack &item, size_t count)
     {
         ProxyItemModel::removeItem(item, count);
-        /// \todo check if player is detected
     }
 
     bool PickpocketItemModel::allowedToInsertItems() const
@@ -115,7 +115,14 @@ namespace MWGui
         if (mActor.getClass().getCreatureStats(mActor).getKnockedDown())
             return mSourceModel->onTakeItem(item, count);
 
-        return stealItem(item, count);
+        bool success = stealItem(item, count);
+        if (success)
+        {
+            MWWorld::Ptr player = MWMechanics::getPlayer();
+            MWBase::Environment::get().getMechanicsManager()->itemTaken(player, item, mActor, count, false);
+        }
+
+        return success;
     }
 
     bool PickpocketItemModel::stealItem(const MWWorld::Ptr &item, int count)

--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -4,6 +4,7 @@
 #include <components/esm/loadskil.hpp>
 
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/pickpocket.hpp"
 
 #include "../mwworld/class.hpp"
@@ -80,12 +81,21 @@ namespace MWGui
 
     bool PickpocketItemModel::allowedToInsertItems() const
     {
-        // don't allow "reverse pickpocket" (yet)
+        // don't allow "reverse pickpocket" (it will be handled by scripts after 1.0)
+        return false;
+    }
+
+    bool PickpocketItemModel::onDropItem(const MWWorld::Ptr &item, int count)
+    {
+        // don't allow "reverse pickpocket" (it will be handled by scripts after 1.0)
         return false;
     }
 
     bool PickpocketItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
+        if (mActor.getClass().getCreatureStats(mActor).getKnockedDown())
+            return mSourceModel->onTakeItem(item, count);
+
         MWWorld::Ptr player = MWMechanics::getPlayer();
         MWMechanics::Pickpocket pickpocket(player, mActor);
         if (pickpocket.pick(item, count))

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -18,6 +18,7 @@ namespace MWGui
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
         virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
     protected:

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -18,11 +18,14 @@ namespace MWGui
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;
-        virtual bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        virtual void onClose();
+        virtual bool onDropItem(const MWWorld::Ptr &item, int count);
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
     protected:
         MWWorld::Ptr mActor;
+        bool mPickpocketDetected;
+        bool stealItem(const MWWorld::Ptr &item, int count);
 
     private:
         std::vector<ItemStack> mHiddenItems;

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -18,6 +18,10 @@ namespace MWGui
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual bool allowedToInsertItems() const;
+        virtual bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+
+    protected:
+        MWWorld::Ptr mActor;
 
     private:
         std::vector<ItemStack> mHiddenItems;

--- a/apps/openmw/mwgui/pickpocketitemmodel.hpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.hpp
@@ -17,7 +17,6 @@ namespace MWGui
         virtual size_t getItemCount();
         virtual void update();
         virtual void removeItem (const ItemStack& item, size_t count);
-        virtual bool allowedToInsertItems() const;
         virtual void onClose();
         virtual bool onDropItem(const MWWorld::Ptr &item, int count);
         virtual bool onTakeItem(const MWWorld::Ptr &item, int count);

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -311,4 +311,8 @@ namespace MWGui
         std::sort(mItems.begin(), mItems.end(), cmp);
     }
 
+    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem (item, count);
+    }
 }

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -311,7 +311,12 @@ namespace MWGui
         std::sort(mItems.begin(), mItems.end(), cmp);
     }
 
-    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    bool SortFilterItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    {
+        return mSourceModel->onDropItem (item, count);
+    }
+
+    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
     {
         return mSourceModel->onTakeItem (item, count);
     }

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -311,13 +311,18 @@ namespace MWGui
         std::sort(mItems.begin(), mItems.end(), cmp);
     }
 
-    bool SortFilterItemModel::onDropItem(const MWWorld::Ptr &item, int count) const
+    void SortFilterItemModel::onClose()
     {
-        return mSourceModel->onDropItem (item, count);
+        mSourceModel->onClose();
     }
 
-    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count) const
+    bool SortFilterItemModel::onDropItem(const MWWorld::Ptr &item, int count)
     {
-        return mSourceModel->onTakeItem (item, count);
+        return mSourceModel->onDropItem(item, count);
+    }
+
+    bool SortFilterItemModel::onTakeItem(const MWWorld::Ptr &item, int count)
+    {
+        return mSourceModel->onTakeItem(item, count);
     }
 }

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -29,6 +29,8 @@ namespace MWGui
         /// Use ItemStack::Type for sorting?
         void setSortByType(bool sort) { mSortByType = sort; }
 
+        bool onTakeItem(const MWWorld::Ptr &item, int count);
+
         static const int Category_Weapon = (1<<1);
         static const int Category_Apparel = (1<<2);
         static const int Category_Misc = (1<<3);

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -29,7 +29,8 @@ namespace MWGui
         /// Use ItemStack::Type for sorting?
         void setSortByType(bool sort) { mSortByType = sort; }
 
-        bool onTakeItem(const MWWorld::Ptr &item, int count);
+        bool onDropItem(const MWWorld::Ptr &item, int count) const;
+        bool onTakeItem(const MWWorld::Ptr &item, int count) const;
 
         static const int Category_Weapon = (1<<1);
         static const int Category_Apparel = (1<<2);

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -29,8 +29,9 @@ namespace MWGui
         /// Use ItemStack::Type for sorting?
         void setSortByType(bool sort) { mSortByType = sort; }
 
-        bool onDropItem(const MWWorld::Ptr &item, int count) const;
-        bool onTakeItem(const MWWorld::Ptr &item, int count) const;
+        void onClose();
+        bool onDropItem(const MWWorld::Ptr &item, int count);
+        bool onTakeItem(const MWWorld::Ptr &item, int count);
 
         static const int Category_Weapon = (1<<1);
         static const int Category_Apparel = (1<<2);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1024,7 +1024,7 @@ namespace MWMechanics
     }
 
     void MechanicsManager::itemTaken(const MWWorld::Ptr &ptr, const MWWorld::Ptr &item, const MWWorld::Ptr& container,
-                                     int count)
+                                     int count, bool alarm)
     {
         if (ptr != getPlayer())
             return;
@@ -1053,19 +1053,29 @@ namespace MWMechanics
             return;
 
         Owner owner;
-        owner.first = ownerCellRef->getOwner();
         owner.second = false;
-        if (owner.first.empty())
+        if (!container.isEmpty() && container.getClass().isActor())
         {
-            owner.first = ownerCellRef->getFaction();
-            owner.second = true;
+            // "container" is an actor inventory, so just take actor's ID
+            owner.first = ownerCellRef->getRefId();
         }
+        else
+        {
+            owner.first = ownerCellRef->getOwner();
+            if (owner.first.empty())
+            {
+                owner.first = ownerCellRef->getFaction();
+                owner.second = true;
+            }
+        }
+
         Misc::StringUtils::lowerCaseInPlace(owner.first);
 
         if (!Misc::StringUtils::ciEqual(item.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
             mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
 
-        commitCrime(ptr, victim, OT_Theft, item.getClass().getValue(item) * count);
+        if (alarm)
+            commitCrime(ptr, victim, OT_Theft, item.getClass().getValue(item) * count);
     }
 
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -204,6 +204,8 @@ namespace MWMechanics
             /// Has the player stolen this item from the given owner?
             virtual bool isItemStolenFrom(const std::string& itemid, const std::string& ownerid);
 
+            virtual bool isBoundItem(const MWWorld::Ptr& item);
+
             /// @return is \a ptr allowed to take/use \a target or is it a crime?
             virtual bool isAllowedToUse (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target, MWWorld::Ptr& victim);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -135,7 +135,7 @@ namespace MWMechanics
             /// Utility to check if taking this item is illegal and calling commitCrime if so
             /// @param container The container the item is in; may be empty for an item in the world
             virtual void itemTaken (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item, const MWWorld::Ptr& container,
-                                    int count);
+                                    int count, bool alarm = true);
             /// Utility to check if opening (i.e. unlocking) this object is illegal and calling commitCrime if so
             virtual void objectOpened (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item);
             /// Attempt sleeping in a bed. If this is illegal, call commitCrime.


### PR DESCRIPTION
Splits refactoring code from #1491 from the reverse pickpocketing related stuff.

1) Moves model-specific stuff from container.cpp to item models:
1.1 Pickpocketing mechanics
1.2 Put items to containers conditions

2) Moves the bound items check to the mechanics manager

3) Changes an item owner and stolen items counter when the player steals the item via pickpocketing.

Item models now have three additional methods where you can put a custom mechanics:
1. onClose() - when closing the window
2. onDropItem() - when the player puts an item to the item model
3. onTakeItem() - when the player takes an item from the item model

An additional testing would be helpful, especially with the "owned crosshair" and "tfh".