### PR TITLE
Improve GUI cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active
+    Bug #4715: "Cannot get class of an empty object" exception after pressing ESC in the dialogue mode
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #4673: Weapon sheathing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #3623: Fix HiDPI on Windows
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers
+    Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #4673: Weapon sheathing

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -740,6 +740,9 @@ namespace MWGui
 
     bool DialogueWindow::isCompanion(const MWWorld::Ptr& actor)
     {
+        if (actor.isEmpty())
+            return false;
+
         return !actor.getClass().getScript(actor).empty()
                 && actor.getRefData().getLocals().getIntVar(actor.getClass().getScript(actor), "companion");
     }

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -330,6 +330,21 @@ namespace MWGui
         }
     }
 
+    void ToolTips::clear()
+    {
+        mFocusObject = MWWorld::Ptr();
+
+        while (mDynamicToolTipBox->getChildCount())
+        {
+            MyGUI::Gui::getInstance().destroyWidget(mDynamicToolTipBox->getChildAt(0));
+        }
+
+        for (unsigned int i=0; i < mMainWidget->getChildCount(); ++i)
+        {
+            mMainWidget->getChildAt(i)->setVisible(false);
+        }
+    }
+
     void ToolTips::setFocusObject(const MWWorld::Ptr& focus)
     {
         mFocusObject = focus;

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -59,6 +59,8 @@ namespace MWGui
 
         void setDelay(float delay);
 
+        void clear();
+
         void setFocusObject(const MWWorld::Ptr& focus);
         void setFocusObjectScreenCoords(float min_x, float min_y, float max_x, float max_y);
         ///< set the screen-space position of the tooltip for focused object

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1728,7 +1728,7 @@ namespace MWGui
 
         mMessageBoxManager->clear();
 
-        mToolTips->setFocusObject(MWWorld::Ptr());
+        mToolTips->clear();
 
         mSelectedSpell.clear();
         mCustomMarkers.clear();


### PR DESCRIPTION
Fixes [bug #4714](https://gitlab.com/OpenMW/openmw/issues/4714) and [bug #4715](https://gitlab.com/OpenMW/openmw/issues/4715).
Currently we cleanup tooltips by calling the 
```
mToolTips->setFocusObject(MWWorld::Ptr());
```
upon game load, but this method also tries to check if it needs to create new tooltips by reading data from focused widget.
Since we call it in the middle of GUI system cleanup, it may lead to undefined behaviour (if the focused widget already was cleaned up, for example).

A suggested solution: provide a clear() method for ToolTips class, which does only tooltips cleanup and does not try to create anything.


As for dialogue weirdness, there is just a missing check if actor pointer is empty.

Note: I did not create a separate PR since there will be merge conflicts in the CHANGELOG.md.