### PR TITLE
Requested refactoring

### DIFF
--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -123,14 +123,9 @@ bool parseOptions (int argc, char** argv, Arguments &info)
 
         bpo::store(valid_opts, variables);
     }
-    catch(boost::program_options::unknown_option & x)
+    catch(std::exception &e)
     {
-        std::cerr << "ERROR: " << x.what() << std::endl;
-        return false;
-    }
-    catch(boost::program_options::invalid_command_line_syntax & x)
-    {
-        std::cerr << "ERROR: " << x.what() << std::endl;
+        std::cout << "ERROR parsing arguments: " << e.what() << std::endl;
         return false;
     }
 

--- a/apps/niftest/niftest.cpp
+++ b/apps/niftest/niftest.cpp
@@ -10,7 +10,6 @@
 #include <components/vfs/bsaarchive.hpp>
 #include <components/vfs/filesystemarchive.hpp>
 
-#include <boost/exception/all.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
@@ -81,7 +80,7 @@ void readVFS(VFS::Archive* anArchive,std::string archivePath = "")
     }
 }
 
-std::vector<std::string> parseOptions (int argc, char** argv)
+bool parseOptions (int argc, char** argv, std::vector<std::string>& files)
 {
     bpo::options_description desc("Ensure that OpenMW can use the provided NIF and BSA files\n\n"
         "Usages:\n"
@@ -108,37 +107,31 @@ std::vector<std::string> parseOptions (int argc, char** argv)
     {
         std::cout << "ERROR parsing arguments: " << e.what() << "\n\n"
             << desc << std::endl;
-        exit(1);
+        return false;
     }
 
     bpo::notify(variables);
     if (variables.count ("help"))
     {
         std::cout << desc << std::endl;
-        exit(1);
+        return false;
     }
     if (variables.count("input-file"))
     {
-        return variables["input-file"].as< std::vector<std::string> >();
+        files = variables["input-file"].as< std::vector<std::string> >();
+        return true;
     }
 
     std::cout << "No input files or directories specified!" << std::endl;
     std::cout << desc << std::endl;
-    exit(1);
+    return false;
 }
 
 int main(int argc, char **argv)
 {
     std::vector<std::string> files;
-    try
-    {
-        files = parseOptions (argc, argv);
-    }
-    catch( boost::exception &e )
-    {
-        std::cout << "ERROR parsing arguments: " << boost::diagnostic_information(e) << std::endl;
-        exit(1);
-    }
+    if(!parseOptions (argc, argv, files))
+        return 1;
 
 //     std::cout << "Reading Files" << std::endl;
     for(std::vector<std::string>::const_iterator it=files.begin(); it!=files.end(); ++it)

--- a/apps/opencs/model/world/commands.cpp
+++ b/apps/opencs/model/world/commands.cpp
@@ -198,12 +198,7 @@ CSMWorld::ModifyCommand::ModifyCommand (QAbstractItemModel& model, const QModelI
 
     if (mIndex.parent().isValid())
     {
-        CSMWorld::IdTree* tree = dynamic_cast<CSMWorld::IdTree*>(mModel);
-        if (tree == nullptr)
-        {
-            throw std::logic_error("CSMWorld::ModifyCommand: Attempt to add nested values to the non-nested model");
-        }
-
+        CSMWorld::IdTree* tree = &dynamic_cast<CSMWorld::IdTree&>(*mModel);
         setText ("Modify " + tree->nestedHeaderData (
                     mIndex.parent().column(), mIndex.column(), Qt::Horizontal, Qt::DisplayRole).toString());
     }
@@ -249,12 +244,7 @@ void CSMWorld::CreateCommand::applyModifications()
 {
     if (!mNestedValues.empty())
     {
-        CSMWorld::IdTree *tree = dynamic_cast<CSMWorld::IdTree *>(&mModel);
-        if (tree == nullptr)
-        {
-            throw std::logic_error("CSMWorld::CreateCommand: Attempt to add nested values to the non-nested model");
-        }
-
+        CSMWorld::IdTree* tree = &dynamic_cast<CSMWorld::IdTree&>(mModel);
         std::map<int, std::pair<int, QVariant> >::const_iterator current = mNestedValues.begin();
         std::map<int, std::pair<int, QVariant> >::const_iterator end = mNestedValues.end();
         for (; current != end; ++current)

--- a/apps/opencs/view/render/pathgrid.cpp
+++ b/apps/opencs/view/render/pathgrid.cpp
@@ -224,11 +224,7 @@ namespace CSVRender
 
     void Pathgrid::applyPoint(CSMWorld::CommandMacro& commands, const osg::Vec3d& worldPos)
     {
-        CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
-        if (model == nullptr)
-        {
-            throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
-        }
+        CSMWorld::IdTree* model = &dynamic_cast<CSMWorld::IdTree&>(*mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
 
         const CSMWorld::Pathgrid* source = getPathgridSource();
         if (source)
@@ -360,11 +356,7 @@ namespace CSVRender
         const CSMWorld::Pathgrid* source = getPathgridSource();
         if (source)
         {
-            CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
-            if (model == nullptr)
-            {
-                throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
-            }
+            CSMWorld::IdTree* model = &dynamic_cast<CSMWorld::IdTree&>(*mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
 
             // Want to remove nodes from end of list first
             std::sort(mSelected.begin(), mSelected.end(), std::greater<int>());
@@ -464,12 +456,7 @@ namespace CSVRender
                 }
             }
 
-            CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
-            if (model == nullptr)
-            {
-                throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
-            }
-
+            CSMWorld::IdTree* model = &dynamic_cast<CSMWorld::IdTree&>(*mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
             int parentColumn = mPathgridCollection.findColumnIndex(CSMWorld::Columns::ColumnId_PathgridEdges);
 
             std::set<int, std::greater<int> >::iterator row;
@@ -642,11 +629,7 @@ namespace CSVRender
     void Pathgrid::addEdge(CSMWorld::CommandMacro& commands, const CSMWorld::Pathgrid& source, unsigned short node1,
         unsigned short node2)
     {
-        CSMWorld::IdTree* model = dynamic_cast<CSMWorld::IdTree*>(mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
-        if (model == nullptr)
-        {
-            throw std::logic_error("CSVRender::Pathgrid: Attempt to add nested values to the non-nested model");
-        }
+        CSMWorld::IdTree* model = &dynamic_cast<CSMWorld::IdTree&>(*mData.getTableModel(CSMWorld::UniversalId::Type_Pathgrids));
 
         int recordIndex = mPathgridCollection.getIndex(mId);
         int parentColumn = mPathgridCollection.findColumnIndex(CSMWorld::Columns::ColumnId_PathgridEdges);

--- a/apps/opencs/view/world/cellcreator.cpp
+++ b/apps/opencs/view/world/cellcreator.cpp
@@ -24,11 +24,7 @@ std::string CSVWorld::CellCreator::getId() const
 
 void CSVWorld::CellCreator::configureCreateCommand(CSMWorld::CreateCommand& command) const
 {
-    CSMWorld::IdTree *model = dynamic_cast<CSMWorld::IdTree *>(getData().getTableModel(getCollectionId()));
-    if (model == nullptr)
-    {
-        throw std::logic_error("CSVWorld::CellCreator: Attempt to add nested values to the non-nested model");
-    }
+    CSMWorld::IdTree* model = &dynamic_cast<CSMWorld::IdTree&>(*getData().getTableModel(getCollectionId()));
 
     int parentIndex = model->findColumnIndex(CSMWorld::Columns::ColumnId_Cell);
     int index = model->findNestedColumnIndex(parentIndex, CSMWorld::Columns::ColumnId_Interior);

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -555,12 +555,7 @@ void CSVWorld::EditWidget::remake(int row)
             if (mTable->hasChildren(mTable->index(row, i)) &&
                     !(flags & CSMWorld::ColumnBase::Flag_Dialogue_List))
             {
-                CSMWorld::IdTree *innerTable = dynamic_cast<CSMWorld::IdTree*>(mTable);
-                if (innerTable == nullptr)
-                {
-                    throw std::logic_error("CSVWorld::EditWidget: Attempt to add nested values to the non-nested model");
-                }
-
+                CSMWorld::IdTree* innerTable = &dynamic_cast<CSMWorld::IdTree&>(*mTable);
                 mNestedModels.push_back(new CSMWorld::NestedTableProxyModel (mTable->index(row, i), display, innerTable));
 
                 int idColumn = mTable->findColumnIndex (CSMWorld::Columns::ColumnId_Id);


### PR DESCRIPTION
Changes, requested by @zinnschlag.

Summary of changes:
1. Modify dynamic_casts in the editor to throw exceptions automatically.
2. Refactor NIFTest to use `return` statements instead of `exit(1)`.
3. Do not use redundant boost exceptions handlers in ESMTool and NIFTest - according to my tests, std::exception handles a subset of used exceptions indeed.