### PR TITLE
Make weapon durability short unsigned (bug #4435)

### DIFF
--- a/components/esm/loadweap.hpp
+++ b/components/esm/loadweap.hpp
@@ -57,7 +57,7 @@ struct Weapon
         float mWeight;
         int mValue;
         short mType;
-        short mHealth;
+        unsigned short mHealth;
         float mSpeed, mReach;
         short mEnchant; // Enchantment points. The real value is mEnchant/10.f
         unsigned char mChop[2], mSlash[2], mThrust[2]; // Min and max


### PR DESCRIPTION
[Bug #4435](https://bugs.openmw.org/issues/4435). Looks like only weapon durability has short type.