### PR TITLE
Fix primary edit dragging redundant drag call (bug #4593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
     Bug #4575: Weird result of attack animation blending with movement animations
     Bug #4576: Reset of idle animations when attack can not be started
     Bug #4591: Attack strength should be 0 if player did not hold the attack button
+    Bug #4593: Editor: Instance dragging is broken
     Bug #4597: <> operator causes a compile error
     Bug #4604: Picking up gold from the ground only makes 1 grabbed
     Bug #4607: Scaling for animated collision shapes is applied twice

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -648,11 +648,6 @@ void CSVRender::WorldspaceWidget::mouseMoveEvent (QMouseEvent *event)
             mDragX = event->posF().x();
             mDragY = height() - event->posF().y();
 #endif
-
-            if (mDragMode == InteractionType_PrimaryEdit)
-            {
-                editMode.drag (event->pos(), mDragX, mDragY, mDragFactor); // note: terraintexturemode only uses pos
-            }
         }
     }
     else


### PR DESCRIPTION
[Bug 4593](https://gitlab.com/OpenMW/openmw/issues/4593).

This is a 0.44.0 regression caused by an odd-looking drag call added by unelsson [here](https://github.com/Capostrophic/openmw/commit/cf7a0f715ea5f20ee5b3892fbf5ac0c888167566#diff-804251c4ace510bce2e04c0c9f7df1ed) for some reason. I removed it and dragging seems to work OK now. In PR it seems to have been some kind of hardcoding necessary to set something up, but I frankly don't understand what specifically, so please enlighten me if I did something wrong.