### PR TITLE
Generate docs using doxygen when build commit from branch master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
       # The other ones from OpenMW ppa
       libbullet-dev, libswresample-dev, libopenscenegraph-3.4-dev, libmygui-dev,
       # Docs dependencies
-      doxygen, doxygen-doc, doxygen-latex, doxygen-gui, graphviz
+      doxygen, doxygen-doc, doxygen-latex, doxygen-gui, graphviz, python-sphinx
     ]
 
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ matrix:
       env:
         ANALYZE="scan-build-3.6 --use-cc clang-3.6 --use-c++ clang++-3.6 "
       compiler: clang
+    - os: linux
+      script: ./CI/generateDocumentationAndDeploy.sh
   allow_failures:
     - env: ANALYZE="scan-build-3.6 --use-cc clang-3.6 --use-c++ clang++-3.6 "
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ addons:
       # Audio & Video
       libsdl2-dev, libqt4-dev, libopenal-dev,
       # The other ones from OpenMW ppa
-      libbullet-dev, libswresample-dev, libopenscenegraph-3.4-dev, libmygui-dev
+      libbullet-dev, libswresample-dev, libopenscenegraph-3.4-dev, libmygui-dev,
+      # Docs dependencies
+      doxygen, doxygen-doc, doxygen-latex, doxygen-gui, graphviz
     ]
 
   coverity_scan:

--- a/CI/before_script.linux.sh
+++ b/CI/before_script.linux.sh
@@ -12,6 +12,7 @@ if [ "${CC}" = "clang" ]; then export CODE_COVERAGE=0; fi
 ${ANALYZE}cmake \
     -DBUILD_WITH_CODE_COVERAGE=${CODE_COVERAGE} \
     -DBUILD_UNITTESTS=1 \
+    -DBUILD_DOCS=ON \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBINDIR=/usr/games \
     -DCMAKE_BUILD_TYPE="None" \

--- a/CI/generateDocumentationAndDeploy.sh
+++ b/CI/generateDocumentationAndDeploy.sh
@@ -69,7 +69,7 @@ git reset --soft $CURRENTCOMMIT
 # to be seen on the gh-pages site. Therefore creating an empty .nojekyll file.
 # Presumably this is only needed when the SHORT_NAMES option in Doxygen is set
 # to NO, which it is by default. So creating the file just in case.
-echo "" > .nojekyll
+touch .nojekyll
 
 ################################################################################
 ##### Generate the Doxygen code documentation and log the output.          #####

--- a/CI/generateDocumentationAndDeploy.sh
+++ b/CI/generateDocumentationAndDeploy.sh
@@ -9,32 +9,22 @@ __AUTHOR__="generated"
 #   must be installed.
 # - Doxygen configuration file must have the destination directory empty and
 #   source code directory with a $(TRAVIS_BUILD_DIR) prefix.
-# - An gh-pages branch should already exist. See below for mor info on hoe to
-#   create a gh-pages branch.
 #
 # Required global variables:
-# - TRAVIS_BUILD_NUMBER : The number of the current build.
-# - TRAVIS_COMMIT       : The commit that the current build is testing.
-# - DOXYFILE            : The Doxygen configuration file.
-# - GH_REPO_NAME        : The name of the repository.
-# - GH_REPO_REF         : The GitHub reference to the repository.
-# - GH_REPO_TOKEN       : Secure token to the github repository.
+# - TRAVIS_BUILD_NUMBER    : The number of the current build.
+# - TRAVIS_COMMIT          : The commit that the current build is testing.
+# - DOXYFILE               : The Doxygen configuration file.
+# - OPENMW_GITHUB_IO_TOKEN : Secure token to the github repository.
 #
 # For information on how to encrypt variables for Travis CI please go to
 # https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables
 # or https://gist.github.com/vidavidorra/7ed6166a46c537d3cbd2
-# For information on how to create a clean gh-pages branch from the master
-# branch, please go to https://gist.github.com/vidavidorra/846a2fc7dd51f4fe56a0
 #
 # This script will generate Doxygen documentation and push the documentation to
-# the gh-pages branch of a repository specified by GH_REPO_REF.
-# Before this script is used there should already be a gh-pages branch in the
-# repository.
+# the epository specified by GH_REPO_REF.
 #
 ################################################################################
 
-################################################################################
-##### Setup this script and get the current gh-pages branch.               #####
 # Exit with nonzero exit code if anything fails
 set -e
 
@@ -56,9 +46,9 @@ git config --global push.default simple
 git config user.name "Travis CI"
 git config user.email "travis@travis-ci.org"
 
-# Remove everything currently in the gh-pages branch.
+# Remove everything currently in the repository.
 # GitHub is smart enough to know which files have changed and which files have
-# stayed the same and will only update the changed files. So the gh-pages branch
+# stayed the same and will only update the changed files. So the repository
 # can be safely cleaned, and it is sure that everything pushed later is the new
 # documentation.
 CURRENTCOMMIT=`git rev-parse HEAD`
@@ -80,7 +70,7 @@ doxygen $DOXYFILE 2>&1 | tee doxygen.log
 DOCDIR="$TRAVIS_BUILD_DIR/build/docs/Doxygen"
 echo "Checking existence of $DOCDIR/html/index.html"
 ################################################################################
-##### Upload the documentation to the gh-pages branch of the repository.   #####
+##### Upload the documentation to the repository.                          #####
 # Only upload if Doxygen successfully created the documentation.
 # Check this by verifying that the html directory and the file html/index.html
 # both exist. This is a good indication that Doxygen did it's work.
@@ -89,8 +79,7 @@ if [ -f "$DOCDIR/html/index.html" ]; then
     cp -R "$DOCDIR/html/." .
 
     echo 'Uploading documentation ...'
-    # Add everything in this directory (the Doxygen code documentation) to the
-    # gh-pages branch.
+    # Add everything in this directory (the Doxygen code documentation).
     # GitHub is smart enough to know which files have changed and which files have
     # stayed the same and will only update the changed files.
     git add --all
@@ -99,10 +88,10 @@ if [ -f "$DOCDIR/html/index.html" ]; then
     # build number and the GitHub commit reference that issued this build.
     git commit -m "Deploy code docs to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
 
-    # Force push to the remote gh-pages branch.
+    # Force push to the remote repository.
     # The ouput is redirected to /dev/null to hide any sensitive credential data
     # that might otherwise be exposed.
-    git push --force "https://${GH_REPO_TOKEN}@${GH_REPO_REF}" > /dev/null 2>&1
+    git push --force "https://${OPENMW_GITHUB_IO_TOKEN}@${GH_REPO_REF}" > /dev/null 2>&1
 else
     echo '' >&2
     echo 'Warning: No documentation (html) files have been found!' >&2

--- a/CI/generateDocumentationAndDeploy.sh
+++ b/CI/generateDocumentationAndDeploy.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+################################################################################
+# Title         : generateDocumentationAndDeploy.sh
+# Date created  : 2016/02/22
+# Notes         :
+__AUTHOR__="generated"
+# Preconditions:
+# - Packages doxygen doxygen-doc doxygen-latex doxygen-gui graphviz
+#   must be installed.
+# - Doxygen configuration file must have the destination directory empty and
+#   source code directory with a $(TRAVIS_BUILD_DIR) prefix.
+# - An gh-pages branch should already exist. See below for mor info on hoe to
+#   create a gh-pages branch.
+#
+# Required global variables:
+# - TRAVIS_BUILD_NUMBER : The number of the current build.
+# - TRAVIS_COMMIT       : The commit that the current build is testing.
+# - DOXYFILE            : The Doxygen configuration file.
+# - GH_REPO_NAME        : The name of the repository.
+# - GH_REPO_REF         : The GitHub reference to the repository.
+# - GH_REPO_TOKEN       : Secure token to the github repository.
+#
+# For information on how to encrypt variables for Travis CI please go to
+# https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables
+# or https://gist.github.com/vidavidorra/7ed6166a46c537d3cbd2
+# For information on how to create a clean gh-pages branch from the master
+# branch, please go to https://gist.github.com/vidavidorra/846a2fc7dd51f4fe56a0
+#
+# This script will generate Doxygen documentation and push the documentation to
+# the gh-pages branch of a repository specified by GH_REPO_REF.
+# Before this script is used there should already be a gh-pages branch in the
+# repository.
+#
+################################################################################
+
+################################################################################
+##### Setup this script and get the current gh-pages branch.               #####
+# Exit with nonzero exit code if anything fails
+set -e
+
+GH_REPO_NAME="openmw.github.io"
+DOXYFILE="$TRAVIS_BUILD_DIR/build/docs/Doxyfile"
+GH_REPO_REF="github.com/openmw/openmw.github.io.git"
+
+# Create a clean working directory for this script.
+mkdir -p code_docs
+cd code_docs
+
+git clone https://git@$GH_REPO_REF
+cd "$GH_REPO_NAME"
+
+##### Configure git.
+# Set the push default to simple i.e. push only the current branch.
+git config --global push.default simple
+# Pretend to be an user called Travis CI.
+git config user.name "Travis CI"
+git config user.email "travis@travis-ci.org"
+
+# Remove everything currently in the gh-pages branch.
+# GitHub is smart enough to know which files have changed and which files have
+# stayed the same and will only update the changed files. So the gh-pages branch
+# can be safely cleaned, and it is sure that everything pushed later is the new
+# documentation.
+CURRENTCOMMIT=`git rev-parse HEAD`
+git reset --hard `git rev-list HEAD | tail -n 1`
+git reset --soft $CURRENTCOMMIT
+
+# Need to create a .nojekyll file to allow filenames starting with an underscore
+# to be seen on the gh-pages site. Therefore creating an empty .nojekyll file.
+# Presumably this is only needed when the SHORT_NAMES option in Doxygen is set
+# to NO, which it is by default. So creating the file just in case.
+echo "" > .nojekyll
+
+################################################################################
+##### Generate the Doxygen code documentation and log the output.          #####
+echo 'Generating Doxygen code documentation...'
+# Redirect both stderr and stdout to the log file AND the console.
+doxygen $DOXYFILE 2>&1 | tee doxygen.log
+
+DOCDIR="$TRAVIS_BUILD_DIR/build/docs/Doxygen"
+echo "Checking existence of $DOCDIR/html/index.html"
+################################################################################
+##### Upload the documentation to the gh-pages branch of the repository.   #####
+# Only upload if Doxygen successfully created the documentation.
+# Check this by verifying that the html directory and the file html/index.html
+# both exist. This is a good indication that Doxygen did it's work.
+if [ -f "$DOCDIR/html/index.html" ]; then
+
+    cp -R "$DOCDIR/html/." .
+
+    echo 'Uploading documentation ...'
+    # Add everything in this directory (the Doxygen code documentation) to the
+    # gh-pages branch.
+    # GitHub is smart enough to know which files have changed and which files have
+    # stayed the same and will only update the changed files.
+    git add --all
+
+    # Commit the added files with a title and description containing the Travis CI
+    # build number and the GitHub commit reference that issued this build.
+    git commit -m "Deploy code docs to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
+
+    # Force push to the remote gh-pages branch.
+    # The ouput is redirected to /dev/null to hide any sensitive credential data
+    # that might otherwise be exposed.
+    git push --force "https://${GH_REPO_TOKEN}@${GH_REPO_REF}" > /dev/null 2>&1
+else
+    echo '' >&2
+    echo 'Warning: No documentation (html) files have been found!' >&2
+    echo 'Warning: Not going to push the documentation to GitHub!' >&2
+    exit 1
+fi
+

--- a/CI/generateDocumentationAndDeploy.sh
+++ b/CI/generateDocumentationAndDeploy.sh
@@ -86,7 +86,7 @@ if [ -f "$DOCDIR/html/index.html" ]; then
 
     # Commit the added files with a title and description containing the Travis CI
     # build number and the GitHub commit reference that issued this build.
-    git commit -m "Deploy code docs to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
+    git commit -q -m "Deploy code docs to GitHub Pages Travis build: ${TRAVIS_BUILD_NUMBER}" -m "Commit: ${TRAVIS_COMMIT}"
 
     # Force push to the remote repository.
     # The ouput is redirected to /dev/null to hide any sensitive credential data

--- a/CI/generateDocumentationAndDeploy.sh
+++ b/CI/generateDocumentationAndDeploy.sh
@@ -65,7 +65,7 @@ touch .nojekyll
 ##### Generate the Doxygen code documentation and log the output.          #####
 echo 'Generating Doxygen code documentation...'
 # Redirect both stderr and stdout to the log file AND the console.
-doxygen $DOXYFILE 2>&1 | tee doxygen.log
+doxygen $DOXYFILE > /dev/null
 
 DOCDIR="$TRAVIS_BUILD_DIR/build/docs/Doxygen"
 echo "Checking existence of $DOCDIR/html/index.html"

--- a/docs/Doxyfile.cmake
+++ b/docs/Doxyfile.cmake
@@ -405,7 +405,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # the optimal cache size from a speed point of view.
 # Minimum value: 0, maximum value: 9, default value: 0.
 
-LOOKUP_CACHE_SIZE      = 0
+LOOKUP_CACHE_SIZE      = 1
 
 #---------------------------------------------------------------------------
 # Build related configuration options


### PR DESCRIPTION
This pr will enable update of https://openmw.github.io/ for each commit pushed into master. Now this site looks quite abandoned, I want to change this. Example of generated docs from this branch with additional commits 2f566fc318 and 0175c7240 is available at https://elsid.github.io/openmw.github.io/ . But additional setup is required to make this work for openmw organization. Similar to 2f566fc318 secure token should be generated for travis to push to https://github.com/OpenMW/openmw.github.io . This could be done by only who has access to openmw organization settings (I don't have) using this instruction https://gist.github.com/vidavidorra/7ed6166a46c537d3cbd2 (method 2). TLDR: create token and encrypt using command  `travis encrypt OPENMW_GITHUB_IO_TOKEN=<token>`. If you have so, just add encrypted one as comment to this pr, and I will add it as commit.

