### PR TITLE
Make dialogue choices trigger goodbye if Goodbye option is present (bug #3897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 0.45.0
 ------
-    Feature #3897: Have Goodbye give all choices the effects of Goodbye
+    Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4433: Guard behaviour is incorrect with Alarm = 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.45.0
 ------
+    Feature #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4433: Guard behaviour is incorrect with Alarm = 0

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -431,11 +431,8 @@ namespace MWDialogue
 
     void DialogueManager::addChoice (const std::string& text, int choice)
     {
-        if (!mGoodbye)
-        {
-            mIsInChoice = true;
-            mChoices.push_back(std::make_pair(text, choice));
-        }
+        mIsInChoice = true;
+        mChoices.push_back(std::make_pair(text, choice));
     }
 
     const std::vector<std::pair<std::string, int> >& DialogueManager::getChoices()
@@ -450,8 +447,8 @@ namespace MWDialogue
 
     void DialogueManager::goodbye()
     {
-        if (!mIsInChoice)
-            mGoodbye = true;
+        mIsInChoice = false;
+        mGoodbye = true;
     }
 
     void DialogueManager::persuade(int type, ResponseCallback* callback)

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -635,6 +635,11 @@ namespace MWGui
 
     void DialogueWindow::onChoiceActivated(int id)
     {
+        if (mGoodbye)
+        {
+            onGoodbyeActivated();
+            return;
+        }
         MWBase::Environment::get().getDialogueManager()->questionAnswered(id, mCallback.get());
         updateTopics();
     }


### PR DESCRIPTION
[Bug report 3897.](https://bugs.openmw.org/issues/3897)

The window closes and nothing happens in this case.

I added Goodbye to the script text of "did you bring the mushrooms" topic info of Ajira. On master Ajira answers the choice and Goodbye option is still present to be chosen, with PR the dialogue window closes immediately upon any choice.