### PR TITLE
Fix crash in the ESM reader, when SCVR has no variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
     Bug #4672: Pitch factor is handled incorrectly for crossbow animations
     Bug #4674: Journal can be opened when settings window is open
     Bug #4677: Crash in ESM reader when NPC record has DNAM record without DODT one
+    Bug #4678: Crash in ESP parser when SCVR has no variable names
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/components/esm/loadscpt.cpp
+++ b/components/esm/loadscpt.cpp
@@ -30,6 +30,12 @@ namespace ESM
         // The tmp buffer is a null-byte separated string list, we
         // just have to pick out one string at a time.
         char* str = &tmp[0];
+        if (!str && mVarNames.size() > 0)
+        {
+            Log(Debug::Warning) << "SCVR with no variable names";
+            return;
+        }
+
         for (size_t i = 0; i < mVarNames.size(); i++)
         {
             // Support '\r' terminated strings like vanilla.  See Bug #1324.


### PR DESCRIPTION
Fixes bug [#4678](https://gitlab.com/OpenMW/openmw/issues/4678)
The `loadSCVR` method assumes that the list of variable
names won't be empty, which it might.
Instead of crashing, we gracefully fail.

I don't know much C++, so it's entirely possible that this commit
is completely wrong.