### PR TITLE
Fix white artifacts when MSAA is used with shader lighting (bug #4143)

### DIFF
--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -47,9 +47,9 @@ varying float depth;
 #define PER_PIXEL_LIGHTING (@normalMap || @forcePPL)
 
 #if !PER_PIXEL_LIGHTING
-varying vec4 lighting;
+centroid varying vec4 lighting;
 #else
-varying vec4 passColor;
+centroid varying vec4 passColor;
 #endif
 varying vec3 passViewPos;
 varying vec3 passNormal;

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -38,9 +38,9 @@ varying float depth;
 #define PER_PIXEL_LIGHTING (@normalMap || @forcePPL)
 
 #if !PER_PIXEL_LIGHTING
-varying vec4 lighting;
+centroid varying vec4 lighting;
 #else
-varying vec4 passColor;
+centroid varying vec4 passColor;
 #endif
 varying vec3 passViewPos;
 varying vec3 passNormal;

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -17,9 +17,9 @@ varying float depth;
 #define PER_PIXEL_LIGHTING (@normalMap || @forcePPL)
 
 #if !PER_PIXEL_LIGHTING
-varying vec4 lighting;
+centroid varying vec4 lighting;
 #else
-varying vec4 passColor;
+centroid varying vec4 passColor;
 #endif
 varying vec3 passViewPos;
 varying vec3 passNormal;

--- a/files/shaders/terrain_vertex.glsl
+++ b/files/shaders/terrain_vertex.glsl
@@ -6,9 +6,9 @@ varying float depth;
 #define PER_PIXEL_LIGHTING (@normalMap || @forcePPL)
 
 #if !PER_PIXEL_LIGHTING
-varying vec4 lighting;
+centroid varying vec4 lighting;
 #else
-varying vec4 passColor;
+centroid varying vec4 passColor;
 #endif
 varying vec3 passViewPos;
 varying vec3 passNormal;


### PR DESCRIPTION
> The centroid and sample (the latter requires OpenGL 4.0 or ARB_gpu_shader5) qualifiers affect interpolation, but they are somewhat special, grammatically speaking. [...]
> 
> They may not technically be interpolation qualifiers, but they do control aspects of interpolation. **They only have an effect when Multisampling is being used.**
> 
> During multisampling, if centroid is not present, then the written value can be interpolated to to an arbitrary position within the pixel. This may be the pixel's center, one of the sample locations within the pixel, or an arbitrary location. Most importantly of all, **this sample may lie outside of the actual primitive** being rendered, since a primitive can cover only part of a pixel's area.

— from [here](https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)#Interpolation_qualifiers)

So, I added that. Seems to work just right.