### PR TITLE
Do not show any book text after last <BR> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     Bug #3997: Almalexia doesn't pace
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID
     Bug #4047: OpenMW not reporting its version number in MacOS; OpenMW-CS not doing it fully
+    Bug #4215: OpenMW shows book text after last <BR> tag
     Bug #4221: Characters get stuck in V-shaped terrain
     Bug #4251: Stationary NPCs do not return to their position after combat
     Bug #4293: Faction members are not aware of faction ownerships in barter

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -31,6 +31,14 @@ namespace MWGui
 
             boost::algorithm::replace_all(mText, "\r", "");
 
+            // vanilla game does not show any text after last <BR> tag.
+            const std::string lowerText = Misc::StringUtils::lowerCase(mText);
+            int index = lowerText.rfind("<br>");
+            if (index == -1)
+                mText = "";
+            else
+                mText = mText.substr(0, index+4);
+
             registerTag("br", Event_BrTag);
             registerTag("p", Event_PTag);
             registerTag("img", Event_ImgTag);


### PR DESCRIPTION
Fixes last case from [bug #4215](https://bugs.openmw.org/issues/4215).
Vanilla game does not show any text after last "\<BR\>" tag (probably a bug in the trailing newlines removal).
OpenMW renders this text, so there are trailing symbols in some books in the German version of  game.

If we do not want to replicate this quirk, we can just close this bug and describe that our current behaviour is intended.