### PR TITLE
[Regression] Fix fixme behavior in interiors

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -262,8 +262,8 @@ namespace MWBase
             ///< Adjust position after load to be on ground. Must be called after model load.
             /// @param force do this even if the ptr is flying
 
-            virtual void fixPosition (const MWWorld::Ptr& actor) = 0;
-            ///< Attempt to fix position so that the Ptr is no longer inside collision geometry.
+            virtual void fixPosition () = 0;
+            ///< Attempt to fix position so that the player is not stuck inside the geometry.
 
             /// @note No-op for items in containers. Use ContainerStore::removeItem instead.
             virtual void deleteObject (const MWWorld::Ptr& ptr) = 0;

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -738,8 +738,7 @@ namespace MWScript
 
             virtual void execute (Interpreter::Runtime& runtime)
             {
-                const MWWorld::Ptr ptr = MWMechanics::getPlayer();
-                MWBase::Environment::get().getWorld()->fixPosition(ptr);
+                MWBase::Environment::get().getWorld()->fixPosition();
             }
         };
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1351,8 +1351,9 @@ namespace MWWorld
         moveObject(ptr, ptr.getCell(), pos.x(), pos.y(), pos.z());
     }
 
-    void World::fixPosition(const Ptr &actor)
+    void World::fixPosition()
     {
+        const MWWorld::Ptr actor = getPlayerPtr();
         const float distance = 128.f;
         ESM::Position esmPos = actor.getRefData().getPosition();
         osg::Quat orientation(esmPos.rot[2], osg::Vec3f(0,0,-1));
@@ -1382,7 +1383,7 @@ namespace MWWorld
             esmPos.pos[0] = traced.x();
             esmPos.pos[1] = traced.y();
             esmPos.pos[2] = traced.z();
-            MWWorld::ActionTeleport("", esmPos, false).execute(actor);
+            MWWorld::ActionTeleport(actor.getCell()->isExterior() ? "" : actor.getCell()->getCell()->mName, esmPos, false).execute(actor);
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -291,8 +291,8 @@ namespace MWWorld
             ///< Adjust position after load to be on ground. Must be called after model load.
             /// @param force do this even if the ptr is flying
 
-            void fixPosition (const Ptr& actor) override;
-            ///< Attempt to fix position so that the Ptr is no longer inside collision geometry.
+            void fixPosition () override;
+            ///< Attempt to fix position so that the player is not stuck inside the geometry.
 
             void enable (const Ptr& ptr) override;
 


### PR DESCRIPTION
This passed by unnoticed when the changes were tested. ActionTeleport was using an empty cell name instead of the current cell name and this only works properly for exteriors; in interiors, it caused the player to be teleported to 0, 0 because the absolute coordinates in interiors are very small.