### PR TITLE
[Discussion] Refactor AiState usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
     Bug #4458: AiWander console command handles idle chances incorrectly
     Bug #4459: NotCell dialogue condition doesn't support partial matches
     Bug #4461: "Open" spell from non-player caster isn't a crime
+    Bug #4464: OpenMW keeps AiState cached storages even after we cancel AI packages
     Bug #4469: Abot Silt Striders – Model turn 90 degrees on horizontal
     Bug #4471: Retrieve SDL window settings instead of using magic numbers
     Bug #4474: No fallback when getVampireHead fails

--- a/apps/openmw/mwmechanics/actor.cpp
+++ b/apps/openmw/mwmechanics/actor.cpp
@@ -4,7 +4,6 @@
 
 namespace MWMechanics
 {
-
     Actor::Actor(const MWWorld::Ptr &ptr, MWRender::Animation *animation)
     {
         mCharacterController.reset(new CharacterController(ptr, animation));
@@ -19,10 +18,4 @@ namespace MWMechanics
     {
         return mCharacterController.get();
     }
-
-    AiState& Actor::getAiState()
-    {
-        return mAiState;
-    }
-
 }

--- a/apps/openmw/mwmechanics/actor.hpp
+++ b/apps/openmw/mwmechanics/actor.hpp
@@ -3,8 +3,6 @@
 
 #include <memory>
 
-#include "aistate.hpp"
-
 namespace MWRender
 {
     class Animation;
@@ -29,12 +27,8 @@ namespace MWMechanics
 
         CharacterController* getCharacterController();
 
-        AiState& getAiState();
-
     private:
         std::unique_ptr<CharacterController> mCharacterController;
-
-        AiState mAiState;
     };
 
 }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1365,7 +1365,7 @@ namespace MWMechanics
                         {
                             CreatureStats &stats = iter->first.getClass().getCreatureStats(iter->first);
                             if (isConscious(iter->first))
-                                stats.getAiSequence().execute(iter->first, *iter->second->getCharacterController(), iter->second->getAiState(), duration);
+                                stats.getAiSequence().execute(iter->first, *iter->second->getCharacterController(), duration);
                         }
                     }
 
@@ -1993,7 +1993,7 @@ namespace MWMechanics
                     || ptr.getClass().getCreatureStats(ptr).isParalyzed())
                 continue;
             MWMechanics::AiSequence& seq = ptr.getClass().getCreatureStats(ptr).getAiSequence();
-            seq.fastForward(ptr, it->second->getAiState());
+            seq.fastForward(ptr);
         }
     }
 }

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -35,74 +35,6 @@ namespace
 
 namespace MWMechanics
 {
-    
-    /// \brief This class holds the variables AiCombat needs which are deleted if the package becomes inactive.
-    struct AiCombatStorage : AiTemporaryBase
-    {
-        float mAttackCooldown;
-        float mTimerReact;
-        float mTimerCombatMove;
-        bool mReadyToAttack;
-        bool mAttack;
-        float mAttackRange;
-        bool mCombatMove;
-        osg::Vec3f mLastTargetPos;
-        const MWWorld::CellStore* mCell;
-        std::shared_ptr<Action> mCurrentAction;
-        float mActionCooldown;
-        float mStrength;
-        bool mForceNoShortcut;
-        ESM::Position mShortcutFailPos;
-        MWMechanics::Movement mMovement;
-
-        enum FleeState
-        {
-            FleeState_None,
-            FleeState_Idle,
-            FleeState_RunBlindly,
-            FleeState_RunToDestination
-        };
-        FleeState mFleeState;
-        bool mLOS;
-        float mUpdateLOSTimer;
-        float mFleeBlindRunTimer;
-        ESM::Pathgrid::Point mFleeDest;
-        
-        AiCombatStorage():
-        mAttackCooldown(0.0f),
-        mTimerReact(AI_REACTION_TIME),
-        mTimerCombatMove(0.0f),
-        mReadyToAttack(false),
-        mAttack(false),
-        mAttackRange(0.0f),
-        mCombatMove(false),
-        mLastTargetPos(0,0,0),
-        mCell(NULL),
-        mCurrentAction(),
-        mActionCooldown(0.0f),
-        mStrength(),
-        mForceNoShortcut(false),
-        mShortcutFailPos(),
-        mMovement(),
-        mFleeState(FleeState_None),
-        mLOS(false),
-        mUpdateLOSTimer(0.0f),
-        mFleeBlindRunTimer(0.0f)
-        {}
-
-        void startCombatMove(bool isDistantCombat, float distToTarget, float rangeAttack, const MWWorld::Ptr& actor, const MWWorld::Ptr& target);
-        void updateCombatMove(float duration);
-        void stopCombatMove();
-        void startAttackIfReady(const MWWorld::Ptr& actor, CharacterController& characterController, 
-            const ESM::Weapon* weapon, bool distantCombat);
-        void updateAttack(CharacterController& characterController);
-        void stopAttack();
-
-        void startFleeing();
-        void stopFleeing();
-        bool isFleeing();
-    };
-    
     AiCombat::AiCombat(const MWWorld::Ptr& actor)
     {
         mTargetActorId = actor.getClass().getCreatureStats(actor).getActorId();
@@ -115,7 +47,7 @@ namespace MWMechanics
 
     void AiCombat::init()
     {
-        
+
     }
 
     /*

--- a/apps/openmw/mwmechanics/aicombat.hpp
+++ b/apps/openmw/mwmechanics/aicombat.hpp
@@ -23,7 +23,72 @@ namespace MWMechanics
 {
     class Action;
 
-    struct AiCombatStorage;
+    /// \brief This class holds the variables AiCombat needs which are deleted if the package becomes inactive.
+    struct AiCombatStorage : AiTemporaryBase
+    {
+        float mAttackCooldown;
+        float mTimerReact;
+        float mTimerCombatMove;
+        bool mReadyToAttack;
+        bool mAttack;
+        float mAttackRange;
+        bool mCombatMove;
+        osg::Vec3f mLastTargetPos;
+        const MWWorld::CellStore* mCell;
+        std::shared_ptr<Action> mCurrentAction;
+        float mActionCooldown;
+        float mStrength;
+        bool mForceNoShortcut;
+        ESM::Position mShortcutFailPos;
+        MWMechanics::Movement mMovement;
+
+        enum FleeState
+        {
+            FleeState_None,
+            FleeState_Idle,
+            FleeState_RunBlindly,
+            FleeState_RunToDestination
+        };
+        FleeState mFleeState;
+        bool mLOS;
+        float mUpdateLOSTimer;
+        float mFleeBlindRunTimer;
+        ESM::Pathgrid::Point mFleeDest;
+
+        AiCombatStorage():
+        mAttackCooldown(0.0f),
+        mTimerReact(AI_REACTION_TIME),
+        mTimerCombatMove(0.0f),
+        mReadyToAttack(false),
+        mAttack(false),
+        mAttackRange(0.0f),
+        mCombatMove(false),
+        mLastTargetPos(0,0,0),
+        mCell(NULL),
+        mCurrentAction(),
+        mActionCooldown(0.0f),
+        mStrength(),
+        mForceNoShortcut(false),
+        mShortcutFailPos(),
+        mMovement(),
+        mFleeState(FleeState_None),
+        mLOS(false),
+        mUpdateLOSTimer(0.0f),
+        mFleeBlindRunTimer(0.0f)
+        {}
+
+        void startCombatMove(bool isDistantCombat, float distToTarget, float rangeAttack, const MWWorld::Ptr& actor, const MWWorld::Ptr& target);
+        void updateCombatMove(float duration);
+        void stopCombatMove();
+        void startAttackIfReady(const MWWorld::Ptr& actor, CharacterController& characterController,
+            const ESM::Weapon* weapon, bool distantCombat);
+        void updateAttack(CharacterController& characterController);
+        void stopAttack();
+
+        void startFleeing();
+        void stopFleeing();
+        bool isFleeing();
+    };
 
     /// \brief Causes the actor to fight another actor
     class AiCombat : public AiPackage

--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -17,22 +17,6 @@
 namespace MWMechanics
 {
 
-
-struct AiFollowStorage : AiTemporaryBase
-{
-    float mTimer;
-    bool mMoving;
-    float mTargetAngleRadians;
-    bool mTurnActorToTarget;
-
-    AiFollowStorage() :
-        mTimer(0.f),
-        mMoving(false),
-        mTargetAngleRadians(0.f),
-        mTurnActorToTarget(false)
-    {}
-};
-
 int AiFollow::mFollowIndexCounter = 0;
 
 AiFollow::AiFollow(const std::string &actorId, float duration, float x, float y, float z)

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -19,6 +19,21 @@ namespace AiSequence
 
 namespace MWMechanics
 {
+    struct AiFollowStorage : AiTemporaryBase
+    {
+        float mTimer;
+        bool mMoving;
+        float mTargetAngleRadians;
+        bool mTurnActorToTarget;
+
+        AiFollowStorage() :
+            mTimer(0.f),
+            mMoving(false),
+            mTargetAngleRadians(0.f),
+            mTurnActorToTarget(false)
+        {}
+    };
+
     /// \brief AiPackage for an actor to follow another actor/the PC
     /** The AI will follow the target until a condition (time, or position) are set. Both can be disabled to cause the actor to follow the other indefinitely
     **/

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -188,7 +188,7 @@ bool isActualAiPackage(int packageTypeId)
                    && packageTypeId != AiPackage::TypeIdInternalTravel);
 }
 
-void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration)
+void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& characterController, float duration)
 {
     if(actor != getPlayer())
     {
@@ -262,7 +262,7 @@ void AiSequence::execute (const MWWorld::Ptr& actor, CharacterController& charac
 
         try
         {
-            if (package->execute (actor,characterController,state,duration))
+            if (package->execute (actor, characterController, mAiState, duration))
             {
                 // Put repeating noncombat AI packages on the end of the stack so they can be used again
                 if (isActualAiPackage(packageTypeId) && (mRepeat || package->getRepeat()))
@@ -494,12 +494,12 @@ void AiSequence::readState(const ESM::AiSequence::AiSequence &sequence)
     mLastAiPackage = sequence.mLastAiPackage;
 }
 
-void AiSequence::fastForward(const MWWorld::Ptr& actor, AiState& state)
+void AiSequence::fastForward(const MWWorld::Ptr& actor)
 {
     if (!mPackages.empty())
     {
         MWMechanics::AiPackage* package = mPackages.front();
-        package->fastForward(actor, state);
+        package->fastForward(actor, mAiState);
     }
 }
 

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -360,6 +360,14 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor, boo
     }
 
     mPackages.push_back (package.clone());
+
+    // Make sure that temporary storage is empty
+    if (cancelOther)
+    {
+        mAiState.moveIn(new AiCombatStorage());
+        mAiState.moveIn(new AiFollowStorage());
+        mAiState.moveIn(new AiWanderStorage());
+    }
 }
 
 AiPackage* MWMechanics::AiSequence::getActivePackage()

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -3,6 +3,8 @@
 
 #include <list>
 
+#include "aistate.hpp"
+
 #include <components/esm/loadnpc.hpp>
 
 namespace MWWorld
@@ -47,6 +49,7 @@ namespace MWMechanics
 
             /// The type of AI package that ran last
             int mLastAiPackage;
+            AiState mAiState;
 
         public:
             ///Default constructor
@@ -104,10 +107,10 @@ namespace MWMechanics
             void stopPursuit();
 
             /// Execute current package, switching if needed.
-            void execute (const MWWorld::Ptr& actor, CharacterController& characterController, MWMechanics::AiState& state, float duration);
+            void execute (const MWWorld::Ptr& actor, CharacterController& characterController, float duration);
 
             /// Simulate the passing of time using the currently active AI package
-            void fastForward(const MWWorld::Ptr &actor, AiState &state);
+            void fastForward(const MWWorld::Ptr &actor);
 
             /// Remove all packages.
             void clear();

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -21,8 +21,81 @@ namespace ESM
 }
 
 namespace MWMechanics
-{       
-    struct AiWanderStorage;
+{
+    /// \brief This class holds the variables AiWander needs which are deleted if the package becomes inactive.
+    struct AiWanderStorage : AiTemporaryBase
+    {
+        // the z rotation angle to reach
+        // when mTurnActorGivingGreetingToFacePlayer is true
+        float mTargetAngleRadians;
+        bool mTurnActorGivingGreetingToFacePlayer;
+        float mReaction; // update some actions infrequently
+
+        enum GreetingState
+        {
+            Greet_None,
+            Greet_InProgress,
+            Greet_Done
+        };
+        GreetingState mSaidGreeting;
+        int mGreetingTimer;
+
+        const MWWorld::CellStore* mCell; // for detecting cell change
+
+        // AiWander states
+        enum WanderState
+        {
+            Wander_ChooseAction,
+            Wander_IdleNow,
+            Wander_MoveNow,
+            Wander_Walking
+        };
+        WanderState mState;
+
+        bool mIsWanderingManually;
+        bool mCanWanderAlongPathGrid;
+
+        unsigned short mIdleAnimation;
+        std::vector<unsigned short> mBadIdles; // Idle animations that when called cause errors
+
+        // do we need to calculate allowed nodes based on mDistance
+        bool mPopulateAvailableNodes;
+
+        // allowed pathgrid nodes based on mDistance from the spawn point
+        // in local coordinates of mCell
+        std::vector<ESM::Pathgrid::Point> mAllowedNodes;
+
+        ESM::Pathgrid::Point mCurrentNode;
+        bool mTrimCurrentNode;
+
+        float mDoorCheckDuration;
+        int mStuckCount;
+
+        AiWanderStorage():
+            mTargetAngleRadians(0),
+            mTurnActorGivingGreetingToFacePlayer(false),
+            mReaction(0),
+            mSaidGreeting(Greet_None),
+            mGreetingTimer(0),
+            mCell(NULL),
+            mState(Wander_ChooseAction),
+            mIsWanderingManually(false),
+            mCanWanderAlongPathGrid(true),
+            mIdleAnimation(0),
+            mBadIdles(),
+            mPopulateAvailableNodes(true),
+            mAllowedNodes(),
+            mTrimCurrentNode(false),
+            mDoorCheckDuration(0), // TODO: maybe no longer needed
+            mStuckCount(0)
+            {};
+
+        void setState(const WanderState wanderState, const bool isManualWander = false)
+        {
+            mState = wanderState;
+            mIsWanderingManually = isManualWander;
+        }
+    };
 
     /// \brief Causes the Actor to wander within a specified range
     class AiWander : public AiPackage
@@ -51,19 +124,6 @@ namespace MWMechanics
             bool getRepeat() const;
 
             osg::Vec3f getDestination(const MWWorld::Ptr& actor) const;
-
-            enum GreetingState {
-                Greet_None,
-                Greet_InProgress,
-                Greet_Done
-            };
-
-            enum WanderState {
-                Wander_ChooseAction,
-                Wander_IdleNow,
-                Wander_MoveNow,
-                Wander_Walking
-            };
 
         private:
             // NOTE: mDistance and mDuration must be set already


### PR DESCRIPTION
Fixes [bug #4464](https://gitlab.com/OpenMW/openmw/issues/4464).

The main idea: since we do not handle AiState in Actor code, we can move it into AiSequence and clean storage when we cancel AI packages.

Can we move AiState to target AI package instead?
I use this approach [here](https://github.com/akortunov/openmw/tree/removeAiState).
Since the storage is a part of AI package here, we do not need to clean it manually after AI package expiration, also AI API is cleaner.