### PR TITLE
Adding version number of macOS build of OpenMW

### DIFF
--- a/files/mac/openmw-Info.plist.in
+++ b/files/mac/openmw-Info.plist.in
@@ -18,6 +18,8 @@
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${OPENMW_VERSION}</string>
 	<key>CFBundleVersion</key>
 	<string>${OPENMW_VERSION}</string>
 	<key>CSResourcesFileMapped</key>


### PR DESCRIPTION
Fixes [#4047](https://bugs.openmw.org/issues/4047).

Using the "Get Info" command on a Mac, here is the Get Info dialog before:

<img width="377" alt="openmw mac get info no version" src="https://user-images.githubusercontent.com/6200170/41197266-61ffc2a4-6c1d-11e8-8961-8f0c5b883a72.png">

And here is the Get Info dialog after:

<img width="377" alt="openmw mac get info fixed version" src="https://user-images.githubusercontent.com/6200170/41197362-87b4bf74-6c20-11e8-8484-06851cd7afb1.png">