### PR TITLE
[Regression] Fix combat engagement for creatures

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1346,7 +1346,7 @@ namespace MWMechanics
                             {
                                 if (it->first == iter->first || isPlayer) // player is not AI-controlled
                                     continue;
-                                engageCombat(iter->first, it->first, cachedAllies, isPlayer);
+                                engageCombat(iter->first, it->first, cachedAllies, it->first == player);
                             }
                         }
                         if (timerUpdateHeadTrack == 0)


### PR DESCRIPTION
Fixes a regression introduced by commit 126b2fdd42836d0c62afc4e9374e4123669cd2c4. Sorry for that.

P.S. Probably we need to avoid to use variable names such as "it" and "iter", especially for inner loops.