### PR TITLE
Clean up redundant getClass() calls in classes

### DIFF
--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -301,7 +301,7 @@ namespace MWClass
             return std::make_pair(0, "#{sInventoryMessage1}");
 
         // slots that this item can be equipped in
-        std::pair<std::vector<int>, bool> slots_ = ptr.getClass().getEquipmentSlots(ptr);
+        std::pair<std::vector<int>, bool> slots_ = getEquipmentSlots(ptr);
 
         if (slots_.first.empty())
             return std::make_pair(0, "");

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -215,7 +215,7 @@ namespace MWClass
     std::pair<int, std::string> Clothing::canBeEquipped(const MWWorld::ConstPtr &ptr, const MWWorld::Ptr &npc) const
     {
         // slots that this item can be equipped in
-        std::pair<std::vector<int>, bool> slots_ = ptr.getClass().getEquipmentSlots(ptr);
+        std::pair<std::vector<int>, bool> slots_ = getEquipmentSlots(ptr);
 
         if (slots_.first.empty())
             return std::make_pair(0, "");

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -137,7 +137,7 @@ namespace MWClass
 
             // Persistent actors with 0 health do not play death animation
             if (data->mCreatureStats.isDead())
-                data->mCreatureStats.setDeathAnimationFinished(ptr.getClass().isPersistent(ptr));
+                data->mCreatureStats.setDeathAnimationFinished(isPersistent(ptr));
 
             // spells
             for (std::vector<std::string>::const_iterator iter (ref->mBase->mSpells.mList.begin());
@@ -194,9 +194,9 @@ namespace MWClass
             models.push_back(model);
 
         // FIXME: use const version of InventoryStore functions once they are available
-        if (ptr.getClass().hasInventoryStore(ptr))
+        if (hasInventoryStore(ptr))
         {
-            const MWWorld::InventoryStore& invStore = ptr.getClass().getInventoryStore(ptr);
+            const MWWorld::InventoryStore& invStore = getInventoryStore(ptr);
             for (int slot = 0; slot < MWWorld::InventoryStore::Slots; ++slot)
             {
                 MWWorld::ConstContainerStoreIterator equipped = invStore.getSlot(slot);
@@ -237,7 +237,7 @@ namespace MWClass
 
         // Get the weapon used (if hand-to-hand, weapon = inv.end())
         MWWorld::Ptr weapon;
-        if (ptr.getClass().hasInventoryStore(ptr))
+        if (hasInventoryStore(ptr))
         {
             MWWorld::InventoryStore &inv = getInventoryStore(ptr);
             MWWorld::ContainerStoreIterator weaponslot = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
@@ -253,8 +253,7 @@ namespace MWClass
 
         // For AI actors, get combat targets to use in the ray cast. Only those targets will return a positive hit result.
         std::vector<MWWorld::Ptr> targetActors;
-        if (!ptr.isEmpty() && ptr.getClass().isActor())
-            ptr.getClass().getCreatureStats(ptr).getAiSequence().getCombatTargets(targetActors);
+        stats.getAiSequence().getCombatTargets(targetActors);
 
         std::pair<MWWorld::Ptr, osg::Vec3f> result = MWBase::Environment::get().getWorld()->getHitContact(ptr, dist, targetActors);
         if (result.first.isEmpty())
@@ -332,7 +331,7 @@ namespace MWClass
 
     void Creature::onHit(const MWWorld::Ptr &ptr, float damage, bool ishealth, const MWWorld::Ptr &object, const MWWorld::Ptr &attacker, const osg::Vec3f &hitPosition, bool successful) const
     {
-        MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+        MWMechanics::CreatureStats& stats = getCreatureStats(ptr);
 
         // NOTE: 'object' and/or 'attacker' may be empty.        
         if (!attacker.isEmpty() && attacker.getClass().isActor() && !stats.getAiSequence().isInCombat(attacker))
@@ -346,7 +345,7 @@ namespace MWClass
             setOnPcHitMe = MWBase::Environment::get().getMechanicsManager()->actorAttacked(ptr, attacker);
 
         // Attacker and target store each other as hitattemptactor if they have no one stored yet
-        if (!attacker.isEmpty() && attacker.getClass().isActor() && !ptr.isEmpty() && ptr.getClass().isActor())
+        if (!attacker.isEmpty() && attacker.getClass().isActor())
         {
             MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
             // First handle the attacked actor
@@ -522,7 +521,7 @@ namespace MWClass
         const MWBase::World *world = MWBase::Environment::get().getWorld();
         const MWMechanics::MagicEffects &mageffects = stats.getMagicEffects();
 
-        bool running = ptr.getClass().getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Run);
+        bool running = stats.getStance(MWMechanics::CreatureStats::Stance_Run);
 
         // The Run speed difference for creatures comes from the animation speed difference (see runStateToWalkState in character.cpp)
         float runSpeed = walkSpeed;
@@ -808,7 +807,7 @@ namespace MWClass
 
     void Creature::respawn(const MWWorld::Ptr &ptr) const
     {
-        const MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
+        const MWMechanics::CreatureStats& creatureStats = getCreatureStats(ptr);
         if (ptr.getRefData().getCount() > 0 && !creatureStats.isDead())
             return;
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -357,7 +357,7 @@ namespace MWClass
 
             // Persistent actors with 0 health do not play death animation
             if (data->mNpcStats.isDead())
-                data->mNpcStats.setDeathAnimationFinished(ptr.getClass().isPersistent(ptr));
+                data->mNpcStats.setDeathAnimationFinished(isPersistent(ptr));
 
             // race powers
             const ESM::Race *race = MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(ref->mBase->mRace);
@@ -469,41 +469,38 @@ namespace MWClass
 
         // FIXME: use const version of InventoryStore functions once they are available
         // preload equipped items
-        if (ptr.getClass().hasInventoryStore(ptr))
+        const MWWorld::InventoryStore& invStore = getInventoryStore(ptr);
+        for (int slot = 0; slot < MWWorld::InventoryStore::Slots; ++slot)
         {
-            const MWWorld::InventoryStore& invStore = ptr.getClass().getInventoryStore(ptr);
-            for (int slot = 0; slot < MWWorld::InventoryStore::Slots; ++slot)
+            MWWorld::ConstContainerStoreIterator equipped = invStore.getSlot(slot);
+            if (equipped != invStore.end())
             {
-                MWWorld::ConstContainerStoreIterator equipped = invStore.getSlot(slot);
-                if (equipped != invStore.end())
+                std::vector<ESM::PartReference> parts;
+                if(equipped->getTypeName() == typeid(ESM::Clothing).name())
                 {
-                    std::vector<ESM::PartReference> parts;
-                    if(equipped->getTypeName() == typeid(ESM::Clothing).name())
-                    {
-                        const ESM::Clothing *clothes = equipped->get<ESM::Clothing>()->mBase;
-                        parts = clothes->mParts.mParts;
-                    }
-                    else if(equipped->getTypeName() == typeid(ESM::Armor).name())
-                    {
-                        const ESM::Armor *armor = equipped->get<ESM::Armor>()->mBase;
-                        parts = armor->mParts.mParts;
-                    }
-                    else
-                    {
-                        std::string model = equipped->getClass().getModel(*equipped);
-                        if (!model.empty())
-                            models.push_back(model);
-                    }
+                    const ESM::Clothing *clothes = equipped->get<ESM::Clothing>()->mBase;
+                    parts = clothes->mParts.mParts;
+                }
+                else if(equipped->getTypeName() == typeid(ESM::Armor).name())
+                {
+                    const ESM::Armor *armor = equipped->get<ESM::Armor>()->mBase;
+                    parts = armor->mParts.mParts;
+                }
+                else
+                {
+                    std::string model = equipped->getClass().getModel(*equipped);
+                    if (!model.empty())
+                        models.push_back(model);
+                }
 
-                    for (std::vector<ESM::PartReference>::const_iterator it = parts.begin(); it != parts.end(); ++it)
-                    {
-                        std::string partname = female ? it->mFemale : it->mMale;
-                        if (partname.empty())
-                            partname = female ? it->mMale : it->mFemale;
-                        const ESM::BodyPart* part = MWBase::Environment::get().getWorld()->getStore().get<ESM::BodyPart>().search(partname);
-                        if (part && !part->mModel.empty())
-                            models.push_back("meshes/"+part->mModel);
-                    }
+                for (std::vector<ESM::PartReference>::const_iterator it = parts.begin(); it != parts.end(); ++it)
+                {
+                    std::string partname = female ? it->mFemale : it->mMale;
+                    if (partname.empty())
+                        partname = female ? it->mMale : it->mFemale;
+                    const ESM::BodyPart* part = MWBase::Environment::get().getWorld()->getStore().get<ESM::BodyPart>().search(partname);
+                    if (part && !part->mModel.empty())
+                        models.push_back("meshes/"+part->mModel);
                 }
             }
         }
@@ -573,8 +570,8 @@ namespace MWClass
 
         // For AI actors, get combat targets to use in the ray cast. Only those targets will return a positive hit result.
         std::vector<MWWorld::Ptr> targetActors;
-        if (!ptr.isEmpty() && ptr.getClass().isActor() && ptr != MWMechanics::getPlayer())
-            ptr.getClass().getCreatureStats(ptr).getAiSequence().getCombatTargets(targetActors);
+        if (ptr != MWMechanics::getPlayer())
+            getCreatureStats(ptr).getAiSequence().getCombatTargets(targetActors);
 
         // TODO: Use second to work out the hit angle
         std::pair<MWWorld::Ptr, osg::Vec3f> result = world->getHitContact(ptr, dist, targetActors);
@@ -597,7 +594,7 @@ namespace MWClass
         if(!weapon.isEmpty())
             weapskill = weapon.getClass().getEquipmentSkill(weapon);
 
-        float hitchance = MWMechanics::getHitChance(ptr, victim, ptr.getClass().getSkill(ptr, weapskill));
+        float hitchance = MWMechanics::getHitChance(ptr, victim, getSkill(ptr, weapskill));
 
         if (Misc::Rng::roll0to99() >= hitchance)
         {
@@ -667,7 +664,7 @@ namespace MWClass
     void Npc::onHit(const MWWorld::Ptr &ptr, float damage, bool ishealth, const MWWorld::Ptr &object, const MWWorld::Ptr &attacker, const osg::Vec3f &hitPosition, bool successful) const
     {
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-        MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+        MWMechanics::CreatureStats& stats = getCreatureStats(ptr);
         bool wasDead = stats.isDead();
 
         // Note OnPcHitMe is not set for friendly hits.
@@ -681,7 +678,7 @@ namespace MWClass
         }
 
         // Attacker and target store each other as hitattemptactor if they have no one stored yet
-        if (!attacker.isEmpty() && attacker.getClass().isActor() && !ptr.isEmpty() && ptr.getClass().isActor())
+        if (!attacker.isEmpty() && attacker.getClass().isActor())
         {
             MWMechanics::CreatureStats& statsAttacker = attacker.getClass().getCreatureStats(attacker);
             // First handle the attacked actor
@@ -702,7 +699,7 @@ namespace MWClass
 
         if (setOnPcHitMe && !attacker.isEmpty() && attacker == MWMechanics::getPlayer())
         {
-            const std::string &script = ptr.getClass().getScript(ptr);
+            const std::string &script = getScript(ptr);
             /* Set the OnPCHitMe script variable. The script is responsible for clearing it. */
             if(!script.empty())
                 ptr.getRefData().getLocals().setVarByInt(script, "onpchitme", 1);
@@ -891,12 +888,11 @@ namespace MWClass
         if(stats.getAiSequence().isInCombat())
             return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
 
-        if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak)
-            || ptr.getClass().getCreatureStats(ptr).getKnockedDown())
+        if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak) || stats.getKnockedDown())
             return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
 
         // Can't talk to werewolfs
-        if(ptr.getClass().isNpc() && ptr.getClass().getNpcStats(ptr).isWerewolf())
+        if(getNpcStats(ptr).isWerewolf())
             return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
 
         return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
@@ -927,7 +923,7 @@ namespace MWClass
 
     float Npc::getSpeed(const MWWorld::Ptr& ptr) const
     {
-        const MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+        const MWMechanics::CreatureStats& stats = getCreatureStats(ptr);
         if (stats.isParalyzed() || stats.getKnockedDown() || stats.isDead())
             return 0.f;
 
@@ -993,7 +989,7 @@ namespace MWClass
         if(getEncumbrance(ptr) > getCapacity(ptr))
             return 0.f;
 
-        const MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+        const MWMechanics::CreatureStats& stats = getCreatureStats(ptr);
         if (stats.isParalyzed() || stats.getKnockedDown() || stats.isDead())
             return 0.f;
 
@@ -1213,13 +1209,13 @@ namespace MWClass
                 return (name == "left") ? "FootWaterLeft" : "FootWaterRight";
             if(world->isOnGround(ptr))
             {
-                if (ptr.getClass().getNpcStats(ptr).isWerewolf()
-                        && ptr.getClass().getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Run))
+                if (getNpcStats(ptr).isWerewolf()
+                        && getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Run))
                 {
                     MWMechanics::WeaponType weaponType = MWMechanics::WeapType_None;
-                    MWMechanics::getActiveWeapon(ptr.getClass().getCreatureStats(ptr), ptr.getClass().getInventoryStore(ptr), &weaponType);
+                    MWMechanics::getActiveWeapon(getCreatureStats(ptr), getInventoryStore(ptr), &weaponType);
                     if (weaponType == MWMechanics::WeapType_None)
-                        return "";
+                        return std::string();
                 }
 
                 const MWWorld::InventoryStore &inv = Npc::getInventoryStore(ptr);
@@ -1237,12 +1233,12 @@ namespace MWClass
                         return (name == "left") ? "FootHeavyLeft" : "FootHeavyRight";
                 }
             }
-            return "";
+            return std::string();
         }
 
         // Morrowind ignores land soundgen for NPCs
         if(name == "land")
-            return "";
+            return std::string();
         if(name == "swimleft")
             return "Swim Left";
         if(name == "swimright")
@@ -1252,11 +1248,11 @@ namespace MWClass
         // only for biped creatures?
 
         if(name == "moan")
-            return "";
+            return std::string();
         if(name == "roar")
-            return "";
+            return std::string();
         if(name == "scream")
-            return "";
+            return std::string();
 
         throw std::runtime_error(std::string("Unexpected soundgen type: ")+name);
     }
@@ -1270,7 +1266,7 @@ namespace MWClass
 
     int Npc::getSkill(const MWWorld::Ptr& ptr, int skill) const
     {
-        return ptr.getClass().getNpcStats(ptr).getSkill(skill).getModified();
+        return getNpcStats(ptr).getSkill(skill).getModified();
     }
 
     int Npc::getBloodTexture(const MWWorld::ConstPtr &ptr) const
@@ -1352,7 +1348,7 @@ namespace MWClass
 
     void Npc::respawn(const MWWorld::Ptr &ptr) const
     {
-        const MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
+        const MWMechanics::CreatureStats& creatureStats = getCreatureStats(ptr);
         if (ptr.getRefData().getCount() > 0 && !creatureStats.isDead())
             return;
 

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -391,7 +391,7 @@ namespace MWClass
             && MWBase::Environment::get().getWindowManager()->isGuiMode())
             return std::make_pair(0, "#{sCantEquipWeapWarning}");
 
-        std::pair<std::vector<int>, bool> slots_ = ptr.getClass().getEquipmentSlots(ptr);
+        std::pair<std::vector<int>, bool> slots_ = getEquipmentSlots(ptr);
 
         if (slots_.first.empty())
             return std::make_pair (0, "");


### PR DESCRIPTION
In lion's share of cases this must not be necessary because we already know what the class is. It makes no sense to make calls like `ptr1.getClass().doSomething(ptr2)` or `ptr.getClass().doSomething(nullptr)` elsewhere (not in the class itself), so we effectivelly make calls to the functions that are already present in the very same class. It especially not very useful to make such calls if we already made calls to stuff that would throw an exception if the input is invalid earlier.

So, for example, NPCs always have inventory store and there's no need to check for that since the relevant function will always return true.