### PR TITLE
Autoequip previous item when the bound spell expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.45.0
 ------
 
+    Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
     Bug #2835: Player able to slowly move when overencumbered
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3591: Angled hit distance too low

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -262,7 +262,10 @@ namespace MWMechanics
             MWBase::Environment::get().getWorld()->getPlayer().setDrawState(MWMechanics::DrawState_Weapon);
 
         if (prevItem != store.end())
-            mPreviousItems[itemId] = (*prevItem).getCellRef().getRefId();
+        {
+            MWWorld::Player* player = &MWBase::Environment::get().getWorld()->getPlayer();
+            player->setPreviousItem(itemId, prevItem->getCellRef().getRefId());
+        }
     }
 
     void Actors::removeBoundItem (const std::string& itemId, const MWWorld::Ptr& actor)
@@ -272,16 +275,16 @@ namespace MWMechanics
 
         MWWorld::ContainerStoreIterator currentItem = store.getSlot(slot);
 
-        bool wasEquipped = currentItem != store.end() && Misc::StringUtils::ciEqual((*currentItem).getCellRef().getRefId(), itemId);
+        bool wasEquipped = currentItem != store.end() && Misc::StringUtils::ciEqual(currentItem->getCellRef().getRefId(), itemId);
 
         store.remove(itemId, 1, actor, true);
 
         if (actor != MWMechanics::getPlayer())
             return;
 
-        std::string prevItemId = mPreviousItems[itemId];
-
-        mPreviousItems.erase(itemId);
+        MWWorld::Player* player = &MWBase::Environment::get().getWorld()->getPlayer();
+        std::string prevItemId = player->getPreviousItem(itemId);
+        player->erasePreviousItem(itemId);
 
         if (prevItemId.empty())
             return;
@@ -1956,7 +1959,6 @@ namespace MWMechanics
         }
         mActors.clear();
         mDeathCount.clear();
-        mPreviousItems.clear();
     }
 
     void Actors::updateMagicEffects(const MWWorld::Ptr &ptr)

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -257,15 +257,14 @@ namespace MWMechanics
         if (newItem.isEmpty() || boundPtr != newItem)
             return;
 
+        MWWorld::Player& player = MWBase::Environment::get().getWorld()->getPlayer();
+
         // change draw state only if the item is in player's right hand
         if (slot == MWWorld::InventoryStore::Slot_CarriedRight)
-            MWBase::Environment::get().getWorld()->getPlayer().setDrawState(MWMechanics::DrawState_Weapon);
+            player.setDrawState(MWMechanics::DrawState_Weapon);
 
         if (prevItem != store.end())
-        {
-            MWWorld::Player* player = &MWBase::Environment::get().getWorld()->getPlayer();
-            player->setPreviousItem(itemId, prevItem->getCellRef().getRefId());
-        }
+            player.setPreviousItem(itemId, prevItem->getCellRef().getRefId());
     }
 
     void Actors::removeBoundItem (const std::string& itemId, const MWWorld::Ptr& actor)
@@ -282,9 +281,9 @@ namespace MWMechanics
         if (actor != MWMechanics::getPlayer())
             return;
 
-        MWWorld::Player* player = &MWBase::Environment::get().getWorld()->getPlayer();
-        std::string prevItemId = player->getPreviousItem(itemId);
-        player->erasePreviousItem(itemId);
+        MWWorld::Player& player = MWBase::Environment::get().getWorld()->getPlayer();
+        std::string prevItemId = player.getPreviousItem(itemId);
+        player.erasePreviousItem(itemId);
 
         if (prevItemId.empty())
             return;

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -264,7 +264,7 @@ namespace MWMechanics
             if (slot == MWWorld::InventoryStore::Slot_CarriedRight)
                 MWBase::Environment::get().getWorld()->getPlayer().setDrawState(MWMechanics::DrawState_Weapon);
 
-            mPreviousItems[slot] = std::make_pair(itemId, prevItem.isEmpty() ? "" : prevItem.getCellRef().getRefId());
+            mPreviousItems[slot] = std::make_pair(itemId, prevItem);
         }
         else
         {
@@ -275,21 +275,28 @@ namespace MWMechanics
 
             int slot = getBoundItemSlot(itemId);
 
-            std::pair<std::string, std::string> prevItem = mPreviousItems[slot];
+            std::pair<std::string, MWWorld::Ptr> prevItem = mPreviousItems[slot];
 
             if (prevItem.first != itemId)
                 return;
 
-            MWWorld::Ptr ptr = MWWorld::Ptr();
-            if (prevItem.second != "")
-                ptr = store.search (prevItem.second);
-
             mPreviousItems.erase(slot);
 
-            if (ptr.isEmpty())
+            if (prevItem.second.isEmpty())
                 return;
 
-            MWWorld::ActionEquip action(ptr);
+            // check if the item is still in the player's inventory
+            MWWorld::ContainerStoreIterator it = store.begin();
+            for (; it != store.end(); ++it)
+            {
+                if (*it == prevItem.second)
+                    break;
+            }
+
+            if (it == store.end())
+                return;
+
+            MWWorld::ActionEquip action(prevItem.second);
             action.execute(actor);
         }
     }

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -25,7 +25,7 @@ namespace MWMechanics
     class Actors
     {
             std::map<std::string, int> mDeathCount;
-            typedef std::map<int, std::pair<std::string, std::string>> PreviousItems;
+            typedef std::map<int, std::pair<std::string, MWWorld::Ptr>> PreviousItems;
             PreviousItems mPreviousItems;
 
             void adjustBoundItem (const std::string& itemId, bool bound, const MWWorld::Ptr& actor);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -25,6 +25,10 @@ namespace MWMechanics
     class Actors
     {
             std::map<std::string, int> mDeathCount;
+            typedef std::map<int, std::pair<std::string, std::string>> PreviousItems;
+            PreviousItems mPreviousItems;
+
+            void adjustBoundItem (const std::string& itemId, bool bound, const MWWorld::Ptr& actor);
 
             void updateNpc(const MWWorld::Ptr &ptr, float duration);
 

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -25,7 +25,7 @@ namespace MWMechanics
     class Actors
     {
             std::map<std::string, int> mDeathCount;
-            typedef std::map<int, std::pair<std::string, MWWorld::Ptr>> PreviousItems;
+            typedef std::map<std::string, MWWorld::Ptr> PreviousItems;
             PreviousItems mPreviousItems;
 
             void adjustBoundItem (const std::string& itemId, bool bound, const MWWorld::Ptr& actor);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -28,7 +28,8 @@ namespace MWMechanics
             typedef std::map<std::string, MWWorld::Ptr> PreviousItems;
             PreviousItems mPreviousItems;
 
-            void adjustBoundItem (const std::string& itemId, bool bound, const MWWorld::Ptr& actor);
+            void addBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);
+            void removeBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);
 
             void updateNpc(const MWWorld::Ptr &ptr, float duration);
 

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -25,7 +25,7 @@ namespace MWMechanics
     class Actors
     {
             std::map<std::string, int> mDeathCount;
-            typedef std::map<std::string, MWWorld::Ptr> PreviousItems;
+            typedef std::map<std::string, std::string> PreviousItems;
             PreviousItems mPreviousItems;
 
             void addBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -4,7 +4,6 @@
 #include <set>
 #include <vector>
 #include <string>
-#include <map>
 #include <list>
 
 #include "../mwbase/world.hpp"
@@ -25,8 +24,6 @@ namespace MWMechanics
     class Actors
     {
             std::map<std::string, int> mDeathCount;
-            typedef std::map<std::string, std::string> PreviousItems;
-            PreviousItems mPreviousItems;
 
             void addBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);
             void removeBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -287,6 +287,7 @@ namespace MWWorld
         mAttackingOrSpell = false;
         mCurrentCrimeId = -1;
         mPaidCrimeId = -1;
+        mPreviousItems.clear();
         mLastKnownExteriorPosition = osg::Vec3f(0,0,0);
 
         for (int i=0; i<ESM::Skill::Length; ++i)
@@ -460,5 +461,20 @@ namespace MWWorld
     int Player::getCrimeId() const
     {
         return mPaidCrimeId;
+    }
+
+    void Player::setPreviousItem(const std::string& boundItemId, const std::string& previousItemId)
+    {
+        mPreviousItems[boundItemId] = previousItemId;
+    }
+
+    std::string Player::getPreviousItem(const std::string& boundItemId)
+    {
+        return mPreviousItems[boundItemId];
+    }
+
+    void Player::erasePreviousItem(const std::string& boundItemId)
+    {
+        mPreviousItems.erase(boundItemId);
     }
 }

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -342,6 +342,8 @@ namespace MWWorld
         for (int i=0; i<ESM::Skill::Length; ++i)
             mSaveSkills[i].writeState(player.mSaveSkills[i]);
 
+        player.mPreviousItems = mPreviousItems;
+
         writer.startRecord (ESM::REC_PLAY);
         player.save (writer);
         writer.endRecord (ESM::REC_PLAY);
@@ -441,6 +443,8 @@ namespace MWWorld
 
             mForwardBackward = 0;
             mTeleported = false;
+
+            mPreviousItems = player.mPreviousItems;
 
             return true;
         }

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -1,6 +1,8 @@
 #ifndef GAME_MWWORLD_PLAYER_H
 #define GAME_MWWORLD_PLAYER_H
 
+#include <map>
+
 #include "../mwworld/refdata.hpp"
 #include "../mwworld/livecellref.hpp"
 
@@ -45,6 +47,9 @@ namespace MWWorld
 
         int                     mCurrentCrimeId;    // the id assigned witnesses
         int                     mPaidCrimeId;      // the last id paid off (0 bounty)
+
+        typedef std::map<std::string, std::string> PreviousItems; // previous equipped items, needed for bound spells
+        PreviousItems mPreviousItems;
 
         // Saved stats prior to becoming a werewolf
         MWMechanics::SkillValue mSaveSkills[ESM::Skill::Length];
@@ -120,6 +125,10 @@ namespace MWWorld
         int getNewCrimeId();  // get new id for witnesses
         void recordCrimeId(); // record the paid crime id when bounty is 0
         int getCrimeId() const;     // get the last paid crime id
+
+        void setPreviousItem(const std::string& boundItemId, const std::string& previousItemId);
+        std::string getPreviousItem(const std::string& boundItemId);
+        void erasePreviousItem(const std::string& boundItemId);
     };
 }
 #endif

--- a/components/esm/player.cpp
+++ b/components/esm/player.cpp
@@ -31,6 +31,18 @@ void ESM::Player::load (ESMReader &esm)
     mPaidCrimeId = -1;
     esm.getHNOT (mPaidCrimeId, "PAYD");
 
+    bool checkPrevItems = true;
+    while (checkPrevItems)
+    {
+        std::string boundItemId = esm.getHNOString("BOUN");
+        std::string prevItemId = esm.getHNOString("PREV");
+
+        if (!boundItemId.empty())
+            mPreviousItems[boundItemId] = prevItemId;
+        else
+            checkPrevItems = false;
+    }
+
     if (esm.hasMoreSubs())
     {
         for (int i=0; i<ESM::Attribute::Length; ++i)
@@ -61,6 +73,12 @@ void ESM::Player::save (ESMWriter &esm) const
 
     esm.writeHNT ("CURD", mCurrentCrimeId);
     esm.writeHNT ("PAYD", mPaidCrimeId);
+
+    for (PreviousItems::const_iterator it=mPreviousItems.begin(); it != mPreviousItems.end(); ++it)
+    {
+        esm.writeHNString ("BOUN", it->first);
+        esm.writeHNString ("PREV", it->second);
+    }
 
     for (int i=0; i<ESM::Attribute::Length; ++i)
         mSaveAttributes[i].save(esm);

--- a/components/esm/player.hpp
+++ b/components/esm/player.hpp
@@ -34,6 +34,9 @@ namespace ESM
         StatState<int> mSaveAttributes[ESM::Attribute::Length];
         StatState<int> mSaveSkills[ESM::Skill::Length];
 
+        typedef std::map<std::string, std::string> PreviousItems; // previous equipped items, needed for bound spells
+        PreviousItems mPreviousItems;
+
         void load (ESMReader &esm);
         void save (ESMWriter &esm) const;
     };

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -5,7 +5,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 4;
+int ESM::SavedGame::sCurrentFormat = 5;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
Fixes [bug #2326](https://bugs.openmw.org/issues/2326).

Note: this feature is bugged in Morrowind. I suggest to equip previous item **only if the expired bound item was equipped**.