### PR TITLE
fix win32 app manifest copy-paste error

### DIFF
--- a/files/windows/openmw.exe.manifest
+++ b/files/windows/openmw.exe.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
     <assemblyIdentity type="win32" name="openmw" version="1.0.0.0"/>
-    <description>Q2PRO</description>
+    <description>openmw</description>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
         <security>
             <requestedPrivileges>


### PR DESCRIPTION
There's an error in the win32 manifest file I originally sent, referencing other application's name. Fix this.

In case any of you are worried–I'm very confident the manifest file doesn't fall under copyright. There's no violation by copying it over from another project. It's something from MSDN people reuse all the time to get win32 working correctly (UAC, DPI).

sh
