### PR TITLE
Fix Equip command stack overflow (bug #3072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     Bug #2872: Tab completion in console doesn't work with explicit reference
     Bug #2971: Compiler did not reject lines with naked expressions beginning with x.y
     Bug #3049: Drain and Fortify effects are not properly applied on health, magicka and fatigue
+    Bug #3072: Fatal error on AddItem <item> that has a script containing Equip <item>
     Bug #3249: Fixed revert function not updating views properly
     Bug #3374: Touch spells not hitting kwama foragers
     Bug #3486: [Mod] NPC Commands does not work

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -517,7 +517,7 @@ namespace MWGui
 
         // Give the script a chance to run once before we do anything else
         // this is important when setting pcskipequip as a reaction to onpcequip being set (bk_treasuryreport does this)
-        if (!script.empty() && MWBase::Environment::get().getWorld()->getScriptsEnabled())
+        if (!force && !script.empty() && MWBase::Environment::get().getWorld()->getScriptsEnabled())
         {
             MWScript::InterpreterContext interpreterContext (&ptr.getRefData().getLocals(), ptr);
             MWBase::Environment::get().getScriptManager()->run (script, interpreterContext);

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -192,8 +192,9 @@ namespace MWScript
                     if (it == invStore.end())
                     {
                         it = ptr.getClass().getContainerStore (ptr).add (item, 1, ptr);
-                        Log(Debug::Warning) << "Implicitly adding one " << item << " to container "
-                            "to fulfil requirements of Equip instruction";
+                        Log(Debug::Warning) << "Implicitly adding one " << item << 
+                            " to the inventory store of " << ptr.getCellRef().getRefId() <<
+                            " to fulfill the requirements of Equip instruction";
                     }
 
                     if (ptr == MWMechanics::getPlayer())


### PR DESCRIPTION
[Bug 3072](https://gitlab.com/OpenMW/openmw/issues/3072).

Use the force argument recently added by akortunov for Equip command specifically to decide whether we should run the script in useItem or not. As far as I can tell this still allows the script to run every frame, so you can hear the equip sound, you can't use the inventory, etc. when an item that has a "broken" script is added to the inventory, like in Morrowind.

And when you use the plugin from [bug 4556](https://gitlab.com/OpenMW/openmw/issues/4556), which is a duplicate of bug 3072, the testring item works as an un-unequippable ring, as it should.