### PR TITLE
Optimize new magic effects update system

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1679,7 +1679,7 @@ namespace MWMechanics
 
             MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(iter->first);
             if (animation)
-                animation->updateEffects(duration);
+                animation->updateEffects();
 
         }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2219,9 +2219,6 @@ void CharacterController::update(float duration)
             moved *= (l / newLength);
     }
 
-    if (mSkipAnim)
-        mAnimation->updateEffects(duration);
-
     if (mFloatToSurface && cls.isActor() && cls.getCreatureStats(mPtr).isDead() && cls.canSwim(mPtr))
         moved.z() = 1.0;
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -263,6 +263,7 @@ protected:
     osg::ref_ptr<RotateController> mHeadController;
     float mHeadYawRadians;
     float mHeadPitchRadians;
+    bool mHasMagicEffects;
 
     osg::ref_ptr<SceneUtil::LightSource> mGlowLight;
     osg::ref_ptr<GlowUpdater> mGlowUpdater;
@@ -450,7 +451,7 @@ public:
     void setLoopingEnabled(const std::string &groupname, bool enabled);
 
     /// This is typically called as part of runAnimation, but may be called manually if needed.
-    void updateEffects(float duration);
+    void updateEffects();
 
     /// Return a node with the specified name, or NULL if not existing.
     /// @note The matching is case-insensitive.


### PR DESCRIPTION
Continue of #1720.
I realized that we really do not need to remove finished callbacks every frame since the most of objects have no magic VFX.

The main idea:
1. Add the new mHasMagicEffects flag to Animation object (false by default).
2. Set it to true when attach any magic VFX to object node.
3. Search for finished callbacks only when this flag is true.
4. After search set this flag to false when there are no active VFX found. 

There is no need for new changelog entry.