### PR TITLE
 Fix error: invalid application of 'sizeof' to an incomplete type 'Video::VideoPlayer'

### DIFF
--- a/apps/openmw/mwgui/videowidget.hpp
+++ b/apps/openmw/mwgui/videowidget.hpp
@@ -1,12 +1,9 @@
 #ifndef OPENMW_MWGUI_VIDEOWIDGET_H
 #define OPENMW_MWGUI_VIDEOWIDGET_H
 
-#include <MyGUI_Widget.h>
+#include <extern/osg-ffmpeg-videoplayer/videoplayer.hpp>
 
-namespace Video
-{
-    class VideoPlayer;
-}
+#include <MyGUI_Widget.h>
 
 namespace VFS
 {


### PR DESCRIPTION
Fixes compile error encountered on OSX 10.9 using g++

## The compilation error:

```
[ 55%] Building CXX object apps/openmw/CMakeFiles/openmw.dir/mwgui/windowmanagerimp.cpp.o
In file included from /Users/pineapple/git/openmw/apps/openmw/mwgui/windowmanagerimp.cpp:1:
In file included from /Users/pineapple/git/openmw/apps/openmw/mwgui/windowmanagerimp.hpp:10:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/stack:86:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/deque:159:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__split_buffer:7:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:627:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2424:27: error: invalid application of
      'sizeof' to an incomplete type 'Video::VideoPlayer'
            static_assert(sizeof(_Tp) > 0, "default_delete can not delete incomplete type");
                          ^~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2625:13: note: in instantiation of
      member function 'std::__1::default_delete<Video::VideoPlayer>::operator()' requested here
            __ptr_.second()(__tmp);
            ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2593:46: note: in instantiation of
      member function 'std::__1::unique_ptr<Video::VideoPlayer, std::__1::default_delete<Video::VideoPlayer> >::reset' requested here
    _LIBCPP_INLINE_VISIBILITY ~unique_ptr() {reset();}
                                             ^
/Users/pineapple/git/openmw/apps/openmw/mwgui/videowidget.hpp:22:11: note: in instantiation of member function
      'std::__1::unique_ptr<Video::VideoPlayer, std::__1::default_delete<Video::VideoPlayer> >::~unique_ptr' requested here
    class VideoWidget : public MyGUI::Widget
          ^
/Users/pineapple/git/openmw/apps/openmw/mwgui/videowidget.hpp:8:11: note: forward declaration of 'Video::VideoPlayer'
    class VideoPlayer;
          ^
1 error generated.
make[3]: *** [apps/openmw/CMakeFiles/openmw.dir/mwgui/windowmanagerimp.cpp.o] Error 1
make[2]: *** [apps/openmw/CMakeFiles/openmw.dir/all] Error 2
make[1]: *** [apps/openmw/CMakeFiles/openmw.dir/rule] Error 2
make: *** [openmw] Error 2
sophie:build pineapple$ sublime /Users/pineapple/git/openmw/apps/openmw/mwgui/videowidget.hpp
59cf552
```

## The fix:

Include `extern/osg-ffmpeg-videoplayer/videoplayer.hpp` which defines `Video::VideoPlayer` instead of forward-declaring `Video::VideoPlayer`.

## Compiler info

```
sophie:build pineapple$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix
```