### PR TITLE
Fix Windows builds

### DIFF
--- a/components/terrain/compositemaprenderer.cpp
+++ b/components/terrain/compositemaprenderer.cpp
@@ -6,6 +6,8 @@
 #include <osg/Texture2D>
 #include <osg/RenderInfo>
 
+#include <algorithm>
+
 namespace Terrain
 {
 


### PR DESCRIPTION
`std::min`/`std::max` are part of algorithm, which is not implicitly included in Windows builds