### PR TITLE
Ensure forward-compatibility of death animations of pre-0.43.0 saves (bug #4274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     Bug #4215: OpenMW shows book text after last EOL tag
     Bug #4221: Characters get stuck in V-shaped terrain
     Bug #4251: Stationary NPCs do not return to their position after combat
+    Bug #4274: Pre-0.43 death animations are not forward-compatible with 0.43+
     Bug #4286: Scripted animations can be interrupted
     Bug #4291: Non-persistent actors that started the game as dead do not play death animations
     Bug #4293: Faction members are not aware of faction ownerships in barter

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -662,16 +662,19 @@ MWWorld::ContainerStoreIterator getActiveWeapon(CreatureStats &stats, MWWorld::I
 
 void CharacterController::playDeath(float startpoint, CharacterState death)
 {
+    // Make sure the character was swimming upon death for forward-compatibility
+    const bool wasSwimming = MWBase::Environment::get().getWorld()->isSwimming(mPtr);
+
     switch (death)
     {
     case CharState_SwimDeath:
         mCurrentDeath = "swimdeath";
         break;
     case CharState_SwimDeathKnockDown:
-        mCurrentDeath = "swimdeathknockdown";
+        mCurrentDeath = (wasSwimming ? "swimdeathknockdown" : "deathknockdown");
         break;
     case CharState_SwimDeathKnockOut:
-        mCurrentDeath = "swimdeathknockout";
+        mCurrentDeath = (wasSwimming ? "swimdeathknockout" : "deathknockout");
         break;
     case CharState_DeathKnockDown:
         mCurrentDeath = "deathknockdown";


### PR DESCRIPTION
[Bug 4274](https://gitlab.com/OpenMW/openmw/issues/4274)
Better late than never.
Add a check that the character is actually swimming before applying (or fast-forwarding, as in the case of the report) two swimming death animations added in 0.43.0.