### PR TITLE
RotateWorld: rotate around world axis

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -564,6 +564,8 @@ namespace MWBase
 
             virtual bool isPlayerInJail() const = 0;
 
+            virtual void rotateWorldObject (const MWWorld::Ptr& ptr, osg::Quat rotate) = 0;
+
             /// Return terrain height at \a worldPos position.
             virtual float getTerrainHeightAt(const osg::Vec3f& worldPos) const = 0;
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -579,26 +579,25 @@ namespace MWScript
                     Interpreter::Type_Float rotation = osg::DegreesToRadians(runtime[0].mFloat*MWBase::Environment::get().getFrameDuration());
                     runtime.pop();
 
-                    const float *objRot = ptr.getRefData().getPosition().rot;
+                    if (!ptr.getRefData().getBaseNode())
+                        return;
 
-                    float ax = objRot[0];
-                    float ay = objRot[1];
-                    float az = objRot[2];
+                    // We can rotate actors only around Z axis
+                    if (ptr.getClass().isActor() && (axis == "x" || axis == "y"))
+                        return;
 
+                    osg::Quat rot;
                     if (axis == "x")
-                    {
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax+rotation,ay,az);
-                    }
+                        rot = osg::Quat(rotation, -osg::X_AXIS);
                     else if (axis == "y")
-                    {
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay+rotation,az);
-                    }
+                        rot = osg::Quat(rotation, -osg::Y_AXIS);
                     else if (axis == "z")
-                    {
-                        MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,az+rotation);
-                    }
+                        rot = osg::Quat(rotation, -osg::Z_AXIS);
                     else
                         throw std::runtime_error ("invalid rotation axis: " + axis);
+
+                    osg::Quat attitude = ptr.getRefData().getBaseNode()->getAttitude();
+                    MWBase::Environment::get().getWorld()->rotateWorldObject(ptr, attitude * rot);
                 }
         };
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1342,6 +1342,15 @@ namespace MWWorld
         rotateObjectImp(ptr, osg::Vec3f(x, y, z), adjust);
     }
 
+    void World::rotateWorldObject (const Ptr& ptr, osg::Quat rotate)
+    {
+        if(ptr.getRefData().getBaseNode() != 0)
+        {
+            mRendering->rotateObject(ptr, rotate);
+            mPhysics->updateRotation(ptr);
+        }
+    }
+
     MWWorld::Ptr World::placeObject(const MWWorld::ConstPtr& ptr, MWWorld::CellStore* cell, ESM::Position pos)
     {
         return copyObjectToCell(ptr,cell,pos,ptr.getRefData().getCount(),false);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -214,6 +214,8 @@ namespace MWWorld
 
             void setWaterHeight(const float height) override;
 
+            void rotateWorldObject (const MWWorld::Ptr& ptr, osg::Quat rotate) override;
+
             bool toggleWater() override;
             bool toggleWorld() override;
 


### PR DESCRIPTION
Fixes [bug #4426](https://bugs.openmw.org/issues/4426).

RotateWorld console command should rotate object around selected world axis, but for now it fully replicates Rotate command behaviour. It can lead to wrong rotation, if object instance has an initial rotation.
Examples: skull-lever in Shishi (misc_skull00_shishi) and watermill in Arktwend (a_Muhlrad_01 in (0, 3) cell).

Also RotateWorld in vanilla does not change object ESM-rotation.

I attached a simple plugin to test rotation:
[Rotate.zip](https://github.com/OpenMW/openmw/files/2053912/Rotate.zip)
Print in console:
**tcl
coc platform**

There are three rotating carpets in this cell. In vanilla game and upstream OpenMW rotation directions are different.