### PR TITLE
Replace all NULLs to nullptr

### DIFF
--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -22,7 +22,7 @@ CS::Editor::Editor (int argc, char **argv)
 : mSettingsState (mCfgMgr), mDocumentManager (mCfgMgr),
   mViewManager (mDocumentManager), mPid(""),
   mLock(), mMerge (mDocumentManager),
-  mIpcServerName ("org.openmw.OpenCS"), mServer(NULL), mClientSocket(NULL)
+  mIpcServerName ("org.openmw.OpenCS"), mServer(nullptr), mClientSocket(nullptr)
 {    
     std::pair<Files::PathContainer, std::vector<std::string> > config = readConfig();
 
@@ -339,7 +339,7 @@ bool CS::Editor::makeIPCServer()
     }
 
     mServer->close();
-    mServer = NULL;
+    mServer = nullptr;
     return false;
 }
 

--- a/apps/opencs/model/doc/operationholder.cpp
+++ b/apps/opencs/model/doc/operationholder.cpp
@@ -3,7 +3,7 @@
 #include "operation.hpp"
 
 CSMDoc::OperationHolder::OperationHolder (Operation *operation)
-    : mOperation(NULL)
+    : mOperation(nullptr)
     , mRunning (false)
 {
     if (operation)

--- a/apps/opencs/model/world/columnimp.cpp
+++ b/apps/opencs/model/world/columnimp.cpp
@@ -318,7 +318,7 @@ namespace CSMWorld
 
     QVariant BodyPartRaceColumn::get(const Record<ESM::BodyPart> &record) const
     {
-        if (mMeshType != NULL && mMeshType->get(record) == ESM::BodyPart::MT_Skin)
+        if (mMeshType != nullptr && mMeshType->get(record) == ESM::BodyPart::MT_Skin)
         {
             return QString::fromUtf8(record.get().mRace.c_str());
         }

--- a/apps/opencs/model/world/commands.cpp
+++ b/apps/opencs/model/world/commands.cpp
@@ -244,7 +244,7 @@ void CSMWorld::CreateCommand::applyModifications()
     if (!mNestedValues.empty())
     {
         CSMWorld::IdTree *tree = dynamic_cast<CSMWorld::IdTree *>(&mModel);
-        if (tree == NULL)
+        if (tree == nullptr)
         {
             throw std::logic_error("CSMWorld::CreateCommand: Attempt to add nested values to the non-nested model");
         }

--- a/apps/opencs/model/world/idcompletionmanager.cpp
+++ b/apps/opencs/model/world/idcompletionmanager.cpp
@@ -92,7 +92,7 @@ void CSMWorld::IdCompletionManager::generateCompleters(CSMWorld::Data &data)
     {
         QAbstractItemModel *model = data.getTableModel(current->second);
         CSMWorld::IdTableBase *table = dynamic_cast<CSMWorld::IdTableBase *>(model);
-        if (table != NULL)
+        if (table != nullptr)
         {
             int idColumn = table->searchColumnIndex(CSMWorld::Columns::ColumnId_Id);
             if (idColumn != -1)

--- a/apps/opencs/model/world/idtableproxymodel.cpp
+++ b/apps/opencs/model/world/idtableproxymodel.cpp
@@ -18,7 +18,7 @@ namespace
 
 void CSMWorld::IdTableProxyModel::updateColumnMap()
 {
-    Q_ASSERT(mSourceModel != NULL);
+    Q_ASSERT(mSourceModel != nullptr);
 
     mColumnMap.clear();
     if (mFilter)
@@ -33,7 +33,7 @@ void CSMWorld::IdTableProxyModel::updateColumnMap()
 bool CSMWorld::IdTableProxyModel::filterAcceptsRow (int sourceRow, const QModelIndex& sourceParent)
     const
 {
-    Q_ASSERT(mSourceModel != NULL);
+    Q_ASSERT(mSourceModel != nullptr);
 
     // It is not possible to use filterAcceptsColumn() and check for
     // sourceModel()->headerData (sourceColumn, Qt::Horizontal, CSMWorld::ColumnBase::Role_Flags)
@@ -51,14 +51,14 @@ bool CSMWorld::IdTableProxyModel::filterAcceptsRow (int sourceRow, const QModelI
 
 CSMWorld::IdTableProxyModel::IdTableProxyModel (QObject *parent)
     : QSortFilterProxyModel (parent), 
-      mSourceModel(NULL)
+      mSourceModel(nullptr)
 {
     setSortCaseSensitivity (Qt::CaseInsensitive);
 }
 
 QModelIndex CSMWorld::IdTableProxyModel::getModelIndex (const std::string& id, int column) const
 {
-    Q_ASSERT(mSourceModel != NULL);
+    Q_ASSERT(mSourceModel != nullptr);
 
     return mapFromSource(mSourceModel->getModelIndex (id, column));
 }
@@ -113,7 +113,7 @@ bool CSMWorld::IdTableProxyModel::lessThan(const QModelIndex &left, const QModel
 
 QString CSMWorld::IdTableProxyModel::getRecordId(int sourceRow) const
 {
-    Q_ASSERT(mSourceModel != NULL);
+    Q_ASSERT(mSourceModel != nullptr);
 
     int idColumn = mSourceModel->findColumnIndex(Columns::ColumnId_Id);
     return mSourceModel->data(mSourceModel->index(sourceRow, idColumn)).toString();

--- a/apps/opencs/model/world/infotableproxymodel.cpp
+++ b/apps/opencs/model/world/infotableproxymodel.cpp
@@ -28,7 +28,7 @@ void CSMWorld::InfoTableProxyModel::setSourceModel(QAbstractItemModel *sourceMod
 {
     IdTableProxyModel::setSourceModel(sourceModel);
 
-    if (mSourceModel != NULL)
+    if (mSourceModel != nullptr)
     {
         mInfoColumnIndex = mSourceModel->findColumnIndex(mInfoColumnId);
         mFirstRowCache.clear();
@@ -37,7 +37,7 @@ void CSMWorld::InfoTableProxyModel::setSourceModel(QAbstractItemModel *sourceMod
 
 bool CSMWorld::InfoTableProxyModel::lessThan(const QModelIndex &left, const QModelIndex &right) const
 {
-    Q_ASSERT(mSourceModel != NULL);
+    Q_ASSERT(mSourceModel != nullptr);
 
     QModelIndex first = mSourceModel->index(getFirstInfoRow(left.row()), left.column());
     QModelIndex second = mSourceModel->index(getFirstInfoRow(right.row()), right.column());
@@ -52,7 +52,7 @@ bool CSMWorld::InfoTableProxyModel::lessThan(const QModelIndex &left, const QMod
 
 int CSMWorld::InfoTableProxyModel::getFirstInfoRow(int currentRow) const
 {
-    Q_ASSERT(mSourceModel != NULL);
+    Q_ASSERT(mSourceModel != nullptr);
 
     int row = currentRow;
     int column = mInfoColumnIndex;

--- a/apps/opencs/model/world/refidadapterimp.cpp
+++ b/apps/opencs/model/world/refidadapterimp.cpp
@@ -453,13 +453,13 @@ void CSMWorld::ContainerRefIdAdapter::setData (const RefIdColumn *column, RefIdD
 
 CSMWorld::CreatureColumns::CreatureColumns (const ActorColumns& actorColumns)
 : ActorColumns (actorColumns),
-  mType(NULL),
-  mScale(NULL),
-  mOriginal(NULL),
-  mAttributes(NULL),
-  mAttacks(NULL),
-  mMisc(NULL),
-  mBloodType(NULL)
+  mType(nullptr),
+  mScale(nullptr),
+  mOriginal(nullptr),
+  mAttributes(nullptr),
+  mAttacks(nullptr),
+  mMisc(nullptr),
+  mBloodType(nullptr)
 {}
 
 CSMWorld::CreatureRefIdAdapter::CreatureRefIdAdapter (const CreatureColumns& columns)
@@ -748,16 +748,16 @@ void CSMWorld::MiscRefIdAdapter::setData (const RefIdColumn *column, RefIdData& 
 
 CSMWorld::NpcColumns::NpcColumns (const ActorColumns& actorColumns)
 : ActorColumns (actorColumns),
-  mRace(NULL),
-  mClass(NULL),
-  mFaction(NULL),
-  mHair(NULL),
-  mHead(NULL),
-  mAttributes(NULL),
-  mSkills(NULL),
-  mMisc(NULL),
-  mBloodType(NULL),
-  mGender(NULL)
+  mRace(nullptr),
+  mClass(nullptr),
+  mFaction(nullptr),
+  mHair(nullptr),
+  mHead(nullptr),
+  mAttributes(nullptr),
+  mSkills(nullptr),
+  mMisc(nullptr),
+  mBloodType(nullptr),
+  mGender(nullptr)
 {}
 
 CSMWorld::NpcRefIdAdapter::NpcRefIdAdapter (const NpcColumns& columns)

--- a/apps/opencs/model/world/resourcesmanager.cpp
+++ b/apps/opencs/model/world/resourcesmanager.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 CSMWorld::ResourcesManager::ResourcesManager()
-    : mVFS(NULL)
+    : mVFS(nullptr)
 {
 }
 

--- a/apps/opencs/view/doc/filedialog.cpp
+++ b/apps/opencs/view/doc/filedialog.cpp
@@ -189,7 +189,7 @@ void CSVDoc::FileDialog::slotRejected()
     if(mFileWidget)
     {
         delete mFileWidget;
-        mFileWidget = NULL;
+        mFileWidget = nullptr;
     }
     close();
 }
@@ -200,7 +200,7 @@ void CSVDoc::FileDialog::slotNewFile()
     if(mFileWidget)
     {
         delete mFileWidget;
-        mFileWidget = NULL;
+        mFileWidget = nullptr;
     }
     disconnect (ui.projectButtonBox, SIGNAL (accepted()), this, SLOT (slotNewFile()));
     close();

--- a/apps/opencs/view/doc/subview.hpp
+++ b/apps/opencs/view/doc/subview.hpp
@@ -64,7 +64,7 @@ namespace CSVDoc
 
             void updateTitle();
 
-            void updateSubViewIndices (SubView *view = NULL);
+            void updateSubViewIndices (SubView *view = nullptr);
 
             void universalIdChanged (const CSMWorld::UniversalId& universalId);
 

--- a/apps/opencs/view/doc/view.cpp
+++ b/apps/opencs/view/doc/view.cpp
@@ -400,7 +400,7 @@ void CSVDoc::View::updateSubViewIndices(SubView *view)
             else
             {
                 delete subView->titleBarWidget();
-                subView->setTitleBarWidget (NULL);
+                subView->setTitleBarWidget (nullptr);
             }
         }
     }
@@ -429,7 +429,7 @@ void CSVDoc::View::updateActions()
 
 CSVDoc::View::View (ViewManager& viewManager, CSMDoc::Document *document, int totalViews)
     : mViewManager (viewManager), mDocument (document), mViewIndex (totalViews-1),
-      mViewTotal (totalViews), mScroll(NULL), mScrollbarOnly(false)
+      mViewTotal (totalViews), mScroll(nullptr), mScrollbarOnly(false)
 {
     CSMPrefs::Category& windows = CSMPrefs::State::get()["Windows"];
 
@@ -563,7 +563,7 @@ void CSVDoc::View::addSubView (const CSMWorld::UniversalId& id, const std::strin
         return;
     }
 
-    SubView *view = NULL;
+    SubView *view = nullptr;
     if(isReferenceable)
     {
         view = mSubViewFactory.makeSubView (CSMWorld::UniversalId(CSMWorld::UniversalId::Type_Referenceable, id.getId()), *mDocument);
@@ -631,7 +631,7 @@ void CSVDoc::View::moveScrollBarToEnd(int min, int max)
 void CSVDoc::View::settingChanged (const CSMPrefs::Setting *setting)
 {
     if (*setting=="Windows/hide-subview")
-        updateSubViewIndices (NULL);
+        updateSubViewIndices (nullptr);
     else if (*setting=="Windows/mainwindow-scrollbar")
     {
         if (setting->toString()!="Grow Only")
@@ -659,7 +659,7 @@ void CSVDoc::View::settingChanged (const CSMPrefs::Setting *setting)
             mScroll->takeWidget();
             setCentralWidget (&mSubViewWindow);
             mScroll->deleteLater();
-            mScroll = NULL;
+            mScroll = nullptr;
         }
     }
 }

--- a/apps/opencs/view/doc/view.hpp
+++ b/apps/opencs/view/doc/view.hpp
@@ -149,7 +149,7 @@ namespace CSVDoc
             void updateTitle();
 
             // called when subviews are added or removed
-            void updateSubViewIndices (SubView *view = NULL);
+            void updateSubViewIndices (SubView *view = nullptr);
 
         private slots:
 

--- a/apps/opencs/view/render/cameracontroller.cpp
+++ b/apps/opencs/view/render/cameracontroller.cpp
@@ -38,7 +38,7 @@ namespace CSVRender
         , mCameraSensitivity(1/650.f)
         , mSecondaryMoveMult(50)
         , mWheelMoveMult(8)
-        , mCamera(NULL)
+        , mCamera(nullptr)
     {
     }
 
@@ -81,7 +81,7 @@ namespace CSVRender
         bool wasActive = mActive;
 
         mCamera = camera;
-        mActive = (mCamera != NULL);
+        mActive = (mCamera != nullptr);
 
         if (mActive != wasActive)
         {

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -86,7 +86,7 @@ void CSVRender::Object::update()
     const int ModelIndex = referenceables.findColumnIndex (CSMWorld::Columns::ColumnId_Model);
 
     int index = referenceables.searchId (mReferenceableId);
-    const ESM::Light* light = NULL;
+    const ESM::Light* light = nullptr;
 
     mBaseNode->removeChildren(0, mBaseNode->getNumChildren());
 

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -527,7 +527,7 @@ void CSVRender::PagedWorldspaceWidget::addCellToSceneFromCamera (int offsetX, in
 
 CSVRender::PagedWorldspaceWidget::PagedWorldspaceWidget (QWidget* parent, CSMDoc::Document& document)
 : WorldspaceWidget (document, parent), mDocument (document), mWorldspace ("std::default"),
-  mControlElements(NULL), mDisplayCellCoord(true)
+  mControlElements(nullptr), mDisplayCellCoord(true)
 {
     QAbstractItemModel *cells =
         document.getData().getTableModel (CSMWorld::UniversalId::Type_Cells);

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -185,7 +185,7 @@ SceneWidget::SceneWidget(std::shared_ptr<Resource::ResourceSystem> resourceSyste
     bool retrieveInput)
     : RenderWidget(parent, f)
     , mResourceSystem(resourceSystem)
-    , mLighting(NULL)
+    , mLighting(nullptr)
     , mHasDefaultAmbient(false)
     , mPrevMouseX(0)
     , mPrevMouseY(0)
@@ -425,21 +425,21 @@ void SceneWidget::selectNavigationMode (const std::string& mode)
 {
     if (mode=="1st")
     {
-        mCurrentCamControl->setCamera(NULL);
+        mCurrentCamControl->setCamera(nullptr);
         mCurrentCamControl = mFreeCamControl;
         mFreeCamControl->setCamera(getCamera());
         mFreeCamControl->fixUpAxis(CameraController::WorldUp);
     }
     else if (mode=="free")
     {
-        mCurrentCamControl->setCamera(NULL);
+        mCurrentCamControl->setCamera(nullptr);
         mCurrentCamControl = mFreeCamControl;
         mFreeCamControl->setCamera(getCamera());
         mFreeCamControl->unfixUpAxis();
     }
     else if (mode=="orbit")
     {
-        mCurrentCamControl->setCamera(NULL);
+        mCurrentCamControl->setCamera(nullptr);
         mCurrentCamControl = mOrbitCamControl;
         mOrbitCamControl->setCamera(getCamera());
         mOrbitCamControl->reset();

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -18,7 +18,7 @@ namespace CSVRender
         // has to wrap the vertices of the last row and column to the next cell, which may be a nonexisting cell
         int index = mData.getLand().searchId(CSMWorld::Land::createUniqueRecordId(cellX, cellY));
         if (index == -1)
-            return NULL;
+            return nullptr;
 
         const ESM::Land& land = mData.getLand().getRecord(index).get();
         return new ESMTerrain::LandObject(&land, ESM::Land::DATA_VHGT | ESM::Land::DATA_VNML | ESM::Land::DATA_VCLR | ESM::Land::DATA_VTEX);

--- a/apps/opencs/view/widget/colorpickerpopup.cpp
+++ b/apps/opencs/view/widget/colorpickerpopup.cpp
@@ -45,7 +45,7 @@ void CSVWidget::ColorPickerPopup::showPicker(const QPoint &position, const QColo
 void CSVWidget::ColorPickerPopup::mousePressEvent(QMouseEvent *event)
 {
     QPushButton *button = qobject_cast<QPushButton *>(parentWidget());
-    if (button != NULL)
+    if (button != nullptr)
     {
         QStyleOptionButton option;
         option.init(button);

--- a/apps/opencs/view/widget/completerpopup.cpp
+++ b/apps/opencs/view/widget/completerpopup.cpp
@@ -11,7 +11,7 @@ CSVWidget::CompleterPopup::CompleterPopup(QWidget *parent)
 
 int CSVWidget::CompleterPopup::sizeHintForRow(int row) const
 {
-    if (model() == NULL)
+    if (model() == nullptr)
     {
         return -1;
     }

--- a/apps/opencs/view/world/cellcreator.cpp
+++ b/apps/opencs/view/world/cellcreator.cpp
@@ -25,7 +25,7 @@ std::string CSVWorld::CellCreator::getId() const
 void CSVWorld::CellCreator::configureCreateCommand(CSMWorld::CreateCommand& command) const
 {
     CSMWorld::IdTree *model = dynamic_cast<CSMWorld::IdTree *>(getData().getTableModel(getCollectionId()));
-    Q_ASSERT(model != NULL);
+    Q_ASSERT(model != nullptr);
     int parentIndex = model->findColumnIndex(CSMWorld::Columns::ColumnId_Cell);
     int index = model->findNestedColumnIndex(parentIndex, CSMWorld::Columns::ColumnId_Interior);
     command.addNestedValue(parentIndex, index, mType->currentIndex() == 0);

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -158,7 +158,7 @@ mNotEditableDelegate(table, parent)
 
 CSVWorld::CommandDelegate* CSVWorld::DialogueDelegateDispatcher::makeDelegate(CSMWorld::ColumnBase::Display display)
 {
-    CommandDelegate *delegate = NULL;
+    CommandDelegate *delegate = nullptr;
     std::map<int, CommandDelegate*>::const_iterator delegateIt(mDelegates.find(display));
     if (delegateIt == mDelegates.end())
     {
@@ -251,11 +251,11 @@ QWidget* CSVWorld::DialogueDelegateDispatcher::makeEditor(CSMWorld::ColumnBase::
         variant = index.data(Qt::DisplayRole);
         if (!variant.isValid())
         {
-            return NULL;
+            return nullptr;
         }
     }
 
-    QWidget* editor = NULL;
+    QWidget* editor = nullptr;
     if (! (mTable->flags (index) & Qt::ItemIsEditable))
     {
         return mNotEditableDelegate.createEditor(qobject_cast<QWidget*>(mParent),
@@ -325,7 +325,7 @@ CSVWorld::IdContextMenu::IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Di
       mWidget(widget),
       mIdType(CSMWorld::TableMimeData::convertEnums(display))
 {
-    Q_ASSERT(mWidget != NULL);
+    Q_ASSERT(mWidget != nullptr);
     Q_ASSERT(CSMWorld::ColumnBase::isId(display));
     Q_ASSERT(mIdType != CSMWorld::UniversalId::Type_None);
 
@@ -339,7 +339,7 @@ CSVWorld::IdContextMenu::IdContextMenu(QWidget *widget, CSMWorld::ColumnBase::Di
     connect(mEditIdAction, SIGNAL(triggered()), this, SLOT(editIdRequest()));
 
     QLineEdit *lineEdit = qobject_cast<QLineEdit *>(mWidget);
-    if (lineEdit != NULL)
+    if (lineEdit != nullptr)
     {
         mContextMenu = lineEdit->createStandardContextMenu();
     }
@@ -360,11 +360,11 @@ QString CSVWorld::IdContextMenu::getWidgetValue() const
     QLabel *label = qobject_cast<QLabel *>(mWidget);
 
     QString value = "";
-    if (lineEdit != NULL)
+    if (lineEdit != nullptr)
     {
         value = lineEdit->text();
     }
-    else if (label != NULL)
+    else if (label != nullptr)
     {
         value = label->text();
     }
@@ -436,7 +436,7 @@ void CSVWorld::EditWidget::createEditorContextMenu(QWidget *editor,
                                                    CSMWorld::ColumnBase::Display display,
                                                    int currentRow) const
 {
-    Q_ASSERT(editor != NULL);
+    Q_ASSERT(editor != nullptr);
 
     if (CSMWorld::ColumnBase::isId(display) &&
         CSMWorld::TableMimeData::convertEnums(display) != CSMWorld::UniversalId::Type_None)
@@ -470,11 +470,11 @@ CSVWorld::EditWidget::EditWidget(QWidget *parent,
         int row, CSMWorld::IdTable* table, CSMWorld::CommandDispatcher& commandDispatcher,
         CSMDoc::Document& document, bool createAndDelete) :
 QScrollArea(parent),
-mWidgetMapper(NULL),
-mNestedTableMapper(NULL),
-mDispatcher(NULL),
-mNestedTableDispatcher(NULL),
-mMainWidget(NULL),
+mWidgetMapper(nullptr),
+mNestedTableMapper(nullptr),
+mDispatcher(nullptr),
+mNestedTableDispatcher(nullptr),
+mMainWidget(nullptr),
 mTable(table),
 mCommandDispatcher (commandDispatcher),
 mDocument (document)
@@ -733,7 +733,7 @@ bool CSVWorld::SimpleDialogueSubView::isLocked() const
 CSVWorld::SimpleDialogueSubView::SimpleDialogueSubView (const CSMWorld::UniversalId& id, CSMDoc::Document& document) :
     SubView (id),
     mEditWidget(0),
-    mMainLayout(NULL),
+    mMainLayout(nullptr),
     mTable(dynamic_cast<CSMWorld::IdTable*>(document.getData().getTableModel(id))),
     mLocked(false),
     mDocument(document),

--- a/apps/opencs/view/world/dragdroputils.cpp
+++ b/apps/opencs/view/world/dragdroputils.cpp
@@ -12,7 +12,7 @@ const CSMWorld::TableMimeData *CSVWorld::DragDropUtils::getTableMimeData(const Q
 bool CSVWorld::DragDropUtils::canAcceptData(const QDropEvent &event, CSMWorld::ColumnBase::Display type)
 {
     const CSMWorld::TableMimeData *data = getTableMimeData(event);
-    return data != NULL && data->holdsType(type);
+    return data != nullptr && data->holdsType(type);
 }
 
 CSMWorld::UniversalId CSVWorld::DragDropUtils::getAcceptedData(const QDropEvent &event, 

--- a/apps/opencs/view/world/dragrecordtable.cpp
+++ b/apps/opencs/view/world/dragrecordtable.cpp
@@ -83,7 +83,7 @@ void CSVWorld::DragRecordTable::dropEvent(QDropEvent *event)
 
 CSMWorld::ColumnBase::Display CSVWorld::DragRecordTable::getIndexDisplayType(const QModelIndex &index) const
 {
-    Q_ASSERT(model() != NULL);
+    Q_ASSERT(model() != nullptr);
 
     if (index.isValid())
     {

--- a/apps/opencs/view/world/dragrecordtable.hpp
+++ b/apps/opencs/view/world/dragrecordtable.hpp
@@ -28,7 +28,7 @@ namespace CSVWorld
             bool mEditLock;
 
         public:
-            DragRecordTable(CSMDoc::Document& document, QWidget* parent = NULL);
+            DragRecordTable(CSMDoc::Document& document, QWidget* parent = nullptr);
 
             virtual std::vector<CSMWorld::UniversalId> getDraggedRecords() const = 0;
 

--- a/apps/opencs/view/world/extendedcommandconfigurator.cpp
+++ b/apps/opencs/view/world/extendedcommandconfigurator.cpp
@@ -95,7 +95,7 @@ void CSVWorld::ExtendedCommandConfigurator::setupGroupLayout()
     int divider = 1;
     do
     {
-        while (layout->itemAt(0) != NULL)
+        while (layout->itemAt(0) != nullptr)
         {
             layout->removeItem(layout->itemAt(0));
         }

--- a/apps/opencs/view/world/idcompletiondelegate.cpp
+++ b/apps/opencs/view/world/idcompletiondelegate.cpp
@@ -25,7 +25,7 @@ QWidget *CSVWorld::IdCompletionDelegate::createEditor(QWidget *parent,
 {
     if (!index.data(Qt::EditRole).isValid() && !index.data(Qt::DisplayRole).isValid())
     {
-        return NULL;
+        return nullptr;
     }
 
     // The completer for InfoCondVar needs to return a completer based on the first column

--- a/apps/opencs/view/world/nestedtable.cpp
+++ b/apps/opencs/view/world/nestedtable.cpp
@@ -23,9 +23,9 @@ CSVWorld::NestedTable::NestedTable(CSMDoc::Document& document,
                                    bool editable,
                                    bool fixedRows)
     : DragRecordTable(document, parent),
-      mAddNewRowAction(NULL),
-      mRemoveRowAction(NULL),
-      mEditIdAction(NULL),
+      mAddNewRowAction(nullptr),
+      mRemoveRowAction(nullptr),
+      mEditIdAction(nullptr),
       mModel(model)
 {
     mDispatcher = new CSMWorld::CommandDispatcher (document, id, this);

--- a/apps/opencs/view/world/nestedtable.hpp
+++ b/apps/opencs/view/world/nestedtable.hpp
@@ -38,7 +38,7 @@ namespace CSVWorld
         NestedTable(CSMDoc::Document& document,
                     CSMWorld::UniversalId id,
                     CSMWorld::NestedTableProxyModel* model,
-                    QWidget* parent = NULL,
+                    QWidget* parent = nullptr,
                     bool editable = true,
                     bool fixedRows = false);
 

--- a/apps/opencs/view/world/scenesubview.cpp
+++ b/apps/opencs/view/world/scenesubview.cpp
@@ -27,7 +27,7 @@
 #include "creator.hpp"
 
 CSVWorld::SceneSubView::SceneSubView (const CSMWorld::UniversalId& id, CSMDoc::Document& document)
-: SubView (id), mScene(NULL), mLayout(new QHBoxLayout), mDocument(document), mToolbar(NULL)
+: SubView (id), mScene(nullptr), mLayout(new QHBoxLayout), mDocument(document), mToolbar(nullptr)
 {
     QVBoxLayout *layout = new QVBoxLayout;
 
@@ -35,7 +35,7 @@ CSVWorld::SceneSubView::SceneSubView (const CSMWorld::UniversalId& id, CSMDoc::D
 
     mLayout->setContentsMargins (QMargins (0, 0, 0, 0));
 
-    CSVRender::WorldspaceWidget* worldspaceWidget = NULL;
+    CSVRender::WorldspaceWidget* worldspaceWidget = nullptr;
     widgetType whatWidget;
 
     if (id.getId()==ESM::CellId::sDefaultWorldspace)
@@ -189,9 +189,9 @@ void CSVWorld::SceneSubView::cellSelectionChanged (const CSMWorld::CellSelection
 
 void CSVWorld::SceneSubView::handleDrop (const std::vector< CSMWorld::UniversalId >& universalIdData)
 {
-    CSVRender::PagedWorldspaceWidget* pagedNewWidget = NULL;
-    CSVRender::UnpagedWorldspaceWidget* unPagedNewWidget = NULL;
-    CSVWidget::SceneToolbar* toolbar = NULL;
+    CSVRender::PagedWorldspaceWidget* pagedNewWidget = nullptr;
+    CSVRender::UnpagedWorldspaceWidget* unPagedNewWidget = nullptr;
+    CSVWidget::SceneToolbar* toolbar = nullptr;
 
     CSVRender::WorldspaceWidget::DropType type = CSVRender::WorldspaceWidget::getDropType (universalIdData);
 

--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -129,7 +129,7 @@ void CSVWorld::CommandDelegate::setModelDataImp (QWidget *editor, QAbstractItemM
 
     // Color columns use a custom editor, so we need to fetch selected color from it.
     CSVWidget::ColorEditor *colorEditor = qobject_cast<CSVWidget::ColorEditor *>(editor);
-    if (colorEditor != NULL)
+    if (colorEditor != nullptr)
     {
         variant = colorEditor->colorInt();
     }
@@ -322,7 +322,7 @@ void CSVWorld::CommandDelegate::setEditorData (QWidget *editor, const QModelInde
 
     // Color columns use a custom editor, so we need explicitly set a data for it
     CSVWidget::ColorEditor *colorEditor = qobject_cast<CSVWidget::ColorEditor *>(editor);
-    if (colorEditor != NULL)
+    if (colorEditor != nullptr)
     {
         colorEditor->setColor(variant.toInt());
         return;

--- a/apps/openmw/android_main.c
+++ b/apps/openmw/android_main.c
@@ -20,14 +20,14 @@ void releaseArgv();
 
 int Java_org_libsdl_app_SDLActivity_getMouseX(JNIEnv *env, jclass cls, jobject obj) {
     int ret = 0;
-    SDL_GetMouseState(&ret, NULL);
+    SDL_GetMouseState(&ret, nullptr);
     return ret;
 }
 
 
 int Java_org_libsdl_app_SDLActivity_getMouseY(JNIEnv *env, jclass cls, jobject obj) {
     int ret = 0;
-    SDL_GetMouseState(NULL, &ret);
+    SDL_GetMouseState(nullptr, &ret);
     return ret;
 }
 

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -197,9 +197,9 @@ bool OMW::Engine::frame(float frametime)
 }
 
 OMW::Engine::Engine(Files::ConfigurationManager& configurationManager)
-  : mWindow(NULL)
+  : mWindow(nullptr)
   , mEncoding(ToUTF8::WINDOWS_1252)
-  , mEncoder(NULL)
+  , mEncoder(nullptr)
   , mScreenCaptureOperation(nullptr)
   , mSkipMenu (false)
   , mUseSound (true)
@@ -237,18 +237,18 @@ OMW::Engine::~Engine()
     mEnvironment.cleanup();
 
     delete mScriptContext;
-    mScriptContext = NULL;
+    mScriptContext = nullptr;
 
-    mWorkQueue = NULL;
+    mWorkQueue = nullptr;
 
     mResourceSystem.reset();
 
-    mViewer = NULL;
+    mViewer = nullptr;
 
     if (mWindow)
     {
         SDL_DestroyWindow(mWindow);
-        mWindow = NULL;
+        mWindow = nullptr;
     }
 
     SDL_Quit();

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -74,7 +74,7 @@ namespace MWClass
         if (ref->mBase->mFlags & ESM::Container::Respawn)
         {
             MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
-            ptr.getRefData().setCustomData(NULL);
+            ptr.getRefData().setCustomData(nullptr);
         }
     }
 

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -298,7 +298,7 @@ namespace MWClass
         bool healthdmg = true;
         if (!weapon.isEmpty())
         {
-            const unsigned char *attack = NULL;
+            const unsigned char *attack = nullptr;
             if(type == ESM::Weapon::AT_Chop)
                 attack = weapon.get<ESM::Weapon>()->mBase->mData.mChop;
             else if(type == ESM::Weapon::AT_Slash)
@@ -828,7 +828,7 @@ namespace MWClass
                     ptr.getRefData().setCount(1);
 
                 MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
-                ptr.getRefData().setCustomData(NULL);
+                ptr.getRefData().setCustomData(nullptr);
 
                 // Reset to original position
                 MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -41,7 +41,7 @@ namespace MWClass
     {
         MWWorld::LiveCellRef<ESM::Light> *ref =
             ptr.get<ESM::Light>();
-        assert (ref->mBase != NULL);
+        assert (ref->mBase != nullptr);
 
         // TODO: add option somewhere to enable collision for placeable objects
         if (!model.empty() && (ref->mBase->mData.mFlags & ESM::Light::Carry) == 0)

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -610,7 +610,7 @@ namespace MWClass
         float damage = 0.0f;
         if(!weapon.isEmpty())
         {
-            const unsigned char *attack = NULL;
+            const unsigned char *attack = nullptr;
             if(type == ESM::Weapon::AT_Chop)
                 attack = weapon.get<ESM::Weapon>()->mBase->mData.mChop;
             else if(type == ESM::Weapon::AT_Slash)
@@ -1382,7 +1382,7 @@ namespace MWClass
                     ptr.getRefData().setCount(1);
 
                 MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
-                ptr.getRefData().setCustomData(NULL);
+                ptr.getRefData().setCustomData(nullptr);
 
                 // Reset to original position
                 MWBase::Environment::get().getWorld()->moveObject(ptr, ptr.getCellRef().getPosition().pos[0],

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -572,7 +572,7 @@ namespace MWDialogue
         const MWMechanics::CreatureStats& creatureStats = actor.getClass().getCreatureStats(actor);
         Filter filter(actor, 0, creatureStats.hasTalkedToPlayer());
         const ESM::DialInfo *info = filter.search(*dial, false);
-        if(info != NULL)
+        if(info != nullptr)
         {
             MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
             if(winMgr->getSubtitlesEnabled())

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -621,7 +621,7 @@ const ESM::DialInfo* MWDialogue::Filter::search (const ESM::Dialogue& dialogue, 
     std::vector<const ESM::DialInfo *> suitableInfos = list (dialogue, fallbackToInfoRefusal, false);
 
     if (suitableInfos.empty())
-        return NULL;
+        return nullptr;
     else
         return suitableInfos[0];
 }

--- a/apps/openmw/mwdialogue/journalentry.cpp
+++ b/apps/openmw/mwdialogue/journalentry.cpp
@@ -30,7 +30,7 @@ namespace MWDialogue
             {
                 if (actor.isEmpty())
                 {
-                    MWScript::InterpreterContext interpreterContext(NULL,MWWorld::Ptr());
+                    MWScript::InterpreterContext interpreterContext(nullptr, MWWorld::Ptr());
                     mText = Interpreter::fixDefinesDialog(iter->mResponse, interpreterContext);
                 }
                 else

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -30,7 +30,7 @@ namespace MWGui
 
     AlchemyWindow::AlchemyWindow()
         : WindowBase("openmw_alchemy_window.layout")
-        , mSortModel(NULL)
+        , mSortModel(nullptr)
         , mAlchemy(new MWMechanics::Alchemy())
         , mApparatus (4)
         , mIngredients (4)

--- a/apps/openmw/mwgui/backgroundimage.cpp
+++ b/apps/openmw/mwgui/backgroundimage.cpp
@@ -10,7 +10,7 @@ void BackgroundImage::setBackgroundImage (const std::string& image, bool fixedRa
     if (mChild)
     {
         MyGUI::Gui::getInstance().destroyWidget(mChild);
-        mChild = NULL;
+        mChild = nullptr;
     }
     if (!stretch)
     {

--- a/apps/openmw/mwgui/backgroundimage.hpp
+++ b/apps/openmw/mwgui/backgroundimage.hpp
@@ -14,7 +14,7 @@ namespace MWGui
     MYGUI_RTTI_DERIVED(BackgroundImage)
 
     public:
-        BackgroundImage() : mChild(NULL), mAspect(0) {}
+        BackgroundImage() : mChild(nullptr), mAspect(0) {}
 
         /**
          * @param fixedRatio Use a fixed ratio of 4:3, regardless of the image dimensions

--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -110,7 +110,7 @@ struct TypesetBookImpl : TypesetBook
         Contents::iterator i = mContents.insert (mContents.end (), Content (text.first, text.second));
 
         if (i->empty())
-            return Range (Utf8Point (NULL), Utf8Point (NULL));
+            return Range (Utf8Point (nullptr), Utf8Point (nullptr));
 
         Utf8Point begin = &i->front ();
         Utf8Point end   = &i->front () + i->size ();
@@ -148,7 +148,7 @@ struct TypesetBookImpl : TypesetBook
     template <typename Visitor>
     void visitRuns (int top, int bottom, Visitor const & visitor) const
     {
-        visitRuns (top, bottom, NULL, visitor);
+        visitRuns (top, bottom, nullptr, visitor);
     }
 
     /// hit test with a margin for error. only hits on interactive text fragments are reported.
@@ -176,7 +176,7 @@ struct TypesetBookImpl : TypesetBook
                     return hit;
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     StyleImpl * hitTest (int left, int top) const
@@ -213,7 +213,7 @@ struct TypesetBookImpl : TypesetBook
         for (Styles::iterator i = mStyles.begin (); i != mStyles.end (); ++i)
             if (&*i == style)
                 return i->mFont;
-        return NULL;
+        return nullptr;
     }
 
     struct Typesetter;
@@ -253,8 +253,8 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
 
     Typesetter (size_t width, size_t height) :
         mPageWidth (width), mPageHeight(height),
-        mSection (NULL), mLine (NULL), mRun (NULL),
-        mCurrentContent (NULL),
+        mSection (nullptr), mLine (nullptr), mRun (nullptr),
+        mCurrentContent (nullptr),
         mCurrentAlignment (AlignLeft)
     {
         mBook = std::make_shared <Book> ();
@@ -342,7 +342,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
 
     void write (Style * style, size_t begin, size_t end)
     {
-        assert (mCurrentContent != NULL);
+        assert (mCurrentContent != nullptr);
         assert (end <= mCurrentContent->size ());
         assert (begin <= mCurrentContent->size ());
 
@@ -358,8 +358,8 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
 
         add_partial_text();
 
-        mRun = NULL;
-        mLine = NULL;
+        mRun = nullptr;
+        mLine = nullptr;
     }
 
     void sectionBreak (int margin)
@@ -368,9 +368,9 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
 
         if (mBook->mSections.size () > 0)
         {
-            mRun = NULL;
-            mLine = NULL;
-            mSection = NULL;
+            mRun = nullptr;
+            mLine = nullptr;
+            mSection = nullptr;
 
             if (mBook->mRect.bottom < (mBook->mSections.back ().mRect.bottom + margin))
                 mBook->mRect.bottom = (mBook->mSections.back ().mRect.bottom + margin);
@@ -381,7 +381,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
     {
         add_partial_text();
 
-        if (mSection != NULL)
+        if (mSection != nullptr)
             mSectionAlignment.back () = sectionAlignment;
         mCurrentAlignment = sectionAlignment;
     }
@@ -491,7 +491,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
             {
                 add_partial_text();
                 stream.consume ();
-                mLine = NULL, mRun = NULL;
+                mLine = nullptr, mRun = nullptr;
                 continue;
             }
 
@@ -551,7 +551,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
 
         if (left + space_width + word_width > mPageWidth)
         {
-            mLine = NULL, mRun = NULL, left = 0;
+            mLine = nullptr, mRun = nullptr, left = 0;
         }
         else
         {
@@ -580,7 +580,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
 
     void append_run (StyleImpl * style, Utf8Stream::Point begin, Utf8Stream::Point end, int pc, int right, int bottom)
     {
-        if (mSection == NULL)
+        if (mSection == nullptr)
         {
             mBook->mSections.push_back (Section ());
             mSection = &mBook->mSections.back ();
@@ -588,7 +588,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
             mSectionAlignment.push_back (mCurrentAlignment);
         }
 
-        if (mLine == NULL)
+        if (mLine == nullptr)
         {
             mSection->mLines.push_back (Line ());
             mLine = &mSection->mLines.back ();
@@ -613,7 +613,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
         if (mLine->mRect.bottom < bottom)
             mLine->mRect.bottom = bottom;
 
-        if (mRun == NULL || mRun->mStyle != style || mRun->mRange.second != begin)
+        if (mRun == nullptr || mRun->mStyle != style || mRun->mRange.second != begin)
         {
             int left = mRun ? mRun->mRight : mLine->mRect.left;
 
@@ -843,17 +843,17 @@ protected:
         TextFormat (MyGUI::IFont* id, PageDisplay * display) :
             mFont (id),
             mCountVertex (0),
-            mTexture (NULL),
-            mRenderItem (NULL),
+            mTexture (nullptr),
+            mRenderItem (nullptr),
             mDisplay (display)
         {
         }
 
         void createDrawItem (MyGUI::ILayerNode* node)
         {
-            assert (mRenderItem == NULL);
+            assert (mRenderItem == nullptr);
 
-            if (mTexture != NULL)
+            if (mTexture != nullptr)
             {
                 mRenderItem = node->addToRenderItem(mTexture, false, false);
                 mRenderItem->addDrawItem(this, mCountVertex);
@@ -862,12 +862,12 @@ protected:
 
         void destroyDrawItem (MyGUI::ILayerNode* node)
         {
-            assert (mTexture != NULL ? mRenderItem != NULL : mRenderItem == NULL);
+            assert (mTexture != nullptr ? mRenderItem != nullptr : mRenderItem == nullptr);
 
-            if (mTexture != NULL)
+            if (mTexture != nullptr)
             {
                 mRenderItem->removeDrawItem (this);
-                mRenderItem = NULL;
+                mRenderItem = nullptr;
             }
         }
 
@@ -920,9 +920,9 @@ public:
         resetPage ();
         mViewTop = 0;
         mViewBottom = 0;
-        mFocusItem = NULL;
+        mFocusItem = nullptr;
         mItemActive = false;
-        mNode = NULL;
+        mNode = nullptr;
     }
 
     void dirtyFocusItem ()
@@ -1053,7 +1053,7 @@ public:
 
             for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
             {
-                if (mNode != NULL)
+                if (mNode != nullptr)
                     i->second->destroyDrawItem (mNode);
                 i->second.reset();
             }
@@ -1089,7 +1089,7 @@ public:
         else
         if (mBook && isPageDifferent (newPage))
         {
-            if (mNode != NULL)
+            if (mNode != nullptr)
                 for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
                     mNode->outOfDate(i->second->mRenderItem);
 
@@ -1137,7 +1137,7 @@ public:
     {
         newBook->visitRuns (0, 0x7FFFFFFF, CreateActiveFormat (this));
 
-        if (mNode != NULL)
+        if (mNode != nullptr)
             for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
                 i->second->createDrawItem (mNode);
     }
@@ -1238,7 +1238,7 @@ public:
     {
         _checkMargin();
 
-        if (mNode != NULL)
+        if (mNode != nullptr)
             for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
                 mNode->outOfDate (i->second->mRenderItem);
     }
@@ -1247,7 +1247,7 @@ public:
     {
         _checkMargin ();
 
-        if (mNode != NULL)
+        if (mNode != nullptr)
             for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
                 mNode->outOfDate (i->second->mRenderItem);
 
@@ -1258,7 +1258,7 @@ public:
         for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
             i->second->destroyDrawItem (mNode);
 
-        mNode = NULL;
+        mNode = nullptr;
     }
 };
 
@@ -1269,7 +1269,7 @@ MYGUI_RTTI_DERIVED(BookPage)
 public:
 
     BookPageImpl()
-        : mPageDisplay(NULL)
+        : mPageDisplay(nullptr)
     {
     }
 

--- a/apps/openmw/mwgui/class.cpp
+++ b/apps/openmw/mwgui/class.cpp
@@ -399,12 +399,12 @@ namespace MWGui
 
     CreateClassDialog::CreateClassDialog()
       : WindowModal("openmw_chargen_create_class.layout")
-      , mSpecDialog(NULL)
-      , mAttribDialog(NULL)
-      , mSkillDialog(NULL)
-      , mDescDialog(NULL)
-      , mAffectedAttribute(NULL)
-      , mAffectedSkill(NULL)
+      , mSpecDialog(nullptr)
+      , mAttribDialog(nullptr)
+      , mSkillDialog(nullptr)
+      , mDescDialog(nullptr)
+      , mAffectedAttribute(nullptr)
+      , mAffectedSkill(nullptr)
     {
         // Centre dialog
         center();

--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -37,8 +37,8 @@ namespace MWGui
 
 CompanionWindow::CompanionWindow(DragAndDrop *dragAndDrop, MessageBoxManager* manager)
     : WindowBase("openmw_companion_window.layout")
-    , mSortModel(NULL)
-    , mModel(NULL)
+    , mSortModel(nullptr)
+    , mModel(nullptr)
     , mSelectedItem(-1)
     , mDragAndDrop(dragAndDrop)
     , mMessageBoxManager(manager)
@@ -89,7 +89,7 @@ void CompanionWindow::onItemSelected(int index)
         dialog->eventOkClicked += MyGUI::newDelegate(this, &CompanionWindow::dragItem);
     }
     else
-        dragItem (NULL, count);
+        dragItem (nullptr, count);
 }
 
 void CompanionWindow::dragItem(MyGUI::Widget* sender, int count)
@@ -179,9 +179,9 @@ void CompanionWindow::onReferenceUnavailable()
 void CompanionWindow::resetReference()
 {
     ReferenceInterface::resetReference();
-    mItemView->setModel(NULL);
-    mModel = NULL;
-    mSortModel = NULL;
+    mItemView->setModel(nullptr);
+    mModel = nullptr;
+    mSortModel = nullptr;
 }
 
 

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -31,8 +31,8 @@ namespace MWGui
     ContainerWindow::ContainerWindow(DragAndDrop* dragAndDrop)
         : WindowBase("openmw_container_window.layout")
         , mDragAndDrop(dragAndDrop)
-        , mSortModel(NULL)
-        , mModel(NULL)
+        , mSortModel(nullptr)
+        , mModel(nullptr)
         , mSelectedItem(-1)
     {
         getWidget(mDisposeCorpseButton, "DisposeCorpseButton");
@@ -83,7 +83,7 @@ namespace MWGui
             dialog->eventOkClicked += MyGUI::newDelegate(this, &ContainerWindow::dragItem);
         }
         else
-            dragItem (NULL, count);
+            dragItem (nullptr, count);
     }
 
     void ContainerWindow::dragItem(MyGUI::Widget* sender, int count)
@@ -151,9 +151,9 @@ namespace MWGui
     void ContainerWindow::resetReference()
     {
         ReferenceInterface::resetReference();
-        mItemView->setModel(NULL);
-        mModel = NULL;
-        mSortModel = NULL;
+        mItemView->setModel(nullptr);
+        mModel = nullptr;
+        mSortModel = nullptr;
     }
 
     void ContainerWindow::onClose()
@@ -171,7 +171,7 @@ namespace MWGui
 
     void ContainerWindow::onTakeAllButtonClicked(MyGUI::Widget* _sender)
     {
-        if(mDragAndDrop != NULL && mDragAndDrop->mIsOnDragAndDrop)
+        if(mDragAndDrop != nullptr && mDragAndDrop->mIsOnDragAndDrop)
             return;
 
         MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
@@ -219,7 +219,7 @@ namespace MWGui
 
     void ContainerWindow::onDisposeCorpseButtonClicked(MyGUI::Widget *sender)
     {
-        if(mDragAndDrop == NULL || !mDragAndDrop->mIsOnDragAndDrop)
+        if(mDragAndDrop == nullptr || !mDragAndDrop->mIsOnDragAndDrop)
         {
             MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
 

--- a/apps/openmw/mwgui/countdialog.cpp
+++ b/apps/openmw/mwgui/countdialog.cpp
@@ -63,7 +63,7 @@ namespace MWGui
 
     void CountDialog::onOkButtonClicked(MyGUI::Widget* _sender)
     {
-        eventOkClicked(NULL, mSlider->getScrollPosition()+1);
+        eventOkClicked(nullptr, mSlider->getScrollPosition()+1);
 
         setVisible(false);
     }
@@ -72,7 +72,7 @@ namespace MWGui
     // Enter key
     void CountDialog::onEnterKeyPressed(MyGUI::EditBox* _sender)
     {
-        eventOkClicked(NULL, mSlider->getScrollPosition()+1);
+        eventOkClicked(nullptr, mSlider->getScrollPosition()+1);
         setVisible(false);
 
         // To do not spam onEnterKeyPressed() again and again

--- a/apps/openmw/mwgui/cursor.cpp
+++ b/apps/openmw/mwgui/cursor.cpp
@@ -10,7 +10,7 @@ namespace MWGui
 
 
     ResourceImageSetPointerFix::ResourceImageSetPointerFix()
-        : mImageSet(NULL)
+        : mImageSet(nullptr)
         , mRotation(0)
     {
     }
@@ -47,7 +47,7 @@ namespace MWGui
 
     void ResourceImageSetPointerFix::setImage(MyGUI::ImageBox* _image)
     {
-        if (mImageSet != NULL)
+        if (mImageSet != nullptr)
             _image->setItemResourceInfo(mImageSet->getIndexInfo(0, 0));
     }
 

--- a/apps/openmw/mwgui/draganddrop.cpp
+++ b/apps/openmw/mwgui/draganddrop.cpp
@@ -20,10 +20,10 @@ namespace MWGui
 
 DragAndDrop::DragAndDrop()
     : mIsOnDragAndDrop(false)
-    , mDraggedWidget(NULL)
-    , mSourceModel(NULL)
-    , mSourceView(NULL)
-    , mSourceSortModel(NULL)
+    , mDraggedWidget(nullptr)
+    , mSourceModel(nullptr)
+    , mSourceView(nullptr)
+    , mSourceSortModel(nullptr)
     , mDraggedCount(0)
 {
 }

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -28,7 +28,7 @@ namespace MWGui
     EnchantingDialog::EnchantingDialog()
         : WindowBase("openmw_enchanting_dialog.layout")
         , EffectEditorBase(EffectEditorBase::Enchanting)
-        , mItemSelectionDialog(NULL)
+        , mItemSelectionDialog(nullptr)
     {
         getWidget(mName, "NameEdit");
         getWidget(mCancelButton, "CancelButton");

--- a/apps/openmw/mwgui/exposedwindow.cpp
+++ b/apps/openmw/mwgui/exposedwindow.cpp
@@ -14,7 +14,7 @@ namespace MWGui
         if (widgets.empty())
         {
             MYGUI_ASSERT( ! _throw, "widget name '" << _name << "' not found in skin of layout '" << getName() << "'");
-            return NULL;
+            return nullptr;
         }
         else
         {

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -27,7 +27,7 @@ namespace MWGui
         BookTextParser::BookTextParser(const std::string & text)
             : mIndex(0), mText(text), mIgnoreNewlineTags(true), mIgnoreLineEndings(true), mClosingTag(false)
         {
-            MWScript::InterpreterContext interpreterContext(NULL, MWWorld::Ptr()); // empty arguments, because there is no locals or actor
+            MWScript::InterpreterContext interpreterContext(nullptr, MWWorld::Ptr()); // empty arguments, because there is no locals or actor
             mText = Interpreter::fixDefinesBook(mText, interpreterContext);
 
             boost::algorithm::replace_all(mText, "\r", "");

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -70,20 +70,20 @@ namespace MWGui
     HUD::HUD(CustomMarkerCollection &customMarkers, DragAndDrop* dragAndDrop, MWRender::LocalMap* localMapRender)
         : WindowBase("openmw_hud.layout")
         , LocalMapBase(customMarkers, localMapRender, Settings::Manager::getBool("local map hud fog of war", "Map"))
-        , mHealth(NULL)
-        , mMagicka(NULL)
-        , mStamina(NULL)
-        , mDrowning(NULL)
-        , mWeapImage(NULL)
-        , mSpellImage(NULL)
-        , mWeapStatus(NULL)
-        , mSpellStatus(NULL)
-        , mEffectBox(NULL)
-        , mMinimap(NULL)
-        , mCrosshair(NULL)
-        , mCellNameBox(NULL)
-        , mDrowningFrame(NULL)
-        , mDrowningFlash(NULL)
+        , mHealth(nullptr)
+        , mMagicka(nullptr)
+        , mStamina(nullptr)
+        , mDrowning(nullptr)
+        , mWeapImage(nullptr)
+        , mSpellImage(nullptr)
+        , mWeapStatus(nullptr)
+        , mSpellStatus(nullptr)
+        , mEffectBox(nullptr)
+        , mMinimap(nullptr)
+        , mCrosshair(nullptr)
+        , mCellNameBox(nullptr)
+        , mDrowningFrame(nullptr)
+        , mDrowningFlash(nullptr)
         , mHealthManaStaminaBaseLeft(0)
         , mWeapBoxBaseLeft(0)
         , mSpellBoxBaseLeft(0)
@@ -247,7 +247,7 @@ namespace MWGui
             float mouseY = cursorPosition.top / float(viewSize.height);
 
             WorldItemModel drop (mouseX, mouseY);
-            mDragAndDrop->drop(&drop, NULL);
+            mDragAndDrop->drop(&drop, nullptr);
 
             MWBase::Environment::get().getWindowManager()->changePointer("arrow");
         }

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -60,8 +60,8 @@ namespace MWGui
         : WindowPinnableBase("openmw_inventory_window.layout")
         , mDragAndDrop(dragAndDrop)
         , mSelectedItem(-1)
-        , mSortModel(NULL)
-        , mTradeModel(NULL)
+        , mSortModel(nullptr)
+        , mTradeModel(nullptr)
         , mGuiMode(GM_Inventory)
         , mLastXSize(0)
         , mLastYSize(0)
@@ -157,9 +157,9 @@ namespace MWGui
     void InventoryWindow::clear()
     {
         mPtr = MWWorld::Ptr();
-        mTradeModel = NULL;
-        mSortModel = NULL;
-        mItemView->setModel(NULL);
+        mTradeModel = nullptr;
+        mSortModel = nullptr;
+        mItemView->setModel(nullptr);
     }
 
     void InventoryWindow::setGuiMode(GuiMode mode)
@@ -296,9 +296,9 @@ namespace MWGui
         {
             mSelectedItem = index;
             if (mTrading)
-                sellItem (NULL, count);
+                sellItem (nullptr, count);
             else
-                dragItem (NULL, count);
+                dragItem (nullptr, count);
         }
     }
 

--- a/apps/openmw/mwgui/itemchargeview.cpp
+++ b/apps/openmw/mwgui/itemchargeview.cpp
@@ -21,7 +21,7 @@
 namespace MWGui
 {
     ItemChargeView::ItemChargeView()
-        : mScrollView(NULL),
+        : mScrollView(nullptr),
           mDisplayMode(DisplayMode_Health)
     {
     }
@@ -36,7 +36,7 @@ namespace MWGui
         Base::initialiseOverride();
 
         assignWidget(mScrollView, "ScrollView");
-        if (mScrollView == NULL)
+        if (mScrollView == nullptr)
             throw std::runtime_error("Item charge view needs a scroll view");
 
         mScrollView->setCanvasAlign(MyGUI::Align::Left | MyGUI::Align::Top);

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -31,7 +31,7 @@ namespace MWGui
     ItemStack::ItemStack()
         : mType(Type_Normal)
         , mFlags(0)
-        , mCreator(NULL)
+        , mCreator(nullptr)
         , mCount(0)
     {
     }
@@ -106,7 +106,7 @@ namespace MWGui
 
 
     ProxyItemModel::ProxyItemModel()
-        : mSourceModel(NULL)
+        : mSourceModel(nullptr)
     {
     }
 
@@ -167,7 +167,7 @@ namespace MWGui
         if (mSourceModel)
         {
             delete mSourceModel;
-            mSourceModel = NULL;
+            mSourceModel = nullptr;
         }
 
         mSourceModel = sourceModel;

--- a/apps/openmw/mwgui/itemselection.cpp
+++ b/apps/openmw/mwgui/itemselection.cpp
@@ -12,8 +12,8 @@ namespace MWGui
 
     ItemSelectionDialog::ItemSelectionDialog(const std::string &label)
         : WindowModal("openmw_itemselection_dialog.layout")
-        , mSortModel(NULL)
-        , mModel(NULL)
+        , mSortModel(nullptr)
+        , mModel(nullptr)
     {
         getWidget(mItemView, "ItemView");
         mItemView->eventItemClicked += MyGUI::newDelegate(this, &ItemSelectionDialog::onSelectedItem);

--- a/apps/openmw/mwgui/itemview.cpp
+++ b/apps/openmw/mwgui/itemview.cpp
@@ -18,8 +18,8 @@ namespace MWGui
 {
 
 ItemView::ItemView()
-    : mModel(NULL)
-    , mScrollView(NULL)
+    : mModel(nullptr)
+    , mScrollView(nullptr)
 {
 }
 
@@ -44,7 +44,7 @@ void ItemView::initialiseOverride()
     Base::initialiseOverride();
 
     assignWidget(mScrollView, "ScrollView");
-    if (mScrollView == NULL)
+    if (mScrollView == nullptr)
         throw std::runtime_error("Item view needs a scroll view");
 
     mScrollView->setCanvasAlign(MyGUI::Align::Left | MyGUI::Align::Top);

--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -32,10 +32,10 @@ namespace MWGui
 {
 
     ItemWidget::ItemWidget()
-        : mItem(NULL)
-        , mItemShadow(NULL)
-        , mFrame(NULL)
-        , mText(NULL)
+        : mItem(nullptr)
+        , mItemShadow(nullptr)
+        , mFrame(nullptr)
+        , mText(nullptr)
     {
 
     }

--- a/apps/openmw/mwgui/journalviewmodel.cpp
+++ b/apps/openmw/mwgui/journalviewmodel.cpp
@@ -39,7 +39,7 @@ struct JournalViewModelImpl : JournalViewModel
     static Utf8Span toUtf8Span (std::string const & str)
     {
         if (str.size () == 0)
-            return Utf8Span (Utf8Point (NULL), Utf8Point (NULL));
+            return Utf8Span (Utf8Point (nullptr), Utf8Point (nullptr));
 
         Utf8Point point = reinterpret_cast <Utf8Point> (str.c_str ());
 

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -140,7 +140,7 @@ namespace MWGui
 
             // Callback removes itself when done
             if (renderInfo.getCurrentCamera())
-                renderInfo.getCurrentCamera()->setInitialDrawCallback(NULL);
+                renderInfo.getCurrentCamera()->setInitialDrawCallback(nullptr);
         }
 
     private:
@@ -208,7 +208,7 @@ namespace MWGui
         else
             mImportantLabel = false; // label was already shown on loading screen
 
-        mViewer->getSceneData()->setComputeBoundingSphereCallback(NULL);
+        mViewer->getSceneData()->setComputeBoundingSphereCallback(nullptr);
         mViewer->getSceneData()->dirtyBound();
 
         //std::cout << "loading took " << mTimer.time_m() - mLoadingOnTime << std::endl;

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -25,10 +25,10 @@ namespace MWGui
         : WindowBase("openmw_mainmenu.layout")
         , mWidth (w), mHeight (h)
         , mVFS(vfs), mButtonBox(0)
-        , mBackground(NULL)
-        , mVideoBackground(NULL)
-        , mVideo(NULL)
-        , mSaveGameDialog(NULL)
+        , mBackground(nullptr)
+        , mVideoBackground(nullptr)
+        , mVideo(nullptr)
+        , mSaveGameDialog(nullptr)
     {
         getWidget(mVersionText, "VersionText");
         mVersionText->setCaption(versionDescription);
@@ -147,13 +147,13 @@ namespace MWGui
         if (mVideo && !show)
         {
             MyGUI::Gui::getInstance().destroyWidget(mVideoBackground);
-            mVideoBackground = NULL;
-            mVideo = NULL;
+            mVideoBackground = nullptr;
+            mVideo = nullptr;
         }
         if (mBackground && !show)
         {
             MyGUI::Gui::getInstance().destroyWidget(mBackground);
-            mBackground = NULL;
+            mBackground = nullptr;
         }
 
         if (!show)

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -161,8 +161,8 @@ namespace MWGui
         , mCurX(0)
         , mCurY(0)
         , mInterior(false)
-        , mLocalMap(NULL)
-        , mCompass(NULL)
+        , mLocalMap(nullptr)
+        , mCompass(nullptr)
         , mChanged(true)
         , mFogOfWarToggled(true)
         , mFogOfWarEnabled(fogOfWarEnabled)
@@ -388,7 +388,7 @@ namespace MWGui
                     box->getSubWidgetMain()->_setUVSet(MyGUI::FloatRect(0.f, 0.f, 1.f, 1.f));
                 }
                 else
-                    box->setRenderItemTexture(NULL);
+                    box->setRenderItemTexture(nullptr);
             }
         }
         mMapTextures.swap(textures);
@@ -598,7 +598,7 @@ namespace MWGui
         addDetectionMarkers(MWBase::World::Detect_Enchantment);
 
         // Add marker for the spot marked with Mark magic effect
-        MWWorld::CellStore* markedCell = NULL;
+        MWWorld::CellStore* markedCell = nullptr;
         ESM::Position markedPosition;
         MWBase::Environment::get().getWorld()->getPlayer().getMarkedPosition(markedCell, markedPosition);
         if (markedCell && markedCell->isExterior() == !mInterior
@@ -627,11 +627,11 @@ namespace MWGui
         , LocalMapBase(customMarkers, localMapRender)
         , NoDrop(drag, mMainWidget)
         , mGlobalMap(0)
-        , mGlobalMapImage(NULL)
-        , mGlobalMapOverlay(NULL)
+        , mGlobalMapImage(nullptr)
+        , mGlobalMapOverlay(nullptr)
         , mGlobal(Settings::Manager::getBool("global", "Map"))
-        , mEventBoxGlobal(NULL)
-        , mEventBoxLocal(NULL)
+        , mEventBoxGlobal(nullptr)
+        , mEventBoxLocal(nullptr)
         , mGlobalMapRender(new MWRender::GlobalMap(localMapRender->getRoot(), workQueue))
         , mEditNoteDialog()
     {
@@ -872,7 +872,7 @@ namespace MWGui
 
         if (!destNotes.empty())
         {
-            MarkerUserData data (NULL);
+            MarkerUserData data (nullptr);
             data.notes = destNotes;
             data.caption = markerWidget->getUserString("Caption_TextOneLine");
             markerWidget->setUserData(data);

--- a/apps/openmw/mwgui/messagebox.cpp
+++ b/apps/openmw/mwgui/messagebox.cpp
@@ -20,8 +20,8 @@ namespace MWGui
 
     MessageBoxManager::MessageBoxManager (float timePerChar)
     {
-        mInterMessageBoxe = NULL;
-        mStaticMessageBox = NULL;
+        mInterMessageBoxe = nullptr;
+        mStaticMessageBox = nullptr;
         mLastButtonPressed = -1;
         mMessageBoxSpeed = timePerChar;
     }
@@ -42,14 +42,14 @@ namespace MWGui
             mInterMessageBoxe->setVisible(false);
 
             delete mInterMessageBoxe;
-            mInterMessageBoxe = NULL;
+            mInterMessageBoxe = nullptr;
         }
 
         std::vector<MessageBox*>::iterator it(mMessageBoxes.begin());
         for (; it != mMessageBoxes.end(); ++it)
         {
             if (*it == mStaticMessageBox)
-                mStaticMessageBox = NULL;
+                mStaticMessageBox = nullptr;
             delete *it;
         }
         mMessageBoxes.clear();
@@ -81,11 +81,11 @@ namespace MWGui
                 ++it;
         }
 
-        if(mInterMessageBoxe != NULL && mInterMessageBoxe->mMarkedToDelete) {
+        if(mInterMessageBoxe != nullptr && mInterMessageBoxe->mMarkedToDelete) {
             mLastButtonPressed = mInterMessageBoxe->readPressedButton();
             mInterMessageBoxe->setVisible(false);
             delete mInterMessageBoxe;
-            mInterMessageBoxe = NULL;
+            mInterMessageBoxe = nullptr;
             MWBase::Environment::get().getInputManager()->changeInputMode(
                         MWBase::Environment::get().getWindowManager()->isGuiMode());
         }
@@ -119,17 +119,17 @@ namespace MWGui
     void MessageBoxManager::removeStaticMessageBox ()
     {
         removeMessageBox(mStaticMessageBox);
-        mStaticMessageBox = NULL;
+        mStaticMessageBox = nullptr;
     }
 
     bool MessageBoxManager::createInteractiveMessageBox (const std::string& message, const std::vector<std::string>& buttons)
     {
-        if (mInterMessageBoxe != NULL)
+        if (mInterMessageBoxe != nullptr)
         {
             Log(Debug::Warning) << "Warning: replacing an interactive message box that was not answered yet";
             mInterMessageBoxe->setVisible(false);
             delete mInterMessageBoxe;
-            mInterMessageBoxe = NULL;
+            mInterMessageBoxe = nullptr;
         }
 
         mInterMessageBoxe = new InteractiveMessageBox(*this, message, buttons);
@@ -140,7 +140,7 @@ namespace MWGui
 
     bool MessageBoxManager::isInteractiveMessageBox ()
     {
-        return mInterMessageBoxe != NULL;
+        return mInterMessageBoxe != nullptr;
     }
 
 
@@ -373,7 +373,7 @@ namespace MWGui
                 }
             }
         }
-        return NULL;
+        return nullptr;
     }
 
     void InteractiveMessageBox::mousePressed (MyGUI::Widget* pressed)

--- a/apps/openmw/mwgui/race.cpp
+++ b/apps/openmw/mwgui/race.cpp
@@ -129,10 +129,10 @@ namespace MWGui
         updateSkills();
         updateSpellPowers();
 
-        mPreviewImage->setRenderItemTexture(NULL);
+        mPreviewImage->setRenderItemTexture(nullptr);
 
-        mPreview.reset(NULL);
-        mPreviewTexture.reset(NULL);
+        mPreview.reset(nullptr);
+        mPreviewTexture.reset(nullptr);
 
         mPreview.reset(new MWRender::RaceSelectionPreview(mParent, mResourceSystem));
         mPreview->rebuild();
@@ -190,10 +190,10 @@ namespace MWGui
     {
         WindowModal::onClose();
 
-        mPreviewImage->setRenderItemTexture(NULL);
+        mPreviewImage->setRenderItemTexture(nullptr);
 
-        mPreviewTexture.reset(NULL);
-        mPreview.reset(NULL);
+        mPreviewTexture.reset(nullptr);
+        mPreview.reset(nullptr);
     }
 
     // widget controls

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -31,7 +31,7 @@ namespace MWGui
 
 Recharge::Recharge()
     : WindowBase("openmw_recharge_dialog.layout")
-    , mItemSelectionDialog(NULL)
+    , mItemSelectionDialog(nullptr)
 {
     getWidget(mBox, "Box");
     getWidget(mGemBox, "GemBox");
@@ -90,7 +90,7 @@ void Recharge::updateView()
     mBox->update();
 
     Gui::Box* box = dynamic_cast<Gui::Box*>(mMainWidget);
-    if (box == NULL)
+    if (box == nullptr)
         throw std::runtime_error("main widget must be a box");
 
     box->notifyChildrenSizeChanged();

--- a/apps/openmw/mwgui/repair.cpp
+++ b/apps/openmw/mwgui/repair.cpp
@@ -27,7 +27,7 @@ namespace MWGui
 
 Repair::Repair()
     : WindowBase("openmw_repair.layout")
-    , mItemSelectionDialog(NULL)
+    , mItemSelectionDialog(nullptr)
 {
     getWidget(mRepairBox, "RepairBox");
     getWidget(mToolBox, "ToolBox");
@@ -99,7 +99,7 @@ void Repair::updateRepairView()
     mRepairBox->update();
 
     Gui::Box* box = dynamic_cast<Gui::Box*>(mMainWidget);
-    if (box == NULL)
+    if (box == nullptr)
         throw std::runtime_error("main widget must be a box");
 
     box->notifyChildrenSizeChanged();

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -379,7 +379,7 @@ namespace MWGui
         // starting spells
         std::vector<std::string> spells;
 
-        const ESM::Race* race = NULL;
+        const ESM::Race* race = nullptr;
         if (!mRaceId.empty())
             race = MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(mRaceId);
 

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -37,8 +37,8 @@ namespace MWGui
     SaveGameDialog::SaveGameDialog()
         : WindowModal("openmw_savegame_dialog.layout")
         , mSaving(true)
-        , mCurrentCharacter(NULL)
-        , mCurrentSlot(NULL)
+        , mCurrentCharacter(nullptr)
+        , mCurrentSlot(nullptr)
     {
         getWidget(mScreenshot, "Screenshot");
         getWidget(mCharacterSelection, "SelectCharacter");
@@ -99,7 +99,7 @@ namespace MWGui
         if (mSaveList->getItemCount() == 0)
         {
             size_t previousIndex = mCharacterSelection->getIndexSelected();
-            mCurrentCharacter = NULL;
+            mCurrentCharacter = nullptr;
             mCharacterSelection->removeItemAt(previousIndex);
             if (mCharacterSelection->getItemCount())
             {
@@ -146,8 +146,8 @@ namespace MWGui
 
         mCharacterSelection->setCaption("");
         mCharacterSelection->removeAllItems();
-        mCurrentCharacter = NULL;
-        mCurrentSlot = NULL;
+        mCurrentCharacter = nullptr;
+        mCurrentSlot = nullptr;
         mSaveList->removeAllItems();
         onSlotSelected(mSaveList, MyGUI::ITEM_NONE);
 
@@ -250,12 +250,12 @@ namespace MWGui
     void SaveGameDialog::accept(bool reallySure)
     {
         // Remove for MyGUI 3.2.2
-        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(NULL);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nullptr);
 
         if (mSaving)
         {
             // If overwriting an existing slot, ask for confirmation first
-            if (mCurrentSlot != NULL && !reallySure)
+            if (mCurrentSlot != nullptr && !reallySure)
             {
                 ConfirmationDialog* dialog = MWBase::Environment::get().getWindowManager()->getConfirmationDialog();
                 dialog->askForConfirmation("#{sMessage4}");
@@ -318,7 +318,7 @@ namespace MWGui
         MWBase::StateManager* mgr = MWBase::Environment::get().getStateManager();
 
         unsigned int i=0;
-        const MWState::Character* character = NULL;
+        const MWState::Character* character = nullptr;
         for (MWBase::StateManager::CharacterIterator it = mgr->characterBegin(); it != mgr->characterEnd(); ++it, ++i)
         {
             if (i == pos)
@@ -327,7 +327,7 @@ namespace MWGui
         assert(character && "Can't find selected character");
 
         mCurrentCharacter = character;
-        mCurrentSlot = NULL;
+        mCurrentSlot = nullptr;
         fillSaveList();
     }
 
@@ -379,7 +379,7 @@ namespace MWGui
 
         if (pos == MyGUI::ITEM_NONE || !mCurrentCharacter)
         {
-            mCurrentSlot = NULL;
+            mCurrentSlot = nullptr;
             mInfoText->setCaption("");
             mScreenshot->setImageTexture("");
             return;
@@ -388,7 +388,7 @@ namespace MWGui
         if (mSaving)
             mSaveNameEdit->setCaption(sender->getItemNameAt(pos));
 
-        mCurrentSlot = NULL;
+        mCurrentSlot = nullptr;
         unsigned int i=0;
         for (MWState::Character::SlotIterator it = mCurrentCharacter->begin(); it != mCurrentCharacter->end(); ++it, ++i)
         {
@@ -404,7 +404,7 @@ namespace MWGui
         timeinfo = localtime(&time);
 
         // Use system/environment locale settings for datetime formatting
-        char* oldLctime = setlocale(LC_TIME, NULL);
+        char* oldLctime = setlocale(LC_TIME, nullptr);
         setlocale(LC_TIME, "");
 
         const int size=1024;

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -55,7 +55,7 @@ namespace MWGui
     EditEffectDialog::EditEffectDialog()
         : WindowModal("openmw_edit_effect.layout")
         , mEditing(false)
-        , mMagicEffect(NULL)
+        , mMagicEffect(nullptr)
         , mConstantEffect(false)
     {
         init(mEffect);
@@ -481,7 +481,7 @@ namespace MWGui
 
         mPriceLabel->setCaption(MyGUI::utility::toString(int(price)));
 
-        float chance = MWMechanics::calcSpellBaseSuccessChance(&mSpell, MWMechanics::getPlayer(), NULL);
+        float chance = MWMechanics::calcSpellBaseSuccessChance(&mSpell, MWMechanics::getPlayer(), nullptr);
 
         int intChance = std::min(100, int(chance));
         mSuccessChance->setCaption(MyGUI::utility::toString(intChance));
@@ -491,11 +491,11 @@ namespace MWGui
 
 
     EffectEditorBase::EffectEditorBase(Type type)
-        : mAvailableEffectsList(NULL)
-        , mUsedEffectsView(NULL)
+        : mAvailableEffectsList(nullptr)
+        , mUsedEffectsView(nullptr)
         , mAddEffectDialog()
-        , mSelectAttributeDialog(NULL)
-        , mSelectSkillDialog(NULL)
+        , mSelectAttributeDialog(nullptr)
+        , mSelectSkillDialog(nullptr)
         , mSelectedEffect(0)
         , mSelectedKnownEffectId(0)
         , mConstantEffect(false)

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -71,7 +71,7 @@ namespace MWGui
             {
                 newSpell.mType = Spell::Type_Spell;
                 std::string cost = std::to_string(spell->mData.mCost);
-                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor, NULL, true, true)));
+                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor, nullptr, true, true)));
                 newSpell.mCostColumn = cost + "/" + chance;
             }
             else

--- a/apps/openmw/mwgui/spellview.cpp
+++ b/apps/openmw/mwgui/spellview.cpp
@@ -24,7 +24,7 @@ namespace MWGui
     }
 
     SpellView::SpellView()
-        : mScrollView(NULL)
+        : mScrollView(nullptr)
         , mShowCostColumn(true)
         , mHighlightSelected(true)
     {
@@ -35,7 +35,7 @@ namespace MWGui
         Base::initialiseOverride();
 
         assignWidget(mScrollView, "ScrollView");
-        if (mScrollView == NULL)
+        if (mScrollView == nullptr)
             throw std::runtime_error("Item view needs a scroll view");
 
         mScrollView->setCanvasAlign(MyGUI::Align::Left | MyGUI::Align::Top);
@@ -131,7 +131,7 @@ namespace MWGui
                 mLines.push_back(LineInfo(t, costChance, i));
             }
             else
-                mLines.push_back(LineInfo(t, (MyGUI::Widget*)NULL, i));
+                mLines.push_back(LineInfo(t, (MyGUI::Widget*)nullptr, i));
 
             t->setStateSelected(spell.mSelected);
         }
@@ -177,7 +177,7 @@ namespace MWGui
                 {
                     maxSpellIndexFound = spellIndex;
                     Gui::SharedStateButton* costButton = reinterpret_cast<Gui::SharedStateButton*>(it->mRightWidget);
-                    if ((costButton != NULL) && (costButton->getCaption() != spell.mCostColumn))
+                    if ((costButton != nullptr) && (costButton->getCaption() != spell.mCostColumn))
                     {
                         costButton->setCaption(spell.mCostColumn);
                     }
@@ -238,7 +238,7 @@ namespace MWGui
                 MyGUI::IntCoord(0, 0, mScrollView->getWidth(), 18),
                 MyGUI::Align::Left | MyGUI::Align::Top);
             separator->setNeedMouseFocus(false);
-            mLines.push_back(LineInfo(separator, (MyGUI::Widget*)NULL, NoSpellIndex));
+            mLines.push_back(LineInfo(separator, (MyGUI::Widget*)nullptr, NoSpellIndex));
         }
 
         MyGUI::TextBox* groupWidget = mScrollView->createWidget<Gui::TextBox>("SandBrightText",
@@ -260,7 +260,7 @@ namespace MWGui
             mLines.push_back(LineInfo(groupWidget, groupWidget2, NoSpellIndex));
         }
         else
-            mLines.push_back(LineInfo(groupWidget, (MyGUI::Widget*)NULL, NoSpellIndex));
+            mLines.push_back(LineInfo(groupWidget, (MyGUI::Widget*)nullptr, NoSpellIndex));
     }
 
 

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -32,7 +32,7 @@ namespace MWGui
     SpellWindow::SpellWindow(DragAndDrop* drag)
         : WindowPinnableBase("openmw_spell_window.layout")
         , NoDrop(drag, mMainWidget)
-        , mSpellView(NULL)
+        , mSpellView(nullptr)
         , mUpdateTimer(0.0f)
     {
         mSpellIcons = new SpellIcons();
@@ -72,7 +72,7 @@ namespace MWGui
         // Reset the filter focus when opening the window
         MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
         if (focus == mFilterEdit)
-            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(NULL);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nullptr);
 
         updateSpells();
     }

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -26,7 +26,7 @@ namespace MWGui
     StatsWindow::StatsWindow (DragAndDrop* drag)
       : WindowPinnableBase("openmw_stats_window.layout")
       , NoDrop(drag, mMainWidget)
-      , mSkillView(NULL)
+      , mSkillView(nullptr)
       , mMajorSkills()
       , mMinorSkills()
       , mMiscSkills()
@@ -68,7 +68,7 @@ namespace MWGui
         for (int i = 0; i < ESM::Skill::Length; ++i)
         {
             mSkillValues.insert(std::make_pair(i, MWMechanics::SkillValue()));
-            mSkillWidgetMap.insert(std::make_pair(i, std::make_pair((MyGUI::TextBox*)NULL, (MyGUI::TextBox*)NULL)));
+            mSkillWidgetMap.insert(std::make_pair(i, std::make_pair((MyGUI::TextBox*)nullptr, (MyGUI::TextBox*)nullptr)));
         }
 
         MyGUI::Window* t = mMainWidget->castType<MyGUI::Window>();

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -50,8 +50,8 @@ namespace MWGui
 
     TradeWindow::TradeWindow()
         : WindowBase("openmw_trade_window.layout")
-        , mSortModel(NULL)
-        , mTradeModel(NULL)
+        , mSortModel(nullptr)
+        , mTradeModel(nullptr)
         , mItemToSell(-1)
         , mCurrentBalance(0)
         , mCurrentMerchantOffer(0)
@@ -205,7 +205,7 @@ namespace MWGui
         else
         {
             mItemToSell = mSortModel->mapToSource(index);
-            sellItem (NULL, count);
+            sellItem (nullptr, count);
         }
     }
 
@@ -514,8 +514,8 @@ namespace MWGui
     void TradeWindow::resetReference()
     {
         ReferenceInterface::resetReference();
-        mItemView->setModel(NULL);
-        mTradeModel = NULL;
-        mSortModel = NULL;
+        mItemView->setModel(nullptr);
+        mTradeModel = nullptr;
+        mSortModel = nullptr;
     }
 }

--- a/apps/openmw/mwgui/videowidget.cpp
+++ b/apps/openmw/mwgui/videowidget.cpp
@@ -16,7 +16,7 @@ namespace MWGui
 {
 
 VideoWidget::VideoWidget()
-    : mVFS(NULL)
+    : mVFS(nullptr)
 {
     mPlayer.reset(new Video::VideoPlayer());
     setNeedKeyFocus(true);

--- a/apps/openmw/mwgui/waitdialog.cpp
+++ b/apps/openmw/mwgui/waitdialog.cpp
@@ -281,7 +281,7 @@ namespace MWGui
         mSleeping = canRest;
 
         Gui::Box* box = dynamic_cast<Gui::Box*>(mMainWidget);
-        if (box == NULL)
+        if (box == nullptr)
             throw std::runtime_error("main widget must be a box");
         box->notifyChildrenSizeChanged();
         center();

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -23,8 +23,8 @@ namespace MWGui
 
         MWSkill::MWSkill()
             : mSkillId(ESM::Skill::Length)
-            , mSkillNameWidget(NULL)
-            , mSkillValueWidget(NULL)
+            , mSkillNameWidget(nullptr)
+            , mSkillValueWidget(nullptr)
         {
         }
 
@@ -114,8 +114,8 @@ namespace MWGui
 
         MWAttribute::MWAttribute()
             : mId(-1)
-            , mAttributeNameWidget(NULL)
-            , mAttributeValueWidget(NULL)
+            , mAttributeNameWidget(nullptr)
+            , mAttributeValueWidget(nullptr)
         {
         }
 
@@ -204,7 +204,7 @@ namespace MWGui
         /* MWSpell */
 
         MWSpell::MWSpell()
-            : mSpellNameWidget(NULL)
+            : mSpellNameWidget(nullptr)
         {
         }
 
@@ -286,7 +286,7 @@ namespace MWGui
         {
             // We don't know the width of all the elements beforehand, so we do it in
             // 2 steps: first, create all widgets and check their width....
-            MWSpellEffectPtr effect = NULL;
+            MWSpellEffectPtr effect = nullptr;
             int maxwidth = coord.width;
 
             for (SpellEffectList::iterator it=mEffectList.begin();
@@ -359,8 +359,8 @@ namespace MWGui
         /* MWSpellEffect */
 
         MWSpellEffect::MWSpellEffect()
-            : mImageWidget(NULL)
-            , mTextWidget(NULL)
+            : mImageWidget(nullptr)
+            , mTextWidget(nullptr)
             , mRequestedWidth(0)
         {
         }
@@ -489,9 +489,9 @@ namespace MWGui
         MWDynamicStat::MWDynamicStat()
         : mValue(0)
         , mMax(1)
-        , mTextWidget(NULL)
-        , mBarWidget(NULL)
-        , mBarTextWidget(NULL)
+        , mTextWidget(nullptr)
+        , mBarWidget(nullptr)
+        , mBarTextWidget(nullptr)
         {
         }
 

--- a/apps/openmw/mwgui/windowbase.cpp
+++ b/apps/openmw/mwgui/windowbase.cpp
@@ -33,11 +33,11 @@ void WindowBase::setVisible(bool visible)
     if (!visible)
     {
         MyGUI::Widget* keyFocus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
-        while (keyFocus != mMainWidget && keyFocus != NULL)
+        while (keyFocus != mMainWidget && keyFocus != nullptr)
             keyFocus = keyFocus->getParent();
 
         if (keyFocus == mMainWidget)
-            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(NULL);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nullptr);
     }
 }
 

--- a/apps/openmw/mwgui/windowbase.hpp
+++ b/apps/openmw/mwgui/windowbase.hpp
@@ -23,7 +23,7 @@ namespace MWGui
         public:
         WindowBase(const std::string& parLayout);
 
-        virtual MyGUI::Widget* getDefaultKeyFocus() { return NULL; }
+        virtual MyGUI::Widget* getDefaultKeyFocus() { return nullptr; }
 
         // Events
         typedef MyGUI::delegates::CMultiDelegate1<WindowBase*> EventHandle_WindowBase;

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -134,44 +134,44 @@ namespace MWGui
             osgViewer::Viewer* viewer, osg::Group* guiRoot, Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
             const std::string& logpath, const std::string& resourcePath, bool consoleOnlyScripts, Translation::Storage& translationDataStorage,
             ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string, std::string>& fallbackMap, const std::string& versionDescription, const std::string& userDataPath)
-      : mStore(NULL)
+      : mStore(nullptr)
       , mResourceSystem(resourceSystem)
       , mWorkQueue(workQueue)
       , mViewer(viewer)
       , mConsoleOnlyScripts(consoleOnlyScripts)
       , mCurrentModals()
-      , mHud(NULL)
-      , mMap(NULL)
-      , mLocalMapRender(NULL)
-      , mToolTips(NULL)
-      , mStatsWindow(NULL)
-      , mMessageBoxManager(NULL)
-      , mConsole(NULL)
-      , mDialogueWindow(NULL)
-      , mDragAndDrop(NULL)
-      , mInventoryWindow(NULL)
-      , mScrollWindow(NULL)
-      , mBookWindow(NULL)
-      , mCountDialog(NULL)
-      , mTradeWindow(NULL)
-      , mSettingsWindow(NULL)
-      , mConfirmationDialog(NULL)
-      , mSpellWindow(NULL)
-      , mQuickKeysMenu(NULL)
-      , mLoadingScreen(NULL)
-      , mWaitDialog(NULL)
-      , mSoulgemDialog(NULL)
-      , mVideoBackground(NULL)
-      , mVideoWidget(NULL)
-      , mWerewolfFader(NULL)
-      , mBlindnessFader(NULL)
-      , mHitFader(NULL)
-      , mScreenFader(NULL)
-      , mDebugWindow(NULL)
-      , mJailScreen(NULL)
+      , mHud(nullptr)
+      , mMap(nullptr)
+      , mLocalMapRender(nullptr)
+      , mToolTips(nullptr)
+      , mStatsWindow(nullptr)
+      , mMessageBoxManager(nullptr)
+      , mConsole(nullptr)
+      , mDialogueWindow(nullptr)
+      , mDragAndDrop(nullptr)
+      , mInventoryWindow(nullptr)
+      , mScrollWindow(nullptr)
+      , mBookWindow(nullptr)
+      , mCountDialog(nullptr)
+      , mTradeWindow(nullptr)
+      , mSettingsWindow(nullptr)
+      , mConfirmationDialog(nullptr)
+      , mSpellWindow(nullptr)
+      , mQuickKeysMenu(nullptr)
+      , mLoadingScreen(nullptr)
+      , mWaitDialog(nullptr)
+      , mSoulgemDialog(nullptr)
+      , mVideoBackground(nullptr)
+      , mVideoWidget(nullptr)
+      , mWerewolfFader(nullptr)
+      , mBlindnessFader(nullptr)
+      , mHitFader(nullptr)
+      , mScreenFader(nullptr)
+      , mDebugWindow(nullptr)
+      , mJailScreen(nullptr)
       , mTranslationDataStorage (translationDataStorage)
-      , mCharGen(NULL)
-      , mInputBlocker(NULL)
+      , mCharGen(nullptr)
+      , mInputBlocker(nullptr)
       , mCrosshairEnabled(Settings::Manager::getBool ("crosshair", "HUD"))
       , mSubtitlesEnabled(Settings::Manager::getBool ("subtitles", "GUI"))
       , mHitFaderEnabled(Settings::Manager::getBool ("hit fader", "GUI"))
@@ -185,9 +185,9 @@ namespace MWGui
       , mPlayerMajorSkills()
       , mPlayerMinorSkills()
       , mPlayerSkillValues()
-      , mGui(NULL)
+      , mGui(nullptr)
       , mGuiModes()
-      , mCursorManager(NULL)
+      , mCursorManager(nullptr)
       , mGarbageDialogs()
       , mShown(GW_ALL)
       , mForceHidden(GW_None)
@@ -704,7 +704,7 @@ namespace MWGui
             setCursorVisible(!gameMode);
 
         if (gameMode)
-            setKeyFocusWidget (NULL);
+            setKeyFocusWidget (nullptr);
 
         // Icons of forced hidden windows are displayed
         setMinimapVisibility((mAllowed & GW_Map) && (!mMap->pinned() || (mForceHidden & GW_Map)));
@@ -1651,7 +1651,7 @@ namespace MWGui
     // Remove this method for MyGUI 3.2.2
     void WindowManager::setKeyFocusWidget(MyGUI::Widget *widget)
     {
-        if (widget == NULL)
+        if (widget == nullptr)
             MyGUI::InputManager::getInstance().resetKeyFocusWidget();
         else
             MyGUI::InputManager::getInstance().setKeyFocusWidget(widget);
@@ -1913,7 +1913,7 @@ namespace MWGui
         }
         if (mCurrentModals.empty())
         {
-            mKeyboardNavigation->setModalWindow(NULL);
+            mKeyboardNavigation->setModalWindow(nullptr);
             mKeyboardNavigation->restoreFocus(getMode());
         }
         else

--- a/apps/openmw/mwgui/windowpinnablebase.cpp
+++ b/apps/openmw/mwgui/windowpinnablebase.cpp
@@ -14,7 +14,7 @@ namespace MWGui
 
         mPinButton->eventMouseButtonPressed += MyGUI::newDelegate(this, &WindowPinnableBase::onPinButtonPressed);
 
-        MyGUI::Button* button = NULL;
+        MyGUI::Button* button = nullptr;
         MyGUI::VectorWidgetPtr widgets = window->getSkinWidgetsByName("Action");
         for (MyGUI::VectorWidgetPtr::iterator it = widgets.begin(); it != widgets.end(); ++it)
         {

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -46,9 +46,9 @@ namespace MWInput
         , mScreenCaptureHandler(screenCaptureHandler)
         , mScreenCaptureOperation(screenCaptureOperation)
         , mJoystickLastUsed(false)
-        , mPlayer(NULL)
-        , mInputManager(NULL)
-        , mVideoWrapper(NULL)
+        , mPlayer(nullptr)
+        , mInputManager(nullptr)
+        , mVideoWrapper(nullptr)
         , mUserFile(userFile)
         , mDragDrop(false)
         , mGrabCursor (Settings::Manager::getBool("grab cursor", "Input"))
@@ -84,7 +84,7 @@ namespace MWInput
                                         Settings::Manager::getFloat("contrast", "Video"));
 
         std::string file = userFileExists ? userFile : "";
-        mInputBinder = new ICS::InputControlSystem(file, true, this, NULL, A_Last);
+        mInputBinder = new ICS::InputControlSystem(file, true, this, nullptr, A_Last);
 
         loadKeyDefaults();
         loadControllerDefaults();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1420,7 +1420,7 @@ namespace MWMechanics
                 iter->second->getCharacterController()->updateContinuousVfx();
 
             // Animation/movement update
-            CharacterController* playerCharacter = NULL;
+            CharacterController* playerCharacter = nullptr;
             for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
             {
                 const float animationDistance = aiProcessingDistance + 400; // Slightly larger than AI distance so there is time to switch back to the idle animation.
@@ -1987,7 +1987,7 @@ namespace MWMechanics
         for (; it != mActors.end(); ++it)
         {
             delete it->second;
-            it->second = NULL;
+            it->second = nullptr;
         }
         mActors.clear();
         mDeathCount.clear();

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -586,7 +586,7 @@ std::string chooseBestAttack(const ESM::Weapon* weapon)
 {
     std::string attackType;
 
-    if (weapon != NULL)
+    if (weapon != nullptr)
     {
         //the more damage attackType deals the more probability it has
         int slash = (weapon->mData.mSlash[0] + weapon->mData.mSlash[1])/2;

--- a/apps/openmw/mwmechanics/aicombat.hpp
+++ b/apps/openmw/mwmechanics/aicombat.hpp
@@ -64,7 +64,7 @@ namespace MWMechanics
         mAttackRange(0.0f),
         mCombatMove(false),
         mLastTargetPos(0,0,0),
-        mCell(NULL),
+        mCell(nullptr),
         mCurrentAction(),
         mActionCooldown(0.0f),
         mStrength(),

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -138,7 +138,7 @@ namespace MWMechanics
     const ESM::Weapon* ActionWeapon::getWeapon() const
     {
         if (mWeapon.isEmpty())
-            return NULL;
+            return nullptr;
         return mWeapon.get<ESM::Weapon>()->mBase;
     }
 

--- a/apps/openmw/mwmechanics/aicombataction.hpp
+++ b/apps/openmw/mwmechanics/aicombataction.hpp
@@ -17,7 +17,7 @@ namespace MWMechanics
         virtual void prepare(const MWWorld::Ptr& actor) = 0;
         virtual float getCombatRange (bool& isRanged) const = 0;
         virtual float getActionCooldown() { return 0.f; }
-        virtual const ESM::Weapon* getWeapon() const { return NULL; };
+        virtual const ESM::Weapon* getWeapon() const { return nullptr; };
         virtual bool isAttackingOrSpell() const { return true; }
         virtual bool isFleeing() const { return false; }
     };

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -275,7 +275,7 @@ bool MWMechanics::AiPackage::shortcutPath(const ESM::Pathgrid::Point& startPoint
             static_cast<float>(startPoint.mX), static_cast<float>(startPoint.mY), static_cast<float>(startPoint.mZ),
             static_cast<float>(endPoint.mX), static_cast<float>(endPoint.mY), static_cast<float>(endPoint.mZ));
 
-        if (destInLOS != NULL) *destInLOS = isPathClear;
+        if (destInLOS != nullptr) *destInLOS = isPathClear;
 
         if (!isPathClear)
             return false;

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -114,7 +114,7 @@ namespace MWMechanics
 
             /// Check if there aren't any obstacles along the path to make shortcut possible
             /// If a shortcut is possible then path will be cleared and filled with the destination point.
-            /// \param destInLOS If not NULL function will return ray cast check result
+            /// \param destInLOS If not nullptr function will return ray cast check result
             /// \return If can shortcut the path
             bool shortcutPath(const ESM::Pathgrid::Point& startPoint, const ESM::Pathgrid::Point& endPoint, const MWWorld::Ptr& actor, bool *destInLOS, bool isPathClear);
 

--- a/apps/openmw/mwmechanics/aistate.hpp
+++ b/apps/openmw/mwmechanics/aistate.hpp
@@ -59,7 +59,7 @@ namespace MWMechanics
         
         bool empty() const
         {
-            return mStorage == NULL;
+            return mStorage == nullptr;
         }
         
         const std::type_info& getType() const
@@ -67,16 +67,12 @@ namespace MWMechanics
             return typeid(mStorage);
         }
         
-        
-        DerivedClassStorage():mStorage(NULL){}
+        DerivedClassStorage():mStorage(nullptr){}
         ~DerivedClassStorage()
         {
             if(mStorage)
                 delete mStorage;
         }
-        
-        
-        
     };
 
 

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -77,7 +77,7 @@ namespace MWMechanics
             mReaction(0),
             mSaidGreeting(Greet_None),
             mGreetingTimer(0),
-            mCell(NULL),
+            mCell(nullptr),
             mState(Wander_ChooseAction),
             mIsWanderingManually(false),
             mCanWanderAlongPathGrid(true),

--- a/apps/openmw/mwmechanics/autocalcspell.cpp
+++ b/apps/openmw/mwmechanics/autocalcspell.cpp
@@ -149,7 +149,7 @@ namespace MWMechanics
 
         float baseMagicka = fPCbaseMagickaMult * actorAttributes[ESM::Attribute::Intelligence];
         bool reachedLimit = false;
-        const ESM::Spell* weakestSpell = NULL;
+        const ESM::Spell* weakestSpell = nullptr;
         int minCost = std::numeric_limits<int>::max();
 
         std::vector<std::string> selectedSpells;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -931,7 +931,7 @@ CharacterController::~CharacterController()
     if (mAnimation)
     {
         persistAnimationState();
-        mAnimation->setTextKeyListener(NULL);
+        mAnimation->setTextKeyListener(nullptr);
     }
 }
 
@@ -1159,7 +1159,7 @@ bool CharacterController::updateCreatureState()
 
                 if (!spellid.empty() && canCast)
                 {
-                    MWMechanics::CastSpell cast(mPtr, NULL, false, mCastingManualSpell);
+                    MWMechanics::CastSpell cast(mPtr, nullptr, false, mCastingManualSpell);
                     cast.playSpellCastingEffects(spellid);
 
                     if (!mAnimation->hasAnimation("spellcast"))
@@ -1463,7 +1463,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
 
                 if(!spellid.empty() && canCast)
                 {
-                    MWMechanics::CastSpell cast(mPtr, NULL, false, mCastingManualSpell);
+                    MWMechanics::CastSpell cast(mPtr, nullptr, false, mCastingManualSpell);
                     cast.playSpellCastingEffects(spellid);
 
                     const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
@@ -2319,7 +2319,7 @@ void CharacterController::persistAnimationState()
         {
             anim.mLoopCount = mAnimation->getCurrentLoopCount(anim.mGroup);
             float complete;
-            mAnimation->getInfo(anim.mGroup, &complete, NULL);
+            mAnimation->getInfo(anim.mGroup, &complete, nullptr);
             anim.mTime = complete;
         }
         else
@@ -2451,7 +2451,7 @@ bool CharacterController::isPersistentAnimPlaying()
 
 bool CharacterController::isAnimPlaying(const std::string &groupName)
 {
-    if(mAnimation == NULL)
+    if(mAnimation == nullptr)
         return false;
     return mAnimation->isPlaying(groupName);
 }
@@ -2748,9 +2748,9 @@ void CharacterController::updateHeadTracking(float duration)
         if (const MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(mHeadTrackTarget))
         {
             const osg::Node* node = anim->getNode("Head");
-            if (node == NULL)
+            if (node == nullptr)
                 node = anim->getNode("Bip01 Head");
-            if (node != NULL)
+            if (node != nullptr)
             {
                 nodepaths = node->getParentalNodePaths();
                 if (!nodepaths.empty())

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -240,8 +240,8 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     void playRandomDeath(float startpoint = 0.0f);
 
     /// choose a random animation group with \a prefix and numeric suffix
-    /// @param num if non-NULL, the chosen animation number will be written here
-    std::string chooseRandomGroup (const std::string& prefix, int* num = NULL) const;
+    /// @param num if non-nullptr, the chosen animation number will be written here
+    std::string chooseRandomGroup (const std::string& prefix, int* num = nullptr) const;
 
     bool updateCarriedLeftVisible(WeaponType weaptype) const;
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -203,7 +203,7 @@ namespace MWMechanics
         }
 
         // F_PCStart spells
-        const ESM::Race* race = NULL;
+        const ESM::Race* race = nullptr;
         if (mRaceSelected)
             race = esmStore.get<ESM::Race>().find(player->mRace);
 

--- a/apps/openmw/mwmechanics/objects.cpp
+++ b/apps/openmw/mwmechanics/objects.cpp
@@ -20,7 +20,7 @@ Objects::~Objects()
   for (; it != mObjects.end();++it)
   {
     delete it->second;
-    it->second = NULL;
+    it->second = nullptr;
   }
 }
 

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -16,7 +16,7 @@ namespace MWMechanics
     bool proximityToDoor(const MWWorld::Ptr& actor, float minDist);
 
     /// Returns door pointer within range. No guarantee is given as to which one
-    /** \return Pointer to the door, or NULL if none exists **/
+    /** \return Pointer to the door, or empty pointer if none exists **/
     const MWWorld::Ptr getNearbyDoor(const MWWorld::Ptr& actor, float minDist);
 
     class ObstacleCheck

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -120,8 +120,8 @@ namespace MWMechanics
     }
 
     PathFinder::PathFinder()
-        : mPathgrid(NULL)
-        , mCell(NULL)
+        : mPathgrid(nullptr)
+        , mCell(nullptr)
     {
     }
 

--- a/apps/openmw/mwmechanics/pathgrid.cpp
+++ b/apps/openmw/mwmechanics/pathgrid.cpp
@@ -50,8 +50,8 @@ namespace
 namespace MWMechanics
 {
     PathgridGraph::PathgridGraph(const MWWorld::CellStore *cell)
-        : mCell(NULL)
-        , mPathgrid(NULL)
+        : mCell(nullptr)
+        , mPathgrid(nullptr)
         , mIsExterior(0)
         , mGraph(0)
         , mIsGraphConstructed(false)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -242,9 +242,9 @@ namespace MWMechanics
 
         // This makes spells that are easy to cast harder to resist and vice versa
         float castChance = 100.f;
-        if (spell != NULL && !caster.isEmpty() && caster.getClass().isActor())
+        if (spell != nullptr && !caster.isEmpty() && caster.getClass().isActor())
         {
-            castChance = getSpellSuccessChance(spell, caster, NULL, false); // Uncapped casting chance
+            castChance = getSpellSuccessChance(spell, caster, nullptr, false); // Uncapped casting chance
         }
         if (castChance > 0)
             x *= 50 / castChance;
@@ -737,7 +737,7 @@ namespace MWMechanics
             }
             else if (effectId == ESM::MagicEffect::Recall)
             {
-                MWWorld::CellStore* markedCell = NULL;
+                MWWorld::CellStore* markedCell = nullptr;
                 ESM::Position markedPosition;
 
                 MWBase::Environment::get().getWorld()->getPlayer().getMarkedPosition(markedCell, markedPosition);

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -39,8 +39,8 @@ namespace MWMechanics
      * @note actor can be an NPC or a creature
      * @return success chance from 0 to 100 (in percent), if cap=false then chance above 100 may be returned.
      */
-    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool = NULL, bool cap=true, bool checkMagicka=false);
-    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool = NULL, bool cap=true, bool checkMagicka=false);
+    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool = nullptr, bool cap=true, bool checkMagicka=false);
+    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool = nullptr, bool cap=true, bool checkMagicka=false);
 
     int getSpellSchool(const std::string& spellId, const MWWorld::Ptr& actor);
     int getSpellSchool(const ESM::Spell* spell, const MWWorld::Ptr& actor);
@@ -58,14 +58,14 @@ namespace MWMechanics
     /// @param effects Override the actor's current magicEffects. Useful if there are effects currently
     ///                being applied (but not applied yet) that should also be considered.
     float getEffectResistance (short effectId, const MWWorld::Ptr& actor, const MWWorld::Ptr& caster,
-                               const ESM::Spell* spell = NULL, const MagicEffects* effects = NULL);
+                               const ESM::Spell* spell = nullptr, const MagicEffects* effects = nullptr);
 
     /// Get an effect multiplier for applying an effect cast by the given actor in the given spell (optional).
     /// @return effect multiplier from 0 to 2.  (100% net resistance to 100% net weakness)
     /// @param effects Override the actor's current magicEffects. Useful if there are effects currently
     ///                being applied (but not applied yet) that should also be considered.
     float getEffectMultiplier(short effectId, const MWWorld::Ptr& actor, const MWWorld::Ptr& caster,
-                              const ESM::Spell* spell = NULL, const MagicEffects* effects = NULL);
+                              const ESM::Spell* spell = nullptr, const MagicEffects* effects = nullptr);
 
     bool checkEffectTarget (int effectId, const MWWorld::Ptr& target, const MWWorld::Ptr& caster, bool castByPlayer);
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -810,7 +810,7 @@ namespace MWPhysics
         btScalar mLeastDistSqr;
 
         DeepestNotMeContactTestResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3 &origin)
-          : mMe(me), mTargets(targets), mOrigin(origin), mObject(NULL), mContactPoint(0,0,0),
+          : mMe(me), mTargets(targets), mOrigin(origin), mObject(nullptr), mContactPoint(0,0,0),
             mLeastDistSqr(std::numeric_limits<float>::max())
         { }
 
@@ -873,7 +873,7 @@ namespace MWPhysics
         object.setCollisionShape(&shape);
         object.setWorldTransform(btTransform(toBullet(orient), toBullet(center)));
 
-        const btCollisionObject* me = NULL;
+        const btCollisionObject* me = nullptr;
         std::vector<const btCollisionObject*> targetCollisionObjects;
 
         const Actor* physactor = getActor(actor);
@@ -906,7 +906,7 @@ namespace MWPhysics
 
     float PhysicsSystem::getHitDistance(const osg::Vec3f &point, const MWWorld::ConstPtr &target) const
     {
-        btCollisionObject* targetCollisionObj = NULL;
+        btCollisionObject* targetCollisionObj = nullptr;
         const Actor* actor = getActor(target);
         if (actor)
             targetCollisionObj = actor->getCollisionObject();
@@ -968,7 +968,7 @@ namespace MWPhysics
         btVector3 btFrom = toBullet(from);
         btVector3 btTo = toBullet(to);
 
-        const btCollisionObject* me = NULL;
+        const btCollisionObject* me = nullptr;
         std::vector<const btCollisionObject*> targetCollisionObjects;
 
         if (!ignore.isEmpty())
@@ -1127,7 +1127,7 @@ namespace MWPhysics
 
     std::vector<MWWorld::Ptr> PhysicsSystem::getCollisions(const MWWorld::ConstPtr &ptr, int collisionGroup, int collisionMask) const
     {
-        btCollisionObject* me = NULL;
+        btCollisionObject* me = nullptr;
 
         ObjectMap::const_iterator found = mObjects.find(ptr);
         if (found != mObjects.end())
@@ -1255,7 +1255,7 @@ namespace MWPhysics
         ActorMap::iterator found = mActors.find(ptr);
         if (found != mActors.end())
             return found->second;
-        return NULL;
+        return nullptr;
     }
 
     const Actor *PhysicsSystem::getActor(const MWWorld::ConstPtr &ptr) const
@@ -1263,7 +1263,7 @@ namespace MWPhysics
         ActorMap::const_iterator found = mActors.find(ptr);
         if (found != mActors.end())
             return found->second;
-        return NULL;
+        return nullptr;
     }
 
     const Object* PhysicsSystem::getObject(const MWWorld::ConstPtr &ptr) const
@@ -1271,7 +1271,7 @@ namespace MWPhysics
         ObjectMap::const_iterator found = mObjects.find(ptr);
         if (found != mObjects.end())
             return found->second;
-        return NULL;
+        return nullptr;
     }
 
     void PhysicsSystem::updateScale(const MWWorld::Ptr &ptr)

--- a/apps/openmw/mwphysics/trace.cpp
+++ b/apps/openmw/mwphysics/trace.cpp
@@ -86,7 +86,7 @@ void ActorTracer::doTrace(const btCollisionObject *actor, const osg::Vec3f& star
         mPlaneNormal = osg::Vec3f(0.0f, 0.0f, 1.0f);
         mFraction = 1.0f;
         mHitPoint = end;
-        mHitObject = NULL;
+        mHitObject = nullptr;
     }
 }
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -367,7 +367,7 @@ namespace
         void applyNode(osg::Node& node)
         {
             if (node.getStateSet())
-                node.setStateSet(NULL);
+                node.setStateSet(nullptr);
 
             if (node.getNodeMask() == 0x1 && node.getNumParents() == 1)
                 mToRemove.push_back(std::make_pair(&node, node.getParent(0)));
@@ -635,12 +635,12 @@ namespace MWRender
 
     Animation::Animation(const MWWorld::Ptr &ptr, osg::ref_ptr<osg::Group> parentNode, Resource::ResourceSystem* resourceSystem)
         : mInsert(parentNode)
-        , mSkeleton(NULL)
+        , mSkeleton(nullptr)
         , mNodeMapCreated(false)
         , mPtr(ptr)
         , mResourceSystem(resourceSystem)
         , mAccumulate(1.f, 1.f, 0.f)
-        , mTextKeyListener(NULL)
+        , mTextKeyListener(nullptr)
         , mHeadYawRadians(0.f)
         , mHeadPitchRadians(0.f)
         , mHasMagicEffects(false)
@@ -826,7 +826,7 @@ namespace MWRender
         for(size_t i = 0;i < sNumBlendMasks;i++)
             mAnimationTimePtr[i]->setTimePtr(std::shared_ptr<float>());
 
-        mAccumCtrl = NULL;
+        mAccumCtrl = nullptr;
 
         mAnimSources.clear();
 
@@ -1084,12 +1084,12 @@ namespace MWRender
             node->removeUpdateCallback(it->second);
 
             // Should be no longer needed with OSG 3.4
-            it->second->setNestedCallback(NULL);
+            it->second->setNestedCallback(nullptr);
         }
 
         mActiveControllers.clear();
 
-        mAccumCtrl = NULL;
+        mAccumCtrl = nullptr;
 
         for(size_t blendMask = 0;blendMask < sNumBlendMasks;blendMask++)
         {
@@ -1416,14 +1416,14 @@ namespace MWRender
             previousStateset = mObjectRoot->getStateSet();
             mObjectRoot->getParent(0)->removeChild(mObjectRoot);
         }
-        mObjectRoot = NULL;
-        mSkeleton = NULL;
+        mObjectRoot = nullptr;
+        mSkeleton = nullptr;
 
         mNodeMap.clear();
         mNodeMapCreated = false;
         mActiveControllers.clear();
-        mAccumRoot = NULL;
-        mAccumCtrl = NULL;
+        mAccumRoot = nullptr;
+        mAccumCtrl = nullptr;
 
         if (!forceskeleton)
         {
@@ -1556,7 +1556,7 @@ namespace MWRender
         node->addUpdateCallback(glowUpdater);
 
         // set a texture now so that the ShaderVisitor can find it
-        osg::ref_ptr<osg::StateSet> writableStateSet = NULL;
+        osg::ref_ptr<osg::StateSet> writableStateSet = nullptr;
         if (!node->getStateSet())
             writableStateSet = node->getOrCreateStateSet();
         else
@@ -1735,7 +1735,7 @@ namespace MWRender
         std::string lowerName = Misc::StringUtils::lowerCase(name);
         NodeMap::const_iterator found = getNodeMap().find(lowerName);
         if (found == getNodeMap().end())
-            return NULL;
+            return nullptr;
         else
             return found->second;
     }
@@ -1766,7 +1766,7 @@ namespace MWRender
         }
         else
         {
-            mObjectRoot->setStateSet(NULL);
+            mObjectRoot->setStateSet(nullptr);
 
             mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
         }
@@ -1793,7 +1793,7 @@ namespace MWRender
             if (mGlowLight)
             {
                 mInsert->removeChild(mGlowLight);
-                mGlowLight = NULL;
+                mGlowLight = nullptr;
             }
         }
         else
@@ -1807,7 +1807,7 @@ namespace MWRender
                 if (mGlowLight)
                 {
                     mInsert->removeChild(mGlowLight);
-                    mGlowLight = NULL;
+                    mGlowLight = nullptr;
                 }
 
                 osg::ref_ptr<osg::Light> light (new osg::Light);
@@ -1828,7 +1828,7 @@ namespace MWRender
 
     void Animation::addControllers()
     {
-        mHeadController = NULL;
+        mHeadController = nullptr;
 
         if (mPtr.getClass().isBipedal(mPtr))
         {

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -425,7 +425,7 @@ public:
      * \param speedmult Stores the animation speed multiplier
      * \return True if the animation is active, false otherwise.
      */
-    bool getInfo(const std::string &groupname, float *complete=NULL, float *speedmult=NULL) const;
+    bool getInfo(const std::string &groupname, float *complete=nullptr, float *speedmult=nullptr) const;
 
     /// Get the absolute position in the animation track of the first text key with the given group.
     float getStartTime(const std::string &groupname) const;
@@ -453,7 +453,7 @@ public:
     /// This is typically called as part of runAnimation, but may be called manually if needed.
     void updateEffects();
 
-    /// Return a node with the specified name, or NULL if not existing.
+    /// Return a node with the specified name, or nullptr if not existing.
     /// @note The matching is case-insensitive.
     const osg::Node* getNode(const std::string& name) const;
 

--- a/apps/openmw/mwrender/bulletdebugdraw.cpp
+++ b/apps/openmw/mwrender/bulletdebugdraw.cpp
@@ -54,9 +54,9 @@ void DebugDrawer::destroyGeometry()
     if (mGeometry)
     {
         mParentNode->removeChild(mGeometry);
-        mGeometry = NULL;
-        mVertices = NULL;
-        mDrawArrays = NULL;
+        mGeometry = nullptr;
+        mVertices = nullptr;
+        mDrawArrays = nullptr;
     }
 }
 

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -45,7 +45,7 @@ namespace MWRender
     Camera::Camera (osg::Camera* camera)
     : mHeightScale(1.f),
       mCamera(camera),
-      mAnimation(NULL),
+      mAnimation(nullptr),
       mFirstPersonView(true),
       mPreviewMode(false),
       mFreeLook(true),

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -239,7 +239,7 @@ namespace MWRender
 
     void CharacterPreview::rebuild()
     {
-        mAnimation = NULL;
+        mAnimation = nullptr;
 
         mAnimation = new NpcAnimation(mCharacter, mNode, mResourceSystem, true,
                                       (renderHeadOnly() ? NpcAnimation::VM_HeadOnly : NpcAnimation::VM_Normal));
@@ -380,7 +380,7 @@ namespace MWRender
 
     void InventoryPreview::updatePtr(const MWWorld::Ptr &ptr)
     {
-        mCharacter = MWWorld::Ptr(ptr.getBase(), NULL);
+        mCharacter = MWWorld::Ptr(ptr.getBase(), nullptr);
     }
 
     void InventoryPreview::onSetup()
@@ -403,7 +403,7 @@ namespace MWRender
         , mRef(&mBase)
         , mPitchRadians(osg::DegreesToRadians(6.f))
     {
-        mCharacter = MWWorld::Ptr(&mRef, NULL);
+        mCharacter = MWWorld::Ptr(&mRef, nullptr);
     }
 
     RaceSelectionPreview::~RaceSelectionPreview()

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -170,7 +170,7 @@ void CreatureWeaponAnimation::releaseArrow(float attackStrength)
 osg::Group *CreatureWeaponAnimation::getArrowBone()
 {
     if (!mWeapon)
-        return NULL;
+        return nullptr;
 
     SceneUtil::FindByNameVisitor findVisitor ("ArrowBone");
     mWeapon->getNode()->accept(findVisitor);
@@ -180,7 +180,7 @@ osg::Group *CreatureWeaponAnimation::getArrowBone()
 
 osg::Node *CreatureWeaponAnimation::getWeaponNode()
 {
-    return mWeapon ? mWeapon->getNode().get() : NULL;
+    return mWeapon ? mWeapon->getNode().get() : nullptr;
 }
 
 Resource::ResourceSystem *CreatureWeaponAnimation::getResourceSystem()

--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -563,7 +563,7 @@ namespace MWRender
 
             requestOverlayTextureUpdate(0, 0, mWidth, mHeight, osg::ref_ptr<osg::Texture2D>(), true, false);
 
-            mWorkItem = NULL;
+            mWorkItem = nullptr;
         }
     }
 

--- a/apps/openmw/mwrender/landmanager.cpp
+++ b/apps/openmw/mwrender/landmanager.cpp
@@ -14,7 +14,7 @@ namespace MWRender
 {
 
 LandManager::LandManager(int loadFlags)
-    : ResourceManager(NULL)
+    : ResourceManager(nullptr)
     , mLoadFlags(loadFlags)
 {
 }
@@ -32,7 +32,7 @@ osg::ref_ptr<ESMTerrain::LandObject> LandManager::getLand(int x, int y)
     {
         const ESM::Land* land = MWBase::Environment::get().getWorld()->getStore().get<ESM::Land>().search(x,y);
         if (!land)
-            return NULL;
+            return nullptr;
         osg::ref_ptr<ESMTerrain::LandObject> landObj (new ESMTerrain::LandObject(land, mLoadFlags));
         mCache->addEntryToObjectCache(idstr, landObj.get());
         return landObj;

--- a/apps/openmw/mwrender/landmanager.hpp
+++ b/apps/openmw/mwrender/landmanager.hpp
@@ -19,7 +19,7 @@ namespace MWRender
     public:
         LandManager(int loadFlags);
 
-        /// @note Will return NULL if not found.
+        /// @note Will return nullptr if not found.
         osg::ref_ptr<ESMTerrain::LandObject> getLand(int x, int y);
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) const;

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -72,7 +72,7 @@ std::string getVampireHead(const std::string& race, bool female)
     }
 
     if (sVampireMapping.find(thisCombination) == sVampireMapping.end())
-        sVampireMapping[thisCombination] = NULL;
+        sVampireMapping[thisCombination] = nullptr;
 
     const ESM::BodyPart* bodyPart = sVampireMapping[thisCombination];
     if (!bodyPart)
@@ -535,7 +535,7 @@ void NpcAnimation::updateParts()
     };
     static const size_t slotlistsize = sizeof(slotlist)/sizeof(slotlist[0]);
 
-    bool wasArrowAttached = (mAmmunition.get() != NULL);
+    bool wasArrowAttached = (mAmmunition.get() != nullptr);
     mAmmunition.reset();
 
     const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
@@ -823,7 +823,7 @@ void NpcAnimation::addPartGroup(int group, int priority, const std::vector<ESM::
                                  bodypart->mData.mPart == ESM::BodyPart::MP_Wrist ||
                                  bodypart->mData.mPart == ESM::BodyPart::MP_Forearm ||
                                  bodypart->mData.mPart == ESM::BodyPart::MP_Upperarm))
-                    bodypart = NULL;
+                    bodypart = nullptr;
             }
             else if (!bodypart)
                 Log(Debug::Warning) << "Warning: Failed to find body part '" << part->mFemale << "'";
@@ -838,7 +838,7 @@ void NpcAnimation::addPartGroup(int group, int priority, const std::vector<ESM::
                                  bodypart->mData.mPart == ESM::BodyPart::MP_Wrist ||
                                  bodypart->mData.mPart == ESM::BodyPart::MP_Forearm ||
                                  bodypart->mData.mPart == ESM::BodyPart::MP_Upperarm))
-                    bodypart = NULL;
+                    bodypart = nullptr;
             }
             else if (!bodypart)
                 Log(Debug::Warning) << "Warning: Failed to find body part '" << part->mMale << "'";
@@ -855,7 +855,7 @@ void NpcAnimation::addControllers()
 {
     Animation::addControllers();
 
-    mFirstPersonNeckController = NULL;
+    mFirstPersonNeckController = nullptr;
     WeaponAnimation::deleteControllers();
 
     if (mViewMode == VM_FirstPerson)
@@ -947,7 +947,7 @@ osg::Group* NpcAnimation::getArrowBone()
 {
     PartHolderPtr part = mObjectParts[ESM::PRT_Weapon];
     if (!part)
-        return NULL;
+        return nullptr;
 
     SceneUtil::FindByNameVisitor findVisitor ("ArrowBone");
     part->getNode()->accept(findVisitor);
@@ -959,7 +959,7 @@ osg::Node* NpcAnimation::getWeaponNode()
 {
     PartHolderPtr part = mObjectParts[ESM::PRT_Weapon];
     if (!part)
-        return NULL;
+        return nullptr;
     return part->getNode();
 }
 
@@ -1083,7 +1083,7 @@ const std::vector<const ESM::BodyPart *>& NpcAnimation::getBodyParts(const std::
             sBodyPartMap.insert(std::make_pair(ESM::BodyPart::MP_Tail, ESM::PRT_Tail));
         }
 
-        parts.resize(ESM::PRT_Count, NULL);
+        parts.resize(ESM::PRT_Count, nullptr);
 
         const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
         const MWWorld::Store<ESM::BodyPart> &partStore = store.get<ESM::BodyPart>();

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -75,16 +75,16 @@ private:
     void updateNpcBase();
 
     PartHolderPtr insertBoundedPart(const std::string &model, const std::string &bonename,
-                                        const std::string &bonefilter, bool enchantedGlow, osg::Vec4f* glowColor=NULL);
+                                        const std::string &bonefilter, bool enchantedGlow, osg::Vec4f* glowColor=nullptr);
 
     void removeIndividualPart(ESM::PartReferenceType type);
     void reserveIndividualPart(ESM::PartReferenceType type, int group, int priority);
 
     bool addOrReplaceIndividualPart(ESM::PartReferenceType type, int group, int priority, const std::string &mesh,
-                                    bool enchantedGlow=false, osg::Vec4f* glowColor=NULL);
+                                    bool enchantedGlow=false, osg::Vec4f* glowColor=nullptr);
     void removePartGroup(int group);
     void addPartGroup(int group, int priority, const std::vector<ESM::PartReference> &parts,
-                                    bool enchantedGlow=false, osg::Vec4f* glowColor=NULL);
+                                    bool enchantedGlow=false, osg::Vec4f* glowColor=nullptr);
 
     virtual void setRenderBin();
 
@@ -155,7 +155,7 @@ public:
     virtual void updatePtr(const MWWorld::Ptr& updated);
 
     /// Get a list of body parts that may be used by an NPC of given race and gender.
-    /// @note This is a fixed size list, one list item for each ESM::PartReferenceType, may contain NULL body parts.
+    /// @note This is a fixed size list, one list item for each ESM::PartReferenceType, may contain nullptr body parts.
     static const std::vector<const ESM::BodyPart*>& getBodyParts(const std::string& raceId, bool female, bool firstperson, bool werewolf);
 };
 

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -126,14 +126,14 @@ bool Objects::removeObject (const MWWorld::Ptr& ptr)
         if (ptr.getClass().isActor())
         {
             if (ptr.getClass().hasInventoryStore(ptr))
-                ptr.getClass().getInventoryStore(ptr).setInvListener(NULL, ptr);
+                ptr.getClass().getInventoryStore(ptr).setInvListener(nullptr, ptr);
 
-            ptr.getClass().getContainerStore(ptr).setContListener(NULL);
+            ptr.getClass().getContainerStore(ptr).setContListener(nullptr);
         }
 
         ptr.getRefData().getBaseNode()->getParent(0)->removeChild(ptr.getRefData().getBaseNode());
 
-        ptr.getRefData().setBaseNode(NULL);
+        ptr.getRefData().setBaseNode(nullptr);
         return true;
     }
     return false;
@@ -153,8 +153,8 @@ void Objects::removeCell(const MWWorld::CellStore* store)
             if (ptr.getClass().isNpc() && ptr.getRefData().getCustomData())
             {
                 MWWorld::InventoryStore& invStore = ptr.getClass().getInventoryStore(ptr);
-                invStore.setInvListener(NULL, ptr);
-                invStore.setContListener(NULL);
+                invStore.setInvListener(nullptr, ptr);
+                invStore.setContListener(nullptr);
             }
 
             mObjects.erase(iter++);
@@ -218,7 +218,7 @@ Animation* Objects::getAnimation(const MWWorld::Ptr &ptr)
     if(iter != mObjects.end())
         return iter->second;
 
-    return NULL;
+    return nullptr;
 }
 
 const Animation* Objects::getAnimation(const MWWorld::ConstPtr &ptr) const
@@ -227,7 +227,7 @@ const Animation* Objects::getAnimation(const MWWorld::ConstPtr &ptr) const
     if(iter != mObjects.end())
         return iter->second;
 
-    return NULL;
+    return nullptr;
 }
 
 }

--- a/apps/openmw/mwrender/pathgrid.cpp
+++ b/apps/openmw/mwrender/pathgrid.cpp
@@ -27,8 +27,8 @@ namespace MWRender
 Pathgrid::Pathgrid(osg::ref_ptr<osg::Group> root)
     : mPathgridEnabled(false)
     , mRootNode(root)
-    , mPathGridRoot(NULL)
-    , mInteriorPathgridNode(NULL)
+    , mPathGridRoot(nullptr)
+    , mInteriorPathgridNode(nullptr)
 {
 }
 
@@ -94,7 +94,7 @@ void Pathgrid::togglePathgrid()
         if (mPathGridRoot)
         {
             mRootNode->removeChild(mPathGridRoot);
-            mPathGridRoot = NULL;
+            mPathGridRoot = nullptr;
         }
     }
 }
@@ -124,7 +124,7 @@ void Pathgrid::enableCellPathgrid(const MWWorld::CellStore *store)
     }
     else
     {
-        assert(mInteriorPathgridNode == NULL);
+        assert(mInteriorPathgridNode == nullptr);
         mInteriorPathgridNode = cellPathGrid;
     }
 }
@@ -146,7 +146,7 @@ void Pathgrid::disableCellPathgrid(const MWWorld::CellStore *store)
         if (mInteriorPathgridNode)
         {
             mPathGridRoot->removeChild(mInteriorPathgridNode);
-            mInteriorPathgridNode = NULL;
+            mInteriorPathgridNode = nullptr;
         }
     }
 }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -232,7 +232,7 @@ namespace MWRender
 
         mObjects.reset(new Objects(mResourceSystem, sceneRoot, mUnrefQueue.get()));
 
-        if (getenv("OPENMW_DONT_PRECOMPILE") == NULL)
+        if (getenv("OPENMW_DONT_PRECOMPILE") == nullptr)
         {
             mViewer->setIncrementalCompileOperation(new osgUtil::IncrementalCompileOperation);
             mViewer->getIncrementalCompileOperation()->setTargetFrameRate(Settings::Manager::getFloat("target framerate", "Cells"));
@@ -336,7 +336,7 @@ namespace MWRender
     RenderingManager::~RenderingManager()
     {
         // let background loading thread finish before we delete anything else
-        mWorkQueue = NULL;
+        mWorkQueue = nullptr;
     }
 
     MWRender::Objects& RenderingManager::getObjects()
@@ -832,7 +832,7 @@ namespace MWRender
         stateset->setTextureAttributeAndModes(0,cubeTexture,osg::StateAttribute::ON);
             
         quad->setStateSet(stateset);
-        quad->setUpdateCallback(NULL);
+        quad->setUpdateCallback(nullptr);
 
         screenshotCamera->addChild(quad);
 
@@ -975,7 +975,7 @@ namespace MWRender
             result.mHitNormalWorld = intersection.getWorldIntersectNormal();
             result.mRatio = intersection.ratio;
 
-            PtrHolder* ptrHolder = NULL;
+            PtrHolder* ptrHolder = nullptr;
             for (osg::NodePath::const_iterator it = intersection.nodePath.begin(); it != intersection.nodePath.end(); ++it)
             {
                 osg::UserDataContainer* userDataContainer = (*it)->getUserDataContainer();
@@ -1113,7 +1113,7 @@ namespace MWRender
 
     void RenderingManager::rebuildPtr(const MWWorld::Ptr &ptr)
     {
-        NpcAnimation *anim = NULL;
+        NpcAnimation *anim = nullptr;
         if(ptr == mPlayerAnimation->getPtr())
             anim = mPlayerAnimation.get();
         else

--- a/apps/openmw/mwrender/ripplesimulation.cpp
+++ b/apps/openmw/mwrender/ripplesimulation.cpp
@@ -196,7 +196,7 @@ void RippleSimulation::emitRipple(const osg::Vec3f &pos)
 {
     if (std::abs(pos.z() - mParticleNode->getPosition().z()) < 20)
     {
-        osgParticle::Particle* p = mParticleSystem->createParticle(NULL);
+        osgParticle::Particle* p = mParticleSystem->createParticle(nullptr);
         p->setPosition(osg::Vec3f(pos.x(), pos.y(), 0.f));
         p->setAngle(osg::Vec3f(0,0, Misc::Rng::rollProbability() * osg::PI * 2 - osg::PI));
     }

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -629,7 +629,7 @@ private:
         if (mSunFlashNode)
         {
             mSunFlashNode->removeCullCallback(mSunFlashCallback);
-            mSunFlashCallback = NULL;
+            mSunFlashCallback = nullptr;
         }
     }
 
@@ -671,7 +671,7 @@ private:
         if (mSunGlareNode)
         {
             mSunGlareNode->removeCullCallback(mSunGlareCallback);
-            mSunGlareCallback = NULL;
+            mSunGlareCallback = nullptr;
         }
     }
 
@@ -1095,8 +1095,8 @@ private:
 
 SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneManager)
     : mSceneManager(sceneManager)
-    , mCamera(NULL)
-    , mRainIntensityUniform(NULL)
+    , mCamera(nullptr)
+    , mRainIntensityUniform(nullptr)
     , mAtmosphereNightRoll(0.f)
     , mCreated(false)
     , mIsStorm(false)
@@ -1302,7 +1302,7 @@ public:
             {
                 if (stateset->getAttribute(osg::StateAttribute::MATERIAL))
                 {
-                    SceneUtil::CompositeStateSetUpdater* composite = NULL;
+                    SceneUtil::CompositeStateSetUpdater* composite = nullptr;
                     osg::Callback* callback = node.getUpdateCallback();
 
                     while (callback)
@@ -1383,12 +1383,12 @@ public:
 
     virtual osg::Object *cloneType() const override
     {
-        return NULL;
+        return nullptr;
     }
 
     virtual osg::Object *clone(const osg::CopyOp &op) const override
     {
-        return NULL;
+        return nullptr;
     }
 
     virtual void operate(osgParticle::Particle *P, double dt) override
@@ -1520,10 +1520,10 @@ void SkyManager::destroyRain()
         return;
 
     mRootNode->removeChild(mRainNode);
-    mRainNode = NULL;
-    mRainParticleSystem = NULL;
-    mRainShooter = NULL;
-    mRainFader = NULL;
+    mRainNode = nullptr;
+    mRainParticleSystem = nullptr;
+    mRainShooter = nullptr;
+    mRainFader = nullptr;
 }
 
 SkyManager::~SkyManager()
@@ -1531,7 +1531,7 @@ SkyManager::~SkyManager()
     if (mRootNode)
     {
         mRootNode->getParent(0)->removeChild(mRootNode);
-        mRootNode = NULL;
+        mRootNode = nullptr;
     }
 }
 
@@ -1554,7 +1554,7 @@ bool SkyManager::isEnabled()
 
 bool SkyManager::hasRain()
 {
-    return mRainNode != NULL;
+    return mRainNode != nullptr;
 }
 
 void SkyManager::update(float duration)
@@ -1658,7 +1658,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
         if (mParticleEffect)
         {
             mParticleNode->removeChild(mParticleEffect);
-            mParticleEffect = NULL;
+            mParticleEffect = nullptr;
             mParticleFaders.clear();
         }
 
@@ -1667,7 +1667,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
             if (mParticleNode)
             {
                 mRootNode->removeChild(mParticleNode);
-                mParticleNode = NULL;
+                mParticleNode = nullptr;
             }
         }
         else

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -441,13 +441,13 @@ void Water::updateWaterMaterial()
     {
         mReflection->removeChildren(0, mReflection->getNumChildren());
         mParent->removeChild(mReflection);
-        mReflection = NULL;
+        mReflection = nullptr;
     }
     if (mRefraction)
     {
         mRefraction->removeChildren(0, mRefraction->getNumChildren());
         mParent->removeChild(mRefraction);
-        mRefraction = NULL;
+        mRefraction = nullptr;
     }
 
     if (Settings::Manager::getBool("shader", "Water"))
@@ -579,7 +579,7 @@ void Water::createShaderWaterStateSet(osg::Node* node, Reflection* reflection, R
     shaderStateset->setAttributeAndModes(program, osg::StateAttribute::ON);
 
     node->setStateSet(shaderStateset);
-    node->setUpdateCallback(NULL);
+    node->setUpdateCallback(nullptr);
 }
 
 void Water::processChangedSettings(const Settings::CategorySettingVector& settings)
@@ -595,13 +595,13 @@ Water::~Water()
     {
         mReflection->removeChildren(0, mReflection->getNumChildren());
         mParent->removeChild(mReflection);
-        mReflection = NULL;
+        mReflection = nullptr;
     }
     if (mRefraction)
     {
         mRefraction->removeChildren(0, mRefraction->getNumChildren());
         mParent->removeChild(mRefraction);
-        mRefraction = NULL;
+        mRefraction = nullptr;
     }
 }
 

--- a/apps/openmw/mwrender/weaponanimation.cpp
+++ b/apps/openmw/mwrender/weaponanimation.cpp
@@ -164,7 +164,7 @@ void WeaponAnimation::addControllers(const std::map<std::string, osg::ref_ptr<os
 {
     for (int i=0; i<2; ++i)
     {
-        mSpineControllers[i] = NULL;
+        mSpineControllers[i] = nullptr;
 
         std::map<std::string, osg::ref_ptr<osg::MatrixTransform> >::const_iterator found = nodes.find(i == 0 ? "bip01 spine1" : "bip01 spine2");
         if (found != nodes.end())
@@ -180,7 +180,7 @@ void WeaponAnimation::addControllers(const std::map<std::string, osg::ref_ptr<os
 void WeaponAnimation::deleteControllers()
 {
     for (int i=0; i<2; ++i)
-        mSpineControllers[i] = NULL;
+        mSpineControllers[i] = nullptr;
 }
 
 void WeaponAnimation::configureControllers(float characterPitchRadians)

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -1156,7 +1156,7 @@ namespace MWScript
                         // HACK: disable/enable object to re-add it to the scene properly (need a new Animation).
                         MWBase::Environment::get().getWorld()->disable(ptr);
                         // resets runtime state such as inventory, stats and AI. does not reset position in the world
-                        ptr.getRefData().setCustomData(NULL);
+                        ptr.getRefData().setCustomData(nullptr);
                         if (wasEnabled)
                             MWBase::Environment::get().getWorld()->enable(ptr);
                     }

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -484,7 +484,7 @@ namespace MWScript
                     if (!player.isInCell())
                         throw std::runtime_error("player not in a cell");
 
-                    MWWorld::CellStore* store = NULL;
+                    MWWorld::CellStore* store = nullptr;
                     if (player.getCell()->isExterior())
                     {
                         int cx,cy;

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -122,7 +122,7 @@ bool FFmpeg_Decoder::getAVAudioData()
             if(!mDataBuf || mDataBufLen < mFrame->nb_samples)
             {
                 av_freep(&mDataBuf);
-                if(av_samples_alloc(&mDataBuf, NULL, av_get_channel_layout_nb_channels(mOutputChannelLayout),
+                if(av_samples_alloc(&mDataBuf, nullptr, av_get_channel_layout_nb_channels(mOutputChannelLayout),
                                     mFrame->nb_samples, mOutputSampleFormat, 0) < 0)
                     return false;
                 else
@@ -181,34 +181,34 @@ void FFmpeg_Decoder::open(const std::string &fname)
     close();
     mDataStream = mResourceMgr->get(fname);
 
-    if((mFormatCtx=avformat_alloc_context()) == NULL)
+    if((mFormatCtx=avformat_alloc_context()) == nullptr)
         throw std::runtime_error("Failed to allocate context");
 
     try
     {
-        mFormatCtx->pb = avio_alloc_context(NULL, 0, 0, this, readPacket, writePacket, seek);
-        if(!mFormatCtx->pb || avformat_open_input(&mFormatCtx, fname.c_str(), NULL, NULL) != 0)
+        mFormatCtx->pb = avio_alloc_context(nullptr, 0, 0, this, readPacket, writePacket, seek);
+        if(!mFormatCtx->pb || avformat_open_input(&mFormatCtx, fname.c_str(), nullptr, nullptr) != 0)
         {
             // "Note that a user-supplied AVFormatContext will be freed on failure".
             if (mFormatCtx)
             {
-                if (mFormatCtx->pb != NULL)
+                if (mFormatCtx->pb != nullptr)
                 {
-                    if (mFormatCtx->pb->buffer != NULL)
+                    if (mFormatCtx->pb->buffer != nullptr)
                     {
                         av_free(mFormatCtx->pb->buffer);
-                        mFormatCtx->pb->buffer = NULL;
+                        mFormatCtx->pb->buffer = nullptr;
                     }
                     av_free(mFormatCtx->pb);
-                    mFormatCtx->pb = NULL;
+                    mFormatCtx->pb = nullptr;
                 }
                 avformat_free_context(mFormatCtx);
             }
-            mFormatCtx = NULL;
+            mFormatCtx = nullptr;
             throw std::runtime_error("Failed to allocate input stream");
         }
 
-        if(avformat_find_stream_info(mFormatCtx, NULL) < 0)
+        if(avformat_find_stream_info(mFormatCtx, nullptr) < 0)
             throw std::runtime_error("Failed to find stream info in "+fname);
 
         for(size_t j = 0;j < mFormatCtx->nb_streams;j++)
@@ -231,7 +231,7 @@ void FFmpeg_Decoder::open(const std::string &fname)
                              std::to_string((*mStream)->codec->codec_id);
             throw std::runtime_error(ss);
         }
-        if(avcodec_open2((*mStream)->codec, codec, NULL) < 0)
+        if(avcodec_open2((*mStream)->codec, codec, nullptr) < 0)
             throw std::runtime_error(std::string("Failed to open audio codec ") +
                                      codec->long_name);
 
@@ -255,17 +255,17 @@ void FFmpeg_Decoder::open(const std::string &fname)
     {
         if(mStream)
             avcodec_close((*mStream)->codec);
-        mStream = NULL;
+        mStream = nullptr;
 
-        if (mFormatCtx != NULL)
+        if (mFormatCtx != nullptr)
         {
-            if (mFormatCtx->pb->buffer != NULL)
+            if (mFormatCtx->pb->buffer != nullptr)
             {
                 av_free(mFormatCtx->pb->buffer);
-                mFormatCtx->pb->buffer = NULL;
+                mFormatCtx->pb->buffer = nullptr;
             }
             av_free(mFormatCtx->pb);
-            mFormatCtx->pb = NULL;
+            mFormatCtx->pb = nullptr;
 
             avformat_close_input(&mFormatCtx);
         }
@@ -276,7 +276,7 @@ void FFmpeg_Decoder::close()
 {
     if(mStream)
         avcodec_close((*mStream)->codec);
-    mStream = NULL;
+    mStream = nullptr;
 
     av_free_packet(&mPacket);
     av_freep(&mFrame);
@@ -285,20 +285,20 @@ void FFmpeg_Decoder::close()
 
     if(mFormatCtx)
     {
-        if (mFormatCtx->pb != NULL)
+        if (mFormatCtx->pb != nullptr)
         {
             // mFormatCtx->pb->buffer must be freed by hand,
             // if not, valgrind will show memleak, see:
             //
             // https://trac.ffmpeg.org/ticket/1357
             //
-            if (mFormatCtx->pb->buffer != NULL)
+            if (mFormatCtx->pb->buffer != nullptr)
             {
                 av_free(mFormatCtx->pb->buffer);
-                mFormatCtx->pb->buffer = NULL;
+                mFormatCtx->pb->buffer = nullptr;
             }
             av_free(mFormatCtx->pb);
-            mFormatCtx->pb = NULL;
+            mFormatCtx->pb = nullptr;
         }
         avformat_close_input(&mFormatCtx);
     }
@@ -373,7 +373,7 @@ void FFmpeg_Decoder::getInfo(int *samplerate, ChannelConfig *chans, SampleType *
                           (*mStream)->codec->sample_fmt,  // input sample format
                           (*mStream)->codec->sample_rate, // input sample rate
                           0,                              // logging level offset
-                          NULL);                          // log context
+                          nullptr);                          // log context
         if(!mSwr)
             throw std::runtime_error("Couldn't allocate SwrContext");
         if(swr_init(mSwr) < 0)
@@ -417,17 +417,17 @@ size_t FFmpeg_Decoder::getSampleOffset()
 
 FFmpeg_Decoder::FFmpeg_Decoder(const VFS::Manager* vfs)
   : Sound_Decoder(vfs)
-  , mFormatCtx(NULL)
-  , mStream(NULL)
-  , mFrame(NULL)
+  , mFormatCtx(nullptr)
+  , mStream(nullptr)
+  , mFrame(nullptr)
   , mFrameSize(0)
   , mFramePos(0)
   , mNextPts(0.0)
   , mSwr(0)
   , mOutputSampleFormat(AV_SAMPLE_FMT_NONE)
   , mOutputChannelLayout(0)
-  , mDataBuf(NULL)
-  , mFrameData(NULL)
+  , mDataBuf(nullptr)
+  , mFrameData(nullptr)
   , mDataBufLen(0)
 {
     memset(&mPacket, 0, sizeof(mPacket));

--- a/apps/openmw/mwsound/movieaudiofactory.cpp
+++ b/apps/openmw/mwsound/movieaudiofactory.cpp
@@ -19,7 +19,7 @@ namespace MWSound
     {
     public:
         MWSoundDecoderBridge(MWSound::MovieAudioDecoder* decoder)
-            : Sound_Decoder(NULL)
+            : Sound_Decoder(nullptr)
             , mDecoder(decoder)
         {
         }

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -572,10 +572,10 @@ std::vector<std::string> OpenAL_Output::enumerate()
     std::vector<std::string> devlist;
     const ALCchar *devnames;
 
-    if(alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT"))
-        devnames = alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER);
+    if(alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT"))
+        devnames = alcGetString(nullptr, ALC_ALL_DEVICES_SPECIFIER);
     else
-        devnames = alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+        devnames = alcGetString(nullptr, ALC_DEVICE_SPECIFIER);
     while(devnames && *devnames)
     {
         devlist.push_back(devnames);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -819,7 +819,7 @@ namespace MWSound
         }
 
         const ESM::Region *regn = world->getStore().get<ESM::Region>().search(regionName);
-        if(regn == NULL)
+        if(regn == nullptr)
             return;
 
         if(total == 0)

--- a/apps/openmw/mwstate/charactermanager.cpp
+++ b/apps/openmw/mwstate/charactermanager.cpp
@@ -46,7 +46,7 @@ void MWState::CharacterManager::deleteSlot(const MWState::Character *character, 
         // All slots deleted, cleanup and remove this character
         it->cleanup();
         if (character == mCurrent)
-            mCurrent = NULL;
+            mCurrent = nullptr;
         mCharacters.erase(it);
     }
 }
@@ -96,7 +96,7 @@ std::list<MWState::Character>::iterator MWState::CharacterManager::findCharacter
 void MWState::CharacterManager::setCurrentCharacter (const Character *character)
 {
     if (!character)
-        mCurrent = NULL;
+        mCurrent = nullptr;
     else
     {
         std::list<Character>::iterator it = findCharacter(character);

--- a/apps/openmw/mwstate/quicksavemanager.cpp
+++ b/apps/openmw/mwstate/quicksavemanager.cpp
@@ -20,7 +20,7 @@ void MWState::QuickSaveManager::visitSave(const Slot *saveSlot)
 
 bool MWState::QuickSaveManager::isOldestSave(const Slot *compare)
 {
-    if(mOldestSlotVisited == NULL)
+    if(mOldestSlotVisited == nullptr)
         return true;
     return (compare->mTimeStamp <= mOldestSlotVisited->mTimeStamp);
 }
@@ -33,6 +33,6 @@ bool MWState::QuickSaveManager::shouldCreateNewSlot()
 const MWState::Slot *MWState::QuickSaveManager::getNextQuickSaveSlot()
 {
     if(shouldCreateNewSlot())
-        return NULL;
+        return nullptr;
     return mOldestSlotVisited;
 }

--- a/apps/openmw/mwstate/quicksavemanager.hpp
+++ b/apps/openmw/mwstate/quicksavemanager.hpp
@@ -28,7 +28,7 @@ namespace MWState{
         const Slot *getNextQuickSaveSlot();
         ///< Get the slot that the next quicksave should use.
         ///
-        ///\return Either the oldest quicksave slot visited, or NULL if a new slot can be made
+        ///\return Either the oldest quicksave slot visited, or nullptr if a new slot can be made
     };
 }
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -55,7 +55,7 @@ void MWState::StateManager::cleanup (bool force)
         MWBase::Environment::get().getMechanicsManager()->clear();
 
         mState = State_NoGame;
-        mCharacterManager.setCurrentCharacter(NULL);
+        mCharacterManager.setCurrentCharacter(nullptr);
         mTimePlayed = 0;
 
         MWMechanics::CreatureStats::cleanup();

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -206,13 +206,13 @@ namespace MWWorld
         {
             mTerrainPreloadItem->abort();
             mTerrainPreloadItem->waitTillDone();
-            mTerrainPreloadItem = NULL;
+            mTerrainPreloadItem = nullptr;
         }
 
         if (mUpdateCacheItem)
         {
             mUpdateCacheItem->waitTillDone();
-            mUpdateCacheItem = NULL;
+            mUpdateCacheItem = nullptr;
         }
 
         for (PreloadMap::iterator it = mPreloadCells.begin(); it != mPreloadCells.end();++it)

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -340,7 +340,7 @@ public:
         }
         catch (...)
         {
-            return NULL;
+            return nullptr;
         }
     }
 };

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -156,7 +156,7 @@ namespace
         ESM::RefNum mRefNumToFind;
 
         SearchByRefNumVisitor(const ESM::RefNum& toFind)
-            : mFound(NULL)
+            : mFound(nullptr)
             , mRefNumToFind(toFind)
         {
         }
@@ -259,7 +259,7 @@ namespace MWWorld
         {
             MWWorld::Ptr copied = object.getClass().copyToCell(object, *cellToMoveTo, object.getRefData().getCount());
             object.getRefData().setCount(0);
-            object.getRefData().setBaseNode(NULL);
+            object.getRefData().setBaseNode(nullptr);
             return copied;
         }
 
@@ -901,7 +901,7 @@ namespace MWWorld
 
             CellStore* otherCell = callback->getCellStore(movedTo);
 
-            if (otherCell == NULL)
+            if (otherCell == nullptr)
             {
                 Log(Debug::Warning) << "Warning: Dropping moved ref tag for " << movedRef->mRef.getRefId()
                                     << " (target cell " << movedTo.mWorldspace << " no longer exists). Reference moved back to its original location.";

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -64,7 +64,7 @@ namespace MWWorld
 
             // Even though fog actually belongs to the player and not cells,
             // it makes sense to store it here since we need it once for each cell.
-            // Note this is NULL until the cell is explored to save some memory
+            // Note this is nullptr until the cell is explored to save some memory
             std::shared_ptr<ESM::FogState> mFogState;
 
             const ESM::Cell *mCell;
@@ -367,7 +367,7 @@ namespace MWWorld
             struct GetCellStoreCallback
             {
             public:
-                ///@note must return NULL if the cell is not found
+                ///@note must return nullptr if the cell is not found
                 virtual CellStore* getCellStore(const ESM::CellId& cellId) = 0;
             };
 

--- a/apps/openmw/mwworld/cellvisitors.hpp
+++ b/apps/openmw/mwworld/cellvisitors.hpp
@@ -17,7 +17,7 @@ namespace MWWorld
         {
             if (ptr.getRefData().getBaseNode())
             {
-                ptr.getRefData().setBaseNode(NULL);
+                ptr.getRefData().setBaseNode(nullptr);
                 mObjects.push_back (ptr);
             }
 

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -114,7 +114,7 @@ void MWWorld::ContainerStore::storeStates (const CellRefList<T>& collection,
 
 const std::string MWWorld::ContainerStore::sGoldId = "gold_001";
 
-MWWorld::ContainerStore::ContainerStore() : mListener(NULL), mCachedWeight (0), mWeightUpToDate (false) {}
+MWWorld::ContainerStore::ContainerStore() : mListener(nullptr), mCachedWeight (0), mWeightUpToDate (false) {}
 
 MWWorld::ContainerStore::~ContainerStore() {}
 
@@ -286,7 +286,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr
     MWWorld::Ptr item = *it;
 
     // we may have copied an item from the world, so reset a few things first
-    item.getRefData().setBaseNode(NULL); // Especially important, otherwise scripts on the item could think that it's actually in a cell
+    item.getRefData().setBaseNode(nullptr); // Especially important, otherwise scripts on the item could think that it's actually in a cell
     ESM::Position pos;
     pos.rot[0] = 0;
     pos.rot[1] = 0;

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -99,7 +99,7 @@ void MWWorld::InventoryStore::readEquipmentState(const MWWorld::ContainerStoreIt
 }
 
 MWWorld::InventoryStore::InventoryStore()
- : mListener(NULL)
+ : mListener(nullptr)
  , mUpdatesEnabled (true)
  , mFirstAutoEquip(true)
  , mSelectedEnchantItem(end())

--- a/apps/openmw/mwworld/livecellref.hpp
+++ b/apps/openmw/mwworld/livecellref.hpp
@@ -76,11 +76,11 @@ namespace MWWorld
     template <typename X>
     struct LiveCellRef : public LiveCellRefBase
     {
-        LiveCellRef(const ESM::CellRef& cref, const X* b = NULL)
+        LiveCellRef(const ESM::CellRef& cref, const X* b = nullptr)
             : LiveCellRefBase(typeid(X).name(), cref), mBase(b)
         {}
 
-        LiveCellRef(const X* b = NULL)
+        LiveCellRef(const X* b = nullptr)
             : LiveCellRefBase(typeid(X).name()), mBase(b)
         {}
 

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -30,7 +30,7 @@ namespace MWWorld
     Player::Player (const ESM::NPC *player)
       : mCellStore(0),
         mLastKnownExteriorPosition(0,0,0),
-        mMarkedCell(NULL),
+        mMarkedCell(nullptr),
         mAutoMove(false),
         mForwardBackward(0),
         mTeleported(false),
@@ -406,7 +406,7 @@ namespace MWWorld
             {
                 Log(Debug::Warning) << "Warning: Player cell '" << player.mCellId.mWorldspace << "' no longer exists";
                 // Cell no longer exists. The loader will have to choose a default cell.
-                mCellStore = NULL;
+                mCellStore = nullptr;
             }
 
             if (!player.mBirthsign.empty())

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -38,7 +38,7 @@ namespace MWWorld
         osg::Vec3f mLastKnownExteriorPosition;
 
         ESM::Position           mMarkedPosition;
-        // If no position was marked, this is NULL
+        // If no position was marked, this is nullptr
         CellStore*              mMarkedCell;
 
         bool                    mAutoMove;

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -94,7 +94,7 @@ namespace
     void updateObjectScale(const MWWorld::Ptr& ptr, MWPhysics::PhysicsSystem& physics,
                             MWRender::RenderingManager& rendering)
     {
-        if (ptr.getRefData().getBaseNode() != NULL)
+        if (ptr.getRefData().getBaseNode() != nullptr)
         {
             float scale = ptr.getCellRef().getScale();
             osg::Vec3f scaleVec (scale, scale, scale);
@@ -330,7 +330,7 @@ namespace MWWorld
         while (active!=mActiveCells.end())
             unloadCell (active++);
         assert(mActiveCells.empty());
-        mCurrentCell = NULL;
+        mCurrentCell = nullptr;
 
         mPreloader->clear();
     }
@@ -519,7 +519,7 @@ namespace MWWorld
     void Scene::changeToInteriorCell (const std::string& cellName, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent)
     {
         CellStore *cell = MWBase::Environment::get().getWorld()->getInterior(cellName);
-        bool loadcell = (mCurrentCell == NULL);
+        bool loadcell = (mCurrentCell == nullptr);
         if(!loadcell)
             loadcell = *mCurrentCell != *cell;
 

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -96,7 +96,7 @@ namespace MWWorld
         typename Static::const_iterator it = mStatic.find(index);
         if (it != mStatic.end())
             return &(it->second);
-        return NULL;
+        return nullptr;
     }
     template<typename T>
     const T *IndexedStore<T>::find(int index) const
@@ -165,7 +165,7 @@ namespace MWWorld
         std::for_each(mShared.begin(), mShared.end(), GetRecords<T>(id, &results));
         if(!results.empty())
             return results[Misc::Rng::rollDice(results.size())];
-        return NULL;
+        return nullptr;
     }
     template<typename T>
     const T *Store<T>::find(const std::string &id) const
@@ -358,7 +358,7 @@ namespace MWWorld
         const LandTextureList &ltexl = mStatic[plugin];
 
         if (index >= ltexl.size())
-            return NULL;
+            return nullptr;
         return &ltexl[index];
     }
     const ESM::LandTexture *Store<ESM::LandTexture>::find(size_t index, size_t plugin) const
@@ -867,7 +867,7 @@ namespace MWWorld
     //=========================================================================
 
     Store<ESM::Pathgrid>::Store()
-        : mCells(NULL)
+        : mCells(nullptr)
     {
     }
 
@@ -887,7 +887,7 @@ namespace MWWorld
         // mX and mY will be (0,0) for interior cells, but there is also an exterior cell with the coordinates of (0,0), so that doesn't help.
         // Check whether mCell is an interior cell. This isn't perfect, will break if a Region with the same name as an interior cell is created.
         // A proper fix should be made for future versions of the file format.
-        bool interior = mCells->search(pathgrid.mCell) != NULL;
+        bool interior = mCells->search(pathgrid.mCell) != nullptr;
 
         // Try to overwrite existing record
         if (interior)
@@ -917,14 +917,14 @@ namespace MWWorld
         Exterior::const_iterator it = mExt.find(std::make_pair(x,y));
         if (it != mExt.end())
             return &(it->second);
-        return NULL;
+        return nullptr;
     }
     const ESM::Pathgrid *Store<ESM::Pathgrid>::search(const std::string& name) const
     {
         Interior::const_iterator it = mInt.find(name);
         if (it != mInt.end())
             return &(it->second);
-        return NULL;
+        return nullptr;
     }
     const ESM::Pathgrid *Store<ESM::Pathgrid>::find(int x, int y) const
     {

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -166,7 +166,7 @@ namespace MWWorld
          */
         bool isDynamic(const std::string &id) const;
 
-        /** Returns a random record that starts with the named ID, or NULL if not found. */
+        /** Returns a random record that starts with the named ID, or nullptr if not found. */
         const T *searchRandom(const std::string &id) const;
 
         const T *find(const std::string &id) const;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1111,7 +1111,7 @@ namespace MWWorld
 
     void World::deleteObject (const Ptr& ptr)
     {
-        if (!ptr.getRefData().isDeleted() && ptr.getContainerStore() == NULL)
+        if (!ptr.getRefData().isDeleted() && ptr.getContainerStore() == nullptr)
         {
             if (ptr == getPlayerPtr())
                 throw std::runtime_error("can not delete player object");
@@ -2192,7 +2192,7 @@ namespace MWWorld
 
         pos.z() += heightRatio*2*mPhysics->getRenderingHalfExtents(object).z();
 
-        const CellStore *currCell = object.isInCell() ? object.getCell() : NULL; // currCell == NULL should only happen for player, during initial startup
+        const CellStore *currCell = object.isInCell() ? object.getCell() : nullptr; // currCell == nullptr should only happen for player, during initial startup
 
         return isUnderwater(currCell, pos);
     }
@@ -2867,7 +2867,7 @@ namespace MWWorld
 
         // if the faced object can not be activated, do not use it
         if (!target.isEmpty() && !target.getClass().canBeActivated(target))
-            target = NULL;
+            target = nullptr;
 
         if (target.isEmpty())
         {
@@ -2920,14 +2920,14 @@ namespace MWWorld
                     target = result1.first;
                     hitPosition = result1.second;
                     if (dist1 > getMaxActivationDistance())
-                        target = NULL;
+                        target = nullptr;
                 }
                 else if (result2.mHit)
                 {
                     target = result2.mHitObject;
                     hitPosition = result2.mHitPointWorld;
                     if (dist2 > getMaxActivationDistance() && !target.isEmpty() && !target.getClass().canBeActivated(target))
-                        target = NULL;
+                        target = nullptr;
                 }
             }
         }

--- a/apps/openmw_test_suite/mwworld/test_store.cpp
+++ b/apps/openmw_test_suite/mwworld/test_store.cpp
@@ -28,7 +28,7 @@ struct ContentFileTest : public ::testing::Test
         for (std::vector<boost::filesystem::path>::const_iterator it = mContentFiles.begin(); it != mContentFiles.end(); ++it)
         {
             ESM::ESMReader lEsm;
-            lEsm.setEncoder(NULL);
+            lEsm.setEncoder(nullptr);
             lEsm.setIndex(index);
             lEsm.setGlobalReaderList(&readerList);
             lEsm.open(it->string());
@@ -309,7 +309,7 @@ TEST_F(StoreTest, overwrite_test)
     // verify that changes were actually applied
     const RecordType* overwrittenRec = mEsmStore.get<RecordType>().search(recordId);
 
-    ASSERT_TRUE (overwrittenRec != NULL);
+    ASSERT_TRUE (overwrittenRec != nullptr);
 
     ASSERT_TRUE (overwrittenRec && overwrittenRec->mModel == "the_new_model");
 }

--- a/apps/wizard/existinginstallationpage.cpp
+++ b/apps/wizard/existinginstallationpage.cpp
@@ -96,7 +96,7 @@ void Wizard::ExistingInstallationPage::on_browseButton_clicked()
                 tr("Select master file"),
                 QDir::currentPath(),
                 QString(tr("Morrowind master file (*.esm)")),
-                NULL,
+                nullptr,
                 QFileDialog::DontResolveSymlinks);
 
     if (selectedFile.isEmpty())

--- a/components/contentselector/view/contentselector.cpp
+++ b/components/contentselector/view/contentselector.cpp
@@ -196,7 +196,7 @@ void ContentSelectorView::ContentSelector::setGameFileSelected(int index, bool s
 {
     QString fileName = ui.gameFileView->itemText(index);
     const ContentSelectorModel::EsmFile* file = mContentModel->item(fileName);
-    if (file != NULL)
+    if (file != nullptr)
     {
         QModelIndex index2(mContentModel->indexFromItem(file));
         mContentModel->setData(index2, selected, Qt::UserRole + 1);

--- a/components/crashcatcher/crashcatcher.cpp
+++ b/components/crashcatcher/crashcatcher.cpp
@@ -71,7 +71,7 @@ static const struct {
 { "Illegal instruction", SIGILL },
 { "FPU exception", SIGFPE },
 { "System BUS error", SIGBUS },
-{ NULL, 0 }
+{ nullptr, 0 }
 };
 
 static const struct {
@@ -88,7 +88,7 @@ static const struct {
     { ILL_COPROC, "Coprocessor error" },
     { ILL_BADSTK, "Internal stack error" },
     #endif
-    { 0, NULL }
+    { 0, nullptr }
 };
 
 static const struct {
@@ -103,7 +103,7 @@ static const struct {
     { FPE_FLTRES, "Floating point inexact result" },
     { FPE_FLTINV, "Floating point invalid operation" },
     { FPE_FLTSUB, "Subscript out of range" },
-    { 0, NULL }
+    { 0, nullptr }
 };
 
 static const struct {
@@ -114,7 +114,7 @@ static const struct {
     { SEGV_MAPERR, "Address not mapped to object" },
     { SEGV_ACCERR, "Invalid permissions for mapped object" },
     #endif
-    { 0, NULL }
+    { 0, nullptr }
 };
 
 static const struct {
@@ -126,7 +126,7 @@ static const struct {
     { BUS_ADRERR, "Non-existent physical address" },
     { BUS_OBJERR, "Object specific hardware error" },
     #endif
-    { 0, NULL }
+    { 0, nullptr }
 };
 
 static int (*cc_user_info)(char*, char*);
@@ -140,7 +140,7 @@ static void gdb_info(pid_t pid)
 
     /* Create a temp file to put gdb commands into */
     strcpy(respfile, "/tmp/gdb-respfile-XXXXXX");
-    if((fd=mkstemp(respfile)) >= 0 && (f=fdopen(fd, "w")) != NULL)
+    if((fd=mkstemp(respfile)) >= 0 && (f=fdopen(fd, "w")) != nullptr)
     {
         fprintf(f, "attach %d\n"
                 "shell echo \"\"\n"
@@ -267,7 +267,7 @@ static void crash_catcher(int signum, siginfo_t *siginfo, void *context)
         close(fd[0]);
         close(fd[1]);
 
-        execl(argv0, argv0, crash_switch, NULL);
+        execl(argv0, argv0, crash_switch, nullptr);
 
         safe_write(STDERR_FILENO, exec_err, sizeof(exec_err)-1);
         _exit(1);
@@ -407,7 +407,7 @@ static void crash_handler(const char *logfile)
     if(logfile)
     {
         std::string message = "OpenMW has encountered a fatal error.\nCrash log saved to '" + std::string(logfile) + "'.\n Please report this to https://bugs.openmw.org !";
-        SDL_ShowSimpleMessageBox(0, "Fatal Error", message.c_str(), NULL);
+        SDL_ShowSimpleMessageBox(0, "Fatal Error", message.c_str(), nullptr);
     }
 
     exit(0);
@@ -444,7 +444,7 @@ int crashCatcherInstallHandlers(int argc, char **argv, int num_signals, int *sig
     altss.ss_sp = altstack;
     altss.ss_flags = 0;
     altss.ss_size = sizeof(altstack);
-    sigaltstack(&altss, NULL);
+    sigaltstack(&altss, nullptr);
 
     memset(&sa, 0, sizeof(sa));
     sa.sa_sigaction = crash_catcher;
@@ -455,7 +455,7 @@ int crashCatcherInstallHandlers(int argc, char **argv, int num_signals, int *sig
     while(num_signals--)
     {
         if((*signals != SIGSEGV && *signals != SIGILL && *signals != SIGFPE && *signals != SIGABRT &&
-            *signals != SIGBUS) || sigaction(*signals, &sa, NULL) == -1)
+            *signals != SIGBUS) || sigaction(*signals, &sa, nullptr) == -1)
         {
             *signals = 0;
             retval = -1;
@@ -502,7 +502,7 @@ static bool is_debugger_present()
     // Call sysctl.
 
     size = sizeof(info);
-    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, nullptr, 0);
     assert(junk == 0);
 
     // We're being debugged if the P_TRACED flag is set.
@@ -516,7 +516,7 @@ void crashCatcherInstall(int argc, char **argv, const std::string &crashLogPath)
     if ((argc == 2 && strcmp(argv[1], "--cc-handle-crash") == 0) || !is_debugger_present())
     {
         int s[5] = { SIGSEGV, SIGILL, SIGFPE, SIGBUS, SIGABRT };
-        if (crashCatcherInstallHandlers(argc, argv, 5, s, crashLogPath.c_str(), NULL) == -1)
+        if (crashCatcherInstallHandlers(argc, argv, 5, s, crashLogPath.c_str(), nullptr) == -1)
         {
             Log(Debug::Warning) << "Installing crash handler failed";
         }

--- a/components/debug/debugging.cpp
+++ b/components/debug/debugging.cpp
@@ -101,7 +101,7 @@ int wrapApplication(int (*innerApplication)(int argc, char *argv[]), int argc, c
 #if (defined(__APPLE__) || defined(__linux) || defined(__unix) || defined(__posix))
         if (!isatty(fileno(stdin)))
 #endif
-            SDL_ShowSimpleMessageBox(0, (appName + ": Fatal error").c_str(), e.what(), NULL);
+            SDL_ShowSimpleMessageBox(0, (appName + ": Fatal error").c_str(), e.what(), nullptr);
 
         Log(Debug::Error) << "Error: " << e.what();
 

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -23,8 +23,8 @@ ESMReader::ESMReader()
     : mIdx(0)
     , mRecordFlags(0)
     , mBuffer(50*1024)
-    , mGlobalReaderList(NULL)
-    , mEncoder(NULL)
+    , mGlobalReaderList(nullptr)
+    , mEncoder(nullptr)
     , mFileSize(0)
 {
 }

--- a/components/esm/esmwriter.cpp
+++ b/components/esm/esmwriter.cpp
@@ -10,9 +10,9 @@ namespace ESM
 {
     ESMWriter::ESMWriter()
         : mRecords()
-        , mStream(NULL)
+        , mStream(nullptr)
         , mHeaderPos()
-        , mEncoder(NULL)
+        , mEncoder(nullptr)
         , mRecordCount(0)
         , mCounting(true)
         , mHeader()

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -16,7 +16,7 @@ namespace ESM
         , mY(0)
         , mPlugin(0)
         , mDataTypes(0)
-        , mLandData(NULL)
+        , mLandData(nullptr)
     {
     }
 
@@ -73,7 +73,7 @@ namespace ESM
 
         mContext = esm.getContext();
 
-        mLandData = NULL;
+        mLandData = nullptr;
 
         // Skip the land data here. Load it when the cell is loaded.
         while (esm.hasMoreSubs())
@@ -298,7 +298,7 @@ namespace ESM
         if (mLandData)
         {
             delete mLandData;
-            mLandData = NULL;
+            mLandData = nullptr;
         }
     }
 

--- a/components/esm/loadland.hpp
+++ b/components/esm/loadland.hpp
@@ -129,9 +129,9 @@ struct Land
 
     /**
      * Actually loads data into target
-     * If target is NULL, assumed target is mLandData
+     * If target is nullptr, assumed target is mLandData
      */
-    void loadData(int flags, LandData* target = NULL) const;
+    void loadData(int flags, LandData* target = nullptr) const;
 
     /**
      * Frees memory allocated for mLandData

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -50,7 +50,7 @@ namespace ESMTerrain
     const ESM::Land::LandData *LandObject::getData(int flags) const
     {
         if ((mData.mDataLoaded & flags) != flags)
-            return NULL;
+            return nullptr;
         return &mData;
     }
 

--- a/components/files/androidpath.cpp
+++ b/components/files/androidpath.cpp
@@ -40,15 +40,15 @@ namespace
     boost::filesystem::path getUserHome()
     {
         const char* dir = getenv("HOME");
-        if (dir == NULL)
+        if (dir == nullptr)
         {
             struct passwd* pwd = getpwuid(getuid());
-            if (pwd != NULL)
+            if (pwd != nullptr)
             {
                 dir = pwd->pw_dir;
             }
         }
-        if (dir == NULL)
+        if (dir == nullptr)
             return boost::filesystem::path();
         else
             return boost::filesystem::path(dir);

--- a/components/files/linuxpath.cpp
+++ b/components/files/linuxpath.cpp
@@ -14,15 +14,15 @@ namespace
     boost::filesystem::path getUserHome()
     {
         const char* dir = getenv("HOME");
-        if (dir == NULL)
+        if (dir == nullptr)
         {
             struct passwd* pwd = getpwuid(getuid());
-            if (pwd != NULL)
+            if (pwd != nullptr)
             {
                 dir = pwd->pw_dir;
             }
         }
-        if (dir == NULL)
+        if (dir == nullptr)
             return boost::filesystem::path();
         else
             return boost::filesystem::path(dir);

--- a/components/files/lowlevelfile.cpp
+++ b/components/files/lowlevelfile.cpp
@@ -21,22 +21,22 @@
 
 LowLevelFile::LowLevelFile ()
 {
-    mHandle = NULL;
+    mHandle = nullptr;
 }
 
 LowLevelFile::~LowLevelFile ()
 {
-    if (mHandle != NULL)
+    if (mHandle != nullptr)
         fclose (mHandle);
 }
 
 void LowLevelFile::open (char const * filename)
 {
-    assert (mHandle == NULL);
+    assert (mHandle == nullptr);
 
     mHandle = fopen (filename, "rb");
 
-    if (mHandle == NULL)
+    if (mHandle == nullptr)
     {
         std::ostringstream os;
         os << "Failed to open '" << filename << "' for reading.";
@@ -46,16 +46,16 @@ void LowLevelFile::open (char const * filename)
 
 void LowLevelFile::close ()
 {
-    assert (mHandle != NULL);
+    assert (mHandle != nullptr);
 
     fclose (mHandle);
 
-    mHandle = NULL;
+    mHandle = nullptr;
 }
 
 size_t LowLevelFile::size ()
 {
-    assert (mHandle != NULL);
+    assert (mHandle != nullptr);
 
     long oldPosition = ftell (mHandle);
 
@@ -78,7 +78,7 @@ size_t LowLevelFile::size ()
 
 void LowLevelFile::seek (size_t Position)
 {
-    assert (mHandle != NULL);
+    assert (mHandle != nullptr);
 
     if (fseek (mHandle, Position, SEEK_SET) != 0)
         throw std::runtime_error ("A seek operation on a file failed.");
@@ -86,7 +86,7 @@ void LowLevelFile::seek (size_t Position)
 
 size_t LowLevelFile::tell ()
 {
-    assert (mHandle != NULL);
+    assert (mHandle != nullptr);
 
     long Position = ftell (mHandle);
 
@@ -98,7 +98,7 @@ size_t LowLevelFile::tell ()
 
 size_t LowLevelFile::read (void * data, size_t size)
 {
-    assert (mHandle != NULL);
+    assert (mHandle != nullptr);
 
     int amount = fread (data, 1, size, mHandle);
 
@@ -296,7 +296,7 @@ void LowLevelFile::seek (size_t Position)
 {
     assert (mHandle != INVALID_HANDLE_VALUE);
 
-    if (SetFilePointer (mHandle, Position, NULL, SEEK_SET) == INVALID_SET_FILE_POINTER)
+    if (SetFilePointer (mHandle, Position, nullptr, SEEK_SET) == INVALID_SET_FILE_POINTER)
         if (GetLastError () != NO_ERROR)
             throw std::runtime_error ("A seek operation on a file failed.");
 }
@@ -305,7 +305,7 @@ size_t LowLevelFile::tell ()
 {
     assert (mHandle != INVALID_HANDLE_VALUE);
 
-    DWORD value = SetFilePointer (mHandle, 0, NULL, SEEK_CUR);
+    DWORD value = SetFilePointer (mHandle, 0, nullptr, SEEK_CUR);
 
     if (value == INVALID_SET_FILE_POINTER && GetLastError () != NO_ERROR)
         throw std::runtime_error ("A query operation on a file failed.");
@@ -319,7 +319,7 @@ size_t LowLevelFile::read (void * data, size_t size)
 
     DWORD read;
 
-    if (!ReadFile (mHandle, data, size, &read, NULL))
+    if (!ReadFile (mHandle, data, size, &read, nullptr))
         throw std::runtime_error ("A read operation on a file failed.");
 
     return read;

--- a/components/files/macospath.cpp
+++ b/components/files/macospath.cpp
@@ -14,15 +14,15 @@ namespace
     boost::filesystem::path getUserHome()
     {
         const char* dir = getenv("HOME");
-        if (dir == NULL)
+        if (dir == nullptr)
         {
             struct passwd* pwd = getpwuid(getuid());
-            if (pwd != NULL)
+            if (pwd != nullptr)
             {
                 dir = pwd->pw_dir;
             }
         }
-        if (dir == NULL)
+        if (dir == nullptr)
             return boost::filesystem::path();
         else
             return boost::filesystem::path(dir);

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -42,7 +42,7 @@ boost::filesystem::path WindowsPath::getUserConfigPath() const
     WCHAR path[MAX_PATH + 1];
     memset(path, 0, sizeof(path));
 
-    if(SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_PERSONAL | CSIDL_FLAG_CREATE, NULL, 0, path)))
+    if(SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_PERSONAL | CSIDL_FLAG_CREATE, nullptr, 0, path)))
     {
         userPath = boost::filesystem::path(bconv::utf_to_utf<char>(path));
     }
@@ -63,7 +63,7 @@ boost::filesystem::path WindowsPath::getGlobalConfigPath() const
     WCHAR path[MAX_PATH + 1];
     memset(path, 0, sizeof(path));
 
-    if(SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_PROGRAM_FILES | CSIDL_FLAG_CREATE, NULL, 0, path)))
+    if(SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_PROGRAM_FILES | CSIDL_FLAG_CREATE, nullptr, 0, path)))
     {
         globalPath = boost::filesystem::path(bconv::utf_to_utf<char>(path));
     }
@@ -99,7 +99,7 @@ boost::filesystem::path WindowsPath::getInstallPath() const
         std::vector<char> buf(512);
         int len = 512;
 
-        if (RegQueryValueEx(hKey, TEXT("Installed Path"), NULL, NULL, (LPBYTE)&buf[0], (LPDWORD)&len) == ERROR_SUCCESS)
+        if (RegQueryValueEx(hKey, TEXT("Installed Path"), nullptr, nullptr, (LPBYTE)&buf[0], (LPDWORD)&len) == ERROR_SUCCESS)
         {
             installPath = &buf[0];
         }

--- a/components/myguiplatform/additivelayer.cpp
+++ b/components/myguiplatform/additivelayer.cpp
@@ -27,7 +27,7 @@ namespace osgMyGUI
 
         MyGUI::OverlappedLayer::renderToTarget(_target, _update);
 
-        renderManager.setInjectState(NULL);
+        renderManager.setInjectState(nullptr);
     }
 
 }

--- a/components/myguiplatform/myguidatamanager.cpp
+++ b/components/myguiplatform/myguidatamanager.cpp
@@ -24,7 +24,7 @@ MyGUI::IDataStream *DataManager::getData(const std::string &name)
     if (stream->fail())
     {
         Log(Debug::Error) << "DataManager::getData: Failed to open '" << name << "'";
-        return NULL;
+        return nullptr;
     }
     return new MyGUI::DataFileStream(stream.release());
 }

--- a/components/myguiplatform/myguirendermanager.cpp
+++ b/components/myguiplatform/myguirendermanager.cpp
@@ -52,7 +52,7 @@ public:
     {
     public:
         FrameUpdate()
-            : mRenderManager(NULL)
+            : mRenderManager(nullptr)
         {
         }
 
@@ -76,7 +76,7 @@ public:
     {
     public:
         CollectDrawCalls()
-            : mRenderManager(NULL)
+            : mRenderManager(nullptr)
         {
         }
 
@@ -134,9 +134,9 @@ public:
             {
                 state->bindVertexBufferObject(bufferobject);
 
-                glVertexPointer(3, GL_FLOAT, sizeof(MyGUI::Vertex), (char*)NULL);
-                glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(MyGUI::Vertex), (char*)NULL + 12);
-                glTexCoordPointer(2, GL_FLOAT, sizeof(MyGUI::Vertex), (char*)NULL + 16);
+                glVertexPointer(3, GL_FLOAT, sizeof(MyGUI::Vertex), (char*)nullptr);
+                glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(MyGUI::Vertex), (char*)nullptr + 12);
+                glTexCoordPointer(2, GL_FLOAT, sizeof(MyGUI::Vertex), (char*)nullptr + 16);
             }
             else
             {
@@ -355,7 +355,7 @@ RenderManager::RenderManager(osgViewer::Viewer *viewer, osg::Group *sceneroot, R
   , mUpdate(false)
   , mIsInitialise(false)
   , mInvScalingFactor(1.f)
-  , mInjectState(NULL)
+  , mInjectState(nullptr)
 {
     if (scalingFactor != 0.f)
         mInvScalingFactor = 1.f / scalingFactor;
@@ -537,7 +537,7 @@ void RenderManager::destroyTexture(MyGUI::ITexture *texture)
 MyGUI::ITexture* RenderManager::getTexture(const std::string &name)
 {
     if (name.empty())
-        return NULL;
+        return nullptr;
 
     MapTexture::const_iterator item = mTextures.find(name);
     if(item == mTextures.end())

--- a/components/myguiplatform/myguirendermanager.hpp
+++ b/components/myguiplatform/myguirendermanager.hpp
@@ -98,7 +98,7 @@ public:
     /** @see IRenderTarget::doRender */
     virtual void doRender(MyGUI::IVertexBuffer *buffer, MyGUI::ITexture *texture, size_t count);
 
-    /** specify a StateSet to inject for rendering. The StateSet will be used by future doRender calls until you reset it to NULL again. */
+    /** specify a StateSet to inject for rendering. The StateSet will be used by future doRender calls until you reset it to nullptr again. */
     void setInjectState(osg::StateSet* stateSet);
 
     /** @see IRenderTarget::getInfo */

--- a/components/myguiplatform/myguitexture.cpp
+++ b/components/myguiplatform/myguitexture.cpp
@@ -23,7 +23,7 @@ namespace osgMyGUI
     }
 
     OSGTexture::OSGTexture(osg::Texture2D *texture)
-        : mImageManager(NULL)
+        : mImageManager(nullptr)
         , mTexture(texture)
         , mFormat(MyGUI::PixelFormat::Unknow)
         , mUsage(MyGUI::TextureUsage::Default)

--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -162,7 +162,7 @@ void NIFFile::parse(Files::IStreamPtr stream)
 
     for(size_t i = 0;i < recNum;i++)
     {
-        Record *r = NULL;
+        Record *r = nullptr;
 
         std::string rec = nif.getString();
         if(rec.empty())
@@ -182,7 +182,7 @@ void NIFFile::parse(Files::IStreamPtr stream)
         else
             fail("Unknown record type " + rec);
 
-        assert(r != NULL);
+        assert(r != nullptr);
         assert(r->recType != RC_MISSING);
         r->recName = rec;
         r->recIndex = i;
@@ -203,7 +203,7 @@ void NIFFile::parse(Files::IStreamPtr stream)
         }
         else
         {
-            roots[i] = NULL;
+            roots[i] = nullptr;
             warn("Null Root found");
         }
     }

--- a/components/nif/node.hpp
+++ b/components/nif/node.hpp
@@ -53,7 +53,7 @@ public:
             boundXYZ = nif->getVector3();
         }
 
-        parent = NULL;
+        parent = nullptr;
 
         isBone = false;
     }
@@ -64,7 +64,7 @@ public:
         props.post(nif);
     }
 
-    // Parent node, or NULL for the root node. As far as I'm aware, only
+    // Parent node, or nullptr for the root node. As far as I'm aware, only
     // NiNodes (or types derived from NiNodes) can be parents.
     NiNode *parent;
 

--- a/components/nif/recordptr.hpp
+++ b/components/nif/recordptr.hpp
@@ -40,25 +40,25 @@ public:
     void post(NIFFile *nif)
     {
         if(index < 0)
-            ptr = NULL;
+            ptr = nullptr;
         else
         {
             Record *r = nif->getRecord(index);
             // And cast it
             ptr = dynamic_cast<X*>(r);
-            assert(ptr != NULL);
+            assert(ptr != nullptr);
         }
     }
 
     /// Look up the actual object from the index
     const X* getPtr() const
     {
-        assert(ptr != NULL);
+        assert(ptr != nullptr);
         return ptr;
     }
     X* getPtr()
     {
-        assert(ptr != NULL);
+        assert(ptr != nullptr);
         return ptr;
     }
 
@@ -75,7 +75,7 @@ public:
 
     /// Pointers are allowed to be empty
     bool empty() const
-    { return ptr == NULL; }
+    { return ptr == nullptr; }
 };
 
 /** A list of references to other records. These are read as a list,

--- a/components/nifbullet/bulletnifloader.cpp
+++ b/components/nifbullet/bulletnifloader.cpp
@@ -25,7 +25,7 @@ namespace
 
 osg::Matrixf getWorldTransform(const Nif::Node *node)
 {
-    if(node->parent != NULL)
+    if(node->parent != nullptr)
         return node->trafo.toMatrix() * getWorldTransform(node->parent);
     return node->trafo.toMatrix();
 }
@@ -61,8 +61,8 @@ osg::ref_ptr<Resource::BulletShape> BulletNifLoader::load(const Nif::File& nif)
 {
     mShape = new Resource::BulletShape;
 
-    mCompoundShape = NULL;
-    mStaticMesh = NULL;
+    mCompoundShape = nullptr;
+    mStaticMesh = nullptr;
 
     if (nif.numRoots() < 1)
     {
@@ -71,10 +71,10 @@ osg::ref_ptr<Resource::BulletShape> BulletNifLoader::load(const Nif::File& nif)
     }
 
     Nif::Record *r = nif.getRoot(0);
-    assert(r != NULL);
+    assert(r != nullptr);
 
     Nif::Node *node = dynamic_cast<Nif::Node*>(r);
-    if (node == NULL)
+    if (node == nullptr)
     {
         warn("First root in file was not a node, but a " +
              r->recName + ". Skipping file.");
@@ -216,7 +216,7 @@ void BulletNifLoader::handleNode(const std::string& fileName, const Nif::Node *n
     {
         // Get the next extra data in the list
         e = e->extra.getPtr();
-        assert(e != NULL);
+        assert(e != nullptr);
 
         if (e->recType == Nif::RC_NiStringExtraData)
         {
@@ -263,7 +263,7 @@ void BulletNifLoader::handleNode(const std::string& fileName, const Nif::Node *n
 
 void BulletNifLoader::handleNiTriShape(const Nif::NiTriShape *shape, int flags, const osg::Matrixf &transform, bool isAnimated)
 {
-    assert(shape != NULL);
+    assert(shape != nullptr);
 
     // If the object was marked "NCO" earlier, it shouldn't collide with
     // anything. So don't do anything.

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -200,7 +200,7 @@ namespace NifOsg
             }
 
             const Nif::Record *r = nif->getRoot(0);
-            assert(r != NULL);
+            assert(r != nullptr);
 
             if(r->recType != Nif::RC_NiSequenceStreamHelper)
             {
@@ -257,12 +257,12 @@ namespace NifOsg
             const Nif::Record* r = nif->getRoot(0);
 
             const Nif::Node* nifNode = dynamic_cast<const Nif::Node*>(r);
-            if (nifNode == NULL)
+            if (nifNode == nullptr)
                 nif->fail("First root was not a node, but a " + r->recName);
 
             osg::ref_ptr<TextKeyMapHolder> textkeys (new TextKeyMapHolder);
 
-            osg::ref_ptr<osg::Node> created = handleNode(nifNode, NULL, imageManager, std::vector<int>(), 0, false, false, false, &textkeys->mTextKeys);
+            osg::ref_ptr<osg::Node> created = handleNode(nifNode, nullptr, imageManager, std::vector<int>(), 0, false, false, false, &textkeys->mTextKeys);
 
             if (nif->getUseSkinning())
             {
@@ -297,7 +297,7 @@ namespace NifOsg
                 {
                     // Get the lowest numbered recIndex of the NiTexturingProperty root node.
                     // This is what is overridden when a spell effect "particle texture" is used.
-                    if (nifNode->parent == NULL && !mFoundFirstRootTexturingProperty && props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
+                    if (nifNode->parent == nullptr && !mFoundFirstRootTexturingProperty && props[i].getPtr()->recType == Nif::RC_NiTexturingProperty)
                     {
                         mFirstRootTextureIndex = props[i].getPtr()->recIndex;
                         mFoundFirstRootTexturingProperty = true;
@@ -338,7 +338,7 @@ namespace NifOsg
         osg::ref_ptr<osg::Image> handleSourceTexture(const Nif::NiSourceTexture* st, Resource::ImageManager* imageManager)
         {
             if (!st)
-                return NULL;
+                return nullptr;
 
             osg::ref_ptr<osg::Image> image;
             if (!st->external && !st->data.empty())
@@ -464,10 +464,10 @@ namespace NifOsg
         }
 
         osg::ref_ptr<osg::Node> handleNode(const Nif::Node* nifNode, osg::Group* parentNode, Resource::ImageManager* imageManager,
-                                std::vector<int> boundTextures, int animflags, bool skipMeshes, bool hasMarkers, bool isAnimated, TextKeyMap* textKeys, osg::Node* rootNode=NULL)
+                                std::vector<int> boundTextures, int animflags, bool skipMeshes, bool hasMarkers, bool isAnimated, TextKeyMap* textKeys, osg::Node* rootNode=nullptr)
         {
-            if (rootNode != NULL && Misc::StringUtils::ciEqual(nifNode->name, "Bounding Box"))
-                return NULL;
+            if (rootNode != nullptr && Misc::StringUtils::ciEqual(nifNode->name, "Bounding Box"))
+                return nullptr;
 
             osg::ref_ptr<osg::Group> node = createNode(nifNode);
 
@@ -791,7 +791,7 @@ namespace NifOsg
         // Load the initial state of the particle system, i.e. the initial particles and their positions, velocity and colors.
         void handleParticleInitialState(const Nif::Node* nifNode, osgParticle::ParticleSystem* partsys, const Nif::NiParticleSystemController* partctrl)
         {
-            const Nif::NiAutoNormalParticlesData *particledata = NULL;
+            const Nif::NiAutoNormalParticlesData *particledata = nullptr;
             if(nifNode->recType == Nif::RC_NiAutoNormalParticles)
                 particledata = static_cast<const Nif::NiAutoNormalParticles*>(nifNode)->data.getPtr();
             else if(nifNode->recType == Nif::RC_NiRotatingParticles)
@@ -873,7 +873,7 @@ namespace NifOsg
             osg::ref_ptr<ParticleSystem> partsys (new ParticleSystem);
             partsys->setSortMode(osgParticle::ParticleSystem::SORT_BACK_TO_FRONT);
 
-            const Nif::NiParticleSystemController* partctrl = NULL;
+            const Nif::NiParticleSystemController* partctrl = nullptr;
             for (Nif::ControllerPtr ctrl = nifNode->controller; !ctrl.empty(); ctrl = ctrl->next)
             {
                 if (!(ctrl->flags & Nif::NiNode::ControllerFlag_Active))
@@ -1193,11 +1193,11 @@ namespace NifOsg
                 break;
             default:
                 Log(Debug::Info) << "Unhandled internal pixel format " << pixelData->fmt << " in " << mFilename;
-                return NULL;
+                return nullptr;
             }
 
             if (pixelData->mipmaps.empty())
-                return NULL;
+                return nullptr;
 
             int width = 0;
             int height = 0;
@@ -1211,7 +1211,7 @@ namespace NifOsg
                 if (mipSize + mip.dataOffset > pixelData->data.size())
                 {
                     Log(Debug::Info) << "Internal texture's mipmap data out of bounds, ignoring texture";
-                    return NULL;
+                    return nullptr;
                 }
 
                 if (i != 0)
@@ -1226,7 +1226,7 @@ namespace NifOsg
             if (width <= 0 || height <= 0)
             {
                 Log(Debug::Info) << "Internal Texture Width and height must be non zero, ignoring texture";
-                return NULL;
+                return nullptr;
             }
 
             unsigned char* data = new unsigned char[pixelData->data.size()];

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -39,7 +39,7 @@ osgParticle::Particle* ParticleSystem::createParticle(const osgParticle::Particl
 {
     if (numParticles()-numDeadParticles() < mQuota)
         return osgParticle::ParticleSystem::createParticle(ptemplate);
-    return NULL;
+    return nullptr;
 }
 
 void InverseWorldMatrix::operator()(osg::Node *node, osg::NodeVisitor *nv)
@@ -312,7 +312,7 @@ void Emitter::emitParticles(double dt)
 
 FindGroupByRecIndex::FindGroupByRecIndex(int recIndex)
     : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
-    , mFound(NULL)
+    , mFound(nullptr)
     , mRecIndex(recIndex)
 {
 }

--- a/components/resource/bulletshape.cpp
+++ b/components/resource/bulletshape.cpp
@@ -12,7 +12,7 @@ namespace Resource
 {
 
 BulletShape::BulletShape()
-    : mCollisionShape(NULL)
+    : mCollisionShape(nullptr)
 {
 
 }
@@ -32,7 +32,7 @@ BulletShape::~BulletShape()
 
 void BulletShape::deleteShape(btCollisionShape* shape)
 {
-    if(shape!=NULL)
+    if(shape!=nullptr)
     {
         if(shape->isCompound())
         {

--- a/components/resource/bulletshapemanager.cpp
+++ b/components/resource/bulletshapemanager.cpp
@@ -24,7 +24,7 @@ namespace Resource
 struct GetTriangleFunctor
 {
     GetTriangleFunctor()
-        : mTriMesh(NULL)
+        : mTriMesh(nullptr)
     {
     }
 

--- a/components/resource/multiobjectcache.hpp
+++ b/components/resource/multiobjectcache.hpp
@@ -30,7 +30,7 @@ namespace Resource
 
         void addEntryToObjectCache(const std::string& filename, osg::Object* object);
 
-        /** Take an Object from cache. Return NULL if no object found. */
+        /** Take an Object from cache. Return nullptr if no object found. */
         osg::ref_ptr<osg::Object> takeFromObjectCache(const std::string& fileName);
 
         /** call releaseGLObjects on all objects attached to the object cache.*/

--- a/components/sceneutil/clone.cpp
+++ b/components/sceneutil/clone.cpp
@@ -26,7 +26,7 @@ namespace SceneUtil
     osg::StateSet* CopyOp::operator ()(const osg::StateSet* stateset) const
     {
         if (!stateset)
-            return NULL;
+            return nullptr;
         if (stateset->getDataVariance() == osg::StateSet::DYNAMIC)
             return osg::clone(stateset, *this);
         return const_cast<osg::StateSet*>(stateset);

--- a/components/sceneutil/controller.cpp
+++ b/components/sceneutil/controller.cpp
@@ -19,7 +19,7 @@ namespace SceneUtil
 
     bool Controller::hasInput() const
     {
-        return mSource.get() != NULL;
+        return mSource.get() != nullptr;
     }
 
     float Controller::getInputValue(osg::NodeVisitor* nv)

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -102,7 +102,7 @@ namespace SceneUtil
             if (LightManager* lightManager = dynamic_cast<LightManager*>(path[i]))
                 return lightManager;
         }
-        return NULL;
+        return nullptr;
     }
 
     // Set on a LightSource. Adds the light source to its light manager for the current frame.
@@ -299,7 +299,7 @@ namespace SceneUtil
 
         virtual osg::Object* cloneType() const { return new DisableLight(mIndex); }
         virtual osg::Object* clone(const osg::CopyOp& copyop) const { return new DisableLight(*this,copyop); }
-        virtual bool isSameKindAs(const osg::Object* obj) const { return dynamic_cast<const DisableLight *>(obj)!=NULL; }
+        virtual bool isSameKindAs(const osg::Object* obj) const { return dynamic_cast<const DisableLight *>(obj)!=nullptr; }
         virtual const char* libraryName() const { return "SceneUtil"; }
         virtual const char* className() const { return "DisableLight"; }
         virtual Type getType() const { return LIGHT; }
@@ -323,17 +323,17 @@ namespace SceneUtil
         virtual void apply(osg::State& state) const
         {
             int lightNum = GL_LIGHT0 + mIndex;
-            glLightfv( lightNum, GL_AMBIENT,               mNull.ptr() );
-            glLightfv( lightNum, GL_DIFFUSE,               mNull.ptr() );
-            glLightfv( lightNum, GL_SPECULAR,              mNull.ptr() );
+            glLightfv( lightNum, GL_AMBIENT,               mnullptr.ptr() );
+            glLightfv( lightNum, GL_DIFFUSE,               mnullptr.ptr() );
+            glLightfv( lightNum, GL_SPECULAR,              mnullptr.ptr() );
 
             LightStateCache* cache = getLightStateCache(state.getContextID());
-            cache->lastAppliedLight[mIndex] = NULL;
+            cache->lastAppliedLight[mIndex] = nullptr;
         }
 
     private:
         unsigned int mIndex;
-        osg::Vec4f mNull;
+        osg::Vec4f mnullptr;
     };
 
     void LightManager::setStartLight(int start)
@@ -447,7 +447,7 @@ namespace SceneUtil
         {
             unsigned int maxLights = static_cast<unsigned int> (8 - mLightManager->getStartLight());
 
-            osg::StateSet* stateset = NULL;
+            osg::StateSet* stateset = nullptr;
 
             if (mLightList.size() > maxLights)
             {

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -158,7 +158,7 @@ namespace SceneUtil
     {
     public:
         LightListCallback()
-            : mLightManager(NULL)
+            : mLightManager(nullptr)
             , mLastFrameNumber(0)
         {}
         LightListCallback(const LightListCallback& copy, const osg::CopyOp& copyop)

--- a/components/sceneutil/lightutil.cpp
+++ b/components/sceneutil/lightutil.cpp
@@ -45,7 +45,7 @@ namespace SceneUtil
         SceneUtil::FindByNameVisitor visitor("AttachLight");
         node->accept(visitor);
 
-        osg::Group* attachTo = NULL;
+        osg::Group* attachTo = nullptr;
         if (visitor.mFoundNode)
         {
             attachTo = visitor.mFoundNode;

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -166,7 +166,7 @@ class CollectLowestTransformsVisitor : public BaseOptimizerVisitor
             }
             else
             {
-                // for all current objects mark a NULL transform for them.
+                // for all current objects mark a nullptr transform for them.
                 registerWithCurrentObjects(0);
             }
         }
@@ -826,7 +826,7 @@ void Optimizer::RemoveRedundantNodesVisitor::apply(osg::Transform& transform)
         isOperationPermissible(transform))
     {
         osg::Matrix matrix;
-        transform.computeWorldToLocalMatrix(matrix,NULL);
+        transform.computeWorldToLocalMatrix(matrix,nullptr);
         if (matrix.isIdentity())
         {
             _redundantNodeList.insert(&transform);
@@ -1000,7 +1000,7 @@ struct LessGeometryPrimitiveType
 };
 
 
-/// Shortcut to get size of an array, even if pointer is NULL.
+/// Shortcut to get size of an array, even if pointer is nullptr.
 inline unsigned int getSize(const osg::Array * a) { return a ? a->getNumElements() : 0; }
 
 /// When merging geometries, tests if two arrays can be merged, regarding to their number of components, and the number of vertices.
@@ -1170,7 +1170,7 @@ bool Optimizer::MergeGeometryVisitor::mergeGroup(osg::Group& group)
                 MergeList::iterator eachMergeList=mergeListTmp.begin();
                 for(;eachMergeList!=mergeListTmp.end();++eachMergeList)
                 {
-                    if (!eachMergeList->empty() && eachMergeList->front()!=NULL
+                    if (!eachMergeList->empty() && eachMergeList->front()!=nullptr
                         && isAbleToMerge(*eachMergeList->front(),*geomToPush))
                     {
                         eachMergeList->push_back(geomToPush);

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -37,7 +37,7 @@ namespace SceneUtil
 {
 
 RigGeometry::RigGeometry()
-    : mSkeleton(NULL)
+    : mSkeleton(nullptr)
     , mLastFrameNumber(0)
     , mBoundsFirstFrame(true)
 {
@@ -47,7 +47,7 @@ RigGeometry::RigGeometry()
 
 RigGeometry::RigGeometry(const RigGeometry &copy, const osg::CopyOp &copyop)
     : Drawable(copy, copyop)
-    , mSkeleton(NULL)
+    , mSkeleton(nullptr)
     , mInfluenceMap(copy.mInfluenceMap)
     , mLastFrameNumber(0)
     , mBoundsFirstFrame(true)
@@ -98,7 +98,7 @@ void RigGeometry::setSourceGeometry(osg::ref_ptr<osg::Geometry> sourceGeometry)
             to.setTexCoordArray(7, tangentArray, osg::Array::BIND_PER_VERTEX);
         }
         else
-            mSourceTangents = NULL;
+            mSourceTangents = nullptr;
     }
 }
 
@@ -296,7 +296,7 @@ void RigGeometry::updateGeomToSkelMatrix(const osg::NodePath& nodePath)
             {
                 if (!geomToSkelMatrix)
                     geomToSkelMatrix = new osg::RefMatrix;
-                trans->computeWorldToLocalMatrix(*geomToSkelMatrix, NULL);
+                trans->computeWorldToLocalMatrix(*geomToSkelMatrix, nullptr);
             }
         }
     }

--- a/components/sceneutil/skeleton.cpp
+++ b/components/sceneutil/skeleton.cpp
@@ -64,7 +64,7 @@ Bone* Skeleton::getBone(const std::string &name)
 
     BoneCache::iterator found = mBoneCache.find(Misc::StringUtils::lowerCase(name));
     if (found == mBoneCache.end())
-        return NULL;
+        return nullptr;
 
     // find or insert in the bone hierarchy
 
@@ -81,7 +81,7 @@ Bone* Skeleton::getBone(const std::string &name)
         if (!matrixTransform)
             continue;
 
-        Bone* child = NULL;
+        Bone* child = nullptr;
         for (unsigned int i=0; i<bone->mChildren.size(); ++i)
         {
             if (bone->mChildren[i]->mNode == *it)
@@ -117,7 +117,7 @@ void Skeleton::updateBoneMatrices(unsigned int traversalNumber)
         if (mRootBone.get())
         {
             for (unsigned int i=0; i<mRootBone->mChildren.size(); ++i)
-                mRootBone->mChildren[i]->update(NULL);
+                mRootBone->mChildren[i]->update(nullptr);
         }
 
         mNeedToUpdateBoneMatrices = false;
@@ -167,7 +167,7 @@ void Skeleton::childRemoved(unsigned int, unsigned int)
 }
 
 Bone::Bone()
-    : mNode(NULL)
+    : mNode(nullptr)
 {
 }
 

--- a/components/sceneutil/statesetupdater.cpp
+++ b/components/sceneutil/statesetupdater.cpp
@@ -30,8 +30,8 @@ namespace SceneUtil
 
     void StateSetUpdater::reset()
     {
-        mStateSets[0] = NULL;
-        mStateSets[1] = NULL;
+        mStateSets[0] = nullptr;
+        mStateSets[1] = nullptr;
     }
 
     StateSetUpdater::StateSetUpdater()

--- a/components/sceneutil/visitor.cpp
+++ b/components/sceneutil/visitor.cpp
@@ -101,7 +101,7 @@ namespace SceneUtil
     void CleanObjectRootVisitor::applyNode(osg::Node& node)
     {
         if (node.getStateSet())
-            node.setStateSet(NULL);
+            node.setStateSet(nullptr);
 
         if (node.getNodeMask() == 0x1 && node.getNumParents() == 1)
             mToRemove.push_back(std::make_pair(&node, node.getParent(0)));

--- a/components/sceneutil/visitor.hpp
+++ b/components/sceneutil/visitor.hpp
@@ -9,14 +9,14 @@ namespace SceneUtil
 {
 
     // Find a Group by name, case-insensitive
-    // If not found, mFoundNode will be NULL
+    // If not found, mFoundNode will be nullptr
     class FindByNameVisitor : public osg::NodeVisitor
     {
     public:
         FindByNameVisitor(const std::string& nameToFind)
             : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
             , mNameToFind(nameToFind)
-            , mFoundNode(NULL)
+            , mFoundNode(nullptr)
         {
         }
 

--- a/components/sceneutil/workqueue.cpp
+++ b/components/sceneutil/workqueue.cpp
@@ -97,7 +97,7 @@ osg::ref_ptr<WorkItem> WorkQueue::removeWorkItem()
         return item;
     }
     else
-        return NULL;
+        return nullptr;
 }
 
 unsigned int WorkQueue::getNumItems() const

--- a/components/sceneutil/workqueue.hpp
+++ b/components/sceneutil/workqueue.hpp
@@ -57,7 +57,7 @@ namespace SceneUtil
         void addWorkItem(osg::ref_ptr<WorkItem> item, bool front=false);
 
         /// Get the next work item from the front of the queue. If the queue is empty, waits until a new item is added.
-        /// If the workqueue is in the process of being destroyed, may return NULL.
+        /// If the workqueue is in the process of being destroyed, may return nullptr.
         /// @par Used internally by the WorkThread.
         osg::ref_ptr<WorkItem> removeWorkItem();
 

--- a/components/sdlutil/sdlcursormanager.cpp
+++ b/components/sdlutil/sdlcursormanager.cpp
@@ -190,7 +190,7 @@ namespace CursorDecompression
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1");
         SDL_Texture *cursorTexture = SDL_CreateTextureFromSurface(renderer, cursorSurface);
 
-        SDL_RenderCopyEx(renderer, cursorTexture, NULL, NULL, -rotDegrees, NULL, SDL_FLIP_VERTICAL);
+        SDL_RenderCopyEx(renderer, cursorTexture, nullptr, nullptr, -rotDegrees, nullptr, SDL_FLIP_VERTICAL);
 
         SDL_DestroyTexture(cursorTexture);
         SDL_FreeSurface(cursorSurface);

--- a/components/sdlutil/sdlgraphicswindow.cpp
+++ b/components/sdlutil/sdlgraphicswindow.cpp
@@ -77,7 +77,7 @@ void GraphicsWindowSDL2::init()
         return;
 
     WindowData *inheritedWindowData = dynamic_cast<WindowData*>(_traits->inheritedWindowData.get());
-    mWindow = inheritedWindowData ? inheritedWindowData->mWindow : NULL;
+    mWindow = inheritedWindowData ? inheritedWindowData->mWindow : nullptr;
 
     mOwnsWindow = (mWindow == 0);
     if(mOwnsWindow)
@@ -162,7 +162,7 @@ bool GraphicsWindowSDL2::releaseContextImplementation()
         return false;
     }
 
-    return SDL_GL_MakeCurrent(NULL, NULL)==0;
+    return SDL_GL_MakeCurrent(nullptr, nullptr)==0;
 }
 
 
@@ -170,11 +170,11 @@ void GraphicsWindowSDL2::closeImplementation()
 {
     if(mContext)
         SDL_GL_DeleteContext(mContext);
-    mContext = NULL;
+    mContext = nullptr;
 
     if(mWindow && mOwnsWindow)
         SDL_DestroyWindow(mWindow);
-    mWindow = NULL;
+    mWindow = nullptr;
 
     mValid = false;
     mRealized = false;

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -10,10 +10,10 @@ namespace SDLUtil
 InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> viewer, bool grab) :
         mSDLWindow(window),
         mViewer(viewer),
-        mMouseListener(NULL),
-        mKeyboardListener(NULL),
-        mWindowListener(NULL),
-        mConListener(NULL),
+        mMouseListener(nullptr),
+        mKeyboardListener(nullptr),
+        mWindowListener(nullptr),
+        mConListener(nullptr),
         mWarpX(0),
         mWarpY(0),
         mWarpCompensate(false),
@@ -234,7 +234,7 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
 
     bool InputWrapper::isKeyDown(SDL_Scancode key)
     {
-        return (SDL_GetKeyboardState(NULL)[key]) != 0;
+        return (SDL_GetKeyboardState(nullptr)[key]) != 0;
     }
 
     /// \brief Moves the mouse to the specified point within the viewport

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -115,7 +115,7 @@ namespace Shader
             if (stream.fail())
             {
                 Log(Debug::Error) << "Failed to open " << p.string();
-                return NULL;
+                return nullptr;
             }
             std::stringstream buffer;
             buffer << stream.rdbuf();
@@ -123,7 +123,7 @@ namespace Shader
             // parse includes
             std::string source = buffer.str();
             if (!parseIncludes(boost::filesystem::path(mPath), source))
-                return NULL;
+                return nullptr;
 
             templateIt = mShaderTemplates.insert(std::make_pair(shaderTemplate, source)).first;
         }
@@ -136,7 +136,7 @@ namespace Shader
             {
                 // Add to the cache anyway to avoid logging the same error over and over.
                 mShaders.insert(std::make_pair(std::make_pair(shaderTemplate, defines), nullptr));
-                return NULL;
+                return nullptr;
             }
 
             osg::ref_ptr<osg::Shader> shader (new osg::Shader(shaderType));

--- a/components/shader/shadermanager.hpp
+++ b/components/shader/shadermanager.hpp
@@ -26,7 +26,7 @@ namespace Shader
         /// @param shaderTemplate The filename of the shader template.
         /// @param defines Define values that can be retrieved by the shader template.
         /// @param shaderType The type of shader (usually vertex or fragment shader).
-        /// @note May return NULL on failure.
+        /// @note May return nullptr on failure.
         /// @note Thread safe.
         osg::ref_ptr<osg::Shader> getShader(const std::string& shaderTemplate, const DefineMap& defines, osg::Shader::Type shaderType);
 

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -28,7 +28,7 @@ namespace Shader
         , mMaterialOverridden(false)
         , mNormalHeight(false)
         , mTexStageRequiringTangents(-1)
-        , mNode(NULL)
+        , mNode(nullptr)
     {
     }
 
@@ -102,15 +102,15 @@ namespace Shader
 
     void ShaderVisitor::applyStateSet(osg::ref_ptr<osg::StateSet> stateset, osg::Node& node)
     {
-        osg::StateSet* writableStateSet = NULL;
+        osg::StateSet* writableStateSet = nullptr;
         if (mAllowedToModifyStateSets)
             writableStateSet = node.getStateSet();
         const osg::StateSet::TextureAttributeList& texAttributes = stateset->getTextureAttributeList();
         if (!texAttributes.empty())
         {
-            const osg::Texture* diffuseMap = NULL;
-            const osg::Texture* normalMap = NULL;
-            const osg::Texture* specularMap = NULL;
+            const osg::Texture* diffuseMap = nullptr;
+            const osg::Texture* normalMap = nullptr;
+            const osg::Texture* specularMap = nullptr;
             for(unsigned int unit=0;unit<texAttributes.size();++unit)
             {
                 const osg::StateAttribute *attr = stateset->getTextureAttribute(unit, osg::StateAttribute::TEXTURE);
@@ -153,7 +153,7 @@ namespace Shader
                 }
             }
 
-            if (mAutoUseNormalMaps && diffuseMap != NULL && normalMap == NULL && diffuseMap->getImage(0))
+            if (mAutoUseNormalMaps && diffuseMap != nullptr && normalMap == nullptr && diffuseMap->getImage(0))
             {
                 std::string normalMapFileName = diffuseMap->getImage(0)->getFileName();
 
@@ -195,7 +195,7 @@ namespace Shader
                     mRequirements.back().mNormalHeight = normalHeight;
                 }
             }
-            if (mAutoUseSpecularMaps && diffuseMap != NULL && specularMap == NULL && diffuseMap->getImage(0))
+            if (mAutoUseSpecularMaps && diffuseMap != nullptr && specularMap == nullptr && diffuseMap->getImage(0))
             {
                 std::string specularMapFileName = diffuseMap->getImage(0)->getFileName();
                 boost::replace_last(specularMapFileName, ".", mSpecularMapPattern + ".");
@@ -254,7 +254,7 @@ namespace Shader
             return;
 
         osg::Node& node = *reqs.mNode;
-        osg::StateSet* writableStateSet = NULL;
+        osg::StateSet* writableStateSet = nullptr;
         if (mAllowedToModifyStateSets)
             writableStateSet = node.getOrCreateStateSet();
         else
@@ -321,7 +321,7 @@ namespace Shader
             // make sure that all UV sets are there
             for (std::map<int, std::string>::const_iterator it = reqs.mTextures.begin(); it != reqs.mTextures.end(); ++it)
             {
-                if (sourceGeometry.getTexCoordArray(it->first) == NULL)
+                if (sourceGeometry.getTexCoordArray(it->first) == nullptr)
                 {
                     sourceGeometry.setTexCoordArray(it->first, sourceGeometry.getTexCoordArray(0));
                     changed = true;
@@ -342,7 +342,7 @@ namespace Shader
 
     void ShaderVisitor::apply(osg::Geometry& geometry)
     {
-        bool needPop = (geometry.getStateSet() != NULL);
+        bool needPop = (geometry.getStateSet() != nullptr);
         if (geometry.getStateSet()) // TODO: check if stateset affects shader permutation before pushing it
         {
             pushRequirements(geometry);
@@ -365,7 +365,7 @@ namespace Shader
     void ShaderVisitor::apply(osg::Drawable& drawable)
     {
         // non-Geometry drawable (e.g. particle system)
-        bool needPop = (drawable.getStateSet() != NULL);
+        bool needPop = (drawable.getStateSet() != nullptr);
 
         if (drawable.getStateSet())
         {

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -22,7 +22,7 @@ namespace Terrain
 {
 
 ChunkManager::ChunkManager(Storage *storage, Resource::SceneManager *sceneMgr, TextureManager* textureManager, CompositeMapRenderer* renderer)
-    : ResourceManager(NULL)
+    : ResourceManager(nullptr)
     , mStorage(storage)
     , mSceneManager(sceneMgr)
     , mTextureManager(textureManager)

--- a/components/terrain/compositemaprenderer.cpp
+++ b/components/terrain/compositemaprenderer.cpp
@@ -45,7 +45,7 @@ void CompositeMapRenderer::drawImplementation(osg::RenderInfo &renderInfo) const
         CompositeMap* node = *mImmediateCompileSet.begin();
         mCompiled.insert(node);
 
-        compile(*node, renderInfo, NULL);
+        compile(*node, renderInfo, nullptr);
 
         mImmediateCompileSet.erase(mImmediateCompileSet.begin());
     }

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -41,7 +41,7 @@ bool adjacent(ChildDirection dir, Direction dir2)
 QuadTreeNode* searchNeighbour (QuadTreeNode* currentNode, Direction dir)
 {
     if (currentNode->getDirection() == Root)
-        return NULL; // Arrived at root node, the root node does not have neighbours
+        return nullptr; // Arrived at root node, the root node does not have neighbours
 
     QuadTreeNode* nextNode;
     if (adjacent(currentNode->getDirection(), dir))
@@ -52,7 +52,7 @@ QuadTreeNode* searchNeighbour (QuadTreeNode* currentNode, Direction dir)
     if (nextNode && nextNode->getNumChildren())
         return nextNode->getChild(reflect(currentNode->getDirection(), dir));
     else
-        return NULL;
+        return nullptr;
 }
 
 QuadTreeNode::QuadTreeNode(QuadTreeNode* parent, ChildDirection direction, float size, const osg::Vec2f& center)

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -96,8 +96,8 @@ class RootNode : public QuadTreeNode
 {
 public:
     RootNode(float size, const osg::Vec2f& center)
-        : QuadTreeNode(NULL, Root, size, center)
-        , mWorld(NULL)
+        : QuadTreeNode(nullptr, Root, size, center)
+        , mWorld(nullptr)
     {
     }
 
@@ -317,7 +317,7 @@ void loadRenderingNode(ViewData::Entry& entry, ViewData* vd, ChunkManager* chunk
         unsigned int lodFlags = getLodFlags(entry.mNode, ourLod, vd);
         if (lodFlags != entry.mLodFlags)
         {
-            entry.mRenderingNode = NULL;
+            entry.mRenderingNode = nullptr;
             entry.mLodFlags = lodFlags;
         }
     }
@@ -367,7 +367,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
             if (udc && udc->getUserData())
             {
                 mCompositeMapRenderer->setImmediate(static_cast<CompositeMap*>(udc->getUserData()));
-                udc->setUserData(NULL);
+                udc->setUserData(nullptr);
             }
             entry.mRenderingNode->accept(nv);
         }
@@ -430,7 +430,7 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &eyePoint)
     ensureQuadTreeBuilt();
 
     ViewData* vd = static_cast<ViewData*>(view);
-    traverse(mRootNode.get(), vd, NULL, mRootNode->getLodCallback(), eyePoint, false);
+    traverse(mRootNode.get(), vd, nullptr, mRootNode->getLodCallback(), eyePoint, false);
 
     for (unsigned int i=0; i<vd->getNumEntries(); ++i)
     {

--- a/components/terrain/terraindrawable.hpp
+++ b/components/terrain/terraindrawable.hpp
@@ -24,7 +24,7 @@ namespace Terrain
     public:
         virtual osg::Object* cloneType() const { return new TerrainDrawable (); }
         virtual osg::Object* clone(const osg::CopyOp& copyop) const { return new TerrainDrawable (*this,copyop); }
-        virtual bool isSameKindAs(const osg::Object* obj) const { return dynamic_cast<const TerrainDrawable *>(obj)!=NULL; }
+        virtual bool isSameKindAs(const osg::Object* obj) const { return dynamic_cast<const TerrainDrawable *>(obj)!=nullptr; }
         virtual const char* className() const { return "TerrainDrawable"; }
         virtual const char* libraryName() const { return "Terrain"; }
 

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -34,7 +34,7 @@ TerrainGrid::~TerrainGrid()
 void TerrainGrid::cacheCell(View* view, int x, int y)
 {
     osg::Vec2f center(x+0.5f, y+0.5f);
-    static_cast<MyView*>(view)->mLoaded =  buildTerrain(NULL, 1.f, center);
+    static_cast<MyView*>(view)->mLoaded =  buildTerrain(nullptr, 1.f, center);
 }
 
 osg::ref_ptr<osg::Node> TerrainGrid::buildTerrain (osg::Group* parent, float chunkSize, const osg::Vec2f& chunkCenter)
@@ -57,7 +57,7 @@ osg::ref_ptr<osg::Node> TerrainGrid::buildTerrain (osg::Group* parent, float chu
     {
         osg::ref_ptr<osg::Node> node = mChunkManager->getChunk(chunkSize, chunkCenter, 0, 0);
         if (!node)
-            return NULL;
+            return nullptr;
         if (parent)
             parent->addChild(node);
 
@@ -71,7 +71,7 @@ void TerrainGrid::loadCell(int x, int y)
         return; // already loaded
 
     osg::Vec2f center(x+0.5f, y+0.5f);
-    osg::ref_ptr<osg::Node> terrainNode = buildTerrain(NULL, 1.f, center);
+    osg::ref_ptr<osg::Node> terrainNode = buildTerrain(nullptr, 1.f, center);
     if (!terrainNode)
         return; // no terrain defined
 

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -64,7 +64,7 @@ void ViewData::reset(unsigned int frame)
 {
     // clear any unused entries
     for (unsigned int i=mNumEntries; i<mEntries.size(); ++i)
-        mEntries[i].set(NULL, false);
+        mEntries[i].set(nullptr, false);
 
     // reset index for next frame
     mNumEntries = 0;
@@ -76,7 +76,7 @@ void ViewData::reset(unsigned int frame)
 void ViewData::clear()
 {
     for (unsigned int i=0; i<mEntries.size(); ++i)
-        mEntries[i].set(NULL, false);
+        mEntries[i].set(nullptr, false);
     mNumEntries = 0;
     mFrameLastUsed = 0;
     mChanged = false;
@@ -91,7 +91,7 @@ bool ViewData::contains(QuadTreeNode *node)
 }
 
 ViewData::Entry::Entry()
-    : mNode(NULL)
+    : mNode(nullptr)
     , mVisible(true)
     , mLodFlags(0)
 {
@@ -107,7 +107,7 @@ bool ViewData::Entry::set(QuadTreeNode *node, bool visible)
     {
         mNode = node;
         // clear cached data
-        mRenderingNode = NULL;
+        mRenderingNode = nullptr;
         return true;
     }
 }
@@ -148,7 +148,7 @@ void ViewDataMap::clearUnusedViews(unsigned int frame)
         ViewData* vd = it->second;
         if (vd->getFrameLastUsed() + 2 < frame)
         {
-            vd->setViewer(NULL);
+            vd->setViewer(nullptr);
             vd->clear();
             mUnusedViews.push_back(vd);
             mViews.erase(it++);

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -90,7 +90,7 @@ namespace Terrain
 
         /// Create a View to use with preload feature. The caller is responsible for deleting the view.
         /// @note Thread safe.
-        virtual View* createView() { return NULL; }
+        virtual View* createView() { return nullptr; }
 
         /// @note Thread safe, as long as you do not attempt to load into the same view from multiple threads.
         virtual void preload(View* view, const osg::Vec3f& eyePoint) {}

--- a/components/translation/translation.cpp
+++ b/components/translation/translation.cpp
@@ -5,7 +5,7 @@
 namespace Translation
 {
     Storage::Storage()
-        : mEncoder(NULL)
+        : mEncoder(nullptr)
     {
     }
 

--- a/components/widgets/windowcaption.cpp
+++ b/components/widgets/windowcaption.cpp
@@ -6,9 +6,9 @@ namespace Gui
 {
 
     WindowCaption::WindowCaption()
-        : mLeft(NULL)
-        , mRight(NULL)
-        , mClient(NULL)
+        : mLeft(nullptr)
+        , mRight(nullptr)
+        , mClient(nullptr)
     {
     }
 


### PR DESCRIPTION
Since I was told many times to use nullptr instead of NULL despite most of the engine actually uses NULLs, I decided to turn all NULLs to nullptrs to avoid such confusion.

Also we may want to add the "Prefer nullptr over NULL" rule to our developer reference.