### PR TITLE
OpenMW-CS: Fix a typo in startup warning.

### DIFF
--- a/apps/opencs/view/doc/startup.cpp
+++ b/apps/opencs/view/doc/startup.cpp
@@ -106,7 +106,7 @@ CSVDoc::StartupDialogue::StartupDialogue() : mWidth (0), mColumn (2)
 
     /// \todo remove this label once we are feature complete and convinced that this thing is
     /// working properly.
-    QLabel *warning = new QLabel ("<font color=Red>WARNING: OpenMW-CS is in alpha stage.<p>The editor is not feature complete and not sufficiently tested.<br>In theory your data should be safe. But we strongly advice to make backups regularly if you are working with live data.</font color>");
+    QLabel *warning = new QLabel ("<font color=Red>WARNING: OpenMW-CS is in alpha stage.<p>The editor is not feature complete and not sufficiently tested.<br>In theory your data should be safe. But we strongly advise to make backups regularly if you are working with live data.</font color>");
 
     QFont font;
     font.setPointSize (12);


### PR DESCRIPTION
A very trivial PR.