### PR TITLE
Rework spell VFX management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
     Bug #4574: Player turning animations are twitchy
     Bug #4575: Weird result of attack animation blending with movement animations
     Bug #4576: Reset of idle animations when attack can not be started
+    Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -536,7 +536,7 @@ namespace MWBase
             /// Spawn a blood effect for \a ptr at \a worldPosition
             virtual void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) = 0;
 
-            virtual void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) = 0;
+            virtual void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos, float scale = 1.f, bool isMagicVFX = true) = 0;
 
             virtual void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster,
                                       const MWWorld::Ptr& ignore, ESM::RangeType rangeType, const std::string& id,

--- a/apps/openmw/mwmechanics/aicast.cpp
+++ b/apps/openmw/mwmechanics/aicast.cpp
@@ -42,7 +42,19 @@ bool MWMechanics::AiCast::execute(const MWWorld::Ptr& actor, MWMechanics::Charac
             return false;
         }
 
-        osg::Vec3f dir = target.getRefData().getPosition().asVec3() - actor.getRefData().getPosition().asVec3();
+        osg::Vec3f targetPos = target.getRefData().getPosition().asVec3();
+        if (target.getClass().isActor())
+        {
+            osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(target);
+            targetPos.z() += halfExtents.z() * 2 * 0.75f;
+        }
+
+        osg::Vec3f actorPos = actor.getRefData().getPosition().asVec3();
+        osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(actor);
+        actorPos.z() += halfExtents.z() * 2 * 0.75f;
+
+        osg::Vec3f dir = targetPos - actorPos;
+
         bool turned = smoothTurn(actor, getZAngleToDir(dir), 2, osg::DegreesToRadians(3.f));
         turned &= smoothTurn(actor, getXAngleToDir(dir), 0, osg::DegreesToRadians(3.f));
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -71,6 +71,17 @@ private:
 };
 typedef std::shared_ptr<PartHolder> PartHolderPtr;
 
+struct EffectParams
+{
+    std::string mModelName; // Just here so we don't add the same effect twice
+    PartHolderPtr mObjects;
+    std::shared_ptr<EffectAnimationTime> mAnimTime;
+    float mMaxControllerLength;
+    int mEffectId;
+    bool mLoop;
+    std::string mBoneName;
+};
+
 class Animation : public osg::Referenced
 {
 public:
@@ -247,19 +258,6 @@ protected:
 
     osg::Vec3f mAccumulate;
 
-    struct EffectParams
-    {
-        std::string mModelName; // Just here so we don't add the same effect twice
-        PartHolderPtr mObjects;
-        std::shared_ptr<EffectAnimationTime> mAnimTime;
-        float mMaxControllerLength;
-        int mEffectId;
-        bool mLoop;
-        std::string mBoneName;
-    };
-
-    std::vector<EffectParams> mEffects;
-
     TextKeyListener* mTextKeyListener;
 
     osg::ref_ptr<RotateController> mHeadController;
@@ -369,7 +367,7 @@ public:
      * @param texture override the texture specified in the model's materials - if empty, do not override
      * @note Will not add an effect twice.
      */
-    void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", const std::string& texture = "");
+    void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", const std::string& texture = "", float scale = 1.0f);
     void removeEffect (int effectId);
     void getLoopingEffects (std::vector<int>& out) const;
 
@@ -487,6 +485,25 @@ private:
 class ObjectAnimation : public Animation {
 public:
     ObjectAnimation(const MWWorld::Ptr& ptr, const std::string &model, Resource::ResourceSystem* resourceSystem, bool animated, bool allowLight);
+};
+
+class UpdateVfxCallback : public osg::NodeCallback
+{
+public:
+    UpdateVfxCallback(EffectParams& params)
+        : mFinished(false)
+        , mParams(params)
+        , mStartingTime(0)
+    {
+    }
+
+    bool mFinished;
+    EffectParams mParams;
+
+    virtual void operator()(osg::Node* node, osg::NodeVisitor* nv);
+
+private:
+    double mStartingTime;
 };
 
 }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -49,6 +49,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "../mwworld/cellstore.hpp"
+#include "../mwworld/class.hpp"
 #include "../mwgui/loadingscreen.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
@@ -1319,6 +1320,29 @@ namespace MWRender
             mFieldOfViewOverride = val;
             updateProjectionMatrix();
         }
+    }
+
+    osg::Vec3f RenderingManager::getHalfExtents(const MWWorld::ConstPtr& object) const
+    {
+        osg::Vec3f halfExtents(0, 0, 0);
+        std::string modelName = object.getClass().getModel(object);
+        if (modelName.empty())
+            return halfExtents;
+
+        osg::ref_ptr<const osg::Node> node = mResourceSystem->getSceneManager()->getTemplate(modelName);
+        osg::ComputeBoundsVisitor computeBoundsVisitor;
+        computeBoundsVisitor.setTraversalMask(~(MWRender::Mask_ParticleSystem|MWRender::Mask_Effect));
+        const_cast<osg::Node*>(node.get())->accept(computeBoundsVisitor);
+        osg::BoundingBox bounds = computeBoundsVisitor.getBoundingBox();
+
+        if (bounds.valid())
+        {
+            halfExtents[0] = std::abs(bounds.xMax() - bounds.xMin()) / 2.f;
+            halfExtents[1] = std::abs(bounds.yMax() - bounds.yMin()) / 2.f;
+            halfExtents[2] = std::abs(bounds.zMax() - bounds.zMin()) / 2.f;
+        }
+
+        return halfExtents;
     }
 
     void RenderingManager::resetFieldOfView()

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -203,6 +203,8 @@ namespace MWRender
         /// reset a previous overrideFieldOfView() call, i.e. revert to field of view specified in the settings file.
         void resetFieldOfView();
 
+        osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& object) const;
+
         void exportSceneGraph(const MWWorld::Ptr& ptr, const std::string& filename, const std::string& format);
 
         LandManager* getLandManager() const;

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1082,6 +1082,7 @@ namespace MWScript
                 MWWorld::Ptr target = MWBase::Environment::get().getWorld()->getPtr (targetId, false);
 
                 MWMechanics::CastSpell cast(ptr, target, false, true);
+                cast.playSpellCastingEffects(spell->mId);
                 cast.mHitPosition = target.getRefData().getPosition().asVec3();
                 cast.mAlwaysSucceed = true;
                 cast.cast(spell);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3407,9 +3407,9 @@ namespace MWWorld
         mRendering->spawnEffect(model, texture, worldPosition, 1.0f, false);
     }
 
-    void World::spawnEffect(const std::string &model, const std::string &textureOverride, const osg::Vec3f &worldPos)
+    void World::spawnEffect(const std::string &model, const std::string &textureOverride, const osg::Vec3f &worldPos, float scale, bool isMagicVFX)
     {
-        mRendering->spawnEffect(model, textureOverride, worldPos);
+        mRendering->spawnEffect(model, textureOverride, worldPos, scale, isMagicVFX);
     }
 
     void World::explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const Ptr& caster, const Ptr& ignore, ESM::RangeType rangeType,

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3339,12 +3339,16 @@ namespace MWWorld
         return mRendering->getTerrainHeightAt(worldPos);
     }
 
-    osg::Vec3f World::getHalfExtents(const ConstPtr& actor, bool rendering) const
+    osg::Vec3f World::getHalfExtents(const ConstPtr& object, bool rendering) const
     {
+        if (!object.getClass().isActor())
+            return mRendering->getHalfExtents(object);
+
+        // Handle actors separately because of bodyparts
         if (rendering)
-            return mPhysics->getRenderingHalfExtents(actor);
+            return mPhysics->getRenderingHalfExtents(object);
         else
-            return mPhysics->getHalfExtents(actor);
+            return mPhysics->getHalfExtents(object);
     }
 
     std::string World::exportSceneGraph(const Ptr &ptr)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -646,7 +646,7 @@ namespace MWWorld
             /// Spawn a blood effect for \a ptr at \a worldPosition
             void spawnBloodEffect (const MWWorld::Ptr& ptr, const osg::Vec3f& worldPosition) override;
 
-            void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos) override;
+            void spawnEffect (const std::string& model, const std::string& textureOverride, const osg::Vec3f& worldPos, float scale = 1.f, bool isMagicVFX = true) override;
 
             void explodeSpell(const osg::Vec3f& origin, const ESM::EffectList& effects, const MWWorld::Ptr& caster, const MWWorld::Ptr& ignore,
                                       ESM::RangeType rangeType, const std::string& id, const std::string& sourceName,


### PR DESCRIPTION
Continue of #1573.
Implements [feature #1645](https://gitlab.com/OpenMW/openmw/issues/1645).

The only thing left is to optimize objects update:
> We should really avoid iterating all objects every frame because there are thousands of them in a normal scene. I remember we had a performance issue caused by the same thing in PhysicsSystem::animateCollisionShapes and it was fixed by tracking animated shapes in a separate container.
Usually the osg::UpdateCallback is a very nice way to do updates every frame. Maybe the updateEffects should be ported to an UpdateCallback?

So the main idea: when we add spell effect to mesh, attach the NodeCalback to it. This callback should update VFX effect state, then mark itself as finished.
Once per frame we remove finished callbacks via visitor inside Animation::runAnimation().
But this implementation has drawback: we do not run runAnimation() for non-animated objects, so we do not remove finished callbacks for statics objects yet.

Note: particle scaling is incorrect due to [bug #3559](https://gitlab.com/OpenMW/openmw/issues/3559).