### PR TITLE
openmw-cs esm load speed up

### DIFF
--- a/apps/opencs/model/world/data.hpp
+++ b/apps/opencs/model/world/data.hpp
@@ -2,6 +2,7 @@
 #define CSM_WOLRD_DATA_H
 
 #include <map>
+#include <unordered_map>
 #include <vector>
 
 #include <boost/filesystem/path.hpp>
@@ -117,7 +118,7 @@ namespace CSMWorld
             const ESM::Dialogue *mDialogue; // last loaded dialogue
             bool mBase;
             bool mProject;
-            std::map<std::string, std::map<ESM::RefNum, std::string> > mRefLoadCache;
+            std::map<std::string, std::unordered_map<unsigned, std::string> > mRefLoadCache;
             int mReaderIndex;
 
             bool mFsStrict;

--- a/apps/opencs/model/world/refcollection.cpp
+++ b/apps/opencs/model/world/refcollection.cpp
@@ -12,7 +12,7 @@
 #include "record.hpp"
 
 void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool base,
-    std::map<ESM::RefNum, std::string>& cache, CSMDoc::Messages& messages)
+    std::unordered_map<unsigned, std::string>& cache, CSMDoc::Messages& messages)
 {
     Record<Cell> cell = mCells.getRecord (cellIndex);
 
@@ -73,12 +73,8 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
             ref.mCell = cell2.mId;
 
         // ignore content file number
-        std::map<ESM::RefNum, std::string>::iterator iter = cache.begin();
-        for (; iter != cache.end(); ++iter)
-        {
-            if (ref.mRefNum.mIndex == iter->first.mIndex)
-                break;
-        }
+        std::unordered_map<unsigned, std::string>::iterator iter;
+        iter = cache.find(ref.mRefNum.mIndex);
 
         if (isDeleted)
         {
@@ -120,7 +116,7 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
 
             appendRecord (record);
 
-            cache.insert (std::make_pair (ref.mRefNum, ref.mId));
+            cache.insert (std::make_pair (ref.mRefNum.mIndex, ref.mId));
         }
         else
         {
@@ -140,7 +136,5 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
 
 std::string CSMWorld::RefCollection::getNewId()
 {
-    std::ostringstream stream;
-    stream << "ref#" << mNextId++;
-    return stream.str();
+    return "ref#" + mNextId++;
 }

--- a/apps/opencs/model/world/refcollection.hpp
+++ b/apps/opencs/model/world/refcollection.hpp
@@ -1,7 +1,7 @@
 #ifndef CSM_WOLRD_REFCOLLECTION_H
 #define CSM_WOLRD_REFCOLLECTION_H
 
-#include <map>
+#include <unordered_map>
 
 #include "../doc/stage.hpp"
 
@@ -27,7 +27,7 @@ namespace CSMWorld
             {}
 
             void load (ESM::ESMReader& reader, int cellIndex, bool base,
-                std::map<ESM::RefNum, std::string>& cache, CSMDoc::Messages& messages);
+                std::unordered_map<unsigned, std::string>& cache, CSMDoc::Messages& messages);
             ///< Load a sequence of references.
 
             std::string getNewId();

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -103,8 +103,12 @@ public:
     /// Returns lower case copy of input string
     static std::string lowerCase(const std::string &in)
     {
-        std::string out = in;
-        lowerCaseInPlace(out);
+        std::string out;
+        out.reserve(in.size());
+
+        for (unsigned int i=0; i<in.size(); ++i)
+            out[i] = toLower(in[i]);
+
         return out;
     }
 


### PR DESCRIPTION
Hello.
I was irritated by speed of esm/esp's loading in openmw-cs on my laptop. It tooks about 2-3 minutes to load 3 main esms and 40k records mod  (in debug mode). So, I took a callgrind and did some profiling. With this small fixes, editor load has speeded up to 10 seconds. So, I thought, it may worth to include this changes in the upstream.