### PR TITLE
Make tab autocompletion work with explicit reference calls (bug #2872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     Bug #2835: Player able to slowly move when overencumbered
     Bug #2852: No murder bounty when a player follower commits murder
     Bug #2862: [macOS] Can't quit launcher using Command-Q or OpenMW->Quit
+    Bug #2872: Tab completion in console doesn't work with explicit reference
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
     Bug #3249: Fixed revert function not updating views properly
     Bug #3374: Touch spells not hitting kwama foragers

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -303,6 +303,14 @@ namespace MWGui
         bool has_front_quote = false;
 
         /* Does the input string contain things that don't have to be completed? If yes erase them. */
+
+        /* Erase a possible call to an explicit reference. */
+        size_t explicitPos = tmp.find("->");
+        if (explicitPos != std::string::npos)
+        {
+            tmp.erase(0, explicitPos+2);
+        }
+
         /* Are there quotation marks? */
         if( tmp.find('"') != std::string::npos ) {
             int numquotes=0;
@@ -338,13 +346,6 @@ namespace MWGui
                     tmp.erase(0, rpos+1);
                 }
             }
-        }
-
-        // Erase a possible call to an explicit reference
-        size_t explicitPos = tmp.find("->");
-        if (explicitPos != std::string::npos)
-        {
-            tmp.erase(0, explicitPos+2);
         }
 
         /* Erase the input from the output string so we can easily append the completed form later. */

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -339,6 +339,14 @@ namespace MWGui
                 }
             }
         }
+
+        // Erase a possible call to an explicit reference
+        size_t explicitPos = tmp.find("->");
+        if (explicitPos != std::string::npos)
+        {
+            tmp.erase(0, explicitPos+2);
+        }
+
         /* Erase the input from the output string so we can easily append the completed form later. */
         output.erase(output.end()-tmp.length(), output.end());
 


### PR DESCRIPTION
[Bug #2872](https://gitlab.com/OpenMW/openmw/issues/2872)
Erase the part which ends on "->" in the temporary string which is used for autocompletion, so OpenMW is able to pick up a proper matching string. Seems to work OK in my testing.