### PR TITLE
Make coc and fixme console commands close to vanilla

### DIFF
--- a/apps/openmw/mwscript/cellextensions.cpp
+++ b/apps/openmw/mwscript/cellextensions.cpp
@@ -46,18 +46,19 @@ namespace MWScript
 
                     ESM::Position pos;
                     MWBase::World *world = MWBase::Environment::get().getWorld();
+                    const MWWorld::Ptr playerPtr = world->getPlayerPtr();
 
                     if (world->findExteriorPosition(cell, pos))
                     {
-                        MWWorld::ActionTeleport("", pos, false).execute(world->getPlayerPtr());
-                        world->fixPosition(world->getPlayerPtr());
+                        MWWorld::ActionTeleport("", pos, false).execute(playerPtr);
+                        world->adjustPosition(playerPtr, false);
                     }
                     else
                     {
                         // Change to interior even if findInteriorPosition()
                         // yields false. In this case position will be zero-point.
                         world->findInteriorPosition(cell, pos);
-                        MWWorld::ActionTeleport(cell, pos, false).execute(world->getPlayerPtr());
+                        MWWorld::ActionTeleport(cell, pos, false).execute(playerPtr);
                     }
                 }
         };
@@ -76,14 +77,15 @@ namespace MWScript
 
                     ESM::Position pos;
                     MWBase::World *world = MWBase::Environment::get().getWorld();
+                    const MWWorld::Ptr playerPtr = world->getPlayerPtr();
 
                     world->indexToPosition (x, y, pos.pos[0], pos.pos[1], true);
                     pos.pos[2] = 0;
 
                     pos.rot[0] = pos.rot[1] = pos.rot[2] = 0;
 
-                    MWWorld::ActionTeleport("", pos, false).execute(world->getPlayerPtr());
-                    world->fixPosition(world->getPlayerPtr());
+                    MWWorld::ActionTeleport("", pos, false).execute(playerPtr);
+                    world->adjustPosition(playerPtr, false);
                 }
         };
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -732,14 +732,13 @@ namespace MWScript
             }
         };
 
-        template <class R>
         class OpFixme : public Interpreter::Opcode0
         {
         public:
 
             virtual void execute (Interpreter::Runtime& runtime)
             {
-                MWWorld::Ptr ptr = R()(runtime);
+                const MWWorld::Ptr ptr = MWMechanics::getPlayer();
                 MWBase::Environment::get().getWorld()->fixPosition(ptr);
             }
         };
@@ -784,8 +783,7 @@ namespace MWScript
             interpreter.installSegment5(Compiler::Transformation::opcodeGetStartingAngle, new OpGetStartingAngle<ImplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodeGetStartingAngleExplicit, new OpGetStartingAngle<ExplicitRef>);
             interpreter.installSegment5(Compiler::Transformation::opcodeResetActors, new OpResetActors);
-            interpreter.installSegment5(Compiler::Transformation::opcodeFixme, new OpFixme<ImplicitRef>);
-            interpreter.installSegment5(Compiler::Transformation::opcodeFixmeExplicit, new OpFixme<ExplicitRef>);
+            interpreter.installSegment5(Compiler::Transformation::opcodeFixme, new OpFixme);
         }
     }
 }

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -546,7 +546,7 @@ namespace Compiler
             extensions.registerInstruction("moveworld","cf",opcodeMoveWorld,opcodeMoveWorldExplicit);
             extensions.registerFunction("getstartingangle",'f',"c",opcodeGetStartingAngle,opcodeGetStartingAngleExplicit);
             extensions.registerInstruction("resetactors","",opcodeResetActors);
-            extensions.registerInstruction("fixme","",opcodeFixme, opcodeFixmeExplicit);
+            extensions.registerInstruction("fixme","",opcodeFixme);
             extensions.registerInstruction("ra","",opcodeResetActors);
         }
     }

--- a/components/compiler/opcodes.hpp
+++ b/components/compiler/opcodes.hpp
@@ -504,7 +504,6 @@ namespace Compiler
         const int opcodeMoveWorldExplicit = 0x2000209;
         const int opcodeResetActors = 0x20002f4;
         const int opcodeFixme = 0x2000302;
-        const int opcodeFixmeExplicit = 0x2000303;
     }
 
     namespace User


### PR DESCRIPTION
[bug #4292](https://gitlab.com/OpenMW/openmw/issues/4292) and [bug #4217](https://gitlab.com/OpenMW/openmw/issues/4217).

Amount of changes:
1. Fixme:
1.1. Does not work with references and always teleports player, so you can use the "fixme" in console instead of "player->fixme".
1.2. Moves player 128 units away from its current position to unoccupied direction as in vanilla instead of moving hit 8000 units up and then tracing down.
1.3. Use ActionTeleport as for COE/COC to avoid fall damage, if you use fixme in the air.

2. COC:
2.1. Does not use "fixme", just adjusts z position instead.
2.2. Instead of teleporting to first teleporting door in interior, sorts all teleporting doors in cell by ID first, then by destination cell name in alphabet order and selects the first suitable one.
This approach may be not entirely correct, but in my testing Morrowind worked in the same way.
But I tested it on a Russian version of Morrowind, so I do not know how an English one works.