### PR TITLE
Add setting option to scale water refractions

### DIFF
--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -272,6 +272,12 @@ public:
 
     void setWaterLevel(float waterLevel)
     {
+        const float refractionScale = std::min(1.0f,std::max(0.0f,
+            Settings::Manager::getFloat("refraction scale", "Water")));
+
+        setViewMatrix(osg::Matrix::scale(1,1,refractionScale) *
+            osg::Matrix::translate(0,0,(1.0 - refractionScale) * waterLevel));
+
         mClipCullNode->setPlane(osg::Plane(osg::Vec3d(0,0,-1), osg::Vec3d(0,0, waterLevel)));
     }
 

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -272,7 +272,7 @@ public:
 
     void setWaterLevel(float waterLevel)
     {
-        const float refractionScale = std::min(1.0f,std::max(0.0f,
+        const float refractionScale = std::min(1.0f,std::max(0.01f,     // 0.0 crashes the game
             Settings::Manager::getFloat("refraction scale", "Water")));
 
         setViewMatrix(osg::Matrix::scale(1,1,refractionScale) *

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -272,7 +272,7 @@ public:
 
     void setWaterLevel(float waterLevel)
     {
-        const float refractionScale = std::min(1.0f,std::max(0.01f,     // 0.0 crashes the game
+        const float refractionScale = std::min(1.0f,std::max(0.0f,
             Settings::Manager::getFloat("refraction scale", "Water")));
 
         setViewMatrix(osg::Matrix::scale(1,1,refractionScale) *

--- a/docs/source/reference/modding/settings/water.rst
+++ b/docs/source/reference/modding/settings/water.rst
@@ -88,3 +88,20 @@ This setting will have no effect if the shader setting is false,
 or the 'small feature culling' (in the 'Camera' section) is disabled.
 
 This setting can only be configured by editing the settings configuration file.
+
+refraction scale
+----------------
+
+:Type:		floating point
+:Range:		0 to 1
+:Default:	1.0
+
+Simulates light rays refracting when transitioning from air to water, which causes the space under water look scaled down
+in height when viewed from above the water surface. Though adding realism, the setting can cause distortion which can
+make for example aiming at enemies in water more challenging, so it is off by default (i.e. set to 1.0).
+
+This setting only applies if water shader is on and refractions are enabled. Note that if refractions are enabled and this
+setting if off, there will still be small refractions caused by the water waves, which however do not cause such significant
+distortion.
+
+TODO: setting via GUI? Interation with rttsize?

--- a/docs/source/reference/modding/settings/water.rst
+++ b/docs/source/reference/modding/settings/water.rst
@@ -104,4 +104,4 @@ This setting only applies if water shader is on and refractions are enabled. Not
 setting if off, there will still be small refractions caused by the water waves, which however do not cause such significant
 distortion.
 
-TODO: setting via GUI? Interation with rttsize?
+This setting can be edited with the 'Refraction scale' slider in the Water tab of the Video panel of the Options menu.

--- a/docs/source/reference/modding/settings/water.rst
+++ b/docs/source/reference/modding/settings/water.rst
@@ -104,4 +104,4 @@ This setting only applies if water shader is on and refractions are enabled. Not
 setting if off, there will still be small refractions caused by the water waves, which however do not cause such significant
 distortion.
 
-This setting can be edited with the 'Refraction scale' slider in the Water tab of the Video panel of the Options menu.
+TODO: setting via GUI? Interation with rttsize?

--- a/docs/source/reference/modding/settings/water.rst
+++ b/docs/source/reference/modding/settings/water.rst
@@ -98,10 +98,10 @@ refraction scale
 
 Simulates light rays refracting when transitioning from air to water, which causes the space under water look scaled down
 in height when viewed from above the water surface. Though adding realism, the setting can cause distortion which can
-make for example aiming at enemies in water more challenging, so it is off by default (i.e. set to 1.0).
+make for example aiming at enemies in water more challenging, so it is off by default (i.e. set to 1.0). To get a realistic
+look of real-life water, set the value to 0.75.
 
 This setting only applies if water shader is on and refractions are enabled. Note that if refractions are enabled and this
 setting if off, there will still be small refractions caused by the water waves, which however do not cause such significant
 distortion.
 
-TODO: setting via GUI? Interation with rttsize?

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -394,8 +394,30 @@
                                     <Property key="Caption" value="Reflect actors"/>
                                 </Widget>
                             </Widget>
+                            <Widget type="TextBox" skin="NormalText" position="4 84 350 18" align="Left Top">
+                              <Property key="Caption" value="Refraction scale"/>
+                            </Widget>
+                            <Widget type="HBox" skin="" position="4 112 350 24">
+                              <Widget type="MWScrollBar" skin="MW_HScroll" position="4 154 200 18" align="Left Top">
+                              <Property key="Range" value="10000"/>
+                              <Property key="Page" value="100"/>
+                              <UserString key="SettingType" value="Slider"/>
+                              <UserString key="SettingCategory" value="Water"/>
+                              <UserString key="SettingName" value="refraction scale"/>
+                              <UserString key="SettingValueType" value="Float"/>
+                              <UserString key="SettingMin" value="0.01"/>
+                              <UserString key="SettingMax" value="1.0"/>
+                              </Widget>
+                            </Widget>
+                            <Widget type="TextBox" skin="SandText" position="4 140 200 18" align="Left Top">
+                              <Property key="Caption" value="0"/>
+                              <Property key="TextAlign" value="Left"/>
+                            </Widget>
+                            <Widget type="TextBox" skin="SandText" position="4 140 200 18" align="Left Top">
+                              <Property key="Caption" value="1"/>
+                              <Property key="TextAlign" value="Right"/>
+                            </Widget>
                         </Widget>
-
                     </Widget>
                     <!--
                     <Widget type="TabItem" skin="" position="0 28 352 268">

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -394,30 +394,8 @@
                                     <Property key="Caption" value="Reflect actors"/>
                                 </Widget>
                             </Widget>
-                            <Widget type="TextBox" skin="NormalText" position="4 84 350 18" align="Left Top">
-                              <Property key="Caption" value="Refraction scale"/>
-                            </Widget>
-                            <Widget type="HBox" skin="" position="4 112 350 24">
-                              <Widget type="MWScrollBar" skin="MW_HScroll" position="4 154 200 18" align="Left Top">
-                              <Property key="Range" value="10000"/>
-                              <Property key="Page" value="100"/>
-                              <UserString key="SettingType" value="Slider"/>
-                              <UserString key="SettingCategory" value="Water"/>
-                              <UserString key="SettingName" value="refraction scale"/>
-                              <UserString key="SettingValueType" value="Float"/>
-                              <UserString key="SettingMin" value="0.01"/>
-                              <UserString key="SettingMax" value="1.0"/>
-                              </Widget>
-                            </Widget>
-                            <Widget type="TextBox" skin="SandText" position="4 140 200 18" align="Left Top">
-                              <Property key="Caption" value="0"/>
-                              <Property key="TextAlign" value="Left"/>
-                            </Widget>
-                            <Widget type="TextBox" skin="SandText" position="4 140 200 18" align="Left Top">
-                              <Property key="Caption" value="1"/>
-                              <Property key="TextAlign" value="Right"/>
-                            </Widget>
                         </Widget>
+
                     </Widget>
                     <!--
                     <Widget type="TabItem" skin="" position="0 28 352 268">

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -376,6 +376,9 @@ reflect actors = false
 # Overrides the value in '[Camera] small feature culling pixel size' specifically for water reflection/refraction textures.
 small feature culling pixel size = 20.0
 
+# By what factor water downscales objects. Only works with water shader and refractions on. 
+refraction scale = 1.0
+
 [Windows]
 
 # Location and sizes of windows as a fraction of the OpenMW window or


### PR DESCRIPTION
[forum thread](https://forum.openmw.org/viewtopic.php?f=6&t=4810)

Adds option to make water scale down objects for better realism:

![](https://i.imgur.com/3ltXV4l.png)

It's off by default.

Another screenshot, note the oar:

![](https://i.imgur.com/3C5MJFX.png)