### PR TITLE
Update music state in the menu mode (bug #3664)

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1148,6 +1148,46 @@ namespace MWMechanics
         }
     }
 
+    void Actors::updateCombatMusic ()
+    {
+        MWWorld::Ptr player = getPlayer();
+        int hostilesCount = 0; // need to know this to play Battle music
+
+        for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
+        {
+            if (!iter->first.getClass().getCreatureStats(iter->first).isDead())
+            {
+                bool inProcessingRange = (player.getRefData().getPosition().asVec3() - iter->first.getRefData().getPosition().asVec3()).length2()
+                        <= sqrAiProcessingDistance;
+
+                if (MWBase::Environment::get().getMechanicsManager()->isAIActive() && inProcessingRange)
+                {
+                    if (iter->first != player)
+                    {
+                        MWMechanics::CreatureStats& stats = iter->first.getClass().getCreatureStats(iter->first);
+                        if (stats.getAiSequence().isInCombat() && !stats.isDead()) hostilesCount++;
+                    }
+                }
+            }
+        }
+
+        // check if we still have any player enemies to switch music
+        static int currentMusic = 0;
+
+        if (currentMusic != 1 && hostilesCount == 0 && !(player.getClass().getCreatureStats(player).isDead() &&
+        MWBase::Environment::get().getSoundManager()->isMusicPlaying()))
+        {
+            MWBase::Environment::get().getSoundManager()->playPlaylist(std::string("Explore"));
+            currentMusic = 1;
+        }
+        else if (currentMusic != 2 && hostilesCount > 0)
+        {
+            MWBase::Environment::get().getSoundManager()->playPlaylist(std::string("Battle"));
+            currentMusic = 2;
+        }
+
+    }
+
     void Actors::update (float duration, bool paused)
     {
         if(!paused)
@@ -1164,8 +1204,6 @@ namespace MWMechanics
             if (timerUpdateEquippedLight >= updateEquippedLightInterval) timerUpdateEquippedLight = 0;
 
             MWWorld::Ptr player = getPlayer();
-
-            int hostilesCount = 0; // need to know this to play Battle music
 
             /// \todo move update logic to Actor class where appropriate
 
@@ -1257,8 +1295,6 @@ namespace MWMechanics
                             CreatureStats &stats = iter->first.getClass().getCreatureStats(iter->first);
                             if (isConscious(iter->first))
                                 stats.getAiSequence().execute(iter->first, *iter->second->getCharacterController(), iter->second->getAiState(), duration);
-
-                            if (stats.getAiSequence().isInCombat() && !stats.isDead()) hostilesCount++;
                         }
                     }
 
@@ -1331,21 +1367,6 @@ namespace MWMechanics
 
             killDeadActors();
 
-            // check if we still have any player enemies to switch music
-            static int currentMusic = 0;
-
-            if (currentMusic != 1 && hostilesCount == 0 && !(player.getClass().getCreatureStats(player).isDead() &&
-            MWBase::Environment::get().getSoundManager()->isMusicPlaying()))
-            {
-                MWBase::Environment::get().getSoundManager()->playPlaylist(std::string("Explore"));
-                currentMusic = 1;
-            }
-            else if (currentMusic != 2 && hostilesCount > 0)
-            {
-                MWBase::Environment::get().getSoundManager()->playPlaylist(std::string("Battle"));
-                currentMusic = 2;
-            }
-
             static float sneakTimer = 0.f; // times update of sneak icon
 
             // if player is in sneak state see if anyone detects him
@@ -1412,6 +1433,8 @@ namespace MWMechanics
                 MWBase::Environment::get().getWindowManager()->setSneakVisibility(false);
             }
         }
+
+        updateCombatMusic();
     }
 
     void Actors::killDeadActors()

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -81,6 +81,9 @@ namespace MWMechanics
             void dropActors (const MWWorld::CellStore *cellStore, const MWWorld::Ptr& ignore);
             ///< Deregister all actors (except for \a ignore) in the given cell.
 
+            void updateCombatMusic();
+            ///< Update combat music state
+
             void update (float duration, bool paused);
             ///< Update actor stats and store desired velocity vectors in \a movement
 


### PR DESCRIPTION
Fixes [bug #3664](https://bugs.openmw.org/issues/3664).

Just moves the combat music update into separate function and run it in the menu mode too.

If we do not touch the pause mode due to performance loss, we can add a manual update to the MechanicsManager and call it in every place where we need it (e.g. in the starcombat/stopcombat functions). A bit mess, as for me.