### PR TITLE
Preserve AppVeyor artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-parameter")
     endif()
 elseif (MSVC)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /Zi /bigobj")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
     # Enable link-time code generation globally for all linking
     if (OPENMW_LTO_BUILD)
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ platform:
     - x64
 
 configuration:
-    - Debug
-#   - Release
+#    - Debug
+   - Release
 
 # For the Qt, Boost, CMake, etc installs
 #os: Visual Studio 2017
@@ -56,8 +56,8 @@ build_script:
     - cmd: msbuild %build%\OpenMW.sln /t:Build /p:Configuration=%configuration% /m:2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
-    - cmd: if %PLATFORM%==x64 7z a OpenMW_MSVC%msvc%_x64.zip %APPVEYOR_BUILD_FOLDER%\MSVC%msvc%_64\Debug\ -xr"!*.pdb"
-    - cmd: if %PLATFORM%==x64 7z a OpenMW_MSVC%msvc%_x64_pdb.zip %APPVEYOR_BUILD_FOLDER%\MSVC%msvc%_64\Debug\*.pdb
+    - cmd: if %PLATFORM%==x64 7z a OpenMW_MSVC%msvc%_x64.zip %APPVEYOR_BUILD_FOLDER%\MSVC%msvc%_64\Release\ -xr"!*.pdb"
+    - cmd: if %PLATFORM%==x64 7z a OpenMW_MSVC%msvc%_x64_pdb.zip %APPVEYOR_BUILD_FOLDER%\MSVC%msvc%_64\Release\*.pdb
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,10 @@ build_script:
     - cmd: if %PLATFORM%==x64 set build=MSVC%msvc%_64
     - cmd: msbuild %build%\OpenMW.sln /t:Build /p:Configuration=%configuration% /m:2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
+after_build:
+    - cmd: if %PLATFORM%==x64 7z a OpenMW_MSVC%msvc%_x64.zip %APPVEYOR_BUILD_FOLDER%\MSVC%msvc%_64\Debug\ -xr"!*.pdb"
+    - cmd: if %PLATFORM%==x64 7z a OpenMW_MSVC%msvc%_x64_pdb.zip %APPVEYOR_BUILD_FOLDER%\MSVC%msvc%_64\Debug\*.pdb
+
 test: off
 
 #notifications:
@@ -63,3 +67,9 @@ test: off
 #        -  
 #    on_build_failure: true
 #    on_build_status_changed: true
+
+artifacts:
+  - path: OpenMW_MSVC%msvc%_x64.zip
+    name: OpenMW_MSVC%msvc%_x64
+  - path: OpenMW_MSVC%msvc%_x64_pdb.zip
+    name: OpenMW_MSVC%msvc%_x64_pdb


### PR DESCRIPTION
[Feature #4015](https://bugs.openmw.org/issues/4015).
Some discussion can be found at #1709.

Just enable release builds and pack binaries to ZIP-archive, so Windows users in theory can test complex PRs without full environment setup.