### PR TITLE
Typofix: updateCrimePersuit -> updateCrimePursuit

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -992,7 +992,7 @@ namespace MWMechanics
         }
     }
 
-    void Actors::updateCrimePersuit(const MWWorld::Ptr& ptr, float duration)
+    void Actors::updateCrimePursuit(const MWWorld::Ptr& ptr, float duration)
     {
         MWWorld::Ptr player = getPlayer();
         if (ptr != player && ptr.getClass().isNpc())
@@ -1285,7 +1285,7 @@ namespace MWMechanics
                         }
 
                         if (iter->first.getClass().isNpc() && iter->first != player)
-                            updateCrimePersuit(iter->first, duration);
+                            updateCrimePursuit(iter->first, duration);
 
                         if (iter->first != player)
                         {

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -41,7 +41,7 @@ namespace MWMechanics
 
             void updateEquippedLight (const MWWorld::Ptr& ptr, float duration, bool mayEquip);
 
-            void updateCrimePersuit (const MWWorld::Ptr& ptr, float duration);
+            void updateCrimePursuit (const MWWorld::Ptr& ptr, float duration);
 
             void killDeadActors ();
 


### PR DESCRIPTION
typing error in mwmechanix/actors.cpp and mwmechanix/actors.hpp
fixed updateCrimePersuit -> updateCrimePursuit

My first pull request. Am I doing this right?