### PR TITLE
Fix crash when adding items to certain disabled creatures (bug #4441)

### DIFF
--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -123,11 +123,12 @@ bool Objects::removeObject (const MWWorld::Ptr& ptr)
 
         mObjects.erase(iter);
 
-        if (ptr.getClass().isNpc())
+        if (ptr.getClass().isActor())
         {
-            MWWorld::InventoryStore& store = ptr.getClass().getInventoryStore(ptr);
-            store.setInvListener(NULL, ptr);
-            store.setContListener(NULL);
+            if (ptr.getClass().hasInventoryStore(ptr))
+                ptr.getClass().getInventoryStore(ptr).setInvListener(NULL, ptr);
+
+            ptr.getClass().getContainerStore(ptr).setContListener(NULL);
         }
 
         ptr.getRefData().getBaseNode()->getParent(0)->removeChild(ptr.getRefData().getBaseNode());


### PR DESCRIPTION
[Link to bug #4441](https://bugs.openmw.org/issues/4441)

NPCs and creatures are given container store listeners when they are created, but these listeners only get removed for the NPCs.

The result is that adding items to currently disabled weapon-wielding creatures causes OpenMW to crash. The bug report explains how to easily test this in two different ways.

To fix the problem, I've gone ahead and made the container store listeners get removed for all actors.