### PR TITLE
Make unarmed creature attacks not affect armor condition (bug #2455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #1990: Sunrise/sunset not set correct
     Bug #2222: Fatigue's effect on selling price is backwards
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
+    Bug #2455: Creatures attacks degrade armor
     Bug #2562: Forcing AI to activate a teleport door sometimes causes a crash
     Bug #2772: Non-existing class or faction freezes the game
     Bug #2835: Player able to slowly move when overencumbered

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -773,22 +773,24 @@ namespace MWClass
                 float x = damage / (damage + getArmorRating(ptr));
                 damage *= std::max(gmst.fCombatArmorMinMult->getFloat(), x);
                 int damageDiff = static_cast<int>(unmitigatedDamage - damage);
-                if (damage < 1)
-                    damage = 1;
+                damage = std::max(1.f, damage);
+                damageDiff = std::max(1, damageDiff);
 
                 MWWorld::InventoryStore &inv = getInventoryStore(ptr);
                 MWWorld::ContainerStoreIterator armorslot = inv.getSlot(hitslot);
                 MWWorld::Ptr armor = ((armorslot != inv.end()) ? *armorslot : MWWorld::Ptr());
                 if(!armor.isEmpty() && armor.getTypeName() == typeid(ESM::Armor).name())
                 {
-                    int armorhealth = armor.getClass().getItemHealth(armor);
-                    armorhealth -= std::min(std::max(1, damageDiff),
-                                                 armorhealth);
-                    armor.getCellRef().setCharge(armorhealth);
+                    if (!(object.isEmpty() && !attacker.getClass().isNpc())) // Unarmed creature attacks don't affect armor condition
+                    {
+                        int armorhealth = armor.getClass().getItemHealth(armor);
+                        armorhealth -= std::min(damageDiff, armorhealth);
+                        armor.getCellRef().setCharge(armorhealth);
 
-                    // Armor broken? unequip it
-                    if (armorhealth == 0)
-                        armor = *inv.unequipItem(armor, ptr);
+                        // Armor broken? unequip it
+                        if (armorhealth == 0)
+                            armor = *inv.unequipItem(armor, ptr);
+                    }
 
                     if (ptr == MWMechanics::getPlayer())
                         skillUsageSucceeded(ptr, armor.getClass().getEquipmentSkill(armor), 0);

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -781,7 +781,7 @@ namespace MWClass
                 MWWorld::Ptr armor = ((armorslot != inv.end()) ? *armorslot : MWWorld::Ptr());
                 if(!armor.isEmpty() && armor.getTypeName() == typeid(ESM::Armor).name())
                 {
-                    if (!(object.isEmpty() && !attacker.getClass().isNpc())) // Unarmed creature attacks don't affect armor condition
+                    if (attacker.isEmpty() || (!attacker.isEmpty() && !(object.isEmpty() && !attacker.getClass().isNpc()))) // Unarmed creature attacks don't affect armor condition
                     {
                         int armorhealth = armor.getClass().getItemHealth(armor);
                         armorhealth -= std::min(damageDiff, armorhealth);

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -115,14 +115,16 @@ namespace MWMechanics
 
         if (Misc::Rng::roll0to99() < x)
         {
-            // Reduce shield durability by incoming damage
-            int shieldhealth = shield->getClass().getItemHealth(*shield);
+            if (!(weapon.isEmpty() && !attacker.getClass().isNpc())) // Unarmed creature attacks don't affect armor condition
+            {
+                // Reduce shield durability by incoming damage
+                int shieldhealth = shield->getClass().getItemHealth(*shield);
 
-            shieldhealth -= std::min(shieldhealth, int(damage));
-            shield->getCellRef().setCharge(shieldhealth);
-            if (shieldhealth == 0)
-                inv.unequipItem(*shield, blocker);
-
+                shieldhealth -= std::min(shieldhealth, int(damage));
+                shield->getCellRef().setCharge(shieldhealth);
+                if (shieldhealth == 0)
+                    inv.unequipItem(*shield, blocker);
+            }
             // Reduce blocker fatigue
             const float fFatigueBlockBase = gmst.find("fFatigueBlockBase")->getFloat();
             const float fFatigueBlockMult = gmst.find("fFatigueBlockMult")->getFloat();


### PR DESCRIPTION
[Bug 2455](https://gitlab.com/OpenMW/openmw/issues/2455).

Move the armor degradation code behind a check that the attacker is not an unarmed creature.
Initially I tried to make a neat reduceArmorCondition function with more sanity checks to get rid of code duplication but I ran into issues due to shield in combat.cpp being an iterator.