### PR TITLE
Make sure the actor is actually crouching/running before tweaking movement speed (bug #4633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
     Bug #4618: Sneaking is possible while the character is flying
     Bug #4622: Recharging enchanted items with Soul Gems does not award experience if it fails
     Bug #4628: NPC record reputation, disposition and faction rank should have unsigned char type
+    Bug #4633: Sneaking stance affects speed even if the actor is not able to crouch
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
     Feature #3083: Play animation when NPC is casting spell via script

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -938,8 +938,8 @@ namespace MWClass
 
         const float normalizedEncumbrance = getNormalizedEncumbrance(ptr);
 
-        bool sneaking = stats.getStance(MWMechanics::CreatureStats::Stance_Sneak);
-        bool running = stats.getStance(MWMechanics::CreatureStats::Stance_Run);
+        bool sneaking = MWBase::Environment::get().getMechanicsManager()->isSneaking(ptr) && stats.getStance(MWMechanics::CreatureStats::Stance_Sneak);
+        bool running = MWBase::Environment::get().getMechanicsManager()->isRunning(ptr) && stats.getStance(MWMechanics::CreatureStats::Stance_Run);
 
         float walkSpeed = gmst.fMinWalkSpeed->mValue.getFloat() + 0.01f*npcdata->mNpcStats.getAttribute(ESM::Attribute::Speed).getModified()*
                                                       (gmst.fMaxWalkSpeed->mValue.getFloat() - gmst.fMinWalkSpeed->mValue.getFloat());
@@ -964,7 +964,7 @@ namespace MWClass
             flySpeed = std::max(0.0f, flySpeed);
             moveSpeed = flySpeed;
         }
-        else if(world->isSwimming(ptr))
+        else if (world->isSwimming(ptr))
         {
             float swimSpeed = walkSpeed;
             if(running)
@@ -974,7 +974,7 @@ namespace MWClass
                                                     gmst.fSwimRunAthleticsMult->mValue.getFloat();
             moveSpeed = swimSpeed;
         }
-        else if(running && !sneaking)
+        else if (running)
             moveSpeed = runSpeed;
         else
             moveSpeed = walkSpeed;


### PR DESCRIPTION
[Bug 4633](https://gitlab.com/OpenMW/openmw/issues/4633).

Add animation checks to make sure the sneaking movement speed multiplier doesn't slow down the player due to simply holding the sneaking button while swimming.

Hopefully I didn't break anything.