### PR TITLE
Remove getFallbackString missing value warnings

### DIFF
--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -1,7 +1,5 @@
 #include "fallback.hpp"
 
-#include <iostream>
-
 #include <boost/lexical_cast.hpp>
 
 
@@ -18,10 +16,8 @@ namespace Fallback
     {
         std::map<std::string,std::string>::const_iterator it;
         if((it = mFallbackMap.find(fall)) == mFallbackMap.end())
-        {
-            std::cerr << "Warning: fallback value " << fall << " not found." << std::endl;
             return "";
-        }
+
         return it->second;
     }
 


### PR DESCRIPTION
Ultimately these are too spammy, because there are a lot of weather settings that are tried to be retrieved "just in case", and the warnings appear every startup.