### PR TITLE
Don't hide topic/journal info ID columns (bug #4356)

### DIFF
--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -261,7 +261,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     mJournals.addColumn (new FixedRecordTypeColumn<ESM::Dialogue> (UniversalId::Type_Journal));
     mJournals.addColumn (new DialogueTypeColumn<ESM::Dialogue> (true));
 
-    mTopicInfos.addColumn (new StringIdColumn<Info> (true));
+    mTopicInfos.addColumn (new StringIdColumn<Info>);
     mTopicInfos.addColumn (new RecordStateColumn<Info>);
     mTopicInfos.addColumn (new FixedRecordTypeColumn<Info> (UniversalId::Type_TopicInfo));
     mTopicInfos.addColumn (new TopicColumn<Info> (false));
@@ -298,7 +298,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     mTopicInfos.getNestableColumn(index)->addColumn(
         new NestedChildColumn (Columns::ColumnId_Value, ColumnBase::Display_Var));
 
-    mJournalInfos.addColumn (new StringIdColumn<Info> (true));
+    mJournalInfos.addColumn (new StringIdColumn<Info>);
     mJournalInfos.addColumn (new RecordStateColumn<Info>);
     mJournalInfos.addColumn (new FixedRecordTypeColumn<Info> (UniversalId::Type_JournalInfo));
     mJournalInfos.addColumn (new TopicColumn<Info> (true));


### PR DESCRIPTION
[Report.](https://bugs.openmw.org/issues/4356)
So usually records have their full IDs shown in a column to the left of the state column in their tables. Journal and topic info records don't, and so do land texture records (but displaying their IDs would have been redundant in their case). Apparently their respective ID columns were hidden, making their full IDs only available from their info tables. I enabled those columns, as was requested.