### PR TITLE
Fix Dark Mode on macOS 

### DIFF
--- a/files/mac/openmw-Info.plist.in
+++ b/files/mac/openmw-Info.plist.in
@@ -32,5 +32,7 @@
 	<string></string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
[Bug 4655.](https://gitlab.com/OpenMW/openmw/issues/4655)

> Apps linked against macOS 10.14 or later should support both light and dark appearances. If you build your app against an earlier SDK, you can still enable Dark Mode support by including the NSRequiresAquaSystemAppearance key (with a value of false) in your app's Info.plist file. Do so only if your app's appearance looks correct when running in macOS 10.14 and later with Dark Mode enabled.

https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app