### PR TITLE
fix build with CI dependencies on all Cygwin derivatives

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -194,7 +194,11 @@ download() {
 }
 
 real_pwd() {
-	pwd | sed "s,/\(.\),\1:,"
+	if type cygpath >/dev/null 2>&1; then
+		cygpath -am "$PWD"
+	else
+		pwd # not git bash, Cygwin or the like
+	fi
 }
 
 CMAKE_OPTS=""


### PR DESCRIPTION
Note that "git bash" that's currently the only supported version, uses msys2 internally for many subcommands. msys2 itself being a Cygwin fork.

It's the fault of the `real_pwd` pattern. Given `cygpath` is available on all aforementioned Cygwin derivatives, let's use it.