### PR TITLE
Add permanent barter disposition change option (feature #3103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
     Bug #4539: Paper Doll is affected by GUI scaling
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
+    Feature #3103: Provide option for disposition to get increased by successful trade
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window
     Feature #3703: Ranged sneak attack criticals

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -75,6 +75,7 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(rebalanceSoulGemValuesCheckBox, "rebalance soul gem values", "Game");
     loadSettingBool(chargeForEveryFollowerCheckBox, "charge for every follower travelling", "Game");
     loadSettingBool(enchantedWeaponsMagicalCheckBox, "enchanted weapons are magical", "Game");
+    loadSettingBool(permanentBarterDispositionChangeCheckBox, "barter disposition change is permanent", "Game");
 
     // Input Settings
     loadSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");
@@ -129,6 +130,7 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(rebalanceSoulGemValuesCheckBox, "rebalance soul gem values", "Game");
     saveSettingBool(chargeForEveryFollowerCheckBox, "charge for every follower travelling", "Game");
     saveSettingBool(enchantedWeaponsMagicalCheckBox, "enchanted weapons are magical", "Game");
+    saveSettingBool(permanentBarterDispositionChangeCheckBox, "barter disposition change is permanent", "Game");
 
     // Input Settings
     saveSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");

--- a/apps/openmw/mwbase/dialoguemanager.hpp
+++ b/apps/openmw/mwbase/dialoguemanager.hpp
@@ -75,8 +75,8 @@ namespace MWBase
             virtual void persuade (int type, ResponseCallback* callback) = 0;
             virtual int getTemporaryDispositionChange () const = 0;
 
-            /// @note This change is temporary and gets discarded when dialogue ends.
-            virtual void applyDispositionChange (int delta) = 0;
+            /// @note Controlled by an option, gets discarded when dialogue ends by default
+            virtual void applyBarterDispositionChange (int delta) = 0;
 
             virtual int countSavedGameRecords() const = 0;
 

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -22,6 +22,8 @@
 #include <components/interpreter/interpreter.hpp>
 #include <components/interpreter/defines.hpp>
 
+#include <components/settings/settings.hpp>
+
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/journal.hpp"
@@ -508,9 +510,11 @@ namespace MWDialogue
         return static_cast<int>(mTemporaryDispositionChange);
     }
 
-    void DialogueManager::applyDispositionChange(int delta)
+    void DialogueManager::applyBarterDispositionChange(int delta)
     {
         mTemporaryDispositionChange += delta;
+        if (Settings::Manager::getBool("barter disposition change is permanent", "Game"))
+            mPermanentDispositionChange += delta;
     }
 
     bool DialogueManager::checkServiceRefused(ResponseCallback* callback)

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.hpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.hpp
@@ -94,8 +94,8 @@ namespace MWDialogue
             virtual void persuade (int type, ResponseCallback* callback);
             virtual int getTemporaryDispositionChange () const;
 
-            /// @note This change is temporary and gets discarded when dialogue ends.
-            virtual void applyDispositionChange (int delta);
+            /// @note Controlled by an option, gets discarded when dialogue ends by default
+            virtual void applyBarterDispositionChange (int delta);
 
             virtual int countSavedGameRecords() const;
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -334,7 +334,7 @@ namespace MWGui
                 ? gmst.find("iBarterSuccessDisposition")->getInt()
                 : gmst.find("iBarterFailDisposition")->getInt();
 
-            MWBase::Environment::get().getDialogueManager()->applyDispositionChange(dispositionDelta);
+            MWBase::Environment::get().getDialogueManager()->applyBarterDispositionChange(dispositionDelta);
         }
 
         // display message on haggle failure

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -130,7 +130,7 @@ enchanted weapons are magical
 :Range:		True/False
 :Default:	True
 
-Makes enchanted weapons without Magical flag bypass normal weapons resistance (and weakness) certain creatures have.
+Make enchanted weapons without Magical flag bypass normal weapons resistance (and weakness) certain creatures have.
 This is how original Morrowind behaves.
 
 This setting can only be configured by editing the settings configuration file.
@@ -142,7 +142,7 @@ prevent merchant equipping
 :Range:		True/False
 :Default:	False
 
-Prevents merchants from equipping items that are sold to them.
+Prevent merchants from equipping items that are sold to them.
 
 This setting can only be configured by editing the settings configuration file.
 
@@ -153,7 +153,7 @@ followers attack on sight
 :Range:		True/False
 :Default:	False
 
-Makes player followers and escorters start combat with enemies who have started combat with them or the player.
+Make player followers and escorters start combat with enemies who have started combat with them or the player.
 Otherwise they wait for the enemies or the player to do an attack first.
 Please note this setting has not been extensively tested and could have side effects with certain quests.
 
@@ -171,3 +171,15 @@ For example, if the main animation mesh has name Meshes/x.nif, an engine will lo
 Can be useful if you want to use several animation replacers without merging them.
 Attention: animations from AnimKit have own format and are not supposed to be directly loaded in-game!
 This setting can only be configured by editing the settings configuration file.
+
+barter disposition change is permanent
+--------------------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, disposition change of merchants caused by trading will be permanent and won't be discarded upon exiting dialogue with them.
+This imitates the option Morrowind Code Patch offers.
+
+This setting can be toggled with a checkbox in Advanced tab of the launcher.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -203,24 +203,27 @@ show effect duration = false
 # Account for the first follower in fast travel cost calculations.
 charge for every follower travelling = false
 
-# Prevents merchants from equipping items that are sold to them.
+# Prevent merchants from equipping items that are sold to them.
 prevent merchant equipping = false
 
 # Make enchanted weaponry without Magical flag bypass normal weapons resistance
 enchanted weapons are magical = true
 
-# Makes player followers and escorters start combat with enemies who have started combat with them
+# Make player followers and escorters start combat with enemies who have started combat with them
 # or the player. Otherwise they wait for the enemies or the player to do an attack first.
 followers attack on sight = false
 
 # Can loot non-fighting actors during death animation
 can loot during death animation = true
 
-# Makes the value of filled soul gems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
+# Make the value of filled soul gems dependent only on soul magnitude (with formula from the Morrowind Code Patch)
 rebalance soul gem values = false
 
 # Allow to load per-group KF-files from Animations folder
 use additional anim sources = false
+
+# Make the disposition change of merchants caused by barter dealings permanent
+barter disposition change is permanent = false
 
 [General]
 

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -22,7 +22,7 @@
         <x>0</x>
         <y>0</y>
         <width>641</width>
-        <height>968</height>
+        <height>998</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="scrollAreaVerticalLayout">
@@ -45,7 +45,7 @@
           <item>
            <widget class="QCheckBox" name="followersAttackOnSightCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Makes player followers and escorters start combat with enemies who have started combat with them or the player. Otherwise they wait for the enemies or the player to do an attack first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make player followers and escorters start combat with enemies who have started combat with them or the player. Otherwise they wait for the enemies or the player to do an attack first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Followers attack on sight</string>
@@ -65,7 +65,7 @@
           <item>
            <widget class="QCheckBox" name="rebalanceSoulGemValuesCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the value of filled soul gems is dependent only on soul magnitude.&lt;/p&gt;&lt;p&gt;The default value is false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make the value of filled soul gems dependent only on soul magnitude.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Rebalance soul gem values</string>
@@ -89,6 +89,16 @@
             </property>
             <property name="text">
              <string>Enchanted weapons are magical</string>
+             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="permanentBarterDispositionChangeCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make disposition change of merchants caused by trading permanent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Barter disposition change is permanent</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
[Feature #3103](https://gitlab.com/OpenMW/openmw/issues/3103).

Add just that - when the option is true, in addition to temporary disposition change which is visible when exiting barter, permanent disposition change is modified, which is applied after the player closes the dialogue with the merchant.

I also added a checkbox to the Advanced tab of the launcher and modified the documentation.