### PR TITLE
Respect selected encoding in the content selector 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
     Bug #4460: Script function "Equip" doesn't bypass beast restrictions
     Bug #4461: "Open" spell from non-player caster isn't a crime
     Bug #4464: OpenMW keeps AiState cached storages even after we cancel AI packages
+    Bug #4467: Content selector: cyrillic characters are decoded incorrectly in plugin descriptions
     Bug #4469: Abot Silt Striders – Model turn 90 degrees on horizontal
     Bug #4470: Non-bipedal creatures with Weapon & Shield flag have inconsistent behaviour
     Bug #4474: No fallback when getVampireHead fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
     Bug #4644: %Name should be available for all actors, not just for NPCs
     Bug #4648: Hud thinks that throwing weapons have condition
     Bug #4649: Levelup fully restores health
+    Bug #4653: Length of non-ASCII strings is handled incorrectly in ESM reader
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1617: Editor: Enchantment effect record verifier
     Feature #1645: Casting effects from objects

--- a/apps/launcher/datafilespage.cpp
+++ b/apps/launcher/datafilespage.cpp
@@ -36,6 +36,8 @@ Launcher::DataFilesPage::DataFilesPage(Files::ConfigurationManager &cfg, Config:
     ui.setupUi (this);
     setObjectName ("DataFilesPage");
     mSelector = new ContentSelectorView::ContentSelector (ui.contentSelectorWidget);
+    const QString encoding = mGameSettings.value("encoding", "win1252");
+    mSelector->setEncoding(encoding);
 
     mProfileDialog = new TextInputDialog(tr("New Content List"), tr("Content List name:"), this);
 

--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -108,8 +108,9 @@ std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfi
 
     mCfgMgr.readConfiguration(variables, desc, quiet);
 
-    mDocumentManager.setEncoding (
-        ToUTF8::calculateEncoding (variables["encoding"].as<Files::EscapeHashString>().toStdString()));
+    const std::string encoding = variables["encoding"].as<Files::EscapeHashString>().toStdString();
+    mDocumentManager.setEncoding (ToUTF8::calculateEncoding (encoding));
+    mFileDialog.setEncoding (QString::fromUtf8(encoding.c_str()));
 
     mDocumentManager.setResourceDir (mResources = variables["resources"].as<Files::EscapeHashString>().toStdString());
 

--- a/apps/opencs/model/world/metadata.cpp
+++ b/apps/opencs/model/world/metadata.cpp
@@ -14,8 +14,8 @@ void CSMWorld::MetaData::blank()
 void CSMWorld::MetaData::load (ESM::ESMReader& esm)
 {
     mFormat = esm.getHeader().mFormat;
-    mAuthor = esm.getHeader().mData.author.toString();
-    mDescription = esm.getHeader().mData.desc.toString();
+    mAuthor = esm.getHeader().mData.author;
+    mDescription = esm.getHeader().mData.desc;
 }
 
 void CSMWorld::MetaData::save (ESM::ESMWriter& esm) const

--- a/apps/opencs/view/doc/filedialog.cpp
+++ b/apps/opencs/view/doc/filedialog.cpp
@@ -33,6 +33,11 @@ void CSVDoc::FileDialog::addFiles(const QString &path)
     mSelector->addFiles(path);
 }
 
+void CSVDoc::FileDialog::setEncoding(const QString &encoding)
+{
+    mSelector->setEncoding(encoding);
+}
+
 void CSVDoc::FileDialog::clearFiles()
 {
     mSelector->clearFiles();

--- a/apps/opencs/view/doc/filedialog.hpp
+++ b/apps/opencs/view/doc/filedialog.hpp
@@ -42,6 +42,7 @@ namespace CSVDoc
         void showDialog (ContentAction action);
 
         void addFiles (const QString &path);
+        void setEncoding (const QString &encoding);
         void clearFiles ();
 
         QString filename() const;

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -111,6 +111,11 @@ void ContentSelectorView::ContentSelector::clearCheckStates()
     mContentModel->uncheckAll();
 }
 
+void ContentSelectorView::ContentSelector::setEncoding(const QString &encoding)
+{
+    mContentModel->setEncoding(encoding);
+}
+
 void ContentSelectorView::ContentSelector::setContentList(const QStringList &list)
 {
     if (list.isEmpty())

--- a/components/contentselector/view/contentselector.hpp
+++ b/components/contentselector/view/contentselector.hpp
@@ -32,6 +32,7 @@ namespace ContentSelectorView
         void setProfileContent (const QStringList &fileList);
 
         void clearCheckStates();
+        void setEncoding (const QString &encoding);
         void setContentList(const QStringList &list);
 
         ContentSelectorModel::ContentFileList selectedFiles() const;

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -33,8 +33,8 @@ public:
   int getVer() const { return mHeader.mData.version; }
   int getRecordCount() const { return mHeader.mData.records; }
   float getFVer() const { return (mHeader.mData.version == VER_12) ? 1.2f : 1.3f; }
-  const std::string getAuthor() const { return mHeader.mData.author.toString(); }
-  const std::string getDesc() const { return mHeader.mData.desc.toString(); }
+  const std::string getAuthor() const { return mHeader.mData.author; }
+  const std::string getDesc() const { return mHeader.mData.desc; }
   const std::vector<Header::MasterData> &getGameFiles() const { return mHeader.mMaster; }
   const Header& getHeader() const { return mHeader; }
   int getFormat() const;

--- a/components/esm/loadtes3.cpp
+++ b/components/esm/loadtes3.cpp
@@ -32,8 +32,8 @@ void ESM::Header::load (ESMReader &esm)
       esm.getSubHeader();
       esm.getT(mData.version);
       esm.getT(mData.type);
-      mData.author.assign( esm.getString(mData.author.data_size()) );
-      mData.desc.assign( esm.getString(mData.desc.data_size()) );
+      mData.author.assign( esm.getString(32) );
+      mData.desc.assign( esm.getString(256) );
       esm.getT(mData.records);
     }
 
@@ -73,8 +73,8 @@ void ESM::Header::save (ESMWriter &esm)
     esm.startSubRecord("HEDR");
     esm.writeT(mData.version);
     esm.writeT(mData.type);
-    esm.writeFixedSizeString(mData.author.toString(), mData.author.data_size());
-    esm.writeFixedSizeString(mData.desc.toString(), mData.desc.data_size());
+    esm.writeFixedSizeString(mData.author, 32);
+    esm.writeFixedSizeString(mData.desc, 256);
     esm.writeT(mData.records);
     esm.endRecord("HEDR");
 

--- a/components/esm/loadtes3.hpp
+++ b/components/esm/loadtes3.hpp
@@ -21,8 +21,8 @@ namespace ESM
         */
         unsigned int version;
         int type;           // 0=esp, 1=esm, 32=ess (unused)
-        NAME32 author;      // Author's name
-        NAME256 desc;       // File description
+        std::string author; // Author's name
+        std::string desc;   // File description
         int records;        // Number of records
     };
 


### PR DESCRIPTION
Fixes [bug #4467](https://gitlab.com/OpenMW/openmw/issues/4467).
Works for both launcher and editor.

Also I found an additional issue: maximal length of plugin description is capped in OpenMW for some reason (150 characters), so OpenMW cut descriptions for some plugins (probably because we treat it as a column name in metadata table). @zinnschlag, is there any way to fix it?