### PR TITLE
Use drag and drop for ActionTake when InventoryWindow is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
     Bug #4531: Movement does not reset idle animations
     Bug #4539: Paper Doll is affected by GUI scaling
+    Bug #4543: Picking cursed items through inventory (menumode) makes it disappear
     Bug #4545: Creatures flee from werewolves
     Bug #4551: Replace 0 sound range with default range separately
     Bug #4553: Forcegreeting on non-actor opens a dialogue window which cannot be closed

--- a/apps/openmw/mwworld/actiontake.cpp
+++ b/apps/openmw/mwworld/actiontake.cpp
@@ -5,6 +5,8 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
+#include "../mwgui/inventorywindow.hpp"
+
 #include "class.hpp"
 #include "containerstore.hpp"
 
@@ -14,6 +16,17 @@ namespace MWWorld
 
     void ActionTake::executeImp (const Ptr& actor)
     {
+        // When in GUI mode, we should use drag and drop
+        if (actor == MWBase::Environment::get().getWorld()->getPlayerPtr())
+        {
+            MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
+            if (mode == MWGui::GM_Inventory || mode == MWGui::GM_Container)
+            {
+                MWBase::Environment::get().getWindowManager()->getInventoryWindow()->pickUpObject(getTarget());
+                return;
+            }
+        }
+
         MWBase::Environment::get().getMechanicsManager()->itemTaken(
                     actor, getTarget(), MWWorld::Ptr(), getTarget().getRefData().getCount());
         MWWorld::Ptr newitem = *actor.getClass().getContainerStore (actor).add (getTarget(), getTarget().getRefData().getCount(), actor);


### PR DESCRIPTION
Fixes [bug #4543](https://gitlab.com/OpenMW/openmw/issues/4543).
Just use the pickUpObject() when inventory is opened.
If inventory is pinned, an object will be placed to player's inventory automatically.