### PR TITLE
Mass potion creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
     Feature #4626: Weapon priority: account for weapon speed
     Feature #4632: AI priority: utilize vanilla AI GMSTs for priority rating
     Feature #4636: Use sTo GMST in spellmaking menu
+    Feature #4642: Batching potion creation
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test
     Task #4605: Optimize skinning

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -1,8 +1,6 @@
 #include "util.hpp"
 
 #include <stdexcept>
-#include <climits>
-#include <cfloat>
 
 #include <QUndoStack>
 #include <QMetaProperty>
@@ -209,7 +207,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_Integer:
         {
             DialogueSpinBox *sb = new DialogueSpinBox(parent);
-            sb->setRange(INT_MIN, INT_MAX);
+            sb->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
             return sb;
         }
 

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -1,7 +1,5 @@
 #include "alchemywindow.hpp"
 
-#include <climits>
-
 #include <MyGUI_Gui.h>
 #include <MyGUI_Button.h>
 #include <MyGUI_EditBox.h>
@@ -323,8 +321,8 @@ namespace MWGui
     {
         int currentCount = mBrewCountEdit->getValue();
 
-        // prevent overflows, and prevent entering INT_MIN since abs(INT_MIN) is undefined
-        if (currentCount == INT_MAX || currentCount == INT_MIN+1)
+        // prevent overflows
+        if (currentCount == std::numeric_limits<int>::max())
             return;
 
         mBrewCountEdit->setValue(currentCount+1);

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -1,5 +1,7 @@
 #include "alchemywindow.hpp"
 
+#include <climits>
+
 #include <MyGUI_Gui.h>
 #include <MyGUI_Button.h>
 #include <MyGUI_EditBox.h>
@@ -25,6 +27,9 @@
 
 namespace MWGui
 {
+    const float AlchemyWindow::sCountChangeInitialPause = 0.5f;
+    const float AlchemyWindow::sCountChangeInterval = 0.1f;
+
     AlchemyWindow::AlchemyWindow()
         : WindowBase("openmw_alchemy_window.layout")
         , mSortModel(NULL)
@@ -43,9 +48,21 @@ namespace MWGui
         getWidget(mApparatus[2], "Apparatus3");
         getWidget(mApparatus[3], "Apparatus4");
         getWidget(mEffectsBox, "CreatedEffects");
+        getWidget(mBrewCountEdit, "BrewCount");
+        getWidget(mIncreaseButton, "IncreaseButton");
+        getWidget(mDecreaseButton, "DecreaseButton");
         getWidget(mNameEdit, "NameEdit");
         getWidget(mItemView, "ItemView");
 
+        mBrewCountEdit->eventValueChanged += MyGUI::newDelegate(this, &AlchemyWindow::onCountValueChanged);
+        mBrewCountEdit->eventEditSelectAccept += MyGUI::newDelegate(this, &AlchemyWindow::onAccept);
+        mBrewCountEdit->setMinValue(1);
+        mBrewCountEdit->setValue(1);
+
+        mIncreaseButton->eventMouseButtonPressed += MyGUI::newDelegate(this, &AlchemyWindow::onIncreaseButtonPressed);
+        mIncreaseButton->eventMouseButtonReleased += MyGUI::newDelegate(this, &AlchemyWindow::onCountButtonReleased);
+        mDecreaseButton->eventMouseButtonPressed += MyGUI::newDelegate(this, &AlchemyWindow::onDecreaseButtonPressed);
+        mDecreaseButton->eventMouseButtonReleased += MyGUI::newDelegate(this, &AlchemyWindow::onCountButtonReleased);
 
         mItemView->eventItemClicked += MyGUI::newDelegate(this, &AlchemyWindow::onSelectedItem);
 
@@ -77,7 +94,15 @@ namespace MWGui
 
     void AlchemyWindow::onCreateButtonClicked(MyGUI::Widget* _sender)
     {
-        MWMechanics::Alchemy::Result result = mAlchemy->create (mNameEdit->getCaption ());
+        mAlchemy->setPotionName(mNameEdit->getCaption());
+        int count = mAlchemy->countPotionsToBrew();
+        count = std::min(count, mBrewCountEdit->getValue());
+        createPotions(count);
+    }
+
+    void AlchemyWindow::createPotions(int count)
+    {
+        MWMechanics::Alchemy::Result result = mAlchemy->create(mNameEdit->getCaption(), count);
         MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
 
         switch (result)
@@ -92,8 +117,11 @@ namespace MWGui
             winMgr->messageBox("#{sNotifyMessage6a}");
             break;
         case MWMechanics::Alchemy::Result_Success:
-            winMgr->messageBox("#{sPotionSuccess}");
             winMgr->playSound("potion success");
+            if (count == 1)
+                winMgr->messageBox("#{sPotionSuccess}");
+            else
+                winMgr->messageBox("#{sPotionSuccess} "+mNameEdit->getCaption()+" ("+std::to_string(count)+")");
             break;
         case MWMechanics::Alchemy::Result_NoEffects:
         case MWMechanics::Alchemy::Result_RandomFailure:
@@ -126,6 +154,7 @@ namespace MWGui
         mItemView->resetScrollBars();
 
         mNameEdit->setCaption("");
+        mBrewCountEdit->setValue(1);
 
         int index = 0;
         for (MWMechanics::Alchemy::TToolsIterator iter (mAlchemy->beginTools());
@@ -249,5 +278,62 @@ namespace MWGui
                 mAlchemy->removeIngredient (i);
 
         update();
+    }
+
+    void AlchemyWindow::addRepeatController(MyGUI::Widget *widget)
+    {
+        MyGUI::ControllerItem* item = MyGUI::ControllerManager::getInstance().createItem(Controllers::ControllerRepeatEvent::getClassTypeName());
+        Controllers::ControllerRepeatEvent* controller = item->castType<Controllers::ControllerRepeatEvent>();
+        controller->eventRepeatClick += MyGUI::newDelegate(this, &AlchemyWindow::onRepeatClick);
+        controller->setRepeat(sCountChangeInitialPause, sCountChangeInterval);
+        MyGUI::ControllerManager::getInstance().addItem(widget, controller);
+    }
+
+    void AlchemyWindow::onIncreaseButtonPressed(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id)
+    {
+        addRepeatController(_sender);
+        onIncreaseButtonTriggered();
+    }
+
+    void AlchemyWindow::onDecreaseButtonPressed(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id)
+    {
+        addRepeatController(_sender);
+        onDecreaseButtonTriggered();
+    }
+
+    void AlchemyWindow::onRepeatClick(MyGUI::Widget* widget, MyGUI::ControllerItem* controller)
+    {
+        if (widget == mIncreaseButton)
+            onIncreaseButtonTriggered();
+        else if (widget == mDecreaseButton)
+            onDecreaseButtonTriggered();
+    }
+
+    void AlchemyWindow::onCountButtonReleased(MyGUI::Widget *_sender, int _left, int _top, MyGUI::MouseButton _id)
+    {
+        MyGUI::ControllerManager::getInstance().removeItem(_sender);
+    }
+
+    void AlchemyWindow::onCountValueChanged(int value)
+    {
+        mBrewCountEdit->setValue(std::abs(value));
+    }
+
+    void AlchemyWindow::onIncreaseButtonTriggered()
+    {
+        int currentCount = mBrewCountEdit->getValue();
+
+        // prevent overflows, and prevent entering INT_MIN since abs(INT_MIN) is undefined
+        if (currentCount == INT_MAX || currentCount == INT_MIN+1)
+            return;
+
+        mBrewCountEdit->setValue(currentCount+1);
+    }
+
+    void AlchemyWindow::onDecreaseButtonTriggered()
+    {
+        int currentCount = mBrewCountEdit->getValue();
+        if (currentCount > 1)
+            mBrewCountEdit->setValue(currentCount-1);
     }
 }

--- a/apps/openmw/mwgui/alchemywindow.hpp
+++ b/apps/openmw/mwgui/alchemywindow.hpp
@@ -3,8 +3,13 @@
 
 #include <vector>
 
+#include <MyGUI_ControllerManager.h>
+
 #include "../mwmechanics/alchemy.hpp"
 
+#include <components/widgets/numericeditbox.hpp>
+
+#include "controllers.hpp"
 #include "windowbase.hpp"
 
 namespace MWMechanics
@@ -28,6 +33,10 @@ namespace MWGui
         void onResChange(int, int) { center(); }
 
     private:
+
+        static const float sCountChangeInitialPause; // in seconds
+        static const float sCountChangeInterval; // in seconds
+
         std::string mSuggestedPotionName;
 
         ItemView* mItemView;
@@ -38,16 +47,31 @@ namespace MWGui
 
         MyGUI::Widget* mEffectsBox;
 
+        MyGUI::Button* mIncreaseButton;
+        MyGUI::Button* mDecreaseButton;
         MyGUI::EditBox* mNameEdit;
+        Gui::NumericEditBox* mBrewCountEdit;
 
         void onCancelButtonClicked(MyGUI::Widget* _sender);
         void onCreateButtonClicked(MyGUI::Widget* _sender);
         void onIngredientSelected(MyGUI::Widget* _sender);
         void onAccept(MyGUI::EditBox*);
+        void onIncreaseButtonPressed(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id);
+        void onDecreaseButtonPressed(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id);
+        void onCountButtonReleased(MyGUI::Widget* _sender, int _left, int _top, MyGUI::MouseButton _id);
+        void onCountValueChanged(int value);
+        void onRepeatClick(MyGUI::Widget* widget, MyGUI::ControllerItem* controller);
+
+        void addRepeatController(MyGUI::Widget* widget);
+
+        void onIncreaseButtonTriggered();
+        void onDecreaseButtonTriggered();
 
         void onSelectedItem(int index);
 
         void removeIngredient(MyGUI::Widget* ingredient);
+
+        void createPotions(int count);
 
         void update();
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -1,7 +1,5 @@
 #include "tradewindow.hpp"
 
-#include <climits>
-
 #include <MyGUI_Button.h>
 #include <MyGUI_InputManager.h>
 #include <MyGUI_ControllerManager.h>
@@ -96,7 +94,7 @@ namespace MWGui
 
         mTotalBalance->eventValueChanged += MyGUI::newDelegate(this, &TradeWindow::onBalanceValueChanged);
         mTotalBalance->eventEditSelectAccept += MyGUI::newDelegate(this, &TradeWindow::onAccept);
-        mTotalBalance->setMinValue(INT_MIN+1); // disallow INT_MIN since abs(INT_MIN) is undefined
+        mTotalBalance->setMinValue(std::numeric_limits<int>::min()+1); // disallow INT_MIN since abs(INT_MIN) is undefined
 
         setCoord(400, 0, 400, 300);
     }
@@ -431,7 +429,7 @@ namespace MWGui
     void TradeWindow::onIncreaseButtonTriggered()
     {
         // prevent overflows, and prevent entering INT_MIN since abs(INT_MIN) is undefined
-        if (mCurrentBalance == INT_MAX || mCurrentBalance == INT_MIN+1)
+        if (mCurrentBalance == std::numeric_limits<int>::max() || mCurrentBalance == std::numeric_limits<int>::min()+1)
             return;
         if (mCurrentBalance < 0) mCurrentBalance -= 1;
         else mCurrentBalance += 1;

--- a/apps/openmw/mwmechanics/alchemy.hpp
+++ b/apps/openmw/mwmechanics/alchemy.hpp
@@ -51,10 +51,13 @@ namespace MWMechanics
             TIngredientsContainer mIngredients;
             TEffectsContainer mEffects;
             int mValue;
+            std::string mPotionName;
 
             void applyTools (int flags, float& value) const;
 
             void updateEffects();
+
+            Result getReadyStatus() const;
 
             const ESM::Potion *getRecord(const ESM::Potion& toFind) const;
             ///< Try to find a potion record similar to \a toFind in the record store, or return 0 if not found
@@ -70,6 +73,10 @@ namespace MWMechanics
             void increaseSkill();
             ///< Increase alchemist's skill.
 
+            Result createSingle ();
+            ///< Try to create a potion from the ingredients, place it in the inventory of the alchemist and
+            /// adjust the skills of the alchemist accordingly.
+
             float getAlchemyFactor() const;
 
             int countIngredients() const;
@@ -79,6 +86,8 @@ namespace MWMechanics
             TEffectsIterator endEffects() const;
 
         public:
+            int countPotionsToBrew() const;
+            ///< calculates maximum amount of potions, which you can make from selected ingredients
 
             static bool knownEffect (unsigned int potionEffectIndex, const MWWorld::Ptr& npc);
             ///< Does npc have sufficient alchemy skill to know about this potion effect?
@@ -100,6 +109,9 @@ namespace MWMechanics
             void clear();
             ///< Remove alchemist, tools and ingredients.
 
+            void setPotionName(const std::string& name);
+            ///< Set name of potion to create
+
             std::set<EffectKey> listEffects() const;
             ///< List all effects shared by at least two ingredients.
 
@@ -115,8 +127,8 @@ namespace MWMechanics
             std::string suggestPotionName ();
             ///< Suggest a name for the potion, based on the current effects
 
-            Result create (const std::string& name);
-            ///< Try to create a potion from the ingredients, place it in the inventory of the alchemist and
+            Result create (const std::string& name, int& count);
+            ///< Try to create potions from the ingredients, place them in the inventory of the alchemist and
             /// adjust the skills of the alchemist accordingly.
             /// \param name must not be an empty string, or Result_NoName is returned
     };

--- a/apps/openmw/mwmechanics/autocalcspell.cpp
+++ b/apps/openmw/mwmechanics/autocalcspell.cpp
@@ -1,7 +1,6 @@
 #include "autocalcspell.hpp"
 #include "spellcasting.hpp"
 
-#include <climits>
 #include <limits>
 
 #include "../mwworld/esmstore.hpp"
@@ -50,7 +49,7 @@ namespace MWMechanics
             caps.mCount = 0;
             caps.mLimit = iAutoSpellSchoolMax[i];
             caps.mReachedLimit = iAutoSpellSchoolMax[i] <= 0;
-            caps.mMinCost = INT_MAX;
+            caps.mMinCost = std::numeric_limits<int>::max();
             caps.mWeakestSpell.clear();
             schoolCaps[i] = caps;
         }
@@ -101,7 +100,7 @@ namespace MWMechanics
                 if (found != selectedSpells.end())
                     selectedSpells.erase(found);
 
-                cap.mMinCost = INT_MAX;
+                cap.mMinCost = std::numeric_limits<int>::max();
                 for (std::vector<std::string>::iterator weakIt = selectedSpells.begin(); weakIt != selectedSpells.end(); ++weakIt)
                 {
                     const ESM::Spell* testSpell = spells.find(*weakIt);
@@ -151,7 +150,7 @@ namespace MWMechanics
         float baseMagicka = fPCbaseMagickaMult * actorAttributes[ESM::Attribute::Intelligence];
         bool reachedLimit = false;
         const ESM::Spell* weakestSpell = NULL;
-        int minCost = INT_MAX;
+        int minCost = std::numeric_limits<int>::max();
 
         std::vector<std::string> selectedSpells;
 
@@ -188,7 +187,7 @@ namespace MWMechanics
                 if (it != selectedSpells.end())
                     selectedSpells.erase(it);
 
-                minCost = INT_MAX;
+                minCost = std::numeric_limits<int>::max();
                 for (std::vector<std::string>::iterator weakIt = selectedSpells.begin(); weakIt != selectedSpells.end(); ++weakIt)
                 {
                     const ESM::Spell* testSpell = esmStore.get<ESM::Spell>().find(*weakIt);

--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -1,7 +1,5 @@
 #include "globalmap.hpp"
 
-#include <climits>
-
 #include <osg/Image>
 #include <osg/Texture2D>
 #include <osg/Group>

--- a/components/widgets/numericeditbox.cpp
+++ b/components/widgets/numericeditbox.cpp
@@ -59,6 +59,11 @@ namespace Gui
         }
     }
 
+    int NumericEditBox::getValue()
+    {
+        return mValue;
+    }
+
     void NumericEditBox::setMinValue(int minValue)
     {
         mMinValue = minValue;

--- a/components/widgets/numericeditbox.hpp
+++ b/components/widgets/numericeditbox.hpp
@@ -30,6 +30,7 @@ namespace Gui
 
         /// @note Does not trigger eventValueChanged
         void setValue (int value);
+        int getValue();
 
         void setMinValue(int minValue);
         void setMaxValue(int maxValue);

--- a/files/mygui/openmw_alchemy_window.layout
+++ b/files/mygui/openmw_alchemy_window.layout
@@ -74,7 +74,20 @@
 
         <!-- Buttons -->
 
-        <Widget type="HBox" skin="" position="110 374 452 28" align="Bottom Right">
+        <Widget type="HBox" skin="" position="10 374 552 28" align="Bottom HStretch">
+            <Widget type="AutoSizedButton" skin="MW_Button" name="DecreaseButton">
+                <Property key="Caption" value=" - "/>
+                <Property key="NeedKey" value="false"/>
+            </Widget>
+
+            <Widget type="NumericEditBox" skin="MW_TextEdit" position="0 0 96 25" name="BrewCount">
+                <Property key="TextAlign" value="Center"/>
+            </Widget>
+
+            <Widget type="AutoSizedButton" skin="MW_Button" name="IncreaseButton">
+                <Property key="Caption" value=" + "/>
+                <Property key="NeedKey" value="false"/>
+            </Widget>
 
             <Widget type="Spacer"/>
 


### PR DESCRIPTION
For now mass potion creation is a quite boring - you need to spam Enter button on mouse clicks on Create button to create potions one by one.
This PR adds a numeric edit box which allows to specify a count of potions to create.
Chance of success and skill gain is calculated for every potion, so there should be no difference here.
