### PR TITLE
Utilize all AI GMSTs for priority rating (feature #4632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
     Feature #4624: Spell priority: don't cast hit chance-affecting spells if the enemy is not in respective stance at the moment
     Feature #4625: Weapon priority: use weighted mean for melee damage rating
     Feature #4626: Weapon priority: account for weapon speed
+    Feature #4632: AI priority: utilize vanilla AI GMSTs for priority rating
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test
     Task #4605: Optimize skinning

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -617,13 +617,19 @@ namespace MWMechanics
     float rateEffects(const ESM::EffectList &list, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy)
     {
         // NOTE: enemy may be empty
+
         float rating = 0.f;
+        float ratingMult = 1.f; // NB: this multiplier is applied to the effect rating, not the final rating
+
+        const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        static const float fAIMagicSpellMult = gmst.find("fAIMagicSpellMult")->mValue.getFloat();
+        static const float fAIRangeMagicSpellMult = gmst.find("fAIRangeMagicSpellMult")->mValue.getFloat();
+
         for (std::vector<ESM::ENAMstruct>::const_iterator it = list.mList.begin(); it != list.mList.end(); ++it)
         {
-            rating += rateEffect(*it, actor, enemy);
+            ratingMult = (it->mRange == ESM::RT_Target) ? fAIRangeMagicSpellMult : fAIMagicSpellMult;
 
-            if (it->mRange == ESM::RT_Target)
-                rating *= 1.5f;
+            rating += rateEffect(*it, actor, enemy) * ratingMult;
         }
         return rating;
     }

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -39,7 +39,8 @@ namespace MWMechanics
             return 0.f;
 
         float rating=0.f;
-        float rangedMult=1.f;
+        static const float fAIMeleeWeaponMult = gmst.find("fAIMeleeWeaponMult")->mValue.getFloat();
+        float ratingMult = fAIMeleeWeaponMult;
 
         if (weapon->mData.mType >= ESM::Weapon::MarksmanBow && weapon->mData.mType <= ESM::Weapon::MarksmanThrown)
         {
@@ -48,14 +49,11 @@ namespace MWMechanics
              || world->isUnderwater(MWWorld::ConstPtr(enemy), 0.75f))
                 return 0.f;
 
+            // Use a higher rating multiplier if the actor is out of enemy's reach, use the normal mult otherwise
             if (getDistanceMinusHalfExtents(actor, enemy) >= getMaxAttackDistance(enemy))
             {
-                static const float fAIMeleeWeaponMult = gmst.find("fAIMeleeWeaponMult")->mValue.getFloat();
                 static const float fAIRangeMeleeWeaponMult = gmst.find("fAIRangeMeleeWeaponMult")->mValue.getFloat();
-                if (fAIMeleeWeaponMult != 0)
-                    rangedMult = fAIRangeMeleeWeaponMult / fAIMeleeWeaponMult;
-                else
-                    rangedMult = fAIRangeMeleeWeaponMult;
+                ratingMult = fAIRangeMeleeWeaponMult;
             }
         }
 
@@ -124,7 +122,7 @@ namespace MWMechanics
         if (weapon->mData.mType < ESM::Weapon::MarksmanBow)
             rating *= weapon->mData.mSpeed;
 
-        return rating * rangedMult;
+        return rating * ratingMult;
     }
 
     float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, ESM::Weapon::Type ammoType)


### PR DESCRIPTION
[Bugtracker page.](https://gitlab.com/OpenMW/openmw/issues/4632)

Make use of the mentioned GMSTs. With Morrowind.esm the actors will prefer spells to weapons slightly more and on-target spells slightly less compared to normal spells - or a lot less if you account for the following: a bug in on-target effect multiplier is fixed as a side effect - if I've not mistaken, it had previously been applied to the rating *every time there was an on-target effect in the list*.

Ranged weaponry multiplier is still 250% compared to melee weaponry and ranged weaponry ineffective in the current conditions.