### PR TITLE
Actually fix General (%g) number formatting (bug #4463)

### DIFF
--- a/components/interpreter/miscopcodes.hpp
+++ b/components/interpreter/miscopcodes.hpp
@@ -65,23 +65,18 @@ namespace Interpreter
                             }
                             else if (notation == ShortestNotation)
                             {
-                                std::string scientific;
-                                std::string fixed;
-
-                                out << std::scientific << value;
-
-                                scientific = out.str();
+                                out << value;
+                                std::string standard = out.str();
 
                                 out.str(std::string());
                                 out.clear();
 
-                                out << std::fixed << value;
+                                out << std::scientific << value;
+                                std::string scientific = out.str();
 
-                                fixed = out.str();
-
-                                mFormattedMessage += fixed.length() < scientific.length() ? fixed : scientific;
+                                mFormattedMessage += standard.length() < scientific.length() ? standard : scientific;
                             }
-                            else 
+                            else
                             {
                                 out << std::scientific << value;
                                 mFormattedMessage += out.str();


### PR DESCRIPTION
A regression of sorts found by akortunov.

When MrTopCat attempted to fix issue 4463, he used fixed notation for General format numbers. This is incorrect, because numbers formatted using %g flag must not be handled like normal floating point numbers and should use the default notation instead, which handles the number next to `%.` as the width of the number in significant digits, not floating point number precision. This is the behavior observed in Morrowind and (ironically) described in the printf spec linked by MrTopCat.

Scientific notation is still used when:
1. The specified significant number count is higher than the integral part of the number, or
2. It's more compact

To clarify, this didn't happen in 0.44.0 because General format numbers were handled the same as integer numbers, so the problem was only that they were using only the decimal part of whatever number they should have been for using significant digits from. After the changes General format numbers began to be handled the same as floating point numbers, so they used the specified number not as the number of significant digits, but as the precision. The default precision is 6 so fixed notation returned 6 digits in the decimal part even if these 6 numbers are 0s. The intended behavior for General format numbers is to be as compact as possible (thus the name) but not omit the fractional part and have as many significant digits as specified, but no more (preferably less and by default 6).