### PR TITLE
Fix possible division by zero in the fatigue calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
     Bug #4496: SpellTurnLeft and SpellTurnRight animation groups are unused
     Bug #4497: File names starting with x or X are not classified as animation
     Bug #4503: Cast and ExplodeSpell commands increase alteration skill
+    Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -157,7 +157,7 @@ namespace MWMechanics
                 int endurance    = getAttribute(ESM::Attribute::Endurance).getModified();
                 DynamicStat<float> fatigue = getFatigue();
                 float diff = (strength+willpower+agility+endurance) - fatigue.getBase();
-                float currentToBaseRatio = (fatigue.getCurrent() / fatigue.getBase());
+                float currentToBaseRatio = fatigue.getBase() > 0 ? (fatigue.getCurrent() / fatigue.getBase()) : 0;
                 fatigue.setModified(fatigue.getModified() + diff, 0);
                 fatigue.setCurrent(fatigue.getBase() * currentToBaseRatio);
                 setFatigue(fatigue);


### PR DESCRIPTION
Fixes [bug #4510](https://gitlab.com/OpenMW/openmw/issues/4510).
If fatigue.getBase() = 0, there will be fatigue.setCurrent(0*0) anyway.

As I understand, the point of currentToBaseRatio is too keep fatigue parcentage after recalculation.
There is two possible ways to handle 0/0 fatigue:
1. Consider it as a full fatigue, so if after recalculation base fatigue becomes positive, there will be 100% fatigue level.
2. Consider is as empty fatigue, so if after recalculation base fatigue becomes positive, current fatigue still will be 0.

In master branch we have the second behaviour, so I keep it for now.