### PR TITLE
Combine stacks of similar items when vendor sells items (bug #2842)

### DIFF
--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -34,7 +34,7 @@ namespace MWGui
     private:
         std::vector<MWWorld::Ptr> mItemSources;
         std::vector<MWWorld::Ptr> mWorldItems;
-
+        bool mIsForTrading;
         std::vector<ItemStack> mItems;
     };
 

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -43,16 +43,16 @@ namespace MWGui
 
         // If one of the items is in an inventory and currently equipped, we need to check stacking both ways to be sure
         if (mBase.getContainerStore() && other.mBase.getContainerStore())
-            return mBase.getContainerStore()->stacks(mBase, other.mBase)
-                    && other.mBase.getContainerStore()->stacks(mBase, other.mBase);
+            return mBase.getContainerStore()->stacks(mBase, other.mBase, true)
+                && other.mBase.getContainerStore()->stacks(mBase, other.mBase, true);
 
         if (mBase.getContainerStore())
-            return mBase.getContainerStore()->stacks(mBase, other.mBase);
+            return mBase.getContainerStore()->stacks(mBase, other.mBase, true);
         if (other.mBase.getContainerStore())
-            return other.mBase.getContainerStore()->stacks(mBase, other.mBase);
+            return other.mBase.getContainerStore()->stacks(mBase, other.mBase, true);
 
         MWWorld::ContainerStore store;
-        return store.stacks(mBase, other.mBase);
+        return store.stacks(mBase, other.mBase, true);
 
     }
 
@@ -66,16 +66,16 @@ namespace MWGui
 
         // If one of the items is in an inventory and currently equipped, we need to check stacking both ways to be sure
         if (left.mBase.getContainerStore() && right.mBase.getContainerStore())
-            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase)
-                    && right.mBase.getContainerStore()->stacks(left.mBase, right.mBase);
+            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase, true)
+                && right.mBase.getContainerStore()->stacks(left.mBase, right.mBase, true);
 
         if (left.mBase.getContainerStore())
-            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase);
+            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase, true);
         if (right.mBase.getContainerStore())
-            return right.mBase.getContainerStore()->stacks(left.mBase, right.mBase);
+            return right.mBase.getContainerStore()->stacks(left.mBase, right.mBase, true);
 
         MWWorld::ContainerStore store;
-        return store.stacks(left.mBase, right.mBase);
+        return store.stacks(left.mBase, right.mBase, true);
     }
 
     ItemModel::ItemModel()

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -208,7 +208,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::restack(const MWWorld::
 
     for (MWWorld::ContainerStoreIterator iter (begin()); iter != end(); ++iter)
     {
-        if (stacks(*iter, item))
+        if (stacks(*iter, item, true))
         {
             iter->getRefData().setCount(iter->getRefData().getCount() + item.getRefData().getCount());
             item.getRefData().setCount(0);
@@ -219,7 +219,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::restack(const MWWorld::
     return retval;
 }
 
-bool MWWorld::ContainerStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2) const
+bool MWWorld::ContainerStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2, bool respectOwnership) const
 {
     const MWWorld::Class& cls1 = ptr1.getClass();
     const MWWorld::Class& cls2 = ptr2.getClass();
@@ -240,7 +240,7 @@ bool MWWorld::ContainerStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2)
     }
 
     return ptr1 != ptr2 // an item never stacks onto itself
-        && ptr1.getCellRef().getOwner() == ptr2.getCellRef().getOwner()
+        && (!respectOwnership || (ptr1.getCellRef().getOwner() == ptr2.getCellRef().getOwner()))
         && ptr1.getCellRef().getSoul() == ptr2.getCellRef().getSoul()
 
         && ptr1.getClass().getRemainingUsageTime(ptr1) == ptr2.getClass().getRemainingUsageTime(ptr2)
@@ -369,7 +369,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::addImp (const Ptr& ptr,
     // determine whether to stack or not
     for (MWWorld::ContainerStoreIterator iter (begin(type)); iter!=end(); ++iter)
     {
-        if (stacks(*iter, ptr))
+        if (stacks(*iter, ptr, true))
         {
             // stack
             iter->getRefData().setCount( iter->getRefData().getCount() + count );
@@ -1039,7 +1039,7 @@ bool MWWorld::ContainerStoreIteratorBase<PtrType>::isEqual (const ContainerStore
         case -1: return true;
     }
 
-    return false;  
+    return false;
 }
 
 template<class PtrType>

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -37,7 +37,7 @@ namespace MWWorld
     typedef ContainerStoreIteratorBase<Ptr> ContainerStoreIterator;
     typedef ContainerStoreIteratorBase<ConstPtr> ConstContainerStoreIterator;
 
-    
+
     class ContainerStoreListener
     {
         public:
@@ -123,7 +123,7 @@ namespace MWWorld
             ConstContainerStoreIterator cend() const;
             ConstContainerStoreIterator begin (int mask = Type_All) const;
             ConstContainerStoreIterator end() const;
-            
+
             ContainerStoreIterator begin (int mask = Type_All);
             ContainerStoreIterator end();
 
@@ -180,8 +180,10 @@ namespace MWWorld
 
         public:
 
-            virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2) const;
-            ///< @return true if the two specified objects can stack with each other
+        virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2, bool respectOwnership) const;
+            ///< @return true if the two specified objects can stack with each other.
+            /// Setting respectOwnership to false will allow objects whose owners don't match
+            /// to stack together
 
             void fill (const ESM::InventoryList& items, const std::string& owner);
             ///< Insert items into *this.
@@ -208,7 +210,7 @@ namespace MWWorld
             friend class ContainerStoreIteratorBase<ConstPtr>;
     };
 
-    
+
     template<class PtrType>
     class ContainerStoreIteratorBase
         : public std::iterator<std::forward_iterator_tag, PtrType, std::ptrdiff_t, PtrType *, PtrType&>
@@ -247,7 +249,7 @@ namespace MWWorld
         {
             typedef ContainerStore* type;
         };
-        
+
         template<class Dummy>
         struct ContainerStoreTrait<ConstPtr, Dummy>
         {
@@ -296,9 +298,9 @@ namespace MWWorld
 
         template<class T>
         void copy (const ContainerStoreIteratorBase<T>& src);
-        
+
         void incType ();
-        
+
         void nextType ();
 
         bool resetIterator ();

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -646,7 +646,7 @@ void MWWorld::InventoryStore::flagAsModified()
 
 bool MWWorld::InventoryStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2) const
 {
-    bool canStack = MWWorld::ContainerStore::stacks(ptr1, ptr2);
+    bool canStack = MWWorld::ContainerStore::stacks(ptr1, ptr2, true);
     if (!canStack)
         return false;
 


### PR DESCRIPTION
A fix proposal for [bug #2842](https://bugs.openmw.org/issues/2842)

When merchants have an item in an owned container, and an identical item
on their person, those stacks do not appear combined in the trading
screen.  This is because the items in the container may not have their
ownership set on a per-item basis, but the items on the vendor's person
do.  When trying to combine stacks, the code would see that the owners
didn't match, and would not join them.

Since the code to build the container model for the trader already
checks that the items are owned by the vendor, it is safe for the
model to assume that if it is trading, then item ownership can be
ignored for the sake of stacking.