### PR TITLE
Do not summon a bow if there is no suitable arrows

### DIFF
--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -182,29 +182,11 @@ namespace MWMechanics
                 }
             }
 
-            float bestArrowRating = 0;
             MWWorld::Ptr bestArrow;
-            for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
-            {
-                float rating = rateWeapon(*it, actor, enemy, ESM::Weapon::Arrow);
-                if (rating > bestArrowRating)
-                {
-                    bestArrowRating = rating;
-                    bestArrow = *it;
-                }
-            }
+            float bestArrowRating = rateAmmo(actor, enemy, bestArrow, ESM::Weapon::Arrow);
 
-            float bestBoltRating = 0;
             MWWorld::Ptr bestBolt;
-            for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
-            {
-                float rating = rateWeapon(*it, actor, enemy, ESM::Weapon::Bolt);
-                if (rating > bestBoltRating)
-                {
-                    bestBoltRating = rating;
-                    bestBolt = *it;
-                }
-            }
+            float bestBoltRating = rateAmmo(actor, enemy, bestBolt, ESM::Weapon::Bolt);
 
             for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
             {
@@ -277,25 +259,9 @@ namespace MWMechanics
                 }
             }
 
-            float bestArrowRating = 0;
-            for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
-            {
-                float rating = rateWeapon(*it, actor, enemy, ESM::Weapon::Arrow);
-                if (rating > bestArrowRating)
-                {
-                    bestArrowRating = rating;
-                }
-            }
+            float bestArrowRating = rateAmmo(actor, enemy, ESM::Weapon::Arrow);
 
-            float bestBoltRating = 0;
-            for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
-            {
-                float rating = rateWeapon(*it, actor, enemy, ESM::Weapon::Bolt);
-                if (rating > bestBoltRating)
-                {
-                    bestBoltRating = rating;
-                }
-            }
+            float bestBoltRating = rateAmmo(actor, enemy, ESM::Weapon::Bolt);
 
             for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
             {

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -1,4 +1,5 @@
 #include "spellpriority.hpp"
+#include "weaponpriority.hpp"
 
 #include <components/esm/loadench.hpp>
 #include <components/esm/loadmgef.hpp>
@@ -332,6 +333,12 @@ namespace MWMechanics
         case ESM::MagicEffect::BoundCuirass:
         case ESM::MagicEffect::BoundGloves:
             if (!actor.getClass().isNpc())
+                return 0.f;
+            break;
+
+        case ESM::MagicEffect::BoundLongbow:
+            // AI should not summon the bow if there is no suitable ammo.
+            if (rateAmmo(actor, enemy, ESM::Weapon::Arrow) <= 0.f)
                 return 0.f;
             break;
 

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -8,6 +8,7 @@
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/inventorystore.hpp"
 
 #include "npcstats.hpp"
 #include "combat.hpp"
@@ -109,6 +110,33 @@ namespace MWMechanics
             return 0.f;
 
         return rating + bonus;
+    }
+
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, ESM::Weapon::Type ammoType)
+    {
+        float bestAmmoRating = 0.f;
+        if (!actor.getClass().hasInventoryStore(actor))
+            return bestAmmoRating;
+
+        MWWorld::InventoryStore& store = actor.getClass().getInventoryStore(actor);
+
+        for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
+        {
+            float rating = rateWeapon(*it, actor, enemy, ammoType);
+            if (rating > bestAmmoRating)
+            {
+                bestAmmoRating = rating;
+                bestAmmo = *it;
+            }
+        }
+
+        return bestAmmoRating;
+    }
+
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, ESM::Weapon::Type ammoType)
+    {
+        MWWorld::Ptr emptyPtr;
+        return rateAmmo(actor, enemy, emptyPtr, ammoType);
     }
 
     float vanillaRateWeaponAndAmmo(const MWWorld::Ptr& weapon, const MWWorld::Ptr& ammo, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy)

--- a/apps/openmw/mwmechanics/weaponpriority.hpp
+++ b/apps/openmw/mwmechanics/weaponpriority.hpp
@@ -1,12 +1,17 @@
 #ifndef OPENMW_WEAPON_PRIORITY_H
 #define OPENMW_WEAPON_PRIORITY_H
 
+#include <components/esm/loadweap.hpp>
+
 #include "../mwworld/ptr.hpp"
 
 namespace MWMechanics
 {
     float rateWeapon (const MWWorld::Ptr& item, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy,
                       int type=-1, float arrowRating=0.f, float boltRating=0.f);
+
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, ESM::Weapon::Type ammoType);
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, ESM::Weapon::Type ammoType);
 
     float vanillaRateWeaponAndAmmo(const MWWorld::Ptr& weapon, const MWWorld::Ptr& ammo, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
 }


### PR DESCRIPTION
1. Provide a rateAmmo() function to avoid the code duplication
2. Before summon we can check the best ammo rating. If the rating is <= 0, there is no suitable arrows. For example:
2.1. There is no arrows at all
2.2. The target has immunity to normal weapons and there is no magic arrows