### PR TITLE
Make Open spells casted by anything trigger player crime event (bug #4461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
     Bug #4457: Item without CanCarry flag prevents shield autoequipping in dark areas
     Bug #4458: AiWander console command handles idle chances incorrectly
     Bug #4459: NotCell dialogue condition doesn't support partial matches
+    Bug #4461: "Open" spell from non-player caster isn't a crime
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #4222: 360° screenshots

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -665,8 +665,9 @@ namespace MWMechanics
                     if (target.getCellRef().getLockLevel() > 0)
                     {
                         MWBase::Environment::get().getSoundManager()->playSound3D(target, "Open Lock", 1.f, 1.f);
-                        if (!caster.isEmpty() && caster.getClass().isActor())
-                            MWBase::Environment::get().getMechanicsManager()->objectOpened(caster, target);
+                        if (!caster.isEmpty())
+                            MWBase::Environment::get().getMechanicsManager()->objectOpened(getPlayer(), target); 
+                            // Use the player instead of the caster for vanilla crime compatibility
 
                         if (caster == getPlayer())
                             MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicOpenSuccess}");

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -644,8 +644,9 @@ namespace MWMechanics
             {
                 const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
                 const ESM::MagicEffect *magiceffect = store.get<ESM::MagicEffect>().find(effectId);
-                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);     
-                animation->addSpellCastGlow(magiceffect);
+                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
+                if (animation)
+                    animation->addSpellCastGlow(magiceffect);
                 if (target.getCellRef().getLockLevel() < magnitude) //If the door is not already locked to a higher value, lock it to spell magnitude
                 {
                     if (caster == getPlayer())
@@ -658,15 +659,16 @@ namespace MWMechanics
             {
                 const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
                 const ESM::MagicEffect *magiceffect = store.get<ESM::MagicEffect>().find(effectId);
-                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);     
-                animation->addSpellCastGlow(magiceffect);
+                MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
+                if (animation)
+                    animation->addSpellCastGlow(magiceffect);
                 if (target.getCellRef().getLockLevel() <= magnitude)
                 {
                     if (target.getCellRef().getLockLevel() > 0)
                     {
                         MWBase::Environment::get().getSoundManager()->playSound3D(target, "Open Lock", 1.f, 1.f);
                         if (!caster.isEmpty())
-                            MWBase::Environment::get().getMechanicsManager()->objectOpened(getPlayer(), target); 
+                            MWBase::Environment::get().getMechanicsManager()->objectOpened(getPlayer(), target);
                             // Use the player instead of the caster for vanilla crime compatibility
 
                         if (caster == getPlayer())


### PR DESCRIPTION
[Bug 4461](https://gitlab.com/OpenMW/openmw/issues/4461)

~~I really like rot tor's game mechanics bug reports, they're simple to fix~~

If anything has managed to cast an Open spell successfully, the player is blamed for that instead. Situation from the bug report seems to work fine.

I noticed that OpenMW crashes if you try to use ExplodeSpell on a door in a different cell. It's not related to this specific change, it also happens on master. Looking at the crashlog, it seems to fail to add spellcasting glow on the object? (the last call is MWRender::Animation::addSpellCastGlow)
Edit: the crash also happens on OpenMW 0.43.0. I suggest to file a bug report.
Edit 2: I managed to fix the crashes, apparently the animation pointer would have been null in this case. Not sure if it's worth it to track every small optimization.