### PR TITLE
Reset an inventory filter after reload or a new game start

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -129,6 +129,12 @@ namespace MWGui
 
         mItemView->setModel(mSortModel);
 
+        mFilterAll->setStateSelected(true);
+        mFilterWeapon->setStateSelected(false);
+        mFilterApparel->setStateSelected(false);
+        mFilterMagic->setStateSelected(false);
+        mFilterMisc->setStateSelected(false);
+
         mPreview->updatePtr(mPtr);
         mPreview->rebuild();
         mPreview->update();


### PR DESCRIPTION
Fixes [bug #4392](https://bugs.openmw.org/issues/4392).

Just reset inventory filter buttons when we call the WindowManager::updatePlayer() - after a start of new game or after reload.
