### PR TITLE
Update pinned windows in-game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
     Bug #4553: Forcegreeting on non-actor opens a dialogue window which cannot be closed
     Bug #4557: Topics with reserved names are handled differently from vanilla
     Bug #4558: Mesh optimizer: check for reserved node name is case-sensitive
+    Bug #4560: OpenMW does not update pinned windows properly
     Bug #4563: Fast travel price logic checks destination cell instead of service actor cell
     Bug #4565: Underwater view distance should be limited
     Bug #4573: Player uses headtracking in the 1st-person mode

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -68,6 +68,7 @@ namespace MWGui
         , mPreview(new MWRender::InventoryPreview(parent, resourceSystem, MWMechanics::getPlayer()))
         , mTrading(false)
         , mScaleFactor(1.0f)
+        , mUpdateTimer(0.f)
     {
         float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
         if (uiScale > 1.0)
@@ -631,6 +632,22 @@ namespace MWGui
     void InventoryWindow::onFrame(float dt)
     {
         updateEncumbranceBar();
+
+        if (mPinned)
+        {
+            mUpdateTimer += dt;
+            if (0.1f < mUpdateTimer)
+            {
+                mUpdateTimer = 0;
+
+                // Update pinned inventory in-game
+                if (!MWBase::Environment::get().getWindowManager()->isGuiMode())
+                {
+                    mItemView->update();
+                    notifyContentChanged();
+                }
+            }
+        }
     }
 
     void InventoryWindow::setTrading(bool trading)

--- a/apps/openmw/mwgui/inventorywindow.hpp
+++ b/apps/openmw/mwgui/inventorywindow.hpp
@@ -102,6 +102,7 @@ namespace MWGui
 
             bool mTrading;
             float mScaleFactor;
+            float mUpdateTimer;
 
             void onItemSelected(int index);
             void onItemSelectedFromSourceModel(int index);

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -86,6 +86,10 @@ namespace MWGui
             mUpdateTimer = 0;
             mSpellView->incrementalUpdate();
         }
+
+        // Update effects in-game too if the window is pinned
+        if (mPinned && !MWBase::Environment::get().getWindowManager()->isGuiMode())
+            mSpellIcons->updateWidgets(mEffectBox, false);
     }
 
     void SpellWindow::updateSpells()


### PR DESCRIPTION
Fixes [bug #4560](https://gitlab.com/OpenMW/openmw/issues/4560).

Note: In theory, we can update inventory window during "added item", "removed item", "equipped item", "hit" and other events, but performance will be pretty the same and amount of changes over codebase will be larger.
So it just simplier to update pinned windows directly.