### PR TITLE
[Discussion] Option to discard small amount of movement from animations

### DIFF
--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -257,6 +257,7 @@ protected:
     Resource::ResourceSystem* mResourceSystem;
 
     osg::Vec3f mAccumulate;
+    float mDiscardThresholdSquare;
 
     TextKeyListener* mTextKeyListener;
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -236,6 +236,10 @@ barter disposition change is permanent = false
 # 2 means werewolves are ignored) 
 strength influences hand to hand = 0
 
+# Allows to discard a small amount of movement from animation files
+# Especially useful for idle animations
+discard movement threshold = 0.0
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
This PR is not aimed to be merged upstream yet.
Attempt to fix the cause of [bug #1298](https://gitlab.com/OpenMW/openmw/issues/1298).

The main idea: add an option to treat amount of resulting movement in animations below given threshold as non-intended and discard it. Zero by default (vanilla behaviour).
Can be useful when player can not fix animations himself.

Note: "discard movement threshold = 0.1" allows to workaround most of animation issues for scamps.