### PR TITLE
Make several NPC fields have unsigned char type (bug #4628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
     Bug #4617: First person sneaking offset is not applied while the character is in air
     Bug #4618: Sneaking is possible while the character is flying
     Bug #4622: Recharging enchanted items with Soul Gems does not award experience if it fails
+    Bug #4628: NPC record reputation, disposition and faction rank should have unsigned char type
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script

--- a/components/esm/loadnpc.hpp
+++ b/components/esm/loadnpc.hpp
@@ -90,7 +90,7 @@ struct NPC
 
         char mFactionID;
         unsigned short mHealth, mMana, mFatigue;
-        signed char mDisposition, mReputation, mRank;
+        unsigned char mDisposition, mReputation, mRank;
         char mUnknown;
         int mGold;
     }; // 52 bytes
@@ -101,7 +101,7 @@ struct NPC
     {
         short mLevel;
         // see above
-        signed char mDisposition, mReputation, mRank;
+        unsigned char mDisposition, mReputation, mRank;
         char mUnknown1, mUnknown2, mUnknown3;
         int mGold;
     }; // 12 bytes


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4628).

According to NullCascade (and partially MWSE sources), all of these three fields - faction rank, disposition and reputation - must be loaded with unsigned char type.