### PR TITLE
Handle current health level during levelup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
     Bug #4633: Sneaking stance affects speed even if the actor is not able to crouch
     Bug #4641: GetPCJumping is handled incorrectly
     Bug #4644: %Name should be available for all actors, not just for NPCs
+    Bug #4649: Levelup fully restores health
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1617: Editor: Enchantment effect record verifier
     Feature #1645: Casting effects from objects

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -298,7 +298,12 @@ void MWMechanics::NpcStats::levelUp()
     // "When you gain a level, in addition to increasing three primary attributes, your Health
     // will automatically increase by 10% of your Endurance attribute. If you increased Endurance this level,
     // the Health increase is calculated from the increased Endurance"
-    setHealth(getHealth().getBase() + endurance * gmst.find("fLevelUpHealthEndMult")->mValue.getFloat());
+    // Note: we should add bonus Health points to current level too.
+    float healthGain = endurance * gmst.find("fLevelUpHealthEndMult")->mValue.getFloat();
+    MWMechanics::DynamicStat<float> health(getHealth());
+    health.setBase(getHealth().getBase() + healthGain);
+    health.setCurrent(std::max(1.f, getHealth().getCurrent() + healthGain));
+    setHealth(health);
 
     setLevel(getLevel()+1);
 }


### PR DESCRIPTION
Fixes [bug #4649](https://gitlab.com/OpenMW/openmw/issues/4649).
The main idea is to calculate a health gain and apply it to base and current health separately.
Do not touch modifiers.