### PR TITLE
Handle last Coverity Scan issues left

### DIFF
--- a/apps/opencs/view/world/scriptsubview.cpp
+++ b/apps/opencs/view/world/scriptsubview.cpp
@@ -7,6 +7,8 @@
 #include <QSplitter>
 #include <QTimer>
 
+#include <components/debug/debuglog.hpp>
+
 #include "../../model/doc/document.hpp"
 #include "../../model/world/universalid.hpp"
 #include "../../model/world/data.hpp"
@@ -210,18 +212,28 @@ void CSVWorld::ScriptSubView::useHint (const std::string& hint)
     unsigned line = 0, column = 0;
     char c;
     std::istringstream stream (hint.c_str()+1);
-    switch(hint[0]){
+    switch(hint[0])
+    {
         case 'R':
         case 'r':
         {
             QModelIndex index = mModel->getModelIndex (getUniversalId().getId(), mColumn);
             QString source = mModel->data (index).toString();
+            unsigned stringSize = source.length();
             unsigned pos, dummy;
             if (!(stream >> c >> dummy >> pos) )
                 return;
 
-            for (unsigned i = 0; i <= pos; ++i){
-                if (source[i] == '\n'){
+            if (pos > stringSize)
+            {
+                Log(Debug::Warning) << "CSVWorld::ScriptSubView: requested position is higher than actual string length";
+                pos = stringSize;
+            }
+
+            for (unsigned i = 0; i <= pos; ++i)
+            {
+                if (source[i] == '\n')
+                {
                     ++line;
                     column = i+1;
                 }
@@ -231,7 +243,7 @@ void CSVWorld::ScriptSubView::useHint (const std::string& hint)
         }
         case 'l':
             if (!(stream >> c >> line >> column))
-                    return;
+                return;
     }
 
     QTextCursor cursor = mEditor->textCursor();

--- a/components/config/gamesettings.cpp
+++ b/components/config/gamesettings.cpp
@@ -338,6 +338,9 @@ bool Config::GameSettings::writeFileWithComments(QFile &file)
             if (!comments.empty() && index != -1 && settingRegex.captureCount() >= 2 &&
                 mUserSettings.find(settingRegex.cap(1)) != mUserSettings.end())
             {
+                if (commentStart == fileCopy.end())
+                    throw std::runtime_error("Config::GameSettings: failed to parse settings - iterator is past of end of settings file");
+
                 for (std::vector<QString>::const_iterator it = comments.begin(); it != comments.end(); ++it)
                 {
                     *commentStart = *it;


### PR DESCRIPTION
CID 83467 - it is a false positive, can be dismissed.

CID 121666 - Coverity Scan complains about possible case when `comments` vector contains values, but the `commentStart == fileCopy.end()` is true. 
We can check iterator just for sure or dismiss this issue too as a false positive.
Not sure which option is better.

CID 134779 - here we parse a `pos` variable from input string and use it as a loop bound, despite actual string size can be lesser.
We can print a warning here, cap `pos` silently or throw an exception.

CID 184322 - related to redundant logging system for pathfinding, which probably should be removed, so there is no need to handle it right now.