### PR TITLE
Update CMake lists for Windows (task #2490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
     Feature #4444: Per-group KF-animation files support
     Feature #4466: Editor: Add option to ignore "Base" records when running verifier
     Feature #4012: Editor: Write a log file if OpenCS crashes
+    Task #2490: Don't open command prompt window on Release-mode builds automatically
 
 0.44.0
 ------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,10 +610,10 @@ if (WIN32)
     endif()
 
     if (BUILD_OPENMW)
-        # Release builds use the debug console
-        set_target_properties(openmw PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:CONSOLE")
-        set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS_RELEASE "_CONSOLE")
-        set_target_properties(openmw PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:CONSOLE")
+        # Release builds don't use the debug console
+        set_target_properties(openmw PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
+        set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS_RELEASE "_WINDOWS")
+        set_target_properties(openmw PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
     endif()
 
     # Play a bit with the warning levels
@@ -642,9 +642,11 @@ if (WIN32)
 
         # caused by boost
         4191 # 'type cast' : unsafe conversion (1.56, thread_primitives.hpp, normally off)
+        5032 # detected #pragma warning(push) with no corresponding #pragma warning(pop)
 
         # caused by MyGUI
         4275 # non dll-interface class 'std::exception' used as base for dll-interface class 'MyGUI::Exception'
+        4297 # function assumed not to throw an exception but does
 
         # OpenMW specific warnings
         4099 # Type mismatch, declared class or struct is defined with other type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,8 @@ if (WIN32)
         # Warnings that aren't enabled normally and don't need to be enabled
         # They're unneeded and sometimes completely retarded warnings that /Wall enables
         # Not going to bother commenting them as they tend to warn on every standard library file
-        4061 4263 4264 4266 4350 4371 4435 4514 4548 4571 4610 4619 4623 4625 4626 4628 4640 4668 4710 4711 4820 4826 4917 4946
+        4061 4263 4264 4266 4350 4371 4435 4514 4548 4571 4610 4619 4623 4625 
+        4626 4628 4640 4668 4710 4711 4768 4820 4826 4917 4946 5032 5039 5045
 
         # Warnings that are thrown on standard libraries and not OpenMW
         4347 # Non-template function with same name and parameter count as template function
@@ -642,7 +643,6 @@ if (WIN32)
 
         # caused by boost
         4191 # 'type cast' : unsafe conversion (1.56, thread_primitives.hpp, normally off)
-        5032 # detected #pragma warning(push) with no corresponding #pragma warning(pop)
 
         # caused by MyGUI
         4275 # non dll-interface class 'std::exception' used as base for dll-interface class 'MyGUI::Exception'


### PR DESCRIPTION
[Task #2490](https://gitlab.com/OpenMW/openmw/issues/2490)
See also [feature #4487](https://gitlab.com/OpenMW/openmw/issues/4487), which is related and should be implemented later to make this change useful.

Let's see what AppVeyor will say now.

- Automatic command prompt logging has been disabled in Release builds on Windows
- Five especially spammy warnings were disabled

For that the subsystem of release builds was changed from CONSOLE to WINDOWS. These warnings are C4297 and C5032, which are fired for MyGUI and Boost respectively, and they can't be fixed from the side of OpenMW, even though AppVeyor constantly spams them, and C5039, C5045, C4768, which are also not OpenMW's fault. C5032, C5039, C5045, C4768 are also supposed to be disabled by default at least in VS2015 and later, but they're enabled again by Wall flag.

Note that I "redesigned" the original issue because it's, well, not really possible to make something set via precompiler directives and cmake magic a configuration option.

As far as I know main.cpp should already handle this.