### PR TITLE
Ignore the rest of the line after else operator (bug #3006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #2969: Scripted items can stack
     Bug #2987: Editor: some chance and AI data fields can overflow
+    Bug #3006: 'else if' operator breaks script compilation
     Bug #3282: Unintended behaviour when assigning F3 and Windows keys
     Bug #3623: Fix HiDPI on Windows
     Bug #3733: Normal maps are inverted on mirrored UVs

--- a/components/compiler/controlparser.cpp
+++ b/components/compiler/controlparser.cpp
@@ -179,6 +179,14 @@ namespace Compiler
             scanner.scan (mLineParser);
             return true;
         }
+        else if (mState==IfElseJunkState)
+        {
+            getErrorHandler().warning ("Ignoring extra text after else", loc);
+            SkipParser skip (getErrorHandler(), getContext());
+            scanner.scan (skip);
+            mState = IfElseBodyState;
+            return true;
+        }
 
         return Parser::parseName (name, loc, scanner);
     }
@@ -207,8 +215,7 @@ namespace Compiler
                 return true;
             }
         }
-        else if (mState==IfBodyState || mState==IfElseifBodyState || mState==IfElseBodyState ||
-            mState==IfElseJunkState)
+        else if (mState==IfBodyState || mState==IfElseifBodyState || mState==IfElseBodyState)
         {
             if (parseIfBody (keyword, loc, scanner))
                 return true;
@@ -217,6 +224,14 @@ namespace Compiler
         {
             if ( parseWhileBody (keyword, loc, scanner))
                 return true;
+        }
+        else if (mState==IfElseJunkState)
+        {
+            getErrorHandler().warning ("Ignoring extra text after else", loc);
+            SkipParser skip (getErrorHandler(), getContext());
+            scanner.scan (skip);
+            mState = IfElseBodyState;
+            return true;
         }
 
         return Parser::parseKeyword (keyword, loc, scanner);
@@ -250,8 +265,9 @@ namespace Compiler
                 default: ;
             }
         }
-        else if (code==Scanner::S_open && mState==IfElseJunkState)
+        else if (mState==IfElseJunkState)
         {
+            getErrorHandler().warning ("Ignoring extra text after else", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
             mState = IfElseBodyState;


### PR DESCRIPTION
[Bug 3006](https://gitlab.com/OpenMW/openmw/issues/3006)

TESCS compiler actually ignores literally anything put after else operator, so so should our compiler. I put in more handling of IfElseJunkState so that the rest of the line is ignored, like the original bytecode of such scripts demonstrates. This allows mods which erroneously use "else if" instead of "elseif" in some scripts such as Sotha Sil Expanded and Farmer's Mod to compile properly, albeit with a potential loss of functionality, replicating vanilla behavior.