### PR TITLE
Fix isWithinMaxRange function in AiTravel [0.45.0 regression]

### DIFF
--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -22,7 +22,7 @@ bool isWithinMaxRange(const osg::Vec3f& pos1, const osg::Vec3f& pos2)
     // Maximum travel distance for vanilla compatibility.
     // Was likely meant to prevent NPCs walking into non-loaded exterior cells, but for some reason is used in interior cells as well.
     // We can make this configurable at some point, but the default *must* be the below value. Anything else will break shoddily-written content (*cough* MW *cough*) in bizarre ways.
-    bool aiDistance = MWBase::Environment::get().getMechanicsManager()->getActorsProcessingRange();
+    float aiDistance = MWBase::Environment::get().getMechanicsManager()->getActorsProcessingRange();
     return (pos1 - pos2).length2() <= aiDistance*aiDistance;
 }
 


### PR DESCRIPTION
This fixes the major problem brought in (surprisingly) by actor processing optimization and not recastnavigation introduction: AiTravel is completely broken.

isWithinMaxRange was using incorrect type for AI processing range so it almost always returned false, breaking AiTravel. JDGBOLT discovered this.

This should be cherry-picked to 0.45.0 branch. I wanted to make some cleanup but it was too specific to recastnavigation pathfinding.