### PR TITLE
Do not check owner during stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.45.0
 ------
 
+    Bug #1933: Actors can have few stocks of the same item
     Bug #1990: Sunrise/sunset not set correct
     Bug #2131: Lustidrike's spell misses the player every time
     Bug #2222: Fatigue's effect on selling price is backwards

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -241,7 +241,6 @@ bool MWWorld::ContainerStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2)
     }
 
     return ptr1 != ptr2 // an item never stacks onto itself
-        && ptr1.getCellRef().getOwner() == ptr2.getCellRef().getOwner()
         && ptr1.getCellRef().getSoul() == ptr2.getCellRef().getSoul()
 
         && ptr1.getClass().getRemainingUsageTime(ptr1) == ptr2.getClass().getRemainingUsageTime(ptr2)


### PR DESCRIPTION
Attempt to fix [bug #1933](https://gitlab.com/OpenMW/openmw/issues/1933).
There is no point to check owner during stacking check - we consider that all items in ContanerStore belong to owner of that container store anyway.

This PR should fix stacking in the trading window.
For pickpocketing and looting it will work only for newly added items - we do not use update stacks for these windows on the fly since it causes issues with stacking equippable items (such as throwing weapons and ammo).
For newly added items we just add them to existing item in NPC's inventory, just increase the count.
If we really need it, I can add update on the fly (excepts of stacking equippable items), but it can break something else.

Probably #1622 is not needed.

