### PR TITLE
Use middle gray fallback color instead of black in case a fallback color wasn't found (bug #2841)

### DIFF
--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -1,5 +1,7 @@
 #include "fallback.hpp"
 
+#include <iostream>
+
 #include <boost/lexical_cast.hpp>
 
 
@@ -17,6 +19,7 @@ namespace Fallback
         std::map<std::string,std::string>::const_iterator it;
         if((it = mFallbackMap.find(fall)) == mFallbackMap.end())
         {
+            std::cerr << "Warning: fallback value " << fall << " not found." << std::endl;
             return "";
         }
         return it->second;
@@ -25,7 +28,7 @@ namespace Fallback
     float Map::getFallbackFloat(const std::string& fall) const
     {
         std::string fallback=getFallbackString(fall);
-        if(fallback.empty())
+        if (fallback.empty())
             return 0;
         else
             return boost::lexical_cast<float>(fallback);
@@ -34,7 +37,7 @@ namespace Fallback
     int Map::getFallbackInt(const std::string& fall) const
     {
         std::string fallback=getFallbackString(fall);
-        if(fallback.empty())
+        if (fallback.empty())
             return 0;
         else
             return std::stoi(fallback);
@@ -43,7 +46,7 @@ namespace Fallback
     bool Map::getFallbackBool(const std::string& fall) const
     {
         std::string fallback=getFallbackString(fall);
-        if(fallback.empty())
+        if (fallback.empty())
             return false;
         else
             return stob(fallback);
@@ -52,7 +55,7 @@ namespace Fallback
     osg::Vec4f Map::getFallbackColour(const std::string& fall) const
     {
         std::string sum=getFallbackString(fall);
-        if(sum.empty())
+        if (sum.empty())
             return osg::Vec4f(0.5f,0.5f,0.5f,1.f);
         else
         {

--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -53,7 +53,7 @@ namespace Fallback
     {
         std::string sum=getFallbackString(fall);
         if(sum.empty())
-            return osg::Vec4f(0.f,0.f,0.f,1.f);
+            return osg::Vec4f(0.5f,0.5f,0.5f,1.f);
         else
         {
             std::string ret[3];


### PR DESCRIPTION
[Bug report](http://bugs.openmw.org/issues/2841)

Apparently there *was* fallback for cases the fallback wasn't defined... which resulted in the behavior the reporter experienced, making the world uniformly black with some light source influence if the whole weather sections of Morrowind.ini were missing. I changed the color to middle gray to make things a) visible b) look not worse than they were with pure black lighting and c) look generic. This also means that a text which uses a missing fallback setting will be gray instead of black.

I've also added a warning in case a fallback value wasn't found.