### PR TITLE
Avoid item condition and charge zero divisions

### DIFF
--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -297,7 +297,7 @@ namespace MWClass
     {
         const MWWorld::InventoryStore& invStore = npc.getClass().getInventoryStore(npc);
 
-        if (ptr.getCellRef().getCharge() == 0)
+        if (getItemHealth(ptr) == 0)
             return std::make_pair(0, "#{sInventoryMessage1}");
 
         // slots that this item can be equipped in

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1148,9 +1148,16 @@ namespace MWClass
                 const bool hasHealth = it->getClass().hasItemHealth(*it);
                 if (hasHealth)
                 {
-                    int armorHealth = it->getClass().getItemHealth(*it);
                     int armorMaxHealth = it->getClass().getItemMaxHealth(*it);
-                    ratings[i] *= (float(armorHealth) / armorMaxHealth);
+                    if (armorMaxHealth == 0)
+                    {
+                        ratings[i] = 0;
+                    }
+                    else
+                    {
+                        int armorHealth = it->getClass().getItemHealth(*it);
+                        ratings[i] *= (float(armorHealth) / armorMaxHealth);
+                    }
                 }
             }
         }

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -383,7 +383,7 @@ namespace MWClass
 
     std::pair<int, std::string> Weapon::canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const
     {
-        if (hasItemHealth(ptr) && ptr.getCellRef().getCharge() == 0)
+        if (hasItemHealth(ptr) && getItemHealth(ptr) == 0)
             return std::make_pair(0, "#{sInventoryMessage1}");
 
         // Do not allow equip weapons from inventory during attack

--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -51,7 +51,7 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
         {
             int maxDurability = iter->getClass().getItemMaxHealth(*iter);
             int durability = iter->getClass().getItemHealth(*iter);
-            if (maxDurability == durability)
+            if (maxDurability == durability || maxDurability == 0)
                 continue;
 
             int basePrice = iter->getClass().getValue(*iter);

--- a/apps/openmw/mwgui/sortfilteritemmodel.cpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.cpp
@@ -86,26 +86,66 @@ namespace
             if (!leftName.empty())
             {
                 const ESM::Enchantment* ench = MWBase::Environment::get().getWorld()->getStore().get<ESM::Enchantment>().search(leftName);
+
                 if (ench)
                 {
                     if (ench->mData.mType == ESM::Enchantment::ConstantEffect)
+                    {
                         leftChargePercent = 101;
+                    }
                     else
-                        leftChargePercent = (left.mBase.getCellRef().getEnchantmentCharge() == -1) ? 100
-                            : static_cast<int>(left.mBase.getCellRef().getEnchantmentCharge() / static_cast<float>(ench->mData.mCharge) * 100);
+                    {
+                        int maxEnchCharge = ench->mData.mCharge;
+                        if (maxEnchCharge == 0)
+                        {
+                            leftChargePercent = 0;
+                        }
+                        else
+                        {
+                            float enchCharge = left.mBase.getCellRef().getEnchantmentCharge();
+                            if (enchCharge == -1)
+                            {
+                                leftChargePercent = 100;
+                            }
+                            else
+                            {
+                                leftChargePercent = static_cast<int>(enchCharge / static_cast<float>(maxEnchCharge) * 100);
+                            }
+                        }
+                    }
                 }
             }
 
             if (!rightName.empty())
             {
                 const ESM::Enchantment* ench = MWBase::Environment::get().getWorld()->getStore().get<ESM::Enchantment>().search(rightName);
+                
                 if (ench)
                 {
                     if (ench->mData.mType == ESM::Enchantment::ConstantEffect)
+                    {
                         rightChargePercent = 101;
+                    }
                     else
-                        rightChargePercent = (right.mBase.getCellRef().getEnchantmentCharge() == -1) ? 100
-                            : static_cast<int>(right.mBase.getCellRef().getEnchantmentCharge() / static_cast<float>(ench->mData.mCharge) * 100);
+                    {
+                        int maxEnchCharge = ench->mData.mCharge;
+                        if (maxEnchCharge == 0)
+                        {
+                            rightChargePercent = 0;
+                        }
+                        else
+                        {
+                            float enchCharge = right.mBase.getCellRef().getEnchantmentCharge();
+                            if (enchCharge == -1)
+                            {
+                                rightChargePercent = 100;
+                            }
+                            else
+                            {
+                                rightChargePercent = static_cast<int>(enchCharge / static_cast<float>(maxEnchCharge) * 100);
+                            }
+                        }
+                    }
                 }
             }
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -35,8 +35,15 @@ namespace
         float price = static_cast<float>(item.getClass().getValue(item));
         if (item.getClass().hasItemHealth(item))
         {
-            price *= item.getClass().getItemHealth(item);
-            price /= item.getClass().getItemMaxHealth(item);
+            if (item.getClass().getItemMaxHealth(item) == 0)
+            {
+                price = 0;
+            }
+            else
+            {
+                price *= item.getClass().getItemHealth(item);
+                price /= item.getClass().getItemMaxHealth(item);
+            }
         }
         return static_cast<int>(price * count);
     }

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1369,8 +1369,22 @@ namespace MWGui
         const ESM::Enchantment* ench = mStore->get<ESM::Enchantment>()
                 .find(item.getClass().getEnchantment(item));
 
-        int chargePercent = (item.getCellRef().getEnchantmentCharge() == -1) ? 100
-                : static_cast<int>(item.getCellRef().getEnchantmentCharge() / static_cast<float>(ench->mData.mCharge) * 100);
+        int chargePercent = 100;
+
+        int maxEnchCharge = ench->mData.mCharge;
+        if (maxEnchCharge == 0)
+        {
+            chargePercent = 0;
+        }
+        else
+        {
+            float enchCharge = item.getCellRef().getEnchantmentCharge();
+            if (enchCharge != -1)
+            {
+                chargePercent = static_cast<int>(enchCharge / static_cast<float>(maxEnchCharge) * 100);
+            }
+        }
+
         mHud->setSelectedEnchantItem(item, chargePercent);
         mSpellWindow->setTitle(item.getClass().getName(item));
     }
@@ -1386,7 +1400,16 @@ namespace MWGui
         int durabilityPercent = 100;
         if (item.getClass().hasItemHealth(item))
         {
-            durabilityPercent = static_cast<int>(item.getClass().getItemHealth(item) / static_cast<float>(item.getClass().getItemMaxHealth(item)) * 100);
+            int weapmaxhealth = item.getClass().getItemMaxHealth(item);
+            if (weapmaxhealth == 0)
+            {
+                durabilityPercent = 0;
+            }
+            else
+            {
+                int weaphealth = item.getClass().getItemHealth(item);
+                durabilityPercent = static_cast<int>(weaphealth / static_cast<float>(weapmaxhealth) * 100);
+            }
         }
         mHud->setSelectedWeapon(item, durabilityPercent);
         mInventoryWindow->setTitle(item.getClass().getName(item));

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -371,10 +371,17 @@ namespace MWMechanics
             return;
 
         const bool weaphashealth = weapon.getClass().hasItemHealth(weapon);
-        if(weaphashealth)
+        if (weaphashealth)
         {
-            int weaphealth = weapon.getClass().getItemHealth(weapon);
             int weapmaxhealth = weapon.getClass().getItemMaxHealth(weapon);
+
+            if (weapmaxhealth == 0)
+            {
+                damage = 0;
+                return;
+            }
+
+            int weaphealth = weapon.getClass().getItemHealth(weapon);
             damage *= (float(weaphealth) / weapmaxhealth);
         }
 


### PR DESCRIPTION
While normally this shouldn't be necessary, in the hypothetical situations the maximum values of these stats are 0 and the divided value is e.g. also 0 and you are able to use them the zero division results in a +inf value and all sorts of weird issues.

I actually ran into such situation while testing a custom weapon record in tes3mp that I forgot to set maximum condition to. It got 0/0 condition and the damage was infinite, which was pretty funny I admit. That weapon wasn't considered "broken" until I gave it away to a different player, seems that some kind of issue (probably not on openmw's side) didn't properly assign the charge to the item cell reference.

This doesn't actually affect anything in the frontend of openmw.