### PR TITLE
Fix a typo in the name of retrieved absorb spell behavior setting

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -568,7 +568,7 @@ namespace MWMechanics
                                     ActiveSpells::ActiveEffect effect_ = effect;
                                     effect_.mMagnitude *= -1;
                                     absorbEffects.push_back(effect_);
-                                    if (reflected && Settings::Manager::getBool("classic reflected absorb attribute behavior", "Game"))
+                                    if (reflected && Settings::Manager::getBool("classic reflect absorb attribute behavior", "Game"))
                                         target.getClass().getCreatureStats(target).getActiveSpells().addSpell("", true,
                                             absorbEffects, mSourceName, caster.getClass().getCreatureStats(caster).getActorId());
                                     else


### PR DESCRIPTION
This is a really dumb one and I don't know why did I think everything worked fine. ~~Probably because Dremoras have a low Reflect magnitude.~~ This is because reflected absorb spells didn't adjust the caster's health under any circumstances due to the setting retrieved being non-existent.

I'd prefer if this were merged ASAP because due to a goof I done Reflect doesn't work on absorb spells properly at all.