### PR TITLE
Don't apply iWereWolfFleeMod to creatures (bug #4545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
     Bug #4539: Paper Doll is affected by GUI scaling
+    Bug #4545: Creatures flee from werewolves
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -499,7 +499,7 @@ namespace MWMechanics
             if (enemy.getClass().getNpcStats(enemy).isWerewolf() && stats.getLevel() < iWereWolfLevelToAttack)
             {
                 static const int iWereWolfFleeMod = gmst.find("iWereWolfFleeMod")->getInt();
-                rating += iWereWolfFleeMod;
+                rating = iWereWolfFleeMod;
             }
         }
 

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -494,10 +494,13 @@ namespace MWMechanics
 
         static const int iWereWolfLevelToAttack = gmst.find("iWereWolfLevelToAttack")->getInt();
 
-        if (enemy.getClass().isNpc() && enemy.getClass().getNpcStats(enemy).isWerewolf() && stats.getLevel() < iWereWolfLevelToAttack)
+        if (actor.getClass().isNpc() && enemy.getClass().isNpc())
         {
-            static const int iWereWolfFleeMod = gmst.find("iWereWolfFleeMod")->getInt();
-            rating = iWereWolfFleeMod;
+            if (enemy.getClass().getNpcStats(enemy).isWerewolf() && stats.getLevel() < iWereWolfLevelToAttack)
+            {
+                static const int iWereWolfFleeMod = gmst.find("iWereWolfFleeMod")->getInt();
+                rating += iWereWolfFleeMod;
+            }
         }
 
         if (rating != 0.0f)


### PR DESCRIPTION
[Bug #4545](https://gitlab.com/OpenMW/openmw/issues/4545).
In OpenMW iWerewolfFightMod is only applied if the actor is an NPC, which makes sense, since creatures logically don't care that you are a lycanthrope. However, iWerewolfFlee mod is then applied regardless of the class the actor has, which causes all creatures below certain level to try and flee from a raving lycanthrope. This doesn't happen in Morrowind - the creatures continue to attack the player as a werewolf. I figured out that all the creatures shouldn't want player's blood for no reason, so they don't need FightMod applied, however FleeMod will have to go.

~~Also, I made the behavior of FleeMod consistent -- now it's added to the previously calculated rating and doesn't replace it, like "mod" part is supposed to work (and it does work like that in case of FightMod).~~