### PR TITLE
Improve jailing and traveling detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     Bug #3486: [Mod] NPC Commands does not work
     Bug #3591: Angled hit distance too low
     Bug #3629: DB assassin attack never triggers creature spawning
+    Bug #3788: GetPCInJail and GetPCTraveling do not work as in vanilla
     Bug #3876: Landscape texture painting is misaligned
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3911: [macOS] Typing in the "Content List name" dialog box produces double characters

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -566,6 +566,9 @@ namespace MWBase
 
             virtual bool isPlayerInJail() const = 0;
 
+            virtual void setPlayerTraveling(bool traveling) = 0;
+            virtual bool isPlayerTraveling() const = 0;
+
             virtual void rotateWorldObject (const MWWorld::Ptr& ptr, osg::Quat rotate) = 0;
 
             /// Return terrain height at \a worldPos position.

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -154,6 +154,10 @@ namespace MWGui
         if (playerGold<price)
             return;
 
+        // Set "traveling" flag, so GetPCTraveling can detect teleportation.
+        // We will reset this flag during next world update.
+        MWBase::Environment::get().getWorld()->setPlayerTraveling(true);
+
         if (!mPtr.getCell()->isExterior())
             // Interior cell -> mages guild transport
             MWBase::Environment::get().getWindowManager()->playSound("mysticism cast");

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1155,8 +1155,7 @@ namespace MWScript
 
                 virtual void execute (Interpreter::Runtime &runtime)
                 {
-                    /// \todo implement traveling check
-                    runtime.push (0);
+                    runtime.push (MWBase::Environment::get().getWorld()->isPlayerTraveling());
                 }
         };
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -153,7 +153,8 @@ namespace MWWorld
       mGodMode(false), mScriptsEnabled(true), mContentFiles (contentFiles), mUserDataPath(userDataPath),
       mActivationDistanceOverride (activationDistanceOverride), mStartupScript(startupScript),
       mStartCell (startCell), mDistanceToFacedObject(-1), mTeleportEnabled(true),
-      mLevitationEnabled(true), mGoToJail(false), mDaysInPrison(0), mSpellPreloadTimer(0.f)
+      mLevitationEnabled(true), mGoToJail(false), mDaysInPrison(0),
+      mPlayerTraveling(false), mSpellPreloadTimer(0.f)
     {
         mPhysics.reset(new MWPhysics::PhysicsSystem(resourceSystem, rootNode));
         mRendering.reset(new MWRender::RenderingManager(viewer, rootNode, resourceSystem, workQueue, &mFallback, resourcePath));
@@ -311,6 +312,7 @@ namespace MWWorld
         mGoToJail = false;
         mTeleportEnabled = true;
         mLevitationEnabled = true;
+        mPlayerTraveling = false;
 
         fillGlobalVariables();
     }
@@ -1639,6 +1641,9 @@ namespace MWWorld
 
     void World::update (float duration, bool paused)
     {
+        // Reset "traveling" flag - there was a frame to detect traveling.
+        mPlayerTraveling = false;
+
         if (mGoToJail && !paused)
             goToJail();
 
@@ -3310,6 +3315,16 @@ namespace MWWorld
             return true;
 
         return MWBase::Environment::get().getWindowManager()->containsMode(MWGui::GM_Jail);
+    }
+
+    void World::setPlayerTraveling(bool traveling)
+    {
+        mPlayerTraveling = traveling;
+    }
+
+    bool World::isPlayerTraveling() const
+    {
+        return mPlayerTraveling;
     }
 
     float World::getTerrainHeightAt(const osg::Vec3f& worldPos) const

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -169,6 +169,7 @@ namespace MWWorld
             bool mGoToJail;
             int mDaysInPrison;
             bool mPlayerTraveling;
+            bool mPlayerInJail;
 
             float mSpellPreloadTimer;
 
@@ -673,8 +674,8 @@ namespace MWWorld
 
             bool isPlayerInJail() const override;
 
-            void setPlayerTraveling(bool traveling);
-            bool isPlayerTraveling() const;
+            void setPlayerTraveling(bool traveling) override;
+            bool isPlayerTraveling() const override;
 
             /// Return terrain height at \a worldPos position.
             float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -168,6 +168,7 @@ namespace MWWorld
             bool mLevitationEnabled;
             bool mGoToJail;
             int mDaysInPrison;
+            bool mPlayerTraveling;
 
             float mSpellPreloadTimer;
 
@@ -671,6 +672,9 @@ namespace MWWorld
             float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
 
             bool isPlayerInJail() const override;
+
+            void setPlayerTraveling(bool traveling);
+            bool isPlayerTraveling() const;
 
             /// Return terrain height at \a worldPos position.
             float getTerrainHeightAt(const osg::Vec3f& worldPos) const override;


### PR DESCRIPTION
Fixes [bug #3788](https://gitlab.com/OpenMW/openmw/issues/3788), replaces PR #1378.

Currently we update our scripts, world and GUI in this order every frame:
1. Scripts
2. World
3. GUI

Since we update GUI last, we need to reset "jailing" and "traveling" flags only in the next world update, so scripts may catch the moment when the player stops traveling or leaving the jail.
For traviling it is the first frame after reaching the destination.
For jailing it is the first frame near prison marker, when a messagebox about decreased skill appears.
