### PR TITLE
Replace 0 sound ranges with default distances separately (bug #4551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
     Bug #4539: Paper Doll is affected by GUI scaling
+    Bug #4551: Replace 0 sound range with default range separately
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -142,16 +142,12 @@ namespace MWSound
         float volume, min, max;
 
         volume = static_cast<float>(pow(10.0, (sound->mData.mVolume / 255.0*3348.0 - 3348.0) / 2000.0));
-        if(sound->mData.mMinRange == 0 && sound->mData.mMaxRange == 0)
-        {
+        min = sound->mData.mMinRange;
+        max = sound->mData.mMaxRange;
+        if (min == 0)
             min = fAudioDefaultMinDistance;
+        if (max == 0)
             max = fAudioDefaultMaxDistance;
-        }
-        else
-        {
-            min = sound->mData.mMinRange;
-            max = sound->mData.mMaxRange;
-        }
 
         min *= fAudioMinDistanceMult;
         max *= fAudioMaxDistanceMult;


### PR DESCRIPTION
To make sound attenuation for sounds that don't have both min and max range equal to 0 work properly, as mentioned by Chris under [bug 3674](https://gitlab.com/OpenMW/openmw/issues/3674).