### PR TITLE
Befriend hasMaster() and capital-case game file extensions (bug #3618)

### DIFF
--- a/components/config/gamesettings.cpp
+++ b/components/config/gamesettings.cpp
@@ -493,8 +493,10 @@ bool Config::GameSettings::hasMaster()
 {
     bool result = false;
     QStringList content = mSettings.values(QString(Config::GameSettings::sContentKey));
-    for (int i = 0; i < content.count(); ++i) {
-        if (content.at(i).contains(".omwgame") || content.at(i).contains(".esm")) {
+    for (int i = 0; i < content.count(); ++i) 
+    {
+        if (content.at(i).endsWith(QLatin1String(".omwgame"), Qt::CaseInsensitive) || content.at(i).endsWith(QLatin1String(".esm"), Qt::CaseInsensitive)) 
+        {
             result = true;
             break;
         }


### PR DESCRIPTION
Qt compare(), contains(), endsWith() etc. are case-sensitive by default and accept a second case sensitivity argument.

This replaces contains with arguably more logical endsWith like it's used in isGameFile() and makes the comparison case-insensitive.