### PR TITLE
Ignore movement from scripted animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
     Bug #4469: Abot Silt Striders – Model turn 90 degrees on horizontal
     Bug #4471: Retrieve SDL window settings instead of using magic numbers
     Bug #4474: No fallback when getVampireHead fails
+    Bug #4475: Scripted animations should not cause movement
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #4222: 360° screenshots
     Feature #4256: Implement ToggleBorders (TB) console command

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2141,7 +2141,7 @@ void CharacterController::unpersistAnimationState()
 
         bool loopfallback = (mAnimQueue.front().mGroup.compare(0,4,"idle") == 0);
         mAnimation->play(anim.mGroup,
-                         Priority_Default, MWRender::Animation::BlendMask_All, false, 1.0f,
+                         Priority_Persistent, MWRender::Animation::BlendMask_All, false, 1.0f,
                          "start", "stop", complete, anim.mLoopCount, loopfallback);
     }
 }

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1190,6 +1190,10 @@ namespace MWRender
                 mHeadController->setRotate(osg::Quat(mHeadPitchRadians, osg::Vec3f(1,0,0)) * osg::Quat(mHeadYawRadians, osg::Vec3f(0,0,1)));
         }
 
+        // Scripted animations should not cause movement
+        if (hasScriptedAnims)
+            return osg::Vec3f(0, 0, 0);
+
         return movement;
     }
 


### PR DESCRIPTION
Fixes [bug #4475](https://gitlab.com/OpenMW/openmw/issues/4475).
Abot's Silt Striders should work fine now.