### PR TITLE
Explicitly setting CMAKE_CXX_STANDARD to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ if (NOT WIN32 AND NOT APPLE)
 endif()
 
 # CXX Compiler settings
+set(CMAKE_CXX_STANDARD 11)
 if (CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wundef -Wno-unused-parameter -std=c++11 -pedantic -Wno-long-long")
     add_definitions( -DBOOST_NO_CXX11_SCOPED_ENUMS=ON )


### PR DESCRIPTION
This was necessary for me to actually build OpenMW on my Mac. Without it, I was getting the fatal error `'bind' is not a member of 'std'`. Documentation for CMAKE_CXX_STANDARD can be found [here](https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_STANDARD.html).