### PR TITLE
Recast global allocator

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -25,7 +25,7 @@
 
 #include <components/detournavigator/debug.hpp>
 #include <components/detournavigator/navigator.hpp>
-#include <components/detournavigator/debug.hpp>
+#include <components/detournavigator/recastglobalallocator.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/soundmanager.hpp"
@@ -230,6 +230,7 @@ namespace MWWorld
         if (Settings::Manager::getBool("enable log", "Navigator"))
             DetourNavigator::Log::instance().setSink(std::unique_ptr<DetourNavigator::FileSink>(
                 new DetourNavigator::FileSink(Settings::Manager::getString("log path", "Navigator"))));
+        DetourNavigator::RecastGlobalAllocator::init();
         mNavigator.reset(new DetourNavigator::Navigator(navigatorSettings));
 
         mRendering.reset(new MWRender::RenderingManager(viewer, rootNode, resourceSystem, workQueue, &mFallback, resourcePath, *mNavigator));

--- a/components/detournavigator/chunkytrimesh.hpp
+++ b/components/detournavigator/chunkytrimesh.hpp
@@ -50,8 +50,8 @@ namespace DetourNavigator
         ChunkyTriMesh& operator=(const ChunkyTriMesh&) = delete;
 
         /// Returns the chunk indices which overlap the input rectable.
-        template <class OutputIterator>
-        void getChunksOverlappingRect(const Rect& rect, OutputIterator out) const
+        template <class Function>
+        void forEachChunksOverlappingRect(const Rect& rect, Function&& function) const
         {
             // Traverse tree
             for (std::size_t i = 0; i < mNodes.size(); )
@@ -61,7 +61,7 @@ namespace DetourNavigator
                 const bool isLeafNode = node->mOffset >= 0;
 
                 if (isLeafNode && overlap)
-                    *out++ = i;
+                    function(i);
 
                 if (overlap || isLeafNode)
                     i++;

--- a/components/detournavigator/recastallocutils.hpp
+++ b/components/detournavigator/recastallocutils.hpp
@@ -1,0 +1,90 @@
+#ifndef OPENMW_COMPONENTS_DETOURNAVIGATOR_RECASTALLOCUTILS_H
+#define OPENMW_COMPONENTS_DETOURNAVIGATOR_RECASTALLOCUTILS_H
+
+#include <RecastAlloc.h>
+
+#include <cstdint>
+
+namespace DetourNavigator
+{
+    static_assert(sizeof(std::size_t) == sizeof(void*), "");
+
+    enum BufferType : std::size_t
+    {
+        BufferType_perm,
+        BufferType_temp,
+        BufferType_unused,
+    };
+
+    inline BufferType* tempPtrBufferType(void* ptr)
+    {
+        return reinterpret_cast<BufferType*>(static_cast<std::size_t*>(ptr) + 1);
+    }
+
+    inline BufferType getTempPtrBufferType(void* ptr)
+    {
+        return *tempPtrBufferType(ptr);
+    }
+
+    inline void setTempPtrBufferType(void* ptr, BufferType value)
+    {
+        *tempPtrBufferType(ptr) = value;
+    }
+
+    inline void** tempPtrPrev(void* ptr)
+    {
+        return static_cast<void**>(ptr);
+    }
+
+    inline void* getTempPtrPrev(void* ptr)
+    {
+        return *tempPtrPrev(ptr);
+    }
+
+    inline void setTempPtrPrev(void* ptr, void* value)
+    {
+        *tempPtrPrev(ptr) = value;
+    }
+
+    inline void* getTempPtrDataPtr(void* ptr)
+    {
+        return reinterpret_cast<void*>(static_cast<std::size_t*>(ptr) + 2);
+    }
+
+    inline BufferType* dataPtrBufferType(void* dataPtr)
+    {
+        return reinterpret_cast<BufferType*>(static_cast<std::size_t*>(dataPtr) - 1);
+    }
+
+    inline BufferType getDataPtrBufferType(void* dataPtr)
+    {
+        return *dataPtrBufferType(dataPtr);
+    }
+
+    inline void setDataPtrBufferType(void* dataPtr, BufferType value)
+    {
+        *dataPtrBufferType(dataPtr) = value;
+    }
+
+    inline void* getTempDataPtrStackPtr(void* dataPtr)
+    {
+        return static_cast<std::size_t*>(dataPtr) - 2;
+    }
+
+    inline void* getPermDataPtrHeapPtr(void* dataPtr)
+    {
+        return static_cast<std::size_t*>(dataPtr) - 1;
+    }
+
+    inline void setPermPtrBufferType(void* ptr, BufferType value)
+    {
+        *static_cast<BufferType*>(ptr) = value;
+    }
+
+    inline void* getPermPtrDataPtr(void* ptr)
+    {
+        return static_cast<std::size_t*>(ptr) + 1;
+    }
+}
+
+#endif

--- a/components/detournavigator/recastallocutils.hpp
+++ b/components/detournavigator/recastallocutils.hpp
@@ -85,6 +85,18 @@ namespace DetourNavigator
     {
         return static_cast<std::size_t*>(ptr) + 1;
     }
+
+    // TODO: use std::align
+    inline void* align(std::size_t align, std::size_t size, void*& ptr, std::size_t& space) noexcept
+    {
+        const auto intptr = reinterpret_cast<std::uintptr_t>(ptr);
+        const auto aligned = (intptr - 1u + align) & - align;
+        const auto diff = aligned - intptr;
+        if ((size + diff) > space)
+            return nullptr;
+        space -= diff;
+        return ptr = reinterpret_cast<void*>(aligned);
+    }
 }
 
 #endif

--- a/components/detournavigator/recastglobalallocator.hpp
+++ b/components/detournavigator/recastglobalallocator.hpp
@@ -1,0 +1,68 @@
+#ifndef OPENMW_COMPONENTS_DETOURNAVIGATOR_RECASTGLOBALALLOCATOR_H
+#define OPENMW_COMPONENTS_DETOURNAVIGATOR_RECASTGLOBALALLOCATOR_H
+
+#include "recasttempallocator.hpp"
+
+namespace DetourNavigator
+{
+    class RecastGlobalAllocator
+    {
+    public:
+        static void init()
+        {
+            instance();
+        }
+
+        static void* alloc(size_t size, rcAllocHint hint)
+        {
+            void* result = nullptr;
+            if (rcLikely(hint == RC_ALLOC_TEMP))
+                result = tempAllocator().alloc(size);
+            if (rcUnlikely(!result))
+                result = allocPerm(size);
+            return result;
+        }
+
+        static void free(void* ptr)
+        {
+            if (rcUnlikely(!ptr))
+                return;
+            if (rcLikely(BufferType_temp == getDataPtrBufferType(ptr)))
+                tempAllocator().free(ptr);
+            else
+            {
+                assert(BufferType_perm == getDataPtrBufferType(ptr));
+                ::free(getPermDataPtrHeapPtr(ptr));
+            }
+        }
+
+    private:
+        RecastGlobalAllocator()
+        {
+            rcAllocSetCustom(&RecastGlobalAllocator::alloc, &RecastGlobalAllocator::free);
+        }
+
+        static RecastGlobalAllocator& instance()
+        {
+            static RecastGlobalAllocator value;
+            return value;
+        }
+
+        static RecastTempAllocator& tempAllocator()
+        {
+            static thread_local RecastTempAllocator value(1024ul * 1024ul);
+            return value;
+        }
+
+        static void* allocPerm(size_t size)
+        {
+            const auto ptr = ::malloc(size + sizeof(std::size_t));
+            if (rcUnlikely(!ptr))
+                return ptr;
+            setPermPtrBufferType(ptr, BufferType_perm);
+            return getPermPtrDataPtr(ptr);
+        }
+    };
+}
+
+#endif

--- a/components/detournavigator/recasttempallocator.hpp
+++ b/components/detournavigator/recasttempallocator.hpp
@@ -1,0 +1,65 @@
+#ifndef OPENMW_COMPONENTS_DETOURNAVIGATOR_RECASTTEMPALLOCATOR_H
+#define OPENMW_COMPONENTS_DETOURNAVIGATOR_RECASTTEMPALLOCATOR_H
+
+#include "recastallocutils.hpp"
+
+#include <cassert>
+#include <memory>
+#include <vector>
+
+namespace DetourNavigator
+{
+    class RecastTempAllocator
+    {
+    public:
+        RecastTempAllocator(std::size_t capacity)
+            : mStack(capacity), mTop(mStack.data()), mPrev(nullptr)
+        {}
+
+        void* alloc(std::size_t size)
+        {
+            std::size_t space = mStack.size() - getUsedSize();
+            void* top = mTop;
+            const auto itemSize = 2 * sizeof(std::size_t) + size;
+            if (rcUnlikely(!std::align(sizeof(std::size_t), itemSize, top, space)))
+                return nullptr;
+            setTempPtrBufferType(top, BufferType_temp);
+            setTempPtrPrev(top, mPrev);
+            mTop = static_cast<char*>(top) + itemSize;
+            mPrev = static_cast<char*>(top);
+            return getTempPtrDataPtr(top);
+        }
+
+        void free(void* ptr)
+        {
+            if (rcUnlikely(!ptr))
+                return;
+            assert(BufferType_temp == getDataPtrBufferType(ptr));
+            if (!mPrev || getTempDataPtrStackPtr(ptr) != mPrev)
+            {
+                setDataPtrBufferType(ptr, BufferType_unused);
+                return;
+            }
+            mTop = getTempDataPtrStackPtr(ptr);
+            mPrev = getTempPtrPrev(mTop);
+            while (mPrev && BufferType_unused == getTempPtrBufferType(mPrev))
+            {
+                mTop = mPrev;
+                mPrev = getTempPtrPrev(mTop);
+            }
+            return;
+        }
+
+    private:
+        std::vector<char> mStack;
+        void* mTop;
+        void* mPrev;
+
+        std::size_t getUsedSize() const
+        {
+            return static_cast<std::size_t>(static_cast<char*>(mTop) - mStack.data());
+        }
+    };
+}
+
+#endif

--- a/components/detournavigator/recasttempallocator.hpp
+++ b/components/detournavigator/recasttempallocator.hpp
@@ -21,7 +21,7 @@ namespace DetourNavigator
             std::size_t space = mStack.size() - getUsedSize();
             void* top = mTop;
             const auto itemSize = 2 * sizeof(std::size_t) + size;
-            if (rcUnlikely(!std::align(sizeof(std::size_t), itemSize, top, space)))
+            if (rcUnlikely(!align(sizeof(std::size_t), itemSize, top, space)))
                 return nullptr;
             setTempPtrBufferType(top, BufferType_temp);
             setTempPtrPrev(top, mPrev);


### PR DESCRIPTION
To fix https://github.com/OpenMW/openmw/pull/1633#issuecomment-435601824 . Recastnavigation uses a lot of small vectors to perform internal calculations like [this](https://github.com/OpenMW/openmw/blob/d3633bbada6ec44c9e6dc3e04404a1438ce71afa/extern/recastnavigation/Recast/Source/RecastContour.cpp#L904) one. It has allocator function customization which supports different allocation policies: permanent and temporary. By default both of them use `malloc`. `rcIntArray` allocates using temporary policy. To reduce `malloc` calls all temporary allocations should use preallocated buffer. This pr set custom allocator for recastnavigation with stack allocator for temporary allocations.

Here is memory profiles to compare:

[openmw-45](https://github.com/OpenMW/openmw/commit/de381d0d49c702b8e52a5208cb783144aec53216) branch:
![openmw-45 summary](https://user-images.githubusercontent.com/764107/47967120-316ab780-e06b-11e8-8bb1-549547532248.png)
![openmw-45 allocated](https://user-images.githubusercontent.com/764107/47967122-362f6b80-e06b-11e8-8294-32381787cf2c.png)

[master](https://github.com/OpenMW/openmw/commit/d3633bbada6ec44c9e6dc3e04404a1438ce71afa) branch:
![master summary](https://user-images.githubusercontent.com/764107/47967137-49dad200-e06b-11e8-9a35-b17abdff621d.png)
![master allocated](https://user-images.githubusercontent.com/764107/47967142-52cba380-e06b-11e8-9c24-72e22d0d3096.png)

[this](https://github.com/OpenMW/openmw/commit/b477775e1602893c6586b0525ed104b1b383636e) pr:
![with_allocator summary](https://user-images.githubusercontent.com/764107/47967156-7393f900-e06b-11e8-8f08-a90523463b6c.png)
![with_allocator allocated](https://user-images.githubusercontent.com/764107/47967157-7858ad00-e06b-11e8-9d58-7f2d92e30922.png)