### PR TITLE
Prevent PlaySound overlapping

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -337,7 +337,7 @@ namespace MWBase
             /// Cycle to next or previous weapon
             virtual void cycleWeapon(bool next) = 0;
 
-            virtual void playSound(const std::string& soundId, bool preventOverlapping = false, float volume = 1.f, float pitch = 1.f) = 0;
+            virtual void playSound(const std::string& soundId, float volume = 1.f, float pitch = 1.f) = 0;
 
             // In WindowManager for now since there isn't a VFS singleton
             virtual std::string correctIconPath(const std::string& path) = 0;

--- a/apps/openmw/mwgui/bookwindow.cpp
+++ b/apps/openmw/mwgui/bookwindow.cpp
@@ -200,7 +200,7 @@ namespace MWGui
     {
         if ((mCurrentPage+1)*2 < mPages.size())
         {
-            MWBase::Environment::get().getWindowManager()->playSound("book page2", true);
+            MWBase::Environment::get().getWindowManager()->playSound("book page2");
 
             ++mCurrentPage;
 
@@ -211,7 +211,7 @@ namespace MWGui
     {
         if (mCurrentPage > 0)
         {
-            MWBase::Environment::get().getWindowManager()->playSound("book page", true);
+            MWBase::Environment::get().getWindowManager()->playSound("book page");
 
             --mCurrentPage;
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1919,16 +1919,12 @@ namespace MWGui
             mInventoryWindow->cycle(next);
     }
 
-    void WindowManager::playSound(const std::string& soundId, bool preventOverlapping, float volume, float pitch)
+    void WindowManager::playSound(const std::string& soundId, float volume, float pitch)
     {
         if (soundId.empty())
             return;
 
-        MWBase::SoundManager *sndmgr = MWBase::Environment::get().getSoundManager();
-        if (preventOverlapping && sndmgr->getSoundPlaying(MWWorld::Ptr(), soundId))
-            return;
-
-        sndmgr->playSound(soundId, volume, pitch, MWSound::Type::Sfx, MWSound::PlayMode::NoEnv);
+        MWBase::Environment::get().getSoundManager()->playSound(soundId, volume, pitch, MWSound::Type::Sfx, MWSound::PlayMode::NoEnv);
     }
 
     void WindowManager::updateSpellWindow()

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -366,7 +366,7 @@ namespace MWGui
     /// Cycle to next or previous weapon
     virtual void cycleWeapon(bool next);
 
-    virtual void playSound(const std::string& soundId, bool preventOverlapping = false, float volume = 1.f, float pitch = 1.f);
+    virtual void playSound(const std::string& soundId, float volume = 1.f, float pitch = 1.f);
 
     // In WindowManager for now since there isn't a VFS singleton
     virtual std::string correctIconPath(const std::string& path);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -577,6 +577,9 @@ namespace MWSound
         Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
         if(!sfx) return nullptr;
 
+        // Only one copy of given sound can be played at time, so stop previous copy
+        stopSound(soundId);
+
         Sound *sound = getSoundRef();
         sound->init(volume * sfx->mVolume, volumeFromType(type), pitch, mode|type|Play_2D);
         if(!mOutput->playSound(sound, sfx->mHandle, offset))

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -20,9 +20,9 @@
 
 #include "../mwmechanics/actorutil.hpp"
 
-#include "sound_output.hpp"
 #include "sound_buffer.hpp"
 #include "sound_decoder.hpp"
+#include "sound_output.hpp"
 #include "sound.hpp"
 
 #include "openal_output.hpp"
@@ -578,7 +578,7 @@ namespace MWSound
         if(!sfx) return nullptr;
 
         // Only one copy of given sound can be played at time, so stop previous copy
-        stopSound(soundId);
+        stopSound(sfx, MWWorld::ConstPtr());
 
         Sound *sound = getSoundRef();
         sound->init(volume * sfx->mVolume, volumeFromType(type), pitch, mode|type|Play_2D);
@@ -614,7 +614,7 @@ namespace MWSound
             return nullptr;
 
         // Only one copy of given sound can be played at time on ptr, so stop previous copy
-        stopSound3D(ptr, soundId);
+        stopSound(sfx, ptr);
 
         bool played;
         Sound *sound = getSoundRef();
@@ -681,18 +681,33 @@ namespace MWSound
             mOutput->finishSound(sound);
     }
 
-    void SoundManager::stopSound3D(const MWWorld::ConstPtr &ptr, const std::string& soundId)
+    void SoundManager::stopSound(Sound_Buffer *sfx, const MWWorld::ConstPtr &ptr)
     {
         SoundMap::iterator snditer = mActiveSounds.find(ptr);
         if(snditer != mActiveSounds.end())
         {
-            Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
             for(SoundBufferRefPair &snd : snditer->second)
             {
                 if(snd.second == sfx)
                     mOutput->finishSound(snd.first);
             }
         }
+    }
+
+    void SoundManager::stopSound(const std::string& soundId)
+    {
+        Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
+        if (!sfx) return;
+
+        stopSound(sfx, MWWorld::ConstPtr());
+    }
+
+    void SoundManager::stopSound3D(const MWWorld::ConstPtr &ptr, const std::string& soundId)
+    {
+        Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
+        if (!sfx) return;
+
+        stopSound(sfx, ptr);
     }
 
     void SoundManager::stopSound3D(const MWWorld::ConstPtr &ptr)
@@ -718,24 +733,11 @@ namespace MWSound
                     mOutput->finishSound(sndbuf.first);
             }
         }
+
         for(SaySoundMap::value_type &snd : mActiveSaySounds)
         {
             if(!snd.first.isEmpty() && snd.first != MWMechanics::getPlayer() && snd.first.getCell() == cell)
                 mOutput->finishStream(snd.second);
-        }
-    }
-
-    void SoundManager::stopSound(const std::string& soundId)
-    {
-        SoundMap::iterator snditer = mActiveSounds.find(MWWorld::ConstPtr());
-        if(snditer != mActiveSounds.end())
-        {
-            Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
-            for(SoundBufferRefPair &sndbuf : snditer->second)
-            {
-                if(sndbuf.second == sfx)
-                    mOutput->finishSound(sndbuf.first);
-            }
         }
     }
 

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -145,6 +145,9 @@ namespace MWSound
         DecoderPtr getDecoder();
         friend class OpenAL_Output;
 
+        void stopSound(Sound_Buffer *sfx, const MWWorld::ConstPtr &ptr);
+        ///< Stop the given object from playing given sound buffer.
+
     public:
         SoundManager(const VFS::Manager* vfs, const std::map<std::string, std::string>& fallbackMap, bool useSound);
         virtual ~SoundManager();


### PR DESCRIPTION
If we play a new sound, we should stop the previous copy of this sound. This is easily to check: execute "playsound X" several times in console in vanilla game.
We already use similar approach for 3D sounds: we allow to play only one copy of given sound per object, so this PR just makes sound playing consistent.

As a side effect, this PR fixes a nightmare scene in Arktwend, so it should not crash now.