### PR TITLE
Rework actors update

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -233,6 +233,10 @@ namespace MWBase
 
             virtual void castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell) = 0;
 
+            virtual void processChangedSettings (const std::set< std::pair<std::string, std::string> >& settings) = 0;
+
+            virtual float getActorsProcessingRange() const = 0;
+
             /// Check if the target actor was detected by an observer
             /// If the observer is a non-NPC, check all actors in AI processing distance as observers
             virtual bool isActorDetected(const MWWorld::Ptr& actor, const MWWorld::Ptr& observer) = 0;

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -302,6 +302,9 @@ namespace MWBase
 
             virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) = 0;
 
+            virtual void setActorCollisionMode(const MWWorld::Ptr& ptr, bool enabled) = 0;
+            virtual bool isActorCollisionEnabled(const MWWorld::Ptr& ptr) = 0;
+
             virtual bool toggleCollisionMode() = 0;
             ///< Toggle collision mode for player. If disabled player object should ignore
             /// collisions and gravity.

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -20,6 +20,7 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/soundmanager.hpp"
 #include "../mwbase/inputmanager.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 
 #include "confirmationdialog.hpp"
@@ -437,6 +438,7 @@ namespace MWGui
         MWBase::Environment::get().getSoundManager()->processChangedSettings(changed);
         MWBase::Environment::get().getWindowManager()->processChangedSettings(changed);
         MWBase::Environment::get().getInputManager()->processChangedSettings(changed);
+        MWBase::Environment::get().getMechanicsManager()->processChangedSettings(changed);
     }
 
     void SettingsWindow::onKeyboardSwitchClicked(MyGUI::Widget* _sender)

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -65,6 +65,9 @@ namespace MWMechanics
             /// paused we may want to do it manually (after equipping permanent enchantment)
             void updateMagicEffects (const MWWorld::Ptr& ptr);
 
+            void updateProcessingRange();
+            float getProcessingRange() const;
+
             void addActor (const MWWorld::Ptr& ptr, bool updateImmediately=false);
             ///< Register an actor for stats management
             ///
@@ -168,6 +171,7 @@ namespace MWMechanics
     private:
         PtrActorMap mActors;
         float mTimerDisposeSummonsCorpses;
+        float mActorsProcessingRange;
 
     };
 }

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -103,7 +103,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const ESM::Pathgr
     ESM::Position pos = actor.getRefData().getPosition(); //position of the actor
 
     /// Stops the actor when it gets too close to a unloaded cell
-    //... At current time, this test is unnecessary. AI shuts down when actor is more than 7168
+    //... At current time, this test is unnecessary. AI shuts down when actor is more than "actors processing range" setting value
     //... units from player, and exterior cells are 8192 units long and wide.
     //... But AI processing distance may increase in the future.
     if (isNearInactiveCell(pos))
@@ -354,7 +354,7 @@ bool MWMechanics::AiPackage::isNearInactiveCell(const ESM::Position& actorPos)
 
         // currently assumes 3 x 3 grid for exterior cells, with player at center cell.
         // ToDo: (Maybe) use "exterior cell load distance" setting to get count of actual active cells
-        // While AI Process distance is 7168, AI shuts down actors before they reach edges of 3 x 3 grid.
+        // AI shuts down actors before they reach edges of 3 x 3 grid.
         const float distanceFromEdge = 200.0;
         float minThreshold = (-1.0f * ESM::Land::REAL_SIZE) + distanceFromEdge;
         float maxThreshold = (2.0f * ESM::Land::REAL_SIZE) - distanceFromEdge;

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -3,8 +3,9 @@
 #include <components/esm/aisequence.hpp>
 #include <components/esm/loadcell.hpp>
 
-#include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
@@ -21,7 +22,8 @@ bool isWithinMaxRange(const osg::Vec3f& pos1, const osg::Vec3f& pos2)
     // Maximum travel distance for vanilla compatibility.
     // Was likely meant to prevent NPCs walking into non-loaded exterior cells, but for some reason is used in interior cells as well.
     // We can make this configurable at some point, but the default *must* be the below value. Anything else will break shoddily-written content (*cough* MW *cough*) in bizarre ways.
-    return (pos1 - pos2).length2() <= 7168*7168;
+    bool aiDistance = MWBase::Environment::get().getMechanicsManager()->getActorsProcessingRange();
+    return (pos1 - pos2).length2() <= aiDistance*aiDistance;
 }
 
 }

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -257,7 +257,7 @@ public:
 
     void updatePtr(const MWWorld::Ptr &ptr);
 
-    void update(float duration);
+    void update(float duration, bool animationOnly=false);
 
     void persistAnimationState();
     void unpersistAnimationState();
@@ -292,6 +292,7 @@ public:
     bool isTurning() const;
     bool isAttackingOrSpell() const;
 
+    void setVisibility(float visibility);
     void setAttackingOrSpell(bool attackingOrSpell);
     void castSpell(const std::string spellId, bool manualSpell=false);
     void setAIAttackType(const std::string& attackType);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -431,6 +431,25 @@ namespace MWMechanics
         mObjects.update(duration, paused);
     }
 
+    void MechanicsManager::processChangedSettings(const Settings::CategorySettingVector &changed)
+    {
+        for (Settings::CategorySettingVector::const_iterator it = changed.begin(); it != changed.end(); ++it)
+        {
+            if (it->first == "Game" && it->second == "actors processing range")
+            {
+                mActors.updateProcessingRange();
+
+                // Update mechanics for new processing range immediately
+                update(0.f, false);
+            }
+        }
+    }
+
+    float MechanicsManager::getActorsProcessingRange() const
+    {
+        return mActors.getProcessingRange();
+    }
+
     bool MechanicsManager::isActorDetected(const MWWorld::Ptr& actor, const MWWorld::Ptr& observer)
     {
         return mActors.isActorDetected(actor, observer);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -1,6 +1,8 @@
 #ifndef GAME_MWMECHANICS_MECHANICSMANAGERIMP_H
 #define GAME_MWMECHANICS_MECHANICSMANAGERIMP_H
 
+#include <components/settings/settings.hpp>
+
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "../mwworld/ptr.hpp"
@@ -205,6 +207,10 @@ namespace MWMechanics
             virtual bool isAttackingOrSpell(const MWWorld::Ptr &ptr) const;
 
             virtual void castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell=false);
+
+            void processChangedSettings(const Settings::CategorySettingVector& settings) override;
+
+            virtual float getActorsProcessingRange() const;
 
             /// Check if the target actor was detected by an observer
             /// If the observer is a non-NPC, check all actors in AI processing distance as observers

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1366,6 +1366,33 @@ namespace MWPhysics
         return false;
     }
 
+    void PhysicsSystem::setActorCollisionMode(const MWWorld::Ptr& ptr, bool enabled)
+    {
+        ActorMap::iterator found = mActors.find(ptr);
+        if (found != mActors.end())
+        {
+            bool cmode = found->second->getCollisionMode();
+            if (cmode == enabled)
+                return;
+
+            cmode = enabled;
+            found->second->enableCollisionMode(cmode);
+            found->second->enableCollisionBody(cmode);
+        }
+    }
+
+    bool PhysicsSystem::isActorCollisionEnabled(const MWWorld::Ptr& ptr)
+    {
+        ActorMap::iterator found = mActors.find(ptr);
+        if (found != mActors.end())
+        {
+            bool cmode = found->second->getCollisionMode();
+            return cmode;
+        }
+
+        return false;
+    }
+
     void PhysicsSystem::queueObjectMovement(const MWWorld::Ptr &ptr, const osg::Vec3f &movement)
     {
         PtrVelocityList::iterator iter = mMovementQueue.begin();

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -86,6 +86,8 @@ namespace MWPhysics
             void removeHeightField (int x, int y);
 
             bool toggleCollisionMode();
+            bool isActorCollisionEnabled(const MWWorld::Ptr& ptr);
+            void setActorCollisionMode(const MWWorld::Ptr& ptr, bool enabled);
 
             void stepSimulation(float dt);
             void debugDraw();

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1748,21 +1748,31 @@ namespace MWRender
 
         if (alpha != 1.f)
         {
-            osg::StateSet* stateset (new osg::StateSet);
+            // If we have an existing material for alpha transparency, just override alpha level
+            osg::StateSet* stateset = mObjectRoot->getOrCreateStateSet();
+            osg::Material* material = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
+            if (material)
+            {
+                material->setAlpha(osg::Material::FRONT_AND_BACK, alpha);
+            }
+            else
+            {
+                osg::StateSet* stateset (new osg::StateSet);
 
-            osg::BlendFunc* blendfunc (new osg::BlendFunc);
-            stateset->setAttributeAndModes(blendfunc, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+                osg::BlendFunc* blendfunc (new osg::BlendFunc);
+                stateset->setAttributeAndModes(blendfunc, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
 
-            // FIXME: overriding diffuse/ambient/emissive colors
-            osg::Material* material (new osg::Material);
-            material->setColorMode(osg::Material::OFF);
-            material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,alpha));
-            material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
-            stateset->setAttributeAndModes(material, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+                // FIXME: overriding diffuse/ambient/emissive colors
+                material = new osg::Material;
+                material->setColorMode(osg::Material::OFF);
+                material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,alpha));
+                material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+                stateset->setAttributeAndModes(material, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
 
-            mObjectRoot->setStateSet(stateset);
+                mObjectRoot->setStateSet(stateset);
 
-            mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
+                mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
+            }
         }
         else
         {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1582,6 +1582,16 @@ namespace MWWorld
         }
     }
 
+    void World::setActorCollisionMode(const MWWorld::Ptr& ptr, bool enabled)
+    {
+        mPhysics->setActorCollisionMode(ptr, enabled);
+    }
+
+    bool World::isActorCollisionEnabled(const MWWorld::Ptr& ptr)
+    {
+        return mPhysics->isActorCollisionEnabled(ptr);
+    }
+
     bool World::toggleCollisionMode()
     {
         if (mPhysics->toggleCollisionMode())
@@ -3559,7 +3569,13 @@ namespace MWWorld
             MWBase::Environment::get().getMechanicsManager()->getObjectsInRange(
                         origin, feetToGameUnits(static_cast<float>(effectIt->mArea)), objects);
             for (std::vector<MWWorld::Ptr>::iterator affected = objects.begin(); affected != objects.end(); ++affected)
+            {
+                // Ignore actors without collisions here, otherwise it will be possible to hit actors outside processing range.
+                if (affected->getClass().isActor() && !isActorCollisionEnabled(*affected))
+                    continue;
+
                 toApply[*affected].push_back(*effectIt);
+            }
         }
 
         // Now apply the appropriate effects to each actor in range

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -407,6 +407,9 @@ namespace MWWorld
 
             bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
 
+            void setActorCollisionMode(const Ptr& ptr, bool enabled) override;
+            bool isActorCollisionEnabled(const Ptr& ptr) override;
+
             bool toggleCollisionMode() override;
             ///< Toggle collision mode for player. If disabled player object should ignore
             /// collisions and gravity.

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -97,8 +97,21 @@ and values above 500 will result in the player inflicting no damage.
 
 This setting can be controlled in game with the Difficulty slider in the Prefs panel of the Options menu.
 
+actors processing range
+-----------------------
+
+:Type:		integer
+:Range:		3584 to 7168
+:Default:	7168
+
+This setting allows to specify a distance from player in game units, in which OpenMW updates actor's state.
+Actor state update includes AI, animations, and physics processing.
+Actors near that border start softly fade out instead of just appearing/disapperaing.
+
+This setting can be controlled in game with the "Actors processing range slider" in the Prefs panel of the Options menu.
+
 classic reflected absorb spells behavior
------------------------------------------
+----------------------------------------
 
 :Type:		boolean
 :Range: 	True/False

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -73,7 +73,32 @@
                         <Property key="TextAlign" value="Right"/>
                     </Widget>
                 </Widget>
-                <Widget type="HBox" skin="" position="4 200 260 24">
+                <Widget type="Widget" skin="" position="4 184 352 54" align="Left Top HStretch">
+                    <Widget type="TextBox" skin="NormalText" position="0 0 352 16" align="Left Top" name="ActorProcessingText">
+                        <Property key="Caption" value="Actors processing range"/>
+                    </Widget>
+                    <Widget type="MWScrollBar" skin="MW_HScroll" position="0 20 352 14" align="Left Top HStretch">
+                        <Property key="Range" value="3584"/>
+                        <Property key="Page" value="300"/>
+                        <UserString key="SettingType" value="Slider"/>
+                        <UserString key="SettingCategory" value="Game"/>
+                        <UserString key="SettingName" value="actors processing range"/>
+                        <UserString key="SettingValueType" value="Float"/>
+                        <UserString key="SettingMin" value="3584"/>
+                        <UserString key="SettingMax" value="7168"/>
+                        <UserString key="SettingLabelWidget" value="ActorProcessingText"/>
+                        <UserString key="SettingLabelCaption" value="Actors processing range"/>
+                    </Widget>
+                    <Widget type="TextBox" skin="SandText" position="0 38 352 16" align="Left Top">
+                        <Property key="Caption" value="#{sLow}"/>
+                        <Property key="TextAlign" value="Left"/>
+                    </Widget>
+                    <Widget type="TextBox" skin="SandText" position="0 38 352 16" align="Right Top">
+                        <Property key="Caption" value="#{sHigh}"/>
+                        <Property key="TextAlign" value="Right"/>
+                    </Widget>
+                </Widget>
+                <Widget type="HBox" skin="" position="4 250 260 24">
                     <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top">
                         <UserString key="SettingCategory" value="Saves"/>
                         <UserString key="SettingName" value="autosave"/>
@@ -83,7 +108,7 @@
                         <Property key="Caption" value="#{sQuick_Save}"/>
                     </Widget>
                 </Widget>
-                <Widget type="HBox" skin="" position="4 230 260 24">
+                <Widget type="HBox" skin="" position="4 280 260 24">
                     <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top">
                         <UserString key="SettingCategory" value="Game"/>
                         <UserString key="SettingName" value="best attack"/>
@@ -93,7 +118,7 @@
                         <Property key="Caption" value="#{sBestAttack}"/>
                     </Widget>
                 </Widget>
-                <Widget type="HBox" skin="" position="4 260 260 24">
+                <Widget type="HBox" skin="" position="4 310 260 24">
                     <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top">
                         <UserString key="SettingCategory" value="GUI"/>
                         <UserString key="SettingName" value="subtitles"/>
@@ -103,7 +128,7 @@
                         <Property key="Caption" value="#{sSubtitles}"/>
                     </Widget>
                 </Widget>
-                <Widget type="HBox" skin="" position="4 290 260 24">
+                <Widget type="HBox" skin="" position="4 340 260 24">
                     <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top">
                         <UserString key="SettingCategory" value="HUD"/>
                         <UserString key="SettingName" value="crosshair"/>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -200,6 +200,9 @@ best attack = false
 # Difficulty.  Expressed as damage dealt and received. (e.g. -100 to 100).
 difficulty = 0
 
+# The maximum range of actor AI, animations and physics updates.
+actors processing range = 7168
+
 # Make reflected Absorb spells have no practical effect, like in Morrowind.
 classic reflected absorb spells behavior = true
 


### PR DESCRIPTION
Related to [bug #4647](https://gitlab.com/OpenMW/openmw/issues/4647).
Do we really need to render all actors in scene indifferently from distance, and for flying creatures update physics too?

I tried to do not render actors outside of AI processing range, and here is result of my experiments.
Comparison in Caldera on i7-7700, with processing distance 7168:

|ECLD| Master  |   PR  |
|---| ------------- | ------------- |
|4| 15 FPS | 40 FPS |
|3| 30 FPS | 65 FPS |
|2| 65 FPS | 95 FPS |
|1| 110 FPS | 120 FPS |

ECLD is an "exterior cell loading distance".

For now amount of changes in this PR:
1. De-hardcode actor's processing range (including AI, animations and physics stuff)
Note: we handle scripts and stats (drowning, rest and magic effects, for example) outside of this range.
2. Hide actors outside that distance. Flying actors too, instead of animating them and updating physics for them indifferently from distance.
3. Apply alpha to actors near that border instead of just make them appear/disappear.

Can anyone test how it affects performance?
Also I wonder if we can apply fog for actors near processing border.
@AnyOldName3, @wareya, what do you think?

Additionally we can implement a dithering shader rather than just apply alpha, but it is out of my skills.