### PR TITLE
Optimize AI update loop

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1303,6 +1303,16 @@ namespace MWMechanics
 
             std::map<const MWWorld::Ptr, const std::set<MWWorld::Ptr> > cachedAllies; // will be filled as engageCombat iterates
 
+            bool aiActive = MWBase::Environment::get().getMechanicsManager()->isAIActive();
+            int attackedByPlayerId = player.getClass().getCreatureStats(player).getHitAttemptActorId();
+            if (attackedByPlayerId != -1)
+            {
+                const MWWorld::Ptr playerHitAttemptActor = MWBase::Environment::get().getWorld()->searchPtrViaActorId(attackedByPlayerId);
+
+                if (!playerHitAttemptActor.isInCell())
+                    player.getClass().getCreatureStats(player).setHitAttemptActorId(-1);
+            }
+
              // AI and magic effects update
             for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
             {
@@ -1328,11 +1338,6 @@ namespace MWMechanics
                         player.getClass().getCreatureStats(player).setHitAttemptActorId(-1);
                 }
 
-                const MWWorld::Ptr playerHitAttemptActor = MWBase::Environment::get().getWorld()->searchPtrViaActorId(player.getClass().getCreatureStats(player).getHitAttemptActorId());
-
-                if (!playerHitAttemptActor.isInCell())
-                    player.getClass().getCreatureStats(player).setHitAttemptActorId(-1);
-
                 if (!iter->first.getClass().getCreatureStats(iter->first).isDead())
                 {
                     bool cellChanged = MWBase::Environment::get().getWorld()->hasCellChanged();
@@ -1343,7 +1348,7 @@ namespace MWMechanics
                         return; // for now abort update of the old cell when cell changes by teleportation magic effect
                                 // a better solution might be to apply cell changes at the end of the frame
                     }
-                    if (MWBase::Environment::get().getMechanicsManager()->isAIActive() && inProcessingRange)
+                    if (aiActive && inProcessingRange)
                     {
                         if (timerUpdateAITargets == 0)
                         {

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1301,6 +1301,7 @@ namespace MWMechanics
             bool showTorches = MWBase::Environment::get().getWorld()->useTorches();
 
             MWWorld::Ptr player = getPlayer();
+            const osg::Vec3f playerPos = player.getRefData().getPosition().asVec3();
 
             /// \todo move update logic to Actor class where appropriate
 
@@ -1321,7 +1322,7 @@ namespace MWMechanics
             {
                 bool isPlayer = iter->first == player;
 
-                float distSqr = (player.getRefData().getPosition().asVec3() - iter->first.getRefData().getPosition().asVec3()).length2();
+                float distSqr = (playerPos - iter->first.getRefData().getPosition().asVec3()).length2();
                 // AI processing is only done within distance of 7168 units to the player. Note the "AI distance" slider doesn't affect this
                 // (it only does some throttling for targets beyond the "AI distance", so doesn't give any guarantees as to whether AI will be enabled or not)
                 // This distance could be made configurable later, but the setting must be marked with a big warning:
@@ -1431,7 +1432,7 @@ namespace MWMechanics
             for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
             {
                 const float animationDistance = aiProcessingDistance + 400; // Slightly larger than AI distance so there is time to switch back to the idle animation.
-                const float distSqr = (player.getRefData().getPosition().asVec3() - iter->first.getRefData().getPosition().asVec3()).length2();
+                const float distSqr = (playerPos - iter->first.getRefData().getPosition().asVec3()).length2();
                 bool isPlayer = iter->first == player;
                 bool inAnimationRange = isPlayer || (animationDistance == 0 || distSqr <= animationDistance*animationDistance);
                 int activeFlag = 1; // Can be changed back to '2' to keep updating bounding boxes off screen (more accurate, but slower)
@@ -1520,7 +1521,7 @@ namespace MWMechanics
                             continue;
 
                         // is the player in range and can they be detected
-                        if ((observer.getRefData().getPosition().asVec3() - player.getRefData().getPosition().asVec3()).length2() <= radius*radius
+                        if ((observer.getRefData().getPosition().asVec3() - playerPos).length2() <= radius*radius
                             && MWBase::Environment::get().getWorld()->getLOS(player, observer))
                         {
                             if (MWBase::Environment::get().getMechanicsManager()->awarenessCheck(player, observer))
@@ -1664,7 +1665,8 @@ namespace MWMechanics
     void Actors::rest(bool sleep)
     {
         float duration = 3600.f / MWBase::Environment::get().getWorld()->getTimeScaleFactor();
-        MWWorld::Ptr player = MWBase::Environment::get().getWorld()->getPlayerPtr();
+        const MWWorld::Ptr player = MWBase::Environment::get().getWorld()->getPlayerPtr();
+        const osg::Vec3f playerPos = player.getRefData().getPosition().asVec3();
 
         for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
         {
@@ -1674,7 +1676,7 @@ namespace MWMechanics
             restoreDynamicStats(iter->first, sleep);
 
             if ((!iter->first.getRefData().getBaseNode()) ||
-                    (player.getRefData().getPosition().asVec3() - iter->first.getRefData().getPosition().asVec3()).length2() > sqrAiProcessingDistance)
+                    (playerPos - iter->first.getRefData().getPosition().asVec3()).length2() > sqrAiProcessingDistance)
                 continue;
 
             adjustMagicEffects (iter->first);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -28,8 +28,6 @@ namespace MWMechanics
             void addBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);
             void removeBoundItem (const std::string& itemId, const MWWorld::Ptr& actor);
 
-            void updateNpc(const MWWorld::Ptr &ptr, float duration);
-
             void adjustMagicEffects (const MWWorld::Ptr& creature);
 
             void calculateDynamicStats (const MWWorld::Ptr& ptr);
@@ -39,7 +37,7 @@ namespace MWMechanics
 
             void calculateRestoration (const MWWorld::Ptr& ptr, float duration);
 
-            void updateDrowning (const MWWorld::Ptr& ptr, float duration);
+            void updateDrowning (const MWWorld::Ptr& ptr, float duration, bool isKnockedOut, bool isPlayer);
 
             void updateEquippedLight (const MWWorld::Ptr& ptr, float duration, bool mayEquip);
 


### PR DESCRIPTION
Difference especially noticable with increased "exterior cell loading distance".
Affected lines take a most of mechanics update time.

Also this code is a quite strange. As I understand, it supposed to reset the HitAttemptActorId for player, if target actor disappeared from cell for some reason. But we do not set HitAttemptActorId inside affected loop, only reset it, so there is no point to run this code for every actor in scene - it will use the same value or -1.
So run this check only once before AI update.

I decided to do not create a separate task since we already have one for AI optimization in 0.45 milestone.

Also this PR optimizes combat music update a bit.

A little performance comparison: time in milliseconds to update game mechanics (based on profilier output), compared with master on i7-7700 in Vivec:

exterior cell load distance = 4
Master: 12.5ms
PR: 3 ms

exterior cell load distance = 3
Master: 6ms
PR: 2ms

exterior cell load distance = 2
Master: 2ms
PR: 1ms

exterior cell load distance = 1
Master: 0.8ms
PR: 0.6ms