### PR TITLE
Fix division by zero in the FlipController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
     Bug #4604: Picking up gold from the ground only makes 1 grabbed
     Bug #4607: Scaling for animated collision shapes is applied twice
     Bug #4608: Falling damage is applied twice
+    Bug #4614: Crash due to division by zero when FlipController has no textures
     Bug #4615: Flicker effects for light sources are handled incorrectly
     Bug #4617: First person sneaking offset is not applied while the character is in air
     Bug #4618: Sneaking is possible while the character is flying

--- a/components/nifosg/controller.cpp
+++ b/components/nifosg/controller.cpp
@@ -409,7 +409,7 @@ FlipController::FlipController(const FlipController &copy, const osg::CopyOp &co
 
 void FlipController::apply(osg::StateSet* stateset, osg::NodeVisitor* nv)
 {
-    if (hasInput() && mDelta != 0)
+    if (hasInput() && mDelta != 0 && !mTextures.empty())
     {
         int curTexture = int(getInputValue(nv) / mDelta) % mTextures.size();
         stateset->setTextureAttribute(mTexSlot, mTextures[curTexture]);


### PR DESCRIPTION
Fixes [bug #4614](https://gitlab.com/OpenMW/openmw/issues/4614).
In theory, we can ignore empty FlipControllers at all, but they can have child controllers.
Since I do not know how to handle them, I only avoid division by zero.