### PR TITLE
Do not use fall-through to avoid GCC warnings

### DIFF
--- a/extern/oics/tinyxmlparser.cpp
+++ b/extern/oics/tinyxmlparser.cpp
@@ -104,25 +104,17 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 
 	output += *length;
 
-	// Scary scary fall throughs.
-	switch (*length)
-	{
-		case 4:
-			--output;
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
-			input >>= 6;
-		case 3:
-			--output;
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
-			input >>= 6;
-		case 2:
-			--output;
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
-			input >>= 6;
-		case 1:
-			--output;
-			*output = (char)(input | FIRST_BYTE_MARK[*length]);
-	}
+    int lengthLeft = *length;
+    while (lengthLeft > 1)
+    {
+        --output;
+        *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+        input >>= 6;
+        --lengthLeft;
+    }
+
+    --output;
+    *output = (char)(input | FIRST_BYTE_MARK[*length]);
 }
 
 


### PR DESCRIPTION
Fixes annoying "this statement may fall through [-Wimplicit-fallthrough=]" warning with GCC7.
Affected code contains a bad-designed case statement, which is actually a loop.