### PR TITLE
Re-enable handling soundgen land for creatures

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1242,15 +1242,9 @@ namespace MWClass
             return "";
         }
 
+        // Morrowind ignores land soundgen for NPCs
         if(name == "land")
-        {
-            MWBase::World *world = MWBase::Environment::get().getWorld();
-            osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
-            if (world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
-                return "DefaultLandWater";
-
-            return "DefaultLand";
-        }
+            return "";
         if(name == "swimleft")
             return "Swim Left";
         if(name == "swimright")

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -979,17 +979,13 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
             }
         }
 
-        if (soundgen == "land") // Morrowind ignores land soundgen for some reason
-            return;
-
         std::string sound = mPtr.getClass().getSoundIdFromSndGen(mPtr, soundgen);
         if(!sound.empty())
         {
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            if(soundgen == "left" || soundgen == "right")
+            // NB: landing sound is not played for NPCs here
+            if(soundgen == "left" || soundgen == "right" || soundgen == "land")
             {
-                // Don't make foot sounds local for the player, it makes sense to keep them
-                // positioned on the ground.
                 sndMgr->playSound3D(mPtr, sound, volume, pitch, MWSound::Type::Foot,
                                     MWSound::PlayMode::NoPlayerLocal);
             }
@@ -2071,11 +2067,17 @@ void CharacterController::update(float duration)
                 }
             }
 
-            // Play landing sound
-            MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            std::string sound = cls.getSoundIdFromSndGen(mPtr, "land");
-            if (!sound.empty())
+            // Play landing sound for NPCs
+            if (mPtr.getClass().isNpc())
+            {
+                MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+                std::string sound = "DefaultLand";
+                osg::Vec3f pos(mPtr.getRefData().getPosition().asVec3());
+                if (world->isUnderwater(mPtr.getCell(), pos) || world->isWalkingOnWater(mPtr))
+                    sound = "DefaultLandWater";
+
                 sndMgr->playSound3D(mPtr, sound, 1.f, 1.f, MWSound::Type::Foot, MWSound::PlayMode::NoPlayerLocal);
+            }
         }
         else
         {


### PR DESCRIPTION
Apparently creatures are still supposed to play a sound when land soundgen is used in their animations. This fixes a regression: some creature death animations used land soundgen to play body fall impact sound.

It appears that soundgen: land textkeys in base animation files are used because biped creatures need them.