### PR TITLE
Trace down the player after collision being enabled via TCL, make sure actors in air are traced down upon loading (bugs #3219, #4669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     Bug #3049: Drain and Fortify effects are not properly applied on health, magicka and fatigue
     Bug #3059: Unable to hit with marksman weapons when too close to an enemy
     Bug #3072: Fatal error on AddItem <item> that has a script containing Equip <item>
+    Bug #3219: NPC and creature initial position tracing down limit is too small
     Bug #3249: Fixed revert function not updating views properly
     Bug #3288: TrueType fonts are handled incorrectly
     Bug #3374: Touch spells not hitting kwama foragers
@@ -134,6 +135,7 @@
     Bug #4653: Length of non-ASCII strings is handled incorrectly in ESM reader
     Bug #4654: Editor: UpdateVisitor does not initialize skeletons for animated objects
     Bug #4668: Editor: Light source color is displayed as an integer
+    Bug #4669: ToggleCollision should trace the player down after collision being enabled
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1343,7 +1343,7 @@ namespace MWWorld
 
         if (force || !isFlying(ptr))
         {
-            osg::Vec3f traced = mPhysics->traceDown(ptr, pos, 500);
+            osg::Vec3f traced = mPhysics->traceDown(ptr, pos, Constants::CellSizeInUnits);
             if (traced.z() < pos.z())
                 pos.z() = traced.z();
         }
@@ -1581,7 +1581,13 @@ namespace MWWorld
 
     bool World::toggleCollisionMode()
     {
-        return mPhysics->toggleCollisionMode();
+        if (mPhysics->toggleCollisionMode())
+        {
+            adjustPosition(getPlayerPtr(), true);
+            return true;
+        }
+
+        return false;
     }
 
     bool World::toggleRenderMode (MWRender::RenderMode mode)


### PR DESCRIPTION
[Bug 3219](https://gitlab.com/OpenMW/openmw/issues/3219)
[Bug 4669](https://gitlab.com/OpenMW/openmw/issues/4669)

In my testing the player is traced down even when there's a levitation effect applied.

I adjusted adjustPosition to make sure the position is adjusted in all adjustment cases even in interiors when it could possibly not be adjusted due to adjustment being not enough to adjust the player down where there isn't any terrain to adjust the player to and the initial adjusted position is too high for tracedown to work. ~~Sorry~~ but anyway, the actors are adjusted 8192 units down maximum like in the case of fixme.

Neither Morrowind nor OpenMW trace the creatures that were placed under the terrain up so that wasn't changed.

Hopefully I didn't break anything. Tarhiel is fine.