### PR TITLE
Implement ranged crits (feature #3703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window
+    Feature #3703: Ranged sneak attack criticals
     Feature #4222: 360° screenshots
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #4324: Add CFBundleIdentifier in Info.plist to allow for macOS function key shortcuts

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -209,8 +209,21 @@ namespace MWMechanics
 
             adjustWeaponDamage(damage, weapon, attacker);
 
-            if(attacker == getPlayer())
+            if (attacker == getPlayer())
+            {
                 attacker.getClass().skillUsageSucceeded(attacker, weaponSkill, 0);
+                const MWMechanics::AiSequence& sequence = victim.getClass().getCreatureStats(victim).getAiSequence();
+
+                bool unaware = !sequence.isInCombat()
+                    && !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(attacker, victim);
+
+                if (unaware)
+                {
+                    damage *= gmst.find("fCombatCriticalStrikeMult")->getFloat();
+                    MWBase::Environment::get().getWindowManager()->messageBox("#{sTargetCriticalStrike}");
+                    MWBase::Environment::get().getSoundManager()->playSound3D(victim, "critical damage", 1.0f, 1.0f);
+                }
+            }
 
             if (victim.getClass().getCreatureStats(victim).getKnockedDown())
                 damage *= gmst.find("fCombatKODamageMult")->getFloat();


### PR DESCRIPTION
~~Yay, stealth archering!~~

[Feature 3703](https://gitlab.com/OpenMW/openmw/issues/3703).

Replicate the melee weapon code of ranged sneak criticals in projectile hit code. I'm not sure which GMST should really be used, but using critical strike multiplier instead of KO multiplier makes more sense to me, and it seems that this feature is very unfinished in Morrowind so it shouldn't be replicated bug-to-bug.

Quick testing shows that this works pretty good, if you actually manage to lend a hit on an unaware enemy. The character in the saves supplied with the report has really low Marksman skill.

I think this feature is not too "post-1.0" to be implemented and can potentially be useful before that point.