### PR TITLE
Grant Enchant experience even if enchanted item recharging fails (bug #4622)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
     Bug #4615: Flicker effects for light sources are handled incorrectly
     Bug #4617: First person sneaking offset is not applied while the character is in air
     Bug #4618: Sneaking is possible while the character is flying
+    Bug #4622: Recharging enchanted items with Soul Gems does not award experience if it fails
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -169,14 +169,13 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
         MWBase::Environment::get().getWindowManager()->playSound("Enchant Success");
 
         player.getClass().getContainerStore(player).restack(item);
-
-        player.getClass().skillUsageSucceeded (player, ESM::Skill::Enchant, 0);
     }
     else
     {
         MWBase::Environment::get().getWindowManager()->playSound("Enchant Fail");
     }
 
+    player.getClass().skillUsageSucceeded (player, ESM::Skill::Enchant, 0);
     gem.getContainerStore()->remove(gem, 1, player);
 
     if (gem.getRefData().getCount() == 0)


### PR DESCRIPTION
[Bug 4622](https://gitlab.com/OpenMW/openmw/issues/4622).

Who could have thought. But apparently it's true.

Move the skillUsageSucceeded call out of roll successful block.