### PR TITLE
Stop triggering "Journal has been updated" messagebox after Journal script function calls for the same quest stage

### DIFF
--- a/apps/openmw/mwdialogue/journalimp.cpp
+++ b/apps/openmw/mwdialogue/journalimp.cpp
@@ -83,8 +83,10 @@ namespace MWDialogue
             if (i->mTopic == id && i->mInfoId == infoId)
             {
                 if (getJournalIndex(id) < index)
+                {
                     setJournalIndex(id, index);
-                MWBase::Environment::get().getWindowManager()->messageBox ("#{sJournalEntry}");
+                    MWBase::Environment::get().getWindowManager()->messageBox ("#{sJournalEntry}");
+                }
                 return;
             }
 


### PR DESCRIPTION
Currently every time you trigger a response which updates the quest stage you get the message even though you obviously don't get a duplicate entry in the journal. This doesn't look quite right.
I _think_ this is a regression from some time before 0.43.0, but I don't know exactly when this behavior has started.