### PR TITLE
Unstack soulgem, added via AddSoulGem console command

### DIFF
--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -454,7 +454,13 @@ namespace MWScript
                     store.get<ESM::Creature>().find(creature); // This line throws an exception if it can't find the creature
 
                     MWWorld::Ptr item = *ptr.getClass().getContainerStore(ptr).add(gem, 1, ptr);
+
+                    // Set the soul on just one of the gems, not the whole stack
+                    item.getContainerStore()->unstack(item, ptr);
                     item.getCellRef().setSoul(creature);
+
+                    // Restack the gem with other gems with the same soul
+                    item.getContainerStore()->restack(item);
                 }
         };
 


### PR DESCRIPTION
Fixes [bug #4351](https://bugs.openmw.org/issues/4351).

Just unstack added gem before setSoul() call and restack it after the call.
We already do this for soultrapping in actors.cpp.