### PR TITLE
Make casting caster-linked on-self effects no-op (bug #4378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
     Bug #4327: Missing animations during spell/weapon stance switching
     Bug #4358: Running animation is interrupted when magic mode is toggled
     Bug #4368: Settings window ok button doesn't have key focus by default
+    Bug #4378: On-self absorb spells restore stats
     Bug #4393: NPCs walk back to where they were after using ResetActors
     Bug #4416: Handle exception if we try to play non-music file
     Bug #4419: MRK NiStringExtraData is handled incorrectly

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -420,9 +420,9 @@ namespace MWMechanics
             if (!checkEffectTarget(effectIt->mEffectID, target, caster, castByPlayer))
                 continue;
 
-            // caster needs to be an actor for linked effects (e.g. Absorb)
+            // caster needs to be an actor that's not the target for linked effects (e.g. Absorb)
             if (magicEffect->mData.mFlags & ESM::MagicEffect::CasterLinked
-                    && (caster.isEmpty() || !caster.getClass().isActor()))
+                    && (caster.isEmpty() || !caster.getClass().isActor() || caster == target))
                 continue;
 
             // If player is healing someone, show the target's HP bar
@@ -554,7 +554,7 @@ namespace MWMechanics
 
                         // For absorb effects, also apply the effect to the caster - but with a negative
                         // magnitude, since we're transferring stats from the target to the caster
-                        if (!caster.isEmpty() && caster.getClass().isActor())
+                        if (!caster.isEmpty() && caster != target && caster.getClass().isActor())
                         {
                             for (int i=0; i<5; ++i)
                             {


### PR DESCRIPTION
[Bug #4378](https://gitlab.com/OpenMW/openmw/issues/4378).
I decided to add a workaround for such "broken" effects for now. I *think* that no caster-linked magic effects are supposed to be able to be applied to the caster (at least such effects can't have on-self type in TESCS), please do tell me if that's not correct.