### PR TITLE
[Testing needed] AiWander: do not allow flying/swimming creatures to use pathgrid

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -111,7 +111,7 @@ namespace MWMechanics
             /// If a shortcut is possible then path will be cleared and filled with the destination point.
             /// \param destInLOS If not NULL function will return ray cast check result
             /// \return If can shortcut the path
-            bool shortcutPath(const ESM::Pathgrid::Point& startPoint, const ESM::Pathgrid::Point& endPoint, const MWWorld::Ptr& actor, bool *destInLOS);
+            bool shortcutPath(const ESM::Pathgrid::Point& startPoint, const ESM::Pathgrid::Point& endPoint, const MWWorld::Ptr& actor, bool *destInLOS, bool isPathClear);
 
             /// Check if the way to the destination is clear, taking into account actor speed
             bool checkWayIsClearForActor(const ESM::Pathgrid::Point& startPoint, const ESM::Pathgrid::Point& endPoint, const MWWorld::Ptr& actor);


### PR DESCRIPTION
Should fix [bug #3587](https://bugs.openmw.org/issues/3587).
How it works now:
1. AiWander now do not use pathgrid if an actor can move along z-axis 
2. The actor is wandering near start position instead, and using the shortcutting, if the LOS is clear.
3. A pause between movement is a bit lesser for such creatures

As for me, the "Where are all birds going" mod works much better now.


