### PR TITLE
Use the real thrown weapon damage in tooltips and AI (feature #4697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@
     Feature #4642: Batching potion creation
     Feature #4647: Cull actors outside of AI processing range
     Feature #4682: Use the collision box from basic creature mesh if the X one have no collisions
+    Feature #4697: Use the real thrown weapon damage in tooltips and AI
     Task #2490: Don't open command prompt window on Release-mode builds automatically
     Task #4545: Enable is_pod string test
     Task #4605: Optimize skinning

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -265,7 +265,7 @@ namespace MWClass
         std::string text;
 
         // weapon type & damage
-        if ((ref->mBase->mData.mType < 12 || Settings::Manager::getBool("show projectile damage", "Game")) && ref->mBase->mData.mType < 14)
+        if ((ref->mBase->mData.mType < ESM::Weapon::Arrow || Settings::Manager::getBool("show projectile damage", "Game")) && ref->mBase->mData.mType <= ESM::Weapon::Bolt)
         {
             text += "\n#{sType} ";
 
@@ -295,7 +295,15 @@ namespace MWClass
                 ((oneOrTwoHanded != "") ? ", " + store.get<ESM::GameSetting>().find(oneOrTwoHanded)->mValue.getString() : "");
 
             // weapon damage
-            if (ref->mBase->mData.mType >= 9)
+            if (ref->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+            {
+                // Thrown weapons have 2x real damage applied
+                // as they're both the weapon and the ammo
+                text += "\n#{sAttack}: "
+                    + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[0] * 2))
+                    + " - " + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[1] * 2));
+            }
+            else if (ref->mBase->mData.mType >= ESM::Weapon::MarksmanBow)
             {
                 // marksman
                 text += "\n#{sAttack}: "

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -58,8 +58,16 @@ namespace MWMechanics
         }
 
         const float chop = (weapon->mData.mChop[0] + weapon->mData.mChop[1]) / 2.f;
-        if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
+        // We need to account for the fact that thrown weapons have 2x real damage applied to the target
+        // as they're both the weapon and the ammo of the hit
+        if (weapon->mData.mType == ESM::Weapon::MarksmanThrown)
+        {
+            rating = chop * 2;
+        }
+        else if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
+        {
             rating = chop;
+        }
         else
         {
             const float slash = (weapon->mData.mSlash[0] + weapon->mData.mSlash[1]) / 2.f;


### PR DESCRIPTION
[Feature #4697](https://gitlab.com/OpenMW/openmw/issues/4697)

This doubles the damage of thrown weapons for the base weapon rating and in tooltips like what happens in projectileHit - thrown weapons are both the weapon and the ammo of an attack so their damage is effectively applied twice.