### PR TITLE
Add CFBundleIdentifier in Info.plist to allow for macOS function key shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     Bug #4429: [Windows] Error on build INSTALL.vcxproj project (debug) with cmake 3.7.2
     Bug #4432: Guards behaviour is incorrect if they do not have AI packages
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
+    Feature #4324: Add CFBundleIdentifier in Info.plist to allow for macOS function key shortcuts
     Feature #4345: Add equivalents for the command line commands to Launcher
     Feature #4444: Per-group KF-animation files support
 

--- a/files/mac/openmw-Info.plist.in
+++ b/files/mac/openmw-Info.plist.in
@@ -8,6 +8,8 @@
 	<string>English</string>
 	<key>CFBundleExecutable</key>
 	<string>openmw-launcher</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.openmw.openmw</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>


### PR DESCRIPTION
Implements [#4324](https://bugs.openmw.org/issues/4324).

This will allow the function key shortcuts to be used on macOS laptops with a touch bar. It also may allow other accessibility improvements.