### PR TITLE
Make underwater SFX always apply based on camera position (bug #4532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
     Bug #4531: Movement does not reset idle animations
+    Bug #4532: Underwater sfx isn't tied to 3rd person camera
     Bug #4539: Paper Doll is affected by GUI scaling
     Bug #4543: Picking cursed items through inventory (menumode) makes it disappear
     Bug #4545: Creatures flee from werewolves

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1789,7 +1789,7 @@ namespace MWWorld
         osg::Vec3f forward = listenerOrient * osg::Vec3f(0,1,0);
         osg::Vec3f up = listenerOrient * osg::Vec3f(0,0,1);
 
-        bool underwater = isUnderwater(getPlayerPtr().getCell(), listenerPos);
+        bool underwater = isUnderwater(getPlayerPtr().getCell(), mRendering->getCameraPosition());
 
         MWBase::Environment::get().getSoundManager()->setListenerPosDir(listenerPos, forward, up, underwater);
     }


### PR DESCRIPTION
[Bug 4532](https://gitlab.com/OpenMW/openmw/issues/4532).

Make underwater state for sound listener be determined based on camera position and not the position of the listener itself, so that underwater SFX can be applied when the camera and not the listener (player) is underwater, like in Morrowind. Nothing else has been changed.