### PR TITLE
Make Equip console command to bypass most of restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
     Bug #4457: Item without CanCarry flag prevents shield autoequipping in dark areas
     Bug #4458: AiWander console command handles idle chances incorrectly
     Bug #4459: NotCell dialogue condition doesn't support partial matches
+    Bug #4460: Script function "Equip" doesn't bypass beast restrictions
     Bug #4461: "Open" spell from non-player caster isn't a crime
     Bug #4464: OpenMW keeps AiState cached storages even after we cancel AI packages
     Bug #4469: Abot Silt Striders – Model turn 90 degrees on horizontal

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -146,7 +146,7 @@ namespace MWBase
             virtual MWGui::TradeWindow* getTradeWindow() = 0;
 
             /// Make the player use an item, while updating GUI state accordingly
-            virtual void useItem(const MWWorld::Ptr& item) = 0;
+            virtual void useItem(const MWWorld::Ptr& item, bool force=false) = 0;
 
             virtual void updateSpellWindow() = 0;
 

--- a/apps/openmw/mwclass/apparatus.cpp
+++ b/apps/openmw/mwclass/apparatus.cpp
@@ -124,10 +124,9 @@ namespace MWClass
         return info;
     }
 
-
-    std::shared_ptr<MWWorld::Action> Apparatus::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Apparatus::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionAlchemy());
+        return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionAlchemy(force));
     }
 
     MWWorld::Ptr Apparatus::copyToCellImpl(const MWWorld::ConstPtr &ptr, MWWorld::CellStore &cell) const

--- a/apps/openmw/mwclass/apparatus.hpp
+++ b/apps/openmw/mwclass/apparatus.hpp
@@ -50,8 +50,7 @@ namespace MWClass
             virtual std::string getInventoryIcon (const MWWorld::ConstPtr& ptr) const;
             ///< Return name of inventory icon.
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -354,9 +354,9 @@ namespace MWClass
         return std::make_pair(1,"");
     }
 
-    std::shared_ptr<MWWorld::Action> Armor::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Armor::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));
+        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr, force));
 
         action->setSound(getUpSoundId(ptr));
 

--- a/apps/openmw/mwclass/armor.hpp
+++ b/apps/openmw/mwclass/armor.hpp
@@ -73,8 +73,7 @@ namespace MWClass
             ///< Return 0 if player cannot equip item. 1 if can equip. 2 if it's twohanded weapon. 3 if twohanded weapon conflicts with that. \n
             ///  Second item in the pair specifies the error message
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwclass/book.cpp
+++ b/apps/openmw/mwclass/book.cpp
@@ -162,7 +162,7 @@ namespace MWClass
         return record->mId;
     }
 
-    std::shared_ptr<MWWorld::Action> Book::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Book::use (const MWWorld::Ptr& ptr, bool force) const
     {
         return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionRead(ptr));
     }

--- a/apps/openmw/mwclass/book.hpp
+++ b/apps/openmw/mwclass/book.hpp
@@ -53,7 +53,7 @@ namespace MWClass
             virtual std::string applyEnchantment(const MWWorld::ConstPtr &ptr, const std::string& enchId, int enchCharge, const std::string& newName) const;
             ///< Creates a new record using \a ptr as template, with the given name and the given enchantment applied to it.
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr) const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -243,9 +243,9 @@ namespace MWClass
         return std::make_pair (1, "");
     }
 
-    std::shared_ptr<MWWorld::Action> Clothing::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Clothing::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));
+        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr, force));
 
         action->setSound(getUpSoundId(ptr));
 

--- a/apps/openmw/mwclass/clothing.hpp
+++ b/apps/openmw/mwclass/clothing.hpp
@@ -65,8 +65,7 @@ namespace MWClass
             ///< Return 0 if player cannot equip item. 1 if can equip. 2 if it's twohanded weapon. 3 if twohanded weapon conflicts with that.
             ///  Second item in the pair specifies the error message
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -75,7 +75,7 @@ namespace MWClass
     }
 
 
-    std::shared_ptr<MWWorld::Action> Ingredient::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Ingredient::use (const MWWorld::Ptr& ptr, bool force) const
     {
         std::shared_ptr<MWWorld::Action> action (new MWWorld::ActionEat (ptr));
 

--- a/apps/openmw/mwclass/ingredient.hpp
+++ b/apps/openmw/mwclass/ingredient.hpp
@@ -36,8 +36,7 @@ namespace MWClass
             virtual int getValue (const MWWorld::ConstPtr& ptr) const;
             ///< Return trade value of the object. Throws an exception, if the object can't be traded.
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
             
             static void registerSelf();

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -186,9 +186,9 @@ namespace MWClass
         return Class::showsInInventory(ptr);
     }
 
-    std::shared_ptr<MWWorld::Action> Light::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Light::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));
+        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr, force));
 
         action->setSound(getUpSoundId(ptr));
 

--- a/apps/openmw/mwclass/light.hpp
+++ b/apps/openmw/mwclass/light.hpp
@@ -55,8 +55,7 @@ namespace MWClass
             virtual std::string getInventoryIcon (const MWWorld::ConstPtr& ptr) const;
             ///< Return name of inventory icon.
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual void setRemainingUsageTime (const MWWorld::Ptr& ptr, float duration) const;

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -140,9 +140,9 @@ namespace MWClass
         return info;
     }
 
-    std::shared_ptr<MWWorld::Action> Lockpick::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Lockpick::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));
+        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr, force));
 
         action->setSound(getUpSoundId(ptr));
 

--- a/apps/openmw/mwclass/lockpick.hpp
+++ b/apps/openmw/mwclass/lockpick.hpp
@@ -53,8 +53,7 @@ namespace MWClass
 
             virtual std::pair<int, std::string> canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const;
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -226,7 +226,7 @@ namespace MWClass
         return newPtr;
     }
 
-    std::shared_ptr<MWWorld::Action> Miscellaneous::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Miscellaneous::use (const MWWorld::Ptr& ptr, bool force) const
     {
         if (ptr.getCellRef().getSoul().empty() || !MWBase::Environment::get().getWorld()->getStore().get<ESM::Creature>().search(ptr.getCellRef().getSoul()))
             return std::shared_ptr<MWWorld::Action>(new MWWorld::NullAction());

--- a/apps/openmw/mwclass/misc.hpp
+++ b/apps/openmw/mwclass/misc.hpp
@@ -49,8 +49,7 @@ namespace MWClass
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual float getWeight (const MWWorld::ConstPtr& ptr) const;

--- a/apps/openmw/mwclass/potion.cpp
+++ b/apps/openmw/mwclass/potion.cpp
@@ -139,7 +139,7 @@ namespace MWClass
         return info;
     }
 
-    std::shared_ptr<MWWorld::Action> Potion::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Potion::use (const MWWorld::Ptr& ptr, bool force) const
     {
         MWWorld::LiveCellRef<ESM::Potion> *ref =
             ptr.get<ESM::Potion>();

--- a/apps/openmw/mwclass/potion.hpp
+++ b/apps/openmw/mwclass/potion.hpp
@@ -36,7 +36,7 @@ namespace MWClass
             virtual int getValue (const MWWorld::ConstPtr& ptr) const;
             ///< Return trade value of the object. Throws an exception, if the object can't be traded.
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr) const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             static void registerSelf();

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -140,9 +140,9 @@ namespace MWClass
         return info;
     }
 
-    std::shared_ptr<MWWorld::Action> Probe::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Probe::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));
+        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr, force));
 
         action->setSound(getUpSoundId(ptr));
 

--- a/apps/openmw/mwclass/probe.hpp
+++ b/apps/openmw/mwclass/probe.hpp
@@ -53,8 +53,7 @@ namespace MWClass
 
             virtual std::pair<int, std::string> canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const;
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwclass/repair.cpp
+++ b/apps/openmw/mwclass/repair.cpp
@@ -149,9 +149,9 @@ namespace MWClass
         return MWWorld::Ptr(cell.insert(ref), &cell);
     }
 
-    std::shared_ptr<MWWorld::Action> Repair::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Repair::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionRepair(ptr));
+        return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionRepair(ptr, force));
     }
 
     bool Repair::canSell (const MWWorld::ConstPtr& item, int npcServices) const

--- a/apps/openmw/mwclass/repair.hpp
+++ b/apps/openmw/mwclass/repair.hpp
@@ -49,7 +49,7 @@ namespace MWClass
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false)
                 const;
             ///< Generate action for using via inventory menu (default implementation: return a
             /// null action).

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -401,9 +401,9 @@ namespace MWClass
         return std::make_pair(1, "");
     }
 
-    std::shared_ptr<MWWorld::Action> Weapon::use (const MWWorld::Ptr& ptr) const
+    std::shared_ptr<MWWorld::Action> Weapon::use (const MWWorld::Ptr& ptr, bool force) const
     {
-        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr));
+        std::shared_ptr<MWWorld::Action> action(new MWWorld::ActionEquip(ptr, force));
 
         action->setSound(getUpSoundId(ptr));
 

--- a/apps/openmw/mwclass/weapon.hpp
+++ b/apps/openmw/mwclass/weapon.hpp
@@ -72,8 +72,7 @@ namespace MWClass
             ///< Return 0 if player cannot equip item. 1 if can equip. 2 if it's twohanded weapon. 3 if twohanded weapon conflicts with that.
             ///  Second item in the pair specifies the error message
 
-            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr)
-                const;
+            virtual std::shared_ptr<MWWorld::Action> use (const MWWorld::Ptr& ptr, bool force=false) const;
             ///< Generate action for using via inventory menu
 
             virtual std::string getModel(const MWWorld::ConstPtr &ptr) const;

--- a/apps/openmw/mwgui/inventorywindow.hpp
+++ b/apps/openmw/mwgui/inventorywindow.hpp
@@ -58,7 +58,7 @@ namespace MWGui
 
             void clear();
 
-            void useItem(const MWWorld::Ptr& ptr);
+            void useItem(const MWWorld::Ptr& ptr, bool force=false);
 
             void setGuiMode(GuiMode mode);
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1328,10 +1328,10 @@ namespace MWGui
     MWGui::ConfirmationDialog* WindowManager::getConfirmationDialog() { return mConfirmationDialog; }
     MWGui::TradeWindow* WindowManager::getTradeWindow() { return mTradeWindow; }
 
-    void WindowManager::useItem(const MWWorld::Ptr &item)
+    void WindowManager::useItem(const MWWorld::Ptr &item, bool bypassBeastRestrictions)
     {
         if (mInventoryWindow)
-            mInventoryWindow->useItem(item);
+            mInventoryWindow->useItem(item, bypassBeastRestrictions);
     }
 
     bool WindowManager::isAllowed (GuiWindow wnd) const

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -185,7 +185,7 @@ namespace MWGui
     virtual MWGui::TradeWindow* getTradeWindow();
 
     /// Make the player use an item, while updating GUI state accordingly
-    virtual void useItem(const MWWorld::Ptr& item);
+    virtual void useItem(const MWWorld::Ptr& item, bool bypassBeastRestrictions=false);
 
     virtual void updateSpellWindow();
 

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -20,6 +20,7 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/world.hpp"
 
+#include "../mwworld/actionequip.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/inventorystore.hpp"
@@ -193,12 +194,11 @@ namespace MWScript
                             "to fulfil requirements of Equip instruction" << std::endl;
                     }
 
-                    if (ptr == MWBase::Environment::get().getWorld()->getPlayerPtr())
-                        MWBase::Environment::get().getWindowManager()->useItem(*it);
+                    if (ptr == MWMechanics::getPlayer())
+                        MWBase::Environment::get().getWindowManager()->useItem(*it, true);
                     else
                     {
-                        std::shared_ptr<MWWorld::Action> action = it->getClass().use(*it);
-                        // No equip sound for actors other than the player
+                        std::shared_ptr<MWWorld::Action> action = it->getClass().use(*it, true);
                         action->execute(ptr, true);
                     }
                 }

--- a/apps/openmw/mwworld/actionalchemy.cpp
+++ b/apps/openmw/mwworld/actionalchemy.cpp
@@ -9,12 +9,19 @@
 
 namespace MWWorld
 {
+    ActionAlchemy::ActionAlchemy(bool force)
+    : Action (false)
+    , mForce(force)
+    {
+    }
+
     void ActionAlchemy::executeImp (const Ptr& actor)
     {
         if (actor != MWMechanics::getPlayer())
             return;
 
-        if(MWMechanics::isPlayerInCombat()) { //Ensure we're not in combat
+        if(!mForce && MWMechanics::isPlayerInCombat())
+        { //Ensure we're not in combat
             MWBase::Environment::get().getWindowManager()->messageBox("#{sInventoryMessage3}");
             return;
         }

--- a/apps/openmw/mwworld/actionalchemy.hpp
+++ b/apps/openmw/mwworld/actionalchemy.hpp
@@ -7,7 +7,11 @@ namespace MWWorld
 {
     class ActionAlchemy : public Action
     {
-            virtual void executeImp (const Ptr& actor);
+        bool mForce;
+        virtual void executeImp (const Ptr& actor);
+
+    public:
+        ActionAlchemy(bool force=false);
     };
 }
 

--- a/apps/openmw/mwworld/actionequip.cpp
+++ b/apps/openmw/mwworld/actionequip.cpp
@@ -14,7 +14,9 @@
 
 namespace MWWorld
 {
-    ActionEquip::ActionEquip (const MWWorld::Ptr& object) : Action (false, object)
+    ActionEquip::ActionEquip (const MWWorld::Ptr& object, bool force)
+    : Action (false, object)
+    , mForce(force)
     {
     }
 
@@ -23,18 +25,29 @@ namespace MWWorld
         MWWorld::Ptr object = getTarget();
         MWWorld::InventoryStore& invStore = actor.getClass().getInventoryStore(actor);
 
-        std::pair <int, std::string> result = object.getClass().canBeEquipped (object, actor);
-
-        // display error message if the player tried to equip something
-        if (!result.second.empty() && actor == MWMechanics::getPlayer())
-            MWBase::Environment::get().getWindowManager()->messageBox(result.second);
-
-        switch(result.first)
+        if (object.getClass().hasItemHealth(object) && object.getCellRef().getCharge() == 0)
         {
-            case 0:
-                return;
-            default:
-                break;
+            if (actor == MWMechanics::getPlayer())
+                MWBase::Environment::get().getWindowManager()->messageBox("#{sInventoryMessage1}");
+
+            return;
+        }
+
+        if (!mForce)
+        {
+            std::pair <int, std::string> result = object.getClass().canBeEquipped (object, actor);
+
+            // display error message if the player tried to equip something
+            if (!result.second.empty() && actor == MWMechanics::getPlayer())
+                MWBase::Environment::get().getWindowManager()->messageBox(result.second);
+
+            switch(result.first)
+            {
+                case 0:
+                    return;
+                default:
+                    break;
+            }
         }
 
         // slots that this item can be equipped in

--- a/apps/openmw/mwworld/actionequip.hpp
+++ b/apps/openmw/mwworld/actionequip.hpp
@@ -2,17 +2,18 @@
 #define GAME_MWWORLD_ACTIONEQUIP_H
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {
     class ActionEquip : public Action
     {
-            virtual void executeImp (const Ptr& actor);
+        bool mForce;
 
-        public:
-            /// @param item to equip
-            ActionEquip (const Ptr& object);
+        virtual void executeImp (const Ptr& actor);
+
+    public:
+        /// @param item to equip
+        ActionEquip (const Ptr& object, bool force=false);
     };
 }
 

--- a/apps/openmw/mwworld/actionrepair.cpp
+++ b/apps/openmw/mwworld/actionrepair.cpp
@@ -8,8 +8,9 @@
 
 namespace MWWorld
 {
-    ActionRepair::ActionRepair(const Ptr &item)
-        : Action(false, item)
+    ActionRepair::ActionRepair(const Ptr& item, bool force)
+        : Action (false, item)
+        , mForce(force)
     {
     }
 
@@ -18,7 +19,8 @@ namespace MWWorld
         if (actor != MWMechanics::getPlayer())
             return;
 
-        if(MWMechanics::isPlayerInCombat()) {
+        if(!mForce && MWMechanics::isPlayerInCombat())
+        {
             MWBase::Environment::get().getWindowManager()->messageBox("#{sInventoryMessage2}");
             return;
         }

--- a/apps/openmw/mwworld/actionrepair.hpp
+++ b/apps/openmw/mwworld/actionrepair.hpp
@@ -7,10 +7,13 @@ namespace MWWorld
 {
     class ActionRepair : public Action
     {
-            virtual void executeImp (const Ptr& actor);
+        bool mForce;
+
+        virtual void executeImp (const Ptr& actor);
 
     public:
-        ActionRepair(const MWWorld::Ptr& item);
+        /// @param item repair hammer
+        ActionRepair(const Ptr& item, bool force=false);
     };
 }
 

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -113,7 +113,7 @@ namespace MWWorld
         return std::shared_ptr<Action> (new NullAction);
     }
 
-    std::shared_ptr<Action> Class::use (const Ptr& ptr) const
+    std::shared_ptr<Action> Class::use (const Ptr& ptr, bool force) const
     {
         return std::shared_ptr<Action> (new NullAction);
     }

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -141,7 +141,7 @@ namespace MWWorld
             virtual std::shared_ptr<Action> activate (const Ptr& ptr, const Ptr& actor) const;
             ///< Generate action for activation (default implementation: return a null action).
 
-            virtual std::shared_ptr<Action> use (const Ptr& ptr)
+            virtual std::shared_ptr<Action> use (const Ptr& ptr, bool force=false)
                 const;
             ///< Generate action for using via inventory menu (default implementation: return a
             /// null action).


### PR DESCRIPTION
Fixes [bug #4460](https://gitlab.com/OpenMW/openmw/issues/4460).

This solution is hackish, I know, but I do not see any way to make it clean.

The main idea: allow Equip console command to bypass most of restrictions (e.g. allow beast races to wear armor or repair items in combat).
Note: you still can not equip broken items via console command, as in vanilla game. I guess that vanilla game handles this restriction separately.