### PR TITLE
Fix visible sheaths for invisible actors

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -355,10 +355,6 @@ void ActorAnimation::updateQuiver()
                 addGlow(arrow, glowColor);
         }
     }
-
-    // recreate shaders for invisible actors, otherwise new nodes will be visible
-    if (mAlpha != 1.f)
-        mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
 }
 
 void ActorAnimation::itemAdded(const MWWorld::ConstPtr& item, int /*count*/)

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -925,6 +925,10 @@ void NpcAnimation::showWeapons(bool showWeapon)
 
     updateHolsteredWeapon(!mShowWeapons);
     updateQuiver();
+
+    // Recreate shaders for invisible actors, otherwise sheath nodes will be visible
+    if (mAlpha != 1.f && mWeaponSheathing)
+        mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
 }
 
 void NpcAnimation::showCarriedLeft(bool show)


### PR DESCRIPTION
Currently there is a small issue in the Weapon Sheathing feature - scabbard can be visible when actor itself is invisible.
Solution: recreate shaders after sheath meshes update.