### PR TITLE
Add OSG 3.6 binaries to CI script

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -333,7 +333,7 @@ if [ -z $SKIP_DOWNLOAD ]; then
 	# OSG
 	download "OpenSceneGraph 3.6.0-scrawl" \
 		"https://www.lysator.liu.se/~ace/OpenMW/deps/OSG-3.6.0-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}.7z" \
-		"OSG-3.4.1-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}.7z"
+		"OSG-3.6.0-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}.7z"
 
 	# Qt
 	if [ -z $APPVEYOR ]; then

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -332,8 +332,8 @@ if [ -z $SKIP_DOWNLOAD ]; then
 
 	# OSG
 	download "OpenSceneGraph 3.6.0-scrawl" \
-		"https://www.lysator.liu.se/~ace/OpenMW/deps/OSG-3.6.0-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z" \
-		"OSG-3.4.1-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z"
+		"https://www.lysator.liu.se/~ace/OpenMW/deps/OSG-3.6.0-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}.7z" \
+		"OSG-3.4.1-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}.7z"
 
 	# Qt
 	if [ -z $APPVEYOR ]; then
@@ -546,8 +546,8 @@ printf "OSG 3.6.0-scrawl... "
 		printf "Exists. "
 	elif [ -z $SKIP_EXTRACT ]; then
 		rm -rf OSG
-		eval 7z x -y "${DEPS}/OSG-3.6.0-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z" $STRIP
-		mv "OSG-3.6.0-scrawl-msvc${MSVC_YEAR}-win${BITS}" OSG
+		eval 7z x -y "${DEPS}/OSG-3.6.0-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}.7z" $STRIP
+		mv "OSG-3.6.0-scrawl-msvc${MSVC_DISPLAY_YEAR}-win${BITS}" OSG
 	fi
 
 	OSG_SDK="$(real_pwd)/OSG"

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -216,6 +216,7 @@ case $VS_VERSION in
 	15|15.0|2017 )
 		GENERATOR="Visual Studio 15 2017"
 		TOOLSET="vc140"
+		TOOLSET_REAL="vc141"
 		MSVC_REAL_VER="15"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
@@ -225,6 +226,7 @@ case $VS_VERSION in
 	14|14.0|2015 )
 		GENERATOR="Visual Studio 14 2015"
 		TOOLSET="vc140"
+		TOOLSET_REAL="vc140"
 		MSVC_REAL_VER="14"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
@@ -234,6 +236,7 @@ case $VS_VERSION in
 	12|12.0|2013 )
 		GENERATOR="Visual Studio 12 2013"
 		TOOLSET="vc120"
+		TOOLSET_REAL="vc120"
 		MSVC_REAL_VER="12"
 		MSVC_VER="12"
 		MSVC_YEAR="2013"
@@ -424,7 +427,7 @@ fi
 		
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
 			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.${LIB_SUFFIX}"
-		add_cmake_opts -DBoost_COMPILER="-${TOOLSET}"
+		add_cmake_opts -DBoost_COMPILER="-${TOOLSET_REAL}"
 
 		echo Done.
 	fi

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -209,7 +209,7 @@ if [ -z $CONFIGURATION ]; then
 fi
 
 if [ -z $VS_VERSION ]; then
-	VS_VERSION="2013"
+	VS_VERSION="2015"
 fi
 
 case $VS_VERSION in
@@ -232,16 +232,11 @@ case $VS_VERSION in
 		MSVC_YEAR="2015"
 		MSVC_DISPLAY_YEAR="2015"
 		;;
-
+		
 	12|12.0|2013 )
-		GENERATOR="Visual Studio 12 2013"
-		TOOLSET="vc120"
-		TOOLSET_REAL="vc120"
-		MSVC_REAL_VER="12"
-		MSVC_VER="12"
-		MSVC_YEAR="2013"
-		MSVC_DISPLAY_YEAR="2013"
-		;;
+	        echo "Visual Studio 2013 is no longer supported, sorry."
+		exit 1
+	        ;;
 esac
 
 case $PLATFORM in
@@ -336,8 +331,8 @@ if [ -z $SKIP_DOWNLOAD ]; then
 		"OpenAL-Soft-1.17.2.zip"
 
 	# OSG
-	download "OpenSceneGraph 3.4.1-scrawl" \
-		"https://www.lysator.liu.se/~ace/OpenMW/deps/OSG-3.4.1-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z" \
+	download "OpenSceneGraph 3.6.0-scrawl" \
+		"https://www.lysator.liu.se/~ace/OpenMW/deps/OSG-3.6.0-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z" \
 		"OSG-3.4.1-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z"
 
 	# Qt
@@ -539,20 +534,20 @@ cd $DEPS
 echo
 
 # OSG
-printf "OSG 3.4.1-scrawl... "
+printf "OSG 3.6.0-scrawl... "
 {
 	cd $DEPS_INSTALL
 
 	if [ -d OSG ] && \
 		grep "OPENSCENEGRAPH_MAJOR_VERSION    3" OSG/include/osg/Version > /dev/null && \
-		grep "OPENSCENEGRAPH_MINOR_VERSION    4" OSG/include/osg/Version > /dev/null && \
-		grep "OPENSCENEGRAPH_PATCH_VERSION    1" OSG/include/osg/Version > /dev/null
+		grep "OPENSCENEGRAPH_MINOR_VERSION    6" OSG/include/osg/Version > /dev/null && \
+		grep "OPENSCENEGRAPH_PATCH_VERSION    0" OSG/include/osg/Version > /dev/null
 	then
 		printf "Exists. "
 	elif [ -z $SKIP_EXTRACT ]; then
 		rm -rf OSG
-		eval 7z x -y "${DEPS}/OSG-3.4.1-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z" $STRIP
-		mv "OSG-3.4.1-scrawl-msvc${MSVC_YEAR}-win${BITS}" OSG
+		eval 7z x -y "${DEPS}/OSG-3.6.0-scrawl-msvc${MSVC_YEAR}-win${BITS}.7z" $STRIP
+		mv "OSG-3.6.0-scrawl-msvc${MSVC_YEAR}-win${BITS}" OSG
 	fi
 
 	OSG_SDK="$(real_pwd)/OSG"
@@ -568,8 +563,8 @@ printf "OSG 3.4.1-scrawl... "
 	add_runtime_dlls "$(pwd)/OSG/bin/"{OpenThreads,zlib,libpng*}${SUFFIX}.dll \
 		"$(pwd)/OSG/bin/osg"{,Animation,DB,FX,GA,Particle,Text,Util,Viewer}${SUFFIX}.dll
 
-	add_osg_dlls "$(pwd)/OSG/bin/osgPlugins-3.4.1/osgdb_"{bmp,dds,jpeg,osg,png,tga}${SUFFIX}.dll
-	add_osg_dlls "$(pwd)/OSG/bin/osgPlugins-3.4.1/osgdb_serializers_osg"{,animation,fx,ga,particle,text,util,viewer}${SUFFIX}.dll
+	add_osg_dlls "$(pwd)/OSG/bin/osgPlugins-3.6.0/osgdb_"{bmp,dds,jpeg,osg,png,tga}${SUFFIX}.dll
+	add_osg_dlls "$(pwd)/OSG/bin/osgPlugins-3.6.0/osgdb_serializers_osg"{,animation,fx,ga,particle,text,util,viewer}${SUFFIX}.dll
 
 	echo Done.
 }
@@ -728,10 +723,10 @@ if [ -z $CI ]; then
 	echo
 
 	echo "- OSG Plugin DLLs..."
-	mkdir -p $BUILD_CONFIG/osgPlugins-3.4.1
+	mkdir -p $BUILD_CONFIG/osgPlugins-3.6.0
 	for DLL in $OSG_PLUGINS; do
 		echo "    $(basename $DLL)."
-		cp "$DLL" $BUILD_CONFIG/osgPlugins-3.4.1
+		cp "$DLL" $BUILD_CONFIG/osgPlugins-3.6.0
 	done
 	echo
 

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -216,6 +216,7 @@ case $VS_VERSION in
 	15|15.0|2017 )
 		GENERATOR="Visual Studio 15 2017"
 		TOOLSET="vc140"
+		MSVC_REAL_VER="15"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
 		MSVC_DISPLAY_YEAR="2017"
@@ -224,6 +225,7 @@ case $VS_VERSION in
 	14|14.0|2015 )
 		GENERATOR="Visual Studio 14 2015"
 		TOOLSET="vc140"
+		MSVC_REAL_VER="14"
 		MSVC_VER="14"
 		MSVC_YEAR="2015"
 		MSVC_DISPLAY_YEAR="2015"
@@ -232,6 +234,7 @@ case $VS_VERSION in
 	12|12.0|2013 )
 		GENERATOR="Visual Studio 12 2013"
 		TOOLSET="vc120"
+		MSVC_REAL_VER="12"
 		MSVC_VER="12"
 		MSVC_YEAR="2013"
 		MSVC_DISPLAY_YEAR="2013"
@@ -408,13 +411,19 @@ fi
 		echo Done.
 	else
 		# Appveyor unstable has all the boost we need already
-		if [ $MSVC_VER -eq 12 ]; then
+		if [ $MSVC_REAL_VER -eq 12 ]; then
 			BOOST_SDK="c:/Libraries/boost_1_58_0"
 		else
 			BOOST_SDK="c:/Libraries/boost_1_67_0"
 		fi
+		if [ $MSVC_REAL_VER -eq 15 ]; then
+			LIB_SUFFIX="1"
+		else
+			LIB_SUFFIX="0"
+		fi
+		
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
-			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.0"
+			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.${LIB_SUFFIX}"
 		add_cmake_opts -DBoost_COMPILER="-${TOOLSET}"
 
 		echo Done.

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -385,7 +385,7 @@ else
 	if [ $MSVC_VER -eq 12 ]; then
 		printf "Boost 1.58.0 AppVeyor... "
 	else
-		printf "Boost 1.60.0 AppVeyor... "
+		printf "Boost 1.67.0 AppVeyor... "
 	fi
 fi
 {
@@ -411,7 +411,7 @@ fi
 		if [ $MSVC_VER -eq 12 ]; then
 			BOOST_SDK="c:/Libraries/boost_1_58_0"
 		else
-			BOOST_SDK="c:/Libraries/boost_1_60_0"
+			BOOST_SDK="c:/Libraries/boost_1_67_0"
 		fi
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \
 			-DBOOST_LIBRARYDIR="${BOOST_SDK}/lib${BITS}-msvc-${MSVC_VER}.0"
@@ -618,7 +618,7 @@ fi
 
 		echo Done.
 	else
-		QT_SDK="C:/Qt/5.10/msvc${MSVC_YEAR}${SUFFIX}"
+		QT_SDK="C:/Qt/5.10/msvc${MSVC_DISPLAY_YEAR}${SUFFIX}"
 
 		add_cmake_opts -DDESIRED_QT_VERSION=5 \
 			-DQT_QMAKE_EXECUTABLE="${QT_SDK}/bin/qmake.exe" \

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -568,7 +568,7 @@ echo
 if [ -z $APPVEYOR ]; then
 	printf "Qt 5.7.0... "
 else
-	printf "Qt 5.7 AppVeyor... "
+	printf "Qt 5.10 AppVeyor... "
 fi
 {
 	if [ $BITS -eq 64 ]; then
@@ -618,7 +618,7 @@ fi
 
 		echo Done.
 	else
-		QT_SDK="C:/Qt/5.7/msvc${MSVC_YEAR}${SUFFIX}"
+		QT_SDK="C:/Qt/5.10/msvc${MSVC_YEAR}${SUFFIX}"
 
 		add_cmake_opts -DDESIRED_QT_VERSION=5 \
 			-DQT_QMAKE_EXECUTABLE="${QT_SDK}/bin/qmake.exe" \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ branches:
 
 environment:
     matrix:
-        - msvc: 2015
+#       - msvc: 2015
         - msvc: 2017
 
 platform:
@@ -20,7 +20,7 @@ configuration:
 #   - Release
 
 # For the Qt, Boost, CMake, etc installs
-os: Visual Studio 2015
+os: Visual Studio 2017
 
 # We want the git revision for versioning,
 # so shallow clones don't work.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,12 @@ branches:
 
 environment:
     matrix:
-        - msvc: 2013
         - msvc: 2015
+        - msvc: 2017
 
 platform:
-    - Win32
-#   - x64
+#   - Win32
+    - x64
 
 configuration:
     - Debug
@@ -27,16 +27,10 @@ os: Visual Studio 2015
 clone_depth: 1
 
 cache:
-    - C:\projects\openmw\deps\Bullet-2.83.7-msvc2013-win32.7z
-    - C:\projects\openmw\deps\Bullet-2.83.7-msvc2013-win64.7z
     - C:\projects\openmw\deps\Bullet-2.83.7-msvc2015-win32.7z
     - C:\projects\openmw\deps\Bullet-2.83.7-msvc2015-win64.7z
-    - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2013-win32.7z
-    - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2013-win32.7z
     - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win64.7z
     - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win64.7z
-    - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2013-win32.7z
-    - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2013-win32.7z
     - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2015-win64.7z
     - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2015-win64.7z
     - C:\projects\openmw\deps\ffmpeg-3.0.1-dev-win32.7z

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ install:
     - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
 before_build:
-    - cmd: sh %APPVEYOR_BUILD_FOLDER%\CI\before_script.msvc.sh -u -p %PLATFORM% -v %msvc%
+    - cmd: sh %APPVEYOR_BUILD_FOLDER%\CI\before_script.msvc.sh -u -p %PLATFORM% -v %msvc% -V
 
 build_script:
     - cmd: if %PLATFORM%==Win32 set build=MSVC%msvc%_32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,10 @@ branches:
 
 environment:
     matrix:
-#       - msvc: 2015
+        - msvc: 2015
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
         - msvc: 2017
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 platform:
 #   - Win32
@@ -20,7 +22,7 @@ configuration:
 #   - Release
 
 # For the Qt, Boost, CMake, etc installs
-os: Visual Studio 2017
+#os: Visual Studio 2017
 
 # We want the git revision for versioning,
 # so shallow clones don't work.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,12 @@ clone_depth: 1
 cache:
     - C:\projects\openmw\deps\Bullet-2.83.7-msvc2015-win32.7z
     - C:\projects\openmw\deps\Bullet-2.83.7-msvc2015-win64.7z
+    - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win32.7z
     - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win64.7z
-    - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win64.7z
-    - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2015-win64.7z
-    - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2015-win64.7z
+    - C:\projects\openmw\deps\OSG-3.6.0-scrawl-msvc2015-win32.7z
+    - C:\projects\openmw\deps\OSG-3.6.0-scrawl-msvc2015-win64.7z
+    - C:\projects\openmw\deps\OSG-3.6.0-scrawl-msvc2017-win32.7z
+    - C:\projects\openmw\deps\OSG-3.6.0-scrawl-msvc2017-win64.7z
     - C:\projects\openmw\deps\ffmpeg-3.0.1-dev-win32.7z
     - C:\projects\openmw\deps\ffmpeg-3.0.1-dev-win64.7z
     - C:\projects\openmw\deps\ffmpeg-3.0.1-win32.7z


### PR DESCRIPTION
Will have to drop Visual Studio 2013 support for this, don't have the ability to build up new 2013 binaries for 3.6.

Because of this, #1714 is probably going to be required to switch the CI from VS2013 + VS2015 to VS2015 + VS2017