### PR TITLE
Add projectile - projectile collision (Issue #4201) [incomplete]

### DIFF
--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -295,6 +295,24 @@ namespace MWWorld
         osg::Vec4 lightDiffuseColor = getMagicBoltLightDiffuseColor(state.mEffects);
         createModel(state, ptr.getClass().getModel(ptr), pos, orient, true, true, lightDiffuseColor, texture);
 
+        // Get the first effect of the spell
+        const ESM::MagicEffect *magicEffect =
+            MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
+                state.mEffects.mList.at(0).mEffectID);
+
+        const ESM::Weapon* projectile;
+        std::string mesh;
+
+        if (!magicEffect->mBolt.empty())
+        {
+            projectile = MWBase::Environment::get().getWorld()->getStore().get<ESM::Weapon>().find(magicEffect->mBolt);
+            mesh = "meshes\\" + projectile->mModel;
+        }
+        else
+        {
+            mesh = "meshes\\w\\magic_target.nif";
+        }
+
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
         for (size_t it = 0; it != state.mSoundIds.size(); it++)
         {


### PR DESCRIPTION
The idea is to add projectile object to the physics system whenever someone fires a projectile/casts a spell, but spell projectile meshes don't have collision boxes. I can't figure out how to use bounding box instead of normal collision mesh.