### PR TITLE
Fix warnings in the OpenMW-CS and NIFTest

### DIFF
--- a/apps/niftest/niftest.cpp
+++ b/apps/niftest/niftest.cpp
@@ -10,6 +10,7 @@
 #include <components/vfs/bsaarchive.hpp>
 #include <components/vfs/filesystemarchive.hpp>
 
+#include <boost/exception/all.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
@@ -128,14 +129,24 @@ std::vector<std::string> parseOptions (int argc, char** argv)
 
 int main(int argc, char **argv)
 {
-    std::vector<std::string> files = parseOptions (argc, argv);
+    std::vector<std::string> files;
+    try
+    {
+        files = parseOptions (argc, argv);
+    }
+    catch( boost::exception &e )
+    {
+        std::cout << "ERROR parsing arguments: " << boost::diagnostic_information(e) << std::endl;
+        exit(1);
+    }
 
 //     std::cout << "Reading Files" << std::endl;
     for(std::vector<std::string>::const_iterator it=files.begin(); it!=files.end(); ++it)
     {
-         std::string name = *it;
+        std::string name = *it;
 
-        try{
+        try
+        {
             if(isNIF(name))
             {
                 //std::cout << "Decoding: " << name << std::endl;

--- a/apps/opencs/model/world/commands.cpp
+++ b/apps/opencs/model/world/commands.cpp
@@ -199,8 +199,10 @@ CSMWorld::ModifyCommand::ModifyCommand (QAbstractItemModel& model, const QModelI
     if (mIndex.parent().isValid())
     {
         CSMWorld::IdTree* tree = dynamic_cast<CSMWorld::IdTree*>(mModel);
-
-        assert(tree != nullptr);
+        if (tree == nullptr)
+        {
+            throw std::logic_error("CSMWorld::ModifyCommand: Attempt to add nested values to the non-nested model");
+        }
 
         setText ("Modify " + tree->nestedHeaderData (
                     mIndex.parent().column(), mIndex.column(), Qt::Horizontal, Qt::DisplayRole).toString());

--- a/apps/opencs/view/render/pathgrid.cpp
+++ b/apps/opencs/view/render/pathgrid.cpp
@@ -224,10 +224,11 @@ namespace CSVRender
 
     void Pathgrid::applyPoint(CSMWorld::CommandMacro& commands, const osg::Vec3d& worldPos)
     {
-        CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(
-                CSMWorld::UniversalId::Type_Pathgrids));
-
-        assert(model != nullptr);
+        CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
+        if (model == nullptr)
+        {
+            throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
+        }
 
         const CSMWorld::Pathgrid* source = getPathgridSource();
         if (source)
@@ -359,10 +360,11 @@ namespace CSVRender
         const CSMWorld::Pathgrid* source = getPathgridSource();
         if (source)
         {
-            CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(
-                CSMWorld::UniversalId::Type_Pathgrids));
-
-            assert(model != nullptr);
+            CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
+            if (model == nullptr)
+            {
+                throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
+            }
 
             // Want to remove nodes from end of list first
             std::sort(mSelected.begin(), mSelected.end(), std::greater<int>());
@@ -462,10 +464,11 @@ namespace CSVRender
                 }
             }
 
-            CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(
-                CSMWorld::UniversalId::Type_Pathgrids));
-
-            assert(model != nullptr);
+            CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
+            if (model == nullptr)
+            {
+                throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
+            }
 
             int parentColumn = mPathgridCollection.findColumnIndex(CSMWorld::Columns::ColumnId_PathgridEdges);
 
@@ -639,10 +642,11 @@ namespace CSVRender
     void Pathgrid::addEdge(CSMWorld::CommandMacro& commands, const CSMWorld::Pathgrid& source, unsigned short node1,
         unsigned short node2)
     {
-        CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(
-            CSMWorld::UniversalId::Type_Pathgrids));
-
-        assert(model != nullptr);
+        CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
+        if (model == nullptr)
+        {
+            throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
+        }
 
         int recordIndex = mPathgridCollection.getIndex(mId);
         int parentColumn = mPathgridCollection.findColumnIndex(CSMWorld::Columns::ColumnId_PathgridEdges);

--- a/apps/opencs/view/world/cellcreator.cpp
+++ b/apps/opencs/view/world/cellcreator.cpp
@@ -25,7 +25,11 @@ std::string CSVWorld::CellCreator::getId() const
 void CSVWorld::CellCreator::configureCreateCommand(CSMWorld::CreateCommand& command) const
 {
     CSMWorld::IdTree *model = dynamic_cast<CSMWorld::IdTree *>(getData().getTableModel(getCollectionId()));
-    assert(model != nullptr);
+    if (model == nullptr)
+    {
+        throw std::logic_error("CSVWorld::CellCreator: Attempt to add nested values to the non-nested model");
+    }
+
     int parentIndex = model->findColumnIndex(CSMWorld::Columns::ColumnId_Cell);
     int index = model->findNestedColumnIndex(parentIndex, CSMWorld::Columns::ColumnId_Interior);
     command.addNestedValue(parentIndex, index, mType->currentIndex() == 0);

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -556,7 +556,10 @@ void CSVWorld::EditWidget::remake(int row)
                     !(flags & CSMWorld::ColumnBase::Flag_Dialogue_List))
             {
                 CSMWorld::IdTree *innerTable = dynamic_cast<CSMWorld::IdTree*>(mTable);
-                assert(innerTable != nullptr);
+                if (innerTable == nullptr)
+                {
+                    throw std::logic_error("CSVWorld::EditWidget: Attempt to add nested values to the non-nested model");
+                }
 
                 mNestedModels.push_back(new CSMWorld::NestedTableProxyModel (mTable->index(row, i), display, innerTable));
 


### PR DESCRIPTION
If it is OK, it should fix 7 or 8 Coverity Scan warnings.