### PR TITLE
fix rain delay when exiting water

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.46.0
 ------
 
+    Bug #4540: Rain delay when exiting water
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Task #4686: Upgrade media decoder to a more current FFmpeg API

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -401,11 +401,15 @@ public:
     {
     }
 
-    virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
+    bool isUnderwater()
     {
         osg::Vec3f eyePoint = mCameraRelativeTransform->getLastEyePoint();
+        return mEnabled && eyePoint.z() < mWaterLevel;
+    }
 
-        if (mEnabled && eyePoint.z() < mWaterLevel)
+    virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
+    {
+        if (isUnderwater())
             return;
 
         traverse(node, nv);
@@ -1575,6 +1579,8 @@ void SkyManager::update(float duration)
             mRainIntensityUniform->set((float) mWeatherAlpha);
     }
 
+    switchUnderwaterRain();
+
     if (mIsStorm)
     {
         osg::Quat quat;
@@ -1624,6 +1630,15 @@ void SkyManager::updateRainParameters()
         mRainShooter->setVelocity(osg::Vec3f(0, mRainSpeed * windFactor, -mRainSpeed));
         mRainShooter->setAngle(angle);
     }
+}
+
+void SkyManager::switchUnderwaterRain()
+{
+    if (!mRainParticleSystem)
+        return;
+
+    bool freeze = mUnderwaterSwitch->isUnderwater();
+    mRainParticleSystem->setFrozen(freeze);
 }
 
 void SkyManager::setWeather(const WeatherResult& weather)

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -180,6 +180,7 @@ namespace MWRender
 
         void createRain();
         void destroyRain();
+        void switchUnderwaterRain();
         void updateRainParameters();
 
         Resource::SceneManager* mSceneManager;


### PR DESCRIPTION
This fixes [bug 4540](https://gitlab.com/OpenMW/openmw/issues/4540). I've documented own failed attempts in the commit message.

Rain bubbles touching the surface still work, rain doesn't display through the water, and it shows immediately upon exiting the water. I don't know about switching cells, the issue is likely to remain.

Note, I've had to disable culling due to how the osg particle system works. The rationale is that there's barely any detail underwater, and the lack of culling won't degrade performance in any significant manner.

For fixing cell switch I'd go for a hack like increasing particle count *and* velocity by some large factor so that there's already plenty of rain in a fraction of a second. Either that or introducing an artificial delay for rain to show.
