### PR TITLE
[WIP] prevent operating on invalidated iterators

### DIFF
--- a/apps/opencs/model/prefs/shortcutmanager.cpp
+++ b/apps/opencs/model/prefs/shortcutmanager.cpp
@@ -31,7 +31,7 @@ namespace CSMPrefs
         {
             if (it->second == shortcut)
             {
-                mShortcuts.erase(it++);
+                it = mShortcuts.erase(it);
             }
             else
             {

--- a/apps/openmw/mwmechanics/activespells.cpp
+++ b/apps/openmw/mwmechanics/activespells.cpp
@@ -246,7 +246,7 @@ namespace MWMechanics
             }
 
             if (Misc::Rng::roll0to99() < chance)
-                mSpells.erase(it++);
+                it = mSpells.erase(it);
             else
                 ++it;
         }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1240,7 +1240,7 @@ namespace MWMechanics
             if((iter->first.isInCell() && iter->first.getCell()==cellStore) && iter->first != ignore)
             {
                 delete iter->second;
-                mActors.erase(iter++);
+                iter = mActors.erase(iter);
             }
             else
                 ++iter;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1109,7 +1109,7 @@ namespace MWMechanics
                 itemCount -= toRemove;
                 ownerIt->second -= toRemove;
                 if (ownerIt->second == 0)
-                    owners.erase(ownerIt++);
+                    ownerIt = owners.erase(ownerIt);
                 else
                     ++ownerIt;
             }

--- a/apps/openmw/mwmechanics/objects.cpp
+++ b/apps/openmw/mwmechanics/objects.cpp
@@ -63,7 +63,7 @@ void Objects::dropObjects (const MWWorld::CellStore *cellStore)
         if(iter->first.getCell()==cellStore)
         {
             delete iter->second;
-            mObjects.erase(iter++);
+            iter = mObjects.erase(iter);
         }
         else
             ++iter;

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -226,7 +226,7 @@ namespace MWMechanics
             const ESM::Spell *spell = iter->first;
             if (spell->mData.mType == ESM::Spell::ST_Disease)
             {
-                mSpells.erase(iter++);
+                iter = mSpells.erase(iter);
                 mSpellsChanged = true;
             }
             else
@@ -241,7 +241,7 @@ namespace MWMechanics
             const ESM::Spell *spell = iter->first;
             if (spell->mData.mType == ESM::Spell::ST_Blight && !hasCorprusEffect(spell))
             {
-                mSpells.erase(iter++);
+                iter = mSpells.erase(iter);
                 mSpellsChanged = true;
             }
             else
@@ -256,7 +256,7 @@ namespace MWMechanics
             const ESM::Spell *spell = iter->first;
             if (hasCorprusEffect(spell))
             {
-                mSpells.erase(iter++);
+                iter = mSpells.erase(iter);
                 mSpellsChanged = true;
             }
             else
@@ -271,7 +271,7 @@ namespace MWMechanics
             const ESM::Spell *spell = iter->first;
             if (spell->mData.mType == ESM::Spell::ST_Curse)
             {
-                mSpells.erase(iter++);
+                iter = mSpells.erase(iter);
                 mSpellsChanged = true;
             }
             else

--- a/apps/openmw/mwmechanics/summoning.cpp
+++ b/apps/openmw/mwmechanics/summoning.cpp
@@ -93,7 +93,7 @@ namespace MWMechanics
             {
                 // Effect has ended
                 MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(mActor, it->second);
-                creatureMap.erase(it++);
+                it = creatureMap.erase(it);
                 continue;
             }
             ++it;
@@ -133,7 +133,7 @@ namespace MWMechanics
                     mActor.getClass().getInventoryStore(mActor).purgeEffect(it->first.first, it->first.second);
 
                 MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(mActor, it->second);
-                creatureMap.erase(it++);
+                it = creatureMap.erase(it);
             }
             else
                 ++it;

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -912,7 +912,7 @@ namespace MWRender
         while(stateiter != mStates.end())
         {
             if(stateiter->second.mPriority == priority)
-                mStates.erase(stateiter++);
+                stateiter = mStates.erase(stateiter);
             else
                 ++stateiter;
         }
@@ -1338,7 +1338,7 @@ namespace MWRender
 
             if(!state.mPlaying && state.mAutoDisable)
             {
-                mStates.erase(stateiter++);
+                stateiter = mStates.erase(stateiter);
 
                 resetActiveGroups();
             }

--- a/apps/openmw/mwrender/effectmanager.cpp
+++ b/apps/openmw/mwrender/effectmanager.cpp
@@ -65,7 +65,7 @@ void EffectManager::update(float dt)
         if (it->second.mAnimTime->getTime() >= it->second.mMaxControllerLength)
         {
             mParentNode->removeChild(it->first);
-            mEffects.erase(it++);
+            it = mEffects.erase(it);
         }
         else
             ++it;

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -157,7 +157,7 @@ void Objects::removeCell(const MWWorld::CellStore* store)
                 invStore.setContListener(nullptr);
             }
 
-            mObjects.erase(iter++);
+            iter = mObjects.erase(iter);
         }
         else
             ++iter;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -1061,7 +1061,7 @@ namespace MWSound
             {
                 mOutput->finishStream(sound);
                 mUnusedStreams.push_back(sound);
-                mActiveSaySounds.erase(sayiter++);
+                sayiter = mActiveSaySounds.erase(sayiter);
             }
             else
             {

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -301,7 +301,7 @@ namespace MWWorld
                 mUnrefQueue->push(it->second.mWorkItem);
             }
 
-            mPreloadCells.erase(it++);
+            it = mPreloadCells.erase(it);
         }
     }
 
@@ -316,7 +316,7 @@ namespace MWWorld
                     it->second.mWorkItem->abort();
                     mUnrefQueue->push(it->second.mWorkItem);
                 }
-                mPreloadCells.erase(it++);
+                it = mPreloadCells.erase(it);
             }
             else
                 ++it;

--- a/apps/openmw/mwworld/cellreflist.hpp
+++ b/apps/openmw/mwworld/cellreflist.hpp
@@ -36,7 +36,7 @@ namespace MWWorld
             for (typename List::iterator it = mList.begin(); it != mList.end();)
             {
                 if (*it == refNum)
-                    mList.erase(it++);
+                    it = mList.erase(it);
                 else
                     ++it;
             }

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -531,7 +531,7 @@ void MWWorld::ContainerStore::restock (const ESM::InventoryList& items, const MW
                 //Remove it, from shop,
                 remove(it->first.first, itemCount, ptr);//ptr is the NPC
                 //And remove it from map, so that when we restock, the new item will have proper parent.
-                mLevelledItemMap.erase(it++);
+                it = mLevelledItemMap.erase(it);
                 continue;
             }
             //Create the entry if it does not exist yet
@@ -543,7 +543,7 @@ void MWWorld::ContainerStore::restock (const ESM::InventoryList& items, const MW
         //If every of the item was sold
         else if (itemCount == 0)
         {
-            mLevelledItemMap.erase(it++);
+            it = mLevelledItemMap.erase(it);
             continue;
         }
         //If some was sold, but some remain

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -627,7 +627,7 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
             }
         }
         if (!found)
-            mPermanentMagicEffectMagnitudes.erase(it++);
+            it = mPermanentMagicEffectMagnitudes.erase(it);
         else
             ++it;
     }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1601,7 +1601,7 @@ namespace MWWorld
                 // The door is no longer in an active cell, or it was disabled.
                 // Erase from mDoorStates, since we no longer need to move it.
                 // Once we load the door's cell again (or re-enable the door), Door::insertObject will reinsert to mDoorStates.
-                mDoorStates.erase(it++);
+                it = mDoorStates.erase(it);
             }
             else
             {
@@ -1644,7 +1644,7 @@ namespace MWWorld
                 {
                     // Mark as non-moving
                     it->first.getClass().setDoorState(it->first, 0);
-                    mDoorStates.erase(it++);
+                    it = mDoorStates.erase(it);
                 }
                 else
                     ++it;

--- a/components/resource/multiobjectcache.cpp
+++ b/components/resource/multiobjectcache.cpp
@@ -30,7 +30,7 @@ namespace Resource
                 if (oitr->second->referenceCount() <= 1)
                 {
                     objectsToRemove.push_back(oitr->second);
-                    _objectCache.erase(oitr++);
+                    oitr = _objectCache.erase(oitr);
                 }
                 else
                 {

--- a/components/resource/objectcache.cpp
+++ b/components/resource/objectcache.cpp
@@ -98,7 +98,7 @@ void ObjectCache::removeExpiredObjectsInCache(double expiryTime)
             if (oitr->second.second<=expiryTime)
             {
                 objectsToRemove.push_back(oitr->second.first);
-                _objectCache.erase(oitr++);
+                oitr = _objectCache.erase(oitr);
             }
             else
             {

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -151,7 +151,7 @@ void ViewDataMap::clearUnusedViews(unsigned int frame)
             vd->setViewer(nullptr);
             vd->clear();
             mUnusedViews.push_back(vd);
-            mViews.erase(it++);
+            it = mViews.erase(it);
         }
         else
             ++it;


### PR DESCRIPTION
Prevent incorrect usage of STL containers that can lead to use-after-free, crashes, etc. I haven't tested all of the code paths since there's so many of them in different places.