### PR TITLE
Round up encumbrance value in the inventory window (Feature #1786)

### DIFF
--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -132,7 +132,7 @@ void CompanionWindow::updateEncumbranceBar()
         return;
     float capacity = mPtr.getClass().getCapacity(mPtr);
     float encumbrance = mPtr.getClass().getEncumbrance(mPtr);
-    mEncumbranceBar->setValue(std::max(INT_MAX-1, std::ceil(encumbrance)), static_cast<int>(capacity));
+    mEncumbranceBar->setValue(std::min(INT_MAX-1, std::ceil(encumbrance)), static_cast<int>(capacity));
 
     if (mModel && mModel->hasProfit(mPtr))
     {

--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -1,5 +1,8 @@
 #include "companionwindow.hpp"
 
+#include <algorithm>
+#include <cmath>
+
 #include <MyGUI_InputManager.h>
 
 #include "../mwbase/environment.hpp"
@@ -129,7 +132,7 @@ void CompanionWindow::updateEncumbranceBar()
         return;
     float capacity = mPtr.getClass().getCapacity(mPtr);
     float encumbrance = mPtr.getClass().getEncumbrance(mPtr);
-    mEncumbranceBar->setValue(static_cast<int>(encumbrance), static_cast<int>(capacity));
+    mEncumbranceBar->setValue(std::max(INT_MAX-1, std::ceil(encumbrance)), static_cast<int>(capacity));
 
     if (mModel && mModel->hasProfit(mPtr))
     {

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -1,5 +1,6 @@
 #include "inventorywindow.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
@@ -599,7 +600,7 @@ namespace MWGui
         float capacity = player.getClass().getCapacity(player);
         float encumbrance = player.getClass().getEncumbrance(player);
         mTradeModel->adjustEncumbrance(encumbrance);
-        mEncumbranceBar->setValue(std::ceil(encumbrance), static_cast<int>(capacity));
+        mEncumbranceBar->setValue(std::max(INT_MAX-1, std::ceil(encumbrance)), static_cast<int>(capacity));
     }
 
     void InventoryWindow::onFrame(float dt)

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -600,7 +600,7 @@ namespace MWGui
         float capacity = player.getClass().getCapacity(player);
         float encumbrance = player.getClass().getEncumbrance(player);
         mTradeModel->adjustEncumbrance(encumbrance);
-        mEncumbranceBar->setValue(std::max(INT_MAX-1, std::ceil(encumbrance)), static_cast<int>(capacity));
+        mEncumbranceBar->setValue(std::min(INT_MAX-1, std::ceil(encumbrance)), static_cast<int>(capacity));
     }
 
     void InventoryWindow::onFrame(float dt)

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -599,10 +599,7 @@ namespace MWGui
         float capacity = player.getClass().getCapacity(player);
         float encumbrance = player.getClass().getEncumbrance(player);
         mTradeModel->adjustEncumbrance(encumbrance);
-        if (encumbrance != 0.f)
-            mEncumbranceBar->setValue(static_cast<int>(std::round(encumbrance+0.5)), static_cast<int>(capacity));
-        else
-            mEncumbranceBar->setValue(0, static_cast<int>(capacity));
+        mEncumbranceBar->setValue(std::ceil(encumbrance), static_cast<int>(capacity));
     }
 
     void InventoryWindow::onFrame(float dt)

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -1,5 +1,6 @@
 #include "inventorywindow.hpp"
 
+#include <cmath>
 #include <stdexcept>
 
 #include <MyGUI_Window.h>
@@ -598,7 +599,10 @@ namespace MWGui
         float capacity = player.getClass().getCapacity(player);
         float encumbrance = player.getClass().getEncumbrance(player);
         mTradeModel->adjustEncumbrance(encumbrance);
-        mEncumbranceBar->setValue(static_cast<int>(encumbrance), static_cast<int>(capacity));
+        if (encumbrance != 0.f)
+            mEncumbranceBar->setValue(static_cast<int>(std::round(encumbrance+0.5)), static_cast<int>(capacity));
+        else
+            mEncumbranceBar->setValue(0, static_cast<int>(capacity));
     }
 
     void InventoryWindow::onFrame(float dt)


### PR DESCRIPTION
For rounding up, considering the encumbrance displayed is always a non-negative number, I use std::ceil from cmath class. It returns an integer value, so the static cast isn't necessary.