### PR TITLE
Make Goodbye block hyperlinks

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -629,6 +629,9 @@ namespace MWGui
 
     void DialogueWindow::onTopicActivated(const std::string &topicId)
     {
+        if (mGoodbye)
+            return;
+
         MWBase::Environment::get().getDialogueManager()->keywordSelected(topicId, mCallback.get());
         updateTopics();
     }


### PR DESCRIPTION
It's possible to use hyperlinks while Goodbye is in effect, which leads to... some odd behavior. ![odd behavior](https://user-images.githubusercontent.com/21265616/42390444-9516c83a-8154-11e8-8c1a-aed156a3451f.png)

I tested Morrowind and it seems that hyperlinks do nothing when clicked with Goodbye in effect there. So I replicated that.

I consider this a part of bug 3897.