### PR TITLE
Soul gem value rebalance

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -23,6 +23,7 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(showEnchantChanceCheckBox, "show enchant chance", "Game");
     loadSettingBool(showMeleeInfoCheckBox, "show melee info", "Game");
     loadSettingBool(showProjectileDamageCheckBox, "show projectile damage", "Game");
+    loadSettingBool(rebalanceSoulgemValuesCheckBox, "rebalance soulgem values", "Game");
 
     // Expected values are (0, 1, 2, 3)
     int showOwnedIndex = mEngineSettings.getInt("show owned", "Game");
@@ -61,6 +62,7 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(showEnchantChanceCheckBox, "show enchant chance", "Game");
     saveSettingBool(showMeleeInfoCheckBox, "show melee info", "Game");
     saveSettingBool(showProjectileDamageCheckBox, "show projectile damage", "Game");
+    saveSettingBool(rebalanceSoulgemValuesCheckBox, "rebalance soulgem values", "Game");
 
     int showOwnedCurrentIndex = showOwnedComboBox->currentIndex();
     if (showOwnedCurrentIndex != mEngineSettings.getInt("show owned", "Game"))

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -23,7 +23,7 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(showEnchantChanceCheckBox, "show enchant chance", "Game");
     loadSettingBool(showMeleeInfoCheckBox, "show melee info", "Game");
     loadSettingBool(showProjectileDamageCheckBox, "show projectile damage", "Game");
-    loadSettingBool(rebalanceSoulgemValuesCheckBox, "rebalance soulgem values", "Game");
+    loadSettingBool(rebalanceSoulGemValuesCheckBox, "rebalance soul gem values", "Game");
 
     // Expected values are (0, 1, 2, 3)
     int showOwnedIndex = mEngineSettings.getInt("show owned", "Game");
@@ -62,7 +62,7 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(showEnchantChanceCheckBox, "show enchant chance", "Game");
     saveSettingBool(showMeleeInfoCheckBox, "show melee info", "Game");
     saveSettingBool(showProjectileDamageCheckBox, "show projectile damage", "Game");
-    saveSettingBool(rebalanceSoulgemValuesCheckBox, "rebalance soulgem values", "Game");
+    saveSettingBool(rebalanceSoulGemValuesCheckBox, "rebalance soul gem values", "Game");
 
     int showOwnedCurrentIndex = showOwnedComboBox->currentIndex();
     if (showOwnedCurrentIndex != mEngineSettings.getInt("show owned", "Game"))

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -88,7 +88,7 @@ namespace MWClass
             if (creature)
             {
                 int soul = creature->mData.mSoul;
-                if (Settings::Manager::getBool("rebalance soulgem values", "Game"))
+                if (Settings::Manager::getBool("rebalance soul gem values", "Game"))
                 {
                     // use soulgem value rebalance formula from morrowind code patch 
                     float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -87,10 +87,10 @@ namespace MWClass
             const ESM::Creature *creature = MWBase::Environment::get().getWorld()->getStore().get<ESM::Creature>().search(ref->mRef.getSoul());
             if (creature)
             {
+                int soul = creature->mData.mSoul;
                 if (Settings::Manager::getBool("rebalance soulgem values", "Game"))
                 {
                     // use soulgem value rebalance formula from morrowind code patch 
-                    int soul = creature->mData.mSoul;
                     float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;
                     
                     // for Azura's star add the unfilled value
@@ -100,7 +100,7 @@ namespace MWClass
                         value = soulValue;
                 }
                 else
-                    value *= creature->mData.mSoul;
+                    value *= soul;
             }
         }
 

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -90,7 +90,7 @@ namespace MWClass
                 int soul = creature->mData.mSoul;
                 if (Settings::Manager::getBool("rebalance soul gem values", "Game"))
                 {
-                    // use soulgem value rebalance formula from morrowind code patch 
+                    // use the 'Soul gem value rebalance' formula from morrowind code patch 
                     float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;
                     
                     // for Azura's star add the unfilled value

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -89,13 +89,13 @@ namespace MWClass
                 
                 // use soulgem value rebalance formula from morrowind code patch 
                 int soul = creature->mData.mSoul;
-                float soul_value = 0.0001 * pow(soul, 3) + 2 * soul;
+                float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;
                 
                 // for Azura's star add the unfilled value
                 if (Misc::StringUtils::ciEqual(ptr.getCellRef().getRefId(), "Misc_SoulGem_Azura"))
-                    value += soul_value;
+                    value += soulValue;
                 else
-                    value = soul_value;
+                    value = soulValue;
             }
         }
 

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -1,6 +1,7 @@
 #include "misc.hpp"
 
 #include <components/esm/loadmisc.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -84,18 +85,22 @@ namespace MWClass
         if (ptr.getCellRef().getSoul() != "")
         {
             const ESM::Creature *creature = MWBase::Environment::get().getWorld()->getStore().get<ESM::Creature>().search(ref->mRef.getSoul());
-            if (creature) {
-                // value *= creature->mData.mSoul;
-                
-                // use soulgem value rebalance formula from morrowind code patch 
-                int soul = creature->mData.mSoul;
-                float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;
-                
-                // for Azura's star add the unfilled value
-                if (Misc::StringUtils::ciEqual(ptr.getCellRef().getRefId(), "Misc_SoulGem_Azura"))
-                    value += soulValue;
+            if (creature)
+            {
+                if (Settings::Manager::getBool("rebalance soulgem values", "Game"))
+                {
+                    // use soulgem value rebalance formula from morrowind code patch 
+                    int soul = creature->mData.mSoul;
+                    float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;
+                    
+                    // for Azura's star add the unfilled value
+                    if (Misc::StringUtils::ciEqual(ptr.getCellRef().getRefId(), "Misc_SoulGem_Azura"))
+                        value += soulValue;
+                    else
+                        value = soulValue;
+                }
                 else
-                    value = soulValue;
+                    value *= creature->mData.mSoul;
             }
         }
 

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -90,7 +90,7 @@ namespace MWClass
                 int soul = creature->mData.mSoul;
                 if (Settings::Manager::getBool("rebalance soul gem values", "Game"))
                 {
-                    // use the 'Soul gem value rebalance' formula from morrowind code patch 
+                    // use the 'soul gem value rebalance' formula from the Morrowind Code Patch 
                     float soulValue = 0.0001 * pow(soul, 3) + 2 * soul;
                     
                     // for Azura's star add the unfilled value

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -84,8 +84,19 @@ namespace MWClass
         if (ptr.getCellRef().getSoul() != "")
         {
             const ESM::Creature *creature = MWBase::Environment::get().getWorld()->getStore().get<ESM::Creature>().search(ref->mRef.getSoul());
-            if (creature)
-                value *= creature->mData.mSoul;
+            if (creature) {
+                // value *= creature->mData.mSoul;
+                
+                // use soulgem value rebalance formula from morrowind code patch 
+                int soul = creature->mData.mSoul;
+                float soul_value = 0.0001 * pow(soul, 3) + 2 * soul;
+                
+                // for Azura's star add the unfilled value
+                if (Misc::StringUtils::ciEqual(ptr.getCellRef().getRefId(), "Misc_SoulGem_Azura"))
+                    value += soul_value;
+                else
+                    value = soul_value;
+            }
         }
 
         return value;

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -216,8 +216,8 @@ followers attack on sight = false
 # Can loot non-fighting actors during death animation
 can loot during death animation = true
 
-# Makes the value of filled soulgems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
-rebalance soulgem values = false
+# Makes the value of filled soul gems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
+rebalance soul gem values = false
 
 [General]
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -217,7 +217,7 @@ followers attack on sight = false
 can loot during death animation = true
 
 # Makes the value of filled soul gems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
-rebalance soul gem values = false
+rebalance soul gem values = true
 
 [General]
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -216,6 +216,9 @@ followers attack on sight = false
 # Can loot non-fighting actors during death animation
 can loot during death animation = true
 
+# Makes the value of filled soulgems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
+rebalance soulgem values = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -109,6 +109,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="rebalanceSoulgemValuesCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the value of filled soulgems is dependent only on soul magnitude.&lt;/p&gt;&lt;p&gt;The default value is false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Rebalance soulgem values</string>
+            </property>
+           </widget>
+          </item>
           <item alignment="Qt::AlignLeft">
            <widget class="QWidget" name="showOwnedGroup" native="true">
             <property name="toolTip">

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -110,12 +110,12 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="rebalanceSoulgemValuesCheckBox">
+           <widget class="QCheckBox" name="rebalanceSoulGemValuesCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the value of filled soulgems is dependent only on soul magnitude.&lt;/p&gt;&lt;p&gt;The default value is false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the value of filled soul gems is dependent only on soul magnitude.&lt;/p&gt;&lt;p&gt;The default value is false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
-             <string>Rebalance soulgem values</string>
+             <string>Rebalance soul gem values</string>
             </property>
            </widget>
           </item>

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -112,7 +112,7 @@
           <item>
            <widget class="QCheckBox" name="rebalanceSoulGemValuesCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the value of filled soul gems is dependent only on soul magnitude.&lt;/p&gt;&lt;p&gt;The default value is false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the value of filled soul gems is dependent only on soul magnitude.&lt;/p&gt;&lt;p&gt;The default value is true.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Rebalance soul gem values</string>


### PR DESCRIPTION
This branch incorporates the 'Soul gem value rebalance' formula from the Morrowind Code Patch as this was the only major economy-breaker that couldn't be resolved with mods. It's a very small tweak, for which I've added a checkbox in the Advanced page of the launcher.

In a niche case, I also chose to add the value of the empty Azura's Star to the total filled value as it is uniquely not destroyed during enchanting/recharging.

I thought it might be of interest to other people to help balance their playthroughs with OpenMW, but I totally understand if the developers want to reject this merge in order to avoid bloating the settings/launcher (or because my implementation is poor).

P.S. I've also posted a topic related to this merge on the developer application board of the forum.