### PR TITLE
Bring the interface dimensions and positions more in line with Morrowind

### DIFF
--- a/docs/source/reference/modding/settings/windows.rst
+++ b/docs/source/reference/modding/settings/windows.rst
@@ -47,11 +47,11 @@ stats
 -----
 
 :Default:
-	x = 0.0
+	x = 0.015
 
-	y = 0.0
+	y = 0.015
 
-	h = 0.375
+	h = 0.45
 
 	w = 0.4275
 
@@ -64,13 +64,13 @@ spells
 ------
 
 :Default:
-	x = 0.625
+	x = 0.63
 
-	y = 0.5725
+	y = 0.39
 
-	h = 0.375
+	h = 0.36
 
-	w = 0.4275
+	w = 0.51
 
 	pin = false
 
@@ -81,13 +81,13 @@ map
 ---
 
 :Default:
-	x = 0.625
+	x = 0.63
 
-	y = 0.0
+	y = 0.015
 
-	h = 0.375
+	h = 0.36
 
-	w = 0.5725
+	w = 0.37
 
 	pin = false
 
@@ -98,13 +98,13 @@ inventory
 ---------
 
 :Default:
-	x = 0.0
+	x = 0.015
 
-	y = 0.4275
+	y = 0.54
 
-	h = 0.6225
+	h = 0.45
 
-	w = 0.5725
+	w = 0.38
 
 	pin = false
 
@@ -115,14 +115,13 @@ inventory container
 -------------------
 
 :Default:
-	x = 0.0
+	x = 0.015
 
-	y = 0.4275
+	y = 0.54
 
-	h = 0.6225
+	h = 0.45
 
-	w = 0.5725
-
+	w = 0.38
 
 The player's inventory window while searching a container, showing the contents of the character's inventory.
 Activated by clicking on a container. The same window is used for searching dead bodies, and pickpocketing people.
@@ -131,13 +130,13 @@ inventory barter
 ----------------
 
 :Default:
-	x = 0.0
+	x = 0.015
 
-	y = 0.4275
+	y = 0.54
 
-	h = 0.6225
+	h = 0.45
 
-	w = 0.5725
+	w = 0.38
 
 The player's inventory window while bartering. It displays goods owned by the character while bartering.
 Activated by clicking on the Barter choice in the dialog window for an NPC.
@@ -146,13 +145,13 @@ inventory companion
 -------------------
 
 :Default:
-	x = 0.0
+	x = 0.015
 
-	y = 0.4275
+	y = 0.54
 
-	h = 0.6225
+	h = 0.45
 
-	w = 0.5725
+	w = 0.38
 
 The player's inventory window while interacting with a companion.
 The companion windows were added in the Tribunal expansion, but are available everywhere in the OpenMW engine.
@@ -161,13 +160,13 @@ container
 ---------
 
 :Default:
-	x = 0.25
+	x = 0.49
 
-	y = 0.0
+	y = 0.54
 
-	h = 0.75
+	h = 0.39
 
-	w = 0.375
+	w = 0.38
 
 The container window, showing the contents of the container. Activated by clicking on a container.
 The same window is used for searching dead bodies, and pickpocketing people.
@@ -176,13 +175,13 @@ barter
 ------
 
 :Default:
-	x = 0.25
+	x = 0.6
 
-	y = 0.0
+	y = 0.27
 
-	h = 0.75
+	h = 0.38
 
-	w = 0.375
+	w = 0.63
 
 The NPC bartering window, displaying goods owned by the shopkeeper while bartering.
 Activated by clicking on the Barter choice in the dialog window for an NPC.
@@ -191,13 +190,13 @@ companion
 ---------
 
 :Default:
-	x = 0.25
+	x = 0.6
 
-	y = 0.0
+	y = 0.27
 
-	h = 0.75
+	h = 0.38
 
-	w = 0.375
+	w = 0.63
 
 The NPC's inventory window while interacting with a companion.
 The companion windows were added in the Tribunal expansion, but are available everywhere in the OpenMW engine.
@@ -206,13 +205,13 @@ dialogue
 --------
 
 :Default:
-	x = 0.095
+	x = 0.15
 
-	y = 0.095
+	y = 0.5
 
-	h = 0.810
+	h = 0.7
 
-	w = 0.810
+	w = 0.45
 
 The dialog window, for talking with NPCs.
 Activated by clicking on a NPC.
@@ -237,9 +236,9 @@ console
 -------
 
 :Default:
-	x = 0.0
+	x = 0.015
 
-	y = 0.0
+	y = 0.015
 
 	h = 1.0
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -388,34 +388,34 @@ refraction scale = 1.0
 # screen size. (0.0 to 1.0).  X & Y, Width & Height.
 
 # Stats window displaying level, race, class, skills and stats.
-stats x = 0.0
-stats y = 0.0
-stats w = 0.375
-stats h = 0.4275
+stats x = 0.015
+stats y = 0.015
+stats w = 0.4275
+stats h = 0.45
 # Stats window pin status
 stats pin = false
 
 # Spells window displaying powers, spells, and magical items.
-spells x = 0.625
-spells y = 0.5725
-spells w = 0.375
-spells h = 0.4275
+spells x = 0.63
+spells y = 0.39
+spells w = 0.36
+spells h = 0.51
 # Spells window pin status
 spells pin = false
 
 # Local and world map window.
-map x = 0.625
-map y = 0.0
-map w = 0.375
-map h = 0.5725
+map x = 0.63
+map y = 0.015
+map w = 0.36
+map h = 0.37
 # Map window pin status
 map pin = false
 
 # Dialog window for talking with NPCs.
-dialogue x = 0.095
-dialogue y = 0.095
-dialogue w = 0.810
-dialogue h = 0.810
+dialogue x = 0.15
+dialogue y = 0.5
+dialogue w = 0.7
+dialogue h = 0.45
 
 # Alchemy window for crafting potions.
 alchemy x = 0.25
@@ -424,51 +424,51 @@ alchemy w = 0.5
 alchemy h = 0.5
 
 # Console command window for debugging commands.
-console x = 0.0
-console y = 0.0
+console x = 0.015
+console y = 0.015
 console w = 1.0
 console h = 0.5
 
 # Player inventory window when explicitly opened.
-inventory x = 0.0
-inventory y = 0.4275
-inventory w = 0.6225
-inventory h = 0.5725
+inventory x = 0.015
+inventory y = 0.54
+inventory w = 0.45
+inventory h = 0.38
 # Inventory window pin status
 inventory pin = false
 
 # Player inventory window when searching a container.
-inventory container x = 0.0
-inventory container y = 0.4275
-inventory container w = 0.6225
-inventory container h = 0.5725
+inventory container x = 0.015
+inventory container y = 0.54
+inventory container w = 0.45
+inventory container h = 0.38
 
 # Player inventory window when bartering with a shopkeeper.
-inventory barter x = 0.0
-inventory barter y = 0.4275
-inventory barter w = 0.6225
-inventory barter h = 0.5725
+inventory barter x = 0.015
+inventory barter y = 0.54
+inventory barter w = 0.45
+inventory barter h = 0.38
 
 # Player inventory window when trading with a companion.
-inventory companion x = 0.0
-inventory companion y = 0.4275
-inventory companion w = 0.6225
-inventory companion h = 0.5725
+inventory companion x = 0.015
+inventory companion y = 0.54
+inventory companion w = 0.45
+inventory companion h = 0.38
 
 # Container inventory when searching a container.
-container x = 0.25
-container y = 0.0
-container w = 0.75
-container h = 0.375
+container x = 0.49
+container y = 0.54
+container w = 0.39
+container h = 0.38
 
 # NPC inventory window when bartering with a shopkeeper.
-barter x = 0.25
-barter y = 0.0
-barter w = 0.75
-barter h = 0.375
+barter x = 0.6
+barter y = 0.27
+barter w = 0.38
+barter h = 0.63
 
 # NPC inventory window when trading with a companion.
-companion x = 0.25
-companion y = 0.0
-companion w = 0.75
-companion h = 0.375
+companion x = 0.6
+companion y = 0.27
+companion w = 0.38
+companion h = 0.63


### PR DESCRIPTION
Stats, map, inventory, spells menus — [Morrowind](https://user-images.githubusercontent.com/21265616/36628936-4c080cb4-1960-11e8-8535-f4144f1f8fd9.png)/[master](https://user-images.githubusercontent.com/21265616/36628977-d20f17d0-1960-11e8-8d2d-bc0db48fedd0.png)/[pull request](https://user-images.githubusercontent.com/21265616/36628991-02dd1466-1961-11e8-8d76-bf3d53683c14.png)
Dialogue window — [Morrowind](https://user-images.githubusercontent.com/21265616/36628935-4be5ea6c-1960-11e8-8e06-cd35a039808a.png)/[master](https://user-images.githubusercontent.com/21265616/36628976-d1ef55ee-1960-11e8-9ea5-d14920fb409b.png)/[pull request](https://user-images.githubusercontent.com/21265616/36628990-02bb8e18-1961-11e8-9bb0-c14df37da5e2.png)
Barter window — [Morrowind](https://user-images.githubusercontent.com/21265616/36628918-2ad8c984-1960-11e8-981a-931e44c54988.png)/[master](https://user-images.githubusercontent.com/21265616/36628974-d1b09ade-1960-11e8-8870-dcb6ba80bbcb.png)/[pull request](https://user-images.githubusercontent.com/21265616/36628988-027b4790-1961-11e8-9638-4d807c0ae34d.png)
Container window — [Morrowind](https://user-images.githubusercontent.com/21265616/36628934-4bc2a96c-1960-11e8-9f7d-4f3521d48ca4.png)/[master](https://user-images.githubusercontent.com/21265616/36628975-d1d04f0a-1960-11e8-9cce-9f26be4939a0.png)/[pull request](https://user-images.githubusercontent.com/21265616/36628989-029a9640-1961-11e8-9f86-88813d03e605.png)

While these tweaks are not 1:1 recreation of the vanilla, because I had to account for how both Morrowind and OpenMW UI look different on different resolutions and how Morrowind UI is quirky, if we want to truly replicate Morrowind aesthetics for 1.0, this is essential, I guess.

Note that Morrowind screenshots have the UI display quality fix from MCP applied.

inb4 yay more scrolling, but I believe NPCs were not meant to be obscured with the dialogue window and right click menus shouldn't obscure the HUD and container windows were not supposed to be identical to barter windows et cetera, and Morrowind purists may object to these things as to "openmw devs preferences".