### PR TITLE
Use editor markers for lights and creatures levelled lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
     Feature #4444: Per-group KF-animation files support
     Feature #4466: Editor: Add option to ignore "Base" records when running verifier
     Feature #4012: Editor: Write a log file if OpenCS crashes
+    Feature #4512: Editor: Use markers for lights and creatures levelled lists
     Task #2490: Don't open command prompt window on Release-mode builds automatically
 
 0.44.0

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -102,6 +102,14 @@ void CSVRender::Object::update()
         if (recordType == CSMWorld::UniversalId::Type_Light)
         {
             light = &dynamic_cast<const CSMWorld::Record<ESM::Light>& >(referenceables.getRecord(index)).get();
+            if (model.empty())
+                model = "marker_light.nif";
+        }
+
+        if (recordType == CSMWorld::UniversalId::Type_CreatureLevelledList)
+        {
+            if (model.empty())
+                model = "marker_creature.nif";
         }
 
         if (model.empty())


### PR DESCRIPTION
Implements [feature #4512](https://gitlab.com/OpenMW/openmw/issues/4512).

Subject:
![screenshot_20180714_180740](https://user-images.githubusercontent.com/26434804/42725355-47e45e7a-8793-11e8-8e7f-1bcc73de373e.jpg)

There are at least two unused markers in openmw-cs:
1. marker_creature.nif - marker for creatures levelled lists
2. marker_light.nif - default marker for light sources, which do not have own mesh.

Just use them instead of white boxes. Works for both scene and instance preview widgets.