### PR TITLE
Ensure different Boost versions get different names

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -328,7 +328,7 @@ if [ -z $SKIP_DOWNLOAD ]; then
 	if [ -z $APPVEYOR ]; then
 		download "Boost 1.67.0" \
 			"https://sourceforge.net/projects/boost/files/boost-binaries/1.67.0/boost_1_67_0-msvc-${MSVC_VER}-${BITS}.exe" \
-			"boost-1.67.0-msvc${MSVC_YEAR}-win${BITS}.exe"
+			"boost-1.67.0-msvc${MSVC_VER}-win${BITS}.exe"
 	fi
 
 	# Bullet
@@ -434,7 +434,7 @@ fi
 			rm -rf Boost
 			CI_EXTRA_INNO_OPTIONS=""
 			[ -n "$CI" ] && CI_EXTRA_INNO_OPTIONS="//SUPPRESSMSGBOXES //LOG='boost_install.log'"
-			"${DEPS}/boost-1.67.0-msvc${MSVC_YEAR}-win${BITS}.exe" //DIR="${CWD_DRIVE_ROOT}" //VERYSILENT //NORESTART ${CI_EXTRA_INNO_OPTIONS}
+			"${DEPS}/boost-1.67.0-msvc${MSVC_VER}-win${BITS}.exe" //DIR="${CWD_DRIVE_ROOT}" //VERYSILENT //NORESTART ${CI_EXTRA_INNO_OPTIONS}
 			mv "${CWD_DRIVE_ROOT_BASH}" "${BOOST_SDK}"
 		fi
 		add_cmake_opts -DBOOST_ROOT="$BOOST_SDK" \


### PR DESCRIPTION
If, like me, someone has separate VS2017 and VS2015 OpenMW builds, the change to Boost 1.67 accidentally made them share the same Boost installer, which would break one build when the user eventually got around to updating it. This ensures different files get different names again.

It was silly of Microsoft to give VC 14.0 (which comes with VS 2015) and VC 14.1 (which comes with VS 2017) both the year 2015, though. They shouldn't have done that.