### PR TITLE
Journal index fixes

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -146,7 +146,6 @@ namespace MWDialogue
                         // TODO play sound
                     }
 
-
                     MWScript::InterpreterContext interpreterContext(&mActor.getRefData().getLocals(),mActor);
                     callback->addResponse("", Interpreter::fixDefinesDialog(info->mResponse, interpreterContext));
                     executeScript (info->mResultScript, mActor);
@@ -387,7 +386,7 @@ namespace MWDialogue
         {
             Filter filter (mActor, mChoice, mTalkedTo);
 
-            if (dialogue->mType == ESM::Dialogue::Topic || dialogue->mType  == ESM::Dialogue::Greeting)
+            if (dialogue->mType == ESM::Dialogue::Topic || dialogue->mType == ESM::Dialogue::Greeting)
             {
                 if (const ESM::DialInfo *info = filter.search (*dialogue, true))
                 {
@@ -401,15 +400,18 @@ namespace MWDialogue
                     MWScript::InterpreterContext interpreterContext(&mActor.getRefData().getLocals(),mActor);
                     callback->addResponse("", Interpreter::fixDefinesDialog(text, interpreterContext));
 
-                    // Make sure the returned DialInfo is from the Dialogue we supplied. If could also be from the Info refusal group,
-                    // in which case it should not be added to the journal.
-                    for (ESM::Dialogue::InfoContainer::const_iterator iter = dialogue->mInfo.begin();
-                        iter!=dialogue->mInfo.end(); ++iter)
+                    if (dialogue->mType == ESM::Dialogue::Topic)
                     {
-                        if (iter->mId == info->mId)
+                        // Make sure the returned DialInfo is from the Dialogue we supplied. If could also be from the Info refusal group,
+                        // in which case it should not be added to the journal
+                        for (ESM::Dialogue::InfoContainer::const_iterator iter = dialogue->mInfo.begin();
+                            iter!=dialogue->mInfo.end(); ++iter)
                         {
-                            MWBase::Environment::get().getJournal()->addTopic (Misc::StringUtils::lowerCase(mLastTopic), info->mId, mActor);
-                            break;
+                            if (iter->mId == info->mId)
+                            {
+                                MWBase::Environment::get().getJournal()->addTopic (Misc::StringUtils::lowerCase(mLastTopic), info->mId, mActor);
+                                break;
+                            }
                         }
                     }
 

--- a/apps/openmw/mwgui/journalbooks.cpp
+++ b/apps/openmw/mwgui/journalbooks.cpp
@@ -281,6 +281,8 @@ BookTypesetter::Ptr JournalBooks::createCyrillicJournalIndex ()
                                                                    textColours.journalTopicOver,
                                                                    textColours.journalTopicPressed, first);
 
+        ch[1]++;
+
         // Words can not be started with these characters
         if (i == 26 || i == 28)
             continue;
@@ -290,8 +292,6 @@ BookTypesetter::Ptr JournalBooks::createCyrillicJournalIndex ()
 
         typesetter->write (style, to_utf8_span (buffer));
         typesetter->lineBreak ();
-
-        ch[1]++;
     }
 
     return typesetter;


### PR DESCRIPTION
1. Fixes [bug #4242](https://bugs.openmw.org/issues/4242). Now we add only dialogue responses to the journal index.
2. A small fix for cyrillic journal index - it supposed to do not display cyrillic hard/soft signs, but I broke this feature after refactoring. Sorry, I was blind.

