### PR TITLE
Fix gold count calculation in pickupObject (bug #4604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
     Bug #4576: Reset of idle animations when attack can not be started
     Bug #4591: Attack strength should be 0 if player did not hold the attack button
     Bug #4597: <> operator causes a compile error
+    Bug #4604: Picking up gold from the ground only makes 1 grabbed
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -681,6 +681,8 @@ namespace MWGui
             return;
 
         int count = object.getRefData().getCount();
+        if (object.getClass().isGold(object))
+            count *= object.getClass().getValue(object);
 
         MWWorld::Ptr player = MWMechanics::getPlayer();
         MWBase::Environment::get().getWorld()->breakInvisibility(player);


### PR DESCRIPTION
[Bug 4604.](https://gitlab.com/OpenMW/openmw/issues/4604)

Technically a gold stack reference is a single object, and the real count of septims in it is its value. This is accounted for in container addImp method, but it's not in pickupObject, making only 1 (gold_001) coin grabbed and the rest being moved to the inventory immediately. This is fixed here.

I think I didn't break anything. At least it works in my testing.