### PR TITLE
Fix training "can't teach more" message (bug #4494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
     Bug #4480: Segfault in QuickKeysMenu when item no longer in inventory
     Bug #4489: Goodbye doesn't block dialogue hyperlinks
     Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
-    Bug #4491: Training cap based off Base Skill instead of Modified Skill
+    Bug #4494: Training cap based off Base Skill instead of Modified Skill
     Bug #4495: Crossbow animations blending is buggy
     Bug #4496: SpellTurnLeft and SpellTurnRight animation groups are unused
     Bug #4497: File names starting with x or X are not classified as animation

--- a/apps/openmw/mwgui/trainingwindow.cpp
+++ b/apps/openmw/mwgui/trainingwindow.cpp
@@ -143,7 +143,7 @@ namespace MWGui
             return;
 
         MWMechanics::NpcStats& npcStats = mPtr.getClass().getNpcStats (mPtr);
-        if (npcStats.getSkill (skillId).getBase () <= pcStats.getSkill (skillId).getBase ())
+        if (npcStats.getSkill (skillId).getModified () <= pcStats.getSkill (skillId).getBase ())
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sServiceTrainingWords}");
             return;


### PR DESCRIPTION
In PR #1801 when changing training behavior to utilize NPC modified skills instead of base values in training @terabyte25 missed that "can't teach more" message also accounted for base skill instead of modified skill in a comparison of NPC skill and PC skill, so it resulted in the fix not actually working. He realized this today and asked me to fix the line.

~~Changelog should not be updated because this is basically the second part of the fix for the bug 4494 which already has a line there.~~

Edit: though bug 4494 has incorrect number there. I think someone reported some of such issues earlier somewhere. Edit 2: fixed