### PR TITLE
Disable repeating for Accept GUI action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
     Bug #4230: AiTravel package issues break some Tribunal quests
     Bug #4231: Infected rats from the "Crimson Plague" quest rendered unconscious by change in Drain Fatigue functionality
     Bug #4251: Stationary NPCs do not return to their position after combat
+    Bug #4260: Keyboard navigation makes persuasion exploitable
     Bug #4271: Scamp flickers when attacking
     Bug #4274: Pre-0.43 death animations are not forward-compatible with 0.43+
     Bug #4286: Scripted animations can be interrupted

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -351,6 +351,7 @@ namespace MWBase
             virtual const MWGui::TextColours& getTextColours() = 0;
 
             virtual bool injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat) = 0;
+            virtual bool injectKeyRelease(MyGUI::KeyCode key) = 0;
     };
 }
 

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -350,7 +350,7 @@ namespace MWBase
 
             virtual const MWGui::TextColours& getTextColours() = 0;
 
-            virtual bool injectKeyPress(MyGUI::KeyCode key, unsigned int text) = 0;
+            virtual bool injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat) = 0;
     };
 }
 

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -65,6 +65,9 @@ namespace MWGui
     void AlchemyWindow::onAccept(MyGUI::EditBox* sender)
     {
         onCreateButtonClicked(sender);
+
+        // To do not spam onAccept() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     void AlchemyWindow::onCancelButtonClicked(MyGUI::Widget* _sender)

--- a/apps/openmw/mwgui/countdialog.cpp
+++ b/apps/openmw/mwgui/countdialog.cpp
@@ -73,8 +73,10 @@ namespace MWGui
     void CountDialog::onEnterKeyPressed(MyGUI::EditBox* _sender)
     {
         eventOkClicked(NULL, mSlider->getScrollPosition()+1);
-
         setVisible(false);
+
+        // To do not spam onEnterKeyPressed() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     void CountDialog::onEditValueChanged(int value)

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -288,6 +288,9 @@ namespace MWGui
     void EnchantingDialog::onAccept(MyGUI::EditBox *sender)
     {
         onBuyButtonClicked(sender);
+
+        // To do not spam onAccept() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     void EnchantingDialog::onBuyButtonClicked(MyGUI::Widget* sender)

--- a/apps/openmw/mwgui/keyboardnavigation.cpp
+++ b/apps/openmw/mwgui/keyboardnavigation.cpp
@@ -172,7 +172,7 @@ enum Direction
     D_Prev
 };
 
-bool KeyboardNavigation::injectKeyPress(MyGUI::KeyCode key, unsigned int text)
+bool KeyboardNavigation::injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat)
 {
     if (!mEnabled)
         return false;
@@ -192,7 +192,12 @@ bool KeyboardNavigation::injectKeyPress(MyGUI::KeyCode key, unsigned int text)
     case MyGUI::KeyCode::Return:
     case MyGUI::KeyCode::NumpadEnter:
     case MyGUI::KeyCode::Space:
+    {
+        if (repeat)
+            return false;
+
         return accept();
+    }
     default:
         return false;
     }

--- a/apps/openmw/mwgui/keyboardnavigation.cpp
+++ b/apps/openmw/mwgui/keyboardnavigation.cpp
@@ -193,8 +193,10 @@ bool KeyboardNavigation::injectKeyPress(MyGUI::KeyCode key, unsigned int text, b
     case MyGUI::KeyCode::NumpadEnter:
     case MyGUI::KeyCode::Space:
     {
+        // We should disable repeating for activation keys
+        MyGUI::InputManager::getInstance().injectKeyRelease(MyGUI::KeyCode::None);
         if (repeat)
-            return false;
+            return true;
 
         return accept();
     }

--- a/apps/openmw/mwgui/keyboardnavigation.hpp
+++ b/apps/openmw/mwgui/keyboardnavigation.hpp
@@ -14,7 +14,7 @@ namespace MWGui
         ~KeyboardNavigation();
 
         /// @return Was the key handled by this class?
-        bool injectKeyPress(MyGUI::KeyCode key, unsigned int text);
+        bool injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat);
 
         void saveFocus(int mode);
         void restoreFocus(int mode);

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -127,6 +127,9 @@ namespace MWGui
     void SaveGameDialog::onEditSelectAccept(MyGUI::EditBox *sender)
     {
         accept();
+
+        // To do not spam onEditSelectAccept() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     void SaveGameDialog::onOpen()

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -420,6 +420,9 @@ namespace MWGui
     void SpellCreationDialog::onAccept(MyGUI::EditBox *sender)
     {
         onBuyButtonClicked(sender);
+
+        // To do not spam onAccept() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     void SpellCreationDialog::onOpen()

--- a/apps/openmw/mwgui/textinput.cpp
+++ b/apps/openmw/mwgui/textinput.cpp
@@ -65,6 +65,9 @@ namespace MWGui
     void TextInputDialog::onTextAccepted(MyGUI::Edit* _sender)
     {
         onOkClicked(_sender);
+
+        // To do not spam onTextAccepted() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     std::string TextInputDialog::getTextInput() const

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -367,6 +367,9 @@ namespace MWGui
     void TradeWindow::onAccept(MyGUI::EditBox *sender)
     {
         onOfferButtonClicked(sender);
+
+        // To do not spam onAccept() again and again
+        MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
     void TradeWindow::onCancelButtonClicked(MyGUI::Widget* _sender)

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -2091,6 +2091,11 @@ namespace MWGui
             return true;
     }
 
+    bool WindowManager::injectKeyRelease(MyGUI::KeyCode key)
+    {
+        return MyGUI::InputManager::getInstance().injectKeyRelease(key);
+    }
+
     void WindowManager::GuiModeState::update(bool visible)
     {
         for (unsigned int i=0; i<mWindows.size(); ++i)

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -2060,9 +2060,9 @@ namespace MWGui
         return mTextColours;
     }
 
-    bool WindowManager::injectKeyPress(MyGUI::KeyCode key, unsigned int text)
+    bool WindowManager::injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat)
     {
-        if (!mKeyboardNavigation->injectKeyPress(key, text))
+        if (!mKeyboardNavigation->injectKeyPress(key, text, repeat))
         {
             MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
             bool widgetActive = MyGUI::InputManager::getInstance().injectKeyPress(key, text);

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -379,7 +379,7 @@ namespace MWGui
 
     virtual const MWGui::TextColours& getTextColours();
 
-    virtual bool injectKeyPress(MyGUI::KeyCode key, unsigned int text);
+    virtual bool injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat=false);
 
   private:
     const MWWorld::ESMStore* mStore;

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -380,6 +380,7 @@ namespace MWGui
     virtual const MWGui::TextColours& getTextColours();
 
     virtual bool injectKeyPress(MyGUI::KeyCode key, unsigned int text, bool repeat=false);
+    virtual bool injectKeyRelease(MyGUI::KeyCode key);
 
   private:
     const MWWorld::ESMStore* mStore;

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -214,7 +214,7 @@ namespace MWInput
             break;
         }
 
-        MWBase::Environment::get().getWindowManager()->injectKeyPress(key, 0);
+        MWBase::Environment::get().getWindowManager()->injectKeyPress(key, 0, false);
     }
 
     void InputManager::channelChanged(ICS::Channel* channel, float currentValue, float previousValue)
@@ -720,7 +720,7 @@ namespace MWInput
         bool consumed = false;
         if (kc != OIS::KC_UNASSIGNED && !mInputBinder->detectingBindingState())
         {
-            consumed = MWBase::Environment::get().getWindowManager()->injectKeyPress(MyGUI::KeyCode::Enum(kc), 0);
+            consumed = MWBase::Environment::get().getWindowManager()->injectKeyPress(MyGUI::KeyCode::Enum(kc), 0, arg.repeat);
             if (SDL_IsTextInputActive() &&  // Little trick to check if key is printable
                                     ( !(SDLK_SCANCODE_MASK & arg.keysym.sym) && std::isprint(arg.keysym.sym)))
                 consumed = true;
@@ -1153,7 +1153,7 @@ namespace MWInput
         if (MWBase::Environment::get().getWindowManager()->isGuiMode())
         {
             if (!SDL_IsTextInputActive() && !isLeftOrRightButton(A_Activate, mInputBinder, mFakeDeviceID, mJoystickLastUsed))
-                MWBase::Environment::get().getWindowManager()->injectKeyPress(MyGUI::KeyCode::Return, 0);
+                MWBase::Environment::get().getWindowManager()->injectKeyPress(MyGUI::KeyCode::Return, 0, false);
         }
         else if (mControlSwitch["playercontrols"])
             mPlayer->activate();


### PR DESCRIPTION
Fixes [bug #4260](https://gitlab.com/OpenMW/openmw/issues/4260).
There is no need to hold ENTER button and apply the same action again and again.
An additional thing we can do here is to set focus to Cancel button every time we open a persuation window, but it will decrease usability of keyboard navigation feature.