### PR TITLE
Change abs to std::abs

### DIFF
--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -55,7 +55,7 @@ bool AiPursue::execute (const MWWorld::Ptr& actor, CharacterController& characte
     float pathTolerance = 100.0;
 
     if (pathTo(actor, dest, duration, pathTolerance) &&
-        abs(dest.mZ - aPos.pos[2]) < pathTolerance)      // check the true distance in case the target is far away in Z-direction
+        std::abs(dest.mZ - aPos.pos[2]) < pathTolerance)      // check the true distance in case the target is far away in Z-direction
     {
         target.getClass().activate(target,actor).get()->execute(actor); //Arrest player when reached
         return true;


### PR DESCRIPTION
I'm not sure that it is matter but clang prints the following warning
```
apps/openmw/mwmechanics/aipursue.cpp:58:9: warning: using integer absolute value function 'abs' when argument is of floating point type
      [-Wabsolute-value]
        abs(dest.mZ - aPos.pos[2]) < pathTolerance)      // check the true distance in case the target is far away in Z-direction
        ^
/home/greg/Morrowind/openmw/apps/openmw/mwmechanics/aipursue.cpp:58:9: note: use function 'std::abs' instead
        abs(dest.mZ - aPos.pos[2]) < pathTolerance)      // check the true distance in case the target is far away in Z-direction
        ^~~
        std::abs
```
PR opened according to https://stackoverflow.com/questions/21392627/abs-vs-stdabs-what-does-the-reference-say 