### PR TITLE
[Regression] Make sure we reset current weapon animation when resurrect actor

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2523,6 +2523,7 @@ void CharacterController::resurrect()
         mAnimation->disable(mCurrentDeath);
     mCurrentDeath.clear();
     mDeathState = CharState_None;
+    mWeaponType = WeapType_None;
 }
 
 void CharacterController::updateContinuousVfx()


### PR DESCRIPTION
Not sure how to treat this bug.

Technically, it is a part of [bug #2626](https://gitlab.com/OpenMW/openmw/issues/2626) (which is claimed fixed in the 0.45), but we also have a separate [bugreport](https://gitlab.com/OpenMW/openmw/issues/4698) for it.
So I suggest to do not add a separate changelog entry and close the bug 4698 once this PR will be merged.

Note: player will play equipping animation after resurrection if the weapon was drawn. In the Morrowind behaviour is the same.