### PR TITLE
Do not use magic numbers in capacity calculations

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -614,7 +614,7 @@ namespace MWClass
     float Creature::getCapacity (const MWWorld::Ptr& ptr) const
     {
         const MWMechanics::CreatureStats& stats = getCreatureStats (ptr);
-        return static_cast<float>(stats.getAttribute(0).getModified() * 5);
+        return static_cast<float>(stats.getAttribute(ESM::Attribute::Strength).getModified() * 5);
     }
 
     int Creature::getServices(const MWWorld::ConstPtr &actor) const

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1079,7 +1079,7 @@ namespace MWClass
     {
         const MWMechanics::CreatureStats& stats = getCreatureStats (ptr);
         static const float fEncumbranceStrMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fEncumbranceStrMult")->getFloat();
-        return stats.getAttribute(0).getModified()*fEncumbranceStrMult;
+        return stats.getAttribute(ESM::Attribute::Strength).getModified()*fEncumbranceStrMult;
     }
 
     float Npc::getEncumbrance (const MWWorld::Ptr& ptr) const


### PR DESCRIPTION
Not much difference, but improves code readability.
In all other cases we use attribute IDs, so just make behaviour consistent.

A separate question: should we use the fEncumbranceStrMult for creatures too?