### PR TITLE
Do not interrupt scripted animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 
     Bug #2835: Player able to slowly move when overencumbered
     Bug #3374: Touch spells not hitting kwama foragers
+    Bug #3486: [Mod] NPC Commands does not work
     Bug #3591: Angled hit distance too low
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3997: Almalexia doesn't pace
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID
     Bug #4221: Characters get stuck in V-shaped terrain
     Bug #4251: Stationary NPCs do not return to their position after combat
+    Bug #4286: Scripted animations can be interrupted
+    Bug #4291: Non-persistent actors that started the game as dead do not play death animations
     Bug #4293: Faction members are not aware of faction ownerships in barter
+    Bug #4307: World cleanup should remove dead bodies only if death animation is finished
     Bug #4327: Missing animations during spell/weapon stance switching
     Bug #4419: MRK NiStringExtraData is handled incorrectly
     Bug #4426: RotateWorld behavior is incorrect

--- a/apps/openmw/mwclass/actor.cpp
+++ b/apps/openmw/mwclass/actor.cpp
@@ -31,7 +31,7 @@ namespace MWClass
         if (!model.empty())
         {
             physics.addActor(ptr, model);
-            if (getCreatureStats(ptr).isDead())
+            if (getCreatureStats(ptr).isDead() && getCreatureStats(ptr).isDeathAnimationFinished())
                 MWBase::Environment::get().getWorld()->enableActorCollision(ptr, false);
         }
     }

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -136,7 +136,7 @@ namespace MWClass
             data->mCreatureStats.setAiSetting (MWMechanics::CreatureStats::AI_Alarm, ref->mBase->mAiData.mAlarm);
 
             if (data->mCreatureStats.isDead())
-                data->mCreatureStats.setDeathAnimationFinished(true);
+                data->mCreatureStats.setDeathAnimationFinished(ptr.getClass().isPersistent(ptr));
 
             // spells
             for (std::vector<std::string>::const_iterator iter (ref->mBase->mSpells.mList.begin());
@@ -812,6 +812,9 @@ namespace MWClass
     {
         const MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
         if (ptr.getRefData().getCount() > 0 && !creatureStats.isDead())
+            return;
+
+        if (!creatureStats.isDeathAnimationFinished())
             return;
 
         const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -135,6 +135,7 @@ namespace MWClass
             data->mCreatureStats.setAiSetting (MWMechanics::CreatureStats::AI_Flee, ref->mBase->mAiData.mFlee);
             data->mCreatureStats.setAiSetting (MWMechanics::CreatureStats::AI_Alarm, ref->mBase->mAiData.mAlarm);
 
+            // Persistent actors with 0 health do not play death animation
             if (data->mCreatureStats.isDead())
                 data->mCreatureStats.setDeathAnimationFinished(ptr.getClass().isPersistent(ptr));
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -352,6 +352,8 @@ namespace MWClass
 
                 data->mNpcStats.setNeedRecalcDynamicStats(true);
             }
+
+            // Persistent actors with 0 health do not play death animation
             if (data->mNpcStats.isDead())
                 data->mNpcStats.setDeathAnimationFinished(ptr.getClass().isPersistent(ptr));
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -353,7 +353,7 @@ namespace MWClass
                 data->mNpcStats.setNeedRecalcDynamicStats(true);
             }
             if (data->mNpcStats.isDead())
-                data->mNpcStats.setDeathAnimationFinished(true);
+                data->mNpcStats.setDeathAnimationFinished(ptr.getClass().isPersistent(ptr));
 
             // race powers
             const ESM::Race *race = MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(ref->mBase->mRace);
@@ -1349,6 +1349,9 @@ namespace MWClass
     {
         const MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
         if (ptr.getRefData().getCount() > 0 && !creatureStats.isDead())
+            return;
+
+        if (!creatureStats.isDeathAnimationFinished())
             return;
 
         const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -847,7 +847,7 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
     }
 
     // Do not update animation status for dead actors
-    if(mDeathState == CharState_None && !cls.getCreatureStats(mPtr).isDead())
+    if(mDeathState == CharState_None && (!cls.isActor() || !cls.getCreatureStats(mPtr).isDead()))
         refreshCurrentAnims(mIdleState, mMovementState, mJumpState, true);
 
     mAnimation->runAnimation(0.f);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -728,14 +728,6 @@ void CharacterController::playRandomDeath(float startpoint)
         MWBase::Environment::get().getWorld()->useDeathCamera();
     }
 
-    // Do not interrupt scripted animation by death
-    if (!mAnimQueue.empty())
-    {
-        AnimationQueueEntry& first = mAnimQueue.front();
-        if (first.mPersist && isAnimPlaying(first.mGroup))
-            return;
-    }
-
     if(mHitState == CharState_SwimKnockDown && mAnimation->hasAnimation("swimdeathknockdown"))
     {
         mDeathState = CharState_SwimDeathKnockDown;
@@ -760,6 +752,15 @@ void CharacterController::playRandomDeath(float startpoint)
     {
         mDeathState = chooseRandomDeathState();
     }
+
+    // Do not interrupt scripted animation by death
+    if (!mAnimQueue.empty())
+    {
+        AnimationQueueEntry& first = mAnimQueue.front();
+        if (first.mPersist && isAnimPlaying(first.mGroup))
+            return;
+    }
+
     playDeath(startpoint, mDeathState);
 }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2023,7 +2023,11 @@ void CharacterController::update(float duration)
         // not done in constructor since we need to give scripts a chance to set the mSkipAnim flag
         if (!mSkipAnim && mDeathState != CharState_None && mCurrentDeath.empty())
         {
-            playDeath(1.f, mDeathState);
+            // Fast-forward death animation to end for persisting corpses
+            if (cls.isPersistent(mPtr))
+                playDeath(1.f, mDeathState);
+            else
+                playDeath(0.f, mDeathState);
         }
         // We must always queue movement, even if there is none, to apply gravity.
         world->queueMovement(mPtr, osg::Vec3f(0.f, 0.f, 0.f));
@@ -2239,6 +2243,7 @@ void CharacterController::forceStateUpdate()
     clearAnimQueue();
 
     refreshCurrentAnims(mIdleState, mMovementState, mJumpState, true);
+
     if(mDeathState != CharState_None)
     {
         playRandomDeath();

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -845,8 +845,8 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
         mIdleState = CharState_Idle;
     }
 
-
-    if(mDeathState == CharState_None)
+    // Do not update animation status for dead actors
+    if(mDeathState == CharState_None && !cls.getCreatureStats(mPtr).isDead())
         refreshCurrentAnims(mIdleState, mMovementState, mJumpState, true);
 
     mAnimation->runAnimation(0.f);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -728,6 +728,14 @@ void CharacterController::playRandomDeath(float startpoint)
         MWBase::Environment::get().getWorld()->useDeathCamera();
     }
 
+    // Do not interrupt scripted animation by death
+    if (!mAnimQueue.empty())
+    {
+        AnimationQueueEntry& first = mAnimQueue.front();
+        if (first.mPersist && isAnimPlaying(first.mGroup))
+            return;
+    }
+
     if(mHitState == CharState_SwimKnockDown && mAnimation->hasAnimation("swimdeathknockdown"))
     {
         mDeathState = CharState_SwimDeathKnockDown;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2029,13 +2029,10 @@ void CharacterController::update(float duration)
     {
         // initial start of death animation for actors that started the game as dead
         // not done in constructor since we need to give scripts a chance to set the mSkipAnim flag
-        if (!mSkipAnim && mDeathState != CharState_None && mCurrentDeath.empty())
+        if (!mSkipAnim && mDeathState != CharState_None && mCurrentDeath.empty() && cls.isPersistent(mPtr))
         {
             // Fast-forward death animation to end for persisting corpses
-            if (cls.isPersistent(mPtr))
-                playDeath(1.f, mDeathState);
-            else
-                playDeath(0.f, mDeathState);
+            playDeath(1.f, mDeathState);
         }
         // We must always queue movement, even if there is none, to apply gravity.
         world->queueMovement(mPtr, osg::Vec3f(0.f, 0.f, 0.f));

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2035,7 +2035,8 @@ void CharacterController::update(float duration)
         world->queueMovement(mPtr, osg::Vec3f(0.f, 0.f, 0.f));
     }
 
-    osg::Vec3f moved = mAnimation->runAnimation(mSkipAnim ? 0.f : duration);
+    bool isPersist = isPersistentAnimPlaying();
+    osg::Vec3f moved = mAnimation->runAnimation(mSkipAnim && !isPersist ? 0.f : duration);
     if(duration > 0.0f)
         moved /= duration;
     else

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1308,6 +1308,10 @@ bool CharacterController::updateWeaponState()
         }
     }
 
+    // Combat for actors with persistent animations obviously will be buggy
+    if (isPersistentAnimPlaying())
+        return forcestateupdate;
+
     float complete;
     bool animPlaying;
     if(mAttackingOrSpell)
@@ -2186,7 +2190,7 @@ bool CharacterController::playGroup(const std::string &groupname, int mode, int 
 
         mIdleState = CharState_SpecialIdle;
         bool loopfallback = (entry.mGroup.compare(0,4,"idle") == 0);
-        mAnimation->play(groupname, Priority_Default,
+        mAnimation->play(groupname, persist ? Priority_Persistent : Priority_Default,
                             MWRender::Animation::BlendMask_All, false, 1.0f,
                             ((mode==2) ? "loop start" : "start"), "stop", 0.0f, count-1, loopfallback);
     }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -565,7 +565,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
     if (!mAnimQueue.empty())
     {
         AnimationQueueEntry& first = mAnimQueue.front();
-        if (first.mPersist)
+        if (first.mPersist && isAnimPlaying(first.mGroup))
             return;
     }
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -215,7 +215,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     void refreshMovementAnims(const WeaponInfo* weap, CharacterState movement, bool force=false);
     void refreshIdleAnims(const WeaponInfo* weap, CharacterState idle, bool force=false);
 
-    void clearAnimQueue();
+    void clearAnimQueue(bool clearPersistAnims = false);
 
     bool updateWeaponState();
     bool updateCreatureState();

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -39,8 +39,8 @@ enum Priority {
     Priority_Knockdown,
     Priority_Torch,
     Priority_Storm,
-
     Priority_Death,
+    Priority_Persistent,
 
     Num_Priorities
 };

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -221,6 +221,8 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     bool updateCreatureState();
     void updateIdleStormState(bool inwater);
 
+    bool isPersistentAnimPlaying();
+
     void updateAnimQueue();
 
     void updateHeadTracking(float duration);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1089,11 +1089,28 @@ namespace MWRender
 
     osg::Vec3f Animation::runAnimation(float duration)
     {
+        // If we have scripted animations, play only them
+        bool hasScriptedAnims = false;
+        for (AnimStateMap::iterator stateiter = mStates.begin(); stateiter != mStates.end(); stateiter++)
+        {
+            if (stateiter->second.mPriority.contains(int(MWMechanics::Priority_Persistent)) && stateiter->second.mPlaying)
+            {
+                hasScriptedAnims = true;
+                break;
+            }
+        }
+
         osg::Vec3f movement(0.f, 0.f, 0.f);
         AnimStateMap::iterator stateiter = mStates.begin();
         while(stateiter != mStates.end())
         {
             AnimState &state = stateiter->second;
+            if (hasScriptedAnims && !state.mPriority.contains(int(MWMechanics::Priority_Persistent)))
+            {
+                ++stateiter;
+                continue;
+            }
+
             const NifOsg::TextKeyMap &textkeys = state.mSource->getTextKeys();
             NifOsg::TextKeyMap::const_iterator textkey(textkeys.upper_bound(state.getTime()));
 

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -945,8 +945,13 @@ namespace MWWorld
     {
         const MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
         static const float fCorpseClearDelay = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fCorpseClearDelay")->getFloat();
-        if (creatureStats.isDead() && !ptr.getClass().isPersistent(ptr) && creatureStats.getTimeOfDeath() + fCorpseClearDelay <= MWBase::Environment::get().getWorld()->getTimeStamp())
+        if (creatureStats.isDead() &&
+            creatureStats.isDeathAnimationFinished() &&
+            !ptr.getClass().isPersistent(ptr) &&
+            creatureStats.getTimeOfDeath() + fCorpseClearDelay <= MWBase::Environment::get().getWorld()->getTimeStamp())
+        {
             MWBase::Environment::get().getWorld()->deleteObject(ptr);
+        }
     }
 
     void CellStore::respawn()

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -77,6 +77,7 @@ This is how original Morrowind behaves.
 
 If this setting is false, player has to wait until end of death animation in all cases.
 This case is more safe, but makes using of summoned creatures exploit (looting summoned Dremoras and Golden Saints for expensive weapons) a lot harder.
+Conflicts with mannequin mods, which use SkipAnim to prevent end of death animation.
 
 This setting can only be configured by editing the settings configuration file.
 


### PR DESCRIPTION
This PR is aimed to fix [bug #3486](https://bugs.openmw.org/issues/3486), [bug #4286](https://bugs.openmw.org/issues/4286), [bug #4307](https://bugs.openmw.org/issues/4307) and [bug #4291](https://bugs.openmw.org/issues/4291) since all these problems are related.

Tested with NPC_Commands_V8b.esp, Abot's Silt Striders, and Castle Hestatur mannequins.

Main changes:
1. Scripted animations have higher priority than common ones, so common animations should not interrupt them.
Allows such mods as Abot Silt Striders and NPC_Commands to work better.

2. Cell cleanup checks if death animation is finished before remove the corpse 72 hours after death.
3. If an actor has Health = 0 in editor, but does not have the Persistent flag, play death animation.
These two allows mannequins from Castle Hestatur work properly.

4. Scripted animations ignore SkipAnim console command.
5. "PlayGroup idle" removes scripted animations from actor and resumes a common NPC behaviour. 
These two should fix other mannequin mods, which use scripted anims on dead actors.

Should work now, but I suppose that this PR has some side effects.