### PR TITLE
Rescale player avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
     Bug #4503: Cast and ExplodeSpell commands increase alteration skill
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
+    Bug #4539: Paper Doll is affected by GUI scaling
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -67,7 +67,12 @@ namespace MWGui
         , mLastYSize(0)
         , mPreview(new MWRender::InventoryPreview(parent, resourceSystem, MWMechanics::getPlayer()))
         , mTrading(false)
+        , mScaleFactor(1.0f)
     {
+        float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
+        if (uiScale > 1.0)
+            mScaleFactor = uiScale;
+
         mPreviewTexture.reset(new osgMyGUI::OSGTexture(mPreview->getTexture()));
         mPreview->rebuild();
 
@@ -431,10 +436,10 @@ namespace MWGui
         MyGUI::IntSize size = mAvatarImage->getSize();
         int width = std::min(mPreview->getTextureWidth(), size.width);
         int height = std::min(mPreview->getTextureHeight(), size.height);
-        mPreview->setViewport(width, height);
+        mPreview->setViewport(int(width*mScaleFactor), int(height*mScaleFactor));
 
         mAvatarImage->getSubWidgetMain()->_setUVSet(MyGUI::FloatRect(0.f, 0.f,
-                                                                     width/float(mPreview->getTextureWidth()), height/float(mPreview->getTextureHeight())));
+                                                                     width*mScaleFactor/float(mPreview->getTextureWidth()), height*mScaleFactor/float(mPreview->getTextureHeight())));
     }
 
     void InventoryWindow::onFilterChanged(MyGUI::Widget* _sender)
@@ -591,6 +596,11 @@ namespace MWGui
     {
         // convert to OpenGL lower-left origin
         y = (mAvatarImage->getHeight()-1) - y;
+
+        // Scale coordinates
+        x = int(x*mScaleFactor);
+        y = int(y*mScaleFactor);
+
         int slot = mPreview->getSlotSelected (x, y);
 
         if (slot == -1)

--- a/apps/openmw/mwgui/inventorywindow.hpp
+++ b/apps/openmw/mwgui/inventorywindow.hpp
@@ -101,6 +101,7 @@ namespace MWGui
             std::unique_ptr<MWRender::InventoryPreview> mPreview;
 
             bool mTrading;
+            float mScaleFactor;
 
             void onItemSelected(int index);
             void onItemSelectedFromSourceModel(int index);


### PR DESCRIPTION
Attempt to fix [bug #4539](https://gitlab.com/OpenMW/openmw/issues/4539).
The main idea: multiple texture size by UI scaling factor, so after scaling avatar should not look blurred.

I have no 4k display so I can not test it by myself.
[Here](https://i.imgur.com/CCrSikS.jpg) is the comparison (new/old, scaling factor 2.0) on my 1920x1080 display.