### PR TITLE
Decompress cursors using SDL software renderer on Mac or if OSG >= 3.5.8 or if OPENMW_DECOMPRESS_TEXTURES is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
     Bug #4443: Goodbye option and dialogue choices are not mutually exclusive 
     Feature #4444: Per-group KF-animation files support
-    Bug #4424: [macOS] Cursor is either empty or garbage when compiled against macOS 10.13 SDK
 
 0.44.0
 ------
@@ -109,6 +108,7 @@
     Feature #4423: Rebalance soul gem values
     Task #4015: Use AppVeyor build artifact features to make continuous builds available
     Editor: New (and more complete) icon set
+    Bug #4424: [macOS] Cursor is either empty or garbage when compiled against macOS 10.13 SDK
 
 0.43.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
     Bug #4412: openmw-iniimporter ignores data paths from config
     Bug #4413: Moving with 0 strength uses all of your fatigue
     Bug #4420: Camera flickering when I open up and close menus while sneaking
+    Bug #4424: [macOS] Cursor is either empty or garbage when compiled against macOS 10.13 SDK
     Bug #4435: Item health is considered a signed integer
     Bug #4441: Adding items to currently disabled weapon-wielding creatures crashes the game
     Feature #1786: Round up encumbrance value in the encumbrance bar
@@ -108,7 +109,6 @@
     Feature #4423: Rebalance soul gem values
     Task #4015: Use AppVeyor build artifact features to make continuous builds available
     Editor: New (and more complete) icon set
-    Bug #4424: [macOS] Cursor is either empty or garbage when compiled against macOS 10.13 SDK
 
 0.43.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
     Bug #4443: Goodbye option and dialogue choices are not mutually exclusive 
     Feature #4444: Per-group KF-animation files support
+    Bug #4424: [macOS] Cursor is either empty or garbage when compiled against macOS 10.13 SDK
 
 0.44.0
 ------

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -428,9 +428,8 @@ void OMW::Engine::setWindowIcon()
     else
     {
         osg::ref_ptr<osg::Image> image = result.getImage();
-        SDL_Surface* surface = SDLUtil::imageToSurface(image, true);
-        SDL_SetWindowIcon(mWindow, surface);
-        SDL_FreeSurface(surface);
+        auto surface = SDLUtil::imageToSurface(image, true);
+        SDL_SetWindowIcon(mWindow, surface.get());
     }
 }
 

--- a/components/sdlutil/imagetosurface.cpp
+++ b/components/sdlutil/imagetosurface.cpp
@@ -6,7 +6,7 @@
 namespace SDLUtil
 {
 
-SDL_Surface* imageToSurface(osg::Image *image, bool flip)
+SurfaceUniquePtr imageToSurface(osg::Image *image, bool flip)
 {
     int width = image->s();
     int height = image->t();
@@ -22,7 +22,7 @@ SDL_Surface* imageToSurface(osg::Image *image, bool flip)
                 static_cast<Uint8>(clr.g() * 255), static_cast<Uint8>(clr.b() * 255), static_cast<Uint8>(clr.a() * 255));
         }
 
-    return surface;
+    return SurfaceUniquePtr(surface, SDL_FreeSurface);
 }
 
 }

--- a/components/sdlutil/imagetosurface.hpp
+++ b/components/sdlutil/imagetosurface.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENMW_COMPONENTS_SDLUTIL_IMAGETOSURFACE_H
 #define OPENMW_COMPONENTS_SDLUTIL_IMAGETOSURFACE_H
 
+#include <memory>
+
 struct SDL_Surface;
 
 namespace osg
@@ -10,10 +12,10 @@ namespace osg
 
 namespace SDLUtil
 {
+    typedef std::unique_ptr<SDL_Surface, void (*)(SDL_Surface *)> SurfaceUniquePtr;
 
     /// Convert an osg::Image to an SDL_Surface.
-    /// @note The returned surface must be freed using SDL_FreeSurface.
-    SDL_Surface* imageToSurface(osg::Image* image, bool flip=false);
+    SurfaceUniquePtr imageToSurface(osg::Image* image, bool flip=false);
 
 }
 

--- a/components/sdlutil/sdlcursormanager.cpp
+++ b/components/sdlutil/sdlcursormanager.cpp
@@ -221,9 +221,7 @@ namespace SDLUtil
     }
 
 #if OPENMW_USE_SOFTWARE_CURSOR_DECOMPRESSION
-    typedef std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)> SDLSurfacePtr;
-
-    SDLSurfacePtr decompress(osg::Image* source, int rotDegrees)
+    SurfaceUniquePtr decompress(osg::Image* source, int rotDegrees)
     {
         int width = source->s();
         int height = source->t();
@@ -265,7 +263,7 @@ namespace SDLUtil
         SDL_FreeSurface(cursorSurface);
         SDL_DestroyRenderer(renderer);
 
-        return SDLSurfacePtr(targetSurface, SDL_FreeSurface);
+        return SurfaceUniquePtr(targetSurface, SDL_FreeSurface);
     }
 #endif
 
@@ -285,18 +283,13 @@ namespace SDLUtil
             return;
         }
 
-        SDL_Surface* surf = SDLUtil::imageToSurface(decompressed, true);
-
-        //set the cursor and store it for later
-        SDL_Cursor* curs = SDL_CreateColorCursor(surf, hotspot_x, hotspot_y);
-
-        //clean up
-        SDL_FreeSurface(surf);
+        auto surf = SDLUtil::imageToSurface(decompressed, true);
 #else
         auto surf = decompress(image, rotDegrees);
+#endif
         //set the cursor and store it for later
         SDL_Cursor* curs = SDL_CreateColorCursor(surf.get(), hotspot_x, hotspot_y);
-#endif
+
         mCursorMap.insert(CursorMap::value_type(std::string(name), curs));
     }
 


### PR DESCRIPTION
This change fixes [#4424](https://bugs.openmw.org/issues/4424).
It requires OSG 3.6 though & has to be tested on other platforms.