### PR TITLE
Fix issues with sun specularity (bug #4527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
     Bug #4503: Cast and ExplodeSpell commands increase alteration skill
     Bug #4510: Division by zero in MWMechanics::CreatureStats::setAttribute
     Bug #4519: Knockdown does not discard movement in the 1st-person mode
+    Bug #4527: Sun renders on water shader in some situations where it shouldn't
     Bug #4531: Movement does not reset idle animations
     Bug #4532: Underwater sfx isn't tied to 3rd person camera
     Bug #4539: Paper Doll is affected by GUI scaling

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -752,12 +752,15 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
     float underwaterFog = mUnderwaterFog.getValue(time.getHour(), mTimeSettings, "Fog");
 
     float peakHour = mSunriseTime + (mSunsetTime - mSunriseTime) / 2;
+    float glareFade = 1.f;
     if (time.getHour() < mSunriseTime || time.getHour() > mSunsetTime)
-        mRendering.getSkyManager()->setGlareTimeOfDayFade(0);
+        glareFade = 0.f;
     else if (time.getHour() < peakHour)
-        mRendering.getSkyManager()->setGlareTimeOfDayFade(1 - (peakHour - time.getHour()) / (peakHour - mSunriseTime));
+        glareFade -= (peakHour - time.getHour()) / (peakHour - mSunriseTime);
     else
-        mRendering.getSkyManager()->setGlareTimeOfDayFade(1 - (time.getHour() - peakHour) / (mSunsetTime - peakHour));
+        glareFade -= (time.getHour() - peakHour) / (mSunsetTime - peakHour);
+
+    mRendering.getSkyManager()->setGlareTimeOfDayFade(glareFade);
 
     mRendering.getSkyManager()->setMasserState(mMasser.calculateState(time));
     mRendering.getSkyManager()->setSecundaState(mSecunda.calculateState(time));
@@ -765,7 +768,7 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
     mRendering.configureFog(mResult.mFogDepth, underwaterFog, mResult.mDLFogFactor,
                             mResult.mDLFogOffset/100.0f, mResult.mFogColor);
     mRendering.setAmbientColour(mResult.mAmbientColor);
-    mRendering.setSunColour(mResult.mSunColor, mResult.mSunColor * mResult.mGlareView);
+    mRendering.setSunColour(mResult.mSunColor, mResult.mSunColor * mResult.mGlareView * glareFade);
 
     mRendering.getSkyManager()->setWeather(mResult);
 

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -751,14 +751,14 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
 
     float underwaterFog = mUnderwaterFog.getValue(time.getHour(), mTimeSettings, "Fog");
 
-    float peakHour = mSunriseTime + (mSunsetTime - mSunriseTime) / 2;
+    float peakHour = mSunriseTime + (mTimeSettings.mNightStart - mSunriseTime) / 2;
     float glareFade = 1.f;
-    if (time.getHour() < mSunriseTime || time.getHour() > mSunsetTime)
+    if (time.getHour() < mSunriseTime || time.getHour() > mTimeSettings.mNightStart)
         glareFade = 0.f;
     else if (time.getHour() < peakHour)
-        glareFade -= (peakHour - time.getHour()) / (peakHour - mSunriseTime);
+        glareFade = 1.f - (peakHour - time.getHour()) / (peakHour - mSunriseTime);
     else
-        glareFade -= (time.getHour() - peakHour) / (mSunsetTime - peakHour);
+        glareFade = 1.f - (time.getHour() - peakHour) / (mTimeSettings.mNightStart - peakHour);
 
     mRendering.getSkyManager()->setGlareTimeOfDayFade(glareFade);
 

--- a/files/shaders/water_fragment.glsl
+++ b/files/shaders/water_fragment.glsl
@@ -286,6 +286,6 @@ void main(void)
 #if REFRACTION
     gl_FragData[0].w = 1.0;
 #else
-    gl_FragData[0].w = clamp(fresnel*6.0 + specular, 0.0, 1.0);     //clamp(fresnel*2.0 + specular, 0.0, 1.0);
+    gl_FragData[0].w = clamp(fresnel*6.0 + specular * gl_LightSource[0].specular.w, 0.0, 1.0);     //clamp(fresnel*2.0 + specular * gl_LightSource[0].specular.w, 0.0, 1.0);
 #endif
 }


### PR DESCRIPTION
[Bug 4527](https://gitlab.com/OpenMW/openmw/issues/4527).

The idea of fixing the first subissue is applying time of day glare visibility to the sunlight specular color (not just the weather-dependent multiplier). This makes specular lighting change gradual depending on the difference of the current time and sun peak hour, and at nights it's completely disabled - granted it's not used for anything other than the sun, the directional light source, and no point light source has a specular color, and it's already disabled in rainy weather.

For the second subissue wareya's suggestion from the report was used; the shader was modified so that the specular uses the transparency of the sunlight like the color of the sunlight is used elsewhere in the shader.

Feedback would be appreciated.