### PR TITLE
[WIP, Regression] Improve spell effects cleanup

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -40,6 +40,9 @@ ActorAnimation::ActorAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group>
             addHiddenItemLight(*iter, light);
         }
     }
+
+    // Make sure we cleaned object from effects, just in cast if we re-use node
+    removeEffects();
 }
 
 ActorAnimation::~ActorAnimation()

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -213,14 +213,12 @@ namespace
         RemoveFinishedCallbackVisitor()
             : RemoveVisitor()
             , mHasMagicEffects(false)
-            , mEffectId(-1)
         {
         }
 
         RemoveFinishedCallbackVisitor(int effectId)
             : RemoveVisitor()
             , mHasMagicEffects(false)
-            , mEffectId(effectId)
         {
         }
 
@@ -240,9 +238,63 @@ namespace
                 MWRender::UpdateVfxCallback* vfxCallback = dynamic_cast<MWRender::UpdateVfxCallback*>(callback);
                 if (vfxCallback)
                 {
-                    bool finished = vfxCallback->mFinished;
-                    bool toRemove = mEffectId >= 0 && vfxCallback->mParams.mEffectId == mEffectId;
-                    if (finished || toRemove)
+                    if (vfxCallback->mFinished)
+                        mToRemove.push_back(std::make_pair(group.asNode(), group.getParent(0)));
+                    else
+                        mHasMagicEffects = true;
+                }
+            }
+        }
+
+        virtual void apply(osg::MatrixTransform &node)
+        {
+            traverse(node);
+        }
+
+        virtual void apply(osg::Geometry&)
+        {
+        }
+
+    private:
+        int mEffectId;
+    };
+
+    class RemoveCallbackVisitor : public RemoveVisitor
+    {
+    public:
+        bool mHasMagicEffects;
+
+        RemoveCallbackVisitor()
+            : RemoveVisitor()
+            , mHasMagicEffects(false)
+            , mEffectId(-1)
+        {
+        }
+
+        RemoveCallbackVisitor(int effectId)
+            : RemoveVisitor()
+            , mHasMagicEffects(false)
+            , mEffectId(effectId)
+        {
+        }
+
+        virtual void apply(osg::Node &node)
+        {
+            traverse(node);
+        }
+
+        virtual void apply(osg::Group &group)
+        {
+            traverse(group);
+
+            osg::Callback* callback = group.getUpdateCallback();
+            if (callback)
+            {
+                MWRender::UpdateVfxCallback* vfxCallback = dynamic_cast<MWRender::UpdateVfxCallback*>(callback);
+                if (vfxCallback)
+                {
+                    bool toRemove = mEffectId < 0 || vfxCallback->mParams.mEffectId == mEffectId;
+                    if (toRemove)
                         mToRemove.push_back(std::make_pair(group.asNode(), group.getParent(0)));
                     else
                         mHasMagicEffects = true;
@@ -1649,10 +1701,15 @@ namespace MWRender
 
     void Animation::removeEffect(int effectId)
     {
-        RemoveFinishedCallbackVisitor visitor(effectId);
+        RemoveCallbackVisitor visitor(effectId);
         mInsert->accept(visitor);
         visitor.remove();
         mHasMagicEffects = visitor.mHasMagicEffects;
+    }
+
+    void Animation::removeEffects()
+    {
+        removeEffect(-1);
     }
 
     void Animation::getLoopingEffects(std::vector<int> &out) const

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -624,8 +624,8 @@ namespace MWRender
             }
             else
             {
-                // Remove effect immediately
-                mParams.mObjects.reset();
+                // Hide effect immediately
+                node->setNodeMask(0);
                 mFinished = true;
             }
         }
@@ -1686,7 +1686,6 @@ namespace MWRender
         params.mLoop = loop;
         params.mEffectId = effectId;
         params.mBoneName = bonename;
-        params.mObjects = PartHolderPtr(new PartHolder(node));
         params.mAnimTime = std::shared_ptr<EffectAnimationTime>(new EffectAnimationTime);
         trans->addUpdateCallback(new UpdateVfxCallback(params));
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1975,12 +1975,12 @@ namespace MWRender
     PartHolder::~PartHolder()
     {
         if (mNode.get() && !mNode->getNumParents())
-            Log(Debug::Verbose) << "Part has no parents" ;
+            Log(Debug::Verbose) << "Part \"" << mNode->getName() << "\" has no parents" ;
 
         if (mNode.get() && mNode->getNumParents())
         {
             if (mNode->getNumParents() > 1)
-                Log(Debug::Verbose) << "Part has multiple (" << mNode->getNumParents() << ") parents";
+                Log(Debug::Verbose) << "Part \"" << mNode->getName() << "\" has multiple (" << mNode->getNumParents() << ") parents";
             mNode->getParent(0)->removeChild(mNode);
         }
     }

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -370,6 +370,7 @@ public:
      */
     void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", const std::string& texture = "", float scale = 1.0f);
     void removeEffect (int effectId);
+    void removeEffects ();
     void getLoopingEffects (std::vector<int>& out) const;
 
     // Add a spell casting glow to an object. From measuring video taken from the original engine,

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -74,7 +74,6 @@ typedef std::shared_ptr<PartHolder> PartHolderPtr;
 struct EffectParams
 {
     std::string mModelName; // Just here so we don't add the same effect twice
-    PartHolderPtr mObjects;
     std::shared_ptr<EffectAnimationTime> mAnimTime;
     float mMaxControllerLength;
     int mEffectId;


### PR DESCRIPTION
Summary of changes:
1. Cleanup magic effects when creating a new ActorAnimation since we can re-use existing actor's node.
We use such approach for player during save/load.
2. Do not store PartHolderPtr inside callback (we do not need it now anyway), so there should not be additional "Part has no parents" messages after spellcasting.
3. Improve error messages in PartHolder - now we display affected node name.

The only thing left is to remove non-looping effects after rest.