### PR TITLE
Option to have enchanted weapons bypass "resist normal weapons" flag (bug #4136)

### DIFF
--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -1,6 +1,7 @@
 #include "combat.hpp"
 
 #include <components/misc/rng.hpp>
+#include <components/settings/settings.hpp>
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 
@@ -155,7 +156,11 @@ namespace MWMechanics
 
         if (!(weapon.get<ESM::Weapon>()->mBase->mData.mFlags & ESM::Weapon::Silver
               || weapon.get<ESM::Weapon>()->mBase->mData.mFlags & ESM::Weapon::Magical))
-            damage *= multiplier;
+        {
+            if (weapon.getClass().getEnchantment(weapon).empty()
+              || !Settings::Manager::getBool("enchanted weapons are magical", "Game"))
+                damage *= multiplier;
+        }
 
         if ((weapon.get<ESM::Weapon>()->mBase->mData.mFlags & ESM::Weapon::Silver)
                 && actor.getClass().isNpc() && actor.getClass().getNpcStats(actor).isWerewolf())

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -109,6 +109,18 @@ The remaining duration is displayed in the tooltip by hovering over the magical 
 
 The default value is false. This setting can only be configured by editing the settings configuration file.
 
+enchanted weapons are magical
+-----------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	True
+
+Makes enchanted weapons without Magical flag bypass normal weapons resistance (and weakness) certain creatures have.
+This is how original Morrowind behaves.
+
+This setting can only be configured by editing the settings configuration file.
+
 prevent merchant equipping
 --------------------------
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -179,6 +179,9 @@ show effect duration = false
 # Prevents merchants from equipping items that are sold to them.
 prevent merchant equipping = false
 
+# Make enchanted weaponry without Magical flag bypass normal weapons resistance
+enchanted weapons are magical = true
+
 # Makes player followers and escorters start combat with enemies who have started combat with them
 # or the player. Otherwise they wait for the enemies or the player to do an attack first.
 followers attack on sight = false


### PR DESCRIPTION
Morrowind behavior is the default, previous MCP-like behavior is optional.