### PR TITLE
Don't apply falling damage twice (bug #4608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
     Bug #4597: <> operator causes a compile error
     Bug #4604: Picking up gold from the ground only makes 1 grabbed
     Bug #4607: Scaling for animated collision shapes is applied twice
+    Bug #4608: Falling damage is applied twice
     Bug #4615: Flicker effects for light sources are handled incorrectly
     Bug #4617: First person sneaking offset is not applied while the character is in air
     Bug #4618: Sneaking is possible while the character is flying

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2012,10 +2012,7 @@ void CharacterController::update(float duration)
                 // inflict fall damages
                 if (!godmode)
                 {
-                    DynamicStat<float> health = cls.getCreatureStats(mPtr).getHealth();
                     float realHealthLost = static_cast<float>(healthLost * (1.0f - 0.25f * fatigueTerm));
-                    health.setCurrent(health.getCurrent() - realHealthLost);
-                    cls.getCreatureStats(mPtr).setHealth(health);
                     cls.onHit(mPtr, realHealthLost, true, MWWorld::Ptr(), MWWorld::Ptr(), osg::Vec3f(), true);
                 }
 


### PR DESCRIPTION
[Bug 4608](https://gitlab.com/OpenMW/openmw/issues/4608).

Apparently previously we applied the falling damage once in the character controller , ignoring any possible additional modifiers, and then properly applied it *again* in onHit class method, resulting in roughly double falling damage (a bit lower than that due to onHit damage including external modifiers). Can't believe this couldn't have been noticed for so long.

So I removed the erroneous character controller lines and now the applied falling damage appears to be the same as in Morrowind.