### PR TITLE
Ownership by dead actors is not cleared from picked items (Bug #4328)

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1120,7 +1120,7 @@ namespace MWMechanics
         if (!Misc::StringUtils::ciEqual(item.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
         {
             const MWWorld::Ptr victimRef = MWBase::Environment::get().getWorld()->searchPtr(item.getCellRef().getOwner(), true);
-            if (!victimRef.getClass().getCreatureStats(victimRef).isDead())
+            if (victimRef.isEmpty() || !victimRef.getClass().getCreatureStats(victimRef).isDead())
                 mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
         }
         if (alarm)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1118,8 +1118,11 @@ namespace MWMechanics
         Misc::StringUtils::lowerCaseInPlace(owner.first);
 
         if (!Misc::StringUtils::ciEqual(item.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
-            mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
-
+        {
+            const MWWorld::Ptr victimRef = MWBase::Environment::get().getWorld()->searchPtr(item.getCellRef().getOwner(), true);
+            if (!victimRef.getClass().getCreatureStats(victimRef).isDead())
+                mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
+        }
         if (alarm)
             commitCrime(ptr, victim, OT_Theft, item.getClass().getValue(item) * count);
     }

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1119,7 +1119,7 @@ namespace MWMechanics
 
         if (!Misc::StringUtils::ciEqual(item.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
         {
-            const MWWorld::Ptr victimRef = MWBase::Environment::get().getWorld()->searchPtr(item.getCellRef().getOwner(), true);
+            const MWWorld::Ptr victimRef = MWBase::Environment::get().getWorld()->searchPtr(ownerCellRef->getOwner(), true);
             if (victimRef.isEmpty() || !victimRef.getClass().getCreatureStats(victimRef).isDead())
                 mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
         }


### PR DESCRIPTION
[Tracker](http://bugs.openmw.org/issues/4328)

Prevent mStolenItems for specific item ID from increasing in this case.

Note: the stolen tag is not cleared from such items upon loading a saved game.