### PR TITLE
Allow to copy paths to selected content files to clipboard in content selector (feature #2847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
     Feature #1617: Editor: Enchantment effect record verifier
     Feature #1645: Casting effects from objects
     Feature #2606: Editor: Implemented (optional) case sensitive global search
+    Feature #2847: Content selector: allow to copy the path to a file by using the context menu
     Feature #3083: Play animation when NPC is casting spell via script
     Feature #3103: Provide option for disposition to get increased by successful trade
     Feature #3276: Editor: Search - Show number of (remaining) search results and indicate a search without any results

--- a/components/contentselector/model/contentmodel.hpp
+++ b/components/contentselector/model/contentmodel.hpp
@@ -48,6 +48,8 @@ namespace ContentSelectorModel
 
         QModelIndex indexFromItem(const EsmFile *item) const;
         const EsmFile *item(const QString &name) const;
+        const EsmFile *item(int row) const;
+        EsmFile *item(int row);
         QStringList gameFiles() const;
 
         bool isEnabled (QModelIndex index) const;
@@ -65,8 +67,6 @@ namespace ContentSelectorModel
     private:
 
         void addFile(EsmFile *file);
-        const EsmFile *item(int row) const;
-        EsmFile *item(int row);
 
         void sortFiles();
 

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -7,6 +7,7 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 
+#include <QClipboard>
 #include <QGridLayout>
 #include <QMessageBox>
 #include <QModelIndex>
@@ -67,6 +68,7 @@ void ContentSelectorView::ContentSelector::buildContextMenu()
     mContextMenu = new QMenu(ui.addonView);
     mContextMenu->addAction(tr("&Check Selected"), this, SLOT(slotCheckMultiSelectedItems()));
     mContextMenu->addAction(tr("&Uncheck Selected"), this, SLOT(slotUncheckMultiSelectedItems()));
+    mContextMenu->addAction(tr("&Copy Path(s) to Clipboard"), this, SLOT(slotCopySelectedItemsPaths()));
 }
 
 void ContentSelectorView::ContentSelector::setProfileContent(const QStringList &fileList)
@@ -244,4 +246,21 @@ void ContentSelectorView::ContentSelector::slotUncheckMultiSelectedItems()
 void ContentSelectorView::ContentSelector::slotCheckMultiSelectedItems()
 {
     setCheckStateForMultiSelectedItems(true);
+}
+
+void ContentSelectorView::ContentSelector::slotCopySelectedItemsPaths()
+{
+    QClipboard *clipboard = QApplication::clipboard();
+    QString filepaths;
+    foreach (const QModelIndex& index, ui.addonView->selectionModel()->selectedIndexes())
+    {
+        int row = mAddonProxyModel->mapToSource(index).row();
+        const ContentSelectorModel::EsmFile *file = mContentModel->item(row);
+        filepaths += file->filePath() + "\n";
+    }
+
+    if (!filepaths.isEmpty())
+    {
+        clipboard->setText(filepaths);
+    }
 }

--- a/components/contentselector/view/contentselector.hpp
+++ b/components/contentselector/view/contentselector.hpp
@@ -70,6 +70,7 @@ namespace ContentSelectorView
         void slotShowContextMenu(const QPoint& pos);
         void slotCheckMultiSelectedItems();
         void slotUncheckMultiSelectedItems();
+        void slotCopySelectedItemsPaths();
     };
 }
 

--- a/files/ui/datafilespage.ui
+++ b/files/ui/datafilespage.ui
@@ -62,7 +62,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Select a profiile</string>
+         <string>Select a content list</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
[Feature #2847](https://gitlab.com/OpenMW/openmw/issues/2847).

The idea is to recover the real indexes of the selected files in the content file view and use QClipboard for manipulating the global system clipboard. For that I had to make *item(int row) in contentmodel public instead of private. "Copy path(s) to clipboard" is a new option in content file view context menu.

File paths of all selected items are copied to the clipboard separated by a newline. Content selector is used in the launcher and the editor; I think this option works pretty well.

Also I fixed a tooltip in data files page of the launcher (there was a weird typo and "profile" nomenclature is not even used anymore).