### PR TITLE
Set duration of magic effects from ingredients (bug #4261)

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -968,9 +968,9 @@ namespace MWMechanics
         float y = roll / std::min(x, 100.f);
         y *= 0.25f * x;
         if (magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration)
-            effect.mDuration = static_cast<int>(y);
-        else
             effect.mDuration = 1;
+        else
+            effect.mDuration = static_cast<int>(y);
         if (!(magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
         {
             if (!(magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration))


### PR DESCRIPTION
Fixes [bug #4261](https://bugs.openmw.org/issues/4261).

By design, an engine supposed to set effect duration to 1 sec for NoDuration effects, but the "if" statement was opposite, so all effects from eaten ingredients had 1 sec duration.