### PR TITLE
 Fall back to regular head when getVampireHead fails (bug #4474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
     Bug #4461: "Open" spell from non-player caster isn't a crime
     Bug #4469: Abot Silt Striders – Model turn 90 degrees on horizontal
     Bug #4471: Retrieve SDL window settings instead of using magic numbers
+    Bug #4474: No fallback when getVampireHead fails
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #4222: 360° screenshots
     Feature #4256: Implement ToggleBorders (TB) console command

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -416,6 +416,7 @@ void NpcAnimation::updateNpcBase()
     const ESM::Race *race = store.get<ESM::Race>().find(mNpc->mRace);
     bool isWerewolf = (mNpcType == Type_Werewolf);
     bool isVampire = (mNpcType == Type_Vampire);
+    bool isFemale = !mNpc->isMale();
 
     if (isWerewolf)
     {
@@ -425,8 +426,9 @@ void NpcAnimation::updateNpcBase()
     else
     {
         mHeadModel = "";
-        if (isVampire) // FIXME: fall back to regular head when getVampireHead fails?
-            mHeadModel = getVampireHead(mNpc->mRace, mNpc->mFlags & ESM::NPC::Female);
+        const std::string& vampireHead = getVampireHead(mNpc->mRace, isFemale);
+        if (isVampire && !vampireHead.empty())
+            mHeadModel = vampireHead;
         else if (!mNpc->mHead.empty())
         {
             const ESM::BodyPart* bp = store.get<ESM::BodyPart>().search(mNpc->mHead);
@@ -448,7 +450,6 @@ void NpcAnimation::updateNpcBase()
     }
 
     bool isBeast = (race->mData.mFlags & ESM::Race::Beast) != 0;
-    bool isFemale = !mNpc->isMale();
 
     std::string smodel;
     if (mViewMode != VM_FirstPerson)


### PR DESCRIPTION
[Bug #4474](https://gitlab.com/OpenMW/openmw/issues/4474).
If an NPC is a vampire and getVampireHead happens to return an empty string, the NPC won't get anything as the head, as noted by the fixme comment. This adds a fallback for such case, so the NPC gets whatever there was in the NPC record for the head (most probably a vampire head still so there'll be a error if the bodypart weren't found).