### PR TITLE
Render default land texture for Wilderness cells with distant terrain

### DIFF
--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -189,35 +189,22 @@ public:
         node->setViewDataMap(mViewDataMap);
         parent->addChild(node);
 
-        if (center.x() - size > mMaxX
-                || center.x() + size < mMinX
-                || center.y() - size > mMaxY
-                || center.y() + size < mMinY )
-            // Out of bounds of the actual terrain - this will happen because
-            // we rounded the size up to the next power of two
-        {
-            // Still create and return an empty node so as to not break the assumption that each QuadTreeNode has either 4 or 0 children.
-            return node;
-        }
-
-        if (node->getSize() <= mMinSize)
-        {
-            // We arrived at a leaf
-            float minZ,maxZ;
-            if (mStorage->getMinMaxHeights(size, center, minZ, maxZ))
-            {
-                float cellWorldSize = mStorage->getCellWorldSize();
-                osg::BoundingBox boundingBox(osg::Vec3f((center.x()-size)*cellWorldSize, (center.y()-size)*cellWorldSize, minZ),
-                                        osg::Vec3f((center.x()+size)*cellWorldSize, (center.y()+size)*cellWorldSize, maxZ));
-                node->setBoundingBox(boundingBox);
-            }
-            return node;
-        }
-        else
+        if (node->getSize() > mMinSize)
         {
             addChildren(node);
             return node;
         }
+
+        // We arrived at a leaf
+        float minZ, maxZ;
+        mStorage->getMinMaxHeights(size, center, minZ, maxZ);
+
+        float cellWorldSize = mStorage->getCellWorldSize();
+        osg::BoundingBox boundingBox(osg::Vec3f((center.x()-size)*cellWorldSize, (center.y()-size)*cellWorldSize, minZ),
+                                osg::Vec3f((center.x()+size)*cellWorldSize, (center.y()+size)*cellWorldSize, maxZ));
+        node->setBoundingBox(boundingBox);
+
+        return node;
     }
 
     osg::ref_ptr<RootNode> getRootNode()


### PR DESCRIPTION
Partially fixes [bug #4405](https://bugs.openmw.org/issues/4405).
There are still missing textures outside of world map bounds (looks like quad world is not infinite, or I just missed something).
Also default textures are still missing it the editor - looks like it uses a different approach.