### PR TITLE
Do not reset mUpperBodyState for weapon->weapon switch

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1214,7 +1214,6 @@ bool CharacterController::updateWeaponState()
         bool animPlaying = mAnimation->getInfo(mCurrentWeapon, &complete);
         if (!animPlaying || complete >= 1.0f)
         {
-            mUpperBodyState = UpperCharState_Nothing;
             forcestateupdate = true;
             mAnimation->showCarriedLeft(updateCarriedLeftVisible(weaptype));
 


### PR DESCRIPTION
Fixes regression [#4446](https://bugs.openmw.org/issues/4446).

Currently our weapon->weapon switch has no animations.
With my recent changes, actor stucks in UpperCharState_Nothing in this case.
