### PR TITLE
Fix double call of addContainerScripts on player in moveObject (bug #4490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     Bug #3997: Almalexia doesn't pace
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID
     Bug #4047: OpenMW not reporting its version number in MacOS; OpenMW-CS not doing it fully
+    Bug #4110: Fixed undo / redo menu text losing the assigned shortcuts
     Bug #4125: OpenMW logo cropped on bugtracker
     Bug #4215: OpenMW shows book text after last EOL tag
     Bug #4221: Characters get stuck in V-shaped terrain
@@ -55,8 +56,9 @@
     Bug #4474: No fallback when getVampireHead fails
     Bug #4475: Scripted animations should not cause movement
     Bug #4479: "Game" category on Advanced page is getting too long
-    Bug #4480: Segfalt in QuickKeysMenu when item no longer in inventory
-    Bug #4110: Fixed undo / redo menu text losing the assigned shortcuts
+    Bug #4480: Segfault in QuickKeysMenu when item no longer in inventory
+    Bug #4489: Goodbye doesn't block dialogue hyperlinks
+    Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1166,7 +1166,10 @@ namespace MWWorld
             if (isPlayer)
             {
                 if (!newCell->isExterior())
+                {
                     changeToInteriorCell(Misc::StringUtils::lowerCase(newCell->getCell()->mName), pos, false);
+                    removeContainerScripts(getPlayerPtr());
+                }
                 else
                 {
                     if (mWorldScene->isCellActive(*newCell))
@@ -1187,9 +1190,8 @@ namespace MWWorld
                     mWorldScene->addObjectToScene(newPtr);
 
                     std::string script = newPtr.getClass().getScript(newPtr);
-                    if (!script.empty()) {
+                    if (!script.empty())
                         mLocalScripts.add(script, newPtr);
-                    }
                     addContainerScripts(newPtr, newCell);
                 }
                 else if (!newCellActive && currCellActive)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1191,7 +1191,9 @@ namespace MWWorld
 
                     std::string script = newPtr.getClass().getScript(newPtr);
                     if (!script.empty())
+                    {
                         mLocalScripts.add(script, newPtr);
+                    }
                     addContainerScripts(newPtr, newCell);
                 }
                 else if (!newCellActive && currCellActive)


### PR DESCRIPTION
[Bug 4490](https://gitlab.com/OpenMW/openmw/issues/4490)

When PositionCell is called on the player and it moves the player into an interior cell, moveObject adds scripts on items one time in changeToInteriorCell and the second time naturally, when it tries to change the cells the items expect to the new cell. I added another call of removeContainerScripts (because the cel changeToInteriorCell assigns the items to is no longer valid) on the player to prevent the warning.