### PR TITLE
Stop guards trying to arrest player when calm

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1009,7 +1009,8 @@ namespace MWMechanics
             if (player.getClass().getNpcStats(player).isWerewolf())
                 return;
 
-            if (ptr.getClass().isClass(ptr, "Guard") && creatureStats.getAiSequence().getTypeId() != AiPackage::TypeIdPursue && !creatureStats.getAiSequence().isInCombat())
+            if (ptr.getClass().isClass(ptr, "Guard") && creatureStats.getAiSequence().getTypeId() != AiPackage::TypeIdPursue && !creatureStats.getAiSequence().isInCombat()
+                && creatureStats.getMagicEffects().get(ESM::MagicEffect::CalmHumanoid).getMagnitude() == 0)
             {
                 const MWWorld::ESMStore& esmStore = MWBase::Environment::get().getWorld()->getStore();
                 static const int cutoff = esmStore.get<ESM::GameSetting>().find("iCrimeThreshold")->getInt();

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1653,6 +1653,12 @@ namespace MWMechanics
 
     bool MechanicsManager::isAggressive(const MWWorld::Ptr &ptr, const MWWorld::Ptr &target)
     {
+        // Don't become aggressive if a calm effect is active, since it would cause combat to cycle on/off as
+        // combat is activated here and then canceled by the calm effect
+        if ((ptr.getClass().isNpc() && ptr.getClass().getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::CalmHumanoid).getMagnitude() > 0)
+            || (!ptr.getClass().isNpc() && ptr.getClass().getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::CalmCreature).getMagnitude() > 0))
+            return false;
+
         int disposition = 50;
         if (ptr.getClass().isNpc())
             disposition = getDerivedDisposition(ptr, true);


### PR DESCRIPTION
Simple fix for https://bugs.openmw.org/issues/3863.

There is still a minor issue you may see, but it's unrelated. If you have a high enough bounty to make guards attack you, when you talk to a guard that you have placed a Calm effect on, the guard will keep starting to enter combat and then stopping. That issue is not guard-related, though. You can see the same thing happen if you calm Furius Acilius (who is a Warrior class, not Guard) and talk to him. That issue seems to be with StartCombat when it's in a dialogue script, like it keeps being executed over and over.

In the original engine you get a "This character is in combat" message if you try to talk to a calmed guard with the high bounty or to calmed Furius Acilius after his dialogue script has run.