### PR TITLE
[Regression] Do not use book fonts for dialogue window

### DIFF
--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -264,29 +264,24 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
     {
     }
 
-    Style * createStyle (const std::string& fontName, const Colour& fontColour)
+    Style * createStyle (const std::string& fontName, const Colour& fontColour, bool useBookFont)
     {
-        const std::string templateName = "Journalbook ";
-        std::string bookFont;
+        std::string fullFontName;
         if (fontName.empty())
-        {
-            bookFont = MyGUI::FontManager::getInstance().getDefaultFont();
-            bookFont = templateName + bookFont;
-            return createStyle(bookFont, fontColour);
-        }
-
-        if (fontName.compare(0, templateName.size(), templateName) == 0)
-            bookFont = fontName;
+            fullFontName = MyGUI::FontManager::getInstance().getDefaultFont();
         else
-            bookFont = templateName + bookFont;
+            fullFontName = fontName;
+
+        if (useBookFont)
+            fullFontName = "Journalbook " + fullFontName;
 
         for (Styles::iterator i = mBook->mStyles.begin (); i != mBook->mStyles.end (); ++i)
-            if (i->match (bookFont.c_str(), fontColour, fontColour, fontColour, 0))
+            if (i->match (fullFontName.c_str(), fontColour, fontColour, fontColour, 0))
                 return &*i;
 
-        MyGUI::IFont* font = MyGUI::FontManager::getInstance().getByName(bookFont);
+        MyGUI::IFont* font = MyGUI::FontManager::getInstance().getByName(fullFontName);
         if (!font)
-            throw std::runtime_error(std::string("can't find font ") + bookFont);
+            throw std::runtime_error(std::string("can't find font ") + fullFontName);
 
         StyleImpl & style = *mBook->mStyles.insert (mBook->mStyles.end (), StyleImpl ());
         style.mFont = font;

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -102,7 +102,7 @@ namespace MWGui
         static Ptr create (int pageWidth, int pageHeight);
 
         /// Create a simple text style consisting of a font and a text color.
-        virtual Style* createStyle (const std::string& fontName, const Colour& colour) = 0;
+        virtual Style* createStyle (const std::string& fontName, const Colour& colour, bool useBookFont=true) = 0;
 
         /// Create a hyper-link style with a user-defined identifier based on an
         /// existing style. The unique flag forces a new instance of this style

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -137,7 +137,7 @@ namespace MWGui
         if (mTitle != "")
         {
             const MyGUI::Colour& headerColour = MWBase::Environment::get().getWindowManager()->getTextColours().header;
-            BookTypesetter::Style* title = typesetter->createStyle("", headerColour);
+            BookTypesetter::Style* title = typesetter->createStyle("", headerColour, false);
             typesetter->write(title, to_utf8_span(mTitle.c_str()));
             typesetter->sectionBreak();
         }
@@ -182,7 +182,7 @@ namespace MWGui
         {
             const TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
 
-            BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal);
+            BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal, false);
             size_t formatted = 0; // points to the first character that is not laid out yet
             for (std::map<Range, intptr_t>::iterator it = hyperLinks.begin(); it != hyperLinks.end(); ++it)
             {
@@ -223,7 +223,7 @@ namespace MWGui
     {
         const TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
 
-        BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal);
+        BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal, false);
 
 
         if (topicId)
@@ -239,7 +239,7 @@ namespace MWGui
     void Message::write(BookTypesetter::Ptr typesetter, KeywordSearchT* keywordSearch, std::map<std::string, Link*>& topicLinks) const
     {
         const MyGUI::Colour& textColour = MWBase::Environment::get().getWindowManager()->getTextColours().notify;
-        BookTypesetter::Style* title = typesetter->createStyle("", textColour);
+        BookTypesetter::Style* title = typesetter->createStyle("", textColour, false);
         typesetter->sectionBreak(9);
         typesetter->write(title, to_utf8_span(mText.c_str()));
     }
@@ -567,7 +567,7 @@ namespace MWGui
             (*it)->write(typesetter, &mKeywordSearch, mTopicLinks);
 
 
-        BookTypesetter::Style* body = typesetter->createStyle("", MyGUI::Colour::White);
+        BookTypesetter::Style* body = typesetter->createStyle("", MyGUI::Colour::White, false);
 
         typesetter->sectionBreak(9);
         // choices

--- a/apps/openmw/mwgui/formatting.hpp
+++ b/apps/openmw/mwgui/formatting.hpp
@@ -14,7 +14,7 @@ namespace MWGui
         {
             TextStyle() :
                 mColour(0,0,0)
-                , mFont("")
+                , mFont("Journalbook Magic Cards")
                 , mTextSize(16)
             {
             }


### PR DESCRIPTION
Fixes a small bug in the new font scaling system.
For now we use "book" fonts (fonts, scaled for JournalBook widget) for dialogue window too since it uses the same code as the JournalBook widget. As a result, dialogue window output looks slightly different from as it supposed to be.

Added an argument to createStyle() function to control if there is a need to use a "book" font or a common one.