### PR TITLE
Editor: limit FPS in 3D preview windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
     Bug #4474: No fallback when getVampireHead fails
     Bug #4475: Scripted animations should not cause movement
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
+    Feature #3641: Editor: Limit FPS in 3d preview window
     Feature #4222: 360° screenshots
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #4324: Add CFBundleIdentifier in Info.plist to allow for macOS function key shortcuts

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -201,6 +201,9 @@ void CSMPrefs::State::declare()
     declareDouble ("rotate-factor", "Free rotation factor", 0.007).setPrecision(4).setRange(0.0001, 0.1);
 
     declareCategory ("Rendering");
+    declareInt ("framerate-limit", "FPS limit", 60).
+        setTooltip("Framerate limit in 3D preview windows. Zero value means \"unlimited\".").
+        setRange(0, 10000);
     declareInt ("camera-fov", "Camera FOV", 90).setRange(10, 170);
     declareBool ("camera-ortho", "Orthographic projection for camera", false);
     declareInt ("camera-ortho-size", "Orthographic projection size parameter", 100).

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -151,6 +151,9 @@ CompositeViewer::CompositeViewer()
 
     connect( &mTimer, SIGNAL(timeout()), this, SLOT(update()) );
     mTimer.start( 10 );
+
+    int frameRateLimit = CSMPrefs::get()["Rendering"]["framerate-limit"].toInt();
+    setRunMaxFrameRate(frameRateLimit);
 }
 
 CompositeViewer &CompositeViewer::get()
@@ -168,6 +171,12 @@ void CompositeViewer::update()
 
     mSimulationTime += dt;
     frame(mSimulationTime);
+
+    double minFrameTime = _runMaxFrameRate > 0.0 ? 1.0 / _runMaxFrameRate : 0.0;
+    if (dt < minFrameTime)
+    {
+        OpenThreads::Thread::microSleep(1000*1000*(minFrameTime-dt));
+    }
 }
 
 // ---------------------------------------------------
@@ -375,6 +384,10 @@ void SceneWidget::settingChanged (const CSMPrefs::Setting *setting)
     else if (*setting=="3D Scene Input/navi-orbit-const-roll")
     {
         mOrbitCamControl->setConstRoll(setting->isTrue());
+    }
+    else if (*setting=="Rendering/framerate-limit")
+    {
+        CompositeViewer::get().setRunMaxFrameRate(setting->toInt());
     }
     else if (*setting=="Rendering/camera-fov" ||
              *setting=="Rendering/camera-ortho" ||


### PR DESCRIPTION
Implements [feature #3641](https://gitlab.com/OpenMW/openmw/issues/3641).

Note: I am aware of threading model - I can not test it because I do not have Qt4.
In theory, CompositeViewer::update() still should work in the main thread, but rendering update itself inside frame() call should be multithreaded.