### PR TITLE
Add zero-duration spells effects to effect list (bug #3533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     Bug #3249: Fixed revert function not updating views properly
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3486: [Mod] NPC Commands does not work
+    Bug #3533: GetSpellEffects should detect effects with zero duration
     Bug #3591: Angled hit distance too low
     Bug #3629: DB assassin attack never triggers creature spawning
     Bug #3876: Landscape texture painting is misaligned

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -509,9 +509,18 @@ namespace MWMechanics
                 }
                 else // target.getClass().isActor() == true
                 {
+                    ActiveSpells::ActiveEffect effect;
+                    effect.mEffectId = effectIt->mEffectID;
+                    effect.mArg = MWMechanics::EffectKey(*effectIt).mArg;
+                    effect.mMagnitude = magnitude;
+
                     bool hasDuration = !(magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration);
                     if (hasDuration && effectIt->mDuration == 0)
                     {
+                        // We still should add effect to list to allow GetSpellEffects to detect this spell
+                        effect.mDuration = 0.f;
+                        appliedLastingEffects.push_back(effect);
+
                         // duration 0 means apply full magnitude instantly
                         bool wasDead = target.getClass().getCreatureStats(target).isDead();
                         effectTick(target.getClass().getCreatureStats(target), target, EffectKey(*effectIt), magnitude);
@@ -522,18 +531,15 @@ namespace MWMechanics
                     }
                     else
                     {
-                        // add to list of active effects, to apply in next frame
-                        ActiveSpells::ActiveEffect effect;
-                        effect.mEffectId = effectIt->mEffectID;
-                        effect.mArg = MWMechanics::EffectKey(*effectIt).mArg;
+
                         if (!hasDuration)
                             effect.mDuration = 1.0f;
                         else
                             effect.mDuration = static_cast<float>(effectIt->mDuration);
-                        effect.mMagnitude = magnitude;
 
                         targetEffects.add(MWMechanics::EffectKey(*effectIt), MWMechanics::EffectParam(effect.mMagnitude));
 
+                        // add to list of active effects, to apply in next frame
                         appliedLastingEffects.push_back(effect);
 
                         // Unequip all items, if a spell with the ExtraSpell effect was casted


### PR DESCRIPTION
Fixes [bug #3533](https://gitlab.com/OpenMW/openmw/issues/3533).
The main idea: still apply effects with zero duration instantly, but add them to effects list anyway.
In this case in the next frame this effect can be detected via GetSpellEffects, then this effect will be removed from the list during game mechanics update.

Tested on Teleportation Spells mod and Draugr Diversity.