### PR TITLE
[Feedback needed] Do not change z-coordinate of the camera during rotation (1stPerson)

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1280,6 +1280,8 @@ namespace MWMechanics
                                 {
                                     if (it->first == iter->first)
                                         continue;
+                                    if (iter->first == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())
+                                        continue;
                                     updateHeadTracking(iter->first, it->first, headTrackTarget, sqrHeadTrackDistance);
                                 }
                             }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1276,14 +1276,13 @@ namespace MWMechanics
                                 !stats.getAiSequence().isInCombat() &&
                                 !stats.getAiSequence().hasPackage(AiPackage::TypeIdPursue))
                             {
-                                for(PtrActorMap::iterator it(mActors.begin()); it != mActors.end(); ++it)
-                                {
-                                    if (it->first == iter->first)
-                                        continue;
-                                    if (iter->first == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())
-                                        continue;
-                                    updateHeadTracking(iter->first, it->first, headTrackTarget, sqrHeadTrackDistance);
-                                }
+                                if (!(iter->first == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson()))
+                                    for(PtrActorMap::iterator it(mActors.begin()); it != mActors.end(); ++it)
+                                    {
+                                        if (it->first == iter->first)
+                                            continue;
+                                        updateHeadTracking(iter->first, it->first, headTrackTarget, sqrHeadTrackDistance);
+                                    }
                             }
 
                             iter->second->getCharacterController()->setHeadTrackTarget(headTrackTarget);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2421,10 +2421,6 @@ void CharacterController::updateHeadTracking(float duration)
     if (!head)
         return;
 
-    // Disable head tracking for player in First person mode
-    if (mPtr == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())
-        return;
-
     float zAngleRadians = 0.f;
     float xAngleRadians = 0.f;
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2421,6 +2421,10 @@ void CharacterController::updateHeadTracking(float duration)
     if (!head)
         return;
 
+    // Disable head tracking for player in First person mode
+    if (mPtr == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())
+        return;
+
     float zAngleRadians = 0.f;
     float xAngleRadians = 0.f;
 

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -3,6 +3,7 @@
 #include <osg/Camera>
 
 #include <components/sceneutil/positionattitudetransform.hpp>
+#include <components/esm/loadcell.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
@@ -101,6 +102,8 @@ namespace MWRender
             position.z() += mHeight * mHeightScale;
         else
         {
+            if (!mTrackingPtr.getCell()->getCell()->hasWater())
+                return position;
             const osg::Node* baseNode = mAnimation->getNode("Right Foot");
             if (!baseNode || baseNode->getParentalNodePaths().empty())
                 return position;

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -98,10 +98,13 @@ namespace MWRender
         osg::Vec3d position = worldMat.getTrans();
         if (!isFirstPerson())
             position.z() += mHeight * mHeightScale;
-        else {
-            if (mTrackingPtr.getRefData().getBaseNode() && !mTrackingPtr.getRefData().getBaseNode()->getParentalNodePaths().empty()){
-                osg::Vec3d position_base = osg::computeLocalToWorld(mTrackingPtr.getRefData().getBaseNode()->getParentalNodePaths()[0]).getTrans();
-                position.z() = mHeight * mHeightScale + position_base.z();
+        else
+        {
+            const osg::Node* baseNode = mTrackingPtr.getRefData().getBaseNode();
+            if (baseNode && !baseNode->getParentalNodePaths().empty())
+            {
+                const osg::Vec3d positionBase = osg::computeLocalToWorld(baseNode->getParentalNodePaths()[0]).getTrans();
+                position.z() = mHeight * mHeightScale + positionBase.z();
             }
         }
         return position;

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -9,6 +9,7 @@
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/refdata.hpp"
+#include "../mwworld/cellstore.hpp"
 
 #include "npcanimation.hpp"
 
@@ -100,12 +101,15 @@ namespace MWRender
             position.z() += mHeight * mHeightScale;
         else
         {
-            const osg::Node* baseNode = mTrackingPtr.getRefData().getBaseNode();
-            if (baseNode && !baseNode->getParentalNodePaths().empty())
-            {
-                const osg::Vec3d positionBase = osg::computeLocalToWorld(baseNode->getParentalNodePaths()[0]).getTrans();
-                position.z() = mHeight * mHeightScale + positionBase.z();
-            }
+            const osg::Node* baseNode = mAnimation->getNode("Right Foot");
+            if (!baseNode || baseNode->getParentalNodePaths().empty())
+                return position;
+            const double waterlevel = mTrackingPtr.getCell()->getWaterLevel();
+            const osg::Vec3d positionBase = osg::computeLocalToWorld(baseNode->getParentalNodePaths()[0]).getTrans();
+            if (positionBase.z() < waterlevel &&
+                positionBase.z() + mHeight * mHeightScale > waterlevel &&
+                position.z() < waterlevel)
+                position.z() = waterlevel + 0.5;
         }
         return position;
     }

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -104,13 +104,14 @@ namespace MWRender
         {
             if (!mTrackingPtr.getCell()->getCell()->hasWater())
                 return position;
-            const osg::Node* baseNode = mAnimation->getNode("Right Foot");
+            const SceneUtil::PositionAttitudeTransform* baseNode = mTrackingPtr.getRefData().getBaseNode();
             if (!baseNode || baseNode->getParentalNodePaths().empty())
                 return position;
-            const double waterlevel = mTrackingPtr.getCell()->getWaterLevel();
+            const float waterlevel = mTrackingPtr.getCell()->getWaterLevel();
+            const float scale = baseNode->getScale().z();
             const osg::Vec3d positionBase = osg::computeLocalToWorld(baseNode->getParentalNodePaths()[0]).getTrans();
             if (positionBase.z() < waterlevel &&
-                positionBase.z() + mHeight * mHeightScale > waterlevel &&
+                positionBase.z() + mHeight * scale > waterlevel &&
                 position.z() < waterlevel)
                 position.z() = waterlevel + 0.5;
         }

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -98,6 +98,12 @@ namespace MWRender
         osg::Vec3d position = worldMat.getTrans();
         if (!isFirstPerson())
             position.z() += mHeight * mHeightScale;
+        else {
+            if (mTrackingPtr.getRefData().getBaseNode() && !mTrackingPtr.getRefData().getBaseNode()->getParentalNodePaths().empty()){
+                osg::Vec3d position_base = osg::computeLocalToWorld(mTrackingPtr.getRefData().getBaseNode()->getParentalNodePaths()[0]).getTrans();
+                position.z() = mHeight * mHeightScale + position_base.z();
+            }
+        }
         return position;
     }
 

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -102,6 +102,8 @@ namespace MWRender
             position.z() += mHeight * mHeightScale;
         else
         {
+            if (mTrackingPtr.getCell()->getState() != MWWorld::CellStore::State_Loaded)
+                return position;
             if (!mTrackingPtr.getCell()->getCell()->hasWater())
                 return position;
             const SceneUtil::PositionAttitudeTransform* baseNode = mTrackingPtr.getRefData().getBaseNode();


### PR DESCRIPTION
An effort to fix bug #4241 (https://bugs.openmw.org/issues/4241)

position.z() in 1st person mode is set to z-coordinate of mTrackingPtr.getRefData().getBaseNode() instead of mTrackingNode.
position.x() and position.y() are taken from mTrackingNode as before.

z-coordinate of the camera seems to be close to z of eyes.
