### PR TITLE
Discard count arguments for AddSoulGem and RemoveSpell (bug #3762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     Bug #3591: Angled hit distance too low
     Bug #3629: DB assassin attack never triggers creature spawning
     Bug #3681: OpenMW-CS: Clicking Scripts in Preferences spawns many color pickers
+    Bug #3762: AddSoulGem and RemoveSpell redundant count arguments break script execution
     Bug #3788: GetPCInJail and GetPCTraveling do not work as in vanilla
     Bug #3836: Script fails to compile when command argument contains "\n"
     Bug #3876: Landscape texture painting is misaligned

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -276,7 +276,7 @@ namespace Compiler
             extensions.registerInstruction ("gotojail", "", opcodeGoToJail);
             extensions.registerFunction ("getlocked", 'l', "", opcodeGetLocked, opcodeGetLockedExplicit);
             extensions.registerFunction ("geteffect", 'l', "S", opcodeGetEffect, opcodeGetEffectExplicit);
-            extensions.registerInstruction ("addsoulgem", "cc", opcodeAddSoulGem, opcodeAddSoulGemExplicit);
+            extensions.registerInstruction ("addsoulgem", "ccz", opcodeAddSoulGem, opcodeAddSoulGemExplicit);
             extensions.registerInstruction ("removesoulgem", "c/l", opcodeRemoveSoulGem, opcodeRemoveSoulGemExplicit);
             extensions.registerInstruction ("drop", "cl", opcodeDrop, opcodeDropExplicit);
             extensions.registerInstruction ("dropsoulgem", "c", opcodeDropSoulGem, opcodeDropSoulGemExplicit);
@@ -463,7 +463,7 @@ namespace Compiler
             extensions.registerInstruction ("modpccrimelevel", "f", opcodeModPCCrimeLevel);
 
             extensions.registerInstruction ("addspell", "cz", opcodeAddSpell, opcodeAddSpellExplicit);
-            extensions.registerInstruction ("removespell", "c", opcodeRemoveSpell,
+            extensions.registerInstruction ("removespell", "cz", opcodeRemoveSpell,
                 opcodeRemoveSpellExplicit);
             extensions.registerInstruction ("removespelleffects", "c", opcodeRemoveSpellEffects,
                 opcodeRemoveSpellEffectsExplicit);


### PR DESCRIPTION
[Bug 3762](https://gitlab.com/OpenMW/openmw/issues/3762).

AddSoulGem can now handle an optional count argument which does nothing (like in Morrowind).
On a related note, RemoveSpell behavior was too strict and didn't allow to use a redundant count argument unlike AddSpell. This made many of [Magical Trinkets of Tamriel](http://mw.modhistory.com/download-48-6949) mod scripts unusable in OpenMW without modifying them.