### PR TITLE
Update trainer skill cap based off modified skill instead of based skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
     Bug #4480: Segfault in QuickKeysMenu when item no longer in inventory
     Bug #4489: Goodbye doesn't block dialogue hyperlinks
     Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
+    Bug #4491: Training cap based off Base Skill instead of Modified Skill
     Bug #3249: Fixed revert function not updating views properly
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwgui/trainingwindow.cpp
+++ b/apps/openmw/mwgui/trainingwindow.cpp
@@ -80,7 +80,7 @@ namespace MWGui
 
         for (int i=0; i<ESM::Skill::Length; ++i)
         {
-            int value = npcStats.getSkill (i).getBase ();
+            int value = npcStats.getSkill (i).getModified ();
 
             skills.push_back(std::make_pair(i, value));
         }


### PR DESCRIPTION
http://en.uesp.net/wiki/Morrowind:Trainers
>If a Fortify Skill effect is cast on a trainer and makes that skill one of their three highest, it becomes one of the skills in which the trainer will offer training. Use this to make them train different skills and/or train to higher levels. For instance, casting a +100 Unarmored spell on any trainer will turn them into a master-level trainer in Unarmored for the duration of the spell.