### PR TITLE
Make Goodbye and dialogue choices mutually exclusive (bug #4443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
+    Bug #4443: Goodbye option and dialogue choices are not mutually exclusive 
 
 0.44.0
 ------

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -431,9 +431,11 @@ namespace MWDialogue
 
     void DialogueManager::addChoice (const std::string& text, int choice)
     {
-        mIsInChoice = true;
-
-        mChoices.push_back(std::make_pair(text, choice));
+        if (!mGoodbye)
+        {
+            mIsInChoice = true;
+            mChoices.push_back(std::make_pair(text, choice));
+        }
     }
 
     const std::vector<std::pair<std::string, int> >& DialogueManager::getChoices()
@@ -448,8 +450,8 @@ namespace MWDialogue
 
     void DialogueManager::goodbye()
     {
-        mIsInChoice = false;
-        mGoodbye = true;
+        if (!mIsInChoice)
+            mGoodbye = true;
     }
 
     void DialogueManager::persuade(int type, ResponseCallback* callback)


### PR DESCRIPTION
If Goodbye is present, the choices won't get added to the list. If the player is in a choice, Goodbye won't be added to the list. This seems to follow the original behavior.