### PR TITLE
Don't render NiTriShapes without NiTexturingProperty (bug #4483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
     Bug #4475: Scripted animations should not cause movement
     Bug #4479: "Game" category on Advanced page is getting too long
     Bug #4480: Segfault in QuickKeysMenu when item no longer in inventory
+    Bug #4483: Shapes without NiTexturingProperty are rendered
     Bug #4489: Goodbye doesn't block dialogue hyperlinks
     Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
     Bug #4494: Training cap based off Base Skill instead of Modified Skill

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -573,6 +573,10 @@ namespace NifOsg
                 }
             }
 
+            // Make sure we don't render untextured shapes
+            if (nifNode->recType == Nif::RC_NiTriShape && boundTextures.empty())
+                node->setNodeMask(0x1);
+
             if(nifNode->recType == Nif::RC_NiAutoNormalParticles || nifNode->recType == Nif::RC_NiRotatingParticles)
                 handleParticleSystem(nifNode, node, composite, animflags, rootNode);
 


### PR DESCRIPTION
[Bug 4483](https://gitlab.com/OpenMW/openmw/issues/4483).

If the shape has no textures bound to it, it's nodemask is set to 0x1 so it's hidden from view.
I'm not sure if I didn't break something, so please test it. Sprite trees from Better flora from the report seem to work better now - the untextured shape doesn't flicker in and out of view.