### PR TITLE
 Make spellcasting stance transition more smooth (bug #4358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
     Bug #4293: Faction members are not aware of faction ownerships in barter
     Bug #4307: World cleanup should remove dead bodies only if death animation is finished
     Bug #4327: Missing animations during spell/weapon stance switching
+    Bug #4358: Running animation is interrupted when magic mode is toggled
     Bug #4368: Settings window ok button doesn't have key focus by default
     Bug #4393: NPCs walk back to where they were after using ResetActors
     Bug #4416: Handle exception if we try to play non-music file

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -459,9 +459,11 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
             }
         }
 
-        /* If we're playing the same animation, restart from the loop start instead of the
-         * beginning. */
-        int mode = ((movementAnimName == mCurrentMovement) ? 2 : 1);
+        // If we're playing the same animation, start it from the point it ended
+        bool sameAnim = (movementAnimName == mCurrentMovement);
+        float startPoint = 0.f;
+        if (sameAnim)
+            mAnimation->getInfo(mCurrentMovement, &startPoint);
 
         mMovementAnimationControlled = true;
 
@@ -510,7 +512,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
             }
 
             mAnimation->play(mCurrentMovement, Priority_Movement, movemask, false,
-                             1.f, ((mode!=2)?"start":"loop start"), "stop", 0.0f, ~0ul, true);
+                             1.f, (!sameAnim ? "start" : "loop start"), "stop", startPoint, ~0ul, true);
         }
     }
 }


### PR DESCRIPTION
[Bug 4358](https://gitlab.com/OpenMW/openmw/issues/4358)

Somewhat "experimental" fix I made accidentally: if a movement animation was identical to the previous one that was played, restart it from the point the previous animation ended (get the point of completion of the previous animation), instead of cutting it abrupt and restarting from loop start. Seems to work fine from my testing..? Feedback would be appreciated. @akortunov, does this seem OK to you?

It bothers me that I don't account for difference between start and loop start text keys, but when I actually try to do that, I break it again.