### PR TITLE
Take in account PC rank during disposition calculation

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -566,9 +566,16 @@ namespace MWMechanics
             {
                 std::string itFaction = playerFactionIt->first;
 
+                // Ignore the faction, if a player was expelled from it.
+                if (playerStats.getExpelled(itFaction))
+                    continue;
+
                 int itReaction = MWBase::Environment::get().getDialogueManager()->getFactionReaction(npcFaction, itFaction);
                 if (playerFactionIt == playerStats.getFactionRanks().begin() || itReaction < reaction)
+                {
                     reaction = static_cast<float>(itReaction);
+                    rank = playerFactionIt->second;
+                }
             }
         }
         else


### PR DESCRIPTION
Fixes [bug #4322](https://bugs.openmw.org/issues/4322).

We forgot to initialize the "rank" variable when a player is in faction hostile to NPC's one.
Also there is no disposition penalty if the player was expelled from faction.
