### PR TITLE
Force actor to the 'weapon equipped' state if the weapon disappeared in the middle of attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
     Bug #4633: Sneaking stance affects speed even if the actor is not able to crouch
     Bug #4641: GetPCJumping is handled incorrectly
     Bug #4644: %Name should be available for all actors, not just for NPCs
+    Bug #4646: Weapon force-equipment messes up ongoing attack animations
     Bug #4648: Hud thinks that throwing weapons have condition
     Bug #4649: Levelup fully restores health
     Bug #4653: Length of non-ASCII strings is handled incorrectly in ESM reader

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1278,6 +1278,18 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     bool isStillWeapon = weaptype > WeapType_HandToHand && weaptype < WeapType_Spell &&
                             mWeaponType > WeapType_HandToHand && mWeaponType < WeapType_Spell;
 
+    // If the current weapon type was changed in the middle of attack (e.g. by Equip console command or when bound spell expires),
+    // we should force actor to the "weapon equipped" state, interrupt attack and update animations.
+    if (isStillWeapon && mWeaponType != weaptype && mUpperBodyState > UpperCharState_WeapEquiped)
+    {
+        forcestateupdate = true;
+        mUpperBodyState = UpperCharState_WeapEquiped;
+        mAttackingOrSpell = false;
+        mAnimation->disable(mCurrentWeapon);
+        if (mPtr == getPlayer())
+            MWBase::Environment::get().getWorld()->getPlayer().setAttackingOrSpell(false);
+    }
+
     if(!isKnockedOut() && !isKnockedDown() && !isRecovery())
     {
         std::string weapgroup;


### PR DESCRIPTION
Fixes [bug #4646](https://gitlab.com/OpenMW/openmw/issues/4646).
The main idea - if current weapon type changed for some reason in the middle of attack, interrupt current attack and update animations.
If the weapon has the same type, you can continue your attack.

I am not sure if attack interruption is a best solution, but Morrowind behaves in a more strange way.
In case of Bound spells - it allows you to finish current attack with current animation, but without weapon in your hand, and only then equips bound weapon. 
In case of Equip command - it allows you to finish current attack with new weapon, but with animation from previous weapon.