### PR TITLE
Show magic items count in spells window (feature #4509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
     Feature #4444: Per-group KF-animation files support
     Feature #4466: Editor: Add option to ignore "Base" records when running verifier
     Feature #4012: Editor: Write a log file if OpenCS crashes
+    Feature #4509: Show count of enchanted items in stack in the spells list
     Feature #4512: Editor: Use markers for lights and creatures levelled lists
     Task #2490: Don't open command prompt window on Release-mode builds automatically
 

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -80,6 +80,7 @@ namespace MWGui
 
             newSpell.mSelected = (MWBase::Environment::get().getWindowManager()->getSelectedSpell() == spell->mId);
             newSpell.mActive = true;
+            newSpell.mCount = 1;
             mSpells.push_back(newSpell);
         }
 
@@ -109,6 +110,7 @@ namespace MWGui
             newSpell.mItem = item;
             newSpell.mId = item.getCellRef().getRefId();
             newSpell.mName = item.getClass().getName(item);
+            newSpell.mCount = item.getRefData().getCount();
             newSpell.mType = Spell::Type_EnchantedItem;
             newSpell.mSelected = invStore.getSelectedEnchantItem() == it;
 

--- a/apps/openmw/mwgui/spellmodel.hpp
+++ b/apps/openmw/mwgui/spellmodel.hpp
@@ -20,6 +20,7 @@ namespace MWGui
         std::string mCostColumn; // Cost/chance or Cost/charge
         std::string mId; // Item ID or spell ID
         MWWorld::Ptr mItem; // Only for Type_EnchantedItem
+        int mCount; // Only for Type_EnchantedItem
         bool mSelected; // Is this the currently selected spell/item (only one can be selected at a time)
         bool mActive; // (Items only) is the item equipped?
 

--- a/apps/openmw/mwgui/spellview.cpp
+++ b/apps/openmw/mwgui/spellview.cpp
@@ -7,6 +7,8 @@
 
 #include <components/widgets/sharedstatebutton.hpp>
 
+#include "tooltips.hpp"
+
 namespace MWGui
 {
 
@@ -103,11 +105,12 @@ namespace MWGui
             }
 
             const std::string skin = spell.mActive ? "SandTextButton" : "SpellTextUnequipped";
+            const std::string captionSuffix = MWGui::ToolTips::getCountString(spell.mCount);
 
             Gui::SharedStateButton* t = mScrollView->createWidget<Gui::SharedStateButton>(skin,
                 MyGUI::IntCoord(0, 0, 0, spellHeight), MyGUI::Align::Left | MyGUI::Align::Top);
             t->setNeedKeyFocus(true);
-            t->setCaption(spell.mName);
+            t->setCaption(spell.mName + captionSuffix);
             t->setTextAlign(MyGUI::Align::Left);
             adjustSpellWidget(spell, i, t);
 
@@ -163,7 +166,8 @@ namespace MWGui
 
                 // more checking for major change.
                 const Spell& spell = mModel->getItem(spellIndex);
-                if (nameButton->getCaption() != spell.mName)
+                const std::string captionSuffix = MWGui::ToolTips::getCountString(spell.mCount);
+                if (nameButton->getCaption() != (spell.mName + captionSuffix))
                 {
                     fullUpdateRequired = true;
                     break;


### PR DESCRIPTION
Related [feature request](https://gitlab.com/OpenMW/openmw/issues/4509).
![screenshot_20180714_155642](https://user-images.githubusercontent.com/26434804/42724191-c0d080a8-877e-11e8-9ff8-9c71095df972.png)

Notes:
1. Magic item selection in quick keys menu is affected too for now.
2. I did not touch stacking logic: equipped magic items are still in the separate stacks from non-equipped ones, items with depleted charges form own stacks.