### PR TITLE
Fix compiler warning in getNestedData()

### DIFF
--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -1368,13 +1368,15 @@ QVariant CSMWorld::CreatureAttackRefIdAdapter::getNestedData (const RefIdColumn 
 
     const ESM::Creature& creature = record.get();
 
-    if (subRowIndex < 0 || subRowIndex > 2 || subColIndex < 0 || subColIndex > 2)
+    if (subRowIndex < 0 || subRowIndex > 2)
         throw std::runtime_error ("index out of range");
 
     if (subColIndex == 0)
         return subRowIndex + 1;
-    else if (subColIndex < 3) // 1 or 2
+    else if (subColIndex == 1 || subColIndex == 2)
         return creature.mData.mAttack[(subRowIndex * 2) + (subColIndex - 1)];
+    else
+        throw std::runtime_error ("index out of range");
 }
 
 void CSMWorld::CreatureAttackRefIdAdapter::setNestedData (const RefIdColumn *column,


### PR DESCRIPTION
Fixes [bug #4409](https://bugs.openmw.org/issues/4409) (which is not really a bug).

Just split subRowIndex and subColIndex checks and complete "if" statement. It is enough to make compilers happy.

