### PR TITLE
Re-fix water reflections while making a no-GUI screenshot (regression #4603)

### DIFF
--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -169,19 +169,18 @@ namespace MWGui
         // We are already using node masks to avoid the scene from being updated/rendered, but node masks don't work for computeBound()
         mViewer->getSceneData()->setComputeBoundingSphereCallback(new DontComputeBoundCallback);
 
-        mShowWallpaper = visible && (MWBase::Environment::get().getStateManager()->getState()
-                == MWBase::StateManager::State_NoGame);
+        mVisible = visible;
+        mLoadingBox->setVisible(mVisible);
+        setVisible(true);
 
-        if (!visible)
+        if (!mVisible)
         {
+            mShowWallpaper = false;
             draw();
             return;
         }
 
-        mVisible = visible;
-        mLoadingBox->setVisible(mVisible);
-
-        setVisible(true);
+        mShowWallpaper = MWBase::Environment::get().getStateManager()->getState() == MWBase::StateManager::State_NoGame;
 
         if (mShowWallpaper)
         {

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -805,7 +805,7 @@ namespace MWRender
 
         cubeTexture->setFilter(osg::Texture::MIN_FILTER,osg::Texture::NEAREST);
         cubeTexture->setFilter(osg::Texture::MAG_FILTER,osg::Texture::NEAREST);
-        
+
         cubeTexture->setWrap(osg::Texture::WRAP_S, osg::Texture::CLAMP_TO_EDGE);
         cubeTexture->setWrap(osg::Texture::WRAP_T, osg::Texture::CLAMP_TO_EDGE);
 
@@ -830,18 +830,13 @@ namespace MWRender
         stateset->addUniform(new osg::Uniform("cubeMap",0));
         stateset->addUniform(new osg::Uniform("mapping",screenshotMapping));
         stateset->setTextureAttributeAndModes(0,cubeTexture,osg::StateAttribute::ON);
-            
+
         quad->setStateSet(stateset);
         quad->setUpdateCallback(nullptr);
 
         screenshotCamera->addChild(quad);
 
-        mRootNode->addChild(screenshotCamera);
-
         renderCameraToImage(screenshotCamera,image,screenshotW,screenshotH);
-
-        screenshotCamera->removeChildren(0,screenshotCamera->getNumChildren());
-        mRootNode->removeChild(screenshotCamera);
 
         return true;
     }
@@ -867,6 +862,8 @@ namespace MWRender
         image->setDataType(GL_UNSIGNED_BYTE);
         image->setPixelFormat(texture->getInternalFormat());
 
+        mRootNode->addChild(camera);
+
         // The draw needs to complete before we can copy back our image.
         osg::ref_ptr<NotifyDrawCompletedCallback> callback (new NotifyDrawCompletedCallback);
         camera->setFinalDrawCallback(callback);
@@ -882,31 +879,16 @@ namespace MWRender
 
         // now that we've "used up" the current frame, get a fresh framenumber for the next frame() following after the screenshot is completed
         mViewer->advance(mViewer->getFrameStamp()->getSimulationTime());
+
+        camera->removeChildren(0, camera->getNumChildren());
+        mRootNode->removeChild(camera);
     }
 
     void RenderingManager::screenshot(osg::Image *image, int w, int h, osg::Matrixd cameraTransform)
     {
         osg::ref_ptr<osg::Camera> rttCamera (new osg::Camera);
-        rttCamera->setNodeMask(Mask_RenderToTexture);
-        rttCamera->attach(osg::Camera::COLOR_BUFFER, image);
-        rttCamera->setRenderOrder(osg::Camera::PRE_RENDER);
-        rttCamera->setReferenceFrame(osg::Camera::ABSOLUTE_RF);
-        rttCamera->setRenderTargetImplementation(osg::Camera::FRAME_BUFFER_OBJECT, osg::Camera::PIXEL_BUFFER_RTT);
         rttCamera->setProjectionMatrixAsPerspective(mFieldOfView, w/float(h), mNearClip, mViewDistance);
         rttCamera->setViewMatrix(mViewer->getCamera()->getViewMatrix() * cameraTransform);
-
-        rttCamera->setViewport(0, 0, w, h);
-
-        osg::ref_ptr<osg::Texture2D> texture (new osg::Texture2D);
-        texture->setInternalFormat(GL_RGB);
-        texture->setTextureSize(w, h);
-        texture->setResizeNonPowerOfTwoHint(false);
-        texture->setFilter(osg::Texture::MIN_FILTER, osg::Texture::LINEAR);
-        texture->setFilter(osg::Texture::MAG_FILTER, osg::Texture::LINEAR);
-        rttCamera->attach(osg::Camera::COLOR_BUFFER, texture);
-
-        image->setDataType(GL_UNSIGNED_BYTE);
-        image->setPixelFormat(texture->getInternalFormat());
 
         rttCamera->setUpdateCallback(new NoTraverseCallback);
         rttCamera->addChild(mSceneRoot);
@@ -916,14 +898,9 @@ namespace MWRender
 
         rttCamera->setCullMask(mViewer->getCamera()->getCullMask() & (~Mask_GUI));
 
-        mRootNode->addChild(rttCamera);
-
         rttCamera->setClearMask(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         renderCameraToImage(rttCamera.get(),image,w,h);
-
-        rttCamera->removeChildren(0, rttCamera->getNumChildren());
-        mRootNode->removeChild(rttCamera);
     }
 
     osg::Vec4f RenderingManager::getScreenBounds(const MWWorld::Ptr& ptr)


### PR DESCRIPTION
[Regression #4603](https://gitlab.com/OpenMW/openmw/issues/4603).

drummyfish used a smart trick to fix water reflections in no-GUI screenshots which are used for 360 degree screenshots and savegame screenshots: he attached the reflection and refraction cameras to screenshot camera and used an invisible pseudo-loading screen to hide the fact that the main camera now rendered water reflections incorrectly. Unfortunately, it was partially broken after the freeze that appeared afterwards was fixed, so you could see the weird water reflections/refractions when you made saves or 360-degree screenshots - in order to not touch the GUI modes the return call for the invisible loading screen was placed too early and the pseudo-loading screen wasn't enabled so the rendering wasn't stopped. That was fixed.

akortunov didn't have any objections (while drummyfish appears to be MIA), so hopefully this should be good to go.

Also, I cleaned up redundant calls in screenshot(), so superfluous images aren't attached to the screenshot camera and some parameters are not set twice. This might improve the performance of making 360-degree screenshots and quicksaving a bit.