### PR TITLE
[Don't merge yet] Replace 'reflect actors' with a broader range of reflection detail settings

### DIFF
--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -181,6 +181,7 @@ namespace MWGui
         getWidget(mKeyboardSwitch, "KeyboardButton");
         getWidget(mControllerSwitch, "ControllerButton");
         getWidget(mWaterTextureSize, "WaterTextureSize");
+        getWidget(mWaterReflectionDetail, "WaterReflectionDetail");
 
 #ifndef WIN32
         // hide gamma controls since it currently does not work under Linux
@@ -204,6 +205,7 @@ namespace MWGui
         mResolutionList->eventListChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onResolutionSelected);
 
         mWaterTextureSize->eventComboChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onWaterTextureSizeChanged);
+        mWaterReflectionDetail->eventComboChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onWaterReflectionDetailChanged);
 
         mKeyboardSwitch->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onKeyboardSwitchClicked);
         mControllerSwitch->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onControllerSwitchClicked);
@@ -237,13 +239,17 @@ namespace MWGui
         std::string tmip = Settings::Manager::getString("texture mipmap", "General");
         mTextureFilteringButton->setCaption(textureMipmappingToStr(tmip));
 
-        int waterTextureSize = Settings::Manager::getInt ("rtt size", "Water");
+        int waterTextureSize = Settings::Manager::getInt("rtt size", "Water");
         if (waterTextureSize >= 512)
             mWaterTextureSize->setIndexSelected(0);
         if (waterTextureSize >= 1024)
             mWaterTextureSize->setIndexSelected(1);
         if (waterTextureSize >= 2048)
             mWaterTextureSize->setIndexSelected(2);
+
+        int waterReflectionDetail = Settings::Manager::getInt("reflection detail", "Water");
+        waterReflectionDetail = std::min(3, std::max(0, waterReflectionDetail));
+        mWaterReflectionDetail->setIndexSelected(waterReflectionDetail);
 
         mWindowBorderButton->setEnabled(!Settings::Manager::getBool("fullscreen", "Video"));
 
@@ -321,6 +327,13 @@ namespace MWGui
         else if (pos == 2)
             size = 2048;
         Settings::Manager::setInt("rtt size", "Water", size);
+        apply();
+    }
+
+    void SettingsWindow::onWaterReflectionDetailChanged(MyGUI::ComboBox* _sender, size_t pos)
+    {
+        unsigned int level = std::min((unsigned int)3, (unsigned int)pos);
+        Settings::Manager::setInt("reflection detail", "Water", level);
         apply();
     }
 

--- a/apps/openmw/mwgui/settingswindow.hpp
+++ b/apps/openmw/mwgui/settingswindow.hpp
@@ -33,6 +33,7 @@ namespace MWGui
             MyGUI::Widget* mAnisotropyBox;
 
             MyGUI::ComboBox* mWaterTextureSize;
+            MyGUI::ComboBox* mWaterReflectionDetail;
 
             // controls
             MyGUI::ScrollView* mControlsBox;
@@ -52,6 +53,7 @@ namespace MWGui
             void highlightCurrentResolution();
 
             void onWaterTextureSizeChanged(MyGUI::ComboBox* _sender, size_t pos);
+            void onWaterReflectionDetailChanged(MyGUI::ComboBox* _sender, size_t pos);
 
             void onRebindAction(MyGUI::Widget* _sender);
             void onInputTabMouseWheel(MyGUI::Widget* _sender, int _rel);

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -171,7 +171,7 @@ osg::ref_ptr<osg::Camera> LocalMap::createOrthographicCamera(float x, float y, f
     camera->setClearMask(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     camera->setRenderOrder(osg::Camera::PRE_RENDER);
 
-    camera->setCullMask(Mask_Scene|Mask_SimpleWater|Mask_Terrain);
+    camera->setCullMask(Mask_Scene|Mask_SimpleWater|Mask_Terrain|Mask_Static|Mask_Model);
     camera->setNodeMask(Mask_RenderToTexture);
 
     osg::ref_ptr<osg::StateSet> stateset = new osg::StateSet;
@@ -371,7 +371,7 @@ void LocalMap::requestExteriorMap(const MWWorld::CellStore* cell)
 void LocalMap::requestInteriorMap(const MWWorld::CellStore* cell)
 {
     osg::ComputeBoundsVisitor computeBoundsVisitor;
-    computeBoundsVisitor.setTraversalMask(Mask_Scene|Mask_Terrain);
+    computeBoundsVisitor.setTraversalMask(Mask_Scene|Mask_Terrain|Mask_Static|Mask_Model);
     mSceneRoot->accept(computeBoundsVisitor);
 
     osg::BoundingBox bounds = computeBoundsVisitor.getBoundingBox();

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -73,6 +73,10 @@ void Objects::insertBegin(const MWWorld::Ptr& ptr)
 void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh, bool animated, bool allowLight)
 {
     insertBegin(ptr);
+    if(animated)
+        ptr.getRefData().getBaseNode()->setNodeMask(Mask_Model);
+    else
+        ptr.getRefData().getBaseNode()->setNodeMask(Mask_Static);
 
     osg::ref_ptr<ObjectAnimation> anim (new ObjectAnimation(ptr, mesh, mResourceSystem, animated, allowLight));
 

--- a/apps/openmw/mwrender/vismask.hpp
+++ b/apps/openmw/mwrender/vismask.hpp
@@ -51,7 +51,11 @@ namespace MWRender
         Mask_PreCompile = (1<<16),
 
         // Set on a camera's cull mask to enable the LightManager
-        Mask_Lighting = (1<<17)
+        Mask_Lighting = (1<<17),
+
+        // child of Scene
+        Mask_Model = (1<<18),
+        Mask_Static = (1<<19)
     };
 
 }

--- a/apps/openmw/mwrender/water.hpp
+++ b/apps/openmw/mwrender/water.hpp
@@ -68,6 +68,7 @@ namespace MWRender
 
         const std::string mResourcePath;
 
+        bool mInterior;
         bool mEnabled;
         bool mToggled;
         float mTop;

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -385,13 +385,14 @@
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 56 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top">
-                                    <UserString key="SettingCategory" value="Water"/>
-                                    <UserString key="SettingName" value="reflect actors"/>
-                                    <UserString key="SettingType" value="CheckButton"/>
+                                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 115 24" align="Left Top" name="WaterReflectionDetail">
+                                    <Property key="AddItem" value="Terrain"/>
+                                    <Property key="AddItem" value="Statics"/>
+                                    <Property key="AddItem" value="Nonactors"/>
+                                    <Property key="AddItem" value="Everything"/>
                                 </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 79 16" align="Left Top">
-                                    <Property key="Caption" value="Reflect actors"/>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="64 4 90 16" align="Left Top">
+                                    <Property key="Caption" value="Reflection shader detail"/>
                                 </Widget>
                             </Widget>
                         </Widget>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -414,7 +414,7 @@ rtt size = 512
 refraction = false
 
 # Draw NPCs and creatures on water reflections.
-reflect actors = false
+reflection detail = 2
 
 # Overrides the value in '[Camera] small feature culling pixel size' specifically for water reflection/refraction textures.
 small feature culling pixel size = 20.0


### PR DESCRIPTION
I heard there were objections to this, but I think that the performance gain from not reflecting animated models, or not drawing statics, is simply too big to overlook, especially considering that vanilla Morrowind doesn't do true reflection at all (it uses some kind of dynamic cubemap) and doesn't have to worry about the performance impact of it. The default setting is equivalent to the former default setting.

In interiors, statics are always reflected.

https://imgur.com/a/4geOVfL