### PR TITLE
Implement unlockable locks with 'lock 0' console command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     Bug #4419: MRK NiStringExtraData is handled incorrectly
     Bug #4426: RotateWorld behavior is incorrect
     Bug #4429: [Windows] Error on build INSTALL.vcxproj project (debug) with cmake 3.7.2
+    Bug #4431: "Lock 0" console command is a no-op
     Bug #4432: Guards behaviour is incorrect if they do not have AI packages
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
     Bug #4451: Script fails to compile when using "Begin, [ScriptName]" syntax

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -239,7 +239,8 @@ namespace MWClass
         info.caption = ref->mBase->mName;
 
         std::string text;
-        if (ptr.getCellRef().getLockLevel() > 0)
+        int lockLevel = ptr.getCellRef().getLockLevel();
+        if (lockLevel > 0 && lockLevel != ESM::UnbreakableLock)
             text += "\n#{sLockLevel}: " + MWGui::ToolTips::toString(ptr.getCellRef().getLockLevel());
         else if (ptr.getCellRef().getLockLevel() < 0)
             text += "\n#{sUnlocked}";
@@ -271,15 +272,16 @@ namespace MWClass
 
     void Container::lock (const MWWorld::Ptr& ptr, int lockLevel) const
     {
-        if(lockLevel!=0)
-            ptr.getCellRef().setLockLevel(abs(lockLevel)); //Changes lock to locklevel, in positive
+        if(lockLevel != 0)
+            ptr.getCellRef().setLockLevel(abs(lockLevel)); //Changes lock to locklevel, if positive
         else
-            ptr.getCellRef().setLockLevel(abs(ptr.getCellRef().getLockLevel())); //No locklevel given, just flip the original one
+            ptr.getCellRef().setLockLevel(ESM::UnbreakableLock); // If zero, set to max lock level
     }
 
     void Container::unlock (const MWWorld::Ptr& ptr) const
     {
-        ptr.getCellRef().setLockLevel(-abs(ptr.getCellRef().getLockLevel())); //Makes lockLevel negative
+        int lockLevel = ptr.getCellRef().getLockLevel();
+        ptr.getCellRef().setLockLevel(-abs(lockLevel)); //Makes lockLevel negative
     }
 
     bool Container::canLock(const MWWorld::ConstPtr &ptr) const

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -193,7 +193,7 @@ namespace MWClass
                     std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionTeleport (ptr.getCellRef().getDestCell(), ptr.getCellRef().getDoorDest(), true));
                     action->setSound(openSound);
                     return action;
-                }              
+                }
             }
             else
             {
@@ -240,15 +240,16 @@ namespace MWClass
 
     void Door::lock (const MWWorld::Ptr& ptr, int lockLevel) const
     {
-        if(lockLevel!=0)
-            ptr.getCellRef().setLockLevel(abs(lockLevel)); //Changes lock to locklevel, in positive
+        if(lockLevel != 0)
+            ptr.getCellRef().setLockLevel(abs(lockLevel)); //Changes lock to locklevel, if positive
         else
-            ptr.getCellRef().setLockLevel(abs(ptr.getCellRef().getLockLevel())); //No locklevel given, just flip the original one
+            ptr.getCellRef().setLockLevel(ESM::UnbreakableLock); // If zero, set to max lock level
     }
 
     void Door::unlock (const MWWorld::Ptr& ptr) const
     {
-        ptr.getCellRef().setLockLevel(-abs(ptr.getCellRef().getLockLevel())); //Makes lockLevel negative
+        int lockLevel = ptr.getCellRef().getLockLevel();
+        ptr.getCellRef().setLockLevel(-abs(lockLevel)); //Makes lockLevel negative
     }
 
     bool Door::canLock(const MWWorld::ConstPtr &ptr) const
@@ -300,7 +301,8 @@ namespace MWClass
             text += "\n" + getDestination(*ref);
         }
 
-        if (ptr.getCellRef().getLockLevel() > 0)
+        int lockLevel = ptr.getCellRef().getLockLevel();
+        if (lockLevel > 0 && lockLevel != ESM::UnbreakableLock)
             text += "\n#{sLockLevel}: " + MWGui::ToolTips::toString(ptr.getCellRef().getLockLevel());
         else if (ptr.getCellRef().getLockLevel() < 0)
             text += "\n#{sUnlocked}";

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -884,8 +884,13 @@ namespace MWMechanics
 
         const MWWorld::CellRef& cellref = target.getCellRef();
         // there is no harm to use unlocked doors
-        if (target.getClass().isDoor() && cellref.getLockLevel() <= 0 && ptr.getCellRef().getTrap().empty())
+        int lockLevel = cellref.getLockLevel();
+        if (target.getClass().isDoor() &&
+            (lockLevel <= 0 || lockLevel == ESM::UnbreakableLock) &&
+            ptr.getCellRef().getTrap().empty())
+        {
             return true;
+        }
 
         // TODO: implement a better check to check if target is owned bed
         if (target.getClass().isActivator() && target.getClass().getScript(target).compare(0, 3, "Bed") != 0)

--- a/apps/openmw/mwmechanics/security.cpp
+++ b/apps/openmw/mwmechanics/security.cpp
@@ -31,7 +31,9 @@ namespace MWMechanics
     void Security::pickLock(const MWWorld::Ptr &lock, const MWWorld::Ptr &lockpick,
                             std::string& resultMessage, std::string& resultSound)
     {
-        if (!(lock.getCellRef().getLockLevel() > 0) || !lock.getClass().canLock(lock)) //If it's unlocked back out immediately
+        if (lock.getCellRef().getLockLevel() <= 0 ||
+            lock.getCellRef().getLockLevel() == ESM::UnbreakableLock ||
+            !lock.getClass().canLock(lock)) //If it's unlocked or can not be unlocked back out immediately
             return;
 
         int lockStrength = lock.getCellRef().getLockLevel();

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -126,6 +126,9 @@ void ESM::CellRef::loadData(ESMReader &esm, bool &isDeleted)
                 break;
         }
     }
+
+    if (mLockLevel == 0 && !mKey.empty())
+        mLockLevel = UnbreakableLock;
 }
 
 void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory, bool isDeleted) const

--- a/components/esm/cellref.hpp
+++ b/components/esm/cellref.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENMW_ESM_CELLREF_H
 #define OPENMW_ESM_CELLREF_H
 
+#include <limits>
 #include <string>
 
 #include "defs.hpp"
@@ -10,6 +11,7 @@ namespace ESM
     class ESMWriter;
     class ESMReader;
 
+    const int UnbreakableLock = std::numeric_limits<int>::max();
 
     struct RefNum
     {


### PR DESCRIPTION
Should fix [bug #4431](https://bugs.openmw.org/issues/4431).

Note: std::numeric_limits<int>::max() value can depend on target platform, so saves from other platform can cause issues.