### PR TITLE
Apply sneaking offset to camera while the character is in air (bug #4617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
     Bug #4591: Attack strength should be 0 if player did not hold the attack button
     Bug #4597: <> operator causes a compile error
     Bug #4604: Picking up gold from the ground only makes 1 grabbed
+    Bug #4617: First person sneaking offset is not applied while the character is in air
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1706,11 +1706,10 @@ namespace MWWorld
 
         // Sink the camera while sneaking
         bool sneaking = player.getClass().getCreatureStats(getPlayerPtr()).getStance(MWMechanics::CreatureStats::Stance_Sneak);
-        bool inair = !isOnGround(player);
         bool swimming = isSwimming(player);
 
         static const float i1stPersonSneakDelta = getStore().get<ESM::GameSetting>().find("i1stPersonSneakDelta")->getFloat();
-        if (sneaking && !(swimming || inair))
+        if (sneaking && !swimming)
             mRendering->getCamera()->setSneakOffset(i1stPersonSneakDelta);
         else
             mRendering->getCamera()->setSneakOffset(0.f);


### PR DESCRIPTION
[Bug #4617](https://gitlab.com/OpenMW/openmw/issues/4617).

Remove the !inair restriction from the relevant check. This allows the sneak offset to be applied while jumping, like in Morrowind... and levitating, even though you shouldn't be able to enter sneak stance while you are flying.