### PR TITLE
Fix error: member access into incomplete type 'SceneUtil::UnrefWorkItem'

### DIFF
--- a/components/sceneutil/unrefqueue.cpp
+++ b/components/sceneutil/unrefqueue.cpp
@@ -8,10 +8,7 @@ namespace SceneUtil
 {
     void UnrefWorkItem::doWork()
     {
-        //osg::Timer timer;
-        //size_t objcount = mObjects.size();
         mObjects.clear();
-        //Log(Debug::Verbose) << "cleared " << objcount << " objects in " << timer.time_m();
     }
 
     UnrefQueue::UnrefQueue()

--- a/components/sceneutil/unrefqueue.cpp
+++ b/components/sceneutil/unrefqueue.cpp
@@ -1,28 +1,18 @@
 #include "unrefqueue.hpp"
 
-#include <deque>
-
 //#include <osg/Timer>
 
 //#include <components/debug/debuglog.hpp>
-#include <components/sceneutil/workqueue.hpp>
 
 namespace SceneUtil
 {
-
-    class UnrefWorkItem : public SceneUtil::WorkItem
+    void UnrefWorkItem::doWork()
     {
-    public:
-        std::deque<osg::ref_ptr<const osg::Referenced> > mObjects;
-
-        virtual void doWork()
-        {
-            //osg::Timer timer;
-            //size_t objcount = mObjects.size();
-            mObjects.clear();
-            //Log(Debug::Verbose) << "cleared " << objcount << " objects in " << timer.time_m();
-        }
-    };
+        //osg::Timer timer;
+        //size_t objcount = mObjects.size();
+        mObjects.clear();
+        //Log(Debug::Verbose) << "cleared " << objcount << " objects in " << timer.time_m();
+    }
 
     UnrefQueue::UnrefQueue()
     {

--- a/components/sceneutil/unrefqueue.hpp
+++ b/components/sceneutil/unrefqueue.hpp
@@ -1,13 +1,23 @@
 #ifndef OPENMW_COMPONENTS_UNREFQUEUE_H
 #define OPENMW_COMPONENTS_UNREFQUEUE_H
 
+#include <deque>
+
 #include <osg/ref_ptr>
 #include <osg/Referenced>
+
+#include <components/sceneutil/workqueue.hpp>
 
 namespace SceneUtil
 {
     class WorkQueue;
-    class UnrefWorkItem;
+    
+    class UnrefWorkItem : public SceneUtil::WorkItem
+    {
+    public:
+        std::deque<osg::ref_ptr<const osg::Referenced> > mObjects;
+        virtual void doWork();
+    };
 
     /// @brief Handles unreferencing of objects through the WorkQueue. Typical use scenario
     /// would be the main thread pushing objects that are no longer needed, and the background thread deleting them.


### PR DESCRIPTION
Fixes compile error encountered on OSX 10.9 using g++

## The compilation error:

```
[ 24%] Building CXX object apps/openmw/CMakeFiles/openmw.dir/mwrender/renderingmanager.cpp.o
In file included from /Users/pineapple/git/openmw/apps/openmw/mwrender/renderingmanager.cpp:1:
In file included from /Users/pineapple/git/openmw/apps/openmw/mwrender/renderingmanager.hpp:4:
/Users/pineapple/git/openmw/openmw-deps/include/osg/ref_ptr:35:36: error: member access into incomplete type 'SceneUtil::UnrefWorkItem'
        ~ref_ptr() { if (_ptr) _ptr->unref();  _ptr = 0; }
                                   ^
/Users/pineapple/git/openmw/./components/sceneutil/unrefqueue.hpp:14:11: note: in instantiation of member function
      'osg::ref_ptr<SceneUtil::UnrefWorkItem>::~ref_ptr' requested here
    class UnrefQueue : public osg::Referenced
          ^
/Users/pineapple/git/openmw/./components/sceneutil/unrefqueue.hpp:10:11: note: forward declaration of 'SceneUtil::UnrefWorkItem'
    class UnrefWorkItem;
```

## The fix:

Move `SceneUtil::UnrefWorkItem` class definition out of `renderingmanager.cpp` and into `renderingmanager.hpp`.

## Compiler info

```
sophie:build pineapple$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix
```