### PR TITLE
Fix some issues with attack animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
     Bug #4503: Cast and ExplodeSpell commands increase alteration skill
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
+    Bug #4531: Movement does not reset idle animations
     Bug #4539: Paper Doll is affected by GUI scaling
     Bug #4545: Creatures flee from werewolves
     Bug #4551: Replace 0 sound range with default range separately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
     Bug #4230: AiTravel package issues break some Tribunal quests
     Bug #4231: Infected rats from the "Crimson Plague" quest rendered unconscious by change in Drain Fatigue functionality
     Bug #4251: Stationary NPCs do not return to their position after combat
+    Bug #4271: Scamp flickers when attacking
     Bug #4274: Pre-0.43 death animations are not forward-compatible with 0.43+
     Bug #4286: Scripted animations can be interrupted
     Bug #4291: Non-persistent actors that started the game as dead do not play death animations
@@ -92,6 +93,7 @@
     Bug #4574: Player turning animations are twitchy
     Bug #4575: Weird result of attack animation blending with movement animations
     Bug #4576: Reset of idle animations when attack can not be started
+    Bug #4591: Attack strength should be 0 if player did not hold the attack button
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -257,7 +257,7 @@ namespace MWBase
             virtual void cleanupSummonedCreature(const MWWorld::Ptr& caster, int creatureActorId) = 0;
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count) = 0;
-            virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr) = 0;
+            virtual bool isAttackPreparing(const MWWorld::Ptr& ptr) = 0;
             virtual bool isRunning(const MWWorld::Ptr& ptr) = 0;
             virtual bool isSneaking(const MWWorld::Ptr& ptr) = 0;
     };

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1004,9 +1004,9 @@ namespace MWInput
         if (!mControlSwitch["playerfighting"] || !mControlSwitch["playercontrols"])
             return;
 
-        // We want to interrupt animation only if attack is prepairing, but still is not triggered
+        // We want to interrupt animation only if attack is preparing, but still is not triggered
         // Otherwise we will get a "speedshooting" exploit, when player can skip reload animation by hitting "Toggle Weapon" key twice
-        if (MWBase::Environment::get().getMechanicsManager()->isAttackPrepairing(mPlayer->getPlayer()))
+        if (MWBase::Environment::get().getMechanicsManager()->isAttackPreparing(mPlayer->getPlayer()))
             mPlayer->setAttackingOrSpell(false);
         else if (MWBase::Environment::get().getMechanicsManager()->isAttackingOrSpell(mPlayer->getPlayer()))
             return;

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -897,14 +897,14 @@ namespace MWMechanics
         }
     }
 
-    bool Actors::isAttackPrepairing(const MWWorld::Ptr& ptr)
+    bool Actors::isAttackPreparing(const MWWorld::Ptr& ptr)
     {
         PtrActorMap::iterator it = mActors.find(ptr);
         if (it == mActors.end())
             return false;
         CharacterController* ctrl = it->second->getCharacterController();
 
-        return ctrl->isAttackPrepairing();
+        return ctrl->isAttackPreparing();
     }
 
     bool Actors::isRunning(const MWWorld::Ptr& ptr)

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -118,7 +118,7 @@ namespace MWMechanics
             int countDeaths (const std::string& id) const;
             ///< Return the number of deaths for actors with the given ID.
 
-            bool isAttackPrepairing(const MWWorld::Ptr& ptr);
+            bool isAttackPreparing(const MWWorld::Ptr& ptr);
             bool isRunning(const MWWorld::Ptr& ptr);
             bool isSneaking(const MWWorld::Ptr& ptr);
 

--- a/apps/openmw/mwmechanics/aicombat.hpp
+++ b/apps/openmw/mwmechanics/aicombat.hpp
@@ -129,7 +129,7 @@ namespace MWMechanics
             /// Transfer desired movement (from AiCombatStorage) to Actor
             void updateActorsMovement(const MWWorld::Ptr& actor, float duration, AiCombatStorage& storage);
             void rotateActorOnAxis(const MWWorld::Ptr& actor, int axis, 
-                MWMechanics::Movement& actorMovementSettings, MWMechanics::Movement& desiredMovement);
+                MWMechanics::Movement& actorMovementSettings, AiCombatStorage& storage);
     };
     
     

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1685,7 +1685,7 @@ bool CharacterController::updateWeaponState()
                 break;
             case UpperCharState_StartToMinAttack:
             {
-                // If actor is already stopped prepairing attack, do not play the "min attack -> max attack" part.
+                // If actor is already stopped preparing attack, do not play the "min attack -> max attack" part.
                 // Happens if the player did not hold the attack button.
                 // Note: if the "min attack"->"max attack" is a stub, "play" it anyway. Attack strength will be 1.
                 float minAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"min attack");
@@ -2507,7 +2507,7 @@ bool CharacterController::isRandomAttackAnimation(const std::string& group) cons
             group == "attack3" || group == "swimattack3");
 }
 
-bool CharacterController::isAttackPrepairing() const
+bool CharacterController::isAttackPreparing() const
 {
     return mUpperBodyState == UpperCharState_StartToMinAttack ||
             mUpperBodyState == UpperCharState_MinAttackToMaxAttack;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1385,14 +1385,6 @@ bool CharacterController::updateWeaponState()
             MWBase::Environment::get().getWorld()->breakInvisibility(mPtr);
             mAttackStrength = 0;
 
-            // Randomize attacks for non-bipedal creatures with Weapon flag
-            if (mPtr.getClass().getTypeName() == typeid(ESM::Creature).name() &&
-                !mPtr.getClass().isBipedal(mPtr) &&
-                (!mAnimation->hasAnimation(mCurrentWeapon) || isRandomAttackAnimation(mCurrentWeapon)))
-            {
-                mCurrentWeapon = chooseRandomAttackAnimation();
-            }
-
             if(mWeaponType == WeapType_Spell)
             {
                 // Unset casting flag, otherwise pressing the mouse button down would
@@ -1401,15 +1393,10 @@ bool CharacterController::updateWeaponState()
                 if (mPtr == player)
                 {
                     MWBase::Environment::get().getWorld()->getPlayer().setAttackingOrSpell(false);
-                }
 
-                const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
-
-                // For the player, set the spell we want to cast
-                // This has to be done at the start of the casting animation,
-                // *not* when selecting a spell in the GUI (otherwise you could change the spell mid-animation)
-                if (mPtr == player)
-                {
+                    // For the player, set the spell we want to cast
+                    // This has to be done at the start of the casting animation,
+                    // *not* when selecting a spell in the GUI (otherwise you could change the spell mid-animation)
                     std::string selectedSpell = MWBase::Environment::get().getWindowManager()->getSelectedSpell();
                     stats.getSpells().setSelectedSpell(selectedSpell);
                 }
@@ -1421,6 +1408,7 @@ bool CharacterController::updateWeaponState()
                     MWMechanics::CastSpell cast(mPtr, NULL, false, mCastingManualSpell);
                     cast.playSpellCastingEffects(spellid);
 
+                    const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
                     const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);
                     const ESM::ENAMstruct &lastEffect = spell->mEffects.mList.back();
                     const ESM::MagicEffect *effect;
@@ -1520,13 +1508,12 @@ bool CharacterController::updateWeaponState()
                     startKey = mAttackType+" start";
                     stopKey = mAttackType+" min attack";
                 }
-
-                if (isRandomAttackAnimation(mCurrentWeapon))
+                else if (isRandomAttackAnimation(mCurrentWeapon))
                 {
                     startKey = "start";
                     stopKey = "stop";
                 }
-                else if (mAttackType != "shoot")
+                else
                 {
                     if(mPtr == getPlayer())
                     {

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -411,8 +411,8 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
     if(force || movement != mMovementState)
     {
         mMovementState = movement;
-
-        if (movement != CharState_None)
+        // Turning animations should not interrupt idle ones
+        if (movement != CharState_None && !isTurning())
             mIdleState = CharState_None;
 
         std::string movementAnimName;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1670,11 +1670,6 @@ bool CharacterController::updateWeaponState()
         std::string start, stop;
         switch(mUpperBodyState)
         {
-            case UpperCharState_StartToMinAttack:
-                start = mAttackType+" min attack";
-                stop = mAttackType+" max attack";
-                mUpperBodyState = UpperCharState_MinAttackToMaxAttack;
-                break;
             case UpperCharState_MinAttackToMaxAttack:
                 //hack to avoid body pos desync when jumping/sneaking in 'max attack' state
                 if(!mAnimation->isPlaying(mCurrentWeapon))
@@ -1682,6 +1677,23 @@ bool CharacterController::updateWeaponState()
                         MWRender::Animation::BlendMask_All, false,
                         0, mAttackType+" min attack", mAttackType+" max attack", 0.999f, 0);
                 break;
+            case UpperCharState_StartToMinAttack:
+            {
+                // If actor is already stopped prepairing attack, do not play the "min attack -> max attack" part.
+                // Happens if the player did not hold the attack button.
+                // Note: if the "min attack"->"max attack" is a stub, "play" it anyway. Attack strength will be 1.
+                float minAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"min attack");
+                float maxAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"max attack");
+                if (mAttackingOrSpell || minAttackTime == maxAttackTime)
+                {
+                    start = mAttackType+" min attack";
+                    stop = mAttackType+" max attack";
+                    mUpperBodyState = UpperCharState_MinAttackToMaxAttack;
+                    break;
+                }
+                playSwishSound(0.0f);
+            }
+            // Fall-through
             case UpperCharState_MaxAttackToMinHit:
                 if(mAttackType == "shoot")
                 {

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -281,7 +281,7 @@ public:
 
     void forceStateUpdate();
     
-    bool isAttackPrepairing() const;
+    bool isAttackPreparing() const;
     bool isCastingSpell() const;
     bool isReadyToBlock() const;
     bool isKnockedDown() const;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -435,9 +435,9 @@ namespace MWMechanics
         return mActors.isActorDetected(actor, observer);
     }
 
-    bool MechanicsManager::isAttackPrepairing(const MWWorld::Ptr& ptr)
+    bool MechanicsManager::isAttackPreparing(const MWWorld::Ptr& ptr)
     {
-        return mActors.isAttackPrepairing(ptr);
+        return mActors.isAttackPreparing(ptr);
     }
 
     bool MechanicsManager::isRunning(const MWWorld::Ptr& ptr)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -223,7 +223,7 @@ namespace MWMechanics
 
             virtual void confiscateStolenItemToOwner(const MWWorld::Ptr &player, const MWWorld::Ptr &item, const MWWorld::Ptr& victim, int count);
 
-            virtual bool isAttackPrepairing(const MWWorld::Ptr& ptr);
+            virtual bool isAttackPreparing(const MWWorld::Ptr& ptr);
             virtual bool isRunning(const MWWorld::Ptr& ptr);
             virtual bool isSneaking(const MWWorld::Ptr& ptr);
 


### PR DESCRIPTION
1. Fixes a recent regression, when player can not attack with melee weapon, if he shoot from bow before.
2. Fixes [bug #4591](https://gitlab.com/OpenMW/openmw/issues/4591), so attack strength calculation for player should be more corrent.
3. Since some attack animation contain movement, add a threshold when turning to target in melee combat - we use cone shapes anyway.
4. In vanilla turning animations do not reset idle ones. Replicate this behaviour.
3 and 4 together fix [bug #4371](https://gitlab.com/OpenMW/openmw/issues/4271).
5. Since we update mIdleState directly in character controller, we should update idle animations also when mIdleState == CharState_None. Fixes [bug #4531](https://gitlab.com/OpenMW/openmw/issues/4531).
6. We should not reset idle animations in the spellcasting stance.
7. Fix incorrect spelling of "preparing" word.