### PR TITLE
Ownership by dead actors is not cleared from picked items (Bug #4328)

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -940,7 +940,8 @@ namespace MWMechanics
         if (!cellref.getOwner().empty())
         {
             victim = MWBase::Environment::get().getWorld()->searchPtr(cellref.getOwner(), true);
-            if (victim.getClass().getCreatureStats(victim).isDead() && isOwned == true)
+            const bool ownerIsDead = victim.getClass().getCreatureStats(victim).isDead();
+            if (ownerIsDead && isOwned)
                 isOwned = false;
         }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -917,7 +917,7 @@ namespace MWMechanics
         }
 
         const std::string& owner = cellref.getOwner();
-        bool isOwned = !owner.empty() && owner != "player";
+        bool isOwned = !owner.empty() && !owner.getClass().getCreatureStats(owner).isDead() && owner != "player";
 
         const std::string& faction = cellref.getFaction();
         bool isFactionOwned = false;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -917,7 +917,7 @@ namespace MWMechanics
         }
 
         const std::string& owner = cellref.getOwner();
-        bool isOwned = !owner.empty() && !owner.getClass().getCreatureStats(owner).isDead() && owner != "player";
+        bool isOwned = !owner.empty() && owner != "player";
 
         const std::string& faction = cellref.getFaction();
         bool isFactionOwned = false;
@@ -938,7 +938,11 @@ namespace MWMechanics
         }
 
         if (!cellref.getOwner().empty())
+        {
             victim = MWBase::Environment::get().getWorld()->searchPtr(cellref.getOwner(), true);
+            if (victim.getClass().getCreatureStats(victim).isDead() && isOwned == true)
+                isOwned = false;
+        }
 
         return (!isOwned && !isFactionOwned);
     }


### PR DESCRIPTION
This solution should suffice for ~~two cases~~ ~~one case~~ damn if I know what from the [report](http://bugs.openmw.org/issues/4328): if the owner of an item is dead at the time the player picks a certain item up. However, I'm not sure how to go around clearing the item from StolenItemsMap upon game loading. From what I can tell, this requires:

- messing with save loading
- getting the actor state during save loading
- clearing the items with dead owners *every time* a save is loaded
- probably more awkwardness

Any more practical ideas?