### PR TITLE
Fix shield displaying on inventory avatar (bug #4720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active
     Bug #4715: "Cannot get class of an empty object" exception after pressing ESC in the dialogue mode
+    Bug #4720: Inventory avatar has shield with two-handed weapon during [un]equipping animation
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #4673: Weapon sheathing

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -305,24 +305,37 @@ namespace MWRender
                    type == ESM::Weapon::LongBladeOneHand ||
                    type == ESM::Weapon::BluntOneHand ||
                    type == ESM::Weapon::AxeOneHand ||
-                   type == ESM::Weapon::MarksmanThrown ||
-                   type == ESM::Weapon::MarksmanCrossbow ||
-                   type == ESM::Weapon::MarksmanBow)
+                   type == ESM::Weapon::MarksmanThrown)
+                {
                     groupname = "inventoryweapononehand";
+                }
+                else if(type == ESM::Weapon::MarksmanCrossbow ||
+                        type == ESM::Weapon::MarksmanBow)
+                {
+                    groupname = "inventoryweapononehand";
+                    showCarriedLeft = false;
+                }
                 else if(type == ESM::Weapon::LongBladeTwoHand ||
                         type == ESM::Weapon::BluntTwoClose ||
                         type == ESM::Weapon::AxeTwoHand)
+                {
                     groupname = "inventoryweapontwohand";
+                    showCarriedLeft = false;
+                }
                 else if(type == ESM::Weapon::BluntTwoWide ||
                         type == ESM::Weapon::SpearTwoWide)
+                {
                     groupname = "inventoryweapontwowide";
+                    showCarriedLeft = false;
+                }
                 else
+                {
                     groupname = "inventoryhandtohand";
-
-                showCarriedLeft = (iter->getClass().canBeEquipped(*iter, mCharacter).first != 2);
+                    showCarriedLeft = false;
+                }
            }
-            else
-                groupname = "inventoryhandtohand";
+           else
+               groupname = "inventoryhandtohand";
         }
 
         mAnimation->showCarriedLeft(showCarriedLeft);


### PR DESCRIPTION
Fixes [bug #4720](https://gitlab.com/OpenMW/openmw/issues/4720).

The main idea: since we already choose animation manually here (there is a separate animation set for invenotry avatar), check if we need to render shield manually too.