### PR TITLE
Round up displayed encumbrance (Feature #1786)

### DIFF
--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -1,5 +1,7 @@
 #include "companionwindow.hpp"
 
+#include <cmath>
+
 #include <MyGUI_InputManager.h>
 
 #include "../mwbase/environment.hpp"
@@ -129,7 +131,7 @@ void CompanionWindow::updateEncumbranceBar()
         return;
     float capacity = mPtr.getClass().getCapacity(mPtr);
     float encumbrance = mPtr.getClass().getEncumbrance(mPtr);
-    mEncumbranceBar->setValue(static_cast<int>(encumbrance), static_cast<int>(capacity));
+    mEncumbranceBar->setValue(std::ceil(encumbrance), static_cast<int>(capacity));
 
     if (mModel && mModel->hasProfit(mPtr))
     {

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -1,5 +1,6 @@
 #include "inventorywindow.hpp"
 
+#include <cmath>
 #include <stdexcept>
 
 #include <MyGUI_Window.h>
@@ -598,7 +599,7 @@ namespace MWGui
         float capacity = player.getClass().getCapacity(player);
         float encumbrance = player.getClass().getEncumbrance(player);
         mTradeModel->adjustEncumbrance(encumbrance);
-        mEncumbranceBar->setValue(static_cast<int>(encumbrance), static_cast<int>(capacity));
+        mEncumbranceBar->setValue(std::ceil(encumbrance), static_cast<int>(capacity));
     }
 
     void InventoryWindow::onFrame(float dt)


### PR DESCRIPTION
Using std::ceil for rounding the encumbrance up to the smallest integer not smaller that the floating point value. The static cast shouldn't be necessary in normal conditions.