### PR TITLE
Adding max quicksaves to launcher

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -40,7 +40,6 @@ bool Launcher::AdvancedPage::loadSettings()
     maximumQuicksavesComboBox->setValue(mEngineSettings.getInt("max quicksaves", "Saves"));
 
     // Other Settings
-
     QString screenshotFormatString = QString::fromStdString(mEngineSettings.getString("screenshot format", "General")).toUpper();
     if (screenshotFormatComboBox->findText(screenshotFormatString) == -1)
         screenshotFormatComboBox->addItem(screenshotFormatString);

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -35,8 +35,11 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(grabCursorCheckBox, "grab cursor", "Input");
     loadSettingBool(toggleSneakCheckBox, "toggle sneak", "Input");
 
-    // Other Settings
+    // Saves Settings
     loadSettingBool(timePlayedCheckbox, "timeplayed", "Saves");
+    maximumQuicksavesComboBox->setValue(mEngineSettings.getInt("max quicksaves", "Saves"));
+
+    // Other Settings
 
     QString screenshotFormatString = QString::fromStdString(mEngineSettings.getString("screenshot format", "General")).toUpper();
     if (screenshotFormatComboBox->findText(screenshotFormatString) == -1)
@@ -69,9 +72,11 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(grabCursorCheckBox, "grab cursor", "Input");
     saveSettingBool(toggleSneakCheckBox, "toggle sneak", "Input");
 
-    // Other Settings
+    // Saves Settings
     saveSettingBool(timePlayedCheckbox, "timeplayed", "Saves");
+    mEngineSettings.setInt("max quicksaves", "Saves", maximumQuicksavesComboBox->value());
 
+    // Other Settings
     std::string screenshotFormatString = screenshotFormatComboBox->currentText().toLower().toStdString();
     if (screenshotFormatString != mEngineSettings.getString("screenshot format", "General"))
         mEngineSettings.setString("screenshot format", "General", screenshotFormatString);

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>434</width>
+    <width>671</width>
     <height>373</height>
    </rect>
   </property>
@@ -27,9 +27,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>393</width>
-        <height>437</height>
+        <y>-187</y>
+        <width>630</width>
+        <height>510</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="scrollAreaVerticalLayout">
@@ -139,6 +139,9 @@
              </item>
              <item>
               <widget class="QComboBox" name="showOwnedComboBox">
+               <property name="currentIndex">
+                <number>1</number>
+               </property>
                <item>
                 <property name="text">
                  <string>Off</string>
@@ -207,11 +210,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="otherGroup">
+        <widget class="QGroupBox" name="savesGroup">
          <property name="title">
-          <string>Other</string>
+          <string>Saves</string>
          </property>
-         <layout class="QVBoxLayout" name="otherGroupVerticalLayout">
+         <layout class="QVBoxLayout" name="savesGroupVerticalLayout">
           <item>
            <widget class="QCheckBox" name="timePlayedCheckbox">
             <property name="toolTip">
@@ -223,11 +226,58 @@
            </widget>
           </item>
           <item alignment="Qt::AlignLeft">
+           <widget class="QWidget" name="maximumQuicksavesGroup" native="true">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting determines how many quicksave and autosave slots you can have at a time. If greater than 1, quicksaves will be sequentially created each time you quicksave. Once the maximum number of quicksaves has been reached, the oldest quicksave will be recycled the next time you perform a quicksave.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <layout class="QHBoxLayout" name="maximumQuicksavesLayout">
+             <property name="spacing">
+              <number>-1</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="maximumQuicksavesLabel">
+               <property name="text">
+                <string>Maximum Quicksaves</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="maximumQuicksavesComboBox">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="otherGroup">
+         <property name="title">
+          <string>Other</string>
+         </property>
+         <layout class="QVBoxLayout" name="otherGroupVerticalLayout">
+          <item alignment="Qt::AlignLeft">
            <widget class="QWidget" name="screenshotFormatGroup" native="true">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the format for screen shots taken by pressing the screen shot key (bound to F12 by default). This setting should be the file extension commonly associated with the desired format. The formats supported will be determined at compilation, but “jpg”, “png”, and “tga” should be allowed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <layout class="QHBoxLayout" name="screenshotFormatLayout">
              <property name="spacing">
               <number>-1</number>
              </property>


### PR DESCRIPTION
Adding the multiple quicksaves setting introduced in #1597 to the Launcher's Advanced page.

<img width="832" alt="maximum quicksaves in launcher" src="https://user-images.githubusercontent.com/6200170/36766412-6bee4bfe-1bfb-11e8-8961-3966c2835819.png">

I moved *Add "Time Played" to Saves* from the "Other" category to a newly formed "Saves" category.