### PR TITLE
Do not optimize animated shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     Bug #3876: Landscape texture painting is misaligned
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3911: [macOS] Typing in the "Content List name" dialog box produces double characters
+    Bug #3950: FLATTEN_STATIC_TRANSFORMS optimization breaks animated collision shapes
     Bug #3993: Terrain texture blending map is not upscaled
     Bug #3997: Almalexia doesn't pace
     Bug #4036: Weird behaviour of AI packages if package target has non-unique ID

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -626,7 +626,6 @@ namespace MWPhysics
             assert (mShapeInstance->getCollisionShape()->isCompound());
 
             btCompoundShape* compound = static_cast<btCompoundShape*>(mShapeInstance->getCollisionShape());
-
             for (std::map<int, int>::const_iterator it = mShapeInstance->mAnimatedShapes.begin(); it != mShapeInstance->mAnimatedShapes.end(); ++it)
             {
                 int recIndex = it->first;
@@ -640,6 +639,9 @@ namespace MWPhysics
                     if (!visitor.mFound)
                     {
                         std::cerr << "Error: animateCollisionShapes can't find node " << recIndex << " for " << mPtr.getCellRef().getRefId() << std::endl;
+
+                        // Remove nonexistent nodes from animated shapes map and early out
+                        mShapeInstance->mAnimatedShapes.erase(recIndex);
                         return;
                     }
                     osg::NodePath nodePath = visitor.mFoundPath;

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -547,6 +547,11 @@ namespace NifOsg
                 node->setDataVariance(osg::Object::DYNAMIC);
             }
 
+            if (nifNode->recType == Nif::RC_NiTriShape && isAnimated) // the same thing for animated NiTriShapes
+            {
+                node->setDataVariance(osg::Object::DYNAMIC);
+            }
+
             osg::ref_ptr<SceneUtil::CompositeStateSetUpdater> composite = new SceneUtil::CompositeStateSetUpdater;
 
             applyNodeProperties(nifNode, node, composite, imageManager, boundTextures, animflags);


### PR DESCRIPTION
Attempt to fix [bug #3950](https://gitlab.com/OpenMW/openmw/issues/3950).

Tested with problematic meshes in Arktwend, Abot Boats, Ships of Imperial Navy and Darknut's Dwemer Dwelling.

The main idea: physics system reads list of animated collision shapes from NIF file, but works with optimized OSG node, in which some animated shapes can be removed/merged.
So I decided to do not optimize animated shapes for now.

This solutuon is far from ideal, I know.
As a proper solution, we can try to read list of animated of collision shapes from optimized OSG node (in the PhysicsSystem::animateCollisionShapes()), but it is probably out of my skills yet.