### PR TITLE
Init SDL2 before Qt4 to avoid crash on Linux

### DIFF
--- a/apps/launcher/CMakeLists.txt
+++ b/apps/launcher/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LAUNCHER
     datafilespage.cpp
     graphicspage.cpp
+    sdlinit.cpp
     main.cpp
     maindialog.cpp
     playpage.cpp
@@ -19,6 +20,7 @@ set(LAUNCHER
 set(LAUNCHER_HEADER
     datafilespage.hpp
     graphicspage.hpp
+    sdlinit.hpp
     maindialog.hpp
     playpage.hpp
     textslotmsgbox.hpp

--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -12,7 +12,6 @@
 #define MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
 #endif // MAC_OS_X_VERSION_MIN_REQUIRED
 
-#include <SDL.h>
 #include <SDL_video.h>
 
 #include <components/files/configurationmanager.hpp>
@@ -48,27 +47,15 @@ Launcher::GraphicsPage::GraphicsPage(Files::ConfigurationManager &cfg, Settings:
 
 }
 
-bool Launcher::GraphicsPage::connectToSdl() {
-    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
-    SDL_SetMainReady();
-    // Required for determining screen resolution and such on the Graphics tab
-    if (SDL_Init(SDL_INIT_VIDEO) != 0)
-    {
-        return false;
-    }
-    signal(SIGINT, SIG_DFL); // We don't want to use the SDL event loop in the launcher,
-    // so reset SIGINT which SDL wants to redirect to an SDL_Quit event.
-
-    return true;
-}
-
 bool Launcher::GraphicsPage::setupSDL()
 {
-    bool sdlConnectSuccessful = connectToSdl();
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    bool sdlConnectSuccessful = initSDL();
     if (!sdlConnectSuccessful)
     {
         return false;
     }
+#endif
 
     int displays = SDL_GetNumVideoDisplays();
 
@@ -89,8 +76,10 @@ bool Launcher::GraphicsPage::setupSDL()
         screenComboBox->addItem(QString(tr("Screen ")) + QString::number(i + 1));
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
     // Disconnect from SDL processes
-    SDL_Quit();
+    quitSDL();
+#endif
 
     return true;
 }

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -7,6 +7,8 @@
 
 #include <components/settings/settings.hpp>
 
+#include "sdlinit.hpp"
+
 namespace Files { struct ConfigurationManager; }
 
 namespace Launcher
@@ -37,11 +39,6 @@ namespace Launcher
         QStringList getAvailableResolutions(int screen);
         QRect getMaximumResolution();
 
-        /**
-         * Connect to the SDL so that we can use it to determine graphics
-         * @return whether or not connecting to SDL is successful
-         */
-        bool connectToSdl();
         bool setupSDL();
     };
 }

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -12,11 +12,18 @@
 #endif // MAC_OS_X_VERSION_MIN_REQUIRED
 
 #include "maindialog.hpp"
+#include "sdlinit.hpp"
 
 int main(int argc, char *argv[])
 {
     try
     {
+// Note: we should init SDL2 before Qt4 to avoid crashes on Linux,
+// but we should init SDL2 after Qt5 to avoid input issues on MacOS X.
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
+        initSDL();
+#endif
+
         QApplication app(argc, argv);
 
         // Now we make sure the current dir is set to application path
@@ -33,7 +40,14 @@ int main(int argc, char *argv[])
         if (result == Launcher::FirstRunDialogResultContinue)
             mainWin.show();
 
-        return app.exec();
+        int exitCode = app.exec();
+
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
+        // Disconnect from SDL processes
+        quitSDL();
+#endif
+
+        return exitCode;
     }
     catch (std::exception& e)
     {

--- a/apps/launcher/sdlinit.cpp
+++ b/apps/launcher/sdlinit.cpp
@@ -1,0 +1,25 @@
+#include <signal.h>
+
+#include <SDL.h>
+#include <SDL_video.h>
+
+bool initSDL()
+{
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+    SDL_SetMainReady();
+    // Required for determining screen resolution and such on the Graphics tab
+    if (SDL_Init(SDL_INIT_VIDEO) != 0)
+    {
+        return false;
+    }
+    signal(SIGINT, SIG_DFL); // We don't want to use the SDL event loop in the launcher,
+    // so reset SIGINT which SDL wants to redirect to an SDL_Quit event.
+
+    return true;
+}
+
+void quitSDL()
+{
+    // Disconnect from SDL processes
+    SDL_Quit();
+}

--- a/apps/launcher/sdlinit.hpp
+++ b/apps/launcher/sdlinit.hpp
@@ -1,0 +1,8 @@
+#ifndef SDLINIT_H
+#define SDLINIT_H
+
+bool initSDL();
+
+void quitSDL();
+
+#endif


### PR DESCRIPTION
Should fix [bug #4529](https://gitlab.com/OpenMW/openmw/issues/4529).

The main idea: init SDL2 before Qt4, as we do in 0.44. For Qt5 keep our upstream behaviour to solve issues with MacOS ([bug #2862](https://bugs.openmw.org/issues/2862) and [bug #3911](https://bugs.openmw.org/issues/3911)). Actually, we changed bahaviour because of them.

Notes: 
1. I do not have MacOS and Qt4, so I can not test these changes by myself. 
2. If MacOS also uses Qt4, probably it would be better to check for OS instead of Qt version.