### PR TITLE
Implicit Morrowind.esm dependency for dependency-less content addons (bug #2829)

### DIFF
--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -512,7 +512,9 @@ void ContentSelectorModel::ContentModel::sortFiles()
             //dependencies appear.
             for (int j = i + 1; j < fileCount; j++)
             {
-                if (gamefiles.contains(mFiles.at(j)->fileName(), Qt::CaseInsensitive))
+                if (gamefiles.contains(mFiles.at(j)->fileName(), Qt::CaseInsensitive)
+                 || (!mFiles.at(i)->isGameFile() && gamefiles.isEmpty()
+                 && mFiles.at(j)->fileName().compare("Morrowind.esm", Qt::CaseInsensitive) == 0)) // Hack: implicit dependency on Morrowind.esm for dependency-less files
                 {
                         mFiles.move(j, i);
 


### PR DESCRIPTION
Add a hack to content selector dependency sort: dependency-less content addons that are not game files are assumed dependent on Morrowind.esm and are sorted after it.