### PR TITLE
<random>-based RNG

### DIFF
--- a/components/misc/rng.cpp
+++ b/components/misc/rng.cpp
@@ -1,28 +1,31 @@
 #include "rng.hpp"
-#include <cstdlib>
-#include <ctime>
+
+#include <chrono>
+#include <random>
 
 namespace Misc
 {
 
+    std::mt19937 Rng::generator = std::mt19937();
+
     void Rng::init()
     {
-        std::srand(static_cast<unsigned int>(std::time(NULL)));
+        generator.seed(static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
     }
 
     float Rng::rollProbability()
     {
-        return static_cast<float>(std::rand() / (static_cast<double>(RAND_MAX)+1.0));
+        return std::uniform_real_distribution<float>(0, 1 - std::numeric_limits<float>::epsilon())(generator);
     }
 
     float Rng::rollClosedProbability()
     {
-        return static_cast<float>(std::rand() / static_cast<double>(RAND_MAX));
+        return std::uniform_real_distribution<float>(0, 1)(generator);
     }
 
     int Rng::rollDice(int max)
     {
-        return static_cast<int>((std::rand() / (static_cast<double>(RAND_MAX)+1.0)) * (max));
+        return std::uniform_int_distribution<int>(0, max - 1)(generator);
     }
 
 }

--- a/components/misc/rng.hpp
+++ b/components/misc/rng.hpp
@@ -2,6 +2,7 @@
 #define OPENMW_COMPONENTS_MISC_RNG_H
 
 #include <cassert>
+#include <random>
 
 namespace Misc
 {
@@ -12,6 +13,9 @@ namespace Misc
 class Rng
 {
 public:
+
+    /// create a RNG
+    static std::mt19937 generator;
 
     /// seed the RNG
     static void init();


### PR DESCRIPTION
Now that OpenMW is a C++11 project, perhaps it's time to get rid of std::rand.

I'm not too knowledgeable of C++'s random stuff and classes in general, so please let me know if there are major flaws in the logic of this (there usually are).

Note: I only just found #1311 discussion, having forgotten about it earlier.