### PR TITLE
Resume game fully if the player was resurrected (bug #2626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
     Bug #2455: Creatures attacks degrade armor
     Bug #2562: Forcing AI to activate a teleport door sometimes causes a crash
+    Bug #2626: Resurrecting the player does not resume the game
     Bug #2772: Non-existing class or faction freezes the game
     Bug #2835: Player able to slowly move when overencumbered
     Bug #2852: No murder bounty when a player follower commits murder

--- a/apps/openmw/mwbase/statemanager.hpp
+++ b/apps/openmw/mwbase/statemanager.hpp
@@ -55,6 +55,8 @@ namespace MWBase
 
             virtual void endGame() = 0;
 
+            virtual void resumeGame() = 0;
+
             virtual void deleteGame (const MWState::Character *character, const MWState::Slot *slot) = 0;
 
             virtual void saveGame (const std::string& description, const MWState::Slot *slot = 0) = 0;

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -17,6 +17,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/dialoguemanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/statemanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/world.hpp"
 
@@ -1139,7 +1140,11 @@ namespace MWScript
                     MWWorld::Ptr ptr = R()(runtime);
 
                     if (ptr == MWMechanics::getPlayer())
+                    {
                         ptr.getClass().getCreatureStats(ptr).resurrect();
+                        if (MWBase::Environment::get().getStateManager()->getState() == MWBase::StateManager::State_Ended)
+                            MWBase::Environment::get().getStateManager()->resumeGame();
+                    }
                     else if (ptr.getClass().getCreatureStats(ptr).isDead())
                     {
                         bool wasEnabled = ptr.getRefData().isEnabled();

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -173,6 +173,11 @@ void MWState::StateManager::endGame()
     mState = State_Ended;
 }
 
+void MWState::StateManager::resumeGame()
+{
+    mState = State_Running;
+}
+
 void MWState::StateManager::saveGame (const std::string& description, const Slot *slot)
 {
     MWState::Character* character = getCurrentCharacter();

--- a/apps/openmw/mwstate/statemanagerimp.hpp
+++ b/apps/openmw/mwstate/statemanagerimp.hpp
@@ -48,6 +48,8 @@ namespace MWState
 
             virtual void endGame();
 
+            virtual void resumeGame();
+
             virtual void deleteGame (const MWState::Character *character, const MWState::Slot *slot);
             ///< Delete a saved game slot from this character. If all save slots are deleted, the character will be deleted too.
 


### PR DESCRIPTION
[Bug 2626.](https://gitlab.com/OpenMW/openmw/issues/2626)

I've added a method to state manager which is called in the Resurrect function if the game has ended and sets the game state back to "running". 

I'm not sure if this change would actually be useful, but currently even though openmw allows resurrecting the player and makes sure the player's health is not 0 after resurrection, the player is left off with a "broken" game. With this it returns to normal fully (including the menu, movement, music etc.), which looks somewhat better.

If we want the behavior of post-resurrected player game to be broken, then so be it.