### PR TITLE
Fix some issues found by Coverity Scan

### DIFF
--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -7,6 +7,7 @@
 
 #include <components/debug/debuglog.hpp>
 #include <components/fallback/validate.hpp>
+#include <components/misc/rng.hpp>
 #include <components/nifosg/nifloader.hpp>
 
 #include "model/doc/document.hpp"
@@ -354,6 +355,8 @@ int CS::Editor::run()
 {
     if (mLocal.empty())
         return 1;
+
+    Misc::Rng::init();
 
     mStartup.show();
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -190,12 +190,6 @@ namespace
         {
         }
 
-        RemoveFinishedCallbackVisitor(int effectId)
-            : RemoveVisitor()
-            , mHasMagicEffects(false)
-        {
-        }
-
         virtual void apply(osg::Node &node)
         {
             traverse(node);
@@ -228,9 +222,6 @@ namespace
         virtual void apply(osg::Geometry&)
         {
         }
-
-    private:
-        int mEffectId;
     };
 
     class RemoveCallbackVisitor : public RemoveVisitor

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -6,6 +6,7 @@
 #include <osg/Geometry>
 
 #include <components/debug/debuglog.hpp>
+#include <components/misc/rng.hpp>
 #include <components/nif/controlled.hpp>
 #include <components/nif/nifkey.hpp>
 #include <components/nif/data.hpp>
@@ -81,17 +82,17 @@ ParticleShooter::ParticleShooter(const ParticleShooter &copy, const osg::CopyOp 
 
 void ParticleShooter::shoot(osgParticle::Particle *particle) const
 {
-    float hdir = mHorizontalDir + mHorizontalAngle * (2.f * (std::rand() / static_cast<double>(RAND_MAX)) - 1.f);
-    float vdir = mVerticalDir + mVerticalAngle * (2.f * (std::rand() / static_cast<double>(RAND_MAX)) - 1.f);
+    float hdir = mHorizontalDir + mHorizontalAngle * (2.f * Misc::Rng::rollClosedProbability() - 1.f);
+    float vdir = mVerticalDir + mVerticalAngle * (2.f * Misc::Rng::rollClosedProbability() - 1.f);
 
     osg::Vec3f dir = (osg::Quat(vdir, osg::Vec3f(0,1,0)) * osg::Quat(hdir, osg::Vec3f(0,0,1)))
              * osg::Vec3f(0,0,1);
 
-    float vel = mMinSpeed + (mMaxSpeed - mMinSpeed) * std::rand() / static_cast<float>(RAND_MAX);
+    float vel = mMinSpeed + (mMaxSpeed - mMinSpeed) * Misc::Rng::rollClosedProbability();
     particle->setVelocity(dir * vel);
 
     // Not supposed to set this here, but there doesn't seem to be a better way of doing it
-    particle->setLifeTime(mLifetime + mLifetimeRandom * std::rand() / static_cast<float>(RAND_MAX));
+    particle->setLifeTime(mLifetime + mLifetimeRandom * Misc::Rng::rollClosedProbability());
 }
 
 GrowFadeAffector::GrowFadeAffector(float growTime, float fadeTime)
@@ -277,7 +278,8 @@ void Emitter::emitParticles(double dt)
 
     if (!mTargets.empty())
     {
-        int randomRecIndex = mTargets[(std::rand() / (static_cast<double>(RAND_MAX)+1.0)) * mTargets.size()];
+        int randomIndex = Misc::Rng::rollClosedProbability() * (mTargets.size() - 1);
+        int randomRecIndex = mTargets[randomIndex];
 
         // we could use a map here for faster lookup
         FindGroupByRecIndex visitor(randomRecIndex);


### PR DESCRIPTION
Summary of changes:
1. Remove some redundant code (basically, unused field and constructor) from animation.cpp
2. Unify random number usage - the only place where we used the std::rand() was the particle.cpp and the Coverity Scan complained about it.
It is a bit strange since the `std::rand() / static_cast<float>(RAND_MAX)` generates a random float from 0 to 1. In other places we use a more advanced Misc::Rng::rollClosedProbability() for this approach, so it should be safe to use it here too.

Coverity Scan shows additionally two suspicious issues for me:
1. Possible integer overflow inside tinyxml. I suppose we can dismiss it since it is an external code and we usually use an external tinyxml anyway.
2. Passing struct by value [here](https://github.com/OpenMW/openmw/blob/openmw-44/components/esm/loadland.cpp#L327). It was added by [this](https://github.com/OpenMW/openmw/commit/b0641934d4a34b4e462932aa715cc0ca9d854cae) commit.
@zinnschlag, is there an error here, or this change is intended?