### PR TITLE
Make partial binary search case insensitive, as it supposed to be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
     Bug #4539: Paper Doll is affected by GUI scaling
     Bug #4545: Creatures flee from werewolves
     Bug #4551: Replace 0 sound range with default range separately
+    Bug #4558: Mesh optimizer: check for reserved node name is case-sensitive
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/apps/openmw_test_suite/misc/test_stringops.cpp
+++ b/apps/openmw_test_suite/misc/test_stringops.cpp
@@ -7,7 +7,7 @@ struct PartialBinarySearchTest : public ::testing::Test
     std::vector<std::string> mDataVec;
     virtual void SetUp()
     {
-        const char* data[] = { "Head", "Chest", "Tri Head", "Tri Chest", "Bip01" };
+        const char* data[] = { "Head", "Chest", "Tri Head", "Tri Chest", "Bip01", "Tri Bip01" };
         mDataVec = std::vector<std::string>(data, data+sizeof(data)/sizeof(data[0]));
         std::sort(mDataVec.begin(), mDataVec.end(), Misc::StringUtils::ciLess);
     }
@@ -29,7 +29,15 @@ TEST_F(PartialBinarySearchTest, partial_binary_search_test)
     EXPECT_TRUE( matches("Tri Head 01") );
     EXPECT_TRUE( matches("Tri Head") );
     EXPECT_TRUE( matches("tri head") );
+    EXPECT_TRUE( matches("Tri bip01") );
+    EXPECT_TRUE( matches("bip01") );
+    EXPECT_TRUE( matches("bip01 head") );
+    EXPECT_TRUE( matches("Bip01 L Hand") );
+    EXPECT_TRUE( matches("BIp01 r Clavicle") );
+    EXPECT_TRUE( matches("Bip01 SpiNe1") );
 
+    EXPECT_FALSE( matches("") );
+    EXPECT_FALSE( matches("Node Bip01") );
     EXPECT_FALSE( matches("Hea") );
     EXPECT_FALSE( matches(" Head") );
     EXPECT_FALSE( matches("Tri  Head") );

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -146,8 +146,15 @@ public:
         std::string::const_iterator yit = y.begin();
         for(;xit != x.end() && yit != y.end() && len > 0;++xit,++yit,--len)
         {
-            int res = *xit - *yit;
-            if(res != 0 && toLower(*xit) != toLower(*yit))
+            char left = *xit;
+            char right = *yit;
+            if (left == right)
+                continue;
+
+            left = toLower(left);
+            right = toLower(right);
+            int res = left - right;
+            if(res != 0)
                 return (res > 0) ? 1 : -1;
         }
         if(len > 0)

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -393,9 +393,9 @@ namespace Resource
             static std::vector<std::string> reservedNames;
             if (reservedNames.empty())
             {
-                const char* reserved[] = {"Head", "Neck", "Chest", "Groin", "Right Hand", "Left Hand", "Right Wrist", "Left Wrist", "Shield Bone", "Right Forearm", "Left Forearm", "Right Upper Arm", "Left Upper Arm", "Right Foot", "Left Foot", "Right Ankle", "Left Ankle", "Right Knee", "Left Knee", "Right Upper Leg", "Left Upper Leg", "Right Clavicle", "Left Clavicle", "Weapon Bone", "Tail",
-                                         "Bip01 L Hand", "Bip01 R Hand", "Bip01 Head", "Bip01 Spine1", "Bip01 Spine2", "Bip01 L Clavicle", "Bip01 R Clavicle", "bip01", "Root Bone", "Bip01 Neck",
-                                         "BoneOffset", "AttachLight", "ArrowBone", "Camera"};
+                const char* reserved[] = {"Head", "Neck", "Chest", "Groin", "Right Hand", "Left Hand", "Right Wrist", "Left Wrist", "Shield Bone", "Right Forearm", "Left Forearm", "Right Upper Arm",
+                                          "Left Upper Arm", "Right Foot", "Left Foot", "Right Ankle", "Left Ankle", "Right Knee", "Left Knee", "Right Upper Leg", "Left Upper Leg", "Right Clavicle",
+                                          "Left Clavicle", "Weapon Bone", "Tail", "Bip01", "Root Bone", "BoneOffset", "AttachLight", "ArrowBone", "Camera"};
                 reservedNames = std::vector<std::string>(reserved, reserved + sizeof(reserved)/sizeof(reserved[0]));
 
                 for (unsigned int i=0; i<sizeof(reserved)/sizeof(reserved[0]); ++i)


### PR DESCRIPTION
Fixes bug [#4558](https://gitlab.com/OpenMW/openmw/issues/4558).

Currently our partial binary search contains a bug: we choose which half to use for next step via "res" variable, but it contains case-sensitive difference between characters.
As solution, I  transform both characters to lowercase first, and then work with transformed characters.

Summary of changes:
1. Fix mentioned bug.
2. Wipe redundant entries out from "reserved" array - now search considers all nodes, starting with "Bip01" and "Tri Bip01" (case-insensitive) as reserved.
3. Extend existing unit-test to check case-sensitivity.