### PR TITLE
Don't prefer a DDS file if the originally requested file exists (bug #1392)

### DIFF
--- a/components/misc/resourcehelpers.cpp
+++ b/components/misc/resourcehelpers.cpp
@@ -63,27 +63,15 @@ std::string Misc::ResourceHelpers::correctResourcePath(const std::string &topLev
 
     std::string origExt = correctedPath;
 
-    // since we know all (GOTY edition or less) textures end
-    // in .dds, we change the extension
-    bool changedToDds = changeExtensionToDds(correctedPath);
-    if (vfs->exists(correctedPath))
+    if (vfs->exists(origExt)
+     || (changeExtensionToDds(correctedPath) && vfs->exists(correctedPath)))
         return correctedPath;
-    // if it turns out that the above wasn't true in all cases (not for vanilla, but maybe mods)
-    // verify, and revert if false (this call succeeds quickly, but fails slowly)
-    if (changedToDds && vfs->exists(origExt))
-        return origExt;
 
     // fall back to a resource in the top level directory if it exists
-    std::string fallback = topLevelDirectory + "\\" + getBasename(correctedPath);
-    if (vfs->exists(fallback))
+    std::string fallback = topLevelDirectory + "\\" + getBasename(origExt);
+    if (vfs->exists(fallback)
+     || (changeExtensionToDds(fallback) && vfs->exists(fallback)))
         return fallback;
-
-    if (changedToDds)
-    {
-        fallback = topLevelDirectory + "\\" + getBasename(origExt);
-        if (vfs->exists(fallback))
-            return fallback;
-    }
 
     return correctedPath;
 }


### PR DESCRIPTION
Fallback to a DDS file if the requested texture path doesn't point to an existing file, not vice versa.