### PR TITLE
Actually enable is_pod fixed string test (task #4535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
     Feature #4509: Show count of enchanted items in stack in the spells list
     Feature #4512: Editor: Use markers for lights and creatures levelled lists
     Task #2490: Don't open command prompt window on Release-mode builds automatically
+    Task #4545: Enable is_pod string test
 
 0.44.0
 ------

--- a/apps/openmw_test_suite/esm/test_fixed_string.cpp
+++ b/apps/openmw_test_suite/esm/test_fixed_string.cpp
@@ -64,7 +64,7 @@ TEST(EsmFixedString, struct_size)
     ASSERT_EQ(256, sizeof(ESM::NAME256));
 }
 
-TEST(EsmFixedString, DISABLED_is_pod)
+TEST(EsmFixedString, is_pod)
 {
      ASSERT_TRUE(std::is_pod<ESM::NAME>::value);
      ASSERT_TRUE(std::is_pod<ESM::NAME32>::value);


### PR DESCRIPTION
Though I uncommented the code of the test in a PR, it wasn't actually used because it had DISABLED prefix in its name (which means that it's disabled for gtest).