### PR TITLE
getSkill usage cleanup (bug #4671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
     Bug #4653: Length of non-ASCII strings is handled incorrectly in ESM reader
     Bug #4654: Editor: UpdateVisitor does not initialize skeletons for animated objects
     Bug #4668: Editor: Light source color is displayed as an integer
+    Bug #4671: knownEffect functions should use modified Alchemy skill
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -14,8 +14,6 @@
 #include "../mwworld/actioneat.hpp"
 #include "../mwworld/nullaction.hpp"
 
-#include "../mwmechanics/npcstats.hpp"
-
 #include "../mwgui/tooltips.hpp"
 
 #include "../mwrender/objects.hpp"
@@ -134,8 +132,7 @@ namespace MWClass
         }
 
         MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
-        MWMechanics::NpcStats& npcStats = player.getClass().getNpcStats (player);
-        int alchemySkill = npcStats.getSkill (ESM::Skill::Alchemy).getBase();
+        int alchemySkill = player.getClass().getSkill(player, ESM::Skill::Alchemy);
 
         static const float fWortChanceValue =
                 MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fWortChanceValue")->mValue.getFloat();

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -949,7 +949,7 @@ namespace MWClass
         if(sneaking)
             walkSpeed *= gmst.fSneakSpeedMultiplier->mValue.getFloat();
 
-        float runSpeed = walkSpeed*(0.01f * npcdata->mNpcStats.getSkill(ESM::Skill::Athletics).getModified() *
+        float runSpeed = walkSpeed*(0.01f * getSkill(ptr, ESM::Skill::Athletics) *
                                     gmst.fAthleticsRunBonus->mValue.getFloat() + gmst.fBaseRunMultiplier->mValue.getFloat());
 
         float moveSpeed;
@@ -971,7 +971,7 @@ namespace MWClass
             if(running)
                 swimSpeed = runSpeed;
             swimSpeed *= 1.0f + 0.01f * mageffects.get(ESM::MagicEffect::SwiftSwim).getMagnitude();
-            swimSpeed *= gmst.fSwimRunBase->mValue.getFloat() + 0.01f*npcdata->mNpcStats.getSkill(ESM::Skill::Athletics).getModified()*
+            swimSpeed *= gmst.fSwimRunBase->mValue.getFloat() + 0.01f*getSkill(ptr, ESM::Skill::Athletics)*
                                                     gmst.fSwimRunAthleticsMult->mValue.getFloat();
             moveSpeed = swimSpeed;
         }
@@ -1004,7 +1004,7 @@ namespace MWClass
                                           gmst.fJumpEncumbranceMultiplier->mValue.getFloat() *
                                           (1.0f - Npc::getNormalizedEncumbrance(ptr));
 
-        float a = static_cast<float>(npcdata->mNpcStats.getSkill(ESM::Skill::Acrobatics).getModified());
+        float a = static_cast<float>(getSkill(ptr, ESM::Skill::Acrobatics));
         float b = 0.0f;
         if(a > 50.0f)
         {
@@ -1129,7 +1129,7 @@ namespace MWClass
 
         float fUnarmoredBase1 = store.find("fUnarmoredBase1")->mValue.getFloat();
         float fUnarmoredBase2 = store.find("fUnarmoredBase2")->mValue.getFloat();
-        int unarmoredSkill = stats.getSkill(ESM::Skill::Unarmored).getModified();
+        int unarmoredSkill = getSkill(ptr, ESM::Skill::Unarmored);
 
         float ratings[MWWorld::InventoryStore::Slots];
         for(int i = 0;i < MWWorld::InventoryStore::Slots;i++)

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -18,7 +18,6 @@
 #include "../mwworld/esmstore.hpp"
 
 #include "../mwmechanics/creaturestats.hpp"
-#include "../mwmechanics/npcstats.hpp"
 #include "../mwmechanics/actorutil.hpp"
 
 #include "itemwidget.hpp"
@@ -139,7 +138,6 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
 
     MWWorld::Ptr player = MWMechanics::getPlayer();
     MWMechanics::CreatureStats& stats = player.getClass().getCreatureStats(player);
-    MWMechanics::NpcStats& npcStats = player.getClass().getNpcStats(player);
 
     float luckTerm = 0.1f * stats.getAttribute(ESM::Attribute::Luck).getModified();
     if (luckTerm < 1|| luckTerm > 10)
@@ -152,7 +150,7 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
     if (intelligenceTerm < 1)
         intelligenceTerm = 1;
 
-    float x = (npcStats.getSkill(ESM::Skill::Enchant).getModified() + intelligenceTerm + luckTerm) * stats.getFatigueTerm();
+    float x = (player.getClass().getSkill(player, ESM::Skill::Enchant) + intelligenceTerm + luckTerm) * stats.getFatigueTerm();
     int roll = Misc::Rng::roll0to99();
     if (roll < x)
     {

--- a/apps/openmw/mwgui/trainingwindow.cpp
+++ b/apps/openmw/mwgui/trainingwindow.cpp
@@ -73,14 +73,12 @@ namespace MWGui
 
         mPlayerGold->setCaptionWithReplacing("#{sGold}: " + MyGUI::utility::toString(playerGold));
 
-        MWMechanics::NpcStats& npcStats = actor.getClass().getNpcStats (actor);
-
         // NPC can train you in his best 3 skills
         std::vector< std::pair<int, int> > skills;
 
         for (int i=0; i<ESM::Skill::Length; ++i)
         {
-            int value = npcStats.getSkill (i).getModified ();
+            int value = actor.getClass().getSkill(actor, i);
 
             skills.push_back(std::make_pair(i, value));
         }
@@ -142,8 +140,7 @@ namespace MWGui
         if (price > player.getClass().getContainerStore(player).count(MWWorld::ContainerStore::sGoldId))
             return;
 
-        MWMechanics::NpcStats& npcStats = mPtr.getClass().getNpcStats (mPtr);
-        if (npcStats.getSkill (skillId).getModified () <= pcStats.getSkill (skillId).getBase ())
+        if (mPtr.getClass().getSkill(mPtr, skillId) <= pcStats.getSkill (skillId).getBase ())
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sServiceTrainingWords}");
             return;
@@ -168,6 +165,7 @@ namespace MWGui
         player.getClass().getContainerStore(player).remove(MWWorld::ContainerStore::sGoldId, price, player);
 
         // add gold to NPC trading gold pool
+        MWMechanics::NpcStats& npcStats = mPtr.getClass().getNpcStats(mPtr);
         npcStats.setGoldPool(npcStats.getGoldPool() + price);
 
         // advance time

--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -26,7 +26,6 @@
 
 #include "magiceffects.hpp"
 #include "creaturestats.hpp"
-#include "npcstats.hpp"
 
 MWMechanics::Alchemy::Alchemy()
     : mValue(0)
@@ -318,10 +317,9 @@ void MWMechanics::Alchemy::increaseSkill()
 float MWMechanics::Alchemy::getAlchemyFactor() const
 {
     const CreatureStats& creatureStats = mAlchemist.getClass().getCreatureStats (mAlchemist);
-    const NpcStats& npcStats = mAlchemist.getClass().getNpcStats (mAlchemist);
 
     return
-        (npcStats.getSkill (ESM::Skill::Alchemy).getModified() +
+        (mAlchemist.getClass().getSkill(mAlchemist, ESM::Skill::Alchemy) +
         0.1f * creatureStats.getAttribute (ESM::Attribute::Intelligence).getModified()
         + 0.1f * creatureStats.getAttribute (ESM::Attribute::Luck).getModified());
 }
@@ -472,8 +470,7 @@ MWMechanics::Alchemy::TEffectsIterator MWMechanics::Alchemy::endEffects() const
 
 bool MWMechanics::Alchemy::knownEffect(unsigned int potionEffectIndex, const MWWorld::Ptr &npc)
 {
-    MWMechanics::NpcStats& npcStats = npc.getClass().getNpcStats(npc);
-    int alchemySkill = npcStats.getSkill (ESM::Skill::Alchemy).getBase();
+    int alchemySkill = npc.getClass().getSkill (npc, ESM::Skill::Alchemy);
     static const float fWortChanceValue =
             MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fWortChanceValue")->mValue.getFloat();
     return (potionEffectIndex <= 1 && alchemySkill >= fWortChanceValue)

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -10,7 +10,6 @@
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "creaturestats.hpp"
-#include "npcstats.hpp"
 #include "spellcasting.hpp"
 #include "actorutil.hpp"
 
@@ -280,11 +279,11 @@ namespace MWMechanics
 
     float Enchanting::getEnchantChance() const
     {
-        const NpcStats& npcStats = mEnchanter.getClass().getNpcStats (mEnchanter);
+        const CreatureStats& stats = mEnchanter.getClass().getCreatureStats(mEnchanter);
 
-        float chance1 = (npcStats.getSkill (ESM::Skill::Enchant).getModified() + 
-        (0.25f * npcStats.getAttribute (ESM::Attribute::Intelligence).getModified())
-        + (0.125f * npcStats.getAttribute (ESM::Attribute::Luck).getModified()));
+        float chance1 = (mEnchanter.getClass().getSkill(mEnchanter, ESM::Skill::Enchant) + 
+        (0.25f * stats.getAttribute (ESM::Attribute::Intelligence).getModified())
+        + (0.125f * stats.getAttribute (ESM::Attribute::Luck).getModified()));
 
         const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -639,10 +639,10 @@ namespace MWMechanics
         // I suppose the temporary disposition change (second param to getDerivedDisposition()) _has_ to be considered here,
         // otherwise one would get different prices when exiting and re-entering the dialogue window...
         int clampedDisposition = getDerivedDisposition(ptr);
-        float a = static_cast<float>(std::min(playerStats.getSkill(ESM::Skill::Mercantile).getModified(), 100));
+        float a = static_cast<float>(std::min(playerPtr.getClass().getSkill(playerPtr, ESM::Skill::Mercantile), 100));
         float b = std::min(0.1f * playerStats.getAttribute(ESM::Attribute::Luck).getModified(), 10.f);
         float c = std::min(0.2f * playerStats.getAttribute(ESM::Attribute::Personality).getModified(), 10.f);
-        float d = static_cast<float>(std::min(sellerStats.getSkill(ESM::Skill::Mercantile).getModified(), 100));
+        float d = static_cast<float>(std::min(ptr.getClass().getSkill(ptr, ESM::Skill::Mercantile), 100));
         float e = std::min(0.1f * sellerStats.getAttribute(ESM::Attribute::Luck).getModified(), 10.f);
         float f = std::min(0.2f * sellerStats.getAttribute(ESM::Attribute::Personality).getModified(), 10.f);
         float pcTerm = (clampedDisposition - 50 + a + b + c) * playerStats.getFatigueTerm();

--- a/apps/openmw/mwmechanics/repair.cpp
+++ b/apps/openmw/mwmechanics/repair.cpp
@@ -14,7 +14,6 @@
 #include "../mwworld/esmstore.hpp"
 
 #include "creaturestats.hpp"
-#include "npcstats.hpp"
 #include "actorutil.hpp"
 
 namespace MWMechanics
@@ -34,12 +33,11 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
     mTool.getCellRef().setCharge(uses-1);
 
     MWMechanics::CreatureStats& stats = player.getClass().getCreatureStats(player);
-    MWMechanics::NpcStats& npcStats = player.getClass().getNpcStats(player);
 
     float fatigueTerm = stats.getFatigueTerm();
     int pcStrength = stats.getAttribute(ESM::Attribute::Strength).getModified();
     int pcLuck = stats.getAttribute(ESM::Attribute::Luck).getModified();
-    int armorerSkill = npcStats.getSkill(ESM::Skill::Armorer).getModified();
+    int armorerSkill = player.getClass().getSkill(player, ESM::Skill::Armorer);
 
     float fRepairAmountMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
             .find("fRepairAmountMult")->mValue.getFloat();

--- a/apps/openmw/mwmechanics/security.cpp
+++ b/apps/openmw/mwmechanics/security.cpp
@@ -11,7 +11,6 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
-#include "npcstats.hpp"
 #include "creaturestats.hpp"
 
 namespace MWMechanics
@@ -21,10 +20,9 @@ namespace MWMechanics
         : mActor(actor)
     {
         CreatureStats& creatureStats = actor.getClass().getCreatureStats(actor);
-        NpcStats& npcStats = actor.getClass().getNpcStats(actor);
         mAgility = static_cast<float>(creatureStats.getAttribute(ESM::Attribute::Agility).getModified());
         mLuck = static_cast<float>(creatureStats.getAttribute(ESM::Attribute::Luck).getModified());
-        mSecuritySkill = static_cast<float>(npcStats.getSkill(ESM::Skill::Security).getModified());
+        mSecuritySkill = static_cast<float>(actor.getClass().getSkill(actor, ESM::Skill::Security));
         mFatigueTerm = creatureStats.getFatigueTerm();
     }
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -964,10 +964,9 @@ namespace MWMechanics
             MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find (
             effect.mEffectID);
 
-        const MWMechanics::NpcStats& npcStats = mCaster.getClass().getNpcStats(mCaster);
         const MWMechanics::CreatureStats& creatureStats = mCaster.getClass().getCreatureStats(mCaster);
 
-        float x = (npcStats.getSkill (ESM::Skill::Alchemy).getModified() +
+        float x = (mCaster.getClass().getSkill(mCaster, ESM::Skill::Alchemy) +
                     0.2f * creatureStats.getAttribute (ESM::Attribute::Intelligence).getModified()
                     + 0.1f * creatureStats.getAttribute (ESM::Attribute::Luck).getModified())
                     * creatureStats.getFatigueTerm();

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -14,7 +14,7 @@
 #include "../mwworld/actionequip.hpp"
 #include "../mwworld/cellstore.hpp"
 
-#include "npcstats.hpp"
+#include "creaturestats.hpp"
 #include "spellcasting.hpp"
 #include "combat.hpp"
 
@@ -538,7 +538,7 @@ namespace MWMechanics
         case ESM::MagicEffect::DrainSkill:
             if (enemy.isEmpty() || !enemy.getClass().isNpc())
                 return 0.f;
-            if (enemy.getClass().getNpcStats(enemy).getSkill(effect.mSkill).getModified() <= 0)
+            if (enemy.getClass().getSkill(enemy, effect.mSkill) <= 0)
                 return 0.f;
             break;
 

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -250,11 +250,10 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
 {
     const MWBase::World *world = MWBase::Environment::get().getWorld();
     const MWWorld::Store<ESM::GameSetting> &store = world->getStore().get<ESM::GameSetting>();
-    MWMechanics::NpcStats& stats = actor.getClass().getNpcStats(actor);
 
     static float fUnarmoredBase1 = store.find("fUnarmoredBase1")->mValue.getFloat();
     static float fUnarmoredBase2 = store.find("fUnarmoredBase2")->mValue.getFloat();
-    int unarmoredSkill = stats.getSkill(ESM::Skill::Unarmored).getModified();
+    int unarmoredSkill = actor.getClass().getSkill(actor, ESM::Skill::Unarmored);
 
     float unarmoredRating = (fUnarmoredBase1 * unarmoredSkill) * (fUnarmoredBase2 * unarmoredSkill);
 
@@ -384,7 +383,7 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
 
         for (int j = 0; j < static_cast<int>(weaponSkillsLength); ++j)
         {
-            int skillValue = stats.getSkill(static_cast<int>(weaponSkills[j])).getModified();
+            int skillValue = actor.getClass().getSkill(actor, static_cast<int>(weaponSkills[j]));
 
             if (skillValue > max && !weaponSkillVisited[j])
             {


### PR DESCRIPTION
[Bug 4671](https://gitlab.com/OpenMW/openmw/issues/4671)

Instead of using `npcStats.getSkill(skill).getModified()` construction it's possible to use `class.getSkill(ptr, skill)` construction, greatly doubling down on mwmechanics/npcstats.hpp includes and simplifying the code.

Also, I noticed that knownEffect functions use the base skill in OpenMW. You can fortify the Alchemy skill using expansion spells and in vanilla it causes the player to know more effects of potions and ingredients than they would normally do, while in OpenMW nothing happens. I fixed that, so it gets a changelog entry.