### PR TITLE
[Regression] Do not try to handle shape controllers as node controllers

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -579,12 +579,10 @@ namespace NifOsg
             if (composite->getNumControllers() > 0)
                 node->addUpdateCallback(composite);
 
-
             // Note: NiTriShapes are not allowed to have KeyframeControllers (the vanilla engine just crashes when there is one).
             // We can take advantage of this constraint for optimizations later.
-            if (!nifNode->controller.empty() && node->getDataVariance() == osg::Object::DYNAMIC)
+            if (nifNode->recType != Nif::RC_NiTriShape && !nifNode->controller.empty() && node->getDataVariance() == osg::Object::DYNAMIC)
                 handleNodeControllers(nifNode, static_cast<osg::MatrixTransform*>(node.get()), animflags);
-
 
             if (nifNode->recType == Nif::RC_NiLODNode)
             {


### PR DESCRIPTION
Fixes a small regression in 7e0df01c836868bc39badd6fd9753ed8d3228850.
Currently, there are two different sets of controllers: one for triShapes (handled in the handleMeshControllers()) and one for nodes (handled in the handleNodeControllers()).
Previously all triShape were static, so we did not try to handle triShape controllers as node controllers.
Now animated shapes are dynamic, and we have some additional warnings in console (should be harmless).

So I just added a check if the node is a NiTriShape.