### PR TITLE
[Feedback needed] Support for per-group KF-animation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
+    Feature #4444: Per-group KF-animation files support
 
 0.44.0
 ------

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -275,6 +275,8 @@ protected:
 
     osg::ref_ptr<SceneUtil::LightListCallback> mLightListCallback;
 
+    bool mUseAdditionalSources;
+
     const NodeMap& getNodeMap() const;
 
     /* Sets the appropriate animations on the bone groups based on priority.
@@ -309,12 +311,15 @@ protected:
      */
     void setObjectRoot(const std::string &model, bool forceskeleton, bool baseonly, bool isCreature);
 
+    void loadAllAnimationsInFolder(const std::string &model, const std::string &baseModel);
+
     /** Adds the keyframe controllers in the specified model as a new animation source.
      * @note Later added animation sources have the highest priority when it comes to finding a particular animation.
      * @param model The file to add the keyframes for. Note that the .nif file extension will be replaced with .kf.
      * @param baseModel The filename of the mObjectRoot, only used for error messages.
     */
     void addAnimSource(const std::string &model, const std::string& baseModel);
+    void addSingleAnimSource(const std::string &model, const std::string& baseModel);
 
     /** Adds an additional light to the given node using the specified ESM record. */
     void addExtraLight(osg::ref_ptr<osg::Group> parent, const ESM::Light *light);

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -157,3 +157,16 @@ Otherwise they wait for the enemies or the player to do an attack first.
 Please note this setting has not been extensively tested and could have side effects with certain quests.
 
 This setting can only be configured by editing the settings configuration file.
+
+use additional anim sources
+---------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+Allow to load additional animation sources when enabled.
+For example, if the main animation mesh has name Meshes/x.nif, an engine will load all KF-files from Animations/x folder and its child folders.
+Can be useful if you want to use several animation replacers without merging them.
+Attention: animations from AnimKit have own format and are not supposed to be directly loaded in-game!
+This setting can only be configured by editing the settings configuration file.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -219,6 +219,9 @@ can loot during death animation = true
 # Makes the value of filled soul gems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
 rebalance soul gem values = false
 
+# Allow to load per-group KF-files from Animations folder
+use additional anim sources = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Allows to use per-group KF-files to add new animation groups or override existing animation groups instead of replacing the file with all animation groups (xbase_anim.kf, for example).

For example, I have WIP weapon [un]equipping animations to support weapon sheathing:
[Animations.zip](https://github.com/OpenMW/openmw/files/1988735/Animations.zip)
If I want to use them in OpenMW, I need to merge these animations in xbase_anim.kf via external program, e.g. via AnimKit, which is Windows-only executable and requires Morrowind registry keys.
If I want to use animations with some other animation replacers (e.g. with Animation Compilation), I need to merge them too.
WIth this PR I can use new animations as a common ESP-less mod and do not touch original files.

The main idea: when OpenMW adds animation source to NPC (e.g. xbase_anim.kf), it loads also files from Animations folder (Animations/xbase_anim/* for xbase_anim.kf). Animations from these files override animations from base file.

This feature is disabled by default.

Notes: 
1. Unfortunately, source animations from AnimKit are not supposed to be loaded to game directly, at least they have keyframes for beast-specific bones.
2. Maybe we can reduce performance hit by caching merged animations in memory (probably in KeyframeManager).
