### PR TITLE
Fix crash in the ESM reader, when list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@
     Bug #4671: knownEffect functions should use modified Alchemy skill
     Bug #4672: Pitch factor is handled incorrectly for crossbow animations
     Bug #4674: Journal can be opened when settings window is open
+    Bug #4677: Crash in ESM reader when NPC record has DNAM record without DODT one
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/components/esm/transport.cpp
+++ b/components/esm/transport.cpp
@@ -1,5 +1,7 @@
 #include "transport.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 
@@ -16,7 +18,11 @@ namespace ESM
         }
         else if (esm.retSubName().intval == ESM::FourCC<'D','N','A','M'>::value)
         {
-            mList.back().mCellName = esm.getHString();
+            const std::string name = esm.getHString();
+            if (mList.empty())
+                Log(Debug::Warning) << "Encountered DNAM record without DODT record, skipped.";
+            else
+                mList.back().mCellName = name;
         }
     }
 


### PR DESCRIPTION
Fixes [bug #4677](https://gitlab.com/OpenMW/openmw/issues/4677).
The "mList.back().mCellName" makes an assumption that mList is not empty.
Plugin from mentioned bugreport has an "az_NPC_az_poor_m_06" record (this NPC is unused anyway) with malformed destination field. It seems original engine just ignores such fields, but OpenMW crashes instead.

So just print warning and ignore this field instead of crash. Works for game itself, editor and esmtool.