### PR TITLE
fix GCC warnings

### DIFF
--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -125,7 +125,7 @@ namespace MWRender
                     {
                         for (int cellX=0; cellX<mCellSize; ++cellX)
                         {
-                            int vertexX = static_cast<int>(float(cellX)/float(mCellSize) * 9);
+                            int vertexX = static_cast<int>(float(cellX) / float(mCellSize) * 9);
                             int vertexY = static_cast<int>(float(cellY) / float(mCellSize) * 9);
 
                             int texelX = (x-mMinX) * mCellSize + cellX;
@@ -135,9 +135,9 @@ namespace MWRender
 
                             float y2 = 0;
                             if (land && (land->mDataTypes & ESM::Land::DATA_WNAM))
-                                y2 = (land->mWnam[vertexY * 9 + vertexX] << 4) / 2048.f;
+                                y2 = land->mWnam[vertexY * 9 + vertexX] / 128.f;
                             else
-                                y2 = (SCHAR_MIN << 4) / 2048.f;
+                                y2 = SCHAR_MIN / 128.f;
                             if (y2 < 0)
                             {
                                 r = static_cast<unsigned char>(14 * y2 + 38);

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -952,7 +952,7 @@ std::pair<Sound_Handle,size_t> OpenAL_Output::loadSound(const std::string &fname
 
     std::vector<char> data;
     ALenum format = AL_NONE;
-    int srate;
+    int srate = 0;
 
     try
     {

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -951,10 +951,11 @@ std::pair<Sound_Handle,size_t> OpenAL_Output::loadSound(const std::string &fname
     getALError();
 
     std::vector<char> data;
-    ALenum format;
+    ALenum format = AL_NONE;
     int srate;
 
-    try {
+    try
+    {
         DecoderPtr decoder = mManager.getDecoder();
         // Workaround: Bethesda at some point converted some of the files to mp3, but the references were kept as .wav.
         if(decoder->mResourceMgr->exists(fname))
@@ -974,7 +975,8 @@ std::pair<Sound_Handle,size_t> OpenAL_Output::loadSound(const std::string &fname
         format = getALFormat(chans, type);
         if(format) decoder->readAll(data);
     }
-    catch(std::exception &e) {
+    catch(std::exception &e)
+    {
         std::cerr<< "Failed to load audio from "<<fname<<": "<<e.what() <<std::endl;
     }
 


### PR DESCRIPTION
1. Generally we should avoid of negative values shifting, because result can depend on platform.
SCHAR_MIN is -127 or less, depending on platform.
Since we divide result anyway, probably we do not need shifts here at all.
2. GCC complains about possibly uninitialized 'format' variable, it is more likely a false-positive.
I guess it is safe to initialize this variable just for sure.