### PR TITLE
Apply weapon reload animations only for upper body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     Bug #2852: No murder bounty when a player follower commits murder
     Bug #2862: [macOS] Can't quit launcher using Command-Q or OpenMW->Quit
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
+    Bug #3249: Fixed revert function not updating views properly
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3486: [Mod] NPC Commands does not work
     Bug #3591: Angled hit distance too low
@@ -59,7 +60,7 @@
     Bug #4480: Segfault in QuickKeysMenu when item no longer in inventory
     Bug #4489: Goodbye doesn't block dialogue hyperlinks
     Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
-    Bug #3249: Fixed revert function not updating views properly
+    Bug #4495: Crossbow animations blending is buggy
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1627,16 +1627,18 @@ bool CharacterController::updateWeaponState()
                 break;
         }
 
+        // Note: apply reload animations only for upper body since blending with movement animations can give weird result.
+        // Especially noticable with crossbow reload animation.
         if(!start.empty())
         {
             mAnimation->disable(mCurrentWeapon);
             if (mUpperBodyState == UpperCharState_FollowStartToFollowStop)
                 mAnimation->play(mCurrentWeapon, priorityWeapon,
-                                 MWRender::Animation::BlendMask_All, true,
+                                 MWRender::Animation::BlendMask_UpperBody, true,
                                  weapSpeed, start, stop, 0.0f, 0);
             else
                 mAnimation->play(mCurrentWeapon, priorityWeapon,
-                                 MWRender::Animation::BlendMask_All, false,
+                                 MWRender::Animation::BlendMask_UpperBody, false,
                                  weapSpeed, start, stop, 0.0f, 0);
         }
     }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -370,6 +370,10 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
                 {
                     jumpmask = MWRender::Animation::BlendMask_LowerBody;
                     jumpAnimName = "jump";
+
+                    // For crossbow animations use 1h ones as fallback
+                    if (mWeaponType == WeapType_Crossbow)
+                        jumpAnimName += "1h";
                 }
             }
         }
@@ -423,6 +427,10 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
                 {
                     movemask = MWRender::Animation::BlendMask_LowerBody;
                     movementAnimName = movestate->groupname;
+
+                    // For crossbow animations use 1h ones as fallback
+                    if (mWeaponType == WeapType_Crossbow)
+                        movementAnimName += "1h";
                 }
             }
 


### PR DESCRIPTION
Allows to fix a lot of problems with crossbowmans.

Currently in both vanilla and OpenMW there is a twitching when actor starts or stops walking during crossbow reload animation. It looks very weird, so I decided to apply such animation only for upper body.
I managed to solve issues with missing 1th-person mode crossbow animations: I use the 1h animations as fallback.
As for me, it looks decent.

Can we fix this issue from engine side, or it is a strictly up to content developers?

An another approach would be to stop shooter until the end of reload, but I suppose players will not be happy about it.