### PR TITLE
INI importer clean-up

### DIFF
--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -22,8 +22,6 @@ MwIniImporter::MwIniImporter()
     const char *fallback[] = {
 
         // light
-        "LightAttenuation:UseConstant",
-        "LightAttenuation:ConstantValue",
         "LightAttenuation:UseLinear",
         "LightAttenuation:LinearMethod",
         "LightAttenuation:LinearValue",
@@ -73,8 +71,6 @@ MwIniImporter::MwIniImporter()
         "Water:RippleScale",
         "Water:RippleRotSpeed",
         "Water:RippleAlphas",
-        "Water:PSWaterReflectTerrain",
-        "Water:PSWaterReflectUpdate",
         "Water:NearWaterRadius",
         "Water:NearWaterPoints",
         "Water:NearWaterUnderwaterFreq",
@@ -90,11 +86,6 @@ MwIniImporter::MwIniImporter()
         "Water:UnderwaterIndoorFog",
         "Water:UnderwaterColor",
         "Water:UnderwaterColorWeight",
-
-        // pixelwater
-        "PixelWater:SurfaceFPS",
-        "PixelWater:TileCount",
-        "PixelWater:Resolution",
 
         // fonts
         "Fonts:Font 0",
@@ -622,17 +613,6 @@ MwIniImporter::MwIniImporter()
         "Moons:Masser Fade Out Start",
         "Moons:Masser Fade Out Finish",
         "Moons:Script Color",
-
-        // blood
-        "Blood:Model 0",
-        "Blood:Model 1",
-        "Blood:Model 2",
-        "Blood:Texture 0",
-        "Blood:Texture 1",
-        "Blood:Texture 2",
-        "Blood:Texture Name 0",
-        "Blood:Texture Name 1",
-        "Blood:Texture Name 2",
 
         // werewolf (Bloodmoon)
         "General:Werewolf FOV",


### PR DESCRIPTION
See the commit message for clarification.

Some notes: Morrowind engine appears to support up to 8 slots for blood textures that can be made use of in mods - Diverse Blood utilizes them. Both OpenMW and OpenMW-CS lack such support; they're hardcoded to only assign three blood textures.

Even though OpenMW supports level up messages for levels past 20 now, you must add them manually to openmw.cfg, because INI importer only imports messages for levels from 1 to 20 and the default message. It's unclear how many level up messages should ini importer import.