### PR TITLE
Rename Original Creature field into Parent Creature (bug #2897)

### DIFF
--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -105,7 +105,7 @@ namespace CSMWorld
             { ColumnId_Respawn, "Respawn" },
             { ColumnId_CreatureType, "Creature Type" },
             { ColumnId_SoulPoints, "Soul Points" },
-            { ColumnId_OriginalCreature, "Original Creature" },
+            { ColumnId_ParentCreature, "Parent Creature" },
             { ColumnId_Biped, "Biped" },
             { ColumnId_HasWeapon, "Has Weapon" },
             { ColumnId_Swims, "Swims" },

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -99,7 +99,7 @@ namespace CSMWorld
             ColumnId_Respawn = 84,
             ColumnId_CreatureType = 85,
             ColumnId_SoulPoints = 86,
-            ColumnId_OriginalCreature = 87,
+            ColumnId_ParentCreature = 87,
             ColumnId_Biped = 88,
             ColumnId_HasWeapon = 89,
             // unused

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -331,7 +331,7 @@ CSMWorld::RefIdCollection::RefIdCollection()
     creatureColumns.mType = &mColumns.back();
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Scale, ColumnBase::Display_Float));
     creatureColumns.mScale = &mColumns.back();
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_OriginalCreature, ColumnBase::Display_Creature));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_ParentCreature, ColumnBase::Display_Creature));
     creatureColumns.mOriginal = &mColumns.back();
 
     static const struct


### PR DESCRIPTION
[Original report.](https://bugs.openmw.org/issues/2897)
*I think* this variant is good enough.

Yet a tiny change. I'll look into more serious editor stuff later.