### PR TITLE
Use the DejaVuLGCSansMono.ttf for profiler output

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -646,27 +646,18 @@ void OMW::Engine::go()
 
     std::cout << "OSG version: " << osgGetVersion() << std::endl;
 
-    mViewer = new osgViewer::Viewer;
-    mViewer->setReleaseContextAtEndOfFrameHint(false);
-
-    osg::ref_ptr<osgViewer::StatsHandler> statshandler = new osgViewer::StatsHandler;
-    statshandler->setKeyEventTogglesOnScreenStats(osgGA::GUIEventAdapter::KEY_F3);
-
-    statshandler->addUserStatsLine("Script", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
-                                   "script_time_taken", 1000.0, true, false, "script_time_begin", "script_time_end", 10000);
-    statshandler->addUserStatsLine("Mechanics", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
-                                   "mechanics_time_taken", 1000.0, true, false, "mechanics_time_begin", "mechanics_time_end", 10000);
-    statshandler->addUserStatsLine("Physics", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
-                                   "physics_time_taken", 1000.0, true, false, "physics_time_begin", "physics_time_end", 10000);
-
-    mViewer->addEventHandler(statshandler);
-
-    mViewer->addEventHandler(new Resource::StatsHandler);
-
+    // Load settings
     Settings::Manager settings;
     std::string settingspath;
-
     settingspath = loadSettings (settings);
+
+    // Create encoder
+    ToUTF8::Utf8Encoder encoder (mEncoding);
+    mEncoder = &encoder;
+
+    // Setup viewer
+    mViewer = new osgViewer::Viewer;
+    mViewer->setReleaseContextAtEndOfFrameHint(false);
 
     mScreenCaptureOperation = new WriteScreenshotToFileOperation(mCfgMgr.getUserDataPath().string(),
         Settings::Manager::getString("screenshot format", "General"));
@@ -677,12 +668,24 @@ void OMW::Engine::go()
 
     mEnvironment.setFrameRateLimit(Settings::Manager::getFloat("framerate limit", "Video"));
 
-    // Create encoder
-    ToUTF8::Utf8Encoder encoder (mEncoding);
-    mEncoder = &encoder;
-
     prepareEngine (settings);
 
+    // Setup profiler
+    osg::ref_ptr<Resource::Profiler> statshandler = new Resource::Profiler;
+
+    statshandler->addUserStatsLine("Script", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
+                                   "script_time_taken", 1000.0, true, false, "script_time_begin", "script_time_end", 10000);
+    statshandler->addUserStatsLine("Mechanics", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
+                                   "mechanics_time_taken", 1000.0, true, false, "mechanics_time_begin", "mechanics_time_end", 10000);
+    statshandler->addUserStatsLine("Physics", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
+                                   "physics_time_taken", 1000.0, true, false, "physics_time_begin", "physics_time_end", 10000);
+
+    mViewer->addEventHandler(statshandler);
+
+    osg::ref_ptr<Resource::StatsHandler> resourceshandler = new Resource::StatsHandler;
+    mViewer->addEventHandler(resourceshandler);
+
+    // Start the game
     if (!mSaveGameFile.empty())
     {
         mEnvironment.getStateManager()->loadGame(mSaveGameFile);

--- a/components/resource/stats.cpp
+++ b/components/resource/stats.cpp
@@ -10,6 +10,8 @@
 #include <osgViewer/Viewer>
 #include <osgViewer/Renderer>
 
+#include <components/myguiplatform/myguidatamanager.hpp>
+
 namespace Resource
 {
 
@@ -19,7 +21,7 @@ StatsHandler::StatsHandler():
     _statsType(false),
     _statsWidth(1280.0f),
     _statsHeight(1024.0f),
-    _font("fonts/arial.ttf"),
+    _font(""),
     _characterSize(20.0f)
 {
     _camera = new osg::Camera;
@@ -28,6 +30,15 @@ StatsHandler::StatsHandler():
     _camera->setProjectionResizePolicy(osg::Camera::FIXED);
 
     _resourceStatsChildNum = 0;
+
+    _font = osgMyGUI::DataManager::getInstance().getDataPath("DejaVuLGCSansMono.ttf");
+}
+
+Profiler::Profiler()
+{
+    _font = osgMyGUI::DataManager::getInstance().getDataPath("DejaVuLGCSansMono.ttf");
+
+    setKeyEventTogglesOnScreenStats(osgGA::GUIEventAdapter::KEY_F3);
 }
 
 bool StatsHandler::handle(const osgGA::GUIEventAdapter &ea, osgGA::GUIActionAdapter &aa)
@@ -77,7 +88,6 @@ void StatsHandler::setWindowSize(int width, int height)
     {
         _camera->setProjectionMatrix(osg::Matrix::ortho2D(0.0,_statsWidth,_statsHeight-height*_statsWidth/width,_statsHeight));
     }
-
 }
 
 void StatsHandler::toggle(osgViewer::ViewerBase *viewer)

--- a/components/resource/stats.hpp
+++ b/components/resource/stats.hpp
@@ -1,7 +1,7 @@
 #ifndef OPENMW_COMPONENTS_RESOURCE_STATS_H
 #define OPENMW_COMPONENTS_RESOURCE_STATS_H
 
-#include <osgGA/GUIEventHandler>
+#include <osgViewer/ViewerEventHandlers>
 
 namespace osgViewer
 {
@@ -15,6 +15,11 @@ namespace osg
 
 namespace Resource
 {
+    class Profiler : public osgViewer::StatsHandler
+    {
+    public:
+        Profiler();
+    };
 
     class StatsHandler : public osgGA::GUIEventHandler
     {


### PR DESCRIPTION
For now I get a lot of such errors in-game:
`Error reading file fonts/arial.ttf: file not found`

That's because osgViewer::StatsHandler (which we use as profilier) uses hardcoded arial.ttf from "fonts" folder.
But we do not provide arial.ttf with OpenMW, and an engine uses some kind of default font instead of TTF one.

The main idea: derive from osgViewer::StatsHandler and override used font - we can use the DejaVuLGCSansMono.ttf since we already provide it with OpenMW.
If the font was not found for some reason, OpenMW will use the internal OSG font as fallback.
This PR affects both profilier (F3) and stats monitor (F4).

Before merge, it would be nice to test this PR on Windows and Mac with both osg 3.4 and 3.6.
Example of output is [here](https://i.imgur.com/L1iZI0L.jpg).