### PR TITLE
Fix for crash on quickload from the container menu (bug #4239)

### DIFF
--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -154,7 +154,8 @@ namespace MWGui
     {
         WindowBase::onClose();
 
-        mModel->onClose();
+        if (mModel)
+            mModel->onClose();
     }
 
     void ContainerWindow::onCloseButtonClicked(MyGUI::Widget* _sender)


### PR DESCRIPTION
Looks like we do not have the mModel on reload.