### PR TITLE
Add the option for multiple quicksave slots

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -89,7 +89,7 @@ add_openmw_dir (mwmechanics
     )
 
 add_openmw_dir (mwstate
-    statemanagerimp charactermanager character
+    statemanagerimp charactermanager character quicksavemanager
     )
 
 add_openmw_dir (mwbase
@@ -223,4 +223,3 @@ endif (MSVC)
 if (WIN32)
     INSTALL(TARGETS openmw RUNTIME DESTINATION ".")
 endif (WIN32)
-

--- a/apps/openmw/mwstate/quicksavemanager.cpp
+++ b/apps/openmw/mwstate/quicksavemanager.cpp
@@ -1,0 +1,73 @@
+#include "quicksavemanager.hpp"
+
+#include <sstream>
+
+MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, int maxSaves){
+    this->saveName = saveName;
+    this->maxSaves = maxSaves;
+    this->oldestSlotVisited = NULL;
+    this->oldestSlotId = 0;
+    this->slotsVisited = 0;
+}
+
+void MWState::QuickSaveManager::visitSave(const Slot *saveSlot){
+    int slotId;
+    if(tryExtractSlotId(saveSlot->mProfile.mDescription, slotId)){
+        ++slotsVisited;
+        if(isOldestSave(saveSlot)){
+            oldestSlotVisited = saveSlot;
+            oldestSlotId = slotId;
+        }
+    }
+}
+
+bool MWState::QuickSaveManager::isOldestSave(const Slot *compare){
+    if(oldestSlotVisited == NULL)
+        return true;
+    return (compare->mTimeStamp < oldestSlotVisited->mTimeStamp);
+}
+
+bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, int &extractedId){
+    std::istringstream formattedExtractor = std::istringstream(slotName);
+
+    std::string nameToTest;
+    formattedExtractor >> nameToTest;
+    if(nameToTest == saveName){
+        //Only try to extract the id if maxSaves > 1
+        //With maxSaves == 1, we don't append the slotId to the name
+        if(formattedExtractor >> extractedId)
+            return (isSlotIdValid(extractedId));
+        else if(maxSaves == 1)
+            return formattedExtractor.eof();
+    }
+    return false;
+}
+
+bool MWState::QuickSaveManager::isSlotIdValid(int slotId){
+    return (slotId > 0 && slotId <= maxSaves);
+}
+
+bool MWState::QuickSaveManager::shouldCreateNewSlot(){
+    return (slotsVisited < maxSaves);
+}
+
+const MWState::Slot *MWState::QuickSaveManager::getNextQuickSaveSlot(){
+    if(shouldCreateNewSlot())
+        return NULL;
+    return oldestSlotVisited;
+}
+
+std::string MWState::QuickSaveManager::getNextQuickSaveName(){
+    std::ostringstream nameFormatter;
+    nameFormatter << saveName;
+    //Only print the number if there will be more than 1
+    if(maxSaves > 1)
+        nameFormatter << " " << calcNextSlotId();
+    return nameFormatter.str();
+}
+
+int MWState::QuickSaveManager::calcNextSlotId(){
+    if(shouldCreateNewSlot())
+        return (slotsVisited + 1);
+    return oldestSlotId;
+}

--- a/apps/openmw/mwstate/quicksavemanager.cpp
+++ b/apps/openmw/mwstate/quicksavemanager.cpp
@@ -1,27 +1,20 @@
 #include "quicksavemanager.hpp"
 
-#include <sstream>
-
 MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, unsigned int maxSaves)
 {
     this->mSaveName = saveName;
     this->mMaxSaves = maxSaves;
     this->mOldestSlotVisited = NULL;
-    this->mOldestSlotId = 0;
     this->mSlotsVisited = 0;
 }
 
 void MWState::QuickSaveManager::visitSave(const Slot *saveSlot)
 {
-    unsigned int slotId;
-    if(tryExtractSlotId(saveSlot->mProfile.mDescription, slotId))
+    if(mSaveName == saveSlot->mProfile.mDescription)
     {
         ++mSlotsVisited;
         if(isOldestSave(saveSlot))
-        {
             mOldestSlotVisited = saveSlot;
-            mOldestSlotId = slotId;
-        }
     }
 }
 
@@ -30,29 +23,6 @@ bool MWState::QuickSaveManager::isOldestSave(const Slot *compare)
     if(mOldestSlotVisited == NULL)
         return true;
     return (compare->mTimeStamp <= mOldestSlotVisited->mTimeStamp);
-}
-
-bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, unsigned int &extractedId)
-{
-    std::istringstream formattedExtractor(slotName);
-
-    std::string nameToTest;
-    formattedExtractor >> nameToTest;
-    if(nameToTest == mSaveName)
-    {
-        //Only try to extract the id if maxSaves > 1
-        //With maxSaves == 1, we don't append the slotId to the name
-        if(formattedExtractor >> extractedId)
-            return (isSlotIdValid(extractedId));
-        else if(mMaxSaves == 1)
-            return formattedExtractor.eof();
-    }
-    return false;
-}
-
-bool MWState::QuickSaveManager::isSlotIdValid(unsigned int slotId)
-{
-    return (slotId > 0 && slotId <= mMaxSaves);
 }
 
 bool MWState::QuickSaveManager::shouldCreateNewSlot()
@@ -65,21 +35,4 @@ const MWState::Slot *MWState::QuickSaveManager::getNextQuickSaveSlot()
     if(shouldCreateNewSlot())
         return NULL;
     return mOldestSlotVisited;
-}
-
-std::string MWState::QuickSaveManager::getNextQuickSaveName()
-{
-    std::ostringstream nameFormatter;
-    nameFormatter << mSaveName;
-    //Only print the number if there will be more than 1
-    if(mMaxSaves > 1)
-        nameFormatter << " " << calcNextSlotId();
-    return nameFormatter.str();
-}
-
-int MWState::QuickSaveManager::calcNextSlotId()
-{
-    if(shouldCreateNewSlot())
-        return (mSlotsVisited + 1);
-    return mOldestSlotId;
 }

--- a/apps/openmw/mwstate/quicksavemanager.cpp
+++ b/apps/openmw/mwstate/quicksavemanager.cpp
@@ -2,72 +2,84 @@
 
 #include <sstream>
 
-MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, int maxSaves){
-    this->saveName = saveName;
-    this->maxSaves = maxSaves;
-    this->oldestSlotVisited = NULL;
-    this->oldestSlotId = 0;
-    this->slotsVisited = 0;
+MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, int maxSaves)
+{
+    this->mSaveName = saveName;
+    this->mMaxSaves = maxSaves;
+    this->mOldestSlotVisited = NULL;
+    this->mOldestSlotId = 0;
+    this->mSlotsVisited = 0;
 }
 
-void MWState::QuickSaveManager::visitSave(const Slot *saveSlot){
+void MWState::QuickSaveManager::visitSave(const Slot *saveSlot)
+{
     int slotId;
-    if(tryExtractSlotId(saveSlot->mProfile.mDescription, slotId)){
-        ++slotsVisited;
-        if(isOldestSave(saveSlot)){
-            oldestSlotVisited = saveSlot;
-            oldestSlotId = slotId;
+    if(tryExtractSlotId(saveSlot->mProfile.mDescription, slotId))
+    {
+        ++mSlotsVisited;
+        if(isOldestSave(saveSlot))
+        {
+            mOldestSlotVisited = saveSlot;
+            mOldestSlotId = slotId;
         }
     }
 }
 
-bool MWState::QuickSaveManager::isOldestSave(const Slot *compare){
-    if(oldestSlotVisited == NULL)
+bool MWState::QuickSaveManager::isOldestSave(const Slot *compare)
+{
+    if(mOldestSlotVisited == NULL)
         return true;
-    return (compare->mTimeStamp < oldestSlotVisited->mTimeStamp);
+    return (compare->mTimeStamp <= mOldestSlotVisited->mTimeStamp);
 }
 
-bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, int &extractedId){
-    std::istringstream formattedExtractor = std::istringstream(slotName);
+bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, int &extractedId)
+{
+    std::istringstream formattedExtractor(slotName);
 
     std::string nameToTest;
     formattedExtractor >> nameToTest;
-    if(nameToTest == saveName){
+    if(nameToTest == mSaveName)
+    {
         //Only try to extract the id if maxSaves > 1
         //With maxSaves == 1, we don't append the slotId to the name
         if(formattedExtractor >> extractedId)
             return (isSlotIdValid(extractedId));
-        else if(maxSaves == 1)
+        else if(mMaxSaves == 1)
             return formattedExtractor.eof();
     }
     return false;
 }
 
-bool MWState::QuickSaveManager::isSlotIdValid(int slotId){
-    return (slotId > 0 && slotId <= maxSaves);
+bool MWState::QuickSaveManager::isSlotIdValid(int slotId)
+{
+    return (slotId > 0 && slotId <= mMaxSaves);
 }
 
-bool MWState::QuickSaveManager::shouldCreateNewSlot(){
-    return (slotsVisited < maxSaves);
+bool MWState::QuickSaveManager::shouldCreateNewSlot()
+{
+    return (mSlotsVisited < mMaxSaves);
 }
 
-const MWState::Slot *MWState::QuickSaveManager::getNextQuickSaveSlot(){
+const MWState::Slot *MWState::QuickSaveManager::getNextQuickSaveSlot()
+{
     if(shouldCreateNewSlot())
         return NULL;
-    return oldestSlotVisited;
+    return mOldestSlotVisited;
 }
 
-std::string MWState::QuickSaveManager::getNextQuickSaveName(){
+std::string MWState::QuickSaveManager::getNextQuickSaveName()
+{
     std::ostringstream nameFormatter;
-    nameFormatter << saveName;
+    nameFormatter << mSaveName;
     //Only print the number if there will be more than 1
-    if(maxSaves > 1)
+    if(mMaxSaves > 1)
         nameFormatter << " " << calcNextSlotId();
     return nameFormatter.str();
 }
 
-int MWState::QuickSaveManager::calcNextSlotId(){
+int MWState::QuickSaveManager::calcNextSlotId()
+{
     if(shouldCreateNewSlot())
-        return (slotsVisited + 1);
-    return oldestSlotId;
+        return (mSlotsVisited + 1);
+    return mOldestSlotId;
 }

--- a/apps/openmw/mwstate/quicksavemanager.cpp
+++ b/apps/openmw/mwstate/quicksavemanager.cpp
@@ -2,7 +2,7 @@
 
 #include <sstream>
 
-MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, int maxSaves)
+MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, unsigned int maxSaves)
 {
     this->mSaveName = saveName;
     this->mMaxSaves = maxSaves;
@@ -13,7 +13,7 @@ MWState::QuickSaveManager::QuickSaveManager(std::string &saveName, int maxSaves)
 
 void MWState::QuickSaveManager::visitSave(const Slot *saveSlot)
 {
-    int slotId;
+    unsigned int slotId;
     if(tryExtractSlotId(saveSlot->mProfile.mDescription, slotId))
     {
         ++mSlotsVisited;
@@ -32,7 +32,7 @@ bool MWState::QuickSaveManager::isOldestSave(const Slot *compare)
     return (compare->mTimeStamp <= mOldestSlotVisited->mTimeStamp);
 }
 
-bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, int &extractedId)
+bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, unsigned int &extractedId)
 {
     std::istringstream formattedExtractor(slotName);
 
@@ -50,7 +50,7 @@ bool MWState::QuickSaveManager::tryExtractSlotId(const std::string &slotName, in
     return false;
 }
 
-bool MWState::QuickSaveManager::isSlotIdValid(int slotId)
+bool MWState::QuickSaveManager::isSlotIdValid(unsigned int slotId)
 {
     return (slotId > 0 && slotId <= mMaxSaves);
 }

--- a/apps/openmw/mwstate/quicksavemanager.hpp
+++ b/apps/openmw/mwstate/quicksavemanager.hpp
@@ -1,0 +1,42 @@
+#ifndef GAME_STATE_QUICKSAVEMANAGER_H
+#define GAME_STATE_QUICKSAVEMANAGER_H
+
+#include "character.hpp"
+#include "../mwbase/statemanager.hpp"
+
+#include <string>
+
+namespace MWState{
+    class QuickSaveManager{
+        std::string saveName;
+        int maxSaves;
+        int slotsVisited;
+        int oldestSlotId;
+        const Slot *oldestSlotVisited;
+    private:
+        bool tryExtractSlotId(const std::string &slotName, int &extractedIdll);
+        bool isSlotIdValid(int slotId);
+        bool shouldCreateNewSlot();
+        bool isOldestSave(const Slot *compare);
+        int calcNextSlotId();
+    public:
+        QuickSaveManager(std::string &saveName, int maxSaves);
+        ///< A utility class to manage multiple quicksave slots
+        ///
+        /// \param saveName The name of the save ("QuickSave", "AutoSave", etc)
+        /// \param maxSaves The maximum number of save slots to use before recycling old ones
+
+        void visitSave(const Slot *saveSlot);
+        ///< Visits the given \a slot \a
+
+        const Slot *getNextQuickSaveSlot();
+        ///< Get the slot that the next quicksave should use.
+        ///
+        ///\return Either the oldest quicksave slot visited, or NULL if a new slot can be made
+
+        std::string getNextQuickSaveName();
+        ///< Get the name that the next quicksave should use ("QuickSave 1", "AutoSave 10", etc)
+    };
+}
+
+#endif

--- a/apps/openmw/mwstate/quicksavemanager.hpp
+++ b/apps/openmw/mwstate/quicksavemanager.hpp
@@ -1,18 +1,18 @@
 #ifndef GAME_STATE_QUICKSAVEMANAGER_H
 #define GAME_STATE_QUICKSAVEMANAGER_H
 
+#include <string>
+
 #include "character.hpp"
 #include "../mwbase/statemanager.hpp"
 
-#include <string>
-
 namespace MWState{
     class QuickSaveManager{
-        std::string saveName;
-        int maxSaves;
-        int slotsVisited;
-        int oldestSlotId;
-        const Slot *oldestSlotVisited;
+        std::string mSaveName;
+        int mMaxSaves;
+        int mSlotsVisited;
+        int mOldestSlotId;
+        const Slot *mOldestSlotVisited;
     private:
         bool tryExtractSlotId(const std::string &slotName, int &extractedIdll);
         bool isSlotIdValid(int slotId);

--- a/apps/openmw/mwstate/quicksavemanager.hpp
+++ b/apps/openmw/mwstate/quicksavemanager.hpp
@@ -9,18 +9,18 @@
 namespace MWState{
     class QuickSaveManager{
         std::string mSaveName;
-        int mMaxSaves;
-        int mSlotsVisited;
-        int mOldestSlotId;
+        unsigned int mMaxSaves;
+        unsigned int mSlotsVisited;
+        unsigned int mOldestSlotId;
         const Slot *mOldestSlotVisited;
     private:
-        bool tryExtractSlotId(const std::string &slotName, int &extractedIdll);
-        bool isSlotIdValid(int slotId);
+        bool tryExtractSlotId(const std::string &slotName, unsigned int &extractedIdll);
+        bool isSlotIdValid(unsigned int slotId);
         bool shouldCreateNewSlot();
         bool isOldestSave(const Slot *compare);
         int calcNextSlotId();
     public:
-        QuickSaveManager(std::string &saveName, int maxSaves);
+        QuickSaveManager(std::string &saveName, unsigned int maxSaves);
         ///< A utility class to manage multiple quicksave slots
         ///
         /// \param saveName The name of the save ("QuickSave", "AutoSave", etc)

--- a/apps/openmw/mwstate/quicksavemanager.hpp
+++ b/apps/openmw/mwstate/quicksavemanager.hpp
@@ -11,20 +11,16 @@ namespace MWState{
         std::string mSaveName;
         unsigned int mMaxSaves;
         unsigned int mSlotsVisited;
-        unsigned int mOldestSlotId;
         const Slot *mOldestSlotVisited;
     private:
-        bool tryExtractSlotId(const std::string &slotName, unsigned int &extractedIdll);
-        bool isSlotIdValid(unsigned int slotId);
         bool shouldCreateNewSlot();
         bool isOldestSave(const Slot *compare);
-        int calcNextSlotId();
     public:
         QuickSaveManager(std::string &saveName, unsigned int maxSaves);
         ///< A utility class to manage multiple quicksave slots
         ///
         /// \param saveName The name of the save ("QuickSave", "AutoSave", etc)
-        /// \param maxSaves The maximum number of save slots to use before recycling old ones
+        /// \param maxSaves The maximum number of save slots to create before recycling old ones
 
         void visitSave(const Slot *saveSlot);
         ///< Visits the given \a slot \a
@@ -33,9 +29,6 @@ namespace MWState{
         ///< Get the slot that the next quicksave should use.
         ///
         ///\return Either the oldest quicksave slot visited, or NULL if a new slot can be made
-
-        std::string getNextQuickSaveName();
-        ///< Get the name that the next quicksave should use ("QuickSave 1", "AutoSave 10", etc)
     };
 }
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -37,6 +37,8 @@
 
 #include "../mwscript/globalscripts.hpp"
 
+#include "quicksavemanager.hpp"
+
 void MWState::StateManager::cleanup (bool force)
 {
     if (mState!=State_NoGame || force)
@@ -324,20 +326,25 @@ void MWState::StateManager::quickSave (std::string name)
         return;
     }
 
-    const Slot* slot = NULL;
-    Character* currentCharacter = getCurrentCharacter(); //Get current character
+    int maxSaves = Settings::Manager::getInt("max quicksaves", "Saves");
+    if(maxSaves < 1)
+        maxSaves = 1;
 
-    //Find quicksave slot
+    Character* currentCharacter = getCurrentCharacter(); //Get current character
+    QuickSaveManager saveFinder = QuickSaveManager(name, maxSaves);
+
     if (currentCharacter)
     {
         for (Character::SlotIterator it = currentCharacter->begin(); it != currentCharacter->end(); ++it)
         {
-            if (it->mProfile.mDescription == name)
-                slot = &*it;
+            //Visiting slots allows the quicksave finder to find the oldest quicksave
+            saveFinder.visitSave(&*it);
         }
     }
 
-    saveGame(name, slot);
+    //Once all the saves have been visited, the save finder can tell us which
+    //one to replace (or create)
+    saveGame(saveFinder.getNextQuickSaveName(), saveFinder.getNextQuickSaveSlot());
 }
 
 void MWState::StateManager::loadGame(const std::string& filepath)

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -344,7 +344,7 @@ void MWState::StateManager::quickSave (std::string name)
 
     //Once all the saves have been visited, the save finder can tell us which
     //one to replace (or create)
-    saveGame(saveFinder.getNextQuickSaveName(), saveFinder.getNextQuickSaveSlot());
+    saveGame(name, saveFinder.getNextQuickSaveSlot());
 }
 
 void MWState::StateManager::loadGame(const std::string& filepath)

--- a/docs/source/reference/modding/settings/saves.rst
+++ b/docs/source/reference/modding/settings/saves.rst
@@ -5,7 +5,7 @@ character
 ---------
 
 :Type:		string
-:Range:		
+:Range:
 :Default:	""
 
 This setting contains the default character name for loading saved games.
@@ -33,5 +33,16 @@ timeplayed
 
 This setting determines whether the amount of the time the player has spent playing will be displayed
 for each saved game in the Load menu.
+
+This setting can only be configured by editing the settings configuration file.
+
+max quicksaves
+----------
+
+:Type:		integer
+:Range:		>0
+:Default:	5
+
+This setting determines how many quicksave and autosave slots you can have at a time.  If greater than 1, quicksaves will be sequentially created each time you quicksave.  Once the maximum number of quicksaves has been reached, the oldest quicksave will be recycled the next time you perform a quicksave.
 
 This setting can only be configured by editing the settings configuration file.

--- a/docs/source/reference/modding/settings/saves.rst
+++ b/docs/source/reference/modding/settings/saves.rst
@@ -41,7 +41,7 @@ max quicksaves
 
 :Type:		integer
 :Range:		>0
-:Default:	5
+:Default:	1
 
 This setting determines how many quicksave and autosave slots you can have at a time.  If greater than 1, quicksaves will be sequentially created each time you quicksave.  Once the maximum number of quicksaves has been reached, the oldest quicksave will be recycled the next time you perform a quicksave.
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -7,7 +7,7 @@
 # significance of each setting, interaction with other settings, hard
 # limits on value ranges and more information in general, please read
 # the detailed documentation at:
-# 
+#
 #   http://openmw.readthedocs.io/en/master/reference/modding/settings/index.html
 #
 
@@ -288,6 +288,10 @@ autosave = true
 # Display the time played on each save file in the load menu.
 timeplayed = false
 
+# The maximum number of quick (or auto) save slots to have.
+# If all slots are used, the  oldest save is reused
+max quicksaves = 5
+
 [Sound]
 
 # Name of audio device file.  Blank means use the default device.
@@ -376,7 +380,7 @@ reflect actors = false
 # Overrides the value in '[Camera] small feature culling pixel size' specifically for water reflection/refraction textures.
 small feature culling pixel size = 20.0
 
-# By what factor water downscales objects. Only works with water shader and refractions on. 
+# By what factor water downscales objects. Only works with water shader and refractions on.
 refraction scale = 1.0
 
 [Windows]

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -290,7 +290,7 @@ timeplayed = false
 
 # The maximum number of quick (or auto) save slots to have.
 # If all slots are used, the  oldest save is reused
-max quicksaves = 5
+max quicksaves = 1
 
 [Sound]
 


### PR DESCRIPTION
I got tired of accidentally quicksaving in an insta-death situation.  Once that happens, I have to reload my next save, which could mean I've lost an hour or so of progress.

This commit introduces the ability for multiple quicksave (and autosave) slots to exist at once.  Once the limit (default 5) is hit, the oldest saves get automatically recycled the next time you save.