### PR TITLE
Revert untextured shapes rendering changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@
     Bug #4475: Scripted animations should not cause movement
     Bug #4479: "Game" category on Advanced page is getting too long
     Bug #4480: Segfault in QuickKeysMenu when item no longer in inventory
-    Bug #4483: Shapes without NiTexturingProperty are rendered
     Bug #4489: Goodbye doesn't block dialogue hyperlinks
     Bug #4490: PositionCell on player gives "Error: tried to add local script twice"
     Bug #4494: Training cap based off Base Skill instead of Modified Skill

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -573,10 +573,6 @@ namespace NifOsg
                 }
             }
 
-            // Make sure we don't render untextured shapes
-            if (nifNode->recType == Nif::RC_NiTriShape && boundTextures.empty())
-                node->setNodeMask(0x0);
-
             if(nifNode->recType == Nif::RC_NiAutoNormalParticles || nifNode->recType == Nif::RC_NiRotatingParticles)
                 handleParticleSystem(nifNode, node, composite, animflags, rootNode);
 


### PR DESCRIPTION
Revert changes made to fix "bug" 4483.
Apparently vanilla doesn't work that way - Tamriel Rebuilt relies on untextured shapes being rendered in Morrowind - and it was an assets problem all along in Better flora. ~~I was right, thousand times right!~~