### PR TITLE
Make WakeUpPC interrupt waiting if it was supposed to be (bug #3629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #2835: Player able to slowly move when overencumbered
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3591: Angled hit distance too low
+    Bug #3629: DB assassin attack never triggers creature spawning
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3997: Almalexia doesn't pace
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID

--- a/apps/openmw/mwgui/waitdialog.cpp
+++ b/apps/openmw/mwgui/waitdialog.cpp
@@ -310,8 +310,10 @@ namespace MWGui
     void WaitDialog::wakeUp ()
     {
         mSleeping = false;
-        mTimeAdvancer.stop();
-        stopWaiting();
+        if (mInterruptAt != -1)
+            onWaitingInterrupted();
+        else
+            stopWaiting();
     }
 
 }


### PR DESCRIPTION
If there was an interrupt waiting hour set during startWaiting(), WakeUpPC will trigger random creature spawning even if the necessary hour hasn't come yet. Thus both an assassin and a creature might spawn if Tribunal script interferes into player's resting, it's pretty rare, but possible now.

Time advancer is already stopped in stopWaiting(), triggered in the event too.