### PR TITLE
Don't reset sneaking camera offset while in GUI (bug #4420)

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1621,7 +1621,7 @@ namespace MWWorld
         if (!paused)
             doPhysics (duration);
 
-        updatePlayer(paused);
+        updatePlayer();
 
         mPhysics->debugDraw();
 
@@ -1637,7 +1637,7 @@ namespace MWWorld
         }
     }
 
-    void World::updatePlayer(bool paused)
+    void World::updatePlayer()
     {
         MWWorld::Ptr player = getPlayerPtr();
 
@@ -1670,7 +1670,7 @@ namespace MWWorld
         bool swimming = isSwimming(player);
 
         static const float i1stPersonSneakDelta = getStore().get<ESM::GameSetting>().find("i1stPersonSneakDelta")->getFloat();
-        if(!paused && sneaking && !(swimming || inair))
+        if (sneaking && !(swimming || inair))
             mRendering->getCamera()->setSneakOffset(i1stPersonSneakDelta);
         else
             mRendering->getCamera()->setSneakOffset(0.f);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -129,7 +129,7 @@ namespace MWWorld
             Ptr copyObjectToCell(const ConstPtr &ptr, CellStore* cell, ESM::Position pos, int count, bool adjustPos);
 
             void updateSoundListener();
-            void updatePlayer(bool paused);
+            void updatePlayer();
 
             void preloadSpells();
 


### PR DESCRIPTION
There's no real reason to reset the offset, but if updatePlayer gets called while in a GUI and then it gets called when the player is no longer in a GUI, it could cause a momentary flickering back into sneaking point of view.

I don't see this anymore when this is applied.