### PR TITLE
Use file selection dialogue result

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -43,7 +43,6 @@ void Launcher::AdvancedPage::on_runScriptAfterStartupBrowseButton_clicked()
             QDir::currentPath(),
             QString(tr("Text file (*.txt)")));
 
-
     if (scriptFile.isEmpty())
         return;
 
@@ -53,7 +52,7 @@ void Launcher::AdvancedPage::on_runScriptAfterStartupBrowseButton_clicked()
         return;
 
     const QString path(QDir::toNativeSeparators(info.absoluteFilePath()));
-
+    runScriptAfterStartupField->setText(path);
 }
 
 bool Launcher::AdvancedPage::loadSettings()


### PR DESCRIPTION
Fixes [bug #4524](https://gitlab.com/OpenMW/openmw/issues/4524).
Previously local "path" variable was not used, so the file selection dialogue was useless.
Should work now (can not test on Windows by myself).