### PR TITLE
Use SpellTurnLeft/SpellTurnRight animation groups (bug #4496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@
     Bug #4489: Goodbye doesn't block dialogue hyperlinks
     Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
     Bug #4491: Training cap based off Base Skill instead of Modified Skill
-    Bug #4495: Crossbow animations blending is buggy    
+    Bug #4495: Crossbow animations blending is buggy
+    Bug #4496: SpellTurnLeft and SpellTurnRight animation groups are unused
     Bug #3249: Fixed revert function not updating views properly
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -422,7 +422,10 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
             movementAnimName = movestate->groupname;
             if(weap != sWeaponTypeListEnd && movementAnimName.find("swim") == std::string::npos)
             {
-                movementAnimName += weap->shortgroup;
+                if (mWeaponType == WeapType_Spell && (mMovementState == CharState_TurnLeft || mMovementState == CharState_TurnRight)) // Spellcasting stance turning is a special case
+                    movementAnimName = weap->shortgroup + movementAnimName;
+                else
+                    movementAnimName += weap->shortgroup;
                 if(!mAnimation->hasAnimation(movementAnimName))
                 {
                     movemask = MWRender::Animation::BlendMask_LowerBody;


### PR DESCRIPTION
[Bug 4496](https://gitlab.com/OpenMW/openmw/issues/4496)

Add a special case to make use of these groups for spellcasting turning animations and fix spellcasting stance animations once and for all.