### PR TITLE
Make forcegreeting a non-op for non-actor objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,11 @@
     Bug #4539: Paper Doll is affected by GUI scaling
     Bug #4545: Creatures flee from werewolves
     Bug #4551: Replace 0 sound range with default range separately
+    Bug #4553: Forcegreeting on non-actor opens a dialogue window which cannot be closed
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade
-    Feature #3276: Editor: Search- Show number of (remaining) search results and indicate a search without any results
+    Feature #3276: Editor: Search - Show number of (remaining) search results and indicate a search without any results
     Feature #3641: Editor: Limit FPS in 3d preview window
     Feature #3703: Ranged sneak attack criticals
     Feature #4012: Editor: Write a log file if OpenCS crashes

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -408,6 +408,12 @@ namespace MWGui
 
     void DialogueWindow::setPtr(const MWWorld::Ptr& actor)
     {
+        if (!actor.getClass().isActor())
+        {
+            std::cerr << "Warning: can not talk with non-actor object." << std::endl;
+            return;
+        }
+
         bool sameActor = (mPtr == actor);
         if (!sameActor)
         {

--- a/apps/openmw/mwscript/dialogueextensions.cpp
+++ b/apps/openmw/mwscript/dialogueextensions.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "dialogueextensions.hpp"
 
 #include <components/compiler/extensions.hpp>
@@ -133,6 +135,14 @@ namespace MWScript
 
                     if (!ptr.getRefData().isEnabled())
                         return;
+
+                    if (!ptr.getClass().isActor())
+                    {
+                        const std::string error = "Warning: \"forcegreeting\" command works only for actors.";
+                        runtime.getContext().report (error);
+                        std::cerr << error << std::endl;
+                        return;
+                    }
 
                     MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Dialogue, ptr);
                 }


### PR DESCRIPTION
Fixes [bug #4553](https://gitlab.com/OpenMW/openmw/issues/4553).
I encountered it once in unpatched Arktwend.

Note: maybe we have a better way to print warning rather than cerr.