### PR TITLE
Make sure bip01 root node is not optimized away (bug #3856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     Bug #3533: GetSpellEffects should detect effects with zero duration
     Bug #3591: Angled hit distance too low
     Bug #3629: DB assassin attack never triggers creature spawning
+    Bug #3856: Bip01 is not found on creatures, even if it is present
     Bug #3876: Landscape texture painting is misaligned
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3911: [macOS] Typing in the "Content List name" dialog box produces double characters

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -440,7 +440,8 @@ namespace NifOsg
                 // The Root node can be created as a Group if no transformation is required.
                 // This takes advantage of the fact root nodes can't have additional controllers
                 // loaded from an external .kf file (original engine just throws "can't find node" errors if you try).
-                if (!nifNode->parent && nifNode->controller.empty() && nifNode->trafo.isIdentity())
+                if (!nifNode->parent && nifNode->controller.empty() 
+                  && nifNode->trafo.isIdentity() && !Misc::StringUtils::ciEqual(nifNode->name, "bip01"))
                 {
                     node = new osg::Group;
                     dataVariance = osg::Object::STATIC;


### PR DESCRIPTION
[Bug 3856.](https://gitlab.com/OpenMW/openmw/issues/3856)

Implements the "easy" fix suggested by scrawl: don't optimize root nodes named bip01. I think this should do it for now.