### PR TITLE
Improve sorting of imported load order (bug #3926)

### DIFF
--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -859,6 +859,17 @@ std::vector<std::string>::iterator MwIniImporter::findString(std::vector<std::st
     });
 }
 
+void MwIniImporter::addPaths(std::vector<boost::filesystem::path>& output, std::vector<std::string> input) {
+    for (auto& path : input) {
+        if (path.front() == '"')
+        {
+            path.erase(path.begin());
+            path.erase(path.end() - 1);
+        }
+        output.emplace_back(path);
+    }
+}
+
 void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, const boost::filesystem::path& iniFilename) const
 {
     std::vector<std::pair<std::time_t, boost::filesystem::path>> contentFiles;
@@ -869,17 +880,11 @@ void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, co
 
     std::vector<boost::filesystem::path> dataPaths;
     if (cfg.count("data"))
-    {
-        for (std::string filePathString : cfg["data"])
-        {
-            if (filePathString.front() == '"')
-            {
-                filePathString.erase(filePathString.begin());
-                filePathString.erase(filePathString.end() - 1);
-            }
-            dataPaths.emplace_back(filePathString);
-        }
-    }
+        addPaths(dataPaths, cfg["data"]);
+
+    if (cfg.count("data-local"))
+        addPaths(dataPaths, cfg["data-local"]);
+
     dataPaths.push_back(iniFilename.parent_path() /= "Data Files");
 
     multistrmap::const_iterator it = ini.begin();

--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -654,12 +654,6 @@ void MwIniImporter::setVerbose(bool verbose) {
     mVerbose = verbose;
 }
 
-std::string MwIniImporter::numberToString(int n) {
-    std::stringstream str;
-    str << n;
-    return str.str();
-}
-
 MwIniImporter::multistrmap MwIniImporter::loadIniFile(const boost::filesystem::path&  filename) const {
     std::cout << "load ini file: " << filename << std::endl;
 
@@ -801,7 +795,7 @@ void MwIniImporter::importArchives(multistrmap &cfg, const multistrmap &ini) con
     multistrmap::const_iterator it = ini.begin();
     for(int i=0; it != ini.end(); i++) {
         archive = baseArchive;
-        archive.append(this->numberToString(i));
+        archive.append(std::to_string(i));
 
         it = ini.find(archive);
         if(it == ini.end()) {
@@ -892,7 +886,7 @@ void MwIniImporter::importGameFiles(multistrmap &cfg, const multistrmap &ini, co
     for (int i=0; it != ini.end(); i++)
     {
         gameFile = baseGameFile;
-        gameFile.append(this->numberToString(i));
+        gameFile.append(std::to_string(i));
 
         it = ini.find(gameFile);
         if(it == ini.end())

--- a/apps/mwiniimporter/importer.hpp
+++ b/apps/mwiniimporter/importer.hpp
@@ -35,7 +35,6 @@ class MwIniImporter {
     static std::vector<std::string>::iterator findString(std::vector<std::string>& source, const std::string& string);
 
     static void insertMultistrmap(multistrmap &cfg, const std::string& key, const std::string& value);
-    static std::string numberToString(int n);
 
     /// \return file's "last modified time", used in original MW to determine plug-in load order
     static std::time_t lastWriteTime(const boost::filesystem::path& filename, std::time_t defaultTime);

--- a/apps/mwiniimporter/importer.hpp
+++ b/apps/mwiniimporter/importer.hpp
@@ -14,7 +14,7 @@ class MwIniImporter {
   public:
     typedef std::map<std::string, std::string> strmap;
     typedef std::map<std::string, std::vector<std::string> > multistrmap;
-    typedef std::vector< std::pair< std::string, std::vector<std::string> > > deplist;
+    typedef std::vector< std::pair< std::string, std::vector<std::string> > > dependencyList;
 
     MwIniImporter();
     void    setInputEncoding(const ToUTF8::FromType& encoding);
@@ -28,11 +28,11 @@ class MwIniImporter {
     void    importArchives(multistrmap &cfg, const multistrmap &ini) const;
     static void    writeToFile(std::ostream &out, const multistrmap &cfg);
 
-    static std::vector<std::string> dependencySort(MwIniImporter::deplist src);
+    static std::vector<std::string> dependencySort(MwIniImporter::dependencyList source);
 
   private:
-    static void dependencySortStep(std::string& el, MwIniImporter::deplist& src, std::vector<std::string>& ret);
-    static std::vector<std::string>::iterator findString(std::vector<std::string>& v, const std::string& s);
+    static void dependencySortStep(std::string& element, MwIniImporter::dependencyList& source, std::vector<std::string>& result);
+    static std::vector<std::string>::iterator findString(std::vector<std::string>& source, const std::string& string);
 
     static void insertMultistrmap(multistrmap &cfg, const std::string& key, const std::string& value);
     static std::string numberToString(int n);

--- a/apps/mwiniimporter/importer.hpp
+++ b/apps/mwiniimporter/importer.hpp
@@ -14,6 +14,7 @@ class MwIniImporter {
   public:
     typedef std::map<std::string, std::string> strmap;
     typedef std::map<std::string, std::vector<std::string> > multistrmap;
+    typedef std::vector< std::pair< std::string, std::vector<std::string> > > deplist;
 
     MwIniImporter();
     void    setInputEncoding(const ToUTF8::FromType& encoding);
@@ -22,12 +23,17 @@ class MwIniImporter {
     static multistrmap  loadCfgFile(const boost::filesystem::path& filename);
     void    merge(multistrmap &cfg, const multistrmap &ini) const;
     void    mergeFallback(multistrmap &cfg, const multistrmap &ini) const;
-    void    importGameFiles(multistrmap &cfg, const multistrmap &ini, 
+    void    importGameFiles(multistrmap &cfg, const multistrmap &ini,
         const boost::filesystem::path& iniFilename) const;
     void    importArchives(multistrmap &cfg, const multistrmap &ini) const;
     static void    writeToFile(std::ostream &out, const multistrmap &cfg);
 
+    static std::vector<std::string> dependencySort(MwIniImporter::deplist src);
+
   private:
+    static void dependencySortStep(std::string& el, MwIniImporter::deplist& src, std::vector<std::string>& ret);
+    static std::vector<std::string>::iterator findString(std::vector<std::string>& v, const std::string& s);
+
     static void insertMultistrmap(multistrmap &cfg, const std::string& key, const std::string& value);
     static std::string numberToString(int n);
 
@@ -39,6 +45,5 @@ class MwIniImporter {
     std::vector<std::string> mMergeFallback;
     ToUTF8::FromType mEncoding;
 };
-
 
 #endif

--- a/apps/mwiniimporter/importer.hpp
+++ b/apps/mwiniimporter/importer.hpp
@@ -35,6 +35,7 @@ class MwIniImporter {
     static std::vector<std::string>::iterator findString(std::vector<std::string>& source, const std::string& string);
 
     static void insertMultistrmap(multistrmap &cfg, const std::string& key, const std::string& value);
+    static void addPaths(std::vector<boost::filesystem::path>& output, std::vector<std::string> input);
 
     /// \return file's "last modified time", used in original MW to determine plug-in load order
     static std::time_t lastWriteTime(const boost::filesystem::path& filename, std::time_t defaultTime);

--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -231,28 +231,12 @@ void Wizard::MainWizard::setupInstallations()
 
 void Wizard::MainWizard::runSettingsImporter()
 {
+    writeSettings();
+
     QString path(field(QLatin1String("installation.path")).toString());
 
-    // Create the file if it doesn't already exist, else the importer will fail
     QString userPath(toQString(mCfgMgr.getUserConfigPath()));
     QFile file(userPath + QLatin1String("openmw.cfg"));
-
-    if (!file.exists()) {
-        if (!file.open(QIODevice::ReadWrite)) {
-            // File cannot be created
-            QMessageBox msgBox;
-            msgBox.setWindowTitle(tr("Error writing OpenMW configuration file"));
-            msgBox.setIcon(QMessageBox::Critical);
-            msgBox.setStandardButtons(QMessageBox::Ok);
-            msgBox.setText(tr("<html><head/><body><p><b>Could not open or create %1 for writing</b></p> \
-                              <p>Please make sure you have the right permissions \
-                              and try again.</p></body></html>").arg(file.fileName()));
-            msgBox.exec();
-            return qApp->quit();
-        }
-
-        file.close();
-    }
 
     // Construct the arguments to run the importer
     QStringList arguments;

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -57,6 +57,7 @@ void ESMReader::close()
     mCtx.subCached = false;
     mCtx.recName.clear();
     mCtx.subName.clear();
+    mHeader.blank();
 }
 
 void ESMReader::openRaw(Files::IStreamPtr _esm, const std::string& name)


### PR DESCRIPTION
This PR changes sorting in iniimporter. It sorts content files from Morrowind.ini by timestamp and then tries to resolve dependency problems. And it hard-codes Morrowind - Tribunal - Bloodmoon order (if all 3 elements are in list) because Bloodmoon doesn't have a hard dependency on Tribunal.

I used a variation of depth-first topological sort to place dependencies before files that use them.

[Original bug report](https://bugs.openmw.org/issues/3926)

Also there was a little bug with `ESMReader::close` - mHeader was not cleared. So I added `mHeader.blank()` inside it.