### PR TITLE
Use the correct skill for creature AI weapon hit chance rating

### DIFF
--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -108,11 +108,19 @@ namespace MWMechanics
             }
         }
 
-        int skill = item.getClass().getEquipmentSkill(item);
-        if (skill != -1)
+        if (actor.getClass().isNpc())
         {
-            int value = actor.getClass().getSkill(actor, skill);
-            rating *= MWMechanics::getHitChance(actor, enemy, value) / 100.f;
+            int skill = item.getClass().getEquipmentSkill(item);
+            if (skill != -1)
+            {
+               int value = actor.getClass().getSkill(actor, skill);
+               rating *= MWMechanics::getHitChance(actor, enemy, value) / 100.f;
+            }
+        }
+        else
+        {
+            MWWorld::LiveCellRef<ESM::Creature> *ref = actor.get<ESM::Creature>();
+            rating *= MWMechanics::getHitChance(actor, enemy, ref->mBase->mData.mCombat) / 100.f;
         }
 
         return rating * rangedMult;


### PR DESCRIPTION
Fix a regression which arised after #1838 was merged.

Although we use the correct (Combat) skill in the actual getHitChance call in Creature::hit, the AI weapon priority wasn't adjusted for that, which caused Tribunal goblins which use a short sword weapon not to use it because they thought it had 0 hit chance - this happens because their Stealth skill is usually very low and player stats can be so high that they make the "predicted" hit chance 0. Tribunal goblins sheathed their swords and couldn't attack properly because of that - they can't use unarmed attacks. Now the Combat skill is used instead, like in Creature::hit.