### PR TITLE
Fix assertion fail related to NiLookAtController

### DIFF
--- a/components/nif/controller.cpp
+++ b/components/nif/controller.cpp
@@ -104,13 +104,13 @@ namespace Nif
     void NiLookAtController::read(NIFStream *nif)
     {
         Controller::read(nif);
-        data.read(nif);
+        target.read(nif);
     }
 
     void NiLookAtController::post(NIFFile *nif)
     {
         Controller::post(nif);
-        data.post(nif);
+        target.post(nif);
     }
 
     void NiPathController::read(NIFStream *nif)

--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -102,7 +102,7 @@ public:
 class NiLookAtController : public Controller
 {
 public:
-    NiKeyframeDataPtr data;
+    NodePtr target;
 
     void read(NIFStream *nif);
     void post(NIFFile *nif);


### PR DESCRIPTION
In debug mode, one assert currently fails for models with NiLookAtController (related to Arktwend). This PR is aimed to fix it.
This bug does not affect vanilla game and release mode.


