### PR TITLE
Display weapon reach on tooltips in feet

### DIFF
--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -325,7 +325,10 @@ namespace MWClass
         // add reach and attack speed for melee weapon
         if (ref->mBase->mData.mType < 9 && Settings::Manager::getBool("show melee info", "Game"))
         {
-            text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mReach, "#{sRange}");
+            // 64 game units = 1 yard = 3 ft, display value in feet
+            const float combatDistance = store.get<ESM::GameSetting>().find("fCombatDistance")->getFloat() * ref->mBase->mData.mReach;
+            text += MWGui::ToolTips::getWeightString(combatDistance*3/64, "#{sRange}");
+            text += " #{sFeet}";
 
             text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mSpeed, "#{sAttributeSpeed}");
         }


### PR DESCRIPTION
With "show melee info = true" OpenMW displays weapon reach on the tooltip in percents (Reach 1.0 means 100%).
With this PR OpenMW will calculate reach in feet using fCombatDistance GMST:

![screenshot_20180516_111146](https://user-images.githubusercontent.com/26434804/40101980-346a0132-58fa-11e8-9cf0-ba3624a11802.png)

Notes: 
1. 1 yard = 3 feet = 64 game units
2. With default fCombatDistance = 128 Reach = 1.0 means 6 ft combat distance.
