### PR TITLE
Restore dynamic stats for actors in inactive cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.45.0
 ------
 
+    Bug #1875: Actors in inactive cells don't heal from resting
     Bug #1990: Sunrise/sunset not set correct
     Bug #2131: Lustidrike's spell misses the player every time
     Bug #2222: Fatigue's effect on selling price is backwards

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -90,6 +90,8 @@ namespace MWBase
             virtual void setPlayerClass (const ESM::Class& class_) = 0;
             ///< Set player class to custom class.
 
+            virtual void restoreDynamicStats(MWWorld::Ptr actor, bool sleep) = 0;
+
             virtual void rest(bool sleep) = 0;
             ///< If the player is sleeping or waiting, this should be called every hour.
             /// @param sleep is the player sleeping or waiting?

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -571,6 +571,8 @@ namespace MWBase
 
             virtual bool isPlayerInJail() const = 0;
 
+            virtual void rest() = 0;
+
             virtual void setPlayerTraveling(bool traveling) = 0;
             virtual bool isPlayerTraveling() const = 0;
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -453,7 +453,15 @@ namespace MWMechanics
 
     void MechanicsManager::rest(bool sleep)
     {
+        if (sleep)
+            MWBase::Environment::get().getWorld()->rest();
+
         mActors.rest(sleep);
+    }
+
+    void MechanicsManager::restoreDynamicStats(MWWorld::Ptr actor, bool sleep)
+    {
+        mActors.restoreDynamicStats(actor, sleep);
     }
 
     int MechanicsManager::getHoursToRest() const

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -91,6 +91,8 @@ namespace MWMechanics
             virtual void setPlayerClass (const ESM::Class& class_);
             ///< Set player class to custom class.
 
+            virtual void restoreDynamicStats(MWWorld::Ptr actor, bool sleep);
+
             virtual void rest(bool sleep);
             ///< If the player is sleeping or waiting, this should be called every hour.
             /// @param sleep is the player sleeping or waiting?

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -151,6 +151,19 @@ MWWorld::CellStore *MWWorld::Cells::getInterior (const std::string& name)
     return &result->second;
 }
 
+void MWWorld::Cells::rest ()
+{
+    for (auto &interior : mInteriors)
+    {
+        interior.second.rest();
+    }
+
+    for (auto &exterior : mExteriors)
+    {
+        exterior.second.rest();
+    }
+}
+
 MWWorld::CellStore *MWWorld::Cells::getCell (const ESM::CellId& id)
 {
     if (id.mPaged)

--- a/apps/openmw/mwworld/cells.hpp
+++ b/apps/openmw/mwworld/cells.hpp
@@ -61,6 +61,7 @@ namespace MWWorld
 
             /// @note name must be lower case
             Ptr getPtr (const std::string& name);
+            void rest ();
 
             /// Get all Ptrs referencing \a name in exterior cells
             /// @note Due to the current implementation of getPtr this only supports one Ptr per cell.

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -17,6 +17,7 @@
 #include <components/esm/doorstate.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 
 #include "../mwmechanics/creaturestats.hpp"
@@ -951,6 +952,29 @@ namespace MWWorld
             creatureStats.getTimeOfDeath() + fCorpseClearDelay <= MWBase::Environment::get().getWorld()->getTimeStamp())
         {
             MWBase::Environment::get().getWorld()->deleteObject(ptr);
+        }
+    }
+
+    void CellStore::rest()
+    {
+        if (mState == State_Loaded)
+        {
+            for (CellRefList<ESM::Creature>::List::iterator it (mCreatures.mList.begin()); it!=mCreatures.mList.end(); ++it)
+            {
+                Ptr ptr = getCurrentPtr(&*it);
+                if (!ptr.isEmpty() && ptr.getRefData().getCount() > 0)
+                {
+                    MWBase::Environment::get().getMechanicsManager()->restoreDynamicStats(ptr, true);
+                }
+            }
+            for (CellRefList<ESM::NPC>::List::iterator it (mNpcs.mList.begin()); it!=mNpcs.mList.end(); ++it)
+            {
+                Ptr ptr = getCurrentPtr(&*it);
+                if (!ptr.isEmpty() && ptr.getRefData().getCount() > 0)
+                {
+                    MWBase::Environment::get().getMechanicsManager()->restoreDynamicStats(ptr, true);
+                }
+            }
         }
     }
 

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -183,6 +183,8 @@ namespace MWWorld
             /// @return updated MWWorld::Ptr with the new CellStore pointer set.
             MWWorld::Ptr moveTo(const MWWorld::Ptr& object, MWWorld::CellStore* cellToMoveTo);
 
+            void rest();
+
             /// Make a copy of the given object and insert it into this cell.
             /// @note If you get a linker error here, this means the given type can not be inserted into a cell.
             /// The supported types are defined at the bottom of this file.

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3118,6 +3118,10 @@ namespace MWWorld
         return closestMarker;
     }
 
+    void World::rest()
+    {
+        mCells.rest();
+    }
 
     void World::teleportToClosestMarker (const MWWorld::Ptr& ptr,
                                           const std::string& id)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -552,11 +552,9 @@ namespace MWWorld
             void enableActorCollision(const MWWorld::Ptr& actor, bool enable) override;
 
             RestPermitted canRest() const override;
-            ///< check if the player is allowed to rest \n
-            /// 0 - yes \n
-            /// 1 - only waiting \n
-            /// 2 - player is underwater \n
-            /// 3 - enemies are nearby (not implemented)
+            ///< check if the player is allowed to rest
+
+            void rest() override;
 
             /// \todo Probably shouldn't be here
             MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;


### PR DESCRIPTION
Aimed to fix [bug #1875](https://gitlab.com/OpenMW/openmw/issues/1875).
I took code from respawn handling, and it seems it works.

But this code is a bit dirty yet - stats calculations are in Mechanics (Actors), but cells iteration is in World (Cells/Cellstore).

An approach is similar to vanilla: restore stats for actors in all loaded cells when sleeping, and restore fatigue for actors in active cells only when waiting.