### PR TITLE
Handle NiLookAtController

### DIFF
--- a/components/nif/controller.cpp
+++ b/components/nif/controller.cpp
@@ -101,6 +101,18 @@ namespace Nif
         data.post(nif);
     }
 
+    void NiLookAtController::read(NIFStream *nif)
+    {
+        Controller::read(nif);
+        data.read(nif);
+    }
+
+    void NiLookAtController::post(NIFFile *nif)
+    {
+        Controller::post(nif);
+        data.post(nif);
+    }
+
     void NiPathController::read(NIFStream *nif)
     {
         Controller::read(nif);

--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -99,6 +99,15 @@ public:
     void post(NIFFile *nif);
 };
 
+class NiLookAtController : public Controller
+{
+public:
+    NiKeyframeDataPtr data;
+
+    void read(NIFStream *nif);
+    void post(NIFFile *nif);
+};
+
 class NiUVController : public Controller
 {
 public:

--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -108,6 +108,7 @@ static std::map<std::string,RecordFactoryEntry> makeFactory()
     newFactory.insert(makeEntry("NiSequenceStreamHelper",     &construct <NiSequenceStreamHelper>      , RC_NiSequenceStreamHelper        ));
     newFactory.insert(makeEntry("NiSourceTexture",            &construct <NiSourceTexture>             , RC_NiSourceTexture               ));
     newFactory.insert(makeEntry("NiSkinInstance",             &construct <NiSkinInstance>              , RC_NiSkinInstance                ));
+    newFactory.insert(makeEntry("NiLookAtController",         &construct <NiLookAtController>          , RC_NiLookAtController            ));
     return newFactory;
 }
 

--- a/components/nif/record.hpp
+++ b/components/nif/record.hpp
@@ -93,7 +93,8 @@ enum RecordType
   RC_NiSourceTexture,
   RC_NiSkinInstance,
   RC_RootCollisionNode,
-  RC_NiSphericalCollider
+  RC_NiSphericalCollider,
+  RC_NiLookAtController
 };
 
 /// Base class for all records


### PR DESCRIPTION
Implements [feature #4407](https://bugs.openmw.org/issues/4407).
Some models in Arktwend have NiLookAtController (I guess, imported ones).
According to @Capostrophic, vanilla engine just ignores this node.

With this PR user will get a warning about unhandled controller, but at least meshes will be rendered.