### PR TITLE
Display 0 chance for spell if player does not have enought magic energy

### DIFF
--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -60,7 +60,7 @@ namespace MWGui
             {
                 newSpell.mType = Spell::Type_Spell;
                 std::string cost = std::to_string(spell->mData.mCost);
-                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor)));
+                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor, NULL, true, true)));
                 newSpell.mCostColumn = cost + "/" + chance;
             }
             else

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -60,7 +60,7 @@ namespace MWGui
             {
                 newSpell.mType = Spell::Type_Spell;
                 std::string cost = std::to_string(spell->mData.mCost);
-                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor)));
+                std::string chance = std::to_string((stats.getMagicka().getCurrent() >= spell->mData.mCost) ? int(MWMechanics::getSpellSuccessChance(spell, mActor)) : 0);
                 newSpell.mCostColumn = cost + "/" + chance;
             }
             else

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -8,6 +8,7 @@
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/spellcasting.hpp"
+#include "../mwmechanics/actorutil.hpp"
 
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/inventorystore.hpp"
@@ -60,7 +61,11 @@ namespace MWGui
             {
                 newSpell.mType = Spell::Type_Spell;
                 std::string cost = std::to_string(spell->mData.mCost);
-                std::string chance = std::to_string((stats.getMagicka().getCurrent() >= spell->mData.mCost) ? int(MWMechanics::getSpellSuccessChance(spell, mActor)) : 0);
+                std::string chance = std::to_string(
+                    (stats.getMagicka().getCurrent() >= spell->mData.mCost ||
+                    (mActor == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState())
+                    ) ? int(MWMechanics::getSpellSuccessChance(spell, mActor)) : 0
+                );
                 newSpell.mCostColumn = cost + "/" + chance;
             }
             else

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -8,7 +8,6 @@
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/spellcasting.hpp"
-#include "../mwmechanics/actorutil.hpp"
 
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/inventorystore.hpp"
@@ -61,11 +60,7 @@ namespace MWGui
             {
                 newSpell.mType = Spell::Type_Spell;
                 std::string cost = std::to_string(spell->mData.mCost);
-                std::string chance = std::to_string(
-                    (stats.getMagicka().getCurrent() >= spell->mData.mCost ||
-                    (mActor == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState())
-                    ) ? int(MWMechanics::getSpellSuccessChance(spell, mActor)) : 0
-                );
+                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor)));
                 newSpell.mCostColumn = cost + "/" + chance;
             }
             else

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -126,7 +126,10 @@ namespace MWMechanics
         float castChance = calcSpellBaseSuccessChance(spell, actor, effectiveSchool) + castBonus;
         castChance *= stats.getFatigueTerm();
 
-        if (stats.getMagicEffects().get(ESM::MagicEffect::Silence).getMagnitude()&& !godmode)
+        if (godmode)
+            return 100;
+
+        if (stats.getMagicEffects().get(ESM::MagicEffect::Silence).getMagnitude())
             return 0;
 
         if (spell->mData.mType == ESM::Spell::ST_Power)
@@ -135,13 +138,11 @@ namespace MWMechanics
         if (spell->mData.mType != ESM::Spell::ST_Spell)
             return 100;
 
+        if (stats.getMagicka().getCurrent() < spell->mData.mCost)
+            return 0;
+
         if (spell->mData.mFlags & ESM::Spell::F_Always)
             return 100;
-
-        if (godmode)
-        {
-            return 100;
-        }
 
         if (!cap)
             return std::max(0.f, castChance);
@@ -888,6 +889,11 @@ namespace MWMechanics
                             MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicSkillFail}");
                         fail = true;
                     }
+
+                    // Reduce mana
+                    MWMechanics::DynamicStat<float> magicka = stats.getMagicka();
+                    magicka.setCurrent(magicka.getCurrent() - spell->mData.mCost);
+                    stats.setMagicka(magicka);
                 }
 
                 if (fail)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -115,7 +115,7 @@ namespace MWMechanics
         return castChance;
     }
 
-    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool, bool cap)
+    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool, bool cap, bool checkMagicka)
     {
         bool godmode = actor == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState();
 
@@ -135,7 +135,7 @@ namespace MWMechanics
         if (spell->mData.mType != ESM::Spell::ST_Spell)
             return 100;
 
-        if (stats.getMagicka().getCurrent() < spell->mData.mCost && !godmode)
+        if (checkMagicka && stats.getMagicka().getCurrent() < spell->mData.mCost && !godmode)
             return 0;
 
         if (spell->mData.mFlags & ESM::Spell::F_Always)
@@ -152,11 +152,11 @@ namespace MWMechanics
             return std::max(0.f, std::min(100.f, castChance));
     }
 
-    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool, bool cap)
+    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool, bool cap, bool checkMagicka)
     {
         const ESM::Spell* spell =
             MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(spellId);
-        return getSpellSuccessChance(spell, actor, effectiveSchool, cap);
+        return getSpellSuccessChance(spell, actor, effectiveSchool, cap, checkMagicka);
     }
 
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -889,11 +889,6 @@ namespace MWMechanics
                             MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicSkillFail}");
                         fail = true;
                     }
-
-                    // Reduce mana
-                    MWMechanics::DynamicStat<float> magicka = stats.getMagicka();
-                    magicka.setCurrent(magicka.getCurrent() - spell->mData.mCost);
-                    stats.setMagicka(magicka);
                 }
 
                 if (fail)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -126,10 +126,7 @@ namespace MWMechanics
         float castChance = calcSpellBaseSuccessChance(spell, actor, effectiveSchool) + castBonus;
         castChance *= stats.getFatigueTerm();
 
-        if (godmode)
-            return 100;
-
-        if (stats.getMagicEffects().get(ESM::MagicEffect::Silence).getMagnitude())
+        if (stats.getMagicEffects().get(ESM::MagicEffect::Silence).getMagnitude()&& !godmode)
             return 0;
 
         if (spell->mData.mType == ESM::Spell::ST_Power)
@@ -138,11 +135,16 @@ namespace MWMechanics
         if (spell->mData.mType != ESM::Spell::ST_Spell)
             return 100;
 
-        if (stats.getMagicka().getCurrent() < spell->mData.mCost)
+        if (stats.getMagicka().getCurrent() < spell->mData.mCost && !godmode)
             return 0;
 
         if (spell->mData.mFlags & ESM::Spell::F_Always)
             return 100;
+
+        if (godmode)
+        {
+            return 100;
+        }
 
         if (!cap)
             return std::max(0.f, castChance);

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -31,11 +31,12 @@ namespace MWMechanics
      * @param actor calculate spell success chance for this actor (depends on actor's skills)
      * @param effectiveSchool the spell's effective school (relevant for skill progress) will be written here
      * @param cap cap the result to 100%?
+     * @param checkMagicka check magicka?
      * @note actor can be an NPC or a creature
      * @return success chance from 0 to 100 (in percent), if cap=false then chance above 100 may be returned.
      */
-    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool = NULL, bool cap=true);
-    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool = NULL, bool cap=true);
+    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool = NULL, bool cap=true, bool checkMagicka=false);
+    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool = NULL, bool cap=true, bool checkMagicka=false);
 
     int getSpellSchool(const std::string& spellId, const MWWorld::Ptr& actor);
     int getSpellSchool(const ESM::Spell* spell, const MWWorld::Ptr& actor);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2718,13 +2718,6 @@ namespace MWWorld
                 message = "#{sPowerAlreadyUsed}";
                 fail = true;
             }
-
-            // Reduce mana
-            if (!fail && !godmode)
-            {
-                magicka.setCurrent(magicka.getCurrent() - spell->mData.mCost);
-                stats.setMagicka(magicka);
-            }
         }
 
         if (isPlayer && fail)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2718,6 +2718,13 @@ namespace MWWorld
                 message = "#{sPowerAlreadyUsed}";
                 fail = true;
             }
+
+            // Reduce mana
+            if (!fail && !godmode)
+            {
+                magicka.setCurrent(magicka.getCurrent() - spell->mData.mCost);
+                stats.setMagicka(magicka);
+            }
         }
 
         if (isPlayer && fail)


### PR DESCRIPTION
Issue in bugtracker: https://bugs.openmw.org/issues/4223

In vanilla spell chance is displayed as zero if player hasn't enought magic points for spell. In OpenMW displayed chance doesn't depend on magic points.