### PR TITLE
Forbid actors to use teleporting doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #1990: Sunrise/sunset not set correct
     Bug #2222: Fatigue's effect on selling price is backwards
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
+    Bug #2562: Forcing AI to activate a teleport door sometimes causes a crash
     Bug #2835: Player able to slowly move when overencumbered
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
     Bug #3374: Touch spells not hitting kwama foragers

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -121,14 +121,23 @@ namespace MWClass
         bool hasKey = false;
         std::string keyName;
 
+        // FIXME: If NPC activate teleporting door, it can lead to crash due to iterator invalidation in the Actors update.
+        // Make such activation a no-op for now, how in vanilla game.
+        if (actor != MWMechanics::getPlayer() && ptr.getCellRef().getTeleport())
+        {
+            std::shared_ptr<MWWorld::Action> action(new MWWorld::FailedAction(std::string(), ptr));
+            action->setSound(lockedSound);
+            return action;
+        }
+
         // make door glow if player activates it with telekinesis
-        if (actor == MWBase::Environment::get().getWorld()->getPlayerPtr() &&
-            MWBase::Environment::get().getWorld()->getDistanceToFacedObject() > 
+        if (actor == MWMechanics::getPlayer() &&
+            MWBase::Environment::get().getWorld()->getDistanceToFacedObject() >
             MWBase::Environment::get().getWorld()->getMaxActivationDistance())
         {
             MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(ptr);
 
-            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();            
+            const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
             int index = ESM::MagicEffect::effectStringToId("sEffectTelekinesis");
             const ESM::MagicEffect *effect = store.get<ESM::MagicEffect>().find(index);
 

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -122,7 +122,7 @@ namespace MWClass
         std::string keyName;
 
         // FIXME: If NPC activate teleporting door, it can lead to crash due to iterator invalidation in the Actors update.
-        // Make such activation a no-op for now, how in vanilla game.
+        // Make such activation a no-op for now, like how it is in the vanilla game.
         if (actor != MWMechanics::getPlayer() && ptr.getCellRef().getTeleport())
         {
             std::shared_ptr<MWWorld::Action> action(new MWWorld::FailedAction(std::string(), ptr));


### PR DESCRIPTION
Fixes [bug #2562](https://bugs.openmw.org/issues/2562).

Currently if NPC activates teleporting door, it can cause crash in both vanilla and OpenMW.
Disable such activations for now.

After 1.0, if we teach AI to move between cells properly (e.g. via doors and teleportation), we will re-enable them.
