### PR TITLE
Fix untextured shapes nodemask

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -575,7 +575,7 @@ namespace NifOsg
 
             // Make sure we don't render untextured shapes
             if (nifNode->recType == Nif::RC_NiTriShape && boundTextures.empty())
-                node->setNodeMask(0x1);
+                node->setNodeMask(0x0);
 
             if(nifNode->recType == Nif::RC_NiAutoNormalParticles || nifNode->recType == Nif::RC_NiRotatingParticles)
                 handleParticleSystem(nifNode, node, composite, animflags, rootNode);


### PR DESCRIPTION
As pointed out by AnyOldName3 after #1848 was merged, I was misled by the surrounding code and 0x1 mask is not correct in this case (I did find some info about this originally, but somehow decided to discard the "set to 0x0 to hide the node" advice).