### PR TITLE
[Discussion] Make the camera the only sound listener

### DIFF
--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -5,7 +5,9 @@
 #include <components/sceneutil/positionattitudetransform.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/soundmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/refdata.hpp"
@@ -117,6 +119,11 @@ namespace MWRender
         osg::Vec3d up = orient * osg::Vec3d(0,0,1);
 
         cam->setViewMatrixAsLookAt(position, position + forward, up);
+
+        // Sound listener stuff
+        MWBase::World* world = MWBase::Environment::get().getWorld();
+        bool underwater = world->isUnderwater(world->getPlayerPtr().getCell(), position);
+        MWBase::Environment::get().getSoundManager()->setListenerPosDir(position, forward, up, underwater);
     }
 
     void Camera::reset()

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1673,8 +1673,6 @@ namespace MWWorld
 
         mWorldScene->update (duration, paused);
 
-        updateSoundListener();
-
         mSpellPreloadTimer -= duration;
         if (mSpellPreloadTimer <= 0.f)
         {
@@ -1770,28 +1768,6 @@ namespace MWWorld
                     preloadEffects(&ench->mEffects);
             }
         }
-    }
-
-    void World::updateSoundListener()
-    {
-        const ESM::Position& refpos = getPlayerPtr().getRefData().getPosition();
-        osg::Vec3f listenerPos;
-
-        if (isFirstPerson())
-            listenerPos = mRendering->getCameraPosition();
-        else
-            listenerPos = refpos.asVec3() + osg::Vec3f(0, 0, 1.85f * mPhysics->getHalfExtents(getPlayerPtr()).z());
-
-        osg::Quat listenerOrient = osg::Quat(refpos.rot[1], osg::Vec3f(0,-1,0)) *
-                osg::Quat(refpos.rot[0], osg::Vec3f(-1,0,0)) *
-                osg::Quat(refpos.rot[2], osg::Vec3f(0,0,-1));
-
-        osg::Vec3f forward = listenerOrient * osg::Vec3f(0,1,0);
-        osg::Vec3f up = listenerOrient * osg::Vec3f(0,0,1);
-
-        bool underwater = isUnderwater(getPlayerPtr().getCell(), listenerPos);
-
-        MWBase::Environment::get().getSoundManager()->setListenerPosDir(listenerPos, forward, up, underwater);
     }
 
     void World::updateWindowManager ()

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -128,7 +128,6 @@ namespace MWWorld
 
             Ptr copyObjectToCell(const ConstPtr &ptr, CellStore* cell, ESM::Position pos, int count, bool adjustPos);
 
-            void updateSoundListener();
             void updatePlayer();
 
             void preloadSpells();


### PR DESCRIPTION
Like in Morrowind, in third person view the sound listener in OpenMW is the player character. So if you go into third person view, you'll hear any sound as your character would even if the camera is positioned on a large distance from the character and has a different direction than the character has.

This removes updateSoundListener method, moves the stuff it does into updateCamera and makes the only sound listener the camera itself in both first person and third person view, making the sound direction consistent from the player's point of view, because what the player sees is what the player gets, or hears. You'll hear the footsteps and the NPCs speaking exactly at the distance and direction they would sound relatively to the camera.

updateCamera may not be the suitable location for the sound listener stuff. It was just a quick experiment.