### PR TITLE
Preventing max quicksaves from being saved to settings.cfg if unchanged

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -73,7 +73,10 @@ void Launcher::AdvancedPage::saveSettings()
 
     // Saves Settings
     saveSettingBool(timePlayedCheckbox, "timeplayed", "Saves");
-    mEngineSettings.setInt("max quicksaves", "Saves", maximumQuicksavesComboBox->value());
+    int maximumQuicksaves = maximumQuicksavesComboBox->value();
+    if (maximumQuicksaves != mEngineSettings.getInt("max quicksaves", "Saves")) {
+        mEngineSettings.setInt("max quicksaves", "Saves", maximumQuicksaves);
+    }
 
     // Other Settings
     std::string screenshotFormatString = screenshotFormatComboBox->currentText().toLower().toStdString();


### PR DESCRIPTION
Fixes issue identified [here](https://github.com/OpenMW/openmw/pull/1618#issuecomment-370155844)