### PR TITLE
Use sTo GMST in spellmaking menu (feature #4636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
     Feature #4625: Weapon priority: use weighted mean for melee damage rating
     Feature #4626: Weapon priority: account for weapon speed
     Feature #4632: AI priority: utilize vanilla AI GMSTs for priority rating
+    Feature #4636: Use sTo GMST in spellmaking menu
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test
     Task #4605: Optimize skinning

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -147,7 +147,9 @@ namespace MWGui
 
         mDurationValue->setCaption("1");
         mMagnitudeMinValue->setCaption("1");
-        mMagnitudeMaxValue->setCaption("- 1");
+        static const std::string &to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
+
+        mMagnitudeMaxValue->setCaption(to + " 1");
         mAreaValue->setCaption("0");
 
         setVisible(true);
@@ -312,8 +314,9 @@ namespace MWGui
         }
 
         mEffect.mMagnMax = pos+1;
+        static const std::string &to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
 
-        mMagnitudeMaxValue->setCaption("- " + MyGUI::utility::toString(pos+1));
+        mMagnitudeMaxValue->setCaption(to + " " + MyGUI::utility::toString(pos+1));
 
         eventEffectModified(mEffect);
     }

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -147,7 +147,7 @@ namespace MWGui
 
         mDurationValue->setCaption("1");
         mMagnitudeMinValue->setCaption("1");
-        static const std::string &to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
+        const std::string to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
 
         mMagnitudeMaxValue->setCaption(to + " 1");
         mAreaValue->setCaption("0");
@@ -314,7 +314,7 @@ namespace MWGui
         }
 
         mEffect.mMagnMax = pos+1;
-        static const std::string &to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
+        const std::string to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
 
         mMagnitudeMaxValue->setCaption(to + " " + MyGUI::utility::toString(pos+1));
 


### PR DESCRIPTION
[Feature 4636](https://gitlab.com/OpenMW/openmw/issues/4636)

Recover the sTo GMST value for max magnitude caption. On English Morrowind.esm it becomes "to %number%", I can't tell what will it be on other localizations but sTo is definitely used in spellmaking menu in the original engine. I decided to use a hyphen instead of "to" by default because if the GMST is missing we'd most likely want to use as "international" variant of it as possible.