### PR TITLE
Check the actor cell instead of the destination in fast travel price logic (bug #4563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
     Bug #4553: Forcegreeting on non-actor opens a dialogue window which cannot be closed
     Bug #4557: Topics with reserved names are handled differently from vanilla
     Bug #4558: Mesh optimizer: check for reserved node name is case-sensitive
+    Bug #4563: Fast travel price logic checks destination cell instead of service actor cell
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -46,7 +46,7 @@ namespace MWGui
                           mSelect->getHeight());
     }
 
-    void TravelWindow::addDestination(const std::string& name,ESM::Position pos,bool interior)
+    void TravelWindow::addDestination(const std::string& name, ESM::Position pos, bool interior)
     {
         int price;
 
@@ -56,7 +56,7 @@ namespace MWGui
         MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
         int playerGold = player.getClass().getContainerStore(player).count(MWWorld::ContainerStore::sGoldId);
 
-        if(interior)
+        if (!mPtr.getCell()->isExterior())
         {
             price = gmst.find("fMagesGuildTravel")->getInt();
         }

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -168,7 +168,7 @@ namespace MWGui
         ESM::Position pos = *_sender->getUserData<ESM::Position>();
         std::string cellname = _sender->getUserString("Destination");
         bool interior = _sender->getUserString("interior") == "y";
-        if (!interior)
+        if (mPtr.getCell()->isExterior())
         {
             ESM::Position playerPos = player.getRefData().getPosition();
             float d = (osg::Vec3f(pos.pos[0], pos.pos[1], 0) - osg::Vec3f(playerPos.pos[0], playerPos.pos[1], 0)).length();


### PR DESCRIPTION
[Bug 4563](https://gitlab.com/OpenMW/openmw/issues/4563)

Making interior NPCs explicitly use guild guide logic and exterior NPCs use caravaneer logic seems to follow the original behavior exactly. Fixes the prices guild guides charge for exterior cell destinations. Yes, this means that guild guide NPCs that were placed to an exterior will work like silt strider caravaneers or shipmasters. This is how it works in Morrowind.

Interestingly when scrawl added the missing spellcast sound its behavior was correct.