### PR TITLE
Attempt to fix MSVC2015 C4503 warnings

### DIFF
--- a/components/detournavigator/navmeshtilescache.cpp
+++ b/components/detournavigator/navmeshtilescache.cpp
@@ -64,8 +64,8 @@ namespace DetourNavigator
             return Value();
 
         // TODO: use different function to make key to avoid unnecessary std::string allocation
-        const auto tile = tileValues->second.find(makeNavMeshKey(recastMesh, offMeshConnections));
-        if (tile == tileValues->second.end())
+        const auto tile = tileValues->second.Map.find(makeNavMeshKey(recastMesh, offMeshConnections));
+        if (tile == tileValues->second.Map.end())
             return Value();
 
         acquireItemUnsafe(tile->second);
@@ -98,7 +98,7 @@ namespace DetourNavigator
 
         const auto iterator = mFreeItems.emplace(mFreeItems.end(), agentHalfExtents, changedTile, navMeshKey);
         // TODO: use std::string_view or some alternative to avoid navMeshKey copy into both mFreeItems and mValues
-        const auto emplaced = mValues[agentHalfExtents][changedTile].emplace(navMeshKey, iterator);
+        const auto emplaced = mValues[agentHalfExtents][changedTile].Map.emplace(navMeshKey, iterator);
 
         if (!emplaced.second)
         {
@@ -127,15 +127,15 @@ namespace DetourNavigator
         if (tileValues == agentValues->second.end())
             return;
 
-        const auto value = tileValues->second.find(item.mNavMeshKey);
-        if (value == tileValues->second.end())
+        const auto value = tileValues->second.Map.find(item.mNavMeshKey);
+        if (value == tileValues->second.Map.end())
             return;
 
         mUsedNavMeshDataSize -= static_cast<std::size_t>(item.mNavMeshData.mSize) + item.mNavMeshKey.size();
         mFreeItems.pop_back();
 
-        tileValues->second.erase(value);
-        if (!tileValues->second.empty())
+        tileValues->second.Map.erase(value);
+        if (!tileValues->second.Map.empty())
             return;
 
         agentValues->second.erase(tileValues);

--- a/components/detournavigator/navmeshtilescache.hpp
+++ b/components/detournavigator/navmeshtilescache.hpp
@@ -108,13 +108,19 @@ namespace DetourNavigator
             NavMeshData&& value);
 
     private:
+
+        struct TileMap
+        {
+            std::map<std::string, ItemIterator> Map;
+        };
+
         std::mutex mMutex;
         std::size_t mMaxNavMeshDataSize;
         std::size_t mUsedNavMeshDataSize;
         std::size_t mFreeNavMeshDataSize;
         std::list<Item> mBusyItems;
         std::list<Item> mFreeItems;
-        std::map<osg::Vec3f, std::map<TilePosition, std::map<std::string, ItemIterator>>> mValues;
+        std::map<osg::Vec3f, std::map<TilePosition, TileMap>> mValues;
 
         void removeLeastRecentlyUsed();
 


### PR DESCRIPTION
MSVC2015 complains about the 
```
std::map<osg::Vec3f, std::map<TilePosition, std::map<std::string, ItemIterator>>> mValues;
``` 
declaration is too long. Let see if we can do something about it.

EDIT: looks like it works.