### PR TITLE
Minor tweaks for actors processing range setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@
     Feature #4632: AI priority: utilize vanilla AI GMSTs for priority rating
     Feature #4636: Use sTo GMST in spellmaking menu
     Feature #4642: Batching potion creation
+    Feature #4647: Cull actors outside of AI processing range
     Feature #4682: Use the collision box from basic creature mesh if the X one have no collisions
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -17,6 +17,7 @@
 #include "../mwworld/ptr.hpp"
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/statemanager.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/dialoguemanager.hpp"
@@ -437,6 +438,10 @@ namespace MWMechanics
         {
             if (it->first == "Game" && it->second == "actors processing range")
             {
+                int state = MWBase::Environment::get().getStateManager()->getState();
+                if (state != MWBase::StateManager::State_Running)
+                    continue;
+
                 mActors.updateProcessingRange();
 
                 // Update mechanics for new processing range immediately

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -75,7 +75,7 @@
                 </Widget>
                 <Widget type="Widget" skin="" position="4 184 352 54" align="Left Top HStretch">
                     <Widget type="TextBox" skin="NormalText" position="0 0 352 16" align="Left Top" name="ActorProcessingText">
-                        <Property key="Caption" value="Actors processing range"/>
+                        <Property key="Caption" value="Actors Processing Range"/>
                     </Widget>
                     <Widget type="MWScrollBar" skin="MW_HScroll" position="0 20 352 14" align="Left Top HStretch">
                         <Property key="Range" value="3584"/>
@@ -87,7 +87,7 @@
                         <UserString key="SettingMin" value="3584"/>
                         <UserString key="SettingMax" value="7168"/>
                         <UserString key="SettingLabelWidget" value="ActorProcessingText"/>
-                        <UserString key="SettingLabelCaption" value="Actors processing range"/>
+                        <UserString key="SettingLabelCaption" value="Actors Processing Range"/>
                     </Widget>
                     <Widget type="TextBox" skin="SandText" position="0 38 352 16" align="Left Top">
                         <Property key="Caption" value="#{sLow}"/>
@@ -224,7 +224,7 @@
                     </Widget>
                 </Widget>
                 <Widget type="TextBox" skin="NormalText" position="4 254 336 18" align="Left Bottom">
-                    <Property key="Caption" value="Camera sensitivity"/>
+                    <Property key="Caption" value="Camera Sensitivity"/>
                 </Widget>
                 <Widget type="MWScrollBar" skin="MW_HScroll" position="4 278 336 18" align="HStretch Bottom">
                     <Property key="Range" value="10000"/>


### PR DESCRIPTION
As @Capostrophic suggested:
1. Capitalize slider text
2. Add missing changelog entry

Also do not update actors if the game is not actually running.