### PR TITLE
Remove the 'Screenshot saved' message

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1021,8 +1021,6 @@ namespace MWInput
     {
         mScreenCaptureHandler->setFramesToCapture(1);
         mScreenCaptureHandler->captureNextFrame(*mViewer);
-
-        MWBase::Environment::get().getWindowManager()->messageBox ("Screenshot saved");
     }
 
     void InputManager::toggleInventory()


### PR DESCRIPTION
Fixes [bug #4191](https://bugs.openmw.org/issues/4191).

In current master we display the "Screenshot saved" message before we actually take the screenshot. That's a quite odd.

EDIT: Remove the message for now due to possible threading conflicts.
  