### PR TITLE
Do not apply queue movement for standing actors

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -388,6 +388,7 @@ namespace MWBase
             virtual bool isUnderwater(const MWWorld::ConstPtr &object, const float heightRatio) const = 0;
             virtual bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const = 0;
             virtual bool isOnGround(const MWWorld::Ptr &ptr) const = 0;
+            virtual bool isIdle(const MWWorld::Ptr &ptr) const = 0;
 
             virtual osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const = 0;
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -866,8 +866,7 @@ namespace MWMechanics
         }
 
         // place above to prevent moving inside objects, e.g. stairs, because a vector between pathgrids can be underground.
-        // Adding 20 in adjustPosition() is not enough.
-        dest.mZ += 60;
+        dest.mZ += 80;
 
         ToWorldCoordinates(dest, actor.getCell()->getCell());
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2029,7 +2029,8 @@ void CharacterController::update(float duration)
         moved.z() = 1.0;
 
     // Update movement
-    if(mMovementAnimationControlled && mPtr.getClass().isActor())
+    // We should not apply movement for standing actors
+    if(mMovementAnimationControlled && mPtr.getClass().isActor() && (movement.length2() > 0.f || !world->isIdle(mPtr)))
         world->queueMovement(mPtr, moved);
 
     mSkipAnim = false;

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -18,7 +18,7 @@ namespace MWPhysics
 
 Actor::Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<const Resource::BulletShape> shape, btCollisionWorld* world)
   : mCanWaterWalk(false), mWalkingOnWater(false)
-  , mCollisionObject(nullptr), mForce(0.f, 0.f, 0.f), mOnGround(true), mOnSlope(false)
+  , mCollisionObject(nullptr), mForce(0.f, 0.f, 0.f), mOnGround(true), mOnSlope(false), mIdle(true)
   , mInternalCollisionMode(true)
   , mExternalCollisionMode(true)
   , mCollisionWorld(world)
@@ -193,6 +193,11 @@ void Actor::setOnGround(bool grounded)
 void Actor::setOnSlope(bool slope)
 {
     mOnSlope = slope;
+}
+
+void Actor::setIdle(bool idle)
+{
+    mIdle = idle;
 }
 
 bool Actor::isWalkingOnWater() const

--- a/apps/openmw/mwphysics/actor.hpp
+++ b/apps/openmw/mwphysics/actor.hpp
@@ -139,6 +139,13 @@ namespace MWPhysics
             return mInternalCollisionMode && mOnSlope;
         }
 
+        void setIdle(bool idle);
+
+        bool getIdle() const
+        {
+            return mIdle;
+        }
+
         btCollisionObject* getCollisionObject() const
         {
             return mCollisionObject.get();
@@ -179,6 +186,7 @@ namespace MWPhysics
         osg::Vec3f mForce;
         bool mOnGround;
         bool mOnSlope;
+        bool mIdle;
         bool mInternalCollisionMode;
         bool mExternalCollisionMode;
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -683,6 +683,7 @@ namespace MWPhysics
         , mWaterEnabled(false)
         , mParentNode(parentNode)
         , mPhysicsDt(1.f / 60.f)
+        , mIdleUpdateTimer(0)
     {
         mResourceSystem->addResourceManager(mShapeManager.get());
 
@@ -737,6 +738,18 @@ namespace MWPhysics
         delete mCollisionConfiguration;
         delete mDispatcher;
         delete mBroadphase;
+    }
+
+    void PhysicsSystem::updateIdle()
+    {
+        for (ActorMap::iterator it = mActors.begin(); it != mActors.end(); ++it)
+        {
+            osg::Vec3f pos(it->second->getCollisionObjectPosition());
+
+            RayResult result = castRay(pos, pos - osg::Vec3f(0, 0, it->second->getHalfExtents().z() + 2), it->second->getPtr(), std::vector<MWWorld::Ptr>(), CollisionType_World|CollisionType_HeightMap|CollisionType_Door);
+
+            it->second->setIdle(result.mHit);
+        }
     }
 
     void PhysicsSystem::setUnrefQueue(SceneUtil::UnrefQueue *unrefQueue)
@@ -1045,6 +1058,11 @@ namespace MWPhysics
         return physactor && physactor->getOnGround();
     }
 
+    bool PhysicsSystem::isIdle(const MWWorld::Ptr &actor)
+    {
+        Actor* physactor = getActor(actor);
+        return physactor && physactor->getIdle();
+    }
     bool PhysicsSystem::canMoveToWaterSurface(const MWWorld::ConstPtr &actor, const float waterlevel)
     {
         const Actor* physicActor = getActor(actor);
@@ -1337,6 +1355,10 @@ namespace MWPhysics
             cmode = !cmode;
             found->second->enableCollisionMode(cmode);
             found->second->enableCollisionBody(cmode);
+
+            if (cmode)
+                queueObjectMovement(MWMechanics::getPlayer(), osg::Vec3f(0, 0, -0.1f));
+
             return cmode;
         }
 
@@ -1455,6 +1477,13 @@ namespace MWPhysics
     {
         for (std::set<Object*>::iterator it = mAnimatedObjects.begin(); it != mAnimatedObjects.end(); ++it)
             (*it)->animateCollisionShapes(mCollisionWorld);
+
+        mIdleUpdateTimer -= dt;
+        if (mIdleUpdateTimer <= 0.f)
+        {
+            mIdleUpdateTimer = 0.5f;
+            updateIdle();
+        }
 
 #ifndef BT_NO_PROFILE
         CProfileManager::Reset();

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -249,7 +249,7 @@ namespace MWPhysics
                 // Check if we actually found a valid spawn point (use an infinitely thin ray this time).
                 // Required for some broken door destinations in Morrowind.esm, where the spawn point
                 // intersects with other geometry if the actor's base is taken into account
-                btVector3 from = toBullet(position);
+                btVector3 from = toBullet(position + offset);
                 btVector3 to = from - btVector3(0,0,maxHeight);
 
                 btCollisionWorld::ClosestRayResultCallback resultCallback1(from, to);

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -124,6 +124,7 @@ namespace MWPhysics
             bool getLineOfSight(const MWWorld::ConstPtr& actor1, const MWWorld::ConstPtr& actor2) const;
 
             bool isOnGround (const MWWorld::Ptr& actor);
+            bool isIdle (const MWWorld::Ptr& actor);
 
             bool canMoveToWaterSurface (const MWWorld::ConstPtr &actor, const float waterlevel);
 
@@ -173,6 +174,7 @@ namespace MWPhysics
         private:
 
             void updateWater();
+            void updateIdle();
 
             osg::ref_ptr<SceneUtil::UnrefQueue> mUnrefQueue;
 
@@ -221,6 +223,7 @@ namespace MWPhysics
             osg::ref_ptr<osg::Group> mParentNode;
 
             float mPhysicsDt;
+            float mIdleUpdateTimer;
 
             PhysicsSystem (const PhysicsSystem&);
             PhysicsSystem& operator= (const PhysicsSystem&);

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -700,6 +700,8 @@ namespace MWScript
 
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
+                    MWWorld::Ptr ptr = R()(runtime);
+                    MWBase::Environment::get().getWorld()->queueMovement(ptr, osg::Vec3f(0, 0, -0.1f));
                 }
         };
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -506,7 +506,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
         if (firstPersonCam != MWBase::Environment::get().getWorld()->isFirstPerson())
             MWBase::Environment::get().getWorld()->togglePOV();
 
-        MWWorld::ConstPtr ptr = MWMechanics::getPlayer();
+        const MWWorld::Ptr ptr = MWMechanics::getPlayer();
 
         if (ptr.isInCell())
         {
@@ -538,6 +538,9 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
         // Since we passed "changeEvent=false" to changeCell, we shouldn't have triggered the cell change flag.
         // But make sure the flag is cleared anyway in case it was set from an earlier game.
         MWBase::Environment::get().getWorld()->markCellAsUnchanged();
+
+        // Workaround to fix camera position upon game load
+        MWBase::Environment::get().getWorld()->queueMovement(ptr, osg::Vec3f(0, 0, 0));
     }
     catch (const std::exception& e)
     {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1314,8 +1314,6 @@ namespace MWWorld
         if (pos.z() < terrainHeight)
             pos.z() = terrainHeight;
 
-        pos.z() += 20; // place slightly above. will snap down to ground with code below
-
         if (force || !isFlying(ptr))
         {
             osg::Vec3f traced = mPhysics->traceDown(ptr, pos, 500);
@@ -2155,6 +2153,11 @@ namespace MWWorld
     bool World::isOnGround(const MWWorld::Ptr &ptr) const
     {
         return mPhysics->isOnGround(ptr);
+    }
+
+    bool World::isIdle(const MWWorld::Ptr &ptr) const
+    {
+        return mPhysics->isIdle(ptr);
     }
 
     void World::togglePOV()

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -489,6 +489,7 @@ namespace MWWorld
             bool isWading(const MWWorld::ConstPtr &object) const override;
             bool isWaterWalkingCastableOnTarget(const MWWorld::ConstPtr &target) const override;
             bool isOnGround(const MWWorld::Ptr &ptr) const override;
+            bool isIdle(const MWWorld::Ptr &ptr) const override;
 
             osg::Matrixf getActorHeadTransform(const MWWorld::ConstPtr& actor) const override;
 


### PR DESCRIPTION
Fixes [bug #3803](https://bugs.openmw.org/issues/3803), improves physics performance.
Related forum discussion is [here](https://forum.openmw.org/viewtopic.php?f=6&t=5139).

This PR can have side effects, so it would be nice to have an additional testing, especially on CPU-limited hardware (I have the GPU-limited one).