### PR TITLE
Center progress bar when there are active messageboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@
     Bug #4684: Spell Absorption is additive
     Bug #4685: Missing sound causes an exception inside Say command
     Bug #4689: Default creature soundgen entries are not used
+    Bug #4691: Loading bar for cell should be moved up when text is still active at bottom of screen
     Feature #912: Editor: Add missing icons to UniversalId tables
     Feature #1221: Editor: Creature/NPC rendering
     Feature #1617: Editor: Enchantment effect record verifier

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -285,6 +285,8 @@ namespace MWBase
 
             virtual void setEnemy (const MWWorld::Ptr& enemy) = 0;
 
+            virtual int getMessagesCount() const = 0;
+
             virtual const Translation::Storage& getTranslationDataStorage() const = 0;
 
             /// Warning: do not use MyGUI::InputManager::setKeyFocusWidget directly. Instead use this.

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -96,7 +96,7 @@ namespace MWGui
             Log(Debug::Warning) << "Warning: no splash screens found!";
     }
 
-    void LoadingScreen::setLabel(const std::string &label, bool important)
+    void LoadingScreen::setLabel(const std::string &label, bool important, bool center)
     {
         mImportantLabel = important;
 
@@ -105,7 +105,11 @@ namespace MWGui
         MyGUI::IntSize size(mLoadingText->getTextSize().width+padding, mLoadingBox->getHeight());
         size.width = std::max(300, size.width);
         mLoadingBox->setSize(size);
-        mLoadingBox->setPosition(mMainWidget->getWidth()/2 - mLoadingBox->getWidth()/2, mLoadingBox->getTop());
+
+        if (center)
+            mLoadingBox->setPosition(mMainWidget->getWidth()/2 - mLoadingBox->getWidth()/2, mMainWidget->getHeight()/2 - mLoadingBox->getHeight()/2);
+        else
+            mLoadingBox->setPosition(mMainWidget->getWidth()/2 - mLoadingBox->getWidth()/2, mMainWidget->getHeight() - mLoadingBox->getHeight() - 8);
     }
 
     void LoadingScreen::setVisible(bool visible)

--- a/apps/openmw/mwgui/loadingscreen.hpp
+++ b/apps/openmw/mwgui/loadingscreen.hpp
@@ -34,7 +34,7 @@ namespace MWGui
         virtual ~LoadingScreen();
 
         /// Overridden from Loading::Listener, see the Loading::Listener documentation for usage details
-        virtual void setLabel (const std::string& label, bool important);
+        virtual void setLabel (const std::string& label, bool important, bool center);
         virtual void loadingOn(bool visible=true);
         virtual void loadingOff();
         virtual void setProgressRange (size_t range);

--- a/apps/openmw/mwgui/messagebox.cpp
+++ b/apps/openmw/mwgui/messagebox.cpp
@@ -35,6 +35,11 @@ namespace MWGui
         }
     }
 
+    int MessageBoxManager::getMessagesCount()
+    {
+        return mMessageBoxes.size();
+    }
+
     void MessageBoxManager::clear()
     {
         if (mInterMessageBoxe)

--- a/apps/openmw/mwgui/messagebox.hpp
+++ b/apps/openmw/mwgui/messagebox.hpp
@@ -28,6 +28,8 @@ namespace MWGui
             bool createInteractiveMessageBox (const std::string& message, const std::vector<std::string>& buttons);
             bool isInteractiveMessageBox ();
 
+            int getMessagesCount();
+
             const InteractiveMessageBox* getInteractiveMessageBox() const { return mInterMessageBoxe; }
 
             /// Remove all message boxes

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1670,6 +1670,15 @@ namespace MWGui
         mHud->setEnemy(enemy);
     }
 
+    int WindowManager::getMessagesCount() const
+    {
+        int count = 0;
+        if (mMessageBoxManager)
+            count = mMessageBoxManager->getMessagesCount();
+
+        return count;
+    }
+
     Loading::Listener* WindowManager::getLoadingScreen()
     {
         return mLoadingScreen;

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -316,6 +316,8 @@ namespace MWGui
 
     virtual void setEnemy (const MWWorld::Ptr& enemy);
 
+    virtual int getMessagesCount() const;
+
     virtual const Translation::Storage& getTranslationDataStorage() const;
 
     void onSoulgemDialogButtonPressed (int button);

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -265,9 +265,10 @@ void MWState::StateManager::saveGame (const std::string& description, const Slot
         writer.save (stream);
 
         Loading::Listener& listener = *MWBase::Environment::get().getWindowManager()->getLoadingScreen();
+        int messagesCount = MWBase::Environment::get().getWindowManager()->getMessagesCount();
         // Using only Cells for progress information, since they typically have the largest records by far
         listener.setProgressRange(MWBase::Environment::get().getWorld()->countSavedGameCells());
-        listener.setLabel("#{sNotifyMessage4}", true);
+        listener.setLabel("#{sNotifyMessage4}", true, messagesCount > 0);
 
         Loading::ScopedLoad load(&listener);
 
@@ -389,9 +390,10 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
         std::map<int, int> contentFileMap = buildContentFileIndexMap (reader);
 
         Loading::Listener& listener = *MWBase::Environment::get().getWindowManager()->getLoadingScreen();
+        int messagesCount = MWBase::Environment::get().getWindowManager()->getMessagesCount();
 
         listener.setProgressRange(100);
-        listener.setLabel("#{sLoadingMessage14}");
+        listener.setLabel("#{sLoadingMessage14}", false, messagesCount > 0);
 
         Loading::ScopedLoad load(&listener);
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -360,8 +360,9 @@ namespace MWWorld
         Loading::Listener* loadingListener = MWBase::Environment::get().getWindowManager()->getLoadingScreen();
         Loading::ScopedLoad load(loadingListener);
 
+        int messagesCount = MWBase::Environment::get().getWindowManager()->getMessagesCount();
         std::string loadingExteriorText = "#{sLoadingMessage3}";
-        loadingListener->setLabel(loadingExteriorText);
+        loadingListener->setLabel(loadingExteriorText, false, messagesCount > 0);
 
         CellStoreCollection::iterator active = mActiveCells.begin();
         while (active!=mActiveCells.end())
@@ -526,8 +527,9 @@ namespace MWWorld
         MWBase::Environment::get().getWindowManager()->fadeScreenOut(0.5);
 
         Loading::Listener* loadingListener = MWBase::Environment::get().getWindowManager()->getLoadingScreen();
+        int messagesCount = MWBase::Environment::get().getWindowManager()->getMessagesCount();
         std::string loadingInteriorText = "#{sLoadingMessage2}";
-        loadingListener->setLabel(loadingInteriorText);
+        loadingListener->setLabel(loadingInteriorText, false, messagesCount > 0);
         Loading::ScopedLoad load(loadingListener);
 
         if(!loadcell)

--- a/components/loadinglistener/loadinglistener.hpp
+++ b/components/loadinglistener/loadinglistener.hpp
@@ -14,7 +14,7 @@ namespace Loading
         /// @note "non-important" labels may not show on screen if the loading process went so fast
         /// that the implementation decided not to show a loading screen at all. "important" labels
         /// will show in a separate message-box if the loading screen was not shown.
-        virtual void setLabel (const std::string& label, bool important=false) {}
+        virtual void setLabel (const std::string& label, bool important=false, bool center=false) {}
 
         /// Start a loading sequence. Must call loadingOff() when done.
         /// @note To get the loading screen to actually update, you must call setProgress / increaseProgress periodically.


### PR DESCRIPTION
Fixes [bug #4691](https://gitlab.com/OpenMW/openmw/issues/4691).
The approach is very simple:
1. Check if there are active messageboxes on the screen.
2. If yes, place loading bar to center of screen instead of bottom.

Affects both save process and cell change process.