### PR TITLE
Make sure we apply OT_Murder only once

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -766,6 +766,8 @@ namespace MWMechanics
 
             for (ActiveSpells::TIterator it = spells.begin(); it != spells.end(); ++it)
             {
+                bool actorKilled = false;
+
                 const ActiveSpells::ActiveSpellParams& spell = it->second;
                 MWWorld::Ptr caster = MWBase::Environment::get().getWorld()->searchPtrViaActorId(spell.mCasterActorId);
                 for (std::vector<ActiveSpells::ActiveEffect>::const_iterator effectIt = spell.mEffects.begin();
@@ -793,10 +795,14 @@ namespace MWMechanics
                                 caster.getClass().getNpcStats(caster).addWerewolfKill();
 
                             MWBase::Environment::get().getMechanicsManager()->actorKilled(ptr, player);
+                            actorKilled = true;
                             break;
                         }
                     }
                 }
+
+                if (actorKilled)
+                    break;
             }
         }
 


### PR DESCRIPTION
Fixes regression in my commit 9c3da411307b9f7f18db454d9499ec4a58fa48e7.
There was missing "break" from outer loop, so we applied murder bounty once for every active combat spell.
0.44 release is not affected by this bug, so no changelog entry.