### PR TITLE
Decrease dispostion of assault victim even if Alarm = 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
     Bug #4674: Journal can be opened when settings window is open
     Bug #4677: Crash in ESM reader when NPC record has DNAM record without DODT one
     Bug #4678: Crash in ESP parser when SCVR has no variable names
+    Bug #4683: Hitting NPC with Alarm 0 should reduce disposition
     Bug #4685: Missing sound causes an exception inside Say command
     Bug #4689: Default creature soundgen entries are not used
     Feature #912: Editor: Add missing icons to UniversalId tables

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1410,6 +1410,12 @@ namespace MWMechanics
                     // Mark as Alarmed for dialogue
                     observerStats.setAlarmed(true);
                 }
+                else if (type == OT_Assault && *it == victim)
+                {
+                    // Still decrease disposition for victim of attack, even if Alarm = 0
+                    NpcStats& observerStats = it->getClass().getNpcStats(*it);
+                    observerStats.setBaseDisposition(observerStats.getBaseDisposition() + static_cast<int>(dispTerm));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes [bug #4683](https://gitlab.com/OpenMW/openmw/issues/4683).

Currently we decrease disposition [here](https://github.com/OpenMW/openmw/blob/openmw-44/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp#L1357). It means that we decrease disposition only for NPCs with high Alarm rating, which will attack player if he will commit crime.
However, vanilla game decreases disposition for any victim of assault, even if Alarm = 0 and crime was not reported.