### PR TITLE
Take transformation from first node with given name in file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
     Bug #4458: AiWander console command handles idle chances incorrectly
     Bug #4459: NotCell dialogue condition doesn't support partial matches
     Bug #4461: "Open" spell from non-player caster isn't a crime
+    Bug #4469: Abot Silt Striders – Model turn 90 degrees on horizontal
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #4222: 360° screenshots

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -100,7 +100,13 @@ namespace
 
         void apply(osg::MatrixTransform& trans)
         {
-            mMap[Misc::StringUtils::lowerCase(trans.getName())] = &trans;
+            // Take transformation for first found node in file
+            const std::string nodeName = Misc::StringUtils::lowerCase(trans.getName());
+            if (mMap.find(nodeName) == mMap.end())
+            {
+                mMap[nodeName] = &trans;
+            }
+
             traverse(trans);
         }
 


### PR DESCRIPTION
Fixes [bug #4469](https://gitlab.com/OpenMW/openmw/issues/4469).

According to my testing, Morrowind takes transformation from first node with given name in file, OpenMW - from last one. Correct me if I wrong.
Also I can add a warning if we need it (but it will be annoying).

Note: this change can have side effects, so if my assumption is wrong, we can limit new behaviour only for "Root bone".