### PR TITLE
[Feedback needed] Handle 128px Tx_menubook_topics textures

### DIFF
--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -203,8 +203,19 @@ namespace
             int cancelLeft = getWidget<MyGUI::Widget>(CancelBTN)->getPosition().left;
             int cancelRight = getWidget<MyGUI::Widget>(CancelBTN)->getPosition().left + getWidget<MyGUI::Widget>(CancelBTN)->getSize().width;
 
-            getWidget<MyGUI::Widget>(TopicsBTN)->setPosition(cancelLeft - topicsWidth, getWidget<MyGUI::Widget>(TopicsBTN)->getPosition().top);
             getWidget<MyGUI::Widget>(QuestsBTN)->setPosition(cancelRight, getWidget<MyGUI::Widget>(QuestsBTN)->getPosition().top);
+
+            // Usually Topics, Quests, and Cancel buttons have the 64px width, so we can place the Topics left-up from the Cancel button, and the Quests right-up from the Cancel button.
+            // But in some installations, e.g. German one, the Topics button has the 128px width, so we should place it exactly left from the Quests button.
+            if (getWidget<MyGUI::Widget>(TopicsBTN)->getSize().width == 64)
+            {
+                getWidget<MyGUI::Widget>(TopicsBTN)->setPosition(cancelLeft - topicsWidth, getWidget<MyGUI::Widget>(TopicsBTN)->getPosition().top);
+            }
+            else
+            {
+                int questLeft = getWidget<MyGUI::Widget>(QuestsBTN)->getPosition().left;
+                getWidget<MyGUI::Widget>(TopicsBTN)->setPosition(questLeft - topicsWidth, getWidget<MyGUI::Widget>(TopicsBTN)->getPosition().top);
+            }
 
             mQuestMode = false;
             mAllQuests = false;


### PR DESCRIPTION
Related to [bug #4215](https://bugs.openmw.org/issues/4215).

Looks like Morrowind uses absolute coordinates for journal buttons. Should we do the same?

