### PR TITLE
Improve toggleactorspaths console command

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -607,6 +607,8 @@ namespace MWBase
             virtual void updateActorPath(const MWWorld::ConstPtr& actor, const std::deque<osg::Vec3f>& path,
                     const osg::Vec3f& halfExtents, const osg::Vec3f& start, const osg::Vec3f& end) const = 0;
 
+            virtual void removeActorPath(const MWWorld::ConstPtr& actor) const = 0;
+
             virtual void setNavMeshNumberToRender(const std::size_t value) = 0;
     };
 }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1603,6 +1603,7 @@ namespace MWMechanics
                     continue;
             }
 
+            MWBase::Environment::get().getWorld()->removeActorPath(iter->first);
             CharacterController::KillResult killResult = iter->second->getCharacterController()->kill();
             if (killResult == CharacterController::Result_DeathAnimStarted)
             {

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -104,10 +104,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
     const osg::Vec3f position = actor.getRefData().getPosition().asVec3(); //position of the actor
     MWBase::World* world = MWBase::Environment::get().getWorld();
 
-    {
-        const osg::Vec3f halfExtents = world->getHalfExtents(actor);
-        world->updateActorPath(actor, mPathFinder.getPath(), halfExtents, position, dest);
-    }
+    const osg::Vec3f halfExtents = world->getHalfExtents(actor);
 
     /// Stops the actor when it gets too close to a unloaded cell
     //... At current time, this test is unnecessary. AI shuts down when actor is more than "actors processing range" setting value
@@ -116,6 +113,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
     if (isNearInactiveCell(position))
     {
         actor.getClass().getMovementSettings(actor).mPosition[1] = 0;
+        world->updateActorPath(actor, mPathFinder.getPath(), halfExtents, position, dest);
         return false;
     }
 
@@ -180,8 +178,11 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
         // turn to destination point
         zTurn(actor, getZAngleToPoint(position, dest));
         smoothTurn(actor, getXAngleToPoint(position, dest), 0);
+        world->removeActorPath(actor);
         return true;
     }
+
+    world->updateActorPath(actor, mPathFinder.getPath(), halfExtents, position, dest);
 
     if (mRotateOnTheRunChecks == 0
         || isReachableRotatingOnTheRun(actor, *mPathFinder.getPath().begin())) // to prevent circling around a path point

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3790,6 +3790,11 @@ namespace MWWorld
         mRendering->updateActorPath(actor, path, halfExtents, start, end);
     }
 
+    void World::removeActorPath(const MWWorld::ConstPtr& actor) const
+    {
+        mRendering->removeActorPath(actor);
+    }
+
     void World::setNavMeshNumberToRender(const std::size_t value)
     {
         mRendering->setNavMeshNumber(value);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -709,6 +709,8 @@ namespace MWWorld
             void updateActorPath(const MWWorld::ConstPtr& actor, const std::deque<osg::Vec3f>& path,
                     const osg::Vec3f& halfExtents, const osg::Vec3f& start, const osg::Vec3f& end) const override;
 
+            void removeActorPath(const MWWorld::ConstPtr& actor) const override;
+
             void setNavMeshNumberToRender(const std::size_t value) override;
     };
 }

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -321,6 +321,7 @@ namespace Compiler
             extensions.registerInstruction ("tb", "", opcodeToggleBorders);
             extensions.registerInstruction ("toggleborders", "", opcodeToggleBorders);
             extensions.registerInstruction ("togglenavmesh", "", opcodeToggleNavMesh);
+            extensions.registerInstruction ("tap", "", opcodeToggleActorsPaths);
             extensions.registerInstruction ("toggleactorspaths", "", opcodeToggleActorsPaths);
             extensions.registerInstruction ("setnavmeshnumber", "l", opcodeSetNavMeshNumberToRender);
         }


### PR DESCRIPTION
Summary of changes:
1. Do not render paths for dead actors.
2. Do not render path, if an actor (a wandering one, for example) reached the destination, but with destination tolerance.
3. Add a "tap" shortcut for this command.