### PR TITLE
fix #3137

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -168,7 +168,7 @@ namespace MWPhysics
             mTracer.doTrace(mColObj, tracerPos, tracerPos + toMove, mColWorld);
             if(mTracer.mFraction < std::numeric_limits<float>::epsilon())
                 return false; // didn't even move the smallest representable amount
-            
+
             // FIXME: non-levitating aerial actors should not step down to a lower location than their initial location
             /*
              * Try moving back down sStepSizeDown using stepper.
@@ -448,7 +448,7 @@ namespace MWPhysics
                 osg::Vec3f to = newPosition - (physicActor->getOnGround() ?
                              osg::Vec3f(0,0,sStepSizeDown + 2*sGroundOffset) : osg::Vec3f(0,0,2*sGroundOffset));
                 tracer.doTrace(colobj, from, to, collisionWorld);
-                
+
                 if(tracer.mHitObject != NULL
                         && tracer.mHitObject->getBroadphaseHandle()->m_collisionFilterGroup != CollisionType_Actor)
                 {
@@ -463,18 +463,18 @@ namespace MWPhysics
                     isOnGround = true;
 
                     isOnSlope = !isWalkableSlope(tracer.mPlaneNormal);
-                    
+
                     // reject from ground
                     if (!isFlying && !isOnSlope)
                     {
                         float distance = (newPosition.z() - tracer.mEndPos.z()) - fudgeFactor;
                         if(distance > 0)
                             newPosition.z() -= distance;
-                        
+
                         from = newPosition;
                         to = newPosition + osg::Vec3f(0,0,sGroundOffset+fudgeFactor);
                         tracer.doTrace(colobj, from, to, collisionWorld);
-                        
+
                         if(tracer.mHitObject == NULL)
                             newPosition.z() += sGroundOffset;
                         else if (tracer.mEndPos.z() - newPosition.z() > fudgeFactor)

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -427,11 +427,9 @@ namespace MWPhysics
                     // Can't move this way, try to find another spot along the plane
                     osg::Vec3f newVelocity = slide(velocity, tracer.mPlaneNormal);
 
-                    // Do not allow sliding upward if there is gravity.
-                    // Stepping will have taken care of that.
-                    // FIXME: Cancelling out upwards motion here, if in the air, breaks jumping while hugging walls
+                    // Do not allow sliding to accelerate us upwards. Stepping will take care of walkable slopes.
                     if(physicActor->getOnGround() && !(newPosition.z() < swimlevel || isFlying))
-                        newVelocity.z() = std::min(newVelocity.z(), 0.0f);
+                        newVelocity.z() = std::min(newVelocity.z(), std::max(0.0f, velocity.z()));
 
                     if ((newVelocity-velocity).length2() < 0.01)
                         break;


### PR DESCRIPTION
This fixes http://bugs.openmw.org/issues/3137 but another jumping-related issue is relevant so I'm going to go over what I see:

http://bugs.openmw.org/issues/3137 actually has two causes:

1) Being clamped to the ground by the stair/slope code because the actor encountered a wall
2) Having the vertical part of motion cancelled because another part of the code assumed it as accounted for by the stair/slope code

... But the wall was completely vertical so the stair/slope code didn't accomplish anything.

This commit addresses those two causes. Addressing them probably causes other problems, this movement solver seems very elaborate. I have no idea what those two changes will do to steep sloped walls, for instance.

http://bugs.openmw.org/issues/2256 happens the way it does because of the stair stepping code is effectively responsible for placing the actor back on the "ground". If you entirely comment out the block that runs the "stair" code, actors will take an extremely long time to register that they landed on the ground, if they do so at all. This is why my check for not running the stair/slope code also checks for vertical motion direction too, not just whether the actor is in the air.

Also, there are probably cases when the actor **should** be able to climb up a "stair" while in the air, unless vanilla Morrowind doesn't do so. The reason that the "stair" code isn't run when moving up in the air in this commit is because the stair code behaves incorrectly when running into perfectly vertical walls, not because actors shouldn't be able to climb up stairs while in the air. As such, this commit is almost certainly the wrong fix, but I don't know where in the stairs code the problem is.