### PR TITLE
add more precise float-spinbox and use it for rotations

### DIFF
--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -88,6 +88,7 @@ namespace CSMWorld
             Display_UnsignedInteger8,
             Display_Integer,
             Display_Float,
+            Display_Double,
             Display_Var,
             Display_GmstVarType,
             Display_GlobalVarType,

--- a/apps/opencs/model/world/columnimp.hpp
+++ b/apps/opencs/model/world/columnimp.hpp
@@ -1371,7 +1371,7 @@ namespace CSMWorld
         RotColumn (ESM::Position ESXRecordT::* position, int index, bool door)
         : Column<ESXRecordT> (
           (door ? Columns::ColumnId_DoorPositionXRot : Columns::ColumnId_PositionXRot)+index,
-          ColumnBase::Display_Float), mPosition (position), mIndex (index) {}
+          ColumnBase::Display_Double), mPosition (position), mIndex (index) {}
 
         virtual QVariant get (const Record<ESXRecordT>& record) const
         {

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -184,11 +184,11 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.back().addColumn(
             new RefIdColumn (Columns::ColumnId_PosZ, CSMWorld::ColumnBase::Display_Float));
     mColumns.back().addColumn(
-            new RefIdColumn (Columns::ColumnId_RotX, CSMWorld::ColumnBase::Display_Float));
+            new RefIdColumn (Columns::ColumnId_RotX, CSMWorld::ColumnBase::Display_Double));
     mColumns.back().addColumn(
-            new RefIdColumn (Columns::ColumnId_RotY, CSMWorld::ColumnBase::Display_Float));
+            new RefIdColumn (Columns::ColumnId_RotY, CSMWorld::ColumnBase::Display_Double));
     mColumns.back().addColumn(
-            new RefIdColumn (Columns::ColumnId_RotZ, CSMWorld::ColumnBase::Display_Float));
+            new RefIdColumn (Columns::ColumnId_RotZ, CSMWorld::ColumnBase::Display_Double));
 
     // Nested table
     mColumns.push_back(RefIdColumn (Columns::ColumnId_AiPackageList,

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -233,6 +233,15 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
             return dsb;
         }
 
+        case CSMWorld::ColumnBase::Display_Double:
+        {
+            DialogueDoubleSpinBox *dsb = new DialogueDoubleSpinBox(parent);
+            dsb->setRange(-FLT_MAX, FLT_MAX);
+            dsb->setSingleStep(0.01f);
+            dsb->setDecimals(6);
+            return dsb;
+        }
+
         case CSMWorld::ColumnBase::Display_LongString:
         {
             QPlainTextEdit *edit = new QPlainTextEdit(parent);


### PR DESCRIPTION
Currently when editing instances with the CS, the precision of rotations is quite low, which can in some cases lead to visible gaps when entering them by hand.

This commit adds another type of edit that double the number of available decimals and uses them for rotations.

I should note that this is the change that appeared the least invasive to me, though I would consider the following a better solution: Instead of entering the rotations directly, involving the use of transcendental numbers and rounding, consider to normalize rotations to multiples of `2*pi`. That way a 180°-rotation would be written as 0.5, 90° would be 0.25, 45° 0.125 and so on. I believe that this would be a much more natural way of describing rotations. Alternatively degrees could be used, which are less beautifull from a mathematical perspective, but also allow things like 60° to be easy enough. The change for that would certainly be larger and users would have to change the way the use the CS, but I think in the long run it would be well worth it. I would be willing to implement it, if you are fine with that, but I cannot promise any timeframe (so you might want to merge this either way).