### PR TITLE
fix #3876 and #3993

### DIFF
--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -434,19 +434,14 @@ namespace ESMTerrain
         const int imageScaleFactor = 2;
         const int blendmapImageSize = blendmapSize * imageScaleFactor;
         
-        
-        const bool largeImage = true;
-
         for (int i=0; i<numBlendmaps; ++i)
         {
             GLenum format = pack ? GL_RGBA : GL_ALPHA;
 
             osg::ref_ptr<osg::Image> image (new osg::Image);
-            if(!largeImage)
-                image->allocateImage(blendmapSize, blendmapSize, 1, format, GL_UNSIGNED_BYTE);
-            else
-                image->allocateImage(blendmapImageSize, blendmapImageSize, 1, format, GL_UNSIGNED_BYTE);
+            image->allocateImage(blendmapImageSize, blendmapImageSize, 1, format, GL_UNSIGNED_BYTE);
             unsigned char* pData = image->data();
+            
             for (int y=0; y<blendmapSize; ++y)
             {
                 for (int x=0; x<blendmapSize; ++x)
@@ -459,21 +454,13 @@ namespace ESMTerrain
                     
                     int alpha = (blendIndex == i) ? 255 : 0;
                     
-                    if(!largeImage)
-                        pData[((blendmapSize - y - 1)*blendmapSize + x)*channels + channel] = alpha;
-                    else
-                    {
-                        int realY = (blendmapSize - y - 1)*imageScaleFactor;
-                        int realX = x*imageScaleFactor;
-                        if(true)
-                            pData[((realY+0)*blendmapImageSize + realX + 0)*channels + channel] = alpha;
-                        if(realY+1 < blendmapImageSize)
-                            pData[((realY+1)*blendmapImageSize + realX + 0)*channels + channel] = alpha;
-                        if(realX+1 < blendmapImageSize)
-                            pData[((realY+0)*blendmapImageSize + realX + 1)*channels + channel] = alpha;
-                        if(realY+1 < blendmapImageSize && realX+1 < blendmapImageSize)
-                            pData[((realY+1)*blendmapImageSize + realX + 1)*channels + channel] = alpha;
-                    }
+                    int realY = (blendmapSize - y - 1)*imageScaleFactor;
+                    int realX = x*imageScaleFactor;
+                    
+                    pData[((realY+0)*blendmapImageSize + realX + 0)*channels + channel] = alpha;
+                    pData[((realY+1)*blendmapImageSize + realX + 0)*channels + channel] = alpha;
+                    pData[((realY+0)*blendmapImageSize + realX + 1)*channels + channel] = alpha;
+                    pData[((realY+1)*blendmapImageSize + realX + 1)*channels + channel] = alpha;
                 }
             }
             blendmaps.push_back(image);

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -433,7 +433,7 @@ namespace ESMTerrain
         // We need to upscale the blendmap 2x with nearest neighbor sampling to look like Vanilla
         const int imageScaleFactor = 2;
         const int blendmapImageSize = blendmapSize * imageScaleFactor;
-        
+
         for (int i=0; i<numBlendmaps; ++i)
         {
             GLenum format = pack ? GL_RGBA : GL_ALPHA;
@@ -441,7 +441,7 @@ namespace ESMTerrain
             osg::ref_ptr<osg::Image> image (new osg::Image);
             image->allocateImage(blendmapImageSize, blendmapImageSize, 1, format, GL_UNSIGNED_BYTE);
             unsigned char* pData = image->data();
-            
+
             for (int y=0; y<blendmapSize; ++y)
             {
                 for (int x=0; x<blendmapSize; ++x)
@@ -451,12 +451,12 @@ namespace ESMTerrain
                     int layerIndex = textureIndicesMap.find(id)->second;
                     int blendIndex = (pack ? static_cast<int>(std::floor((layerIndex - 1) / 4.f)) : layerIndex - 1);
                     int channel = pack ? std::max(0, (layerIndex-1) % 4) : 0;
-                    
+
                     int alpha = (blendIndex == i) ? 255 : 0;
-                    
+
                     int realY = (blendmapSize - y - 1)*imageScaleFactor;
                     int realX = x*imageScaleFactor;
-                    
+
                     pData[((realY+0)*blendmapImageSize + realX + 0)*channels + channel] = alpha;
                     pData[((realY+1)*blendmapImageSize + realX + 0)*channels + channel] = alpha;
                     pData[((realY+0)*blendmapImageSize + realX + 1)*channels + channel] = alpha;

--- a/components/terrain/material.cpp
+++ b/components/terrain/material.cpp
@@ -25,6 +25,9 @@ namespace Terrain
             matrix.preMultTranslate(osg::Vec3f(0.5f, 0.5f, 0.f));
             matrix.preMultScale(osg::Vec3f(scale, scale, 1.f));
             matrix.preMultTranslate(osg::Vec3f(-0.5f, -0.5f, 0.f));
+            // We need to nudge the blendmap to look like vanilla.
+            // This causes visible seams unless the blendmap's resolution is doubled, but Vanilla also doubles the blendmap, apparently.
+            matrix.preMultTranslate(osg::Vec3f(1.0f/blendmapScale/4.0f, 1.0f/blendmapScale/4.0f, 0.f));
 
             texMat = new osg::TexMat(matrix);
 


### PR DESCRIPTION
Apparently vanilla Morrowind doubles the resolution of the blendmap. This fixes #3993.

Doubling the resolution of the blendmap makes it possible to nudge the blendmap texture uv transformation matrix without causing seams. Doing this without the doubling causes visible texturing seams. This fixes #3876.

Comparison images: https://imgur.com/a/3aYHR1i