### PR TITLE
Remove unnecessary link to osgAnimation

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -204,7 +204,6 @@ target_link_libraries(components
     ${OSGVIEWER_LIBRARIES}
     ${OSGTEXT_LIBRARIES}
     ${OSGGA_LIBRARIES}
-    ${OSGANIMATION_LIBRARIES}
     ${Bullet_LIBRARIES}
     ${SDL2_LIBRARIES}
     ${OPENGL_gl_LIBRARY}


### PR DESCRIPTION
Scrawl wiped out dependency on osgAnimation library a year ago, but forgot to remove it from CMake config file.