### PR TITLE
Avoid overflow when handling output characters

### DIFF
--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -506,7 +506,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
             while (!stream.eof () && !ucsLineBreak (stream.peek ()) && ucsBreakingSpace (stream.peek ()))
             {
                 MWGui::GlyphInfo info = GlyphInfo(style->mFont, stream.peek());
-                if (info.codePoint >= 0)
+                if (info.charFound)
                     space_width += static_cast<int>(info.advance + info.bearingX);
                 stream.consume ();
             }
@@ -516,7 +516,7 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
             while (!stream.eof () && !ucsLineBreak (stream.peek ()) && !ucsBreakingSpace (stream.peek ()))
             {
                 MWGui::GlyphInfo info = GlyphInfo(style->mFont, stream.peek());
-                if (info.codePoint >= 0)
+                if (info.charFound)
                     word_width += static_cast<int>(info.advance + info.bearingX);
                 stream.consume ();
             }
@@ -765,7 +765,7 @@ namespace
         {
             MWGui::GlyphInfo info = GlyphInfo(mFont, ch);
 
-            if (info.codePoint < 0)
+            if (!info.charFound)
                 return;
 
             MyGUI::FloatRect vr;
@@ -787,7 +787,7 @@ namespace
         {
             MWGui::GlyphInfo info = GlyphInfo(mFont, ch);
 
-            if (info.codePoint >= 0)
+            if (info.charFound)
                 mCursor.left += static_cast<int>(info.bearingX + info.advance);
         }
 

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -43,6 +43,7 @@ namespace MWGui
         float advance;
         float bearingX;
         float bearingY;
+        bool charFound;
         MyGUI::FloatRect uvRect;
 
         GlyphInfo(MyGUI::IFont* font, MyGUI::Char ch)
@@ -61,15 +62,17 @@ namespace MWGui
                 height = (int) gi->height / scale;
                 advance = (int) gi->advance / scale;
                 uvRect = gi->uvRect;
+                charFound = true;
             }
             else
             {
-                codePoint = -1;
+                codePoint = 0;
                 bearingX = 0;
                 bearingY = 0;
                 width = 0;
                 height = 0;
                 advance = 0;
+                charFound = false;
             }
         }
     };


### PR DESCRIPTION
Fixes [bug #4676](https://gitlab.com/OpenMW/openmw/issues/4676), which is a regression in my TrueType fonts handling.

Since the codePoint is a char, I did not display some characters properly.