### PR TITLE
Fix quick key activation delay code (regression #4536)

### DIFF
--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -324,15 +324,19 @@ namespace MWGui
 
         bool isReturnNeeded = playerStats.isParalyzed() || playerStats.isDead();
 
-        if (isReturnNeeded)
+        if (isReturnNeeded && key->type != Type_Item)
+        {
             return;
-
-        else if (isDelayNeeded)
+        }
+        else if (isDelayNeeded && key->type != Type_Item)
+        {
             mActivated = key;
-
+            return;
+        }
         else
+        {
             mActivated = nullptr;
-
+        }
 
         if (key->type == Type_Item || key->type == Type_MagicItem)
         {
@@ -370,6 +374,11 @@ namespace MWGui
 
                 // delay weapon switching if player is busy
                 if (isDelayNeeded && (isWeapon || isTool))
+                {
+                    mActivated = key;
+                    return;
+                }
+                else if (isReturnNeeded && (isWeapon || isTool))
                 {
                     return;
                 }


### PR DESCRIPTION
[MR 11](https://gitlab.com/OpenMW/openmw/merge_requests/11) had a bunch of odd edits which removed the special handling of items assigned on quick keys which led to [regression 4536](https://gitlab.com/OpenMW/openmw/issues/4536). Reverting them seems to have fixed the issue. Their purpose seemingly was fixing a crash upon making multiple simultaneous quick key presses, but I don't get any crash when the changes of this PR are applied.