### PR TITLE
Support soundgen calls for activators (feature #4285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
     Feature #4012: Editor: Write a log file if OpenCS crashes
     Feature #4222: 360° screenshots
     Feature #4256: Implement ToggleBorders (TB) console command
+    Feature #4285: Support soundgen calls for activators
     Feature #4324: Add CFBundleIdentifier in Info.plist to allow for macOS function key shortcuts
     Feature #4345: Add equivalents for the command line commands to Launcher
     Feature #4404: Editor: All EnumDelegate fields should have their items sorted alphabetically

--- a/apps/openmw/mwclass/activator.cpp
+++ b/apps/openmw/mwclass/activator.cpp
@@ -138,19 +138,13 @@ namespace MWClass
 
     std::string Activator::getSoundIdFromSndGen(const MWWorld::Ptr &ptr, const std::string &name) const
     {
-        std::string model = getModel(ptr);
-        if (model.empty())
-            return std::string();
-
-        const MWWorld::Store<ESM::Creature> &creaturestore = MWBase::Environment::get().getWorld()->getStore().get<ESM::Creature>();
+        std::string model = getModel(ptr); // Assume it's not empty, since we wouldn't have gotten the soundgen otherwise
+        const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore(); 
         std::string creatureId;
-        
-        for (const ESM::Creature &iter : creaturestore)
-        {
-            if (iter.mModel.empty())
-                continue;
 
-            if (Misc::StringUtils::ciEqual(model, "meshes\\" + iter.mModel))
+        for (const ESM::Creature &iter : store.get<ESM::Creature>())
+        {
+            if (!iter.mModel.empty() && Misc::StringUtils::ciEqual(model, "meshes\\" + iter.mModel))
             {
                 creatureId = !iter.mOriginal.empty() ? iter.mOriginal : iter.mId;
                 break;
@@ -160,19 +154,12 @@ namespace MWClass
         if (creatureId.empty())
             return std::string();
 
-        const MWWorld::Store<ESM::SoundGenerator> &store = MWBase::Environment::get().getWorld()->getStore().get<ESM::SoundGenerator>();
-
         int type = getSndGenTypeFromName(name);
         std::vector<const ESM::SoundGenerator*> sounds;
 
-        MWWorld::Store<ESM::SoundGenerator>::iterator sound = store.begin();
-
-        while (sound != store.end())
-        {
+        for (auto sound = store.get<ESM::SoundGenerator>().begin(); sound != store.get<ESM::SoundGenerator>().end(); ++sound)
             if (type == sound->mType && !sound->mCreature.empty() && (Misc::StringUtils::ciEqual(creatureId, sound->mCreature)))
                 sounds.push_back(&*sound);
-            ++sound;
-        }
 
         if (!sounds.empty())
             return sounds[Misc::Rng::rollDice(sounds.size())]->mSound;
@@ -183,24 +170,24 @@ namespace MWClass
         return std::string();
     }
 
-    int Activator::getSndGenTypeFromName(const std::string &name) const
+    int Activator::getSndGenTypeFromName(const std::string &name)
     {
         if (name == "left")
-            return 0;
+            return ESM::SoundGenerator::LeftFoot;
         if (name == "right")
-            return 1;
+            return ESM::SoundGenerator::RightFoot;
         if (name == "swimleft")
-            return 2;
+            return ESM::SoundGenerator::SwimLeft;
         if (name == "swimright")
-            return 3;
+            return ESM::SoundGenerator::SwimRight;
         if (name == "moan")
-            return 4;
+            return ESM::SoundGenerator::Moan;
         if (name == "roar")
-            return 5;
+            return ESM::SoundGenerator::Roar;
         if (name == "scream")
-            return 6;
+            return ESM::SoundGenerator::Scream;
         if (name == "land")
-            return 7;
+            return ESM::SoundGenerator::Land;
 
         throw std::runtime_error(std::string("Unexpected soundgen type: ")+name);
     }

--- a/apps/openmw/mwclass/activator.hpp
+++ b/apps/openmw/mwclass/activator.hpp
@@ -10,6 +10,8 @@ namespace MWClass
 
             virtual MWWorld::Ptr copyToCellImpl(const MWWorld::ConstPtr &ptr, MWWorld::CellStore &cell) const;
 
+            static int getSndGenTypeFromName(const std::string &name);
+
         public:
 
             virtual void insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const;
@@ -46,8 +48,6 @@ namespace MWClass
             virtual bool isActivator() const;
 
             virtual std::string getSoundIdFromSndGen(const MWWorld::Ptr &ptr, const std::string &name) const;
-
-            virtual int getSndGenTypeFromName(const std::string &name) const;
     };
 }
 

--- a/apps/openmw/mwclass/activator.hpp
+++ b/apps/openmw/mwclass/activator.hpp
@@ -44,6 +44,10 @@ namespace MWClass
             ///< Whether or not to use animated variant of model (default false)
 
             virtual bool isActivator() const;
+
+            virtual std::string getSoundIdFromSndGen(const MWWorld::Ptr &ptr, const std::string &name) const;
+
+            virtual int getSndGenTypeFromName(const std::string &name) const;
     };
 }
 

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -688,9 +688,9 @@ namespace MWClass
             MWBase::World *world = MWBase::Environment::get().getWorld();
             osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
             if(world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
-                return 2;
+                return ESM::SoundGenerator::SwimLeft;
             if(world->isOnGround(ptr))
-                return 0;
+                return ESM::SoundGenerator::LeftFoot;
             return -1;
         }
         if(name == "right")
@@ -698,23 +698,23 @@ namespace MWClass
             MWBase::World *world = MWBase::Environment::get().getWorld();
             osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
             if(world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
-                return 3;
+                return ESM::SoundGenerator::SwimRight;
             if(world->isOnGround(ptr))
-                return 1;
+                return ESM::SoundGenerator::RightFoot;
             return -1;
         }
         if(name == "swimleft")
-            return 2;
+            return ESM::SoundGenerator::SwimLeft;
         if(name == "swimright")
-            return 3;
+            return ESM::SoundGenerator::SwimRight;
         if(name == "moan")
-            return 4;
+            return ESM::SoundGenerator::Moan;
         if(name == "roar")
-            return 5;
+            return ESM::SoundGenerator::Roar;
         if(name == "scream")
-            return 6;
+            return ESM::SoundGenerator::Scream;
         if(name == "land")
-            return 7;
+            return ESM::SoundGenerator::Land;
 
         throw std::runtime_error(std::string("Unexpected soundgen type: ")+name);
     }


### PR DESCRIPTION
[Feature 4285](https://gitlab.com/OpenMW/openmw/issues/4285)

The idea is to iterate through creature store and look for the first creature with the same model as the one activator has, then get the played sound IDs for that creature as normal. It seems to work OK. Note that land soundgen goes unused for creatures and activators alike unlike vanilla after the changes needed for bug 2256: fixed in PR #1970.