### PR TITLE
Play animation when casting spell via script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 
     Bug #1990: Sunrise/sunset not set correct
+    Bug #2131: Lustidrike's spell misses the player every time
     Bug #2222: Fatigue's effect on selling price is backwards
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
     Bug #2455: Creatures attacks degrade armor
@@ -65,7 +66,9 @@
     Bug #4495: Crossbow animations blending is buggy
     Bug #4496: SpellTurnLeft and SpellTurnRight animation groups are unused
     Bug #4497: File names starting with x or X are not classified as animation
+    Bug #4503: Cast and ExplodeSpell commands increase alteration skill
     Feature #2606: Editor: Implemented (optional) case sensitive global search
+    Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window
     Feature #4222: 360° screenshots

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -81,9 +81,9 @@ add_openmw_dir (mwclass
 add_openmw_dir (mwmechanics
     mechanicsmanagerimp stat creaturestats magiceffects movement actorutil
     drawstate spells activespells npcstats aipackage aisequence aipursue alchemy aiwander aitravel aifollow aiavoiddoor aibreathe
-    aiescort aiactivate aicombat repair enchanting pathfinding pathgrid security spellsuccess spellcasting
+    aicast aiescort aiface aiactivate aicombat repair enchanting pathfinding pathgrid security spellsuccess spellcasting
     disease pickpocket levelledlist combat steering obstacle autocalcspell difficultyscaling aicombataction actor summoning
-    character actors objects aistate coordinateconverter trading aiface weaponpriority spellpriority
+    character actors objects aistate coordinateconverter trading weaponpriority spellpriority
     )
 
 add_openmw_dir (mwstate

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -225,8 +225,11 @@ namespace MWBase
             /// Resurrects the player if necessary
             virtual void keepPlayerAlive() = 0;
 
+            virtual bool isCastingSpell (const MWWorld::Ptr& ptr) const = 0;
             virtual bool isReadyToBlock (const MWWorld::Ptr& ptr) const = 0;
             virtual bool isAttackingOrSpell(const MWWorld::Ptr &ptr) const = 0;
+
+            virtual void castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell) = 0;
 
             /// Check if the target actor was detected by an observer
             /// If the observer is a non-NPC, check all actors in AI processing distance as observers

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -487,7 +487,7 @@ namespace MWBase
              */
             virtual bool startSpellCast (const MWWorld::Ptr& actor) = 0;
 
-            virtual void castSpell (const MWWorld::Ptr& actor) = 0;
+            virtual void castSpell (const MWWorld::Ptr& actor, bool manualSpell=false) = 0;
 
             virtual void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) = 0;
             virtual void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1157,6 +1157,13 @@ namespace MWMechanics
         }
     }
 
+    void Actors::castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell)
+    {
+        PtrActorMap::iterator iter = mActors.find(ptr);
+        if(iter != mActors.end())
+            iter->second->getCharacterController()->castSpell(spellId, manualSpell);
+    }
+
     bool Actors::isActorDetected(const MWWorld::Ptr& actor, const MWWorld::Ptr& observer)
     {
         if (!actor.getClass().isActor())
@@ -1966,6 +1973,15 @@ namespace MWMechanics
             return false;
 
         return it->second->getCharacterController()->isReadyToBlock();
+    }
+
+    bool Actors::isCastingSpell(const MWWorld::Ptr &ptr) const
+    {
+        PtrActorMap::const_iterator it = mActors.find(ptr);
+        if (it == mActors.end())
+            return false;
+
+        return it->second->getCharacterController()->isCastingSpell();
     }
 
     bool Actors::isAttackingOrSpell(const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -77,6 +77,8 @@ namespace MWMechanics
             ///
             /// \note Ignored, if \a ptr is not a registered actor.
 
+            void castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell=false);
+
             void updateActor(const MWWorld::Ptr &old, const MWWorld::Ptr& ptr);
             ///< Updates an actor with a new Ptr
 
@@ -161,6 +163,7 @@ namespace MWMechanics
 
             void clear(); // Clear death counter
 
+            bool isCastingSpell(const MWWorld::Ptr& ptr) const;
             bool isReadyToBlock(const MWWorld::Ptr& ptr) const;
             bool isAttackingOrSpell(const MWWorld::Ptr& ptr) const;
 

--- a/apps/openmw/mwmechanics/aicast.cpp
+++ b/apps/openmw/mwmechanics/aicast.cpp
@@ -1,0 +1,84 @@
+#include "aicast.hpp"
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+
+#include "../mwworld/class.hpp"
+
+#include "aicombataction.hpp"
+#include "creaturestats.hpp"
+#include "spellcasting.hpp"
+#include "steering.hpp"
+
+MWMechanics::AiCast::AiCast(const std::string& targetId, const std::string& spellId, bool manualSpell)
+    : mTargetId(targetId), mSpellId(spellId), mCasting(false), mManual(manualSpell), mDistance(0)
+{
+    ActionSpell action = ActionSpell(spellId);
+    bool isRanged;
+    mDistance = action.getCombatRange(isRanged);
+}
+
+MWMechanics::AiPackage *MWMechanics::AiCast::clone() const
+{
+    return new AiCast(*this);
+}
+
+bool MWMechanics::AiCast::execute(const MWWorld::Ptr& actor, MWMechanics::CharacterController& characterController, MWMechanics::AiState& state, float duration)
+{
+    MWWorld::Ptr target;
+    if (actor.getCellRef().getRefId() == mTargetId)
+    {
+        // If the target has the same ID as caster, consider that actor casts spell with Self range.
+        target = actor;
+    }
+    else
+    {
+        target = getTarget();
+        if (!target)
+            return true;
+
+        if (!mManual && !pathTo(actor, target.getRefData().getPosition().pos, duration, mDistance))
+        {
+            return false;
+        }
+
+        osg::Vec3f dir = target.getRefData().getPosition().asVec3() - actor.getRefData().getPosition().asVec3();
+        bool turned = smoothTurn(actor, getZAngleToDir(dir), 2, osg::DegreesToRadians(3.f));
+        turned &= smoothTurn(actor, getXAngleToDir(dir), 0, osg::DegreesToRadians(3.f));
+
+        if (!turned)
+            return false;
+    }
+
+    // Check if the actor is already casting another spell
+    bool isCasting = MWBase::Environment::get().getMechanicsManager()->isCastingSpell(actor);
+    if (isCasting && !mCasting)
+        return false;
+
+    if (!mCasting)
+    {
+        MWBase::Environment::get().getMechanicsManager()->castSpell(actor, mSpellId, mManual);
+        mCasting = true;
+        return false;
+    }
+
+    // Finish package, if actor finished spellcasting
+    return !isCasting;
+}
+
+MWWorld::Ptr MWMechanics::AiCast::getTarget() const
+{
+    MWWorld::Ptr target = MWBase::Environment::get().getWorld()->searchPtr(mTargetId, false);
+
+    return target;
+}
+
+int MWMechanics::AiCast::getTypeId() const
+{
+    return AiPackage::TypeIdCast;
+}
+
+unsigned int MWMechanics::AiCast::getPriority() const
+{
+    return 3;
+}

--- a/apps/openmw/mwmechanics/aicast.hpp
+++ b/apps/openmw/mwmechanics/aicast.hpp
@@ -1,0 +1,37 @@
+#ifndef GAME_MWMECHANICS_AICAST_H
+#define GAME_MWMECHANICS_AICAST_H
+
+#include "../mwbase/world.hpp"
+
+#include "aipackage.hpp"
+
+namespace MWMechanics
+{
+    /// AiPackage which makes an actor to cast given spell.
+    class AiCast : public AiPackage {
+        public:
+            AiCast(const std::string& targetId, const std::string& spellId, bool manualSpell=false);
+
+            virtual AiPackage *clone() const;
+
+            virtual bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration);
+
+            virtual int getTypeId() const;
+
+            virtual MWWorld::Ptr getTarget() const;
+
+            virtual unsigned int getPriority() const;
+
+            virtual bool canCancel() const { return false; }
+            virtual bool shouldCancelPreviousAi() const { return false; }
+
+        private:
+            std::string mTargetId;
+            std::string mSpellId;
+            bool mCasting;
+            bool mManual;
+            float mDistance;
+    };
+}
+
+#endif

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -49,7 +49,8 @@ namespace MWMechanics
                 TypeIdAvoidDoor = 7,
                 TypeIdFace = 8,
                 TypeIdBreathe = 9,
-                TypeIdInternalTravel = 10
+                TypeIdInternalTravel = 10,
+                TypeIdCast = 11
             };
 
             ///Default constructor

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -204,6 +204,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     std::string mAttackType; // slash, chop or thrust
 
     bool mAttackingOrSpell;
+    bool mCastingManualSpell;
 
     float mTimeUntilWake;
 
@@ -276,6 +277,7 @@ public:
     void forceStateUpdate();
     
     bool isAttackPrepairing() const;
+    bool isCastingSpell() const;
     bool isReadyToBlock() const;
     bool isKnockedDown() const;
     bool isKnockedOut() const;
@@ -286,6 +288,7 @@ public:
     bool isAttackingOrSpell() const;
 
     void setAttackingOrSpell(bool attackingOrSpell);
+    void castSpell(const std::string spellId, bool manualSpell=false);
     void setAIAttackType(const std::string& attackType);
     static void setAttackTypeRandomly(std::string& attackType);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -253,6 +253,12 @@ namespace MWMechanics
             mObjects.addObject(ptr);
     }
 
+    void MechanicsManager::castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell)
+    {
+        if(ptr.getClass().isActor())
+            mActors.castSpell(ptr, spellId, manualSpell);
+    }
+
     void MechanicsManager::remove(const MWWorld::Ptr& ptr)
     {
         if(ptr == mWatched)
@@ -1756,6 +1762,11 @@ namespace MWMechanics
         CreatureStats& stats = player.getClass().getCreatureStats(player);
         if (stats.isDead())
             stats.resurrect();
+    }
+
+    bool MechanicsManager::isCastingSpell(const MWWorld::Ptr &ptr) const
+    {
+        return mActors.isCastingSpell(ptr);
     }
 
     bool MechanicsManager::isReadyToBlock(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -190,9 +190,13 @@ namespace MWMechanics
 
             virtual void keepPlayerAlive();
 
+            virtual bool isCastingSpell (const MWWorld::Ptr& ptr) const;
+
             virtual bool isReadyToBlock (const MWWorld::Ptr& ptr) const;
             /// Is \a ptr casting spell or using weapon now?
             virtual bool isAttackingOrSpell(const MWWorld::Ptr &ptr) const;
+
+            virtual void castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell=false);
 
             /// Check if the target actor was detected by an observer
             /// If the observer is a non-NPC, check all actors in AI processing distance as observers

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -315,13 +315,14 @@ namespace MWMechanics
         return true;
     }
 
-    CastSpell::CastSpell(const MWWorld::Ptr &caster, const MWWorld::Ptr &target, const bool fromProjectile)
+    CastSpell::CastSpell(const MWWorld::Ptr &caster, const MWWorld::Ptr &target, const bool fromProjectile, const bool isScripted)
         : mCaster(caster)
         , mTarget(target)
         , mStack(false)
         , mHitPosition(0,0,0)
         , mAlwaysSucceed(false)
         , mFromProjectile(fromProjectile)
+        , mIsScripted(isScripted)
     {
     }
 
@@ -863,7 +864,7 @@ namespace MWMechanics
 
         bool godmode = mCaster == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState();
 
-        if (mCaster.getClass().isActor() && !mAlwaysSucceed)
+        if (mCaster.getClass().isActor() && !mAlwaysSucceed && !mIsScripted)
         {
             school = getSpellSchool(spell, mCaster);
 
@@ -910,7 +911,7 @@ namespace MWMechanics
                 stats.getSpells().usePower(spell);
         }
 
-        if (mCaster == getPlayer() && spellIncreasesSkill(spell))
+        if (mCaster == getPlayer() && spellIncreasesSkill())
             mCaster.getClass().skillUsageSucceeded(mCaster,
                 spellSchoolToSkill(school), 0);
     
@@ -1032,6 +1033,14 @@ namespace MWMechanics
             else
                 sndMgr->playSound3D(mCaster, schools[effect->mData.mSchool]+" cast", 1.0f, 1.0f);
         }
+    }
+
+    bool CastSpell::spellIncreasesSkill()
+    {
+        if (mIsScripted)
+            return false;
+
+        return MWMechanics::spellIncreasesSkill(mId);
     }
 
     int getEffectiveEnchantmentCastCost(float castCost, const MWWorld::Ptr &actor)

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -88,9 +88,10 @@ namespace MWMechanics
         osg::Vec3f mHitPosition; // Used for spawning area orb
         bool mAlwaysSucceed; // Always succeed spells casted by NPCs/creatures regardless of their chance (default: false)
         bool mFromProjectile; // True if spell is cast by enchantment of some projectile (arrow, bolt or thrown weapon)
+        bool mIsScripted; // True if spell is casted from script and ignores some checks (mana level, success chance, etc.)
 
     public:
-        CastSpell(const MWWorld::Ptr& caster, const MWWorld::Ptr& target, const bool fromProjectile=false);
+        CastSpell(const MWWorld::Ptr& caster, const MWWorld::Ptr& target, const bool fromProjectile=false, const bool isScripted=false);
 
         bool cast (const ESM::Spell* spell);
 
@@ -107,6 +108,8 @@ namespace MWMechanics
         bool cast (const std::string& id);
 
         void playSpellCastingEffects(const std::string &spellid);
+
+        bool spellIncreasesSkill();
 
         /// Launch a bolt with the given effects.
         void launchMagicBolt ();

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -602,7 +602,7 @@ namespace MWWorld
              * @brief Cast the actual spell, should be called mid-animation
              * @param actor
              */
-            void castSpell (const MWWorld::Ptr& actor) override;
+            void castSpell (const MWWorld::Ptr& actor, bool manualSpell=false) override;
 
             void launchMagicBolt (const std::string& spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection) override;
             void launchProjectile (MWWorld::Ptr actor, MWWorld::ConstPtr projectile,


### PR DESCRIPTION
Fixes [bug #2131](https://gitlab.com/OpenMW/openmw/issues/2131), [bug #4503](https://gitlab.com/OpenMW/openmw/issues/4503) and implements [feature #3083](https://gitlab.com/OpenMW/openmw/issues/3083).

The main idea: introduce new AiCast package. When actor get this package, he turns to target, cast spell and resumes previous AI package execution.