### PR TITLE
Rework torch usage for NPCs

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -495,8 +495,8 @@ namespace MWBase
 
             virtual void breakInvisibility (const MWWorld::Ptr& actor) = 0;
 
-            // Are we in an exterior or pseudo-exterior cell and it's night?
-            virtual bool isDark() const = 0;
+            // Allow NPCs to use torches?
+            virtual bool useTorches() const = 0;
 
             virtual bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) = 0;
 

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -233,24 +233,6 @@ namespace MWClass
         if (!(ref->mBase->mData.mFlags & ESM::Light::Carry))
             return std::make_pair(0,"");
 
-        const MWWorld::InventoryStore& invStore = npc.getClass().getInventoryStore(npc);
-        MWWorld::ConstContainerStoreIterator weapon = invStore.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-
-        if(weapon == invStore.end())
-            return std::make_pair(1,"");
-
-        /// \todo the 2h check is repeated many times; put it in a function
-        if(weapon->getTypeName() == typeid(ESM::Weapon).name() &&
-                (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::LongBladeTwoHand ||
-        weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::BluntTwoClose ||
-        weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::BluntTwoWide ||
-        weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::SpearTwoWide ||
-        weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::AxeTwoHand ||
-        weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanBow ||
-        weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow))
-        {
-            return std::make_pair(3,"");
-        }
         return std::make_pair(1,"");
     }
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -931,16 +931,11 @@ namespace MWMechanics
                         // For non-hostile NPCs, unequip whatever is in the left slot in favor of a light.
                         if (heldIter != inventoryStore.end() && heldIter->getTypeName() != typeid(ESM::Light).name())
                             inventoryStore.unequipItem(*heldIter, ptr);
-
-                        // Also unequip twohanded weapons which conflict with anything in CarriedLeft
-                        if (torch->getClass().canBeEquipped(*torch, ptr).first == 3)
-                            inventoryStore.unequipSlot(MWWorld::InventoryStore::Slot_CarriedRight, ptr);
                     }
 
                     heldIter = inventoryStore.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
 
-                    // If we have a torch and can equip it (left slot free, no
-                    // twohanded weapon in right slot), then equip it now.
+                    // If we have a torch and can equip it, then equip it now.
                     if (heldIter == inventoryStore.end()
                             && torch->getClass().canBeEquipped(*torch, ptr).first == 1)
                     {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -900,7 +900,7 @@ namespace MWMechanics
             stats.setTimeToStartDrowning(fHoldBreathTime);
     }
 
-    void Actors::updateEquippedLight (const MWWorld::Ptr& ptr, float duration)
+    void Actors::updateEquippedLight (const MWWorld::Ptr& ptr, float duration, bool mayEquip)
     {
         bool isPlayer = (ptr == getPlayer());
 
@@ -922,7 +922,7 @@ namespace MWMechanics
                 }
             }
 
-            if (MWBase::Environment::get().getWorld()->isDark())
+            if (mayEquip)
             {
                 if (torch != inventoryStore.end())
                 {
@@ -1199,6 +1199,9 @@ namespace MWMechanics
             if (mTimerDisposeSummonsCorpses >= 0.2f) mTimerDisposeSummonsCorpses = 0;
             if (timerUpdateEquippedLight >= updateEquippedLightInterval) timerUpdateEquippedLight = 0;
 
+            // show torches only when there are darkness and no precipitations
+            bool showTorches = MWBase::Environment::get().getWorld()->useTorches();
+
             MWWorld::Ptr player = getPlayer();
 
             /// \todo move update logic to Actor class where appropriate
@@ -1297,7 +1300,7 @@ namespace MWMechanics
                         updateNpc(iter->first, duration);
 
                         if (timerUpdateEquippedLight == 0)
-                            updateEquippedLight(iter->first, updateEquippedLightInterval);
+                            updateEquippedLight(iter->first, updateEquippedLightInterval, showTorches);
                     }
                 }
             }

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -39,7 +39,7 @@ namespace MWMechanics
 
             void updateDrowning (const MWWorld::Ptr& ptr, float duration);
 
-            void updateEquippedLight (const MWWorld::Ptr& ptr, float duration);
+            void updateEquippedLight (const MWWorld::Ptr& ptr, float duration, bool mayEquip);
 
             void updateCrimePersuit (const MWWorld::Ptr& ptr, float duration);
 

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -240,8 +240,7 @@ namespace MWWorld
 
         unsigned int getWeatherID() const;
 
-        /// @see World::isDark
-        bool isDark() const;
+        bool useTorches() const;
 
         void write(ESM::ESMWriter& writer, Loading::Listener& progress);
 
@@ -275,6 +274,7 @@ namespace MWWorld
 
         float mWindSpeed;
         bool mIsStorm;
+        bool mPrecipitation;
         osg::Vec3f mStormDirection;
 
         std::string mCurrentRegion;

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -218,14 +218,14 @@ namespace MWWorld
          */
         void changeWeather(const std::string& regionID, const unsigned int weatherID);
         void modRegion(const std::string& regionID, const std::vector<char>& chances);
-        void playerTeleported();
+        void playerTeleported(const std::string& playerRegion, bool isExterior);
 
         /**
          * Per-frame update
          * @param duration
          * @param paused
          */
-        void update(float duration, bool paused = false);
+        void update(float duration, bool paused, const TimeStamp& time, bool isExterior);
 
         void stopSounds();
 
@@ -240,7 +240,7 @@ namespace MWWorld
 
         unsigned int getWeatherID() const;
 
-        bool useTorches() const;
+        bool useTorches(float hour) const;
 
         void write(ESM::ESMWriter& writer, Loading::Listener& progress);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2847,11 +2847,13 @@ namespace MWWorld
         MWBase::Environment::get().getMechanicsManager()->updateMagicEffects(actor);
     }
 
-    bool World::isDark() const
+    bool World::useTorches() const
     {
+        // If we are in exterior, check the weather manager.
+        // In interiors there are no precipitations and sun, so check the ambient
         MWWorld::CellStore* cell = mPlayer->getPlayer().getCell();
         if (cell->isExterior())
-            return mWeatherManager->isDark();
+            return mWeatherManager->useTorches();
         else
         {
             uint32_t ambient = cell->getCell()->mAmbi.mAmbient;

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -604,12 +604,11 @@ namespace MWWorld
             void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,
                                            const osg::Vec3f& worldPos, const osg::Quat& orient, MWWorld::Ptr bow, float speed, float attackStrength) override;
 
-
             const std::vector<std::string>& getContentFiles() const override;
-
             void breakInvisibility (const MWWorld::Ptr& actor) override;
-            // Are we in an exterior or pseudo-exterior cell and it's night?
-            bool isDark() const override;
+
+            // Allow NPCs to use torches?
+            bool useTorches() const override;
 
             bool findInteriorPositionInWorldSpace(const MWWorld::CellStore* cell, osg::Vec3f& result) override;
 


### PR DESCRIPTION
Fixes [bug #4334](https://bugs.openmw.org/issues/4334).

Summary of changes:
1. NPC will hide light sources during bad weather, as they do in vanilla game.
The only difference here - in vanilla this feature does not work well during weather transitions, so I decided to check if there are precipitation particles in scene (rain, snow, etc.).
2. Since we do not want to unequip shields/torches when using two-handed weapons, there is no point to keep such limitation for NPCs. They will not unequp their weapons when they equip torches at night. 