### PR TITLE
Implement fWerewolfHealth GMST (Feature #4142)

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1719,11 +1719,11 @@ namespace MWMechanics
         {
             if (werewolf)
             {
-                player->saveSkillsAttributes();
-                player->setWerewolfSkillsAttributes();
+                player->saveStats();
+                player->setWerewolfStats();
             }
             else
-                player->restoreSkillsAttributes();
+                player->restoreStats();
         }
 
         // Werewolfs can not cast spells, so we need to unset the prepared spell if there is one.

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -46,7 +46,7 @@ namespace MWWorld
         int                     mCurrentCrimeId;    // the id assigned witnesses
         int                     mPaidCrimeId;      // the last id paid off (0 bounty)
 
-        // Saved skills and attributes prior to becoming a werewolf
+        // Saved stats prior to becoming a werewolf
         MWMechanics::SkillValue mSaveSkills[ESM::Skill::Length];
         MWMechanics::AttributeValue mSaveAttributes[ESM::Attribute::Length];
 
@@ -56,9 +56,9 @@ namespace MWWorld
 
         Player(const ESM::NPC *player);
 
-        void saveSkillsAttributes();
-        void restoreSkillsAttributes();
-        void setWerewolfSkillsAttributes();
+        void saveStats();
+        void restoreStats();
+        void setWerewolfStats();
 
         // For mark/recall magic effects
         void markPosition (CellStore* markedCell, const ESM::Position& markedPosition);


### PR DESCRIPTION
Ok, this seems to work exactly or at least similarly to vanilla. When the player character is transformed into a werewolf, their current health is restored and their base health is multiplied by fWerewolfHealth, while any modifier is discarded. When the player transforms back, their original health is restored.

Originally I tried to have saving functionality for the original health, but since that broke the compatibility with existing saves and I realized that it was unnecessary I used a work-around.