### PR TITLE
[discussion] Restore projectiles from game world

### DIFF
--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -4,6 +4,8 @@
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 
+#include <components/settings/settings.hpp>
+
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
@@ -213,13 +215,15 @@ namespace MWMechanics
 
         // Apply "On hit" effect of the weapon & projectile
         bool appliedEnchantment = applyOnStrikeEnchantment(attacker, victim, weapon, hitPosition, true);
-        if (weapon != projectile)
+        if (weapon != projectile && !appliedEnchantment)
             appliedEnchantment = applyOnStrikeEnchantment(attacker, victim, projectile, hitPosition, true);
 
+        static const bool restoreProjectiles = Settings::Manager::getBool("restore projectiles", "Game");
         if (validVictim)
         {
-            // Non-enchanted arrows shot at enemies have a chance to turn up in their inventory
-            if (victim != getPlayer() && !appliedEnchantment)
+            // Non-enchanted projectiles shot at enemies have a chance to turn up in their inventory
+            // If allow to retrieve all projectiles from game world, we allow to restore enchanted projectiles too
+            if (victim != getPlayer() && (restoreProjectiles || !appliedEnchantment))
             {
                 float fProjectileThrownStoreChance = gmst.find("fProjectileThrownStoreChance")->getFloat();
                 if (Misc::Rng::rollProbability() < fProjectileThrownStoreChance / 100.f)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -775,7 +775,7 @@ namespace MWMechanics
             if (item.getCellRef().getEnchantmentCharge() == -1)
                 item.getCellRef().setEnchantmentCharge(static_cast<float>(enchantment->mData.mCharge));
 
-            if (godmode)
+            if (godmode || mFromProjectile)
                 castCost = 0;
 
             if (item.getCellRef().getEnchantmentCharge() < castCost)

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -597,7 +597,12 @@ namespace MWWorld
 
         // Check for impact
         // TODO: use a proper btRigidBody / btGhostObject?
-        MWPhysics::PhysicsSystem::RayResult result1 = mPhysics->castRay(pos, newPos, caster, targetActors, 0xff, checkMeshDimensions ? MWPhysics::CollisionType_Actor : MWPhysics::CollisionType_Projectile);
+        MWPhysics::PhysicsSystem::RayResult result1;
+        if (checkMeshDimensions)
+            result1 = mPhysics->castRay(pos, newPos, caster, targetActors, MWPhysics::CollisionType_Actor);
+        else
+            result1 = mPhysics->castRay(pos, newPos, caster, targetActors, 0xff, MWPhysics::CollisionType_Projectile);
+
         if (result1.mHit)
         {
             hitObject = result1.mHitObject;

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -256,6 +256,30 @@ namespace MWWorld
         MWRender::overrideFirstRootTexture(texture, mResourceSystem, projectile);
     }
 
+    void ProjectileManager::updateProjectileRotation(ProjectileState& state, float duration)
+    {
+        osg::Quat orient;
+
+        if (state.mThrown)
+            orient.set(
+                osg::Matrixd::rotate(state.mEffectAnimationTime->getTime() * -10.0,osg::Vec3f(0,0,1)) *
+                osg::Matrixd::rotate(osg::PI / 2.0,osg::Vec3f(0,1,0)) *
+                osg::Matrixd::rotate(-1 * osg::PI / 2.0,osg::Vec3f(1,0,0)) *
+                osg::Matrixd::inverse(
+                    osg::Matrixd::lookAt(
+                        osg::Vec3f(0,0,0),
+                        state.mVelocity,
+                        osg::Vec3f(0,0,1))
+                    )
+                );
+        else
+            orient.makeRotate(osg::Vec3f(0,1,0), state.mVelocity);
+
+        state.mNode->setAttitude(orient);
+
+        update(state, duration);
+    }
+
     void ProjectileManager::update(State& state, float duration)
     {
         state.mEffectAnimationTime->addTime(duration);
@@ -465,27 +489,8 @@ namespace MWWorld
             osg::Vec3f pos(it->mNode->getPosition());
             osg::Vec3f newPos = pos + it->mVelocity * duration;
 
-            osg::Quat orient;
-
-            if (it->mThrown)
-                orient.set(
-                    osg::Matrixd::rotate(it->mEffectAnimationTime->getTime() * -10.0,osg::Vec3f(0,0,1)) *
-                    osg::Matrixd::rotate(osg::PI / 2.0,osg::Vec3f(0,1,0)) *
-                    osg::Matrixd::rotate(-1 * osg::PI / 2.0,osg::Vec3f(1,0,0)) *
-                    osg::Matrixd::inverse(
-                        osg::Matrixd::lookAt(
-                            osg::Vec3f(0,0,0),
-                            it->mVelocity,
-                            osg::Vec3f(0,0,1))
-                        )
-                    );
-            else
-                orient.makeRotate(osg::Vec3f(0,1,0), it->mVelocity);
-
-            it->mNode->setAttitude(orient);
+            updateProjectileRotation(*it, duration);
             it->mNode->setPosition(newPos);
-
-            update(*it, duration);
 
             MWWorld::Ptr caster = it->getCaster();
 
@@ -542,27 +547,8 @@ namespace MWWorld
             osg::Vec3f pos(it->mNode->getPosition());
             osg::Vec3f newPos = pos + it->mVelocity * duration;
 
-            osg::Quat orient;
-
-            if (it->mThrown)
-                orient.set(
-                    osg::Matrixd::rotate(it->mEffectAnimationTime->getTime() * -10.0,osg::Vec3f(0,0,1)) *
-                    osg::Matrixd::rotate(osg::PI / 2.0,osg::Vec3f(0,1,0)) *
-                    osg::Matrixd::rotate(-1 * osg::PI / 2.0,osg::Vec3f(1,0,0)) *
-                    osg::Matrixd::inverse(
-                        osg::Matrixd::lookAt(
-                            osg::Vec3f(0,0,0),
-                            it->mVelocity,
-                            osg::Vec3f(0,0,1))
-                        )
-                    );
-            else
-                orient.makeRotate(osg::Vec3f(0,1,0), it->mVelocity);
-
-            it->mNode->setAttitude(orient);
+            updateProjectileRotation(*it, duration);
             it->mNode->setPosition(newPos);
-
-            update(*it, duration);
 
             MWWorld::Ptr caster = it->getCaster();
 

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -560,7 +560,7 @@ namespace MWWorld
                         bow = *invIt;
                 }
 
-                MWMechanics::projectileHit(caster, hitObject, bow, projectile, hasHit ? hitPos : newPos, it->mAttackStrength);
+                MWMechanics::projectileHit(caster, hitObject, bow, projectile, hitPos, it->mAttackStrength);
 
                 if (underwater)
                     mRendering->emitWaterRipple(newPos);

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -69,6 +69,7 @@ namespace MWWorld
         MWRender::RenderingManager* mRendering;
         MWPhysics::PhysicsSystem* mPhysics;
         float mCleanupTimer;
+        bool mRestoreProjectiles;
 
         struct State
         {
@@ -122,6 +123,7 @@ namespace MWWorld
         void cleanupMagicBolt(MagicBoltState& state);
         void periodicCleanup(float dt);
 
+        void enhancedMoveProjectiles(float dt);
         void moveProjectiles(float dt);
         void moveMagicBolts(float dt);
 

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -129,6 +129,7 @@ namespace MWWorld
         void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient,
                             bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture = "");
 
+        bool isProjectile(const MWWorld::Ptr& ptr) const;
         bool checkImpact(const MWWorld::Ptr& caster, const osg::Vec3f& pos, const osg::Vec3f& newPos, osg::Vec3f& hitPos, MWWorld::Ptr& hitObject, bool checkMeshDimensions = false);
         void updateProjectileRotation(ProjectileState& state, float duration);
         void restoreProjectile(ProjectileState& state, osg::Vec3f& hitPos);

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -129,6 +129,8 @@ namespace MWWorld
 
         void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient,
                             bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture = "");
+
+        void updateProjectileRotation(ProjectileState& state, float duration);
         void update (State& state, float duration);
 
         void operator=(const ProjectileManager&);

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -123,7 +123,6 @@ namespace MWWorld
         void cleanupMagicBolt(MagicBoltState& state);
         void periodicCleanup(float dt);
 
-        void enhancedMoveProjectiles(float dt);
         void moveProjectiles(float dt);
         void moveMagicBolts(float dt);
 

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -130,6 +130,7 @@ namespace MWWorld
         void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient,
                             bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture = "");
 
+        bool checkImpact(const MWWorld::Ptr& caster, const osg::Vec3f& pos, const osg::Vec3f& newPos, osg::Vec3f& hitPos, MWWorld::Ptr& hitObject, bool checkMeshDimensions = false);
         void updateProjectileRotation(ProjectileState& state, float duration);
         void restoreProjectile(ProjectileState& state, osg::Vec3f& hitPos);
         void update (State& state, float duration);

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -131,6 +131,7 @@ namespace MWWorld
                             bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture = "");
 
         void updateProjectileRotation(ProjectileState& state, float duration);
+        void restoreProjectile(ProjectileState& state, osg::Vec3f& hitPos);
         void update (State& state, float duration);
 
         void operator=(const ProjectileManager&);

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -131,3 +131,16 @@ Otherwise they wait for the enemies or the player to do an attack first.
 Please note this setting has not been extensively tested and could have side effects with certain quests.
 
 This setting can only be configured by editing the settings configuration file.
+
+restore projectiles
+-------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If enabled, spawns projectile in the hit position, if the target is not actor.
+The player can not restore projectile, if the hit object is a water or lava.
+Can alter game balance and decrease performance.
+
+This setting can only be configured by editing the settings configuration file.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -189,6 +189,9 @@ followers attack on sight = false
 # Can loot non-fighting actors during death animation
 can loot during death animation = true
 
+# Restore projectiles from game world, including enchanted ones
+restore projectiles = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Related [forum thread](https://forum.openmw.org/viewtopic.php?f=6&t=5022). Of course, this feature has limitations, but it would be nice to use it.

The basic idea: rewrite the moveProjectiles() function to:
1. Use mesh dimensions instead of collision meshes for projectile collisions, we already do similar thing for magic bolts.
2. If the projectile hit a non-actor object, spawn an item in hit position and move it a bit.

![screenshot_20180321_095417](https://user-images.githubusercontent.com/26434804/37696223-8276eac6-2cee-11e8-8db2-e68df517716c.jpg)
