### PR TITLE
Remove the word "interior" from cell not found message

### DIFF
--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -592,7 +592,7 @@ namespace MWWorld
         const ESM::Cell *ptr = search(id);
         if (ptr == 0) {
             std::ostringstream msg;
-            msg << "Interior cell '" << id << "' not found";
+            msg << "Cell '" << id << "' not found";
             throw std::runtime_error(msg.str());
         }
         return ptr;


### PR DESCRIPTION
[Fixes Bug #4343](https://bugs.openmw.org/issues/4343). Error messages will now say

> Error: Cell 'balmor' not found

This prevents confusion since it works for both interior and exterior cells (the original message implied that it only worked for exterior cells).