### PR TITLE
Adjust magic light source linear attenuation (bug #3890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
     Bug #3788: GetPCInJail and GetPCTraveling do not work as in vanilla
     Bug #3836: Script fails to compile when command argument contains "\n"
     Bug #3876: Landscape texture painting is misaligned
+    Bug #3890: Magic light source attenuation is inaccurate
     Bug #3897: Have Goodbye give all choices the effects of Goodbye
     Bug #3911: [macOS] Typing in the "Content List name" dialog box produces double characters
     Bug #3920: RemoveSpellEffects doesn't remove constant effects

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1789,9 +1789,12 @@ namespace MWRender
         }
         else
         {
-            effect += 3;
-            float radius = effect * 66.f;
-            float linearAttenuation = 0.5f / effect;
+            // TODO: use global attenuation settings
+
+            // 1 pt of Light effect magnitude corresponds to 1 foot of light source radius, which is about 21.33 game units,
+            // but Morrowind uses imprecise value of foot for magic effects.
+            float radius = effect * 22.f;
+            float linearAttenuation = 3.f / radius;
 
             if (!mGlowLight || linearAttenuation != mGlowLight->getLight(0)->getLinearAttenuation())
             {
@@ -1813,7 +1816,8 @@ namespace MWRender
                 mGlowLight->setLight(light);
             }
 
-            mGlowLight->setRadius(radius);
+            // Make the obvious cut-off a bit less obvious
+            mGlowLight->setRadius(radius * 3);
         }
     }
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -15,12 +15,12 @@
 
 #include <components/debug/debuglog.hpp>
 
-#include <components/nifosg/nifloader.hpp>
-
 #include <components/resource/resourcesystem.hpp>
 #include <components/resource/scenemanager.hpp>
 #include <components/resource/keyframemanager.hpp>
 #include <components/resource/imagemanager.hpp>
+
+#include <components/misc/constants.hpp>
 
 #include <components/nifosg/nifloader.hpp> // KeyframeHolder
 #include <components/nifosg/controller.hpp>
@@ -1791,10 +1791,10 @@ namespace MWRender
         {
             // TODO: use global attenuation settings
 
-            // 1 pt of Light effect magnitude corresponds to 1 foot of light source radius, which is about 21.33 game units,
-            // but Morrowind uses imprecise value of foot for magic effects.
-            float radius = effect * 22.f;
-            float linearAttenuation = 3.f / radius;
+            // 1 pt of Light magnitude corresponds to 1 foot of radius
+            float radius = effect * std::ceil(Constants::UnitsPerFoot);
+            const float linearValue = 3.f; // Currently hardcoded: unmodified Morrowind attenuation settings
+            float linearAttenuation = linearValue / radius;
 
             if (!mGlowLight || linearAttenuation != mGlowLight->getLight(0)->getLinearAttenuation())
             {


### PR DESCRIPTION
[Bug 3890](https://gitlab.com/OpenMW/openmw/issues/3890).

Make the linear attenuation formula as close as possible to the original, where 1 point of Light magnitude corresponds to 1 foot of the light source range. Note that global attenuation settings are not used still. Note that cut-off distance is artificially increased because the cut-off was really obvious with the normal radius (radius adjustment doesn't affect the light source brightness). I cannot present comparison pictures at the moment.