### PR TITLE
Improve optional tooltips output

### DIFF
--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -161,7 +161,12 @@ namespace MWClass
         std::string text;
 
         if (Settings::Manager::getBool("show effect duration","Game"))
-            text += "\n#{sDuration}: " + MWGui::ToolTips::toString(ptr.getClass().getRemainingUsageTime(ptr));
+        {
+            // -1 is infinite light source, so duration makes no sense here. Other negative values are treated as 0.
+            float remainingTime = ptr.getClass().getRemainingUsageTime(ptr);
+            if (remainingTime != -1.0f)
+                text += "\n#{sDuration}: " + MWGui::ToolTips::toString(std::max(0.f, remainingTime));
+        }
 
         text += MWGui::ToolTips::getWeightString(ref->mBase->mData.mWeight, "#{sWeight}");
         text += MWGui::ToolTips::getValueString(ref->mBase->mData.mValue, "#{sValue}");

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -65,7 +65,7 @@ namespace MWClass
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
 
-        return (ref->mBase->mData.mType < 11); // thrown weapons and arrows/bolts don't have health, only quantity
+        return (ref->mBase->mData.mType < ESM::Weapon::MarksmanThrown); // thrown weapons and arrows/bolts don't have health, only quantity
     }
 
     int Weapon::getItemMaxHealth (const MWWorld::ConstPtr& ptr) const
@@ -318,21 +318,26 @@ namespace MWClass
             }
         }
 
-        if (ref->mBase->mData.mType < 11) // thrown weapons and arrows/bolts don't have health, only quantity
+        if (hasItemHealth(ptr))
         {
             int remainingHealth = getItemHealth(ptr);
             text += "\n#{sCondition}: " + MWGui::ToolTips::toString(remainingHealth) + "/"
                     + MWGui::ToolTips::toString(ref->mBase->mData.mHealth);
         }
 
-        // add reach and attack speed for melee weapon
-        if (ref->mBase->mData.mType < 9 && Settings::Manager::getBool("show melee info", "Game"))
+        const bool verbose = Settings::Manager::getBool("show melee info", "Game");
+        // add reach for melee weapon
+        if (ref->mBase->mData.mType < ESM::Weapon::MarksmanBow && verbose)
         {
             // 64 game units = 1 yard = 3 ft, display value in feet
             const float combatDistance = store.get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat() * ref->mBase->mData.mReach;
             text += MWGui::ToolTips::getWeightString(combatDistance*3/64, "#{sRange}");
             text += " #{sFeet}";
+        }
 
+        // add attack speed for any weapon excepts arrows and bolts
+        if (ref->mBase->mData.mType < ESM::Weapon::Arrow && verbose)
+        {
             text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mSpeed, "#{sAttributeSpeed}");
         }
 

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -119,7 +119,7 @@ namespace MWMechanics
 
         rating *= getHitChance(actor, enemy, value) / 100.f;
 
-        if (weapon->mData.mType < ESM::Weapon::MarksmanBow)
+        if (weapon->mData.mType < ESM::Weapon::Arrow)
             rating *= weapon->mData.mSpeed;
 
         return rating * ratingMult;

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -36,7 +36,7 @@ show melee info
 :Range:		True/False
 :Default:	False
 
-If this setting is true, the reach and speed of melee weapons will show on their tooltip.
+If this setting is true, the reach and speed of weapons will show on their tooltip.
 
 This setting can only be configured by editing the settings configuration file.
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -188,7 +188,7 @@ show owned = 0
 # Show damage bonus of arrow and bolts.
 show projectile damage = false
 
-# Show additional melee weapon info: reach and attack speed
+# Show additional weapon info: reach and attack speed
 show melee info = false
 
 # Show success probability in self-enchant dialog


### PR DESCRIPTION
1. Since light sources with -1 Duration are infinite, there is no point to show -1 duration on tooltip.
Another negative values will be displayed as 0 (since we treat them as 0).
2. I figured out that ranged weapons have an attack speed too, but for now we display it only for melee weapons. Fixed, but I decided to do not rename setting.