### PR TITLE
Consider <p> tag when discarding post-EOL tag text (regression #4473) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID
     Bug #4047: OpenMW not reporting its version number in MacOS; OpenMW-CS not doing it fully
     Bug #4125: OpenMW logo cropped on bugtracker
-    Bug #4215: OpenMW shows book text after last <BR> tag
+    Bug #4215: OpenMW shows book text after last EOL tag
     Bug #4221: Characters get stuck in V-shaped terrain
     Bug #4251: Stationary NPCs do not return to their position after combat
     Bug #4286: Scripted animations can be interrupted

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -31,13 +31,16 @@ namespace MWGui
 
             boost::algorithm::replace_all(mText, "\r", "");
 
-            // vanilla game does not show any text after last <BR> tag.
+            // vanilla game does not show any text after the last EOL tag.
             const std::string lowerText = Misc::StringUtils::lowerCase(mText);
-            int index = lowerText.rfind("<br>");
-            if (index == -1)
+            int brIndex = lowerText.rfind("<br>");
+            int pIndex = lowerText.rfind("<p>");
+            if (brIndex == pIndex)
                 mText = "";
+            else if (brIndex > pIndex)
+                mText = mText.substr(0, brIndex+4);
             else
-                mText = mText.substr(0, index+4);
+                mText = mText.substr(0, pIndex+3);
 
             registerTag("br", Event_BrTag);
             registerTag("p", Event_PTag);


### PR DESCRIPTION
[Regression #4473](https://gitlab.com/OpenMW/openmw/issues/4473).

Seems to work fine. On master the text in Note to Hrisskar is discarded, after the changes it isn't.