### PR TITLE
Catch exceptions inside the loadVoice()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
     Bug #4674: Journal can be opened when settings window is open
     Bug #4677: Crash in ESM reader when NPC record has DNAM record without DODT one
     Bug #4678: Crash in ESP parser when SCVR has no variable names
+    Bug #4685: Missing sound causes an exception inside Say command
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -245,20 +245,30 @@ namespace MWSound
 
     DecoderPtr SoundManager::loadVoice(const std::string &voicefile)
     {
-        DecoderPtr decoder = getDecoder();
-        // Workaround: Bethesda at some point converted some of the files to mp3, but the references were kept as .wav.
-        if(mVFS->exists(voicefile))
-            decoder->open(voicefile);
-        else
+        try
         {
-            std::string file = voicefile;
-            std::string::size_type pos = file.rfind('.');
-            if(pos != std::string::npos)
-                file = file.substr(0, pos)+".mp3";
-            decoder->open(file);
+            DecoderPtr decoder = getDecoder();
+
+            // Workaround: Bethesda at some point converted some of the files to mp3, but the references were kept as .wav.
+            if(mVFS->exists(voicefile))
+                decoder->open(voicefile);
+            else
+            {
+                std::string file = voicefile;
+                std::string::size_type pos = file.rfind('.');
+                if(pos != std::string::npos)
+                    file = file.substr(0, pos)+".mp3";
+                decoder->open(file);
+            }
+
+            return decoder;
+        }
+        catch(std::exception &e)
+        {
+            Log(Debug::Error) << "Failed to load audio from " << voicefile << ": " << e.what();
         }
 
-        return decoder;
+        return nullptr;
     }
 
     Sound *SoundManager::getSoundRef()
@@ -471,6 +481,8 @@ namespace MWSound
 
         mVFS->normalizeFilename(voicefile);
         DecoderPtr decoder = loadVoice(voicefile);
+        if (!decoder)
+            return;
 
         MWBase::World *world = MWBase::Environment::get().getWorld();
         const osg::Vec3f pos = world->getActorHeadTransform(ptr).getTrans();
@@ -503,6 +515,8 @@ namespace MWSound
 
         mVFS->normalizeFilename(voicefile);
         DecoderPtr decoder = loadVoice(voicefile);
+        if (!decoder)
+            return;
 
         stopSay(MWWorld::ConstPtr());
         Stream *sound = playVoice(decoder, osg::Vec3f(), true);

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -117,7 +117,7 @@ namespace MWSound
         Sound_Buffer *lookupSound(const std::string &soundId) const;
         Sound_Buffer *loadSound(const std::string &soundId);
 
-        // returns a decoder to start streaming
+        // returns a decoder to start streaming, or nullptr if the sound was not found
         DecoderPtr loadVoice(const std::string &voicefile);
 
         Sound *getSoundRef();


### PR DESCRIPTION
Fixes [bug #4685](https://gitlab.com/OpenMW/openmw/issues/4685).
If the voiced speech sound was not found, print error message to log and show messagebox without breaking the script execution or frame update.
Voiced speech error handling now is consistent with how we handle errors for other sounds.