### PR TITLE
Treat <> and << operators as < and  >< and >> as > in scripts (bug #4597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
     Bug #4575: Weird result of attack animation blending with movement animations
     Bug #4576: Reset of idle animations when attack can not be started
     Bug #4591: Attack strength should be 0 if player did not hold the attack button
+    Bug #4597: <> operator causes a compile error
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script

--- a/components/compiler/scanner.cpp
+++ b/components/compiler/scanner.cpp
@@ -502,6 +502,11 @@ namespace Compiler
                     if (get (c) && c!='=') // <== is a allowed as an alternative to <=  :(
                         putback (c);
                 }
+                else if (c == '<' || c == '>') // Treat <> and << as <
+                {
+                    special = S_cmpLT;
+                    mErrorHandler.warning (std::string("invalid operator <") + c + ", treating it as <", mLoc);
+                }
                 else
                 {
                     putback (c);
@@ -524,6 +529,11 @@ namespace Compiler
 
                     if (get (c) && c!='=') // >== is a allowed as an alternative to >=  :(
                         putback (c);
+                }
+                else if (c == '<' || c == '>') // Treat >< and >> as >
+                {
+                    special = S_cmpGT;
+                    mErrorHandler.warning (std::string("invalid operator >") + c + ", treating it as >", mLoc);
                 }
                 else
                 {


### PR DESCRIPTION
[Bug 4597](https://gitlab.com/OpenMW/openmw/issues/4597).

Parses <> as < to make the broken TR scripts work like they do in vanilla: now it's handled like

```
warning t_scbank_bri_currentbank[local variables] line 19, column 36 (<>)
    invalid operator <>, treating it as <
warning T_ScBank_Bri_CurrentBank line 19, column 36 (<>)
    invalid operator <>, treating it as <
```
during the gameplay and as warnings in OpenMW-CS.

And the bank topic infos are used as normal in OpenMW now.
Similar broken operators are handled "just in case" in a style similar to bug 3744 solution: [PR 1267](https://github.com/OpenMW/openmw/pull/1267).

Edit: I verified the new behavior. Morrowind does indeed seem to handle this operator as "less than" instead of "not equal to". This has been acknowledged as potential unintended behavior (if I'm correct) and reported as a bug to TR.