### PR TITLE
Fix arguments parsing for AiWander console command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
     Bug #4451: Script fails to compile when using "Begin, [ScriptName]" syntax
     Bug #4453: Quick keys behaviour is invalid for equipment
     Bug #4454: AI opens doors too slow
+    Bug #4458: AiWander console command handles idle chances incorrectly
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #4222: 360° screenshots

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -193,10 +193,18 @@ namespace MWScript
                     Interpreter::Type_Integer time = static_cast<Interpreter::Type_Integer>(runtime[0].mFloat);
                     runtime.pop();
 
+                    // Chance for Idle is unused
+                    if (arg0)
+                    {
+                        --arg0;
+                        runtime.pop();
+                    }
+
                     std::vector<unsigned char> idleList;
                     bool repeat = false;
 
-                    for(int i=1; i < 10 && arg0; ++i)
+                    // Chances for Idle2-Idle9
+                    for(int i=2; i<=9 && arg0; ++i)
                     {
                         if(!repeat)
                             repeat = true;


### PR DESCRIPTION
Fixes [bug #4458](https://bugs.openmw.org/issues/4458).

In upstream code AiWander console command forms idleList of 9 elements (chances for Idle1-9), then drops last element, but treats array as chances for Idle2-9 for some reason.
Vanilla drops chance for Idle1 instead.