### PR TITLE
Limit difficulty scaling, as mentioned in docs

### DIFF
--- a/apps/openmw/mwmechanics/difficultyscaling.cpp
+++ b/apps/openmw/mwmechanics/difficultyscaling.cpp
@@ -12,8 +12,10 @@ float scaleDamage(float damage, const MWWorld::Ptr& attacker, const MWWorld::Ptr
 {
     const MWWorld::Ptr& player = MWMechanics::getPlayer();
 
-    // [-100, 100]
+    // [-500, 500]
     int difficultySetting = Settings::Manager::getInt("difficulty", "Game");
+    difficultySetting = std::min(difficultySetting, 500);
+    difficultySetting = std::max(difficultySetting, -500);
 
     static const float fDifficultyMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fDifficultyMult")->getFloat();
 


### PR DESCRIPTION
Currently we read difficulty from config and use it directly, despite our docs (game.rst) say that difficulty should be in range [-500, 500].
Coverity Scan does not like such behaviour: in theory, there could be overflow.

So I just made OpenMW behaviour even with docs.