### PR TITLE
Make RemoveSpellEffects behavior closer to vanilla (bug #3920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
     Bug #3876: Landscape texture painting is misaligned
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3911: [macOS] Typing in the "Content List name" dialog box produces double characters
+    Bug #3920: RemoveSpellEffects doesn't remove constant effects
     Bug #3948: AiCombat moving target aiming uses incorrect speed for magic projectiles
     Bug #3950: FLATTEN_STATIC_TRANSFORMS optimization breaks animated collision shapes
     Bug #3993: Terrain texture blending map is not upscaled

--- a/apps/openmw/mwmechanics/activespells.cpp
+++ b/apps/openmw/mwmechanics/activespells.cpp
@@ -197,11 +197,13 @@ namespace MWMechanics
 
     void ActiveSpells::removeEffects(const std::string &id)
     {
-        TContainer::iterator spell(mSpells.find(id));
-        if (spell != end());
+        for (TContainer::iterator spell = mSpells.begin(); spell != mSpells.end(); ++spell)
         {
-            spell->second.mEffects.clear();
-            mSpellsChanged = true;
+            if (spell->first == id)
+            {
+                spell->second.mEffects.clear();
+                mSpellsChanged = true;
+            }
         }
     }
 

--- a/apps/openmw/mwmechanics/activespells.cpp
+++ b/apps/openmw/mwmechanics/activespells.cpp
@@ -197,8 +197,12 @@ namespace MWMechanics
 
     void ActiveSpells::removeEffects(const std::string &id)
     {
-        mSpells.erase(Misc::StringUtils::lowerCase(id));
-        mSpellsChanged = true;
+        TContainer::iterator spell(mSpells.find(id));
+        if (spell != end());
+        {
+            spell->second.mEffects.clear();
+            mSpellsChanged = true;
+        }
     }
 
     void ActiveSpells::visitEffectSources(EffectSourceVisitor &visitor) const

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -283,12 +283,18 @@ namespace MWMechanics
     {
         if (isSpellActive(id))
         {
-            TContainer::iterator spellIt = mSpells.find(getSpell(id));
-            for (long unsigned int i = 0; i != spellIt->first->mEffects.mList.size(); i++)
+            for (TContainer::iterator spell = mSpells.begin(); spell != mSpells.end(); ++spell)
             {
-                spellIt->second.mPurgedEffects.insert(i);
-                mSpellsChanged = true;
+                if (spell->first == getSpell(id))
+                {
+                    for (long unsigned int i = 0; i != spell->first->mEffects.mList.size(); i++)
+                    {
+                        spell->second.mPurgedEffects.insert(i);
+                    }
+                }
             }
+
+            mSpellsChanged = true;
         }
     }
 

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -279,6 +279,19 @@ namespace MWMechanics
         }
     }
 
+    void Spells::removeEffects(const std::string &id)
+    {
+        if (isSpellActive(id))
+        {
+            TContainer::iterator spellIt = mSpells.find(getSpell(id));
+            for (long unsigned int i = 0; i != spellIt->first->mEffects.mList.size(); i++)
+            {
+                spellIt->second.mPurgedEffects.insert(i);
+                mSpellsChanged = true;
+            }
+        }
+    }
+
     void Spells::visitEffectSources(EffectSourceVisitor &visitor) const
     {
         if (mSpellsChanged) {

--- a/apps/openmw/mwmechanics/spells.hpp
+++ b/apps/openmw/mwmechanics/spells.hpp
@@ -124,6 +124,8 @@ namespace MWMechanics
 
             bool hasBlightDisease() const;
 
+            void removeEffects(const std::string& id);
+
             void visitEffectSources (MWMechanics::EffectSourceVisitor& visitor) const;
 
             void readState (const ESM::SpellState& state);

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -501,6 +501,7 @@ namespace MWScript
                     runtime.pop();
 
                     ptr.getClass().getCreatureStats (ptr).getActiveSpells().removeEffects(spellid);
+                    ptr.getClass().getCreatureStats (ptr).getSpells().removeEffects(spellid);
                 }
         };
 


### PR DESCRIPTION
[Bug 3920](https://gitlab.com/OpenMW/openmw/issues/3920).

I made the existing ActiveSpells::RemoveEffects method clear the effect list of the active spell instead of removing said spell from the active spells list and added a new Spells::RemoveEffects method intended for permanent spells (curses, diseases, abilities) that purges all the effects of the spell. Unlike vanilla, though, unless I'm doing something wrong, removing the ability spell with RemoveSpell and adding it back with AddSpell restores the effects - in Morrowind nothing happens. Is it even possible to remove the effects from a permanent spell permanently if the Spell record is supposed to be constant?