### PR TITLE
Add pursue package only when crime was reported

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -224,7 +224,9 @@ namespace MWMechanics
             virtual bool isSneaking(const MWWorld::Ptr& ptr);
 
         private:
-            void reportCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
+            bool canReportCrime(const MWWorld::Ptr &actor, const MWWorld::Ptr &victim, std::set<MWWorld::Ptr> &playerFollowers);
+
+            bool reportCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
                                       OffenseType type, int arg=0);
 
 


### PR DESCRIPTION
Fixes [bug #4433](https://bugs.openmw.org/issues/4433).

The main idea: iterate over neighbors twice. In the first run check if the crime was reported by anyone, in the second check update AI status.

To test this PR you can execute "setalarm 0" in any shop on both guard and shopkeeper and try to steal something.