### PR TITLE
Rework weapon animation blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
     Bug #4563: Fast travel price logic checks destination cell instead of service actor cell
     Bug #4565: Underwater view distance should be limited
     Bug #4573: Player uses headtracking in the 1st-person mode
+    Bug #4575: Weird result of attack animation blending with movement animations
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
     Bug #4565: Underwater view distance should be limited
     Bug #4573: Player uses headtracking in the 1st-person mode
     Bug #4575: Weird result of attack animation blending with movement animations
+    Bug #4576: Reset of idle animations when attack can not be started
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1360,14 +1360,7 @@ bool CharacterController::updateWeaponState()
     {
         MWWorld::Ptr player = getPlayer();
 
-        // We should reset player's idle animation in the first-person mode.
-        if (mPtr == player && MWBase::Environment::get().getWorld()->isFirstPerson())
-            mIdleState = CharState_None;
-
-        // In other cases we should not break swim and sneak animations
-        if (mIdleState != CharState_IdleSneak && mIdleState != CharState_IdleSwim)
-            mIdleState = CharState_None;
-
+        bool resetIdle = ammunition;
         if(mUpperBodyState == UpperCharState_WeapEquiped && (mHitState == CharState_None || mHitState == CharState_Block))
         {
             MWBase::Environment::get().getWorld()->breakInvisibility(mPtr);
@@ -1432,6 +1425,11 @@ bool CharacterController::updateWeaponState()
                                      0.0f, 0);
                     mUpperBodyState = UpperCharState_CastingSpell;
                 }
+                else
+                {
+                    resetIdle = false;
+                }
+
                 if (mPtr.getClass().hasInventoryStore(mPtr))
                 {
                     MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
@@ -1501,6 +1499,14 @@ bool CharacterController::updateWeaponState()
                 mUpperBodyState = UpperCharState_StartToMinAttack;
             }
         }
+
+        // We should reset player's idle animation in the first-person mode.
+        if (resetIdle && mPtr == player && MWBase::Environment::get().getWorld()->isFirstPerson())
+            mIdleState = CharState_None;
+
+        // In other cases we should not break swim and sneak animations
+        if (resetIdle && mIdleState != CharState_IdleSneak && mIdleState != CharState_IdleSwim)
+            mIdleState = CharState_None;
 
         animPlaying = mAnimation->getInfo(mCurrentWeapon, &complete);
         if(mUpperBodyState == UpperCharState_MinAttackToMaxAttack && !isKnockedDown())

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1212,9 +1212,10 @@ bool CharacterController::updateWeaponState()
         mWeapon = weapon != inv.end() ? *weapon : MWWorld::Ptr();
     }
 
+    // Apply 1st-person weapon animations only for upper body
     MWRender::Animation::AnimPriority priorityWeapon(Priority_Weapon);
-    priorityWeapon[MWRender::Animation::BoneGroup_LowerBody] = Priority_WeaponLowerBody;
-
+    if (mPtr != MWMechanics::getPlayer() || !MWBase::Environment::get().getWorld()->isFirstPerson())
+        priorityWeapon[MWRender::Animation::BoneGroup_LowerBody] = Priority_WeaponLowerBody;
 
     bool forcestateupdate = false;
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1215,6 +1215,7 @@ bool CharacterController::updateWeaponState()
     MWRender::Animation::AnimPriority priorityWeapon(Priority_Weapon);
     priorityWeapon[MWRender::Animation::BoneGroup_LowerBody] = Priority_WeaponLowerBody;
 
+
     bool forcestateupdate = false;
 
     // We should not play equipping animation and sound during weapon->weapon transition
@@ -1663,18 +1664,22 @@ bool CharacterController::updateWeaponState()
                 break;
         }
 
-        // Note: apply reload animations only for upper body since blending with movement animations can give weird result.
-        // Especially noticable with crossbow reload animation.
+        // Note: apply crossbow reload animation only for upper body
+        // since blending with movement animations can give weird result.
         if(!start.empty())
         {
+            int mask = MWRender::Animation::BlendMask_All;
+            if (mWeaponType == WeapType_Crossbow)
+                mask = MWRender::Animation::BlendMask_UpperBody;
+
             mAnimation->disable(mCurrentWeapon);
             if (mUpperBodyState == UpperCharState_FollowStartToFollowStop)
                 mAnimation->play(mCurrentWeapon, priorityWeapon,
-                                 MWRender::Animation::BlendMask_UpperBody, true,
+                                 mask, true,
                                  weapSpeed, start, stop, 0.0f, 0);
             else
                 mAnimation->play(mCurrentWeapon, priorityWeapon,
-                                 MWRender::Animation::BlendMask_UpperBody, false,
+                                 mask, false,
                                  weapSpeed, start, stop, 0.0f, 0);
         }
     }


### PR DESCRIPTION
Fixes [bug #4575](https://gitlab.com/OpenMW/openmw/issues/4575) and [bug #4576](https://gitlab.com/OpenMW/openmw/issues/4576).

Summary of changes:
1. Apply reload animations for upper body only for crossbows.
2. Increase priority of 1st-person weapon animations instead. Basically, attack animations in the first-person mode will be the same as when steady.
3. Do not reset idle animations if we can not attack.

Improvements:
1. Try to shoot from bow in the 1st-person mode when steady.
There is a regression in my PR #1776 - there is a bow animation desync during shooting.
Does not happen with this PR.
2. Try to shoot from bow in the 1st-person mode during movement.
Shooting animation blending with movement animation provides a quite weird result in master branch - an arrow has large left offset.
With this PR arrow is rendered fine.
3. Take a longsword and prepare thrust attack in the 1st-person mode. Switch between walking/stopping.
There will be weapon twitching in upstream master, which does not happen with this PR.
4. Try to attack with ranged weapon without ammo or to cast Power several times.
Currently we reset idle animations, despite there is no real attack.
With this PR this should not happen.

Notes:
1. It would it would be nice to get some independent testing.
2. Second commit can break mods with 1st-person legs (if they are compatible). Make these changes optional?

