### PR TITLE
Use getNormalizedEncumbrance where applicable (bug #4413)

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -988,7 +988,7 @@ namespace MWClass
         const MWMechanics::MagicEffects &mageffects = npcdata->mNpcStats.getMagicEffects();
         const float encumbranceTerm = gmst.fJumpEncumbranceBase->getFloat() +
                                           gmst.fJumpEncumbranceMultiplier->getFloat() *
-                                          (1.0f - Npc::getEncumbrance(ptr)/Npc::getCapacity(ptr));
+                                          (1.0f - Npc::getNormalizedEncumbrance(ptr));
 
         float a = static_cast<float>(npcdata->mNpcStats.getSkill(ESM::Skill::Acrobatics).getModified());
         float b = 0.0f;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1751,8 +1751,7 @@ void CharacterController::update(float duration)
 
         if (cls.getEncumbrance(mPtr) <= cls.getCapacity(mPtr))
         {
-            const float encumbrance = cls.getEncumbrance(mPtr) / cls.getCapacity(mPtr);
-
+            const float encumbrance = cls.getNormalizedEncumbrance(mPtr);
             if (sneak)
                 fatigueLoss = fFatigueSneakBase + encumbrance * fFatigueSneakMult;
             else

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -462,10 +462,15 @@ namespace MWWorld
     float Class::getNormalizedEncumbrance(const Ptr &ptr) const
     {
         float capacity = getCapacity(ptr);
+        float encumbrance = getEncumbrance(ptr);
+
+        if (encumbrance == 0)
+            return 0.f;
+
         if (capacity == 0)
             return 1.f;
 
-        return getEncumbrance(ptr) / capacity;
+        return encumbrance / capacity;
     }
 
     std::string Class::getSound(const MWWorld::ConstPtr&) const


### PR DESCRIPTION
At least these two locations in the code directly used the result of dividing encumbrance by inventory capacity, which caused issues when both of them were zero: namely, you couldn't jump when you had zero strength yet zero encumbrance and your fatigue would have been fully depleted if you tried to run in this situation. getNormalizedEncumbrance does exactly the same thing but it accounts for zero capacity (returning 1) so there isn't a division by zero.

I've edited getNormalizedEncumbrance to always return 0 for zero encumbrance so that the behavior of 0/0 encumbrance is actually an assumption of 0% encumbrance, not 100%.