### PR TITLE
Switch playlists if tracks don't exist

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -395,6 +395,7 @@ namespace MWSound
     {
         std::vector<std::string> filelist;
         auto &tracklist = mMusicToPlay[mCurrentPlaylist];
+        // Find all tracks within the playlist
         if (mMusicFiles.find(mCurrentPlaylist) == mMusicFiles.end())
         {
             const std::map<std::string, VFS::File*>& index = mVFS->getIndex();
@@ -417,8 +418,20 @@ namespace MWSound
         else
             filelist = mMusicFiles[mCurrentPlaylist];
 
+        // If there are no tracks, switch to the other playlist if it exists
         if(filelist.empty())
-            return;
+        {
+            if(mCurrentPlaylist == "Combat" && tracklist.find("Explore") != tracklist.end())
+            {
+                mCurrentPlaylist == "Explore";
+                startRandomTitle();
+            }
+            else if (mCurrentPlaylist == "Explore" && tracklist.find("Combat") != tracklist.end())
+            {
+                mCurrentPlaylist == "Combat";
+                startRandomTitle();
+            }
+        }
 
         // Do a Fisher-Yates shuffle
 

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -418,17 +418,17 @@ namespace MWSound
         else
             filelist = mMusicFiles[mCurrentPlaylist];
 
-        // If there are no tracks, switch to the other playlist if it exists
+        // If there are no tracks and the other playlist is populated, switch to the other playlist if it exists
         if(filelist.empty())
         {
-            if(mCurrentPlaylist == "Combat" && tracklist.find("Explore") != tracklist.end())
+            if(mCurrentPlaylist == "Combat" && tracklist.find("Explore") != tracklist.end() && !tracklist["Explore"].empty())
             {
-                mCurrentPlaylist == "Explore";
+                mCurrentPlaylist = "Explore";
                 startRandomTitle();
             }
-            else if (mCurrentPlaylist == "Explore" && tracklist.find("Combat") != tracklist.end())
+            else if (mCurrentPlaylist == "Explore" && tracklist.find("Combat") != tracklist.end() && !tracklist["Combat"].empty())
             {
-                mCurrentPlaylist == "Combat";
+                mCurrentPlaylist = "Combat";
                 startRandomTitle();
             }
         }


### PR DESCRIPTION
Fixes #4134 by editing `playRandomTrack()` so that when either Combat or Explore is chosen but contains no tracks, and when the other playlist does contain tracks, the playlist is switched to the other.