### PR TITLE
Ease AI sequence restrictions in AI allies logic (bug #4304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
     Bug #4286: Scripted animations can be interrupted
     Bug #4291: Non-persistent actors that started the game as dead do not play death animations
     Bug #4293: Faction members are not aware of faction ownerships in barter
+    Bug #4304: "Follow" not working as a second AI package
     Bug #4307: World cleanup should remove dead bodies only if death animation is finished
     Bug #4311: OpenMW does not handle RootCollisionNode correctly
     Bug #4327: Missing animations during spell/weapon stance switching

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -2,7 +2,6 @@
 
 #include <typeinfo>
 #include <iostream>
-
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/loadnpc.hpp>
@@ -1927,7 +1926,8 @@ namespace MWMechanics
         osg::Vec3f position (actor.getRefData().getPosition().asVec3());
         getObjectsInRange(position, aiProcessingDistance, neighbors);
 
-        std::list<MWWorld::Ptr> followers = getActorsFollowing(actor);
+        std::set<MWWorld::Ptr> followers;
+        getActorsFollowing(actor, followers);
         for(auto neighbor = neighbors.begin(); neighbor != neighbors.end(); ++neighbor)
         {
             const CreatureStats &stats = neighbor->getClass().getCreatureStats(*neighbor);

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -403,7 +403,7 @@ namespace MWMechanics
         std::set<MWWorld::Ptr> playerAllies;
         getActorsSidingWith(MWMechanics::getPlayer(), playerAllies, cachedAllies);
 
-        bool isPlayerFollowerOrEscorter = std::find(playerAllies.begin(), playerAllies.end(), actor1) != playerAllies.end();
+        bool isPlayerFollowerOrEscorter = playerAllies.find(actor1) != playerAllies.end();
 
         // If actor2 and at least one actor2 are in combat with actor1, actor1 and its allies start combat with them
         // Doesn't apply for player followers/escorters        
@@ -457,7 +457,7 @@ namespace MWMechanics
         // Do aggression check if actor2 is the player or a player follower or escorter
         if (!aggressive)
         {
-            if (againstPlayer || std::find(playerAllies.begin(), playerAllies.end(), actor2) != playerAllies.end())
+            if (againstPlayer || playerAllies.find(actor2) != playerAllies.end())
             {
                 // Player followers and escorters with high fight should not initiate combat with the player or with
                 // other player followers or escorters
@@ -1928,13 +1928,13 @@ namespace MWMechanics
 
         std::set<MWWorld::Ptr> followers;
         getActorsFollowing(actor, followers);
-        for(auto neighbor = neighbors.begin(); neighbor != neighbors.end(); ++neighbor)
+        for (auto neighbor = neighbors.begin(); neighbor != neighbors.end(); ++neighbor)
         {
             const CreatureStats &stats = neighbor->getClass().getCreatureStats(*neighbor);
             if (stats.isDead() || *neighbor == actor || neighbor->getClass().isPureWaterCreature(*neighbor))
                 continue;
 
-            const bool isFollower = std::find(followers.begin(), followers.end(), *neighbor) != followers.end();
+            const bool isFollower = followers.find(*neighbor) != followers.end();
 
             if (stats.getAiSequence().isInCombat(actor) || (MWBase::Environment::get().getMechanicsManager()->isAggressive(*neighbor, actor) && !isFollower))
                 list.push_back(*neighbor);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1,6 +1,7 @@
 #include "mechanicsmanagerimp.hpp"
 
 #include <limits.h>
+#include <set>
 
 #include <components/misc/rng.hpp>
 
@@ -1445,11 +1446,12 @@ namespace MWMechanics
         if (target == getPlayer() || !attacker.getClass().isActor())
             return false;
 
-        std::list<MWWorld::Ptr> followersAttacker = getActorsSidingWith(attacker);
+        std::set<MWWorld::Ptr> followersAttacker;
+        getActorsSidingWith(attacker, followersAttacker);
 
         MWMechanics::CreatureStats& statsTarget = target.getClass().getCreatureStats(target);
 
-        if (std::find(followersAttacker.begin(), followersAttacker.end(), target) != followersAttacker.end())
+        if (followersAttacker.find(target) != followersAttacker.end())
         {
             statsTarget.friendlyHit();
 


### PR DESCRIPTION
[Bug 4304](https://gitlab.com/OpenMW/openmw/issues/4304).

~~Since evidently checking for whether the **currently active** "real" AI package is AiFollow is not something vanilla does when finding allies of an actor and nobody argued against lifting this restriction OpenMW has, here's something that lifts it.~~

Since without researching how exactly vanilla behaves in certain edge cases when the matter touches finding actor allies lifting the restrictions leads to different issues, for now AiWander is considered another exception in AI ally finding logic.