### PR TITLE
Add virtual destructors

### DIFF
--- a/apps/openmw/mwbase/dialoguemanager.hpp
+++ b/apps/openmw/mwbase/dialoguemanager.hpp
@@ -39,6 +39,7 @@ namespace MWBase
             class ResponseCallback
             {
             public:
+                virtual ~ResponseCallback() = default;
                 virtual void addResponse(const std::string& title, const std::string& text) = 0;
             };
 

--- a/components/sceneutil/controller.hpp
+++ b/components/sceneutil/controller.hpp
@@ -25,6 +25,8 @@ namespace SceneUtil
     class ControllerFunction
     {
     public:
+        virtual ~ControllerFunction() = default;
+
         virtual float calculate(float input) const = 0;
 
         /// Get the "stop time" of the controller function, typically the maximum of the calculate() function.


### PR DESCRIPTION
To fix warnings:
```
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/bits/shared_ptr_base.h:588:8: warning: delete called on non-final 'NifOsg::ControllerFunction' that has virtual functions but non-virtual destructor
      [-Wdelete-non-virtual-dtor]
              delete __p;
              ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/bits/shared_ptr_base.h:595:4: note: in instantiation of function template specialization
      'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<NifOsg::ControllerFunction *>' requested here
        : __shared_count(__p)
          ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/bits/shared_ptr_base.h:1079:17: note: in instantiation of function template specialization
      'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<NifOsg::ControllerFunction *>' requested here
        : _M_ptr(__p), _M_refcount(__p, typename is_array<_Tp>::type())
                       ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/bits/shared_ptr.h:129:25: note: in instantiation of function template specialization 'std::__shared_ptr<NifOsg::ControllerFunction,
      __gnu_cxx::_S_atomic>::__shared_ptr<NifOsg::ControllerFunction, void>' requested here
        shared_ptr(_Yp* __p) : __shared_ptr<_Tp>(__p) { }
                               ^
/home/elsid/dev/openmw/components/nifosg/nifloader.cpp:242:39: note: in instantiation of function template specialization 'std::shared_ptr<NifOsg::ControllerFunction>::shared_ptr<NifOsg::ControllerFunction, void>' requested here
                callback->setFunction(std::shared_ptr<NifOsg::ControllerFunction>(new NifOsg::ControllerFunction(key)));
                                      ^

/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/bits/unique_ptr.h:78:2: warning: delete called on non-final 'MWGui::ResponseCallback' that has virtual functions but non-virtual destructor
      [-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.3.1/../../../../include/c++/7.3.1/bits/unique_ptr.h:268:4: note: in instantiation of member function 'std::default_delete<MWGui::ResponseCallback>::operator()' requested here
          get_deleter()(__ptr);
          ^
/home/elsid/dev/openmw/apps/openmw/mwgui/dialogue.cpp:58:23: note: in instantiation of member function 'std::unique_ptr<MWGui::ResponseCallback, std::default_delete<MWGui::ResponseCallback> >::~unique_ptr' requested here
    PersuasionDialog::PersuasionDialog(ResponseCallback* callback)
                      ^
```