### PR TITLE
[Regression] Move cerr initialization out of 'try' block

### DIFF
--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -5,9 +5,6 @@
 #include <QLocalSocket>
 #include <QMessageBox>
 
-
-#include <components/crashcatcher/crashcatcher.hpp>
-
 #include <components/fallback/validate.hpp>
 
 #include <components/nifosg/nifloader.hpp>
@@ -27,10 +24,6 @@ CS::Editor::Editor (int argc, char **argv)
   mLock(), mMerge (mDocumentManager),
   mIpcServerName ("org.openmw.OpenCS"), mServer(NULL), mClientSocket(NULL)
 {    
-    // install the crash handler as soon as possible. note that the log path
-    // does not depend on config being read.
-    crashCatcherInstall(argc, argv, (mCfgMgr.getLogPath() / "openmw-cs-crash.log").string());
-
     std::pair<Files::PathContainer, std::vector<std::string> > config = readConfig();
 
     setupDataFiles (config.first);

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
 #include <components/version/version.hpp>
-#include <components/crashcatcher/crashcatcher.hpp>
 #include <components/files/configurationmanager.hpp>
 #include <components/files/escape.hpp>
 #include <components/fallback/validate.hpp>


### PR DESCRIPTION
Allows to log fatal exceptions correctly.

Note: instead of crash.log now he have two separate log files:
1. openmw-crash.log for game itself
2. openmw-cs-crash.log for editor
Probably we will need to edit Wiki.