### PR TITLE
Fix #4452

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     Bug #4429: [Windows] Error on build INSTALL.vcxproj project (debug) with cmake 3.7.2
     Bug #4432: Guards behaviour is incorrect if they do not have AI packages
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
+    Bug #4452: Default terrain texture bleeds through texture transitions
     Feature #4345: Add equivalents for the command line commands to Launcher
     Feature #4444: Per-group KF-animation files support
 

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -361,6 +361,11 @@ namespace ESMTerrain
 
     std::string Storage::getTextureName(UniqueTextureId id)
     {
+        // Goes under used terrain blend transitions
+        static const std::string baseTexture = "textures\\tx_black_01.dds";
+        if (id.first == -1)
+            return baseTexture;
+
         static const std::string defaultTexture = "textures\\_land_default.dds";
         if (id.first == 0)
             return defaultTexture; // Not sure if the default texture really is hardcoded?
@@ -396,11 +401,9 @@ namespace ESMTerrain
         // Save the used texture indices so we know the total number of textures
         // and number of required blend maps
         std::set<UniqueTextureId> textureIndices;
-        // Due to the way the blending works, the base layer will always shine through in between
-        // blend transitions (eg halfway between two texels, both blend values will be 0.5, so 25% of base layer visible).
-        // To get a consistent look, we need to make sure to use the same base layer in all cells.
-        // So we're always adding _land_default.dds as the base layer here, even if it's not referenced in this cell.
-        textureIndices.insert(std::make_pair(0,0));
+        // Due to the way the blending works, the base layer will bleed between texture transitions so we want it to be a black texture
+        // The subsequent passes are added instead of blended, so this gives the correct result
+        textureIndices.insert(std::make_pair(-1,0)); // -1 goes to tx_black_01
 
         LandCache cache;
 
@@ -615,15 +618,6 @@ namespace ESMTerrain
 
         mLayerInfoMap[texture] = info;
 
-        return info;
-    }
-
-    Terrain::LayerInfo Storage::getDefaultLayer()
-    {
-        Terrain::LayerInfo info;
-        info.mDiffuseMap = "textures\\_land_default.dds";
-        info.mParallax = false;
-        info.mSpecular = false;
         return info;
     }
 

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -94,8 +94,6 @@ namespace ESMTerrain
 
         virtual float getHeightAt (const osg::Vec3f& worldPos);
 
-        virtual Terrain::LayerInfo getDefaultLayer();
-
         /// Get the transformation factor for mapping cell units to world units.
         virtual float getCellWorldSize();
 

--- a/components/terrain/storage.hpp
+++ b/components/terrain/storage.hpp
@@ -72,8 +72,6 @@ namespace Terrain
 
         virtual float getHeightAt (const osg::Vec3f& worldPos) = 0;
 
-        virtual LayerInfo getDefaultLayer() = 0;
-
         /// Get the transformation factor for mapping cell units to world units.
         virtual float getCellWorldSize() = 0;
 


### PR DESCRIPTION
I had to work around a couple different problems (underwater terrain was broken because of screen fog, statics nearly parallel to the terrain had halos - both worked around) so this probably needs to be tested on computers other than my own. Also, terrain rendering is broken when shaders fail to compile with or without this patch (without the patch it looks like https://i.imgur.com/iPMGzA2.jpg, with the patch it's pure black), so I didn't bother to update the "shaders fail to compile" terrain material codepath.

See http://bugs.openmw.org/issues/4452 and https://imgur.com/a/nzGazLY