### PR TITLE
Improve pitch factor handling for crossbow animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
     Bug #4653: Length of non-ASCII strings is handled incorrectly in ESM reader
     Bug #4654: Editor: UpdateVisitor does not initialize skeletons for animated objects
     Bug #4668: Editor: Light source color is displayed as an integer
+    Bug #4672: Pitch factor is handled incorrectly for crossbow animations
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1666,7 +1666,9 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     }
 
     mAnimation->setPitchFactor(0.f);
-    if (mWeaponType == WeapType_BowAndArrow || mWeaponType == WeapType_Thrown)
+    if (mWeaponType == WeapType_BowAndArrow ||
+        mWeaponType == WeapType_Thrown ||
+        mWeaponType == WeapType_Crossbow)
     {
         switch (mUpperBodyState)
         {
@@ -1680,29 +1682,14 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             break;
         case UpperCharState_FollowStartToFollowStop:
             if (animPlaying)
-                mAnimation->setPitchFactor(1.f-complete);
-            break;
-        default:
-            break;
-        }
-    }
-    else if (mWeaponType == WeapType_Crossbow)
-    {
-        switch (mUpperBodyState)
-        {
-        case UpperCharState_EquipingWeap:
-            mAnimation->setPitchFactor(complete);
-            break;
-        case UpperCharState_UnEquipingWeap:
-            mAnimation->setPitchFactor(1.f-complete);
-            break;
-        case UpperCharState_WeapEquiped:
-        case UpperCharState_StartToMinAttack:
-        case UpperCharState_MinAttackToMaxAttack:
-        case UpperCharState_MaxAttackToMinHit:
-        case UpperCharState_MinHitToHit:
-        case UpperCharState_FollowStartToFollowStop:
-            mAnimation->setPitchFactor(1.f);
+            {
+                // technically we do not need a pitch for crossbow reload animation,
+                // but we should avoid abrupt repositioning
+                if (mWeaponType == WeapType_Crossbow)
+                    mAnimation->setPitchFactor(std::max(0.f, 1.f-complete*10.f));
+                else
+                    mAnimation->setPitchFactor(1.f-complete);
+            }
             break;
         default:
             break;


### PR DESCRIPTION
Fixes [bug #4672](https://gitlab.com/OpenMW/openmw/issues/4672).
Actually, we do not need two switches here - the only special case is a crossbow reload animation.