### PR TITLE
Remove an outdated checkbox from the advanced page of the launcher

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -76,11 +76,9 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(chargeForEveryFollowerCheckBox, "charge for every follower travelling", "Game");
     loadSettingBool(enchantedWeaponsMagicalCheckBox, "enchanted weapons are magical", "Game");
     loadSettingBool(permanentBarterDispositionChangeCheckBox, "barter disposition change is permanent", "Game");
-    loadSettingBool(strengthInfluencesHandToHand, "strength influences hand to hand", "Game");
     int unarmedFactorsStrengthIndex = mEngineSettings.getInt("strength influences hand to hand", "Game");
     if (unarmedFactorsStrengthIndex >= 0 && unarmedFactorsStrengthIndex <= 2)
         unarmedFactorsStrengthComboBox->setCurrentIndex(unarmedFactorsStrengthIndex);
-
 
     // Input Settings
     loadSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");
@@ -136,11 +134,9 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(chargeForEveryFollowerCheckBox, "charge for every follower travelling", "Game");
     saveSettingBool(enchantedWeaponsMagicalCheckBox, "enchanted weapons are magical", "Game");
     saveSettingBool(permanentBarterDispositionChangeCheckBox, "barter disposition change is permanent", "Game");
-    saveSettingBool(strengthInfluencesHandToHand, "strength influences hand to hand", "Game");
     int unarmedFactorsStrengthIndex = unarmedFactorsStrengthComboBox->currentIndex();
     if (unarmedFactorsStrengthIndex != mEngineSettings.getInt("strength influences hand to hand", "Game"))
         mEngineSettings.setInt("strength influences hand to hand", "Game", unarmedFactorsStrengthIndex);
-
 
     // Input Settings
     saveSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>AdvancedPage</class>
  <widget class="QWidget" name="AdvancedPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>671</width>
-    <height>373</height>
-   </rect>
-  </property>
   <layout class="QVBoxLayout" name="pageVerticalLayout">
    <item>
     <widget class="QScrollArea" name="scrollArea">
@@ -17,14 +9,6 @@
       <bool>true</bool>
      </property>
      <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>641</width>
-        <height>998</height>
-       </rect>
-      </property>
       <layout class="QVBoxLayout" name="scrollAreaVerticalLayout">
        <item>
         <widget class="QGroupBox" name="gameGroup">
@@ -100,16 +84,6 @@
             <property name="text">
              <string>Barter disposition change is permanent</string>
             </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="strengthInfluencesHandToHand">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uses the MCP formula (damage * (strength / 40)) to factor the Strength attribute into hand-to-hand combat.&lt;/p&gt;&lt;p&gt;The default value is false.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-           <string>Factor strength into hand-to-hand combat</string>
-           </property>
            </widget>
           </item>
           <item alignment="Qt::AlignLeft">


### PR DESCRIPTION
`strength influences hand to hand` setting shouldn't have been a boolean but during the repo diverge conflict resolution the boolean variant of the setting accidentally got in.