### PR TITLE
Account for all possible count values in getCountString (Bug #4346)

### DIFF
--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -16,7 +16,12 @@ namespace
     {
         if (count == 1)
             return "";
-        if (count > 9999)
+
+        if (count > 999999999)
+            return MyGUI::utility::toString(int(count/1000000000.f)) + "b";
+        else if (count > 999999)
+            return MyGUI::utility::toString(int(count/1000000.f)) + "m";
+        else if (count > 9999)
             return MyGUI::utility::toString(int(count/1000.f)) + "k";
         else
             return MyGUI::utility::toString(count);

--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -18,11 +18,11 @@ namespace
             return "";
 
         if (count > 999999999)
-            return MyGUI::utility::toString(int(count/1000000000.f)) + "b";
+            return MyGUI::utility::toString(count/1000000000) + "b";
         else if (count > 999999)
-            return MyGUI::utility::toString(int(count/1000000.f)) + "m";
+            return MyGUI::utility::toString(count/1000000) + "m";
         else if (count > 9999)
-            return MyGUI::utility::toString(int(count/1000.f)) + "k";
+            return MyGUI::utility::toString(count/1000) + "k";
         else
             return MyGUI::utility::toString(count);
     }


### PR DESCRIPTION
[Bug report](https://bugs.openmw.org/issues/4346)
Icon icon only fits 4 characters. This means that item counts equal to million and more get truncated visually: 999 999 is the highest number that can fit, it gets rounded down to 999k, and 9999 is the highest number that fits without rounding down.
Count value is an integer, so the highest values where no issues should arise are in billions.
I added special cases for millions and billions - numbers higher than 999999 will be reported as, for example, "300m", and numbers higher than 999999999 will appear as 1b and 2b on the icon, because otherwise 1000m gets truncated to (1)000m.

Floating point number division may lead to rounding errors, so that was removed to (hopefully) mitigate the second issue from the report.