### PR TITLE
Utilize the default soundgen entries when necessary (bug #4689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
     Bug #4677: Crash in ESM reader when NPC record has DNAM record without DODT one
     Bug #4678: Crash in ESP parser when SCVR has no variable names
     Bug #4685: Missing sound causes an exception inside Say command
+    Bug #4689: Default creature soundgen entries are not used
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -632,24 +632,26 @@ namespace MWClass
         if(type >= 0)
         {
             std::vector<const ESM::SoundGenerator*> sounds;
+            std::vector<const ESM::SoundGenerator*> fallbacksounds;
 
             MWWorld::LiveCellRef<ESM::Creature>* ref = ptr.get<ESM::Creature>();
 
             const std::string& ourId = (ref->mBase->mOriginal.empty()) ? ptr.getCellRef().getRefId() : ref->mBase->mOriginal;
 
             MWWorld::Store<ESM::SoundGenerator>::iterator sound = store.begin();
-            while(sound != store.end())
+            while (sound != store.end())
             {
                 if (type == sound->mType && !sound->mCreature.empty() && (Misc::StringUtils::ciEqual(ourId, sound->mCreature)))
                     sounds.push_back(&*sound);
+                if (type == sound->mType && sound->mCreature.empty())
+                    fallbacksounds.push_back(&*sound);
                 ++sound;
             }
-            if(!sounds.empty())
+            if (!sounds.empty())
                 return sounds[Misc::Rng::rollDice(sounds.size())]->mSound;
+            if (!fallbacksounds.empty())
+                return fallbacksounds[Misc::Rng::rollDice(fallbacksounds.size())]->mSound;
         }
-
-        if (type == ESM::SoundGenerator::Land)
-            return "Body Fall Large";
 
         return "";
     }


### PR DESCRIPTION
[Bug 4689](https://gitlab.com/OpenMW/openmw/issues/4689)

If a sound generator record isn't found for the specific creature ID, the entries which don't have an ID assigned but have the same soundgen type are used now, fixing footstep sounds for ash creatures, for example. The logic is replicated for activators too.

NPCs don't use sound generator records.

Addendum: the more apparent cases are that other than ash creatures, daedroths, corprus creatures, Flame and Frost Atronachs, bonelords, bonewalkers, Dagoth Ur and other Sixth House members, Dremoras and Nix-Hounds and Vivec (and probably more) don't play footstep sounds in master (or any sound generator sounds in Vivec's case) whatsoever.