### PR TITLE
Fix warnings: catching polymorphic type by value

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2601,11 +2601,11 @@ namespace MWWorld
                 int y = std::stoi(name.substr(name.find(',')+1));
                 ext = getExterior(x, y)->getCell();
             }
-            catch (std::invalid_argument)
+            catch (const std::invalid_argument&)
             {
                 // This exception can be ignored, as this means that name probably refers to a interior cell instead of comma separated coordinates
             }
-            catch (std::out_of_range)
+            catch (const std::out_of_range&)
             {
                 throw std::runtime_error("Cell coordinates out of range.");
             }

--- a/components/widgets/numericeditbox.cpp
+++ b/components/widgets/numericeditbox.cpp
@@ -38,11 +38,11 @@ namespace Gui
                 setCaption(MyGUI::utility::toString(mValue));
             }
         }
-        catch (std::invalid_argument)
+        catch (const std::invalid_argument&)
         {
             setCaption(MyGUI::utility::toString(mValue));
         }
-        catch (std::out_of_range)
+        catch (const std::out_of_range&)
         {
             setCaption(MyGUI::utility::toString(mValue));
         }


### PR DESCRIPTION
```
openmw/apps/openmw/mwworld/worldimp.cpp: In member function ‘virtual bool MWWorld::World::findExteriorPosition(const string&, ESM::Position&)’:
openmw/apps/openmw/mwworld/worldimp.cpp:2650:25: warning: catching polymorphic type ‘class std::invalid_argument’ by value [-Wcatch-value=]
             catch (std::invalid_argument)
                         ^~~~~~~~~~~~~~~~
openmw/apps/openmw/mwworld/worldimp.cpp:2654:25: warning: catching polymorphic type ‘class std::out_of_range’ by value [-Wcatch-value=]
             catch (std::out_of_range)
                         ^~~~~~~~~~~~

openmw/components/widgets/numericeditbox.cpp: In member function ‘void Gui::NumericEditBox::onEditTextChange(MyGUI::EditBox*)’:
openmw/components/widgets/numericeditbox.cpp:41:21: warning: catching polymorphic type ‘class std::invalid_argument’ by value [-Wcatch-value=]
         catch (std::invalid_argument)
                     ^~~~~~~~~~~~~~~~
openmw/components/widgets/numericeditbox.cpp:45:21: warning: catching polymorphic type ‘class std::out_of_range’ by value [-Wcatch-value=]
         catch (std::out_of_range)
                     ^~~~~~~~~~~~
```