### PR TITLE
Rework hitbox usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 0.45.0
 ------
+    Bug #3374: Touch spells not hitting kwama foragers
+    Bug #3591: Angled hit distance too low
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4433: Guard behaviour is incorrect with Alarm = 0

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -846,6 +846,16 @@ namespace MWPhysics
                                                                      const osg::Quat &orient,
                                                                      float queryDistance, std::vector<MWWorld::Ptr> targets)
     {
+        // First of all, try to hit where you aim to
+        int hitmask = CollisionType_World | CollisionType_Door | CollisionType_HeightMap | CollisionType_Actor;
+        RayResult result = castRay(origin, origin + (orient * osg::Vec3f(0.0f, queryDistance, 0.0f)), actor, targets, 0xff, hitmask);
+
+        if (result.mHit)
+        {
+            return std::make_pair(result.mHitObject, result.mHitPos);
+        }
+
+        // Use cone shape as fallback
         const MWWorld::Store<ESM::GameSetting> &store = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
 
         btConeShape shape (osg::DegreesToRadians(store.find("fCombatAngleXY")->getFloat()/2.0f), queryDistance);

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -848,7 +848,7 @@ namespace MWPhysics
     {
         // First of all, try to hit where you aim to
         int hitmask = CollisionType_World | CollisionType_Door | CollisionType_HeightMap | CollisionType_Actor;
-        RayResult result = castRay(origin, origin + (orient * osg::Vec3f(0.0f, queryDistance, 0.0f)), actor, targets, 0xff, hitmask);
+        RayResult result = castRay(origin, origin + (orient * osg::Vec3f(0.0f, queryDistance, 0.0f)), actor, targets, CollisionType_Actor, hitmask);
 
         if (result.mHit)
         {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1083,7 +1083,7 @@ namespace MWWorld
             // general case, compatible with all types of different creatures
             // note: we intentionally do *not* use the collision box offset here, this is required to make
             // some flying creatures work that have their collision box offset in the air
-            pos.z() += halfExtents.z() * 2 * 0.75;
+            pos.z() += halfExtents.z();
         }
 
         // the origin of hitbox is an actor's front, not center
@@ -3468,7 +3468,7 @@ namespace MWWorld
     osg::Vec3f World::aimToTarget(const ConstPtr &actor, const MWWorld::ConstPtr& target)
     {
         osg::Vec3f weaponPos = actor.getRefData().getPosition().asVec3();
-        weaponPos.z() += mPhysics->getHalfExtents(actor).z() * 2 * 0.75;
+        weaponPos.z() += mPhysics->getHalfExtents(actor).z();
         osg::Vec3f targetPos = mPhysics->getCollisionObjectPosition(target);
         return (targetPos - weaponPos);
     }
@@ -3477,7 +3477,7 @@ namespace MWWorld
     {
         osg::Vec3f weaponPos = actor.getRefData().getPosition().asVec3();
         osg::Vec3f halfExtents = mPhysics->getHalfExtents(actor);
-        weaponPos.z() += halfExtents.z() * 2 * 0.75;
+        weaponPos.z() += halfExtents.z();
 
         return mPhysics->getHitDistance(weaponPos, target) - halfExtents.y();
     }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1074,6 +1074,7 @@ namespace MWWorld
         osg::Quat rot = osg::Quat(posdata.rot[0], osg::Vec3f(-1,0,0)) * osg::Quat(posdata.rot[2], osg::Vec3f(0,0,-1));
 
         osg::Vec3f pos = ptr.getRefData().getPosition().asVec3();
+        osg::Vec3f halfExtents = mPhysics->getHalfExtents(ptr);
 
         if (ptr == getPlayerPtr())
             pos = getActorHeadTransform(ptr).getTrans(); // special cased for better aiming with the camera
@@ -1082,10 +1083,11 @@ namespace MWWorld
             // general case, compatible with all types of different creatures
             // note: we intentionally do *not* use the collision box offset here, this is required to make
             // some flying creatures work that have their collision box offset in the air
-            osg::Vec3f halfExtents = mPhysics->getHalfExtents(ptr);
             pos.z() += halfExtents.z() * 2 * 0.75;
-            distance += halfExtents.y();
         }
+
+        // the origin of hitbox is an actor's front, not center
+        distance += halfExtents.y();
 
         std::pair<MWWorld::Ptr,osg::Vec3f> result = mPhysics->getHitContact(ptr, pos, rot, distance, targets);
         if(result.first.isEmpty())

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1073,21 +1073,28 @@ namespace MWWorld
 
         osg::Quat rot = osg::Quat(posdata.rot[0], osg::Vec3f(-1,0,0)) * osg::Quat(posdata.rot[2], osg::Vec3f(0,0,-1));
 
-        osg::Vec3f pos = ptr.getRefData().getPosition().asVec3();
         osg::Vec3f halfExtents = mPhysics->getHalfExtents(ptr);
-
-        if (ptr == getPlayerPtr())
-            pos = getActorHeadTransform(ptr).getTrans(); // special cased for better aiming with the camera
-        else
-        {
-            // general case, compatible with all types of different creatures
-            // note: we intentionally do *not* use the collision box offset here, this is required to make
-            // some flying creatures work that have their collision box offset in the air
-            pos.z() += halfExtents.z();
-        }
 
         // the origin of hitbox is an actor's front, not center
         distance += halfExtents.y();
+
+        // special cased for better aiming with the camera
+        // if we do not hit anything, will use the default approach as fallback
+        if (ptr == getPlayerPtr())
+        {
+            osg::Vec3f pos = getActorHeadTransform(ptr).getTrans();
+
+            std::pair<MWWorld::Ptr,osg::Vec3f> result = mPhysics->getHitContact(ptr, pos, rot, distance, targets);
+            if(!result.first.isEmpty())
+                return std::make_pair(result.first, result.second);
+        }
+
+        osg::Vec3f pos = ptr.getRefData().getPosition().asVec3();
+
+        // general case, compatible with all types of different creatures
+        // note: we intentionally do *not* use the collision box offset here, this is required to make
+        // some flying creatures work that have their collision box offset in the air
+        pos.z() += halfExtents.z();
 
         std::pair<MWWorld::Ptr,osg::Vec3f> result = mPhysics->getHitContact(ptr, pos, rot, distance, targets);
         if(result.first.isEmpty())


### PR DESCRIPTION
Should fix [bug #3591](https://bugs.openmw.org/issues/3591) and [bug #3374](https://bugs.openmw.org/issues/3374), also makes compatibility patch for Morrowind Rebirth obsolete.
Related forum topic is [here](https://forum.openmw.org/viewtopic.php?f=6&t=5154).

Basically, this PR is aimed to fix hit detection for melee combat and touch spells.
I still do not know what to do with flying creatures, so I did not touch them.
Also my observations could be incomplete or partially wrong, so feel free to test this PR or join discussion.