### PR TITLE
Fix crash when rollDice is called with 0.

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -286,7 +286,7 @@ void CharacterController::refreshHitRecoilAnims()
         }
         else if (recovery)
         {
-            std::string anim = isSwimming ? chooseRandomGroup("swimhit") : chooseRandomGroup("hit");
+            std::string anim = chooseRandomGroup("swimhit");
             if (isSwimming && mAnimation->hasAnimation(anim))
             {
                 mHitState = CharState_SwimHit;

--- a/components/misc/rng.cpp
+++ b/components/misc/rng.cpp
@@ -25,7 +25,7 @@ namespace Misc
 
     int Rng::rollDice(int max)
     {
-        return std::uniform_int_distribution<int>(0, max - 1)(generator);
+        return max > 0 ? std::uniform_int_distribution<int>(0, max - 1)(generator) : 0;
     }
 
 }


### PR DESCRIPTION
After introducing new random number generator rollDice function crashes if called with 0. I fixed these places (not sure though if it's possible for iNumberCreatures to be 0) and simplified code a bit.