### PR TITLE
Refactor SDL loading in Launcher to fix macOS errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
     Bug #2222: Fatigue's effect on selling price is backwards
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
     Bug #2835: Player able to slowly move when overencumbered
+    Bug #2862: [macOS] Can't quit launcher using Command-Q or OpenMW->Quit
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3591: Angled hit distance too low
     Bug #3629: DB assassin attack never triggers creature spawning
     Bug #3876: Landscape texture painting is misaligned
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
+    Bug #3911: [macOS] Typing in the "Content List name" dialog box produces double characters
     Bug #3993: Terrain texture blending map is not upscaled
     Bug #3997: Almalexia doesn't pace
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID

--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -1,6 +1,7 @@
 #include "graphicspage.hpp"
 
 #include <boost/math/common_factor.hpp>
+#include <csignal>
 #include <QDesktopWidget>
 #include <QMessageBox>
 #include <QDir>

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -37,6 +37,11 @@ namespace Launcher
         QStringList getAvailableResolutions(int screen);
         QRect getMaximumResolution();
 
+        /**
+         * Connect to the SDL so that we can use it to determine graphics
+         * @return whether or not connecting to SDL is successful
+         */
+        bool connectToSdl();
         bool setupSDL();
     };
 }

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -12,24 +12,12 @@
 #define MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
 #endif // MAC_OS_X_VERSION_MIN_REQUIRED
 
-#include <SDL.h>
-
 #include "maindialog.hpp"
 
 int main(int argc, char *argv[])
 {
     try
     {
-        SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
-        SDL_SetMainReady();
-        if (SDL_Init(SDL_INIT_VIDEO) != 0)
-        {
-            qDebug() << "SDL_Init failed: " << QString::fromUtf8(SDL_GetError());
-            return 0;
-        }
-        signal(SIGINT, SIG_DFL); // We don't want to use the SDL event loop in the launcher,
-                                 // so reset SIGINT which SDL wants to redirect to an SDL_Quit event.
-
         QApplication app(argc, argv);
 
         // Now we make sure the current dir is set to application path
@@ -46,9 +34,7 @@ int main(int argc, char *argv[])
         if (result == Launcher::FirstRunDialogResultContinue)
             mainWin.show();
 
-        int returnValue = app.exec();
-        SDL_Quit();
-        return returnValue;
+        return app.exec();
     }
     catch (std::exception& e)
     {

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <csignal>
 
 #include <QApplication>
 #include <QTextCodec>


### PR DESCRIPTION
Fixes both [Bug #2862](https://bugs.openmw.org/issues/2862) and [Bug #3911](https://bugs.openmw.org/issues/3911).

As suspected in the bug reports, SDL and Qt were interfering with each other, which caused issues on macOS. Since we only need SDL for the graphics tab, I limited the scope to that. This prevents issues with things outside of the graphics panel due to the SDL/Qt conflict, and everything works great now.