### PR TITLE
Set ok button focus in settings window by default (bug #4368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     Bug #4251: Stationary NPCs do not return to their position after combat
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4327: Missing animations during spell/weapon stance switching
+    Bug #4368: Settings window ok button doesn't have key focus by default
     Bug #4419: MRK NiStringExtraData is handled incorrectly
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4429: [Windows] Error on build INSTALL.vcxproj project (debug) with cmake 3.7.2

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -562,8 +562,9 @@ namespace MWGui
 
     void SettingsWindow::onOpen()
     {
-        updateControlsBox ();
+        updateControlsBox();
         resetScrollbars();
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mOkButton);
     }
 
     void SettingsWindow::onWindowResize(MyGUI::Window *_sender)


### PR DESCRIPTION
As suggested by scrawl [in the bug report](https://bugs.openmw.org/issues/4368).

I would've set up actual keyboard navigation for settings window, but it's too cryptic for me to do. I think it should have a separate bug report.