### PR TITLE
Play landing sound manually and ignore land soundgen textkeys (bug #2256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #1990: Sunrise/sunset not set correct
     Bug #2131: Lustidrike's spell misses the player every time
     Bug #2222: Fatigue's effect on selling price is backwards
+    Bug #2256: Landing sound not playing when jumping immediately after landing
     Bug #2326: After a bound item expires the last equipped item of that type is not automatically re-equipped
     Bug #2455: Creatures attacks degrade armor
     Bug #2562: Forcing AI to activate a teleport door sometimes causes a crash

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1241,11 +1241,10 @@ namespace MWClass
         {
             MWBase::World *world = MWBase::Environment::get().getWorld();
             osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
-            if(world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
+            if (world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
                 return "DefaultLandWater";
-            if(world->isOnGround(ptr))
-                return "DefaultLand";
-            return "";
+
+            return "DefaultLand";
         }
         if(name == "swimleft")
             return "Swim Left";

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -913,8 +913,7 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
         sndMgr->playSound3D(mPtr, evt.substr(7), 1.0f, 1.0f);
         return;
     }
-    if(evt.compare(0, 10, "soundgen: ") == 0
-     && evt.compare(10, evt.size()-10, "land") != 0) // Morrowind ignores land soundgen for some reason
+    if(evt.compare(0, 10, "soundgen: ") == 0)
     {
         std::string soundgen = evt.substr(10);
 
@@ -939,11 +938,14 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
             }
         }
 
+        if (soundgen == "land") // Morrowind ignores land soundgen for some reason
+            return;
+
         std::string sound = mPtr.getClass().getSoundIdFromSndGen(mPtr, soundgen);
         if(!sound.empty())
         {
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            if(evt.compare(10, evt.size()-10, "left") == 0 || evt.compare(10, evt.size()-10, "right") == 0)
+            if(soundgen == "left" || soundgen == "right")
             {
                 // Don't make foot sounds local for the player, it makes sense to keep them
                 // positioned on the ground.

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -939,10 +939,10 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
         }
 
         std::string sound = mPtr.getClass().getSoundIdFromSndGen(mPtr, soundgen);
-        if(!sound.empty())
+        if(!sound.empty() && evt.compare(10, evt.size()-10, "land") != 0) // Don't play landing sounds here
         {
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            if(evt.compare(10, evt.size()-10, "left") == 0 || evt.compare(10, evt.size()-10, "right") == 0 || evt.compare(10, evt.size()-10, "land") == 0)
+            if(evt.compare(10, evt.size()-10, "left") == 0 || evt.compare(10, evt.size()-10, "right") == 0)
             {
                 // Don't make foot sounds local for the player, it makes sense to keep them
                 // positioned on the ground.
@@ -2027,6 +2027,12 @@ void CharacterController::update(float duration)
                         cls.skillUsageSucceeded(mPtr, ESM::Skill::Acrobatics, 1);
                 }
             }
+
+            // Play landing sound
+            MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+            std::string sound = cls.getSoundIdFromSndGen(mPtr, "land");
+            if (!sound.empty())
+                sndMgr->playSound3D(mPtr, sound, 1.f, 1.f, MWSound::Type::Foot, MWSound::PlayMode::NoPlayerLocal);
         }
         else
         {

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -913,7 +913,8 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
         sndMgr->playSound3D(mPtr, evt.substr(7), 1.0f, 1.0f);
         return;
     }
-    if(evt.compare(0, 10, "soundgen: ") == 0)
+    if(evt.compare(0, 10, "soundgen: ") == 0
+     && evt.compare(10, evt.size()-10, "land") != 0) // Morrowind ignores land soundgen for some reason
     {
         std::string soundgen = evt.substr(10);
 
@@ -939,7 +940,7 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
         }
 
         std::string sound = mPtr.getClass().getSoundIdFromSndGen(mPtr, soundgen);
-        if(!sound.empty() && evt.compare(10, evt.size()-10, "land") != 0) // Don't play landing sounds here
+        if(!sound.empty())
         {
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
             if(evt.compare(10, evt.size()-10, "left") == 0 || evt.compare(10, evt.size()-10, "right") == 0)


### PR DESCRIPTION
Yet another "landing audio candidate fix"!

[Bug 2256](https://gitlab.com/OpenMW/openmw/issues/2256).

I'll just copy my recap on the origin of the discrepancy:

> Apparently Morrowind ignores the landing sound soundgen textkey and plays the sound manually anyways, *in addition* to not interrupting the landing animation by a new jumping animation. [This diff] manually plays the landing sound immediately upon the beginning of the landing state (NB: about as early as we can do it), making the delay between what GetPCJumping considers jumping and the landing sound 2 frames and rendering both 4462 and this a non-issue, but it doesn't make landing animation play simultaneously with a new jumping animation.
Doublechecked it. Land Soundgen is never used for playing a sound [...] when an NPC uses an animation with it [...]. Landing sound does play [upon landing] even if the landing animation is interrupted before it can even start playing. Dammit, Bethesda.

So, what I did: made the character controller play the landing manually instead when an actor changes to the landing state. This applies to both creatures and NPCs. The land animation textkey is ignored like Morrowind appears to do.

This reduces the delay between the GetPCJumping = 0 after a jump finishes and the landing sound to exactly two frametimes. I don't know if it's possible to reduce it any further.

I didn't replicate the quirk of not interrupting the landing animation with a jumping animation. I don't think it's necessary. It might be even harmful.

Suggestions welcome.