### PR TITLE
 Make AiActivate not stop upon target activation (bug #4456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
     Bug #4452: Default terrain texture bleeds through texture transitions
     Bug #4453: Quick keys behaviour is invalid for equipment
     Bug #4454: AI opens doors too slow
+    Bug #4456: AiActivate should not be cancelled after target activation
     Bug #4457: Item without CanCarry flag prevents shield autoequipping in dark areas
     Bug #4458: AiWander console command handles idle chances incorrectly
     Bug #4459: NotCell dialogue condition doesn't support partial matches

--- a/apps/openmw/mwmechanics/aiactivate.cpp
+++ b/apps/openmw/mwmechanics/aiactivate.cpp
@@ -42,7 +42,6 @@ namespace MWMechanics
         {
             // activate when reached
             MWBase::Environment::get().getWorld()->activate(target, actor);
-            return true;
         }
 
         return false;


### PR DESCRIPTION
[Bug 4456](https://gitlab.com/OpenMW/openmw/issues/4456).

Aaaand now it's broken. Hooray.