### PR TITLE
Handle exception when try to load non-music file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     Bug #4327: Missing animations during spell/weapon stance switching
     Bug #4368: Settings window ok button doesn't have key focus by default
     Bug #4393: NPCs walk back to where they were after using ResetActors
+    Bug #4416: Handle exception if we try to play non-music file
     Bug #4419: MRK NiStringExtraData is handled incorrectly
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4429: [Windows] Error on build INSTALL.vcxproj project (debug) with cmake 3.7.2

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -251,21 +251,24 @@ void FFmpeg_Decoder::open(const std::string &fname)
         if(mOutputChannelLayout == 0)
             mOutputChannelLayout = av_get_default_channel_layout((*mStream)->codec->channels);
     }
-    catch(...) {
+    catch(...)
+    {
         if(mStream)
             avcodec_close((*mStream)->codec);
         mStream = NULL;
 
-        if (mFormatCtx->pb->buffer != NULL)
+        if (mFormatCtx != NULL)
         {
-            av_free(mFormatCtx->pb->buffer);
-            mFormatCtx->pb->buffer = NULL;
-        }
-        av_free(mFormatCtx->pb);
-        mFormatCtx->pb = NULL;
+            if (mFormatCtx->pb->buffer != NULL)
+            {
+                av_free(mFormatCtx->pb->buffer);
+                mFormatCtx->pb->buffer = NULL;
+            }
+            av_free(mFormatCtx->pb);
+            mFormatCtx->pb = NULL;
 
-        avformat_close_input(&mFormatCtx);
-        throw;
+            avformat_close_input(&mFormatCtx);
+        }
     }
 }
 


### PR DESCRIPTION
This PR is aimed to fix [bug #4416](https://bugs.openmw.org/issues/4416).

Currently he have unhandled exception, which causes the skip of frame update.
Should mostly work now, the only issue left is whan player does not have valid tracks in playlist, only invalid ones.

@kcat, can you take a look at this PR?