### PR TITLE
Remove unnecessary command from QuadTreeWorld destructor

### DIFF
--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -246,7 +246,6 @@ QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resour
 
 QuadTreeWorld::~QuadTreeWorld()
 {
-    ensureQuadTreeBuilt();
     mViewDataMap->clear();
 }
 


### PR DESCRIPTION
Fixes [bug #4408](https://bugs.openmw.org/issues/4408), as discussed in referenced thread.