### PR TITLE
Make GetPCJumping return true only when jumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
     Bug #4622: Recharging enchanted items with Soul Gems does not award experience if it fails
     Bug #4628: NPC record reputation, disposition and faction rank should have unsigned char type
     Bug #4633: Sneaking stance affects speed even if the actor is not able to crouch
+    Bug #4641: GetPCJumping is handled incorrectly
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -7,6 +7,7 @@
 #include <components/esm/esmwriter.hpp>
 
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/player.hpp"
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -387,8 +388,11 @@ namespace MWMechanics
         mFallHeight += height;
     }
 
-    float CreatureStats::land()
+    float CreatureStats::land(bool isPlayer)
     {
+        if (isPlayer)
+            MWBase::Environment::get().getWorld()->getPlayer().setJumping(false);
+
         float height = mFallHeight;
         mFallHeight = 0;
         return height;

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -95,7 +95,7 @@ namespace MWMechanics
 
         /// Reset the fall height
         /// @return total fall height
-        float land();
+        float land(bool isPlayer=false);
 
         const AttributeValue & getAttribute(int index) const;
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1394,6 +1394,7 @@ namespace MWPhysics
             mStandingCollisions.clear();
         }
 
+        const MWWorld::Ptr player = MWMechanics::getPlayer();
         const MWBase::World *world = MWBase::Environment::get().getWorld();
         PtrVelocityList::iterator iter = mMovementQueue.begin();
         for(;iter != mMovementQueue.end();++iter)
@@ -1451,7 +1452,7 @@ namespace MWPhysics
 
             MWMechanics::CreatureStats& stats = iter->first.getClass().getCreatureStats(iter->first);
             if ((wasOnGround && physicActor->getOnGround()) || flying || world->isSwimming(iter->first) || slowFall < 1)
-                stats.land();
+                stats.land(iter->first == player);
             else if (heightDiff < 0)
                 stats.addToFallHeight(-heightDiff);
 

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -107,8 +107,7 @@ namespace MWScript
             virtual void execute (Interpreter::Runtime& runtime)
             {
                 MWBase::World* world = MWBase::Environment::get().getWorld();
-                MWWorld::Ptr player = world->getPlayerPtr();
-                runtime.push (!world->isOnGround(player) && !world->isFlying(player));
+                runtime.push (world->getPlayer().getJumping());
             }
         };
 

--- a/apps/openmw/mwworld/actionteleport.cpp
+++ b/apps/openmw/mwworld/actionteleport.cpp
@@ -36,7 +36,7 @@ namespace MWWorld
     void ActionTeleport::teleport(const Ptr &actor)
     {
         MWBase::World* world = MWBase::Environment::get().getWorld();
-        actor.getClass().getCreatureStats(actor).land();
+        actor.getClass().getCreatureStats(actor).land(actor == world->getPlayerPtr());
         if(actor == world->getPlayerPtr())
         {
             world->getPlayer().setTeleported(true);

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -36,7 +36,8 @@ namespace MWWorld
         mTeleported(false),
         mCurrentCrimeId(-1),
         mPaidCrimeId(-1),
-        mAttackingOrSpell(false)
+        mAttackingOrSpell(false),
+        mJumping(false)
     {
         ESM::CellRef cellRef;
         cellRef.blank();
@@ -255,6 +256,16 @@ namespace MWWorld
         return mAttackingOrSpell;
     }
 
+    void Player::setJumping(bool jumping)
+    {
+        mJumping = jumping;
+    }
+
+    bool Player::getJumping() const
+    {
+        return mJumping;
+    }
+
     bool Player::isInCombat() {
         return MWBase::Environment::get().getMechanicsManager()->getActorsFighting(getPlayer()).size() != 0;
     }
@@ -286,6 +297,7 @@ namespace MWWorld
         mForwardBackward = 0;
         mTeleported = false;
         mAttackingOrSpell = false;
+        mJumping = false;
         mCurrentCrimeId = -1;
         mPaidCrimeId = -1;
         mPreviousItems.clear();

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -56,6 +56,7 @@ namespace MWWorld
         MWMechanics::AttributeValue mSaveAttributes[ESM::Attribute::Length];
 
         bool mAttackingOrSpell;
+        bool mJumping;
 
     public:
 
@@ -110,6 +111,9 @@ namespace MWWorld
 
         void setAttackingOrSpell(bool attackingOrSpell);
         bool getAttackingOrSpell() const;
+
+        void setJumping(bool jumping);
+        bool getJumping() const;
 
         ///Checks all nearby actors to see if anyone has an aipackage against you
         bool isInCombat();


### PR DESCRIPTION
Fixes [bug #4641](https://gitlab.com/OpenMW/openmw/issues/4641).
The main idea:
1. Add a flag to player.
2. Make GetPCJumping check this flag.
3. Set the flag to true when player starts jumping (when we train acrobatics).
4. Set flag to false after landing. Unfortunately, I can not do it inside creatureStats - it does not contain a pointer to actor, so I had to add a parameter to land() function.

When this PR is used with #1794, it allows to fix player position and animation during scenic travel in Abot's Gondoliers mod. Unfortunately, gondoliers are still twitchy a bit.