### PR TITLE
TTF font scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     Bug #3059: Unable to hit with marksman weapons when too close to an enemy
     Bug #3072: Fatal error on AddItem <item> that has a script containing Equip <item>
     Bug #3249: Fixed revert function not updating views properly
+    Bug #3288: TrueType fonts are handled incorrectly
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3486: [Mod] NPC Commands does not work
     Bug #3533: GetSpellEffects should detect effects with zero duration

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -516,7 +516,7 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
     MWGui::WindowManager* window = new MWGui::WindowManager(mViewer, guiRoot, mResourceSystem.get(), mWorkQueue.get(),
                 mCfgMgr.getLogPath().string() + std::string("/"), myguiResources,
                 mScriptConsoleMode, mTranslationDataStorage, mEncoding, mExportFonts, mFallbackMap,
-                Version::getOpenmwVersionDescription(mResDir.string()));
+                Version::getOpenmwVersionDescription(mResDir.string()), mCfgMgr.getUserConfigPath().string());
     mEnvironment.setWindowManager (window);
 
     // Create sound system

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -290,6 +290,8 @@ namespace MWBase
             /// Warning: do not use MyGUI::InputManager::setKeyFocusWidget directly. Instead use this.
             virtual void setKeyFocusWidget (MyGUI::Widget* widget) = 0;
 
+            virtual void loadUserFonts() = 0;
+
             virtual Loading::Listener* getLoadingScreen() = 0;
 
             /// Should the cursor be visible?

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -219,6 +219,7 @@ namespace MWBase
             virtual const MWWorld::Ptr& getSelectedEnchantItem() const = 0;
             virtual void setSelectedWeapon(const MWWorld::Ptr& item) = 0;
             virtual const MWWorld::Ptr& getSelectedWeapon() const = 0;
+            virtual int getFontHeight() const = 0;
             virtual void unsetSelectedSpell() = 0;
             virtual void unsetSelectedWeapon() = 0;
 

--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -264,18 +264,29 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
     {
     }
 
-    Style * createStyle (char const * fontName, const Colour& fontColour)
+    Style * createStyle (const std::string& fontName, const Colour& fontColour)
     {
-        if (strcmp(fontName, "") == 0)
-            return createStyle(MyGUI::FontManager::getInstance().getDefaultFont().c_str(), fontColour);
+        const std::string templateName = "Journalbook ";
+        std::string bookFont;
+        if (fontName.empty())
+        {
+            bookFont = MyGUI::FontManager::getInstance().getDefaultFont();
+            bookFont = templateName + bookFont;
+            return createStyle(bookFont, fontColour);
+        }
+
+        if (fontName.compare(0, templateName.size(), templateName) == 0)
+            bookFont = fontName;
+        else
+            bookFont = templateName + bookFont;
 
         for (Styles::iterator i = mBook->mStyles.begin (); i != mBook->mStyles.end (); ++i)
-            if (i->match (fontName, fontColour, fontColour, fontColour, 0))
+            if (i->match (bookFont.c_str(), fontColour, fontColour, fontColour, 0))
                 return &*i;
 
-        MyGUI::IFont* font = MyGUI::FontManager::getInstance().getByName(fontName);
+        MyGUI::IFont* font = MyGUI::FontManager::getInstance().getByName(bookFont);
         if (!font)
-            throw std::runtime_error(std::string("can't find font ") + fontName);
+            throw std::runtime_error(std::string("can't find font ") + bookFont);
 
         StyleImpl & style = *mBook->mStyles.insert (mBook->mStyles.end (), StyleImpl ());
         style.mFont = font;

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -102,7 +102,7 @@ namespace MWGui
         static Ptr create (int pageWidth, int pageHeight);
 
         /// Create a simple text style consisting of a font and a text color.
-        virtual Style* createStyle (char const * Font, const Colour& Colour) = 0;
+        virtual Style* createStyle (const std::string& fontName, const Colour& colour) = 0;
 
         /// Create a hyper-link style with a user-defined identifier based on an
         /// existing style. The unique flag forces a new instance of this style

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -3,9 +3,16 @@
 
 #include "MyGUI_Colour.h"
 #include "MyGUI_Widget.h"
+#include "MyGUI_FontManager.h"
 
 #include <functional>
 #include <stdint.h>
+
+#include <components/settings/settings.hpp>
+#include <components/widgets/widgets.hpp>
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/windowmanager.hpp"
 
 namespace MWGui
 {
@@ -26,6 +33,45 @@ namespace MWGui
         /// right edge. The second integer is the height of all
         /// text combined prior to pagination.
         virtual std::pair <unsigned int, unsigned int> getSize () const = 0;
+    };
+
+    struct GlyphInfo
+    {
+        char codePoint;
+        float width;
+        float height;
+        float advance;
+        float bearingX;
+        float bearingY;
+        MyGUI::FloatRect uvRect;
+
+        GlyphInfo(MyGUI::IFont* font, MyGUI::Char ch)
+        {
+            static const int fontHeight = MWBase::Environment::get().getWindowManager()->getFontHeight();
+
+            MyGUI::GlyphInfo* gi = font->getGlyphInfo(ch);
+            if (gi)
+            {
+                const float scale = font->getDefaultHeight() / (float) fontHeight;
+
+                codePoint = gi->codePoint;
+                bearingX = (int) gi->bearingX / scale;
+                bearingY = (int) gi->bearingY / scale;
+                width = (int) gi->width / scale;
+                height = (int) gi->height / scale;
+                advance = (int) gi->advance / scale;
+                uvRect = gi->uvRect;
+            }
+            else
+            {
+                codePoint = -1;
+                bearingX = 0;
+                bearingY = 0;
+                width = 0;
+                height = 0;
+                advance = 0;
+            }
+        }
     };
 
     /// A factory class for creating a typeset book instance.

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -152,12 +152,6 @@ namespace MWGui
         MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCommandLine);
     }
 
-    void Console::setFont(const std::string &fntName)
-    {
-        mHistory->setFontName(fntName);
-        mCommandLine->setFontName(fntName);
-    }
-
     void Console::print(const std::string &msg, const std::string& color)
     {
         mHistory->addText(color + MyGUI::TextIterator::toTagsString(msg));

--- a/apps/openmw/mwgui/console.hpp
+++ b/apps/openmw/mwgui/console.hpp
@@ -41,8 +41,6 @@ namespace MWGui
 
             virtual void onOpen();
 
-            void setFont(const std::string &fntName);
-
             void onResChange(int width, int height);
 
             // Print a message to the console, in specified color.

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -377,7 +377,7 @@ namespace MWGui
             if (attr.find("face") != attr.end())
             {
                 std::string face = attr.at("face");
-                mTextStyle.mFont = face;
+                mTextStyle.mFont = "Journalbook "+face;
             }
             if (attr.find("size") != attr.end())
             {

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -415,7 +415,7 @@ namespace MWGui
             : GraphicElement(parent, pag, blockStyle),
               mTextStyle(textStyle)
         {
-            MyGUI::EditBox* box = parent->createWidget<MyGUI::EditBox>("NormalText",
+            Gui::EditBox* box = parent->createWidget<Gui::EditBox>("NormalText",
                 MyGUI::IntCoord(0, pag.getCurrentTop(), pag.getPageWidth(), 0), MyGUI::Align::Left | MyGUI::Align::Top,
                 parent->getName() + MyGUI::utility::toString(parent->getChildCount()));
             box->setEditStatic(true);
@@ -432,15 +432,6 @@ namespace MWGui
             mEditBox = box;
         }
 
-        int TextElement::currentFontHeight() const
-        {
-            std::string fontName(mTextStyle.mFont == "Default" ? MyGUI::FontManager::getInstance().getDefaultFont() : mTextStyle.mFont);
-            MyGUI::IFont* font = MyGUI::FontManager::getInstance().getByName(fontName);
-            if (!font)
-                return 0;
-            return font->getDefaultHeight();
-        }
-
         int TextElement::getHeight()
         {
             return mEditBox->getTextSize().height;
@@ -449,7 +440,7 @@ namespace MWGui
         int TextElement::pageSplit()
         {
             // split lines
-            const int lineHeight = currentFontHeight();
+            const int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight();
             unsigned int lastLine = (mPaginator.getStartTop() + mPaginator.getPageHeight() - mPaginator.getCurrentTop());
             if (lineHeight > 0)
                 lastLine /= lineHeight;

--- a/apps/openmw/mwgui/formatting.hpp
+++ b/apps/openmw/mwgui/formatting.hpp
@@ -14,7 +14,7 @@ namespace MWGui
         {
             TextStyle() :
                 mColour(0,0,0)
-                , mFont("Default")
+                , mFont("")
                 , mTextSize(16)
             {
             }

--- a/apps/openmw/mwgui/formatting.hpp
+++ b/apps/openmw/mwgui/formatting.hpp
@@ -4,6 +4,8 @@
 #include <MyGUI_Colour.h>
 #include <map>
 
+#include <components/widgets/box.hpp>
+
 namespace MWGui
 {
     namespace Formatting
@@ -152,7 +154,7 @@ namespace MWGui
             private:
                 int currentFontHeight() const;
                 TextStyle mTextStyle;
-                MyGUI::EditBox * mEditBox;
+                Gui::EditBox * mEditBox;
         };
 
         class ImageElement : public GraphicElement

--- a/apps/openmw/mwgui/journalbooks.cpp
+++ b/apps/openmw/mwgui/journalbooks.cpp
@@ -157,7 +157,7 @@ MWGui::BookTypesetter::Utf8Span to_utf8_span (char const * text)
 typedef TypesetBook::Ptr book;
 
 JournalBooks::JournalBooks (JournalViewModel::Ptr model, ToUTF8::FromType encoding) :
-    mModel (model), mEncoding(encoding)
+    mModel (model), mEncoding(encoding), mIndexPagesCount(0)
 {
 }
 
@@ -218,23 +218,23 @@ book JournalBooks::createQuestBook (const std::string& questName)
     return typesetter->complete ();
 }
 
-book JournalBooks::createTopicIndexBook (int& columnsCount)
+book JournalBooks::createTopicIndexBook ()
 {
     bool isRussian = (mEncoding == ToUTF8::WINDOWS_1251);
 
-    BookTypesetter::Ptr typesetter = isRussian ? createCyrillicJournalIndex(columnsCount) : createLatinJournalIndex(columnsCount);
+    BookTypesetter::Ptr typesetter = isRussian ? createCyrillicJournalIndex() : createLatinJournalIndex();
 
     return typesetter->complete ();
 }
 
-BookTypesetter::Ptr JournalBooks::createLatinJournalIndex (int& columnsCount)
+BookTypesetter::Ptr JournalBooks::createLatinJournalIndex ()
 {
     BookTypesetter::Ptr typesetter = BookTypesetter::create (92, 260);
 
     typesetter->setSectionAlignment (BookTypesetter::AlignCenter);
 
     // Latin journal index always has two columns for now.
-    columnsCount = 2;
+    mIndexPagesCount = 2;
 
     char ch = 'A';
 
@@ -261,7 +261,7 @@ BookTypesetter::Ptr JournalBooks::createLatinJournalIndex (int& columnsCount)
     return typesetter;
 }
 
-BookTypesetter::Ptr JournalBooks::createCyrillicJournalIndex (int& columnsCount)
+BookTypesetter::Ptr JournalBooks::createCyrillicJournalIndex ()
 {
     BookTypesetter::Ptr typesetter = BookTypesetter::create (92, 260);
 
@@ -273,11 +273,11 @@ BookTypesetter::Ptr JournalBooks::createCyrillicJournalIndex (int& columnsCount)
 
     // for small font size split alphabet to two columns (2x15 characers), for big font size split it to three colums (3x10 characters).
     int sectionBreak = 10;
-    columnsCount = 3;
+    mIndexPagesCount = 3;
     if (fontHeight < 18)
     {
         sectionBreak = 15;
-        columnsCount = 2;
+        mIndexPagesCount = 2;
     }
 
     unsigned char ch[2] = {0xd0, 0x90}; // CYRILLIC CAPITAL A is a 0xd090 in UTF-8

--- a/apps/openmw/mwgui/journalbooks.hpp
+++ b/apps/openmw/mwgui/journalbooks.hpp
@@ -22,14 +22,15 @@ namespace MWGui
         Book createTopicBook (uintptr_t topicId);
         Book createTopicBook (const std::string& topicId);
         Book createQuestBook (const std::string& questName);
-        Book createTopicIndexBook (int& columnsCount);
+        Book createTopicIndexBook ();
 
         ToUTF8::FromType mEncoding;
+        int mIndexPagesCount;
 
     private:
         BookTypesetter::Ptr createTypesetter ();
-        BookTypesetter::Ptr createLatinJournalIndex (int& columnsCount);
-        BookTypesetter::Ptr createCyrillicJournalIndex (int& columnsCount);
+        BookTypesetter::Ptr createLatinJournalIndex ();
+        BookTypesetter::Ptr createCyrillicJournalIndex ();
     };
 }
 

--- a/apps/openmw/mwgui/journalbooks.hpp
+++ b/apps/openmw/mwgui/journalbooks.hpp
@@ -22,14 +22,14 @@ namespace MWGui
         Book createTopicBook (uintptr_t topicId);
         Book createTopicBook (const std::string& topicId);
         Book createQuestBook (const std::string& questName);
-        Book createTopicIndexBook ();
+        Book createTopicIndexBook (int& columnsCount);
 
         ToUTF8::FromType mEncoding;
 
     private:
         BookTypesetter::Ptr createTypesetter ();
-        BookTypesetter::Ptr createLatinJournalIndex ();
-        BookTypesetter::Ptr createCyrillicJournalIndex ();
+        BookTypesetter::Ptr createLatinJournalIndex (int& columnsCount);
+        BookTypesetter::Ptr createCyrillicJournalIndex (int& columnsCount);
     };
 }
 

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -43,6 +43,7 @@ namespace
     static char const LeftBookPage [] = "LeftBookPage";
     static char const RightBookPage [] = "RightBookPage";
     static char const LeftTopicIndex [] = "LeftTopicIndex";
+    static char const CenterTopicIndex [] = "CenterTopicIndex";
     static char const RightTopicIndex [] = "RightTopicIndex";
 
     struct JournalWindowImpl : MWGui::JournalBooks, MWGui::JournalWindow
@@ -148,6 +149,7 @@ namespace
                 callback = std::bind(&JournalWindowImpl::notifyIndexLinkClicked, this, std::placeholders::_1);
 
                 getPage (LeftTopicIndex)->adviseLinkClicked (callback);
+                getPage (CenterTopicIndex)->adviseLinkClicked (callback);
                 getPage (RightTopicIndex)->adviseLinkClicked (callback);
             }
 
@@ -312,6 +314,7 @@ namespace
             setVisible (TopicsList, false);
             setVisible (QuestsList, mQuestMode);
             setVisible (LeftTopicIndex, !mQuestMode);
+            setVisible (CenterTopicIndex, !mQuestMode);
             setVisible (RightTopicIndex, !mQuestMode);
             setVisible (ShowAllBTN, mQuestMode && !mAllQuests);
             setVisible (ShowActiveBTN, mQuestMode && mAllQuests);
@@ -462,11 +465,21 @@ namespace
         {
             setOptionsMode ();
 
+            int pagesCount;
             if (!mTopicIndexBook)
-                mTopicIndexBook = createTopicIndexBook ();
+                mTopicIndexBook = createTopicIndexBook (pagesCount);
 
-            getPage (LeftTopicIndex)->showPage (mTopicIndexBook, 0);
-            getPage (RightTopicIndex)->showPage (mTopicIndexBook, 1);
+            if (pagesCount == 3)
+            {
+                getPage (LeftTopicIndex)->showPage (mTopicIndexBook, 0);
+                getPage (CenterTopicIndex)->showPage (mTopicIndexBook, 1);
+                getPage (RightTopicIndex)->showPage (mTopicIndexBook, 2);
+            }
+            else
+            {
+                getPage (LeftTopicIndex)->showPage (mTopicIndexBook, 0);
+                getPage (RightTopicIndex)->showPage (mTopicIndexBook, 1);
+            }
         }
 
         void notifyJournal(MyGUI::Widget* _sender)
@@ -480,6 +493,7 @@ namespace
         void notifyIndexLinkClicked (MWGui::TypesetBook::InteractiveId index)
         {
             setVisible (LeftTopicIndex, false);
+            setVisible (CenterTopicIndex, false);
             setVisible (RightTopicIndex, false);
             setVisible (TopicsList, true);
 
@@ -502,6 +516,7 @@ namespace
             mQuestMode = false;
             mTopicsMode = false;
             setVisible (LeftTopicIndex, true);
+            setVisible (CenterTopicIndex, true);
             setVisible (RightTopicIndex, true);
             setVisible (TopicsList, false);
             setVisible (QuestsList, false);
@@ -540,6 +555,7 @@ namespace
             mQuestMode = true;
 
             setVisible (LeftTopicIndex, false);
+            setVisible (CenterTopicIndex, true);
             setVisible (RightTopicIndex, false);
             setVisible (TopicsList, false);
             setVisible (QuestsList, true);

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -465,11 +465,10 @@ namespace
         {
             setOptionsMode ();
 
-            int pagesCount;
             if (!mTopicIndexBook)
-                mTopicIndexBook = createTopicIndexBook (pagesCount);
+                mTopicIndexBook = createTopicIndexBook ();
 
-            if (pagesCount == 3)
+            if (mIndexPagesCount == 3)
             {
                 getPage (LeftTopicIndex)->showPage (mTopicIndexBook, 0);
                 getPage (CenterTopicIndex)->showPage (mTopicIndexBook, 1);

--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -20,8 +20,6 @@
 
 namespace MWGui
 {
-const int MerchantRepair::sLineHeight = 18;
-
 MerchantRepair::MerchantRepair()
     : WindowBase("openmw_merchantrepair.layout")
 {
@@ -39,6 +37,7 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
     while (mList->getChildCount())
         MyGUI::Gui::getInstance().destroyWidget(mList->getChildAt(0));
 
+    int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
     int currentY = 0;
 
     MWWorld::Ptr player = MWMechanics::getPlayer();
@@ -67,28 +66,26 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
 
             int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mActor, x, true);
 
-
             std::string name = iter->getClass().getName(*iter)
                     + " - " + MyGUI::utility::toString(price)
                     + MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
                     .find("sgp")->mValue.getString();
-
 
             MyGUI::Button* button =
                 mList->createWidget<MyGUI::Button>(price <= playerGold ? "SandTextButton" : "SandTextButtonDisabled", // can't use setEnabled since that removes tooltip
                     0,
                     currentY,
                     0,
-                    sLineHeight,
+                    lineHeight,
                     MyGUI::Align::Default
                 );
 
-            currentY += sLineHeight;
+            currentY += lineHeight;
 
             button->setUserString("Price", MyGUI::utility::toString(price));
             button->setUserData(MWWorld::Ptr(*iter));
             button->setCaptionWithReplacing(name);
-            button->setSize(mList->getWidth(),sLineHeight);
+            button->setSize(mList->getWidth(), lineHeight);
             button->eventMouseWheel += MyGUI::newDelegate(this, &MerchantRepair::onMouseWheel);
             button->setUserString("ToolTipType", "ItemPtr");
             button->eventMouseButtonClick += MyGUI::newDelegate(this, &MerchantRepair::onRepairButtonClick);

--- a/apps/openmw/mwgui/merchantrepair.hpp
+++ b/apps/openmw/mwgui/merchantrepair.hpp
@@ -27,8 +27,6 @@ protected:
     void onMouseWheel(MyGUI::Widget* _sender, int _rel);
     void onRepairButtonClick(MyGUI::Widget* sender);
     void onOkButtonClick(MyGUI::Widget* sender);
-
-    static const int sLineHeight;
 };
 
 }

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -26,9 +26,6 @@ namespace
 
 namespace MWGui
 {
-
-    const int ReviewDialog::sLineHeight = 18;
-
     ReviewDialog::ReviewDialog()
         : WindowModal("openmw_chargen_review.layout"),
           mUpdateSkillArea(false)
@@ -261,8 +258,9 @@ namespace MWGui
         groupWidget->setCaption(label);
         mSkillWidgets.push_back(groupWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
     }
 
     MyGUI::TextBox* ReviewDialog::addValueItem(const std::string& text, const std::string &value, const std::string& state, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2)
@@ -282,8 +280,9 @@ namespace MWGui
         mSkillWidgets.push_back(skillNameWidget);
         mSkillWidgets.push_back(skillValueWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
 
         return skillValueWidget;
     }
@@ -298,8 +297,9 @@ namespace MWGui
 
         mSkillWidgets.push_back(skillNameWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
     }
 
     void ReviewDialog::addItem(const ESM::Spell* spell, MyGUI::IntCoord& coord1, MyGUI::IntCoord& coord2)
@@ -312,8 +312,9 @@ namespace MWGui
 
         mSkillWidgets.push_back(widget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
     }
 
     void ReviewDialog::addSkills(const SkillList &skills, const std::string &titleId, const std::string &titleDefault, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2)

--- a/apps/openmw/mwgui/review.hpp
+++ b/apps/openmw/mwgui/review.hpp
@@ -87,8 +87,6 @@ namespace MWGui
         void addItem(const ESM::Spell* spell, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2);
         void updateSkillArea();
 
-        static const int sLineHeight;
-
         MyGUI::TextBox *mNameWidget, *mRaceWidget, *mClassWidget, *mBirthSignWidget;
         MyGUI::ScrollView* mSkillView;
 

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -18,8 +18,6 @@
 
 namespace MWGui
 {
-    const int SpellBuyingWindow::sLineHeight = 18;
-
     SpellBuyingWindow::SpellBuyingWindow() :
         WindowBase("openmw_spell_buying_window.layout")
         , mCurrentY(0)
@@ -52,21 +50,23 @@ namespace MWGui
 
         // TODO: refactor to use MyGUI::ListBox
 
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+
         MyGUI::Button* toAdd =
             mSpellsView->createWidget<MyGUI::Button>(
                 price <= playerGold ? "SandTextButton" : "SandTextButtonDisabled", // can't use setEnabled since that removes tooltip
                 0,
                 mCurrentY,
                 200,
-                sLineHeight,
+                lineHeight,
                 MyGUI::Align::Default
             );
 
-        mCurrentY += sLineHeight;
+        mCurrentY += lineHeight;
 
         toAdd->setUserData(price);
         toAdd->setCaptionWithReplacing(spell.mName+"   -   "+MyGUI::utility::toString(price)+"#{sgp}");
-        toAdd->setSize(mSpellsView->getWidth(),sLineHeight);
+        toAdd->setSize(mSpellsView->getWidth(), lineHeight);
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &SpellBuyingWindow::onMouseWheel);
         toAdd->setUserString("ToolTipType", "Spell");
         toAdd->setUserString("Spell", spell.mId);

--- a/apps/openmw/mwgui/spellbuyingwindow.hpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.hpp
@@ -48,8 +48,6 @@ namespace MWGui
             void clearSpells();
             int mCurrentY;
 
-            static const int sLineHeight;
-
             void updateLabels();
 
             virtual void onReferenceUnavailable();

--- a/apps/openmw/mwgui/spellview.cpp
+++ b/apps/openmw/mwgui/spellview.cpp
@@ -6,6 +6,7 @@
 #include <MyGUI_Gui.h>
 
 #include <components/widgets/sharedstatebutton.hpp>
+#include <components/widgets/box.hpp>
 
 #include "tooltips.hpp"
 
@@ -240,7 +241,7 @@ namespace MWGui
             mLines.push_back(LineInfo(separator, (MyGUI::Widget*)NULL, NoSpellIndex));
         }
 
-        MyGUI::TextBox* groupWidget = mScrollView->createWidget<MyGUI::TextBox>("SandBrightText",
+        MyGUI::TextBox* groupWidget = mScrollView->createWidget<Gui::TextBox>("SandBrightText",
             MyGUI::IntCoord(0, 0, mScrollView->getWidth(), 24),
             MyGUI::Align::Left | MyGUI::Align::Top);
         groupWidget->setCaptionWithReplacing(label);
@@ -249,7 +250,7 @@ namespace MWGui
 
         if (label2 != "")
         {
-            MyGUI::TextBox* groupWidget2 = mScrollView->createWidget<MyGUI::TextBox>("SandBrightText",
+            MyGUI::TextBox* groupWidget2 = mScrollView->createWidget<Gui::TextBox>("SandBrightText",
                 MyGUI::IntCoord(0, 0, mScrollView->getWidth(), 24),
                 MyGUI::Align::Left | MyGUI::Align::Top);
             groupWidget2->setCaptionWithReplacing(label2);

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -23,9 +23,6 @@
 
 namespace MWGui
 {
-
-    const int StatsWindow::sLineHeight = 18;
-
     StatsWindow::StatsWindow (DragAndDrop* drag)
       : WindowPinnableBase("openmw_stats_window.layout")
       , NoDrop(drag, mMainWidget)
@@ -376,8 +373,9 @@ namespace MWGui
         groupWidget->eventMouseWheel += MyGUI::newDelegate(this, &StatsWindow::onMouseWheel);
         mSkillWidgets.push_back(groupWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
     }
 
     std::pair<MyGUI::TextBox*, MyGUI::TextBox*> StatsWindow::addValueItem(const std::string& text, const std::string &value, const std::string& state, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2)
@@ -401,8 +399,9 @@ namespace MWGui
         mSkillWidgets.push_back(skillNameWidget);
         mSkillWidgets.push_back(skillValueWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
 
         return std::make_pair(skillNameWidget, skillValueWidget);
     }
@@ -421,8 +420,9 @@ namespace MWGui
 
         mSkillWidgets.push_back(skillNameWidget);
 
-        coord1.top += sLineHeight;
-        coord2.top += sLineHeight;
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+        coord1.top += lineHeight;
+        coord2.top += lineHeight;
 
         return skillNameWidget;
     }

--- a/apps/openmw/mwgui/statswindow.hpp
+++ b/apps/openmw/mwgui/statswindow.hpp
@@ -53,8 +53,6 @@ namespace MWGui
             void onWindowResize(MyGUI::Window* window);
             void onMouseWheel(MyGUI::Widget* _sender, int _rel);
 
-            static const int sLineHeight;
-
             MyGUI::Widget* mLeftPane;
             MyGUI::Widget* mRightPane;
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -8,6 +8,7 @@
 #include <MyGUI_ImageBox.h>
 
 #include <components/settings/settings.hpp>
+#include <components/widgets/box.hpp>
 
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
@@ -421,7 +422,7 @@ namespace MWGui
 
         std::string realImage = MWBase::Environment::get().getWindowManager()->correctIconPath(image);
 
-        MyGUI::EditBox* captionWidget = mDynamicToolTipBox->createWidget<MyGUI::EditBox>("NormalText", MyGUI::IntCoord(0, 0, 300, 300), MyGUI::Align::Left | MyGUI::Align::Top, "ToolTipCaption");
+        Gui::EditBox* captionWidget = mDynamicToolTipBox->createWidget<Gui::EditBox>("NormalText", MyGUI::IntCoord(0, 0, 300, 300), MyGUI::Align::Left | MyGUI::Align::Top, "ToolTipCaption");
         captionWidget->setEditStatic(true);
         captionWidget->setNeedKeyFocus(false);
         captionWidget->setCaptionWithReplacing(caption);
@@ -429,7 +430,7 @@ namespace MWGui
 
         int captionHeight = std::max(caption != "" ? captionSize.height : 0, imageSize);
 
-        MyGUI::EditBox* textWidget = mDynamicToolTipBox->createWidget<MyGUI::EditBox>("SandText", MyGUI::IntCoord(0, captionHeight+imageCaptionVPadding, 300, 300-captionHeight-imageCaptionVPadding), MyGUI::Align::Stretch, "ToolTipText");
+        Gui::EditBox* textWidget = mDynamicToolTipBox->createWidget<Gui::EditBox>("SandText", MyGUI::IntCoord(0, captionHeight+imageCaptionVPadding, 300, 300-captionHeight-imageCaptionVPadding), MyGUI::Align::Stretch, "ToolTipText");
         textWidget->setEditStatic(true);
         textWidget->setEditMultiLine(true);
         textWidget->setEditWordWrap(info.wordWrap);
@@ -447,7 +448,7 @@ namespace MWGui
             MyGUI::ImageBox* icon = mDynamicToolTipBox->createWidget<MyGUI::ImageBox>("MarkerButton",
                 MyGUI::IntCoord(padding.left, totalSize.height+padding.top, 8, 8), MyGUI::Align::Default);
             icon->setColour(MyGUI::Colour(1.0f, 0.3f, 0.3f));
-            MyGUI::EditBox* edit = mDynamicToolTipBox->createWidget<MyGUI::EditBox>("SandText",
+            Gui::EditBox* edit = mDynamicToolTipBox->createWidget<Gui::EditBox>("SandText",
                 MyGUI::IntCoord(padding.left+8+4, totalSize.height+padding.top, 300-padding.left-8-4, 300-totalSize.height),
                                                                                     MyGUI::Align::Default);
             edit->setEditMultiLine(true);

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -22,8 +22,6 @@
 
 namespace MWGui
 {
-    const int TravelWindow::sLineHeight = 18;
-
     TravelWindow::TravelWindow() :
         WindowBase("openmw_travel_window.layout")
         , mCurrentY(0)
@@ -79,9 +77,11 @@ namespace MWGui
         else
             price *= std::max(1, static_cast<int>(followers.size()));
 
-        MyGUI::Button* toAdd = mDestinationsView->createWidget<MyGUI::Button>("SandTextButton", 0, mCurrentY, 200, sLineHeight, MyGUI::Align::Default);
+        int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
+
+        MyGUI::Button* toAdd = mDestinationsView->createWidget<MyGUI::Button>("SandTextButton", 0, mCurrentY, 200, lineHeight, MyGUI::Align::Default);
         toAdd->setEnabled(price <= playerGold);
-        mCurrentY += sLineHeight;
+        mCurrentY += lineHeight;
         if(interior)
             toAdd->setUserString("interior","y");
         else
@@ -92,7 +92,7 @@ namespace MWGui
         toAdd->setUserString("price",oss.str());
 
         toAdd->setCaptionWithReplacing("#{sCell=" + name + "}   -   " + MyGUI::utility::toString(price)+"#{sgp}");
-        toAdd->setSize(mDestinationsView->getWidth(),sLineHeight);
+        toAdd->setSize(mDestinationsView->getWidth(),lineHeight);
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &TravelWindow::onMouseWheel);
         toAdd->setUserString("Destination", name);
         toAdd->setUserData(pos);

--- a/apps/openmw/mwgui/travelwindow.hpp
+++ b/apps/openmw/mwgui/travelwindow.hpp
@@ -41,8 +41,6 @@ namespace MWGui
             void clearDestinations();
             int mCurrentY;
 
-            static const int sLineHeight;
-
             void updateLabels();
 
             virtual void onReferenceUnavailable();

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -309,7 +309,7 @@ namespace MWGui
                 // to allow to configure font size via config file, without need to edit XML file.
                 // Also we should take UI scaling factor in account
                 int resolution = Settings::Manager::getInt("ttf resolution", "GUI");
-                resolution = std::max(0, resolution);
+                resolution = std::min(960, std::max(48, resolution));
 
                 float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -38,6 +38,7 @@
 #include <components/translation/translation.hpp>
 
 #include <components/myguiplatform/myguiplatform.hpp>
+#include <components/myguiplatform/myguidatamanager.hpp>
 #include <components/myguiplatform/myguirendermanager.hpp>
 #include <components/myguiplatform/additivelayer.hpp>
 #include <components/myguiplatform/scalinglayer.hpp>
@@ -131,8 +132,8 @@ namespace MWGui
 
     WindowManager::WindowManager(
             osgViewer::Viewer* viewer, osg::Group* guiRoot, Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
-            const std::string& logpath, const std::string& resourcePath, bool consoleOnlyScripts,
-            Translation::Storage& translationDataStorage, ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string, std::string>& fallbackMap, const std::string& versionDescription)
+            const std::string& logpath, const std::string& resourcePath, bool consoleOnlyScripts, Translation::Storage& translationDataStorage,
+            ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string, std::string>& fallbackMap, const std::string& versionDescription, const std::string& userDataPath)
       : mStore(NULL)
       , mResourceSystem(resourceSystem)
       , mWorkQueue(workQueue)
@@ -210,8 +211,8 @@ namespace MWGui
         MyGUI::LanguageManager::getInstance().eventRequestTag = MyGUI::newDelegate(this, &WindowManager::onRetrieveTag);
 
         // Load fonts
-        mFontLoader.reset(new Gui::FontLoader(encoding, resourceSystem->getVFS()));
-        mFontLoader->loadAllFonts(exportFonts);
+        mFontLoader.reset(new Gui::FontLoader(encoding, resourceSystem->getVFS(), userDataPath));
+        mFontLoader->loadBitmapFonts(exportFonts);
 
         //Register own widgets with MyGUI
         MyGUI::FactoryManager::getInstance().registerFactory<MWGui::Widgets::MWSkill>("Widget");
@@ -245,6 +246,7 @@ namespace MWGui
 
         MyGUI::FactoryManager::getInstance().registerFactory<ResourceImageSetPointerFix>("Resource", "ResourceImageSetPointer");
         MyGUI::ResourceManager::getInstance().load("core.xml");
+        loadUserFonts();
 
         bool keyboardNav = Settings::Manager::getBool("keyboard navigation", "GUI");
         mKeyboardNavigation.reset(new KeyboardNavigation());
@@ -377,6 +379,11 @@ namespace MWGui
 
             MyGUI::ResourceManager::getInstance().loadFromXmlNode(copy, _file, _version);
         }
+    }
+
+    void WindowManager::loadUserFonts()
+    {
+        mFontLoader->loadTrueTypeFonts();
     }
 
     void WindowManager::initUI()

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -246,6 +246,7 @@ namespace MWGui
     virtual const MWWorld::Ptr& getSelectedEnchantItem() const;
     virtual void setSelectedWeapon(const MWWorld::Ptr& item);
     virtual const MWWorld::Ptr& getSelectedWeapon() const;
+    virtual int getFontHeight() const;
     virtual void unsetSelectedSpell();
     virtual void unsetSelectedWeapon();
 
@@ -401,6 +402,8 @@ namespace MWGui
     MWWorld::Ptr mSelectedEnchantItem;
     MWWorld::Ptr mSelectedWeapon;
 
+    void loadFontDelegate(MyGUI::xml::ElementPtr _node, const std::string& _file, MyGUI::Version _version);
+
     std::vector<WindowModal*> mCurrentModals;
 
     // Markers placed manually by the player. Must be shared between both map views (the HUD map and the map window).
@@ -512,6 +515,8 @@ namespace MWGui
     int mShowOwned;
 
     ToUTF8::FromType mEncoding;
+
+    int mFontHeight;
 
     std::string mVersionDescription;
 

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -131,14 +131,15 @@ namespace MWGui
     typedef std::vector<Faction> FactionList;
 
     WindowManager(osgViewer::Viewer* viewer, osg::Group* guiRoot, Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
-                  const std::string& logpath, const std::string& cacheDir, bool consoleOnlyScripts,
-                  Translation::Storage& translationDataStorage, ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string,std::string>& fallbackMap, const std::string& versionDescription);
+                  const std::string& logpath, const std::string& cacheDir, bool consoleOnlyScripts, Translation::Storage& translationDataStorage,
+                  ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string,std::string>& fallbackMap, const std::string& versionDescription, const std::string& localPath);
     virtual ~WindowManager();
 
     /// Set the ESMStore to use for retrieving of GUI-related strings.
     void setStore (const MWWorld::ESMStore& store);
 
     void initUI();
+    virtual void loadUserFonts();
 
     virtual Loading::Listener* getLoadingScreen();
 

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -676,6 +676,9 @@ namespace MWInput
                                         Settings::Manager::getInt("resolution y", "Video"),
                                         Settings::Manager::getBool("fullscreen", "Video"),
                                         Settings::Manager::getBool("window border", "Video"));
+
+            // We should reload TrueType fonts to fit new resolution
+            MWBase::Environment::get().getWindowManager()->loadUserFonts();
         }
     }
 

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -76,6 +76,11 @@ LocalMap::LocalMap(osg::Group* root)
     , mAngle(0.f)
     , mInterior(false)
 {
+    // Increase map resolution, if use UI scaling
+    float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
+    if (uiScale > 1.0)
+        mMapResolution *= uiScale;
+
     SceneUtil::FindByNameVisitor find("Scene Root");
     mRoot->accept(find);
     mSceneRoot = find.mFoundNode;

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -130,7 +130,7 @@ add_component_dir (myguiplatform
     )
 
 add_component_dir (widgets
-    box imagebutton tags list numericeditbox sharedstatebutton windowcaption widgets
+    box fontwrapper imagebutton tags list numericeditbox sharedstatebutton windowcaption widgets
     )
 
 add_component_dir (fontloader

--- a/components/fontloader/fontloader.cpp
+++ b/components/fontloader/fontloader.cpp
@@ -145,8 +145,9 @@ namespace
 namespace Gui
 {
 
-    FontLoader::FontLoader(ToUTF8::FromType encoding, const VFS::Manager* vfs)
+    FontLoader::FontLoader(ToUTF8::FromType encoding, const VFS::Manager* vfs, const std::string& userDataPath)
         : mVFS(vfs)
+        , mUserDataPath(userDataPath)
     {
         if (encoding == ToUTF8::WINDOWS_1252)
             mEncoding = ToUTF8::CP437;
@@ -175,7 +176,7 @@ namespace Gui
         mFonts.clear();
     }
 
-    void FontLoader::loadAllFonts(bool exportToFile)
+    void FontLoader::loadBitmapFonts(bool exportToFile)
     {
         const std::map<std::string, VFS::File*>& index = mVFS->getIndex();
 
@@ -196,6 +197,25 @@ namespace Gui
                 break;
             ++found;
         }
+    }
+
+    void FontLoader::loadTrueTypeFonts()
+    {
+        osgMyGUI::DataManager* dataManager = dynamic_cast<osgMyGUI::DataManager*>(&osgMyGUI::DataManager::getInstance());
+        if (!dataManager)
+        {
+            Log(Debug::Error) << "Can not load TrueType fonts: osgMyGUI::DataManager is not available.";
+            return;
+        }
+
+        const std::string cfg = dataManager->getDataPath("");
+        const std::string fontFile = mUserDataPath + "/" + "Fonts" + "/" + "openmw_font.xml";
+        if (!boost::filesystem::exists(fontFile))
+            return;
+
+        dataManager->setResourcePath(mUserDataPath + "/" + "Fonts");
+        MyGUI::ResourceManager::getInstance().load("openmw_font.xml");
+        dataManager->setResourcePath(cfg);
     }
 
 

--- a/components/fontloader/fontloader.cpp
+++ b/components/fontloader/fontloader.cpp
@@ -480,6 +480,14 @@ namespace Gui
 
         font->deserialization(root, MyGUI::Version(3,2,0));
 
+        // Setup "book" version of font as fallback if we will not use TrueType fonts
+        MyGUI::ResourceManualFont* bookFont = static_cast<MyGUI::ResourceManualFont*>(
+                    MyGUI::FactoryManager::getInstance().createObject("Resource", "ResourceManualFont"));
+        mFonts.push_back(bookFont);
+        bookFont->deserialization(root, MyGUI::Version(3,2,0));
+        bookFont->setResourceName("Journalbook " + resourceName);
+
+        // Remove automatically registered fonts
         for (std::vector<MyGUI::ResourceManualFont*>::iterator it = mFonts.begin(); it != mFonts.end();)
         {
             if ((*it)->getResourceName() == font->getResourceName())
@@ -487,10 +495,17 @@ namespace Gui
                 MyGUI::ResourceManager::getInstance().removeByName(font->getResourceName());
                 it = mFonts.erase(it);
             }
+            else if ((*it)->getResourceName() == bookFont->getResourceName())
+            {
+                MyGUI::ResourceManager::getInstance().removeByName(bookFont->getResourceName());
+                it = mFonts.erase(it);
+            }
             else
                 ++it;
         }
+
         MyGUI::ResourceManager::getInstance().addResource(font);
+        MyGUI::ResourceManager::getInstance().addResource(bookFont);
     }
 
 }

--- a/components/fontloader/fontloader.hpp
+++ b/components/fontloader/fontloader.hpp
@@ -1,6 +1,9 @@
 #ifndef OPENMW_COMPONENTS_FONTLOADER_H
 #define OPENMW_COMPONENTS_FONTLOADER_H
 
+#include "boost/filesystem/operations.hpp"
+
+#include <components/myguiplatform/myguidatamanager.hpp>
 #include <components/to_utf8/to_utf8.hpp>
 
 namespace VFS
@@ -23,15 +26,17 @@ namespace Gui
     class FontLoader
     {
     public:
-        FontLoader (ToUTF8::FromType encoding, const VFS::Manager* vfs);
+        FontLoader (ToUTF8::FromType encoding, const VFS::Manager* vfs, const std::string& userDataPath);
         ~FontLoader();
 
         /// @param exportToFile export the converted fonts (Images and XML with glyph metrics) to files?
-        void loadAllFonts (bool exportToFile);
+        void loadBitmapFonts (bool exportToFile);
+        void loadTrueTypeFonts ();
 
     private:
         ToUTF8::FromType mEncoding;
         const VFS::Manager* mVFS;
+        std::string mUserDataPath;
 
         std::vector<MyGUI::ITexture*> mTextures;
         std::vector<MyGUI::ResourceManualFont*> mFonts;

--- a/components/sdlutil/sdlvideowrapper.cpp
+++ b/components/sdlutil/sdlvideowrapper.cpp
@@ -2,6 +2,8 @@
 
 #include <components/debug/debuglog.hpp>
 
+#include <MyGUI_ResourceManager.h>
+
 #include <osgViewer/Viewer>
 
 #include <SDL_video.h>
@@ -89,6 +91,9 @@ namespace SDLUtil
             SDL_SetWindowSize(mWindow, width, height);
             SDL_SetWindowBordered(mWindow, windowBorder ? SDL_TRUE : SDL_FALSE);
         }
+
+        // We should reload TrueType fonts for new resolution
+        MyGUI::ResourceManager::getInstance().load("openmw_font.xml");
     }
 
 }

--- a/components/sdlutil/sdlvideowrapper.cpp
+++ b/components/sdlutil/sdlvideowrapper.cpp
@@ -2,8 +2,6 @@
 
 #include <components/debug/debuglog.hpp>
 
-#include <MyGUI_ResourceManager.h>
-
 #include <osgViewer/Viewer>
 
 #include <SDL_video.h>
@@ -91,9 +89,6 @@ namespace SDLUtil
             SDL_SetWindowSize(mWindow, width, height);
             SDL_SetWindowBordered(mWindow, windowBorder ? SDL_TRUE : SDL_FALSE);
         }
-
-        // We should reload TrueType fonts for new resolution
-        MyGUI::ResourceManager::getInstance().load("openmw_font.xml");
     }
 
 }

--- a/components/widgets/box.cpp
+++ b/components/widgets/box.cpp
@@ -48,7 +48,7 @@ namespace Gui
         }
         else
         {
-            TextBox::setPropertyOverride (_key, _value);
+            Gui::TextBox::setPropertyOverride (_key, _value);
         }
     }
 
@@ -81,10 +81,9 @@ namespace Gui
         }
         else
         {
-            EditBox::setPropertyOverride (_key, _value);
+            Gui::EditBox::setPropertyOverride (_key, _value);
         }
     }
-
 
     MyGUI::IntSize AutoSizedButton::getRequestedSize()
     {
@@ -111,16 +110,14 @@ namespace Gui
         }
         else
         {
-            Button::setPropertyOverride (_key, _value);
+            Gui::Button::setPropertyOverride (_key, _value);
         }
     }
-
     Box::Box()
         : mSpacing(4)
         , mPadding(0)
         , mAutoResize(false)
     {
-
     }
 
     void Box::notifyChildrenSizeChanged ()

--- a/components/widgets/box.hpp
+++ b/components/widgets/box.hpp
@@ -4,10 +4,27 @@
 #include <MyGUI_Widget.h>
 #include <MyGUI_TextBox.h>
 #include <MyGUI_EditBox.h>
+#include <MyGUI_ListBox.h>
 #include <MyGUI_Button.h>
+
+#include "fontwrapper.hpp"
 
 namespace Gui
 {
+    class Button : public FontWrapper<MyGUI::Button>
+    {
+        MYGUI_RTTI_DERIVED( Button )
+    };
+
+    class TextBox : public FontWrapper<MyGUI::TextBox>
+    {
+        MYGUI_RTTI_DERIVED( TextBox )
+    };
+
+    class EditBox : public FontWrapper<MyGUI::EditBox>
+    {
+        MYGUI_RTTI_DERIVED( EditBox )
+    };
 
     class AutoSizedWidget
     {
@@ -22,7 +39,7 @@ namespace Gui
         MyGUI::Align mExpandDirection;
     };
 
-    class AutoSizedTextBox : public AutoSizedWidget, public MyGUI::TextBox
+    class AutoSizedTextBox : public AutoSizedWidget, public TextBox
     {
         MYGUI_RTTI_DERIVED( AutoSizedTextBox )
 
@@ -32,9 +49,10 @@ namespace Gui
 
     protected:
         virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        std::string mFontSize;
     };
 
-    class AutoSizedEditBox : public AutoSizedWidget, public MyGUI::EditBox
+    class AutoSizedEditBox : public AutoSizedWidget, public EditBox
     {
         MYGUI_RTTI_DERIVED( AutoSizedEditBox )
 
@@ -47,9 +65,10 @@ namespace Gui
 
     protected:
         virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        std::string mFontSize;
     };
 
-    class AutoSizedButton : public AutoSizedWidget, public MyGUI::Button
+    class AutoSizedButton : public AutoSizedWidget, public Button
     {
         MYGUI_RTTI_DERIVED( AutoSizedButton )
 
@@ -59,6 +78,7 @@ namespace Gui
 
     protected:
         virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        std::string mFontSize;
     };
 
     /**

--- a/components/widgets/fontwrapper.hpp
+++ b/components/widgets/fontwrapper.hpp
@@ -1,0 +1,45 @@
+#ifndef OPENMW_WIDGETS_WRAPPER_H
+#define OPENMW_WIDGETS_WRAPPER_H
+
+#include "widgets.hpp"
+
+#include <components/settings/settings.hpp>
+
+namespace Gui
+{
+    template<class T>
+    class FontWrapper : public T
+    {
+    public:
+        virtual void setFontName(const std::string& name)
+        {
+            T::setFontName(name);
+            T::setPropertyOverride ("FontHeight", mFontSize);
+        }
+
+    protected:
+        FontWrapper()
+        {
+            // Note: we can not use the WindowManager here, so there is a code duplication a bit.
+            int fontSize = Settings::Manager::getInt("font size", "GUI");
+            fontSize = std::min(std::max(12, fontSize), 20);
+            mFontSize = std::to_string(fontSize);
+        }
+
+        virtual void setPropertyOverride(const std::string& _key, const std::string& _value)
+        {
+            T::setPropertyOverride (_key, _value);
+
+            // There is a bug in MyGUI: when it initializes the FontName property, it reset the font height.
+            // We should restore it.
+            if (_key == "FontName")
+            {
+                T::setPropertyOverride ("FontHeight", mFontSize);
+            }
+        }
+
+        std::string mFontSize;
+    };
+}
+
+#endif

--- a/components/widgets/numericeditbox.hpp
+++ b/components/widgets/numericeditbox.hpp
@@ -3,13 +3,15 @@
 
 #include <MyGUI_EditBox.h>
 
+#include "fontwrapper.hpp"
+
 namespace Gui
 {
 
     /**
      * @brief A variant of the EditBox that only allows integer inputs
      */
-    class NumericEditBox : public MyGUI::EditBox
+    class NumericEditBox : public FontWrapper<MyGUI::EditBox>
     {
         MYGUI_RTTI_DERIVED(NumericEditBox)
 
@@ -17,7 +19,8 @@ namespace Gui
         NumericEditBox()
             : mValue(0), mMinValue(std::numeric_limits<int>::min()),
             mMaxValue(std::numeric_limits<int>::max())
-        {}
+        {
+        }
 
         void initialiseOverride();
         void shutdownOverride();

--- a/components/widgets/sharedstatebutton.cpp
+++ b/components/widgets/sharedstatebutton.cpp
@@ -7,7 +7,6 @@ namespace Gui
         : mIsMousePressed(false)
         , mIsMouseFocus(false)
     {
-
     }
 
     void SharedStateButton::shutdownOverride()

--- a/components/widgets/sharedstatebutton.hpp
+++ b/components/widgets/sharedstatebutton.hpp
@@ -3,6 +3,8 @@
 
 #include <MyGUI_Button.h>
 
+#include "fontwrapper.hpp"
+
 namespace Gui
 {
 
@@ -11,7 +13,7 @@ namespace Gui
     typedef std::vector<SharedStateButton*> ButtonGroup;
 
     /// @brief A button that applies its own state changes to other widgets, to do this you define it as part of a ButtonGroup.
-    class SharedStateButton : public MyGUI::Button
+    class SharedStateButton : public FontWrapper<MyGUI::Button>
     {
     MYGUI_RTTI_DERIVED(SharedStateButton)
 

--- a/components/widgets/widgets.cpp
+++ b/components/widgets/widgets.cpp
@@ -18,9 +18,12 @@ namespace Gui
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::HBox>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::Spacer>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::VBox>("Widget");
+        MyGUI::FactoryManager::getInstance().registerFactory<Gui::EditBox>("Widget");
+        MyGUI::FactoryManager::getInstance().registerFactory<Gui::TextBox>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::AutoSizedTextBox>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::AutoSizedEditBox>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::AutoSizedButton>("Widget");
+        MyGUI::FactoryManager::getInstance().registerFactory<Gui::Button>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::ImageButton>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::NumericEditBox>("Widget");
         MyGUI::FactoryManager::getInstance().registerFactory<Gui::SharedStateButton>("Widget");

--- a/components/widgets/widgets.hpp
+++ b/components/widgets/widgets.hpp
@@ -1,9 +1,10 @@
 #ifndef OPENMW_COMPONENTS_WIDGETS_H
 #define OPENMW_COMPONENTS_WIDGETS_H
 
+extern int GuiFontHeight;
+
 namespace Gui
 {
-
     /// Register all widgets from this component with MyGUI's factory manager.
     void registerAllWidgets();
 

--- a/docs/source/reference/modding/settings/GUI.rst
+++ b/docs/source/reference/modding/settings/GUI.rst
@@ -12,6 +12,27 @@ This setting scales the GUI interface windows.
 A value of 1.0 results in the normal scale. Larger values are useful to increase the scale of the GUI for high resolution displays.
 This setting can only be configured by editing the settings configuration file.
 
+font size
+---------
+
+:Type:		integer
+:Range:		12 to 20
+:Default:	16
+
+Allows to specify glyph size for in-game fonts.
+Note: default bitmap fonts are supposed to work with 16px size, otherwise glyphs will be blurry.
+TrueType fonts do not have this issue.
+
+ttf resolution
+--------------
+
+:Type:		integer
+:Range:		> 0
+:Default:	96
+
+Allows to specify resolution for in-game TrueType fonts.
+Note: actual resolution depends on "scaling factor" setting value, this value is for 1.0 or lower scaling factor.
+
 menu transparency
 -----------------
 

--- a/docs/source/reference/modding/settings/GUI.rst
+++ b/docs/source/reference/modding/settings/GUI.rst
@@ -27,7 +27,7 @@ ttf resolution
 --------------
 
 :Type:		integer
-:Range:		> 0
+:Range:		48 to 960
 :Default:	96
 
 Allows to specify resolution for in-game TrueType fonts.

--- a/docs/source/reference/modding/settings/GUI.rst
+++ b/docs/source/reference/modding/settings/GUI.rst
@@ -31,7 +31,7 @@ ttf resolution
 :Default:	96
 
 Allows to specify resolution for in-game TrueType fonts.
-Note: actual resolution depends on "scaling factor" setting value, this value is for 1.0 or lower scaling factor.
+Note: actual resolution depends on "scaling factor" setting value, this value is for 1.0 scaling factor.
 
 menu transparency
 -----------------

--- a/files/mygui/core.skin
+++ b/files/mygui/core.skin
@@ -2,7 +2,6 @@
 
 <MyGUI type="Resource" version="1.1">
     <Resource type="ResourceSkin" name="TextBox" size="16 16">
-        <Property key="FontHeight" value = "16" />
         <Property key="TextAlign" value = "ALIGN_DEFAULT" />
         <Property key="TextColour" value = "0.7 0.7 0.7" />
 

--- a/files/mygui/openmw_alchemy_window.layout
+++ b/files/mygui/openmw_alchemy_window.layout
@@ -74,7 +74,7 @@
 
         <!-- Buttons -->
 
-        <Widget type="HBox" skin="" position="110 374 452 24" align="Bottom Right">
+        <Widget type="HBox" skin="" position="110 374 452 28" align="Bottom Right">
 
             <Widget type="Spacer"/>
 

--- a/files/mygui/openmw_book.layout
+++ b/files/mygui/openmw_book.layout
@@ -32,11 +32,13 @@
             </Widget>
 
             <Widget type="TextBox" skin="NormalText" position="30 358 250 16" name="LeftPageNumber">
+                <Property key="FontName" value="Journalbook Magic Cards"/>
                 <Property key="TextColour" value="0 0 0"/>
                 <Property key="TextAlign" value="Center"/>
                 <Property key="NeedMouse" value="false"/>
             </Widget>
             <Widget type="TextBox" skin="NormalText" position="310 358 250 16" name="RightPageNumber">
+                <Property key="FontName" value="Journalbook Magic Cards"/>
                 <Property key="TextColour" value="0 0 0"/>
                 <Property key="TextAlign" value="Center"/>
                 <Property key="NeedMouse" value="false"/>

--- a/files/mygui/openmw_chargen_birth.layout
+++ b/files/mygui/openmw_chargen_birth.layout
@@ -16,7 +16,7 @@
         </Widget>>
 
         <!-- Dialog buttons -->
-        <Widget type="HBox" position="0 338 511 24">
+        <Widget type="HBox" position="0 338 511 28">
             <Widget type="Spacer"/>
             <Widget type="AutoSizedButton" skin="MW_Button" name="BackButton">
                 <Property key="Caption" value="#{sBack}"/>

--- a/files/mygui/openmw_chargen_class.layout
+++ b/files/mygui/openmw_chargen_class.layout
@@ -27,11 +27,11 @@
             </Widget>
 
             <!-- Favorite Attributes -->
-            <Widget type="VBox" skin="" position="0 39 166 72" align="Stretch">
+            <Widget type="VBox" skin="" position="0 39 166 76" align="Stretch">
                 <Property key="Spacing" value="0"/>
 
                 <!-- Favorite Attributes -->
-                <Widget type="AutoSizedEditBox" skin="HeaderText" position="0 0 166 18" name="FavoriteAttributesT" align="Left Top">
+                <Widget type="AutoSizedEditBox" skin="HeaderText" position="0 0 166 22" name="FavoriteAttributesT" align="Left Top">
                     <Property key="Caption" value="#{sChooseClassMenu2}"/>
                     <Property key="TextAlign" value="Left Top"/>
                     <Property key="Static" value="true"/>
@@ -73,7 +73,7 @@
         </Widget>
 
         <!-- Dialog buttons -->
-        <Widget type="HBox" position="0 276 475 24">
+        <Widget type="HBox" position="0 276 475 28">
             <Widget type="Spacer"/>
             <Widget type="AutoSizedButton" skin="MW_Button" name="BackButton">
                 <Property key="Caption" value="#{sBack}"/>

--- a/files/mygui/openmw_chargen_create_class.layout
+++ b/files/mygui/openmw_chargen_create_class.layout
@@ -11,7 +11,7 @@
             <Property key="Caption" value="#{sCustomClassName}"/>
         </Widget>
 
-        <Widget type="Widget" skin="" position="8 38 480 110" align="Stretch">
+        <Widget type="Widget" skin="" position="8 38 480 116" align="Stretch">
 
             <!-- Specialization -->
             <Widget type="TextBox" skin="HeaderText" position="0 0 156 18" name="SpecializationT" align="Left Top">
@@ -26,7 +26,7 @@
                 <Property key="TextAlign" value="Left Top"/>
             </Widget>
 
-            <Widget type="VBox" skin="" position="0 41 166 72" align="Stretch">
+            <Widget type="VBox" skin="" position="0 41 166 76" align="Stretch">
                 <Property key="Spacing" value="0"/>
 
                 <!-- Favorite Attributes -->
@@ -74,7 +74,7 @@
         </Widget>
 
         <!-- Dialog buttons -->
-        <Widget type="HBox" position="0 158 482 24">
+        <Widget type="HBox" position="0 158 482 28">
             <Widget type="Spacer"/>
             <Widget type="AutoSizedButton" skin="MW_Button" name="DescriptionButton">
                 <Property key="Caption" value="#{sCreateClassMenu1}"/>

--- a/files/mygui/openmw_chargen_generate_class_result.layout
+++ b/files/mygui/openmw_chargen_generate_class_result.layout
@@ -24,7 +24,7 @@
         </Widget>
 
         <!-- Dialog buttons -->
-        <Widget type="HBox" position="0 216 273 24">
+        <Widget type="HBox" position="0 216 273 28">
             <Widget type="AutoSizedButton" skin="MW_Button" name="BackButton">
                 <Property key="Caption" value="#{sBack}"/>
             </Widget>

--- a/files/mygui/openmw_chargen_race.layout
+++ b/files/mygui/openmw_chargen_race.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 588 433" align="Center" name="_Main">
+    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 640 433" align="Center" name="_Main">
 
         <!-- Appearance -->
         <Widget type="TextBox" skin="HeaderText" position="8 16 241 18" name="AppearanceT" align="Left Top">
@@ -54,28 +54,28 @@
 
         <!-- Race -->
 
-        <Widget type="TextBox" skin="HeaderText" position="261 16 132 18" name="RaceT" align="Left Top">
+        <Widget type="TextBox" skin="HeaderText" position="261 16 160 18" name="RaceT" align="Left Top">
             <Property key="TextAlign" value="Left Top"/>
         </Widget>
-        <Widget type="ListBox" skin="MW_List" position="264 39 132 150" name="RaceList">
+        <Widget type="ListBox" skin="MW_List" position="264 39 160 150" name="RaceList">
         </Widget>
 
         <!-- Spell powers -->
-        <Widget type="TextBox" skin="HeaderText" position="261 210 132 18" name="SpellPowerT" align="Left Top">
+        <Widget type="TextBox" skin="HeaderText" position="261 210 160 18" name="SpellPowerT" align="Left Top">
             <Property key="TextAlign" value="Left Top"/>
         </Widget>
         <!-- Spell power sub-widgets will be placed here, no skin to make it invisible -->
-        <Widget type="Widget" skin="" position="261 230 250 140" name="SpellPowerList"/>
+        <Widget type="Widget" skin="" position="261 230 350 140" name="SpellPowerList"/>
 
         <!-- Skill bonus -->
-        <Widget type="TextBox" skin="HeaderText" position="403 39 159 18" name="SkillsT" align="Left Top">
+        <Widget type="TextBox" skin="HeaderText" position="432 39 190 18" name="SkillsT" align="Left Top">
             <Property key="TextAlign" value="Left Top"/>
         </Widget>
         <!-- Skill bonus sub-widgets will be placed here, no skin to make it invisible -->
-        <Widget type="Widget" skin="" position="403 59 159 360" name="SkillList"/>
+        <Widget type="Widget" skin="" position="432 59 190 360" name="SkillList"/>
 
         <!-- Dialog buttons -->
-        <Widget type="HBox" position="0 393 572 24">
+        <Widget type="HBox" position="0 393 626 28">
             <Widget type="Spacer"/>
 
             <Widget type="AutoSizedButton" skin="MW_Button" position="471 397 53 23" name="BackButton">

--- a/files/mygui/openmw_chargen_select_attribute.layout
+++ b/files/mygui/openmw_chargen_select_attribute.layout
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 217 234" align="Center" name="_Main">
-        <Widget type="Widget" skin="" position="14 14 200 203" align="HCenter VStretch">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 247 231" align="Center" name="_Main">
+        <Widget type="Widget" skin="" position="14 14 216 204" align="HCenter VStretch">
 
             <!-- Label -->
-            <Widget type="TextBox" skin="HeaderText" position="0 0 200 18" name="LabelT" align="HCenter Top">
+            <Widget type="TextBox" skin="HeaderText" position="0 0 216 18" name="LabelT" align="HCenter Top">
                 <Property key="Caption" value="#{sAttributesMenu1}"/>
                 <Property key="TextAlign" value="HCenter Top"/>
             </Widget>
 
             <!-- Attribute list -->
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 28 200 18" name="Attribute0" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 46 200 18" name="Attribute1" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 64 200 18" name="Attribute2" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 82 200 18" name="Attribute3" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 100 200 18" name="Attribute4" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 118 200 18" name="Attribute5" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 136 200 18" name="Attribute6" align="Left Top"/>
-            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 154 200 18" name="Attribute7" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 28 216 18" name="Attribute0" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 46 216 18" name="Attribute1" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 64 216 18" name="Attribute2" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 82 216 18" name="Attribute3" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 100 216 18" name="Attribute4" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 118 216 18" name="Attribute5" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 136 216 18" name="Attribute6" align="Left Top"/>
+            <Widget type="MWAttribute" skin="MW_StatNameButtonC" position="0 154 216 18" name="Attribute7" align="Left Top"/>
 
             <!-- Dialog buttons -->
-            <Widget type="AutoSizedButton" skin="MW_Button" position="120 180 66 21" name="CancelButton">
-                <Property key="ExpandDirection" value="Left"/>
-                <Property key="Caption" value="#{sCancel}"/>
+            <Widget type="HBox" position="0 175 216 28">
+                <Widget type="Spacer" />
+                <Widget type="AutoSizedButton" skin="MW_Button" align="Right Bottom" name="CancelButton">
+                    <Property key="ExpandDirection" value="Left Up"/>
+                    <Property key="Caption" value="#{sCancel}"/>
+                </Widget>
             </Widget>
 
         </Widget>

--- a/files/mygui/openmw_chargen_select_skill.layout
+++ b/files/mygui/openmw_chargen_select_skill.layout
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 477 270" align="Center" name="_Main">
-        <Widget type="Widget" skin="" position="17 14 447 239" align="Stretch">
+    <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 487 275" align="Center" name="_Main">
+        <Widget type="Widget" skin="" position="17 14 457 246" align="Stretch">
 
             <!-- Label -->
-            <Widget type="TextBox" skin="HeaderText" position="0 0 447 18" name="LabelT" align="HCenter Top">
+            <Widget type="TextBox" skin="HeaderText" position="0 0 457 18" name="LabelT" align="HCenter Top">
                 <Property key="Caption" value="#{sSkillsMenu1}"/>
                 <Property key="TextAlign" value="HCenter Top"/>
             </Widget>
@@ -44,20 +44,23 @@
                 <Property key="Caption" value="#{sSpecializationStealth}"/>
                 <Property key="TextAlign" value="Left Top"/>
             </Widget>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 50 131 18" name="StealthSkill0" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 68 131 18" name="StealthSkill1" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 86 131 18" name="StealthSkill2" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 104 131 18" name="StealthSkill3" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 122 131 18" name="StealthSkill4" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 140 131 18" name="StealthSkill5" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 158 131 18" name="StealthSkill6" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 176 131 18" name="StealthSkill7" align="Left Top"/>
-            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 194 131 18" name="StealthSkill8" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 50 154 18" name="StealthSkill0" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 68 154 18" name="StealthSkill1" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 86 154 18" name="StealthSkill2" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 104 154 18" name="StealthSkill3" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 122 154 18" name="StealthSkill4" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 140 154 18" name="StealthSkill5" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 158 154 18" name="StealthSkill6" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 176 154 18" name="StealthSkill7" align="Left Top"/>
+            <Widget type="MWSkill" skin="MW_StatNameButton" position="316 194 154 18" name="StealthSkill8" align="Left Top"/>
 
             <!-- Dialog buttons -->
-            <Widget type="AutoSizedButton" skin="MW_Button" position="381 218 66 21" name="CancelButton">
-                <Property key="ExpandDirection" value="Left"/>
-                <Property key="Caption" value="#{sCancel}"/>
+            <Widget type="HBox" position="0 218 457 28">
+                <Widget type="Spacer" />
+                <Widget type="AutoSizedButton" skin="MW_Button" align="Right Bottom" name="CancelButton">
+                    <Property key="ExpandDirection" value="Left Up"/>
+                    <Property key="Caption" value="#{sCancel}"/>
+                </Widget>
             </Widget>
 
         </Widget>

--- a/files/mygui/openmw_chargen_select_specialization.layout
+++ b/files/mygui/openmw_chargen_select_specialization.layout
@@ -2,7 +2,7 @@
 <MyGUI type="Layout">
     <!-- correct size is 247 144, adjust when skin is changed to a dialog -->
     <Widget type="Window" skin="MW_DialogNoTransp" layer="Windows" position="0 0 247 144" align="Center" name="_Main">
-        <Widget type="Widget" skin="" position="14 14 216 113" align="Stretch">
+        <Widget type="Widget" skin="" position="14 14 216 116" align="Stretch">
 
             <!-- Label -->
             <Widget type="TextBox" skin="HeaderText" position="0 0 216 18" name="LabelT" align="Center Top">
@@ -22,9 +22,12 @@
             </Widget>
 
             <!-- Dialog buttons -->
-            <Widget type="AutoSizedButton" skin="MW_Button" position="150 90 66 21" name="CancelButton">
-                <Property key="ExpandDirection" value="Left"/>
-                <Property key="Caption" value="#{sCancel}"/>
+            <Widget type="HBox" position="0 88 216 28">
+                <Widget type="Spacer" />
+                <Widget type="AutoSizedButton" skin="MW_Button" align="Right Bottom" name="CancelButton">
+                    <Property key="ExpandDirection" value="Left Up"/>
+                    <Property key="Caption" value="#{sCancel}"/>
+                </Widget>
             </Widget>
 
         </Widget>

--- a/files/mygui/openmw_confirmation_dialog.layout
+++ b/files/mygui/openmw_confirmation_dialog.layout
@@ -13,7 +13,7 @@
             <Property key="NeedKey" value="false"/>
         </Widget>
 
-        <Widget type="VBox" position="0 89 352 24" align="Center Bottom">
+        <Widget type="VBox" position="0 89 352 28" align="Center Bottom">
             <Widget type="HBox">
                 <Property key="Spacing" value="8"/>
 

--- a/files/mygui/openmw_container_window.layout
+++ b/files/mygui/openmw_container_window.layout
@@ -9,7 +9,7 @@
         <Widget type="ItemView" skin="MW_ItemView" position="5 5 575 225" name="ItemView" align="Left Top Stretch">
         </Widget>
 
-        <Widget type="HBox" position="0 235 580 24" align="Right Bottom">
+        <Widget type="HBox" position="0 235 580 28" align="Right Bottom">
             <Widget type="Spacer"/>
             <Widget type="AutoSizedButton" skin="MW_Button" name="DisposeCorpseButton" align="Right Bottom">
                 <Property key="Caption" value="#{sDisposeofCorpse}"/>

--- a/files/mygui/openmw_count_window.layout
+++ b/files/mygui/openmw_count_window.layout
@@ -16,12 +16,12 @@
             <Property key="Page" value="1"/>
             <Property key="WheelPage" value="1"/>
         </Widget>
-        <Widget type="HBox" skin="" position="0 91 592 24" align="Center Bottom HStretch">
+        <Widget type="HBox" skin="" position="0 91 592 28" align="Center Bottom HStretch">
             <Widget type="Spacer" />
-            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 53 24" align="Left Top" name="OkButton">
+            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 53 28" align="Left Top" name="OkButton">
                 <Property key="Caption" value="#{sOk}"/>
             </Widget>
-            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 86 24" align="Right Top" name="CancelButton">
+            <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 86 28" align="Right Top" name="CancelButton">
                 <Property key="Caption" value="#{sCancel}"/>
             </Widget>
             <Widget type="Spacer" />

--- a/files/mygui/openmw_enchanting_dialog.layout
+++ b/files/mygui/openmw_enchanting_dialog.layout
@@ -50,7 +50,7 @@
         </Widget>
 
         <!-- Values -->
-        <Widget type="VBox" position="320 7 222 80">
+        <Widget type="VBox" position="320 7 222 96">
             <Widget type="HBox">
                 <UserString key="HStretch" value="true"/>
                 <Widget type="AutoSizedTextBox" skin="NormalText">

--- a/files/mygui/openmw_font.xml
+++ b/files/mygui/openmw_font.xml
@@ -2,8 +2,6 @@
 <MyGUI type="Resource" version="1.1">
     <Resource type="ResourceTrueTypeFont" name="MonoFont">
         <Property key="Source" value="DejaVuLGCSansMono.ttf"/>
-        <Property key="Size" value="17"/>
-        <Property key="Resolution" value="50"/>
         <Property key="Antialias" value="false"/>
         <Property key="TabWidth" value="8"/>
         <Property key="OffsetHeight" value="0"/>

--- a/files/mygui/openmw_inventory_window.layout
+++ b/files/mygui/openmw_inventory_window.layout
@@ -29,7 +29,7 @@
             </Widget>
 
             <!-- Categories -->
-            <Widget type="HBox" position="0 8 350 24" align="Left Top HStretch" name="Categories">
+            <Widget type="HBox" position="0 6 350 28" align="Left Top HStretch" name="Categories">
                 <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 60 24" name="AllButton">
                     <Property key="Caption" value="#{sAllTab}"/>
                     <Property key="NeedKey" value="false"/>

--- a/files/mygui/openmw_journal.layout
+++ b/files/mygui/openmw_journal.layout
@@ -59,8 +59,9 @@
       <Property key="ImageTexture" value="textures\tx_menubook_bookmark.dds"/>
       <Property key="ImageCoord" value="0 0 164 256"/>
 
-      <Widget type="BookPage" skin="MW_BookPage" position="20 15 92 250" name="LeftTopicIndex"/>
-      <Widget type="BookPage" skin="MW_BookPage" position="112 15 92 250" name="RightTopicIndex"/>
+      <Widget type="BookPage" skin="MW_BookPage" position="10 10 92 260" name="LeftTopicIndex"/>
+      <Widget type="BookPage" skin="MW_BookPage" position="66 10 92 260" name="CenterTopicIndex"/>
+      <Widget type="BookPage" skin="MW_BookPage" position="122 10 92 260" name="RightTopicIndex"/>
 
       <Widget type="ImageButton" skin="ImageBox" position="71 15 100 20" Align="Top|Left" name="ShowActiveBTN">
         <!-- Image set at runtime since it may not be available in all versions of the game -->

--- a/files/mygui/openmw_journal.layout
+++ b/files/mygui/openmw_journal.layout
@@ -25,10 +25,12 @@
       </Widget>
 
       <Widget type="TextBox" skin="NormalText" position="150 350 32 16" name="PageOneNum">
+        <Property key="FontName" value="Journalbook Magic Cards"/>
         <Property key="TextColour" value="0 0 0"/>
       </Widget>
 
       <Widget type="TextBox" skin="NormalText" position="410 350 32 16" name="PageTwoNum">
+        <Property key="FontName" value="Journalbook Magic Cards"/>
         <Property key="TextColour" value="0 0 0"/>
       </Widget>
 

--- a/files/mygui/openmw_journal.skin.xml
+++ b/files/mygui/openmw_journal.skin.xml
@@ -13,11 +13,9 @@
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_QuestList" size="516 516" align="Left Top">
+            <Property key="ListItemSkin" value="MW_QuestLink"/>
 
-        <Property key="ListItemSkin" value="MW_QuestLink"/>
-
-        <Child type="Widget" skin="" offset="3 3 510 510" align="Top Left Stretch" name="Client"/>
-
+            <Child type="Widget" skin="" offset="3 3 510 510" align="Top Left Stretch" name="Client"/>
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_QuestLink" size="5 5">

--- a/files/mygui/openmw_journal.skin.xml
+++ b/files/mygui/openmw_journal.skin.xml
@@ -2,7 +2,7 @@
 
 <MyGUI type="Resource" version="1.1">
     <Resource type="ResourceSkin" name="MW_BookClient" size="10 10">
-            <Property key="FontName" value="Default"/>
+            <Property key="FontName" value="Journalbook Magic Cards"/>
             <Property key="TextAlign" value="Left Top"/>
             <Property key="TextColour" value="0 0 0"/>
             <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
@@ -19,7 +19,7 @@
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_QuestLink" size="5 5">
-        <Property key="FontName" value="Default"/>
+        <Property key="FontName" value="Journalbook Magic Cards"/>
         <Property key="TextAlign" value="Left VCenter"/>
 
         <BasisSkin type="SimpleText" offset="2 0 1 5" align="Stretch">

--- a/files/mygui/openmw_list.skin.xml
+++ b/files/mygui/openmw_list.skin.xml
@@ -127,7 +127,6 @@
     <Resource type="ResourceSkin" name="MW_List" size="516 516" align="Left Top">
         <Property key="NeedKey" value="true"/>
         <Property key="SkinLine" value="MW_ListLine"/>
-        <Property key="HeightLine" value="18"/>
 
         <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>
 
@@ -140,8 +139,6 @@
     <Resource type="ResourceSkin" name="MW_PopupList" size="516 516" align="Left Top">
         <Property key="NeedKey" value="true"/>
         <Property key="SkinLine" value="MW_ListLine"/>
-        <Property key="HeightLine" value="18"/>
-
         <Child type="Widget" skin="BlackBG" offset="0 0 516 516" align="Stretch"/>
         <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>
 
@@ -153,7 +150,6 @@
     <Resource type="ResourceSkin" name="MW_PopupListNoTransp" size="516 516" align="Left Top">
         <Property key="NeedKey" value="true"/>
         <Property key="SkinLine" value="MW_ListLine"/>
-        <Property key="HeightLine" value="18"/>
 
         <Child type="Widget" skin="FullBlackBG" offset="0 0 516 516" align="Stretch"/>
         <Child type="Widget" skin="MW_Box" offset="0 0 516 516" align="Stretch"/>

--- a/files/mygui/openmw_trade_window.layout
+++ b/files/mygui/openmw_trade_window.layout
@@ -48,7 +48,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="0 28 566 24" align="Left Top HStretch">
+            <Widget type="HBox" position="0 28 566 28" align="Left Top HStretch">
                 <Widget type="Button" skin="MW_Button" position="0 0 40 24" name="DecreaseButton" align="Left Top">
                     <Property key="Caption" value="-"/>
                     <Property key="NeedKey" value="false"/>
@@ -62,7 +62,7 @@
                 </Widget>
             </Widget>
 
-            <Widget type="HBox" position="0 60 566 24" align="Left Bottom HStretch">
+            <Widget type="HBox" position="0 60 566 28" align="Left Bottom HStretch">
                 <Widget type="AutoSizedButton" skin="MW_Button" name="MaxSaleButton">
                     <Property key="Caption" value="#{sMaxSale}"/>
                 </Widget>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -156,10 +156,10 @@
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>
     </Resource>
-    
+
     <!-- Defines a owned background -->
     <Resource type="ResourceSkin" name="DialogBG_NoTransp_Owned" size="8 8" texture="white">
-        <Property key="Colour" value="#{setting=GUI,color background owned}"/> 
+        <Property key="Colour" value="#{setting=GUI,color background owned}"/>
         <BasisSkin type="MainSkin" offset="0 0 8 8">
             <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>
@@ -443,7 +443,6 @@
     <!-- The actual caption. It contains the edges of the blocks on
          its sides as well -->
     <Resource type="ResourceSkin" name="MW_Caption" size="88 20">
-        <Property key="FontName" value="Default"/>
         <Property key="TextAlign" value="Center"/>
 
         <Child type="Widget" skin="HB_ALL" offset="0 0 30 20" align="Default" name="Left"/>
@@ -458,7 +457,6 @@
 ------------------------------------------------------ -->
 
     <Resource type="ResourceSkin" name="MW_Window" size="256 256">
-        <Property key="FontName" value="Default"/>
         <Property key="TextAlign" value="Center"/>
         <Property key="Snap" value="true"/>
         <Property key="MinSize" value="64 64"/>
@@ -593,7 +591,6 @@
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_Window_NoCaption" size="256 256">
-        <Property key="FontName" value="Default"/>
         <Property key="TextAlign" value="Center"/>
         <Property key="Snap" value="true"/>
         <Property key="MinSize" value="64 64"/>
@@ -730,7 +727,6 @@
     </Resource>
 
     <Resource type="ResourceSkin" name="MW_Window_Pinnable" size="256 256">
-        <Property key="FontName" value="Default"/>
         <Property key="TextAlign" value="Center"/>
         <Property key="Snap" value="true"/>
         <Property key="MinSize" value="64 64"/>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -142,6 +142,12 @@ global = false
 # Scales GUI window and widget size. (<1.0 is smaller, >1.0 is larger).
 scaling factor = 1.0
 
+# Size of in-game fonts
+font size = 16
+
+# Resolution of TrueType fonts glyphs
+ttf resolution = 96
+
 # Transparency of GUI windows (0.0 to 1.0, transparent to opaque).
 menu transparency = 0.84
 


### PR DESCRIPTION
Fixes [bug #3288](https://gitlab.com/OpenMW/openmw/issues/3288), as scrawl suggested (option 1).
You can twik the font size by settings:
```
[GUI]
font size = 16
ttf resolution = 96
```
Also there is no need to edit system-wide openmw_font.xml: you can define your own openmw_font.xml in addition to basic one (an example is [here](https://pastebin.com/Ly91jkrL)).
Just create a Fonts folder near openmw.cfg and place your openmw_font.xml and TTF/OTF files here.

Example if output is [here](https://imgur.com/a/9ojboWg) (before/after, font size = 17, scaling factor = 2, 1920x1080, Pelagiad).

Basically works, but there are issues with large font size, since our UI supposed to work with 16-17px fonts.
Also there could be some refactoring improvements, so any suggestions are welcome.

For testing you can use these fonts: [Fonts.zip](https://github.com/OpenMW/openmw/files/2347975/Fonts.zip) - just place the Fonts folder to your OpenMW configs folder.
