### PR TITLE
Inherit the calling object scale in PlaceAt (bug #4308)

### DIFF
--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -530,7 +530,8 @@ namespace MWScript
                         // create item
                         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), itemID, 1);
 
-                        MWBase::Environment::get().getWorld()->safePlaceObject(ref.getPtr(), actor, actor.getCell(), direction, distance);
+                        MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->safePlaceObject(ref.getPtr(), actor, actor.getCell(), direction, distance);
+                        MWBase::Environment::get().getWorld()->scaleObject(ptr, actor.getCellRef().getScale());
                     }
                 }
         };


### PR DESCRIPTION
Scale the created object in accordance with the original actor's scale.
Works with placed Fargoth when I use commands from [the bug report](https://bugs.openmw.org/issues/4308).