### PR TITLE
Combat AI priority improvements (features #4548, #4549, #4550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,15 +76,13 @@
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
     Bug #4539: Paper Doll is affected by GUI scaling
     Bug #4545: Creatures flee from werewolves
-    Bug #4548: Weapon priority: use the actual chance to hit the target instead of weapon skill
-    Bug #4549: Weapon priority: use the actual damage in weapon rating calculations
-    Bug #4550: Weapon priority: make ranged weapon bonus more sensible
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window
     Feature #3703: Ranged sneak attack criticals
+    Feature #4012: Editor: Write a log file if OpenCS crashes
     Feature #4222: 360° screenshots
     Feature #4256: Implement ToggleBorders (TB) console command
     Feature #4324: Add CFBundleIdentifier in Info.plist to allow for macOS function key shortcuts
@@ -93,9 +91,11 @@
     Feature #4444: Per-group KF-animation files support
     Feature #4466: Editor: Add option to ignore "Base" records when running verifier
     Feature #4488: Make water shader rougher during rain
-    Feature #4012: Editor: Write a log file if OpenCS crashes
     Feature #4509: Show count of enchanted items in stack in the spells list
     Feature #4512: Editor: Use markers for lights and creatures levelled lists
+    Feature #4548: Weapon priority: use the actual chance to hit the target instead of weapon skill
+    Feature #4549: Weapon priority: use the actual damage in weapon rating calculations
+    Feature #4550: Weapon priority: make ranged weapon bonus more sensible
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
     Bug #4539: Paper Doll is affected by GUI scaling
+    Bug #4548: Weapon priority: use the actual chance to hit the target instead of weapon skill
+    Bug #4549: Weapon priority: use the actual damage in weapon rating calculations
+    Bug #4550: Weapon priority: make ranged weapon bonus more sensible
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -103,7 +103,10 @@ namespace MWMechanics
 
         int skill = item.getClass().getEquipmentSkill(item);
         if (skill != -1)
-            rating *= actor.getClass().getSkill(actor, skill) / 100.f;
+        {
+            MWMechanics::SkillValue& value = actor.getClass().getSkill(actor, skill);
+            rating *= MWMechanics::getHitChance(actor, enemy, value) / 100.f;
+        }
 
         // There is no need to apply bonus if weapon rating == 0
         if (rating == 0.f)

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -30,7 +30,7 @@ namespace MWMechanics
             return 0.f;
 
         float rating=0.f;
-        float bonus=0.f;
+        float rangedMult=1.f;
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow && weapon->mData.mType <= ESM::Weapon::MarksmanThrown)
         {
@@ -44,7 +44,8 @@ namespace MWMechanics
             if (MWBase::Environment::get().getWorld()->isUnderwater(MWWorld::ConstPtr(enemy), 0.75f))
                 return 0.f;
 
-            bonus+=1.5f;
+            if (getDistanceMinusHalfExtents(actor, enemy) >= getMaxAttackDistance(enemy))
+                rangedMult = 1.5f;
         }
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
@@ -104,15 +105,11 @@ namespace MWMechanics
         int skill = item.getClass().getEquipmentSkill(item);
         if (skill != -1)
         {
-            MWMechanics::SkillValue& value = actor.getClass().getSkill(actor, skill);
+            int value = actor.getClass().getSkill(actor, skill);
             rating *= MWMechanics::getHitChance(actor, enemy, value) / 100.f;
         }
 
-        // There is no need to apply bonus if weapon rating == 0
-        if (rating == 0.f)
-            return 0.f;
-
-        return rating + bonus;
+        return rating * rangedMult;
     }
 
     float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, ESM::Weapon::Type ammoType)

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -79,7 +79,6 @@ namespace MWMechanics
         {
             if (item.getClass().getItemHealth(item) == 0)
                 return 0.f;
-            rating *= item.getClass().getItemHealth(item) / float(item.getClass().getItemMaxHealth(item));
         }
 
         if (weapon->mData.mType == ESM::Weapon::MarksmanBow)

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -50,20 +50,27 @@ namespace MWMechanics
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
         {
-            rating = (weapon->mData.mChop[0] + weapon->mData.mChop[1]) / 2.f;
+            float rangedDamage = weapon->mData.mChop[0] + weapon->mData.mChop[1];
+            MWMechanics::adjustWeaponDamage(rangedDamage, item, actor);
+
+            rating = rangedDamage / 2.f;
 
             if (weapon->mData.mType >= ESM::Weapon::MarksmanThrown)
                 MWMechanics::resistNormalWeapon(enemy, actor, item, rating);
         }
         else
         {
+            float meleeDamage = 0.f;
+
             for (int i=0; i<2; ++i)
             {
-                rating += weapon->mData.mSlash[i];
-                rating += weapon->mData.mThrust[i];
-                rating += weapon->mData.mChop[i];
+                meleeDamage += weapon->mData.mSlash[i];
+                meleeDamage += weapon->mData.mThrust[i];
+                meleeDamage += weapon->mData.mChop[i];
             }
-            rating /= 6.f;
+
+            MWMechanics::adjustWeaponDamage(meleeDamage, item, actor);
+            rating = meleeDamage / 6.f;
 
             MWMechanics::resistNormalWeapon(enemy, actor, item, rating);
         }


### PR DESCRIPTION
Implements three ideas from [feature #3946](https://gitlab.com/OpenMW/openmw/issues/3946).

* Instead of using the raw skill value as another weapon rating multiplier, the actual hit chance is used.
* Ranged weapon bonus is now a distance-dependent percentage-based (150%) multiplier.
* Use adjustWeaponDamage to determine the actual weapon damage which is influenced by Strength attribute to use for the rating.

I found 150% multiplier to be indeed optimal. It's applied if the distance from the actor to their enemy is higher than the distance the enemy can attack from.

The second idea makes the behavior of Mulvisie Othril in Addamasartus (from [bug 3405](https://gitlab.com/OpenMW/openmw/issues/3405)) much more intelligent: instead of sticking solely to throwing stars, she will switch to her dagger at short distance (or if the player switches to a ranged weapon or spell) and use throwing stars otherwise if the player tries to walk away.

The first and third ideas are kind of hard to test, but it seems that the actor switches to another weapon (like fists) more promptly if it's hopeless to use a weapon.