### PR TITLE
Add Construction Set option to launcher screen

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -57,6 +57,9 @@ Launcher::MainDialog::MainDialog(QWidget *parent)
     QPushButton *playButton = new QPushButton(tr("Play"));
     buttonBox->addButton(playButton, QDialogButtonBox::AcceptRole);
 
+    QPushButton *csButton = new QPushButton(tr("Construction Set"));
+    buttonBox->addButton(csButton, QDialogButtonBox::AcceptRole);
+
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(close()));
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(play()));
 
@@ -82,6 +85,13 @@ void Launcher::MainDialog::createIcons()
     playButton->setText(tr("Play"));
     playButton->setTextAlignment(Qt::AlignCenter);
     playButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+
+    QListWidgetItem *csButton = new QListWidgetItem(iconWidget);
+    csButton->setIcon(QIcon(":/images/openmw.png"));
+    csButton->setText(tr("Construction Set"));
+    csButton->setTextAlignment(Qt::AlignCenter);
+    csButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
     QListWidgetItem *dataFilesButton = new QListWidgetItem(iconWidget);
     dataFilesButton->setIcon(QIcon(":/images/openmw-plugin.png"));
@@ -136,6 +146,7 @@ void Launcher::MainDialog::createPages()
     iconWidget->setCurrentItem(iconWidget->item(0), QItemSelectionModel::Select);
 
     connect(mPlayPage, SIGNAL(playButtonClicked()), this, SLOT(play()));
+    connect(mPlayPage, SIGNAL(csButtonClicked()), this, SLOT(play()));
 
     connect(mPlayPage, SIGNAL(signalProfileChanged(int)), mDataFilesPage, SLOT(slotProfileChanged(int)));
     connect(mDataFilesPage, SIGNAL(signalProfileChanged(int)), mPlayPage, SLOT(setProfilesIndex(int)));

--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -58,10 +58,11 @@ Launcher::MainDialog::MainDialog(QWidget *parent)
     buttonBox->addButton(playButton, QDialogButtonBox::AcceptRole);
 
     QPushButton *csButton = new QPushButton(tr("Construction Set"));
-    buttonBox->addButton(csButton, QDialogButtonBox::AcceptRole);
+    buttonBox->addButton(csButton, QDialogButtonBox::HelpRole);
 
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(close()));
     connect(buttonBox, SIGNAL(accepted()), this, SLOT(play()));
+    connect(buttonBox, SIGNAL(helpRequested()), this, SLOT(cs()));
 
     // Remove what's this? button
     setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -85,13 +86,6 @@ void Launcher::MainDialog::createIcons()
     playButton->setText(tr("Play"));
     playButton->setTextAlignment(Qt::AlignCenter);
     playButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-
-
-    QListWidgetItem *csButton = new QListWidgetItem(iconWidget);
-    csButton->setIcon(QIcon(":/images/openmw.png"));
-    csButton->setText(tr("Construction Set"));
-    csButton->setTextAlignment(Qt::AlignCenter);
-    csButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
     QListWidgetItem *dataFilesButton = new QListWidgetItem(iconWidget);
     dataFilesButton->setIcon(QIcon(":/images/openmw-plugin.png"));
@@ -146,7 +140,7 @@ void Launcher::MainDialog::createPages()
     iconWidget->setCurrentItem(iconWidget->item(0), QItemSelectionModel::Select);
 
     connect(mPlayPage, SIGNAL(playButtonClicked()), this, SLOT(play()));
-    connect(mPlayPage, SIGNAL(csButtonClicked()), this, SLOT(play()));
+    connect(mPlayPage, SIGNAL(csButtonClicked()), this, SLOT(cs()));
 
     connect(mPlayPage, SIGNAL(signalProfileChanged(int)), mDataFilesPage, SLOT(slotProfileChanged(int)));
     connect(mDataFilesPage, SIGNAL(signalProfileChanged(int)), mPlayPage, SLOT(setProfilesIndex(int)));
@@ -609,5 +603,13 @@ void Launcher::MainDialog::play()
     // Launch the game detached
 
     if (mGameInvoker->startProcess(QLatin1String("openmw"), true))
+        return qApp->quit();
+}
+
+void Launcher::MainDialog::cs()
+{
+    // Launch the cs detached
+
+    if (mGameInvoker->startProcess(QLatin1String("openmw-cs"), true))
         return qApp->quit();
 }

--- a/apps/launcher/maindialog.hpp
+++ b/apps/launcher/maindialog.hpp
@@ -59,6 +59,7 @@ namespace Launcher
     public slots:
         void changePage(QListWidgetItem *current, QListWidgetItem *previous);
         void play();
+        void cs();
 
     private slots:
         void wizardStarted();

--- a/apps/launcher/playpage.cpp
+++ b/apps/launcher/playpage.cpp
@@ -11,7 +11,7 @@ Launcher::PlayPage::PlayPage(QWidget *parent) : QWidget(parent)
 
     connect(profilesComboBox, SIGNAL(activated(int)), this, SIGNAL (signalProfileChanged(int)));
     connect(playButton, SIGNAL(clicked()), this, SLOT(slotPlayClicked()));
-
+    connect(csButton, SIGNAL(clicked()), this, SLOT(slotCSClicked()));
 }
 
 void Launcher::PlayPage::setProfilesModel(QAbstractItemModel *model)
@@ -27,4 +27,9 @@ void Launcher::PlayPage::setProfilesIndex(int index)
 void Launcher::PlayPage::slotPlayClicked()
 {
     emit playButtonClicked();
+}
+
+void Launcher::PlayPage::slotCSClicked()
+{
+    emit csButtonClicked();
 }

--- a/apps/launcher/playpage.cpp
+++ b/apps/launcher/playpage.cpp
@@ -11,7 +11,6 @@ Launcher::PlayPage::PlayPage(QWidget *parent) : QWidget(parent)
 
     connect(profilesComboBox, SIGNAL(activated(int)), this, SIGNAL (signalProfileChanged(int)));
     connect(playButton, SIGNAL(clicked()), this, SLOT(slotPlayClicked()));
-    connect(csButton, SIGNAL(clicked()), this, SLOT(slotCSClicked()));
 }
 
 void Launcher::PlayPage::setProfilesModel(QAbstractItemModel *model)
@@ -27,9 +26,4 @@ void Launcher::PlayPage::setProfilesIndex(int index)
 void Launcher::PlayPage::slotPlayClicked()
 {
     emit playButtonClicked();
-}
-
-void Launcher::PlayPage::slotCSClicked()
-{
-    emit csButtonClicked();
 }

--- a/apps/launcher/playpage.hpp
+++ b/apps/launcher/playpage.hpp
@@ -22,14 +22,14 @@ namespace Launcher
     signals:
         void signalProfileChanged(int index);
         void playButtonClicked();
+        void csButtonClicked();
 
     public slots:
         void setProfilesIndex(int index);
 
     private slots:
         void slotPlayClicked();
-
-
+        void slotCSClicked();
 
     };
 }

--- a/apps/launcher/playpage.hpp
+++ b/apps/launcher/playpage.hpp
@@ -22,14 +22,12 @@ namespace Launcher
     signals:
         void signalProfileChanged(int index);
         void playButtonClicked();
-        void csButtonClicked();
 
     public slots:
         void setProfilesIndex(int index);
 
     private slots:
         void slotPlayClicked();
-        void slotCSClicked();
 
     };
 }

--- a/files/ui/playpage.ui
+++ b/files/ui/playpage.ui
@@ -31,7 +31,7 @@
       <property name="rightMargin">
        <number>30</number>
       </property>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="QLabel" name="profileLabel">
         <property name="styleSheet">
          <string notr="true">#profileLabel {
@@ -45,7 +45,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="profilesComboBox">
         <property name="styleSheet">
          <string notr="true">#profilesComboBox {
@@ -103,7 +103,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="4" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -176,68 +176,6 @@
         </property>
         <property name="text">
          <string>Play</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="csButton">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>35</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>200</width>
-          <height>35</height>
-         </size>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">#csButton {
-    height: 50px;
-
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgba(255, 255, 255, 200),
-        stop:0.1 rgba(255, 255, 255, 15),
-        stop:0.49 rgba(255, 255, 255, 75),
-        stop:0.5 rgba(0, 0, 0, 0),
-        stop:0.9 rgba(0, 0, 0, 55),
-        stop:1 rgba(0, 0, 0, 100));
-
-    font-size: 9pt;
-    color: black;
-
-    border-right: 1px solid rgba(0, 0, 0, 155);
-    border-left: 1px solid rgba(0, 0, 0, 55);
-    border-top: 1px solid rgba(0, 0, 0, 55);
-    border-bottom: 1px solid rgba(0, 0, 0, 155);
-
-    border-radius: 5px;
-}
-
-#csButton:hover {
-    border-bottom: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
-    border-top: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
-    border-right: qlineargradient(spread:pad, x1:1, y1:0, x2:0, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
-    border-left: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
-    border-width: 2px;
-    border-style: solid;
-}
-
-#csButton:pressed {
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgba(0, 0, 0, 75),
-        stop:0.1 rgba(0, 0, 0, 15),
-        stop:0.2 rgba(255, 255, 255, 55)
-        stop:0.95 rgba(255, 255, 255, 55),
-        stop:1 rgba(255, 255, 255, 155));
-
-    border: 1px solid rgba(0, 0, 0, 55);
-}</string>
-        </property>
-        <property name="text">
-         <string>Construction Set</string>
         </property>
        </widget>
       </item>

--- a/files/ui/playpage.ui
+++ b/files/ui/playpage.ui
@@ -31,6 +31,20 @@
       <property name="rightMargin">
        <number>30</number>
       </property>
+      <item row="3" column="1">
+       <widget class="QLabel" name="profileLabel">
+        <property name="styleSheet">
+         <string notr="true">#profileLabel {
+    font-size: 18pt;
+	color: black;
+}
+</string>
+        </property>
+        <property name="text">
+         <string>Current Content List:</string>
+        </property>
+       </widget>
+      </item>
       <item row="4" column="1">
        <widget class="QComboBox" name="profilesComboBox">
         <property name="styleSheet">
@@ -89,21 +103,20 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="profileLabel">
-        <property name="styleSheet">
-         <string notr="true">#profileLabel {
-    font-size: 18pt;
-	color: black;
-}
-</string>
+      <item row="5" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
         </property>
-        <property name="text">
-         <string>Current Content List:</string>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
         </property>
-       </widget>
+       </spacer>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="QPushButton" name="playButton">
         <property name="minimumSize">
          <size>
@@ -166,18 +179,68 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
+      <item row="2" column="1">
+       <widget class="QPushButton" name="csButton">
+        <property name="minimumSize">
          <size>
-          <width>20</width>
-          <height>40</height>
+          <width>200</width>
+          <height>35</height>
          </size>
         </property>
-       </spacer>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>35</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">#playButton {
+    height: 50px;
+    margin-bottom: 30px;
+
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgba(255, 255, 255, 200),
+        stop:0.1 rgba(255, 255, 255, 15),
+        stop:0.49 rgba(255, 255, 255, 75),
+        stop:0.5 rgba(0, 0, 0, 0),
+        stop:0.9 rgba(0, 0, 0, 55),
+        stop:1 rgba(0, 0, 0, 100));
+
+    font-size: 26pt;
+    color: black;
+
+    border-right: 1px solid rgba(0, 0, 0, 155);
+    border-left: 1px solid rgba(0, 0, 0, 55);
+    border-top: 1px solid rgba(0, 0, 0, 55);
+    border-bottom: 1px solid rgba(0, 0, 0, 155);
+
+    border-radius: 5px;
+}
+
+#playButton:hover {
+    border-bottom: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
+    border-top: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
+    border-right: qlineargradient(spread:pad, x1:1, y1:0, x2:0, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
+    border-left: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
+    border-width: 2px;
+    border-style: solid;
+}
+
+#playButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgba(0, 0, 0, 75),
+        stop:0.1 rgba(0, 0, 0, 15),
+        stop:0.2 rgba(255, 255, 255, 55)
+        stop:0.95 rgba(255, 255, 255, 55),
+        stop:1 rgba(255, 255, 255, 155));
+
+    border: 1px solid rgba(0, 0, 0, 55);
+}</string>
+        </property>
+        <property name="text">
+         <string>Construction Set</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/files/ui/playpage.ui
+++ b/files/ui/playpage.ui
@@ -194,9 +194,8 @@
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">#playButton {
+         <string notr="true">#csButton {
     height: 50px;
-    margin-bottom: 30px;
 
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
         stop:0 rgba(255, 255, 255, 200),
@@ -206,7 +205,7 @@
         stop:0.9 rgba(0, 0, 0, 55),
         stop:1 rgba(0, 0, 0, 100));
 
-    font-size: 26pt;
+    font-size: 9pt;
     color: black;
 
     border-right: 1px solid rgba(0, 0, 0, 155);
@@ -217,7 +216,7 @@
     border-radius: 5px;
 }
 
-#playButton:hover {
+#csButton:hover {
     border-bottom: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
     border-top: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
     border-right: qlineargradient(spread:pad, x1:1, y1:0, x2:0, y2:0, stop:0 rgba(164, 192, 228, 255), stop:1 rgba(255, 255, 255, 0));
@@ -226,7 +225,7 @@
     border-style: solid;
 }
 
-#playButton:pressed {
+#csButton:pressed {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
         stop:0 rgba(0, 0, 0, 75),
         stop:0.1 rgba(0, 0, 0, 15),


### PR DESCRIPTION
Fix for issue [#4366](https://bugs.openmw.org/issues/4366). I set the CS button to `HelpRole` for convenience, but would it be better for it to have its own separate event handler and switch it to an `ActionRole`? 