### PR TITLE
Experimental animation regression fixes

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -353,7 +353,7 @@ void CharacterController::refreshHitRecoilAnims(CharacterState& idle)
 
 void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, CharacterState& movement, bool force)
 {
-    if (!force && jump == mJumpState && movement == CharState_None)
+    if (!force && jump == mJumpState && idle == CharState_None && movement == CharState_None)
         return;
 
     if (jump != JumpState_None)

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2168,12 +2168,12 @@ void CharacterController::update(float duration)
         if(mAnimQueue.empty() || inwater || sneak)
         {
             // Note: turning animations should not interrupt idle ones
-            if (inwater)
+            if (movestate != CharState_None && !isTurning())
+                idlestate = CharState_None;
+            else if (inwater)
                 idlestate = CharState_IdleSwim;
             else if (sneak && !inJump)
                 idlestate = CharState_IdleSneak;
-            else if (movestate != CharState_None && !isTurning())
-                idlestate = CharState_None;
             else
                 idlestate = CharState_Idle;
         }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -356,7 +356,7 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
     if (!force && jump == mJumpState && idle == CharState_None && movement == CharState_None)
         return;
 
-    if (jump != JumpState_None)
+    if (jump != JumpState_None && !(mPtr == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())) // FIXME
     {
         idle = CharState_None;
         movement = CharState_None;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -351,64 +351,69 @@ void CharacterController::refreshHitRecoilAnims(CharacterState& idle)
         idle = CharState_None;
 }
 
-void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, bool force)
+void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, CharacterState& movement, bool force)
 {
-    if(force || jump != mJumpState)
+    if (!force && jump == mJumpState && movement == CharState_None)
+        return;
+
+    if (jump != JumpState_None)
     {
-        if (jump != JumpState_None)
-            idle = CharState_None;
+        idle = CharState_None;
+        movement = CharState_None;
+    }
 
-        bool startAtLoop = (jump == mJumpState);
-        mJumpState = jump;
-
-        std::string jumpAnimName;
-        MWRender::Animation::BlendMask jumpmask = MWRender::Animation::BlendMask_All;
-        if(mJumpState != JumpState_None)
+    std::string jumpAnimName;
+    MWRender::Animation::BlendMask jumpmask = MWRender::Animation::BlendMask_All;
+    if (jump != JumpState_None)
+    {
+        jumpAnimName = "jump";
+        if(weap != sWeaponTypeListEnd)
         {
-            jumpAnimName = "jump";
-            if(weap != sWeaponTypeListEnd)
+            jumpAnimName += weap->shortgroup;
+            if(!mAnimation->hasAnimation(jumpAnimName))
             {
-                jumpAnimName += weap->shortgroup;
-                if(!mAnimation->hasAnimation(jumpAnimName))
-                {
-                    jumpmask = MWRender::Animation::BlendMask_LowerBody;
-                    jumpAnimName = "jump";
+                jumpmask = MWRender::Animation::BlendMask_LowerBody;
+                jumpAnimName = "jump";
 
-                    // Since we apply movement only for lower body, do not reset idle animations.
-                    // For upper body there will be idle animation.
-                    if (idle == CharState_None)
-                        idle = CharState_Idle;
+                // Since we apply movement only for lower body, do not reset idle animations.
+                // For upper body there will be idle animation.
+                if (idle == CharState_None)
+                    idle = CharState_Idle;
 
-                    // For crossbow animations use 1h ones as fallback
-                    if (mWeaponType == WeapType_Crossbow)
-                        jumpAnimName += "1h";
-                }
+                // For crossbow animations use 1h ones as fallback
+                if (mWeaponType == WeapType_Crossbow)
+                    jumpAnimName += "1h";
             }
         }
+    }
 
-        if (!mCurrentJump.empty())
-        {
-            mAnimation->disable(mCurrentJump);
-            mCurrentJump.clear();
-        }
+    if (!force && jump == mJumpState)
+        return;
 
-        if(mJumpState == JumpState_InAir)
+    mJumpState = jump;
+
+    if (!mCurrentJump.empty())
+    {
+        mAnimation->disable(mCurrentJump);
+        mCurrentJump.clear();
+    }
+
+    if(mJumpState == JumpState_InAir)
+    {
+        if (mAnimation->hasAnimation(jumpAnimName))
         {
-            if (mAnimation->hasAnimation(jumpAnimName))
-            {
-                mAnimation->play(jumpAnimName, Priority_Jump, jumpmask, false,
-                             1.0f, (startAtLoop?"loop start":"start"), "stop", 0.0f, ~0ul);
-                mCurrentJump = jumpAnimName;
-            }
+            mAnimation->play(jumpAnimName, Priority_Jump, jumpmask, false,
+                         1.0f, "start", "stop", 0.f, ~0ul);
+            mCurrentJump = jumpAnimName;
         }
-        else if (mJumpState == JumpState_Landing)
+    }
+    else if (mJumpState == JumpState_Landing)
+    {
+        if (mAnimation->hasAnimation(jumpAnimName))
         {
-             if (mAnimation->hasAnimation(jumpAnimName))
-             {
-                mAnimation->play(jumpAnimName, Priority_Jump, jumpmask, true,
-                             1.0f, "loop stop", "stop", 0.0f, 0);
-                mCurrentJump = jumpAnimName;
-            }
+            mAnimation->play(jumpAnimName, Priority_Jump, jumpmask, true,
+                         1.0f, "loop stop", "stop", 0.0f, 0);
+            mCurrentJump = jumpAnimName;
         }
     }
 }
@@ -494,10 +499,9 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
         }
 
         // If we're playing the same animation, start it from the point it ended
-        bool sameAnim = (movementAnimName == mCurrentMovement);
-        float startPoint = 0.f;
-        if (sameAnim)
-            mAnimation->getInfo(mCurrentMovement, &startPoint);
+        float startpoint = 0.f;
+        if (!mCurrentMovement.empty() && movementAnimName == mCurrentMovement)
+            mAnimation->getInfo(mCurrentMovement, &startpoint);
 
         mMovementAnimationControlled = true;
 
@@ -546,7 +550,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
             }
 
             mAnimation->play(mCurrentMovement, Priority_Movement, movemask, false,
-                             1.f, (!sameAnim ? "start" : "loop start"), "stop", startPoint, ~0ul, true);
+                             1.f, "start", "stop", startpoint, ~0ul, true);
         }
     }
 }
@@ -626,7 +630,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
     if (!mPtr.getClass().hasInventoryStore(mPtr))
         weap = sWeaponTypeListEnd;
 
-    refreshJumpAnims(weap, jump, idle, force);
+    refreshJumpAnims(weap, jump, idle, movement, force);
     refreshMovementAnims(weap, movement, idle, force);
 
     // idle handled last as it can depend on the other states

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -214,7 +214,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
 
     void refreshCurrentAnims(CharacterState idle, CharacterState movement, JumpingState jump, bool force=false);
     void refreshHitRecoilAnims(CharacterState& idle);
-    void refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, bool force=false);
+    void refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, CharacterState& movement, bool force=false);
     void refreshMovementAnims(const WeaponInfo* weap, CharacterState movement, CharacterState& idle, bool force=false);
     void refreshIdleAnims(const WeaponInfo* weap, CharacterState idle, bool force=false);
 


### PR DESCRIPTION
This resolves some of the less severe issues that I've seen happening in the development code.

1. Try to change to spellcasting stance when the running animation has just started (hasn't got to the loop start point). The animation will be visually reset. Specifically, it's reset to the loop start key, because it's the same animation. But as far as I can tell we don't need to do it, because openmw already loops the animations at the correct keys. This is more of an addition to #1792.
2. Try to jump while running, land, and continue to run. The running animation will start from the wrong point. This happens because technically it starts exactly when the player lands, but the landing animation has higher priority (see #1666), so the running animation can only start when it ends. The idea is to reset the movement change in refreshJumpAnims like we do with the idle animations if the character is still jumping. This makes it somewhat more obvious that the character is sliding along the ground in the landing animation while moving, but I still suppose akortunov had to go with the lesser evil for this one.

Neither of these issues appear in 0.44.0, but they were in the code at that point and they became uncovered by the earlier animation fixes of 0.45.0. These are called experimental for a reason, so testing and feedback would be appreciated.