### PR TITLE
Allow partial matches in NotCell condition (bug #4459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     Bug #4454: AI opens doors too slow
     Bug #4457: Item without CanCarry flag prevents shield autoequipping in dark areas
     Bug #4458: AiWander console command handles idle chances incorrectly
+    Bug #4459: NotCell dialogue condition doesn't support partial matches
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #4222: 360° screenshots

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -491,10 +491,11 @@ bool MWDialogue::Filter::getSelectStructBoolean (const SelectWrapper& select) co
             return !Misc::StringUtils::ciEqual(mActor.get<ESM::NPC>()->mBase->mRace, select.getName());
 
         case SelectWrapper::Function_NotCell:
-
-            return !Misc::StringUtils::ciEqual(MWBase::Environment::get().getWorld()->getCellName(mActor.getCell())
-                                               , select.getName());
-
+            {
+                const std::string& actorCell = MWBase::Environment::get().getWorld()->getCellName(mActor.getCell());
+                return !(actorCell.length() >= select.getName().length()
+                      && Misc::StringUtils::ciEqual(actorCell.substr(0, select.getName().length()), select.getName()));
+            }
         case SelectWrapper::Function_SameGender:
 
             return (player.get<ESM::NPC>()->mBase->mFlags & ESM::NPC::Female)==


### PR DESCRIPTION
[Bug report.](https://gitlab.com/OpenMW/openmw/issues/4459)

Extended the condition to return false on partially matching strings. Seems to work just fine with the plugin supplied by rot tor ([only available on redmine](https://bugs.openmw.org/issues/4459)) -- on master the greeting does appear in interiors of Balmora, with the change it does not. It should resolve the reporter's issue too.