### PR TITLE
Fix some GCC warnings

### DIFF
--- a/apps/opencs/view/world/enumdelegate.cpp
+++ b/apps/opencs/view/world/enumdelegate.cpp
@@ -110,7 +110,11 @@ void CSVWorld::EnumDelegate::paint (QPainter *painter, const QStyleOptionViewIte
     int valueIndex = getValueIndex(index);
     if (valueIndex != -1)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(5,7,0)
+        QStyleOptionViewItem itemOption(option);
+#else
         QStyleOptionViewItemV4 itemOption(option);
+#endif
         itemOption.text = mValues.at(valueIndex).second;
         QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &itemOption, painter);
     }

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -328,7 +328,10 @@ namespace MWMechanics
                 if (race->mData.mFlags & ESM::Race::Beast)
                     return 0.f;
             }
-            // Intended fall-through
+            else
+                return 0.f;
+
+            break;
         // Creatures can not wear armor
         case ESM::MagicEffect::BoundCuirass:
         case ESM::MagicEffect::BoundGloves:


### PR DESCRIPTION
1. QStyleOptionViewItemV4 is deprecated since Qt 5.7. Use unversioned item instead.
2. Do not use fall-through in case construction.