### PR TITLE
Take in account transformations of NiTriShape and NiSkinData in skinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
     Bug #4431: "Lock 0" console command is a no-op
     Bug #4432: Guards behaviour is incorrect if they do not have AI packages
     Bug #4433: Guard behaviour is incorrect with Alarm = 0
+    Bug #4437: Transformations for NiSkinInstance are ignored
     Bug #4451: Script fails to compile when using "Begin, [ScriptName]" syntax
     Bug #4452: Default terrain texture bleeds through texture transitions
     Bug #4453: Quick keys behaviour is invalid for equipment

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1082,7 +1082,10 @@ namespace NifOsg
             // Assign bone weights
             osg::ref_ptr<SceneUtil::RigGeometry::InfluenceMap> map (new SceneUtil::RigGeometry::InfluenceMap);
 
+            // We should take in account transformation of NiTriShape and NiSkinData
             const Nif::NiSkinData *data = skin->data.getPtr();
+            osg::Matrixf shapeTransforms = triShape->trafo.toMatrix() * data->trafo.toMatrix();
+
             const Nif::NodeList &bones = skin->bones;
             for(size_t i = 0;i < bones.length();i++)
             {
@@ -1096,11 +1099,12 @@ namespace NifOsg
                     influence.mWeights.insert(indexWeight);
                 }
                 influence.mInvBindMatrix = data->bones[i].trafo.toMatrix();
-                influence.mBoundSphere = osg::BoundingSpheref(data->bones[i].boundSphereCenter, data->bones[i].boundSphereRadius);
+                influence.mBoundSphere = osg::BoundingSpheref(shapeTransforms * data->bones[i].boundSphereCenter, data->bones[i].boundSphereRadius);
 
                 map->mMap.insert(std::make_pair(boneName, influence));
             }
             rig->setInfluenceMap(map);
+            rig->setRigTransforms(*&shapeTransforms);
 
             parentNode->addChild(rig);
         }

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -49,6 +49,7 @@ RigGeometry::RigGeometry(const RigGeometry &copy, const osg::CopyOp &copyop)
     : Drawable(copy, copyop)
     , mSkeleton(NULL)
     , mInfluenceMap(copy.mInfluenceMap)
+    , mRigTransforms(copy.mRigTransforms)
     , mLastFrameNumber(0)
     , mBoundsFirstFrame(true)
 {
@@ -214,6 +215,9 @@ void RigGeometry::cull(osg::NodeVisitor* nv)
         if (mGeomToSkelMatrix)
             resultMat *= (*mGeomToSkelMatrix);
 
+        if (!mRigTransforms.isIdentity())
+            resultMat *= mRigTransforms;
+
         for (auto &vertex : pair.second)
         {
             (*positionDst)[vertex] = resultMat.preMult((*positionSrc)[vertex]);
@@ -307,6 +311,11 @@ void RigGeometry::updateGeomToSkelMatrix(const osg::NodePath& nodePath)
 void RigGeometry::setInfluenceMap(osg::ref_ptr<InfluenceMap> influenceMap)
 {
     mInfluenceMap = influenceMap;
+}
+
+void RigGeometry::setRigTransforms(osg::Matrixf& transform)
+{
+    mRigTransforms = transform;
 }
 
 void RigGeometry::accept(osg::NodeVisitor &nv)

--- a/components/sceneutil/riggeometry.hpp
+++ b/components/sceneutil/riggeometry.hpp
@@ -40,6 +40,7 @@ namespace SceneUtil
         };
 
         void setInfluenceMap(osg::ref_ptr<InfluenceMap> influenceMap);
+        void setRigTransforms(osg::Matrixf& transform);
 
         /// Initialize this geometry from the source geometry.
         /// @note The source geometry will not be modified.
@@ -65,6 +66,7 @@ namespace SceneUtil
         osg::ref_ptr<osg::RefMatrix> mGeomToSkelMatrix;
 
         osg::ref_ptr<InfluenceMap> mInfluenceMap;
+        osg::Matrixf mRigTransforms;
 
         typedef std::pair<Bone*, osg::Matrixf> BoneBindMatrixPair;
 


### PR DESCRIPTION
Fixes [bug #4437](https://gitlab.com/OpenMW/openmw/issues/4437).
Now Abot's Boats should be compatible with OpenMW.