### PR TITLE
Improve ResetActors command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active
     Bug #4715: "Cannot get class of an empty object" exception after pressing ESC in the dialogue mode
     Bug #4720: Inventory avatar has shield with two-handed weapon during [un]equipping animation
+    Bug #4723: ResetActors command works incorrectly
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #4673: Weapon sheathing

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -330,6 +330,17 @@ namespace MWWorld
         visitor.merge();
     }
 
+    bool CellStore::movedHere(const MWWorld::Ptr& ptr) const
+    {
+        if (ptr.isEmpty())
+            return false;
+
+        if (mMovedHere.find(ptr.getBase()) != mMovedHere.end())
+            return true;
+
+        return false;
+    }
+
     CellStore::CellStore (const ESM::Cell *cell, const MWWorld::ESMStore& esmStore, std::vector<ESM::ESMReader>& readerList)
         : mStore(esmStore), mReader(readerList), mCell (cell), mState (State_Unloaded), mHasState (false), mLastRespawn(0,0)
     {

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -233,6 +233,8 @@ namespace MWWorld
 
             float getWaterLevel() const;
 
+            bool movedHere(const MWWorld::Ptr& ptr) const;
+
             void setWaterLevel (float level);
 
             void setFog (ESM::FogState* fog);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3698,10 +3698,13 @@ namespace MWWorld
         {
             if (ptr.getClass().isActor() && ptr.getCellRef().hasContentFile())
             {
+                if (ptr.getCell()->movedHere(ptr))
+                    return true;
+
                 const ESM::Position& origPos = ptr.getCellRef().getPosition();
                 MWBase::Environment::get().getWorld()->moveObject(ptr, origPos.pos[0], origPos.pos[1], origPos.pos[2]);
                 MWBase::Environment::get().getWorld()->rotateObject(ptr, origPos.rot[0], origPos.rot[1], origPos.rot[2]);
-                ptr.getClass().adjustPosition(ptr, false);
+                ptr.getClass().adjustPosition(ptr, true);
             }
             return true;
         }


### PR DESCRIPTION
Fixes [bug #4723](https://gitlab.com/OpenMW/openmw/issues/4723).

Maybe we already have a better way to detect if an actor was moved to his current cell, but I did not find it.