### PR TITLE
Load default markers definitions

### DIFF
--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -962,6 +962,29 @@ int CSMWorld::Data::startLoading (const boost::filesystem::path& path, bool base
     return mReader->getRecordCount();
 }
 
+void CSMWorld::Data::loadFallbackEntries()
+{
+    // Load default marker definitions, if game files do not have them for some reason
+    std::pair<std::string, std::string> markers[] = {
+        std::make_pair("divinemarker", "marker_divine.nif"),
+        std::make_pair("doormarker", "marker_arrow.nif"),
+        std::make_pair("northmarker", "marker_north.nif"),
+        std::make_pair("templemarker", "marker_temple.nif"),
+        std::make_pair("travelmarker", "marker_travel.nif")
+    };
+
+    for (const std::pair<std::string, std::string> marker : markers)
+    {
+        if (mReferenceables.searchId (marker.first)==-1)
+        {
+            CSMWorld::Record<ESM::Static> record;
+            record.mBase = ESM::Static(marker.first, marker.second);
+            record.mState = CSMWorld::RecordBase::State_BaseOnly;
+            mReferenceables.appendRecord (record, CSMWorld::UniversalId::Type_Static);
+        }
+    }
+}
+
 bool CSMWorld::Data::continueLoading (CSMDoc::Messages& messages)
 {
     if (!mReader)
@@ -983,6 +1006,9 @@ bool CSMWorld::Data::continueLoading (CSMDoc::Messages& messages)
         mReader = 0;
 
         mDialogue = 0;
+
+        loadFallbackEntries();
+
         return true;
     }
 

--- a/apps/opencs/model/world/data.hpp
+++ b/apps/opencs/model/world/data.hpp
@@ -144,6 +144,8 @@ namespace CSMWorld
 
             static int count (RecordBase::State state, const CollectionBase& collection);
 
+            void loadFallbackEntries();
+
         public:
 
             Data (ToUTF8::FromType encoding, bool fsStrict, const Files::PathContainer& dataPaths,

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -141,6 +141,7 @@ void ESMStore::setUp()
     mMagicEffects.setUp();
     mAttributes.setUp();
     mDialogs.setUp();
+    mStatics.setUp();
 }
 
     int ESMStore::countSavedGameRecords() const

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1070,12 +1070,10 @@ namespace MWWorld
             if (search(marker.first) == 0)
             {
                 ESM::Static newMarker = ESM::Static(marker.first, marker.second);
-                mStatic.insert(std::make_pair(marker.first, newMarker));
-
-                std::map<std::string, ESM::Static>::iterator found = mStatic.find(marker.first);
-                if (found != mStatic.end())
+                std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(marker.first, newMarker));
+                if (ret.first != mStatic.end())
                 {
-                    mShared.push_back(&found->second);
+                    mShared.push_back(&ret.first->second);
                 }
             }
         }

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1053,6 +1053,34 @@ namespace MWWorld
         }
     }
 
+    template<>
+    void Store<ESM::Static>::setUp()
+    {
+        // Load default marker definitions, if game files do not have them for some reason
+        std::pair<std::string, std::string> markers[] = {
+            std::make_pair("divinemarker", "marker_divine.nif"),
+            std::make_pair("doormarker", "marker_arrow.nif"),
+            std::make_pair("northmarker", "marker_north.nif"),
+            std::make_pair("templemarker", "marker_temple.nif"),
+            std::make_pair("travelmarker", "marker_travel.nif")
+        };
+
+        for (const std::pair<std::string, std::string> marker : markers)
+        {
+            if (search(marker.first) == 0)
+            {
+                ESM::Static newMarker = ESM::Static(marker.first, marker.second);
+                mStatic.insert(std::make_pair(marker.first, newMarker));
+
+                std::map<std::string, ESM::Static>::iterator found = mStatic.find(marker.first);
+                if (found != mStatic.end())
+                {
+                    mShared.push_back(&found->second);
+                }
+            }
+        }
+    }
+
     template <>
     inline RecordId Store<ESM::Dialogue>::load(ESM::ESMReader &esm) {
         // The original letter case of a dialogue ID is saved, because it's printed

--- a/components/esm/loadstat.hpp
+++ b/components/esm/loadstat.hpp
@@ -26,13 +26,23 @@ struct Static
     /// Return a string descriptor for this record type. Currently used for debugging / error logs only.
     static std::string getRecordType() { return "Static"; }
 
-  std::string mId, mModel;
+    std::string mId, mModel;
 
-  void load(ESMReader &esm, bool &isDeleted);
-  void save(ESMWriter &esm, bool isDeleted = false) const;
+    void load(ESMReader &esm, bool &isDeleted);
+    void save(ESMWriter &esm, bool isDeleted = false) const;
 
     void blank();
     ///< Set record to default state (does not touch the ID).
+
+    Static(const std::string id, const std::string &model)
+    : mId(id)
+    , mModel(model)
+    {
+    }
+
+    Static()
+    {
+    }
 };
 }
 #endif


### PR DESCRIPTION
Fixes [bug #4410](https://bugs.openmw.org/issues/4410).
If markers were not found in game files, load default definitions to ESM store.