### PR TITLE
Editor: display light source color as a color (bug #4668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
     Bug #4649: Levelup fully restores health
     Bug #4653: Length of non-ASCII strings is handled incorrectly in ESM reader
     Bug #4654: Editor: UpdateVisitor does not initialize skeletons for animated objects
+    Bug #4668: Editor: Light source color is displayed as an integer
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -437,7 +437,7 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Radius, ColumnBase::Display_Integer));
     lightColumns.mRadius = &mColumns.back();
 
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_Colour, ColumnBase::Display_Integer));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_Colour, ColumnBase::Display_Colour));
     lightColumns.mColor = &mColumns.back();
 
     mColumns.push_back (RefIdColumn (Columns::ColumnId_Sound, ColumnBase::Display_Sound));


### PR DESCRIPTION
[Bug 4668](https://gitlab.com/OpenMW/openmw/issues/4668)

Pardon the nonsensical title.
Minor nit that bugged me greatly picked. Now the light source color is displayed as a colored rectangle and the color is pickable in a color picker, like it should be.