### PR TITLE
Reduce twitching for player turning animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
     Bug #4563: Fast travel price logic checks destination cell instead of service actor cell
     Bug #4565: Underwater view distance should be limited
     Bug #4573: Player uses headtracking in the 1st-person mode
+    Bug #4574: Player turning animations are twitchy
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -170,11 +170,17 @@ namespace MWGui
         // We are already using node masks to avoid the scene from being updated/rendered, but node masks don't work for computeBound()
         mViewer->getSceneData()->setComputeBoundingSphereCallback(new DontComputeBoundCallback);
 
+        mShowWallpaper = visible && (MWBase::Environment::get().getStateManager()->getState()
+                == MWBase::StateManager::State_NoGame);
+
+        if (!visible)
+        {
+            draw();
+            return;
+        }
+
         mVisible = visible;
         mLoadingBox->setVisible(mVisible);
-
-        mShowWallpaper = mVisible && (MWBase::Environment::get().getStateManager()->getState()
-                == MWBase::StateManager::State_NoGame);
 
         setVisible(true);
 
@@ -184,9 +190,6 @@ namespace MWGui
         }
 
         MWBase::Environment::get().getWindowManager()->pushGuiMode(mShowWallpaper ? GM_LoadingWallpaper : GM_Loading);
-
-        if (!mVisible)
-            draw();
     }
 
     void LoadingScreen::loadingOff()

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1980,15 +1980,9 @@ void CharacterController::update(float duration)
             else if(rot.z() != 0.0f && !sneak && !(mPtr == getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson()))
             {
                 if(rot.z() > 0.0f)
-                {
                     movestate = inwater ? CharState_SwimTurnRight : CharState_TurnRight;
-                    mAnimation->disable(mCurrentJump);
-                }
                 else if(rot.z() < 0.0f)
-                {
                     movestate = inwater ? CharState_SwimTurnLeft : CharState_TurnLeft;
-                    mAnimation->disable(mCurrentJump);
-                }
             }
         }
 
@@ -2000,7 +1994,7 @@ void CharacterController::update(float duration)
             bool animPlaying = mAnimation->getInfo(mCurrentMovement, &complete);
             if (movestate == CharState_None && isTurning())
             {
-                if ((animPlaying && complete < threshold) || mJumpState != jumpstate)
+                if (animPlaying && complete < threshold)
                     movestate = mMovementState;
             }
         }

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -31,8 +31,10 @@ enum Priority {
     Priority_WeaponLowerBody,
     Priority_SneakIdleLowerBody,
     Priority_SwimIdle,
-    Priority_Jump,
     Priority_Movement,
+    // Note: in vanilla movement anims have higher priority than jump ones.
+    // It causes issues with landing animations during movement.
+    Priority_Jump,
     Priority_Hit,
     Priority_Weapon,
     Priority_Block,


### PR DESCRIPTION
Fixes [bug #4574](https://gitlab.com/OpenMW/openmw/issues/4574). Related [forum topic](https://forum.openmw.org/viewtopic.php?f=6&t=5039).

During turning for small angles anim speed is near 0, so mTurnAnimationThreshold almost make no sense. As workaround, we use a smoothTurn function for NPCs, but we can not use it for player.

The main idea: play turning animation a bit for player after he stops to turn.
As for me, it is not ideal solution in its current state, but it definely better than our current behaviour.