### PR TITLE
Add murder bounty when a player follower commits murder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     Bug #2222: Fatigue's effect on selling price is backwards
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
     Bug #2835: Player able to slowly move when overencumbered
+    Bug #2852: No murder bounty when a player follower commits murder
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3591: Angled hit distance too low


### PR DESCRIPTION
Should fix [bug #2852](https://bugs.openmw.org/issues/2852).

Created as replacement of #921.

The main idea: if the murderer is the player's follower, assign murder bounty to player in MechanicsManager::actorKilled().