### PR TITLE
Do not touch GUI modes when taking screenshots

### DIFF
--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -170,11 +170,17 @@ namespace MWGui
         // We are already using node masks to avoid the scene from being updated/rendered, but node masks don't work for computeBound()
         mViewer->getSceneData()->setComputeBoundingSphereCallback(new DontComputeBoundCallback);
 
+        mShowWallpaper = visible && (MWBase::Environment::get().getStateManager()->getState()
+                == MWBase::StateManager::State_NoGame);
+
+        if (!visible)
+        {
+            draw();
+            return;
+        }
+
         mVisible = visible;
         mLoadingBox->setVisible(mVisible);
-
-        mShowWallpaper = mVisible && (MWBase::Environment::get().getStateManager()->getState()
-                == MWBase::StateManager::State_NoGame);
 
         setVisible(true);
 
@@ -184,9 +190,6 @@ namespace MWGui
         }
 
         MWBase::Environment::get().getWindowManager()->pushGuiMode(mShowWallpaper ? GM_LoadingWallpaper : GM_Loading);
-
-        if (!mVisible)
-            draw();
     }
 
     void LoadingScreen::loadingOff()


### PR DESCRIPTION
Fixes [bug #4528](https://gitlab.com/OpenMW/openmw/issues/4528).

Note: this PR has a small side effect - now we hide savegame dialog when we start saving, not when we finish it. But it is a lot better than "killall -9 openmw"