### PR TITLE
[Regression] Fix stuck when NPC changes stance during weapon unequipping animation

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -315,14 +315,14 @@ namespace MWMechanics
         return true;
     }
 
-    CastSpell::CastSpell(const MWWorld::Ptr &caster, const MWWorld::Ptr &target, const bool fromProjectile, const bool isScripted)
+    CastSpell::CastSpell(const MWWorld::Ptr &caster, const MWWorld::Ptr &target, const bool fromProjectile, const bool manualSpell)
         : mCaster(caster)
         , mTarget(target)
         , mStack(false)
         , mHitPosition(0,0,0)
         , mAlwaysSucceed(false)
         , mFromProjectile(fromProjectile)
-        , mIsScripted(isScripted)
+        , mManualSpell(manualSpell)
     {
     }
 
@@ -864,7 +864,7 @@ namespace MWMechanics
 
         bool godmode = mCaster == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState();
 
-        if (mCaster.getClass().isActor() && !mAlwaysSucceed && !mIsScripted)
+        if (mCaster.getClass().isActor() && !mAlwaysSucceed && !mManualSpell)
         {
             school = getSpellSchool(spell, mCaster);
 
@@ -1037,7 +1037,7 @@ namespace MWMechanics
 
     bool CastSpell::spellIncreasesSkill()
     {
-        if (mIsScripted)
+        if (mManualSpell)
             return false;
 
         return MWMechanics::spellIncreasesSkill(mId);

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -88,10 +88,10 @@ namespace MWMechanics
         osg::Vec3f mHitPosition; // Used for spawning area orb
         bool mAlwaysSucceed; // Always succeed spells casted by NPCs/creatures regardless of their chance (default: false)
         bool mFromProjectile; // True if spell is cast by enchantment of some projectile (arrow, bolt or thrown weapon)
-        bool mIsScripted; // True if spell is casted from script and ignores some checks (mana level, success chance, etc.)
+        bool mManualSpell; // True if spell is casted from script and ignores some checks (mana level, success chance, etc.)
 
     public:
-        CastSpell(const MWWorld::Ptr& caster, const MWWorld::Ptr& target, const bool fromProjectile=false, const bool isScripted=false);
+        CastSpell(const MWWorld::Ptr& caster, const MWWorld::Ptr& target, const bool fromProjectile=false, const bool manualSpell=false);
 
         bool cast (const ESM::Spell* spell);
 


### PR DESCRIPTION
This bug is a quite easy to reproduce:
1. Select any NPC in console
2. Use something like 'cast fireball "player"'
3. After cast, when NPC will start to return to the idle pose, execute command again.
As result, NPC will stuck in the idle pose.
Should not happen with this PR.