### PR TITLE
Include missing Windows header before calling Windows-specific functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,7 +614,6 @@ if (WIN32)
     if (BUILD_OPENMW)
         # Release builds don't use the debug console
         set_target_properties(openmw PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-        set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS $<$<CONFIG:Release>:_WINDOWS>)
         set_target_properties(openmw PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ if (APPLE)
 endif (APPLE)
 
 # Set up DEBUG define
-set_directory_properties(PROPERTIES COMPILE_DEFINITIONS_DEBUG DEBUG=1)
+set_directory_properties(PROPERTIES COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG=1>)
 
 if (NOT APPLE)
     set(OPENMW_MYGUI_FILES_ROOT ${OpenMW_BINARY_DIR})
@@ -607,7 +607,7 @@ if (WIN32)
     if (USE_DEBUG_CONSOLE AND BUILD_OPENMW)
       set_target_properties(openmw PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
       set_target_properties(openmw PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/SUBSYSTEM:CONSOLE")
-      set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS_DEBUG "_CONSOLE")
+      set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS $<$<CONFIG:Debug>:_CONSOLE>)
     elseif (BUILD_OPENMW)
       # Turn off debug console, debug output will be written to visual studio output instead
       set_target_properties(openmw PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:WINDOWS")
@@ -617,7 +617,7 @@ if (WIN32)
     if (BUILD_OPENMW)
         # Release builds don't use the debug console
         set_target_properties(openmw PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-        set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS_RELEASE "_WINDOWS")
+        set_target_properties(openmw PROPERTIES COMPILE_DEFINITIONS $<$<CONFIG:Release>:_WINDOWS>)
         set_target_properties(openmw PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,9 +275,6 @@ if (APPLE)
         "${APP_BUNDLE_DIR}/Contents/Resources/OpenMW.icns" COPYONLY)
 endif (APPLE)
 
-# Set up DEBUG define
-set_directory_properties(PROPERTIES COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG=1>)
-
 if (NOT APPLE)
     set(OPENMW_MYGUI_FILES_ROOT ${OpenMW_BINARY_DIR})
     set(OPENMW_SHADERS_ROOT ${OpenMW_BINARY_DIR})

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -7,7 +7,6 @@
 #include "engine.hpp"
 
 #if defined(_WIN32)
-// For OutputDebugString
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/components/debug/debugging.hpp
+++ b/components/debug/debugging.hpp
@@ -44,6 +44,10 @@ namespace Debug
     };
 
 #if defined(_WIN32) && defined(_DEBUG)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif // !WIN32_LEAN_AND_MEAN
+#include <Windows.h>
     class DebugOutput : public DebugOutputBase
     {
     public:


### PR DESCRIPTION
https://github.com/OpenMW/openmw/commit/d19839a66670f4410ebf97e7dcd42f1c89300114 bumped the minimum CMake version on Windows, but Windows relied on the old behaviour of CMP0043, which this switched to new. This PR switches the broken calls to use their new forms.

https://github.com/OpenMW/openmw/blob/master/components/debug/debugging.hpp#L55 calls a Windows function, but at some point, an indirect include must have changed, as it's no longer there. This restores the include, making the function available.