### PR TITLE
[Testing needed] Use predetermined cost for AI spell and enchanted item rating

### DIFF
--- a/apps/openmw/mwmechanics/spellpriority.hpp
+++ b/apps/openmw/mwmechanics/spellpriority.hpp
@@ -22,9 +22,13 @@ namespace MWMechanics
     float ratePotion (const MWWorld::Ptr& item, const MWWorld::Ptr &actor);
 
     /// @note target may be empty
-    float rateEffect (const ESM::ENAMstruct& effect, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
+    /// @param autoCalcCost toggles effect cost autocalculation which is then applied to the rating
+    /// @note autoCalcCost must be false if (and must only be false if) you apply a predetermined cost to the rating
+    float rateEffect (const ESM::ENAMstruct& effect, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy, bool autoCalcCost = false);
     /// @note target may be empty
-    float rateEffects (const ESM::EffectList& list, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
+    /// @param autoCalcCost toggles effect cost autocalculation in the rateEffect() calls that follow
+    /// @note autoCalcCost must be false if (and must only be false if) you apply a predetermined cost to the rating
+    float rateEffects (const ESM::EffectList& list, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy, bool autoCalcCost = false);
 
     float vanillaRateSpell(const ESM::Spell* spell, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
 }


### PR DESCRIPTION
In Morrowind, spell's predetermined cost is used for AI spell rating, and mod authors sometimes rely on that (for example, some spellcasters in Draugr Diversity rely on spells with huge cost but a very low duration to make something work). OpenMW currently always autocalculates the spell cost based on the real power of its effects. But it's possible to use enchantment and spell predetermined cost instead of doing that. Effect-specific no-ops, rating buffs, debuffs and whatnot are still used, the cost is just a multiplier to the final rating. Nothing has changed for potions and cast once enchantments.

I removed the racial ability check. Racial powers have zero cost and as such will never be used by NPCs anyways, the same is most probably the case in Morrowind too (MCP might only adjust the rating for zero-cost *powers* and not spells)

I'll probably have limited ability to work on anything starting with this weekend.

I didn't actually test this past testing if spellcasting hasn't been broken in general. But that seemed to be fine. Testing needs to be done before I file a tracker bug report.