### PR TITLE
Wizard: Auto-detect the actual Morrowind assets path (bug #4336)

### DIFF
--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -62,10 +62,11 @@ Wizard::MainWizard::MainWizard(QWidget *parent) :
     setupInstallations();
     setupPages();
 
-    const boost::filesystem::path& installedPath = mCfgMgr.getInstallPath();
-    if (!installedPath.empty())
+    const boost::filesystem::path& installationPath = mCfgMgr.getInstallPath();
+    if (!installationPath.empty())
     {
-        addInstallation(toQString(installedPath));
+        const boost::filesystem::path& dataPath = installationPath / "Data Files";
+        addInstallation(toQString(dataPath));
     }
 }
 


### PR DESCRIPTION
Simply append "Data Files" suffix, which never exists in the grabbed registry installation path. addInstallation appears to be designed to work with this addition just fine.