### PR TITLE
Traverse child nodes of cell node in the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
     Bug #4644: %Name should be available for all actors, not just for NPCs
     Bug #4648: Hud thinks that throwing weapons have condition
     Bug #4649: Levelup fully restores health
+    Bug #4654: Editor: UpdateVisitor does not initialize skeletons for animated objects
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1617: Editor: Enchantment effect record verifier
     Feature #1645: Casting effects from objects

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -47,6 +47,7 @@ namespace CSVRender
 
             virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
             {
+                traverse(node, nv);
                 CellNodeContainer* container = static_cast<CellNodeContainer*>(node->getUserData());
                 container->getCell()->updateLand();
             }


### PR DESCRIPTION
Fixes [bug #4654](https://gitlab.com/OpenMW/openmw/issues/4654).
Just traverse child nodes before do any operations on cell.
Now actors should be rendered fine.