### PR TITLE
Use default tolerance to drop last point from path

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -173,7 +173,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
 
     const auto pointTolerance = std::min(actor.getClass().getSpeed(actor), DEFAULT_TOLERANCE);
 
-    mPathFinder.update(position, pointTolerance, destTolerance);
+    mPathFinder.update(position, pointTolerance, DEFAULT_TOLERANCE);
 
     if (isDestReached || mPathFinder.checkPathCompleted()) // if path is finished
     {


### PR DESCRIPTION
Fixes AiEscort. Before actor tried to reach target with 0 tolerance.
Back to logic like it was before 4fe764c3a53 and bbd82a743 commits.