### PR TITLE
[WIP] Load animations from NIF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
     Bug #4557: Topics with reserved names are handled differently from vanilla
     Bug #4558: Mesh optimizer: check for reserved node name is case-sensitive
     Bug #4563: Fast travel price logic checks destination cell instead of service actor cell
+    Bug #4564: OpenMW does not load animations from custom NIF files attached to NPC
     Bug #4565: Underwater view distance should be limited
     Bug #4573: Player uses headtracking in the 1st-person mode
     Bug #4574: Player turning animations are twitchy

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -717,30 +717,33 @@ namespace MWRender
         }
     }
 
-    void Animation::addAnimSource(const std::string &model, const std::string& baseModel)
+    void Animation::addAnimSource(const std::string &model, const std::string& baseModel, bool useKfFile)
     {
         std::string kfname = model;
         Misc::StringUtils::lowerCaseInPlace(kfname);
 
-        if(kfname.size() > 4 && kfname.compare(kfname.size()-4, 4, ".nif") == 0)
-            kfname.replace(kfname.size()-4, 4, ".kf");
-        else
-            return;
+        if (useKfFile)
+        {
+            if(kfname.size() > 4 && kfname.compare(kfname.size()-4, 4, ".nif") == 0)
+                kfname.replace(kfname.size()-4, 4, ".kf");
+            else
+                return;
+        }
 
-        addSingleAnimSource(kfname, baseModel);
+        addSingleAnimSource(kfname, baseModel, useKfFile);
 
         if (mUseAdditionalSources)
             loadAllAnimationsInFolder(kfname, baseModel);
     }
 
-    void Animation::addSingleAnimSource(const std::string &kfname, const std::string& baseModel)
+    void Animation::addSingleAnimSource(const std::string &kfname, const std::string& baseModel, bool useKfFile)
     {
         if(!mResourceSystem->getVFS()->exists(kfname))
             return;
 
         std::shared_ptr<AnimSource> animsrc;
         animsrc.reset(new AnimSource);
-        animsrc->mKeyframes = mResourceSystem->getKeyframeManager()->get(kfname);
+        animsrc->mKeyframes = mResourceSystem->getKeyframeManager()->get(kfname, useKfFile);
 
         if (!animsrc->mKeyframes || animsrc->mKeyframes->mTextKeys.empty() || animsrc->mKeyframes->mKeyframeControllers.empty())
             return;

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -316,8 +316,8 @@ protected:
      * @param model The file to add the keyframes for. Note that the .nif file extension will be replaced with .kf.
      * @param baseModel The filename of the mObjectRoot, only used for error messages.
     */
-    void addAnimSource(const std::string &model, const std::string& baseModel);
-    void addSingleAnimSource(const std::string &model, const std::string& baseModel);
+    void addAnimSource(const std::string &model, const std::string& baseModel, bool useKfFile=true);
+    void addSingleAnimSource(const std::string &model, const std::string& baseModel, bool useKfFile=true);
 
     /** Adds an additional light to the given node using the specified ESM record. */
     void addExtraLight(osg::ref_ptr<osg::Group> parent, const ESM::Light *light);

--- a/components/nifosg/nifloader.hpp
+++ b/components/nifosg/nifloader.hpp
@@ -62,7 +62,7 @@ namespace NifOsg
     {
     public:
         /// Create a scene graph for the given NIF. Auto-detects when skinning is used and wraps the graph in a Skeleton if so.
-        static osg::ref_ptr<osg::Node> load(Nif::NIFFilePtr file, Resource::ImageManager* imageManager);
+        static osg::ref_ptr<osg::Node> load(Nif::NIFFilePtr file, Resource::ImageManager* imageManager, KeyframeHolder& target);
 
         /// Load keyframe controllers from the given kf file.
         static void loadKf(Nif::NIFFilePtr kf, KeyframeHolder& target);

--- a/components/resource/keyframemanager.cpp
+++ b/components/resource/keyframemanager.cpp
@@ -1,4 +1,5 @@
 #include "keyframemanager.hpp"
+#include <iostream>
 
 #include <components/vfs/manager.hpp>
 
@@ -16,7 +17,7 @@ namespace Resource
     {
     }
 
-    osg::ref_ptr<const NifOsg::KeyframeHolder> KeyframeManager::get(const std::string &name)
+    osg::ref_ptr<const NifOsg::KeyframeHolder> KeyframeManager::get(const std::string &name, bool useKfFile)
     {
         std::string normalized = name;
         mVFS->normalizeFilename(normalized);
@@ -27,7 +28,15 @@ namespace Resource
         else
         {
             osg::ref_ptr<NifOsg::KeyframeHolder> loaded (new NifOsg::KeyframeHolder);
-            NifOsg::Loader::loadKf(Nif::NIFFilePtr(new Nif::NIFFile(mVFS->getNormalized(normalized), normalized)), *loaded.get());
+
+            if (useKfFile)
+                NifOsg::Loader::loadKf(Nif::NIFFilePtr(new Nif::NIFFile(mVFS->getNormalized(normalized), normalized)), *loaded.get());
+            else
+            {
+                std::cout << "use mesh! " << name << " " << normalized << std::endl;
+                NifOsg::Loader::load(Nif::NIFFilePtr(new Nif::NIFFile(mVFS->getNormalized(normalized), normalized)), NULL, *loaded.get());
+                std::cout << loaded.get()->mTextKeys.size() << std::endl;
+            }
 
             mCache->addEntryToObjectCache(normalized, loaded);
             return loaded;

--- a/components/resource/keyframemanager.hpp
+++ b/components/resource/keyframemanager.hpp
@@ -21,7 +21,7 @@ namespace Resource
 
         /// Retrieve a read-only keyframe resource by name (case-insensitive).
         /// @note Throws an exception if the resource is not found.
-        osg::ref_ptr<const NifOsg::KeyframeHolder> get(const std::string& name);
+        osg::ref_ptr<const NifOsg::KeyframeHolder> get(const std::string& name, bool useKfFile=true);
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats) const;
     };

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -355,7 +355,10 @@ namespace Resource
     {
         std::string ext = getFileExtension(normalizedFilename);
         if (ext == "nif")
-            return NifOsg::Loader::load(nifFileManager->get(normalizedFilename), imageManager);
+        {
+            osg::ref_ptr<NifOsg::KeyframeHolder> loaded (new NifOsg::KeyframeHolder);
+            return NifOsg::Loader::load(nifFileManager->get(normalizedFilename), imageManager, *loaded.get());
+        }
         else
         {
             osgDB::ReaderWriter* reader = osgDB::Registry::instance()->getReaderWriterForExtension(ext);


### PR DESCRIPTION
Attempt to fix [bug #4564](https://gitlab.com/OpenMW/openmw/issues/4564).
Main idea: if the custom animation mesh is attached to NPC, but it does not have the KF-file, load animations from attached NIF file.

For now this PR works only for bodyparts, which have skeletons in KF files: animations itself work, but bodyparts without skeletons have [wrong orientation](https://i.imgur.com/iQ505N8.png). Especially noticable with heads and pauldrons.
@kcat, @AnyOldName3, any ideas, what am I doing wrong?