### PR TITLE
Extension-agnostic texture loading (proof-of-concept)

### DIFF
--- a/apps/opencs/model/tools/magiceffectcheck.cpp
+++ b/apps/opencs/model/tools/magiceffectcheck.cpp
@@ -1,7 +1,5 @@
 #include "magiceffectcheck.hpp"
 
-#include <components/misc/resourcehelpers.hpp>
-
 #include "../world/resources.hpp"
 #include "../world/data.hpp"
 
@@ -19,22 +17,8 @@ namespace
 bool CSMTools::MagicEffectCheckStage::isTextureExists(const std::string &texture, bool isIcon) const
 {
     const CSMWorld::Resources &textures = isIcon ? mIcons : mTextures;
-    bool exists = false;
 
-    if (textures.searchId(texture) != -1)
-    {
-        exists = true;
-    }
-    else
-    {
-        std::string ddsTexture = texture;
-        if (Misc::ResourceHelpers::changeExtensionToDds(ddsTexture) && textures.searchId(ddsTexture) != -1)
-        {
-            exists = true;
-        }
-    }
-
-    return exists;
+    return (textures.searchId(texture) != -1);
 }
 
 std::string CSMTools::MagicEffectCheckStage::checkReferenceable(const std::string &id, 

--- a/components/misc/resourcehelpers.cpp
+++ b/components/misc/resourcehelpers.cpp
@@ -29,20 +29,10 @@ namespace
 
 }
 
-bool Misc::ResourceHelpers::changeExtensionToDds(std::string &path)
-{
-    std::string::size_type pos = path.rfind('.');
-    if(pos != std::string::npos && path.compare(pos, path.length() - pos, ".dds") != 0)
-    {
-        path.replace(pos, path.length(), ".dds");
-        return true;
-    }
-    return false;
-}
-
 std::string Misc::ResourceHelpers::correctResourcePath(const std::string &topLevelDirectory, const std::string &resPath, const VFS::Manager* vfs)
 {
-    /* Bethesda at some point converted all their BSA
+    /* 
+     * Bethesda at some point converted all their BSA
      * textures from tga to dds for increased load speed, but all
      * texture file name references were kept as .tga.
      */
@@ -53,24 +43,20 @@ std::string Misc::ResourceHelpers::correctResourcePath(const std::string &topLev
     std::string correctedPath = resPath;
     Misc::StringUtils::lowerCaseInPlace(correctedPath);
 
-    // Apparently, leading separators are allowed
+    // Apparently leading separators are allowed
     while (correctedPath.size() && (correctedPath[0] == '/' || correctedPath[0] == '\\'))
         correctedPath.erase(0, 1);
 
-    if(correctedPath.compare(0, prefix1.size(), prefix1.data()) != 0 &&
-       correctedPath.compare(0, prefix2.size(), prefix2.data()) != 0)
+    if (correctedPath.compare(0, prefix1.size(), prefix1.data()) != 0 &&
+        correctedPath.compare(0, prefix2.size(), prefix2.data()) != 0)
         correctedPath = prefix1 + correctedPath;
 
-    std::string origExt = correctedPath;
-
-    if (vfs->exists(origExt)
-     || (changeExtensionToDds(correctedPath) && vfs->exists(correctedPath)))
+    if (vfs->exists(correctedPath))
         return correctedPath;
 
-    // fall back to a resource in the top level directory if it exists
-    std::string fallback = topLevelDirectory + "\\" + getBasename(origExt);
-    if (vfs->exists(fallback)
-     || (changeExtensionToDds(fallback) && vfs->exists(fallback)))
+    // Fall back to a resource in the top level directory if it exists
+    std::string fallback = prefix1 + getBasename(correctedPath);
+    if (vfs->exists(fallback))
         return fallback;
 
     return correctedPath;

--- a/components/misc/resourcehelpers.cpp
+++ b/components/misc/resourcehelpers.cpp
@@ -51,13 +51,18 @@ std::string Misc::ResourceHelpers::correctResourcePath(const std::string &topLev
         correctedPath.compare(0, prefix2.size(), prefix2.data()) != 0)
         correctedPath = prefix1 + correctedPath;
 
-    if (vfs->exists(correctedPath))
-        return correctedPath;
+    // Find the highest priority file with the same base name (no extension)
+    std::string filePath = vfs->findFirstOf(correctedPath);
+
+    if (!filePath.empty())
+        return filePath;
 
     // Fall back to a resource in the top level directory if it exists
-    std::string fallback = prefix1 + getBasename(correctedPath);
-    if (vfs->exists(fallback))
-        return fallback;
+    filePath = prefix1 + getBasename(correctedPath);
+    filePath = vfs->findFirstOf(filePath);
+
+    if (!filePath.empty())
+        return filePath;
 
     return correctedPath;
 }

--- a/components/misc/resourcehelpers.hpp
+++ b/components/misc/resourcehelpers.hpp
@@ -15,7 +15,6 @@ namespace Misc
     // so we have the opportunity to use proper resource handling for content created in OpenMW-CS.
     namespace ResourceHelpers
     {
-        bool changeExtensionToDds(std::string &path);
         std::string correctResourcePath(const std::string &topLevelDirectory, const std::string &resPath, const VFS::Manager* vfs);
         std::string correctTexturePath(const std::string &resPath, const VFS::Manager* vfs);
         std::string correctIconPath(const std::string &resPath, const VFS::Manager* vfs);

--- a/components/vfs/manager.cpp
+++ b/components/vfs/manager.cpp
@@ -66,7 +66,7 @@ namespace VFS
         for (auto it = mArchives.begin(); it != mArchives.end(); ++it)
         {
             NameFileMap index;
-            (*it)->listResources(mIndex, mStrict ? &strict_normalize_char : &nonstrict_normalize_char);
+            (*it)->listResources(index, mStrict ? &strict_normalize_char : &nonstrict_normalize_char);
             for (NameFileMap::const_iterator nf = index.begin(); nf != index.end(); ++nf)
                 mIndex[nf->first] = nf->second;
             *archiveInserter = index;
@@ -108,7 +108,7 @@ namespace VFS
         normalize_path(name, mStrict);
     }
 
-    const std::string& Manager::findFirstOf(const std::string &name) const
+    std::string Manager::findFirstOf(const std::string &name) const
     {
         std::string normalized = name;
         normalize_path(normalized, mStrict);

--- a/components/vfs/manager.cpp
+++ b/components/vfs/manager.cpp
@@ -108,9 +108,8 @@ namespace VFS
         normalize_path(name, mStrict);
     }
 
-    std::string Manager::findFirstOf(const std::string &name) const
+    const std::string& Manager::findFirstOf(std::string normalized) const
     {
-        std::string normalized = name;
         normalize_path(normalized, mStrict);
         size_t extensionPos = normalized.rfind('.');
         if (extensionPos == std::string::npos || normalized.find('/', extensionPos+1) != std::string::npos)
@@ -131,8 +130,9 @@ namespace VFS
                     return entry->first;
             }
         }
-        
-        return {};
+
+        static const std::string empty;
+        return empty;
     }
 
 }

--- a/components/vfs/manager.cpp
+++ b/components/vfs/manager.cpp
@@ -1,6 +1,7 @@
 #include "manager.hpp"
 
 #include <cctype>
+#include <iterator>
 #include <stdexcept>
 
 #include <components/misc/stringops.hpp>

--- a/components/vfs/manager.hpp
+++ b/components/vfs/manager.hpp
@@ -61,7 +61,7 @@ namespace VFS
         /// Find the highest priority resource of given resource name, ignoring the extension.
         /// @return the path to the resource
         /// @return empty string if no such resources were found
-        std::string findFirstOf(const std::string& name) const;
+        const std::string& findFirstOf(std::string normalized) const;
 
     private:
         bool mStrict;

--- a/components/vfs/manager.hpp
+++ b/components/vfs/manager.hpp
@@ -63,7 +63,11 @@ namespace VFS
 
         std::vector<Archive*> mArchives;
 
-        std::map<std::string, File*> mIndex;
+        typedef std::map<std::string,File*> NameFileMap;
+
+        std::vector<NameFileMap> mArchiveIndexes;
+
+        NameFileMap mIndex;
     };
 
 }

--- a/components/vfs/manager.hpp
+++ b/components/vfs/manager.hpp
@@ -58,6 +58,11 @@ namespace VFS
         /// @note May be called from any thread once the index has been built.
         Files::IStreamPtr getNormalized(const std::string& normalizedName) const;
 
+        /// Find the highest priority resource of given resource name, ignoring the extension.
+        /// @return the path to the resource
+        /// @return empty string if no such resources were found
+        const std::string &findFirstOf(const std::string& name) const;
+
     private:
         bool mStrict;
 

--- a/components/vfs/manager.hpp
+++ b/components/vfs/manager.hpp
@@ -61,7 +61,7 @@ namespace VFS
         /// Find the highest priority resource of given resource name, ignoring the extension.
         /// @return the path to the resource
         /// @return empty string if no such resources were found
-        const std::string &findFirstOf(const std::string& name) const;
+        std::string findFirstOf(const std::string& name) const;
 
     private:
         bool mStrict;


### PR DESCRIPTION
After a sleepless night and plenty of figuring out what did I copypaste wrong and why does it crash...
This is supposed to fix [issue 4202](https://bugs.openmw.org/issues/4402).

It's basically a blatant rip-off of #864, but adapted for textures. It still replicates Chris' idea, as described in his PR and in the issue discussion. So: the engine will try to find a file with the same base name as requested in the index of archives/data folders starting with those which are later in the openmw.cfg lists (have higher priority). The path to the earliest file in the alphabetical index of the first data archive/folder in the list which has such a resource will be used.

Pros:
* It's possible to use literally any image file supported by OSG to replace any texture, provided they're placed in later data folders/archives than the archives they were first added to. So vanilla BSA DDS files can always be replaced with something with a different extension.
* findFirstOf can be utilized later for other resource types.
* GOG version should work properly

Cons:
* No extension blacklist/whitelist yet. If there's random crap with the same base name as the necessary file in user's latter texture folders, OpenMW will fail at loading that file and then not load anything as a texture, period, though it will tell the user there's something wrong. Should there be one?
* In the process I got rid of changeExtensionToDds. It would only be used by the editor magic effect verifier for checking if icon/texture exists in Editor's own resource index. As it is now, there would be warnings spam in verification results. Not sure how to approach the replacement of it.
* Files with the same extensions in the same data folder are assumed to be the same. The file which appears later in the list will be used.
* Probably other stuff I either forget or have implemented incorrectly for now.

Pinging @kcat, of course. Though feedback from anyone (and Hristos Triantafillou) would be appreciated, because I don't use texture replacers much and can't test all the cases.