### PR TITLE
Weapon sheathing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
+    Feature #4673: Weapon sheathing
     Task #4686: Upgrade media decoder to a more current FFmpeg API
-
 
 0.45.0
 ------

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -166,7 +166,7 @@ namespace MWClass
             getContainerStore(ptr).fill(ref->mBase->mInventory, ptr.getCellRef().getRefId());
 
             if (hasInventory)
-                getInventoryStore(ptr).autoEquipShield(ptr);
+                getInventoryStore(ptr).autoEquip(ptr);
         }
     }
 

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -1,5 +1,4 @@
 #include "actoranimation.hpp"
-
 #include <utility>
 
 #include <osg/Node>
@@ -9,10 +8,21 @@
 #include <components/esm/loadligh.hpp>
 #include <components/esm/loadcell.hpp>
 
+#include <components/resource/resourcesystem.hpp>
+#include <components/resource/scenemanager.hpp>
+
+#include <components/sceneutil/attach.hpp>
 #include <components/sceneutil/lightmanager.hpp>
 #include <components/sceneutil/lightutil.hpp>
+#include <components/sceneutil/visitor.hpp>
 
 #include <components/fallback/fallback.hpp>
+
+#include <components/misc/stringops.hpp>
+
+#include <components/settings/settings.hpp>
+
+#include <components/vfs/manager.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -43,6 +53,8 @@ ActorAnimation::ActorAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group>
 
     // Make sure we cleaned object from effects, just in cast if we re-use node
     removeEffects();
+
+    mWeaponSheathing = Settings::Manager::getBool("weapon sheathing", "Game");
 }
 
 ActorAnimation::~ActorAnimation()
@@ -51,6 +63,302 @@ ActorAnimation::~ActorAnimation()
     {
         mInsert->removeChild(iter->second);
     }
+
+    mScabbard.reset();
+}
+
+PartHolderPtr ActorAnimation::getWeaponPart(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor)
+{
+    osg::Group* parent = getBoneByName(bonename);
+    if (!parent)
+        return nullptr;
+
+    osg::ref_ptr<osg::Node> instance = mResourceSystem->getSceneManager()->getInstance(model, parent);
+
+    const NodeMap& nodeMap = getNodeMap();
+    NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
+    if (found == nodeMap.end())
+        return PartHolderPtr();
+
+    if (enchantedGlow)
+        addGlow(instance, *glowColor);
+
+    return PartHolderPtr(new PartHolder(instance));
+}
+
+osg::Group* ActorAnimation::getBoneByName(std::string boneName)
+{
+    if (!mObjectRoot)
+        return nullptr;
+
+    SceneUtil::FindByNameVisitor findVisitor (boneName);
+    mObjectRoot->accept(findVisitor);
+
+    return findVisitor.mFoundNode;
+}
+
+std::string ActorAnimation::getHolsteredWeaponBoneName(const MWWorld::ConstPtr& weapon)
+{
+    std::string boneName;
+    if(weapon.isEmpty())
+        return boneName;
+
+    const std::string &type = weapon.getClass().getTypeName();
+    if(type == typeid(ESM::Weapon).name())
+    {
+        const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon.get<ESM::Weapon>();
+        ESM::Weapon::Type weaponType = (ESM::Weapon::Type)ref->mBase->mData.mType;
+        return getHolsteredWeaponBoneName(weaponType);
+    }
+
+    return boneName;
+}
+
+std::string ActorAnimation::getHolsteredWeaponBoneName(const unsigned int weaponType)
+{
+    std::string boneName;
+
+    switch(weaponType)
+    {
+        case ESM::Weapon::ShortBladeOneHand:
+            boneName = "Bip01 ShortBladeOneHand";
+            break;
+        case ESM::Weapon::LongBladeOneHand:
+            boneName = "Bip01 LongBladeOneHand";
+            break;
+        case ESM::Weapon::BluntOneHand:
+            boneName = "Bip01 BluntOneHand";
+            break;
+        case ESM::Weapon::AxeOneHand:
+            boneName = "Bip01 LongBladeOneHand";
+            break;
+        case ESM::Weapon::LongBladeTwoHand:
+            boneName = "Bip01 LongBladeTwoClose";
+            break;
+        case ESM::Weapon::BluntTwoClose:
+            boneName = "Bip01 BluntTwoClose";
+            break;
+        case ESM::Weapon::AxeTwoHand:
+            boneName = "Bip01 AxeTwoClose";
+            break;
+        case ESM::Weapon::BluntTwoWide:
+            boneName = "Bip01 BluntTwoWide";
+            break;
+        case ESM::Weapon::SpearTwoWide:
+            boneName = "Bip01 SpearTwoWide";
+            break;
+        case ESM::Weapon::MarksmanBow:
+            boneName = "Bip01 MarksmanBow";
+            break;
+        case ESM::Weapon::MarksmanCrossbow:
+            boneName = "Bip01 MarksmanCrossbow";
+            break;
+        case ESM::Weapon::MarksmanThrown:
+            boneName = "Bip01 MarksmanThrown";
+            break;
+        default:
+            break;
+    }
+
+    return boneName;
+}
+
+void ActorAnimation::injectWeaponBones()
+{
+    if (!mResourceSystem->getVFS()->exists("meshes\\xbase_anim_sh.nif"))
+    {
+        mWeaponSheathing = false;
+        return;
+    }
+
+    osg::ref_ptr<osg::Node> sheathSkeleton = mResourceSystem->getSceneManager()->getInstance("meshes\\xbase_anim_sh.nif");
+
+    for (unsigned int type=0; type<=ESM::Weapon::MarksmanThrown; ++type)
+    {
+        const std::string holsteredBoneName = getHolsteredWeaponBoneName(type);
+
+        SceneUtil::FindByNameVisitor findVisitor (holsteredBoneName);
+        sheathSkeleton->accept(findVisitor);
+        osg::ref_ptr<osg::Node> sheathNode = findVisitor.mFoundNode;
+
+        if (sheathNode && sheathNode.get()->getNumParents())
+        {
+            osg::Group* sheathParent = getBoneByName(sheathNode.get()->getParent(0)->getName());
+
+            if (sheathParent)
+            {
+                sheathNode.get()->getParent(0)->removeChild(sheathNode);
+                sheathParent->addChild(sheathNode);
+            }
+        }
+    }
+}
+
+// To make sure we do not run morph controllers for weapons, i.e. bows
+class EmptyCallback : public osg::NodeCallback
+{
+    public:
+
+        virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
+        {
+        }
+};
+
+void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
+{
+    if (!mWeaponSheathing)
+        return;
+
+    if (!mPtr.getClass().hasInventoryStore(mPtr))
+        return;
+
+    mScabbard.reset();
+
+    const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+    MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    if (weapon == inv.end() || weapon->getTypeName() != typeid(ESM::Weapon).name())
+        return;
+
+    // Since throwing weapons stack themselves, do not show such weapon itself
+    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+        showHolsteredWeapons = false;
+
+    std::string mesh = weapon->getClass().getModel(*weapon);
+    std::string scabbardName = mesh;
+
+    std::string boneName = getHolsteredWeaponBoneName(*weapon);
+    if (mesh.empty() || boneName.empty())
+        return;
+
+    // If the scabbard is not found, use a weapon mesh as fallback
+    scabbardName = scabbardName.replace(scabbardName.size()-4, 4, "_sh.nif");
+    bool isEnchanted = !weapon->getClass().getEnchantment(*weapon).empty();
+    if(!mResourceSystem->getVFS()->exists(scabbardName))
+    {
+        if (showHolsteredWeapons)
+        {
+            osg::Vec4f glowColor = getEnchantmentColor(*weapon);
+            mScabbard = getWeaponPart(mesh, boneName, isEnchanted, &glowColor);
+            if (mScabbard)
+                mScabbard->getNode()->setUpdateCallback(new EmptyCallback);
+        }
+
+        return;
+    }
+
+    mScabbard = getWeaponPart(scabbardName, boneName);
+
+    osg::Group* weaponNode = getBoneByName("Bip01 Weapon");
+    if (!weaponNode)
+        return;
+
+    // When we draw weapon, hide the Weapon node from sheath model.
+    // Otherwise add the enchanted glow to it.
+    if (!showHolsteredWeapons)
+    {
+        weaponNode->setNodeMask(0);
+    }
+    else
+    {
+        // If mesh author declared empty weapon node, use transformation from this node, but use the common weapon mesh.
+        // This approach allows to tweak weapon position without need to store the whole weapon mesh in the _sh file.
+        if (!weaponNode->getNumChildren())
+        {
+            osg::ref_ptr<osg::Node> fallbackNode = mResourceSystem->getSceneManager()->getInstance(mesh, weaponNode);
+            fallbackNode->setUpdateCallback(new EmptyCallback);
+        }
+
+        if (isEnchanted)
+        {
+            osg::Vec4f glowColor = getEnchantmentColor(*weapon);
+            addGlow(weaponNode, glowColor);
+        }
+    }
+}
+
+void ActorAnimation::updateQuiver()
+{
+    if (!mWeaponSheathing)
+        return;
+
+    if (!mPtr.getClass().hasInventoryStore(mPtr))
+        return;
+
+    const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+    MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    if(weapon == inv.end() || weapon->getTypeName() != typeid(ESM::Weapon).name())
+        return;
+
+    std::string mesh = weapon->getClass().getModel(*weapon);
+    std::string boneName = getHolsteredWeaponBoneName(*weapon);
+    if (mesh.empty() || boneName.empty())
+        return;
+
+    osg::Group* ammoNode = getBoneByName("Bip01 Ammo");
+    if (!ammoNode)
+        return;
+
+    // Special case for throwing weapons - they do not use ammo, but they stack themselves
+    bool suitableAmmo = false;
+    MWWorld::ConstContainerStoreIterator ammo = weapon;
+    unsigned int ammoCount = 0;
+    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+    {
+        ammoCount = ammo->getRefData().getCount();
+        osg::Group* throwingWeaponNode = getBoneByName("Weapon Bone");
+        if (throwingWeaponNode && throwingWeaponNode->getNumChildren())
+            ammoCount--;
+
+        suitableAmmo = true;
+    }
+    else
+    {
+        ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
+        if (ammo == inv.end())
+            return;
+
+        ammoCount = ammo->getRefData().getCount();
+        bool arrowAttached = isArrowAttached();
+        if (arrowAttached)
+            ammoCount--;
+
+        if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow)
+            suitableAmmo = ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Bolt;
+        else if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanBow)
+            suitableAmmo = ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Arrow;
+    }
+
+    if (ammoNode && suitableAmmo)
+    {
+        // We should not show more ammo than equipped and more than quiver mesh has
+        ammoCount = std::min(ammoCount, ammoNode->getNumChildren());
+
+        // Remove existing ammo nodes
+        for (unsigned int i=0; i<ammoNode->getNumChildren(); ++i)
+        {
+            osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
+            if (!arrowNode->getNumChildren())
+                continue;
+
+            osg::ref_ptr<osg::Node> arrowChildNode = arrowNode->getChild(0);
+            arrowNode->removeChild(arrowChildNode);
+        }
+
+        // Add new ones
+        osg::Vec4f glowColor = getEnchantmentColor(*ammo);
+        std::string model = ammo->getClass().getModel(*ammo);
+        for (unsigned int i=0; i<ammoCount; ++i)
+        {
+            osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
+            osg::ref_ptr<osg::Node> arrow = mResourceSystem->getSceneManager()->getInstance(model, arrowNode);
+            if (!ammo->getClass().getEnchantment(*ammo).empty())
+                addGlow(arrow, glowColor);
+        }
+    }
+
+    // recreate shaders for invisible actors, otherwise new nodes will be visible
+    if (mAlpha != 1.f)
+        mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
 }
 
 void ActorAnimation::itemAdded(const MWWorld::ConstPtr& item, int /*count*/)
@@ -63,6 +371,24 @@ void ActorAnimation::itemAdded(const MWWorld::ConstPtr& item, int /*count*/)
             addHiddenItemLight(item, light);
         }
     }
+
+    if (!mPtr.getClass().hasInventoryStore(mPtr))
+        return;
+
+    // If the count of equipped ammo or throwing weapon was changed, we should update quiver
+    const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+    MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    if(weapon == inv.end() || weapon->getTypeName() != typeid(ESM::Weapon).name())
+        return;
+
+    MWWorld::ConstContainerStoreIterator ammo = inv.end();
+    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+        ammo = weapon;
+    else
+        ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
+
+    if(ammo != inv.end() && item.getCellRef().getRefId() == ammo->getCellRef().getRefId())
+        updateQuiver();
 }
 
 void ActorAnimation::itemRemoved(const MWWorld::ConstPtr& item, int /*count*/)
@@ -78,6 +404,24 @@ void ActorAnimation::itemRemoved(const MWWorld::ConstPtr& item, int /*count*/)
             }
         }
     }
+
+    if (!mPtr.getClass().hasInventoryStore(mPtr))
+        return;
+
+    // If the count of equipped ammo or throwing weapon was changed, we should update quiver
+    const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+    MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    if(weapon == inv.end() || weapon->getTypeName() != typeid(ESM::Weapon).name())
+        return;
+
+    MWWorld::ConstContainerStoreIterator ammo = inv.end();
+    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+        ammo = weapon;
+    else
+        ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
+
+    if(ammo != inv.end() && item.getCellRef().getRefId() == ammo->getCellRef().getRefId())
+        updateQuiver();
 }
 
 void ActorAnimation::addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM::Light* esmLight)

--- a/apps/openmw/mwrender/actoranimation.hpp
+++ b/apps/openmw/mwrender/actoranimation.hpp
@@ -6,6 +6,7 @@
 #include <osg/ref_ptr>
 
 #include "../mwworld/containerstore.hpp"
+#include "../mwworld/inventorystore.hpp"
 
 #include "animation.hpp"
 
@@ -36,6 +37,24 @@ class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
 
         virtual void itemAdded(const MWWorld::ConstPtr& item, int count);
         virtual void itemRemoved(const MWWorld::ConstPtr& item, int count);
+        virtual bool isArrowAttached() const { return false; }
+
+    protected:
+        bool mWeaponSheathing;
+        osg::Group* getBoneByName(std::string boneName);
+        virtual void updateHolsteredWeapon(bool showHolsteredWeapons);
+        virtual void injectWeaponBones();
+        virtual void updateQuiver();
+        virtual std::string getHolsteredWeaponBoneName(const MWWorld::ConstPtr& weapon);
+        virtual std::string getHolsteredWeaponBoneName(const unsigned int weaponType);
+        virtual PartHolderPtr getWeaponPart(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor);
+        virtual PartHolderPtr getWeaponPart(const std::string& model, const std::string& bonename)
+        {
+            osg::Vec4f stubColor = osg::Vec4f(0,0,0,0);
+            return getWeaponPart(model, bonename, false, &stubColor);
+        };
+
+        PartHolderPtr mScabbard;
 
     private:
         void addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM::Light* esmLight);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1748,8 +1748,6 @@ namespace MWRender
             }
             else
             {
-                osg::StateSet* stateset (new osg::StateSet);
-
                 osg::BlendFunc* blendfunc (new osg::BlendFunc);
                 stateset->setAttributeAndModes(blendfunc, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
 

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -49,7 +49,12 @@ CreatureWeaponAnimation::CreatureWeaponAnimation(const MWWorld::Ptr &ptr, const 
         setObjectRoot(model, true, false, true);
 
         if((ref->mBase->mFlags&ESM::Creature::Bipedal))
+        {
+            if (mWeaponSheathing)
+                injectWeaponBones();
+
             addAnimSource("meshes\\xbase_anim.nif", model);
+        }
         addAnimSource(model, model);
 
         mPtr.getClass().getInventoryStore(mPtr).setInvListener(this, mPtr);
@@ -83,6 +88,9 @@ void CreatureWeaponAnimation::updateParts()
     mAmmunition.reset();
     mWeapon.reset();
     mShield.reset();
+
+    updateHolsteredWeapon(!mShowWeapons);
+    updateQuiver();
 
     if (mShowWeapons)
         updatePart(mWeapon, MWWorld::InventoryStore::Slot_CarriedRight);
@@ -157,14 +165,21 @@ void CreatureWeaponAnimation::updatePart(PartHolderPtr& scene, int slot)
     }
 }
 
+bool CreatureWeaponAnimation::isArrowAttached() const
+{
+    return mAmmunition != nullptr;
+}
+
 void CreatureWeaponAnimation::attachArrow()
 {
     WeaponAnimation::attachArrow(mPtr);
+    updateQuiver();
 }
 
 void CreatureWeaponAnimation::releaseArrow(float attackStrength)
 {
     WeaponAnimation::releaseArrow(mPtr, attackStrength);
+    updateQuiver();
 }
 
 osg::Group *CreatureWeaponAnimation::getArrowBone()

--- a/apps/openmw/mwrender/creatureanimation.hpp
+++ b/apps/openmw/mwrender/creatureanimation.hpp
@@ -54,6 +54,8 @@ namespace MWRender
         /// to indicate the facing orientation of the character.
         virtual void setPitchFactor(float factor) { mPitchFactor = factor; }
 
+    protected:
+        virtual bool isArrowAttached() const;
 
     private:
         PartHolderPtr mWeapon;

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -95,6 +95,7 @@ private:
 
 protected:
     virtual void addControllers();
+    virtual bool isArrowAttached() const;
 
 public:
     /**

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -330,7 +330,8 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr
             item.getRefData().getLocals().setVarByInt(script, "onpcadd", 1);
     }
 
-    if (mListener)
+    // we should not fire event for InventoryStore yet - it has some custom logic
+    if (mListener && !actorPtr.getClass().hasInventoryStore(actorPtr))
         mListener->itemAdded(item, count);
 
     return it;
@@ -439,7 +440,8 @@ int MWWorld::ContainerStore::remove(const Ptr& item, int count, const Ptr& actor
 
     flagAsModified();
 
-    if (mListener)
+    // we should not fire event for InventoryStore yet - it has some custom logic
+    if (mListener && !actor.getClass().hasInventoryStore(actor))
         mListener->itemRemoved(item, count - toRemove);
 
     // number of removed items

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -68,6 +68,9 @@ namespace MWWorld
 
             static const std::string sGoldId;
 
+        protected:
+            ContainerStoreListener* mListener;
+
         private:
 
             MWWorld::CellRefList<ESM::Potion>            potions;
@@ -86,8 +89,6 @@ namespace MWWorld
             std::map<std::pair<std::string, std::string>, int> mLevelledItemMap;
             ///< Stores result of levelled item spawns. <(refId, spawningGroup), count>
             /// This is used to restock levelled items(s) if the old item was sold.
-
-            ContainerStoreListener* mListener;
 
             mutable float mCachedWeight;
             mutable bool mWeightUpToDate;

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -69,7 +69,7 @@ namespace MWWorld
 
             MWMechanics::MagicEffects mMagicEffects;
 
-            InventoryStoreListener* mListener;
+            InventoryStoreListener* mInventoryListener;
 
             // Enables updates of magic effects and actor model whenever items are equipped or unequipped.
             // This is disabled during autoequip to avoid excessive updates
@@ -93,6 +93,10 @@ namespace MWWorld
             typedef std::vector<ContainerStoreIterator> TSlots;
 
             TSlots mSlots;
+
+            void autoEquipWeapon(const MWWorld::Ptr& actor, TSlots& slots_);
+            void autoEquipArmor(const MWWorld::Ptr& actor, TSlots& slots_);
+            void autoEquipShield(const MWWorld::Ptr& actor, TSlots& slots_);
 
             // selected magic item (for using enchantments of type "Cast once" or "Cast when used")
             ContainerStoreIterator mSelectedEnchantItem;
@@ -163,9 +167,6 @@ namespace MWWorld
 
             void autoEquip (const MWWorld::Ptr& actor);
             ///< Auto equip items according to stats and item value.
-
-            void autoEquipShield(const MWWorld::Ptr& actor);
-            ///< Auto-equip the shield with most health.
 
             const MWMechanics::MagicEffects& getMagicEffects() const;
             ///< Return magic effects from worn items.

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -396,7 +396,8 @@ namespace Resource
             {
                 const char* reserved[] = {"Head", "Neck", "Chest", "Groin", "Right Hand", "Left Hand", "Right Wrist", "Left Wrist", "Shield Bone", "Right Forearm", "Left Forearm", "Right Upper Arm",
                                           "Left Upper Arm", "Right Foot", "Left Foot", "Right Ankle", "Left Ankle", "Right Knee", "Left Knee", "Right Upper Leg", "Left Upper Leg", "Right Clavicle",
-                                          "Left Clavicle", "Weapon Bone", "Tail", "Bip01", "Root Bone", "BoneOffset", "AttachLight", "ArrowBone", "Camera"};
+                                          "Left Clavicle", "Weapon Bone", "Tail", "Bip01", "Root Bone", "BoneOffset", "AttachLight", "Arrow", "Camera"};
+
                 reservedNames = std::vector<std::string>(reserved, reserved + sizeof(reserved)/sizeof(reserved[0]));
 
                 for (unsigned int i=0; i<sizeof(reserved)/sizeof(reserved[0]); ++i)

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -171,8 +171,19 @@ followers attack on sight
 Make player followers and escorters start combat with enemies who have started combat with them or the player.
 Otherwise they wait for the enemies or the player to do an attack first.
 Please note this setting has not been extensively tested and could have side effects with certain quests.
-
 This setting can be toggled in Advanced tab of the launcher.
+
+weapon sheathing
+----------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, OpenMW will utilize weapon sheathing-compatible assets to display holstered weapons.
+
+To make use of this, you need to have an xbase_anim_sh.nif file with weapon bones that will be injected into the skeleton.
+Additional _sh suffix models are not essential for weapon sheathing to work but will act as quivers or scabbards for the weapons they correspond to.
 
 use additional anim sources
 ---------------------------

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -239,6 +239,9 @@ barter disposition change is permanent = false
 # 2 means werewolves are ignored) 
 strength influences hand to hand = 0
 
+# Render holstered weapons (with quivers and scabbards), requires modded assets
+weapon sheathing = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Implements [feature #4673](https://gitlab.com/OpenMW/openmw/issues/4673).
Related topic is [here](https://forum.openmw.org/viewtopic.php?f=6&t=4973).
Here are WIP animations for this feature: [Animations.zip](https://github.com/OpenMW/openmw/files/2430573/Animations.zip)

[Link](https://ci.appveyor.com/api/buildjobs/c4ycvfcx67c4lbhu/artifacts/OpenMW_MSVC2015_x64_1615_92e45507d8bba9321163e3bfd3099cd92ac9de20.zip) to archive with current build.

Basic idea: add some new bones to humanoid skeleton and attach weapons/quivers/scabbards/etc to these bones.

Data format is compatible with the [Weapon Sheathing mod](https://www.nexusmods.com/morrowind/mods/46069), so you can use meshes from this mod.
xbase_anim_sh.nif is required, other files are optional.

Sheathed models for now are separate meshes with _sh suffix. If there is no scabbard for current weapon mesh, an engine will show only holstered weapon. Also scabbards and quivers do not have enchanting glow (but arrows in quiver do).

The feature is disabled by default. You should enable it in config file:

[Game]
weapon sheathing = true
use additional anim sources = true

Now this feature supports:
1. Weapon holstering.
Holstered weapons also has glow when enchanted.
2. Scabbards for any type of weapon excepts of throwing.
Scabbard itself does not have a glow.
3. Quivers for bows and crossbows.
Quivers itself do not have a glow, but arrows have when enchanted.
Count and type of rendered arrows depends on type and count of equipped arrows.

Notes:
1. I had to rework autoequipping
2. Shield holstering is not supported for now - there is a lot of issues with resources (we will need to add new animation groups, there is a lot of clipping with movement animations, issues with mods that use pseudo-shields, etc).