### PR TITLE
Forbid traders to sell ingredients from owned organic containers

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2446,6 +2446,11 @@ namespace MWWorld
             if (ptr.getRefData().isDeleted())
                 return true;
 
+            // we should not sell ingrediends from owned organic containers
+            MWWorld::LiveCellRef<ESM::Container>* ref = ptr.get<ESM::Container>();
+            if (ref && (ref->mBase->mFlags & ESM::Container::Organic))
+                return true;
+
             if (Misc::StringUtils::ciEqual(ptr.getCellRef().getOwner(), mOwner.getCellRef().getRefId()))
                 mOut.push_back(ptr);
 


### PR DESCRIPTION
[bug #4245](https://bugs.openmw.org/issues/4245).

From my testing, in vanilla game traders do not sell items from organic containers (e.g. plants).
In OpenMW traders sell items from every owned container.

It is easy to reproduce this bug with Desele in Suran: in vanilla game she sells only moon sugar, but in OpenMW she sells also corkbulb roots from plants on the second floor.

Feel free to close this PR if this behaviour is intended.