### PR TITLE
 Fix error: invalid application of 'sizeof' to an incomplete type 'Video::VideoPlayer' (No include)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -153,6 +153,7 @@ Programmers
     Siimacore
     sir_herrbatka
     smbas
+    Sophie Kirschner (pineapplemachine)
     spycrab
     Stefan Galowicz (bogglez)
     Stanislav Bobrov (Jiub)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
     Feature #4581: Use proper logging system
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test
+    Task #4613: Incomplete type errors when compiling with g++ on OSX 10.9
 
 0.44.0
 ------

--- a/apps/openmw/mwgui/videowidget.cpp
+++ b/apps/openmw/mwgui/videowidget.cpp
@@ -22,6 +22,8 @@ VideoWidget::VideoWidget()
     setNeedKeyFocus(true);
 }
 
+VideoWidget::~VideoWidget() = default;
+
 void VideoWidget::setVFS(const VFS::Manager *vfs)
 {
     mVFS = vfs;

--- a/apps/openmw/mwgui/videowidget.hpp
+++ b/apps/openmw/mwgui/videowidget.hpp
@@ -25,6 +25,8 @@ namespace MWGui
         MYGUI_RTTI_DERIVED(VideoWidget)
 
         VideoWidget();
+        
+        ~VideoWidget();
 
         /// Set the VFS (virtual file system) to find the videos on.
         void setVFS(const VFS::Manager* vfs);


### PR DESCRIPTION
Alternate solution to same problem as in https://github.com/OpenMW/openmw/pull/1888 added in response to @zinnschlag's comment https://github.com/OpenMW/openmw/pull/1888#issuecomment-415951250