### PR TITLE
[Regression] Fix revert record button icon

### DIFF
--- a/files/opencs/resources.qrc
+++ b/files/opencs/resources.qrc
@@ -94,6 +94,7 @@
         <file alias="edit-preview">record-preview.png</file>
         <file alias="edit-clone">record-clone.png</file>
         <file alias="edit-add">record-add.png</file>
+        <file alias="edit-undo">record-revert.png</file>
         <file alias="resources-icon">resources-icon.png</file>
         <file alias="resources-mesh">resources-mesh.png</file>
         <file alias="resources-music">resources-music.png</file>


### PR DESCRIPTION
The icon was accidentally removed from resources.qrc when icons were added to editor menus, causing the revert record button in record button bar in subviews to be empty.