### PR TITLE
Fix integer result formatting of scripting functions

### DIFF
--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -38,7 +38,7 @@ namespace Compiler
         {
             case 'l':
 
-                Generator::report (mCode, mLiterals, "%g");
+                Generator::report (mCode, mLiterals, "%d");
                 break;
 
             case 'f':


### PR DESCRIPTION
Fixes regression, caused by [this](https://gitlab.com/OpenMW/openmw/merge_requests/33) PR.
Select any NPC and type something like "getstrength" in console. It will return 0.000000.

Previosly %g format was reserved for integer values, now it supposed to work with floats (because of mRuntime[0].mFloat instead of mRuntime[0].mInteger), so use the "%d" format for integer output values.

Note: it seems this bug does not affect formatted parameters of MessageBox function.