### PR TITLE
Make followers with high Fight actually not fight other followers (bug #4229)

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -391,7 +391,7 @@ namespace MWMechanics
             {
                 // Player followers and escorters with high fight should not initiate combat with the player or with
                 // other player followers or escorters
-                if (std::find(playerAllies.begin(), playerAllies.end(), actor1) == playerAllies.end())
+                if (!isPlayerFollowerOrEscorter)
                     aggressive = MWBase::Environment::get().getMechanicsManager()->isAggressive(actor1, actor2);
             }
         }


### PR DESCRIPTION
Replacing the find() which tries to decide if the actor is not a follower with a check for previously initialized boolean being false seemed to fix the issue in my testing:

- Summon Winged Twilight (using a spell)
- Summon Golden Saint (using a spell)
- Summon Verminous Fabricant (using Mazed Band)

master behavior: the fabricant immediately attacks the Daedra and then the player as well. If "followers attack on sight" is true, then the Daedra will fight back as soon as the fabricant initiates the combat, otherwise they wait for the fabricant's or the player's first hit.

pull request behavior: the fabricant doesn't attack the Daedra.