### PR TITLE
Prevent sound overlapping for journal and books scrolling

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -337,7 +337,7 @@ namespace MWBase
             /// Cycle to next or previous weapon
             virtual void cycleWeapon(bool next) = 0;
 
-            virtual void playSound(const std::string& soundId, float volume = 1.f, float pitch = 1.f) = 0;
+            virtual void playSound(const std::string& soundId, bool preventOverlapping = false, float volume = 1.f, float pitch = 1.f) = 0;
 
             // In WindowManager for now since there isn't a VFS singleton
             virtual std::string correctIconPath(const std::string& path) = 0;

--- a/apps/openmw/mwgui/bookwindow.cpp
+++ b/apps/openmw/mwgui/bookwindow.cpp
@@ -200,7 +200,7 @@ namespace MWGui
     {
         if ((mCurrentPage+1)*2 < mPages.size())
         {
-            MWBase::Environment::get().getWindowManager()->playSound("book page2");
+            MWBase::Environment::get().getWindowManager()->playSound("book page2", true);
 
             ++mCurrentPage;
 
@@ -211,7 +211,7 @@ namespace MWGui
     {
         if (mCurrentPage > 0)
         {
-            MWBase::Environment::get().getWindowManager()->playSound("book page");
+            MWBase::Environment::get().getWindowManager()->playSound("book page", true);
 
             --mCurrentPage;
 

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -616,7 +616,7 @@ namespace
 
                 if (page+2 < book->pageCount())
                 {
-                    MWBase::Environment::get().getWindowManager()->playSound("book page");
+                    MWBase::Environment::get().getWindowManager()->playSound("book page", true);
 
                     page += 2;
                     updateShowingPages ();
@@ -634,7 +634,7 @@ namespace
 
                 if(page >= 2)
                 {
-                    MWBase::Environment::get().getWindowManager()->playSound("book page");
+                    MWBase::Environment::get().getWindowManager()->playSound("book page", true);
 
                     page -= 2;
                     updateShowingPages ();

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1916,11 +1916,16 @@ namespace MWGui
             mInventoryWindow->cycle(next);
     }
 
-    void WindowManager::playSound(const std::string& soundId, float volume, float pitch)
+    void WindowManager::playSound(const std::string& soundId, bool preventOverlapping, float volume, float pitch)
     {
         if (soundId.empty())
             return;
-        MWBase::Environment::get().getSoundManager()->playSound(soundId, volume, pitch, MWSound::Type::Sfx, MWSound::PlayMode::NoEnv);
+
+        MWBase::SoundManager *sndmgr = MWBase::Environment::get().getSoundManager();
+        if (preventOverlapping && sndmgr->getSoundPlaying(MWWorld::Ptr(), soundId))
+            return;
+
+        sndmgr->playSound(soundId, volume, pitch, MWSound::Type::Sfx, MWSound::PlayMode::NoEnv);
     }
 
     void WindowManager::updateSpellWindow()

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -366,7 +366,7 @@ namespace MWGui
     /// Cycle to next or previous weapon
     virtual void cycleWeapon(bool next);
 
-    virtual void playSound(const std::string& soundId, float volume = 1.f, float pitch = 1.f);
+    virtual void playSound(const std::string& soundId, bool preventOverlapping = false, float volume = 1.f, float pitch = 1.f);
 
     // In WindowManager for now since there isn't a VFS singleton
     virtual std::string correctIconPath(const std::string& path);


### PR DESCRIPTION
Easy to notice the difference when scrolling the journal via mouse wheel.
Not sure if this feature should be enabled for other GUI sounds.