### PR TITLE
Update MapWindow every frame, not just when it's open (bug #4279)

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -913,6 +913,9 @@ namespace MWGui
 
         updateMap();
 
+        if (!mMap->isVisible())
+            mMap->onFrame(frameDuration);
+
         mHud->onFrame(frameDuration);
 
         mDebugWindow->onFrame(frameDuration);


### PR DESCRIPTION
[Link to bug #4279](https://bugs.openmw.org/issues/4279)

In OpenMW 0.42, the tiles on your global map were filled in as you went through exterior cells, even if you never checked your global map. The GUI restructuring in OpenMW 0.43 made it so no map tiles were filled in as you went through cells, except for when you pressed right click to enter your "menu mode" and make your MapWindow visible, in which case – with default OpenMW settings – only your 2 most recent tiles were filled in.

This commit brings back the 0.42 behavior of updating the MapWindow every frame, with a visibility check that ensures it is not updated twice in the same frame.