### PR TITLE
[Regression] Handle case in the editor when actor's bodypart was not found

### DIFF
--- a/apps/opencs/model/world/actoradapter.cpp
+++ b/apps/opencs/model/world/actoradapter.cpp
@@ -113,17 +113,22 @@ namespace CSMWorld
     const std::string ActorAdapter::ActorData::getPart(ESM::PartReferenceType index) const
     {
         auto it = mParts.find(index);
-        if (it == mParts.end() && mRaceData && mRaceData->handlesPart(index))
+        if (it == mParts.end())
         {
-            if (mFemale)
+            if (mRaceData && mRaceData->handlesPart(index))
             {
-                // Note: we should use male parts for females as fallback
-                const std::string femalePart = mRaceData->getFemalePart(index);
-                if (!femalePart.empty())
-                    return femalePart;
+                if (mFemale)
+                {
+                    // Note: we should use male parts for females as fallback
+                    const std::string femalePart = mRaceData->getFemalePart(index);
+                    if (!femalePart.empty())
+                        return femalePart;
+                }
+
+                return mRaceData->getMalePart(index);
             }
 
-            return mRaceData->getMalePart(index);
+            return "";
         }
 
         const std::string& partName = it->second.first;


### PR DESCRIPTION
Fixes a regression in the NPC's rendering feature in the editor.
Currently we do not fully handle a case, when a suitable bodypart was not found in the map (for example, a weapon bodypart, or a tail bodypart for humanoid races).
As a result, a bodypart ID string can contain a random data.

@zinnschlag, I suggest you to take a look at this PR ASAP - it may fix your issue with bad allocs.
