### PR TITLE
Restrict opening doors to bipedal actors (Bug #4313)

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -189,7 +189,7 @@ void MWMechanics::AiPackage::evadeObstacles(const MWWorld::Ptr& actor, float dur
     static float distance = MWBase::Environment::get().getWorld()->getMaxActivationDistance();
 
     MWWorld::Ptr door = getNearbyDoor(actor, distance);
-    if (door != MWWorld::Ptr())
+    if (door != MWWorld::Ptr() && actor.getClass().isBipedal(actor))
     {
         // note: AiWander currently does not open doors
         if (getTypeId() != TypeIdWander && !door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == 0)
@@ -224,7 +224,7 @@ void MWMechanics::AiPackage::evadeObstacles(const MWWorld::Ptr& actor, float dur
                 MWBase::Environment::get().getWorld()->activate(door, actor);
         }
     }
-    else // any other obstacle (NPC, crate, etc.)
+    else
     {
         mObstacleCheck.takeEvasiveAction(movement);
     }


### PR DESCRIPTION
Non-bipedal creatures will attempt to evade the door.

#1572 in its current state breaks this.