### PR TITLE
Add NPC validation to esmstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #1990: Sunrise/sunset not set correct
     Bug #2222: Fatigue's effect on selling price is backwards
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
+    Bug #2772: Non-existing class or faction freezes the game
     Bug #2835: Player able to slowly move when overencumbered
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
     Bug #3374: Touch spells not hitting kwama foragers

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -74,6 +74,9 @@ namespace MWWorld
 
         unsigned int mDynamicCount;
 
+        /// Validate entries in store after setup
+        void validate();
+
     public:
         /// \todo replace with SharedIterator<StoreBase>
         typedef std::map<int, StoreBase *>::const_iterator iterator;
@@ -228,7 +231,7 @@ namespace MWWorld
 
         // This method must be called once, after loading all master/plugin files. This can only be done
         //  from the outside, so it must be public.
-        void setUp();
+        void setUp(bool validateRecords = false);
 
         int countSavedGameRecords() const;
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -184,7 +184,7 @@ namespace MWWorld
 
         fillGlobalVariables();
 
-        mStore.setUp();
+        mStore.setUp(true);
         mStore.movePlayerRecord();
 
         mSwimHeightScale = mStore.get<ESM::GameSetting>().find("fSwimHeightScale")->getFloat();


### PR DESCRIPTION
Should fix [bug #2772](https://bugs.openmw.org/issues/2772).

The main idea: after we load ESM store, we can iterate over objects in it, and make sure that they are valid.
We can do it once, during game start. Example of output:
```
NPC 'wr_moreri_s1' (Eriel) has nonexistent faction 'wr_morFaction1', ignoring it.
NPC 'arktdunklegestalt02' (Dark Figure) has nonexistent class 'Menschentöter', using 'warrior' class as replacement.
```

We probably have a better place to store validation, so any suggestions would be welcome.

Notes: 
1. I can not use the Store::setUp() since I have to check content of other tables.
2. This approach is different from one, suggested by scrawl:
> A different solution might be replacing all ID fields by a 'smart' data field that holds both an ID and pointer, with the pointer being retrieved from the game's store on first use, and further uses just use the stored pointer.