### PR TITLE
Do not play unequipping animation when we switch to hand-to-hand

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1229,12 +1229,17 @@ bool CharacterController::updateWeaponState()
             && mUpperBodyState != UpperCharState_UnEquipingWeap
             && !isStillWeapon)
         {
-            // Note: we do not disable unequipping animation automatically to avoid body desync
-            getWeaponGroup(mWeaponType, weapgroup);
-            mAnimation->play(weapgroup, priorityWeapon,
-                              MWRender::Animation::BlendMask_All, false,
-                              1.0f, "unequip start", "unequip stop", 0.0f, 0);
-            mUpperBodyState = UpperCharState_UnEquipingWeap;
+            // We can not play un-equip animation when we switch to HtH
+            // because we already un-equipped weapon
+            if (weaptype != WeapType_HandToHand || mWeaponType == WeapType_Spell)
+            {
+                // Note: we do not disable unequipping animation automatically to avoid body desync
+                getWeaponGroup(mWeaponType, weapgroup);
+                mAnimation->play(weapgroup, priorityWeapon,
+                                MWRender::Animation::BlendMask_All, false,
+                                1.0f, "unequip start", "unequip stop", 0.0f, 0);
+                mUpperBodyState = UpperCharState_UnEquipingWeap;
+            }
 
             if(!downSoundId.empty())
             {


### PR DESCRIPTION
Fixes a small regression in 0.45.
When we switch from weapon to hand-to hand, we play weapon uneqipping animation for now, but there is no weapon in hands during the animation, because the weapon is already unequipped.
Vanilla for weapon->HtH switch plays only weapon unequipping sound and HtH equipping animation.
This PR replicates vanilla behaviour.

Note: we do not need the changelog entry in this case.