### PR TITLE
Shields holstering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@
     Feature #5132: Unique animations for different weapon types
     Feature #5146: Safe Dispose corpse
     Feature #5147: Show spell magicka cost in spell buying window
+    Feature #5193: Weapon sheathing
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4789: Optimize cell transitions

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -62,6 +62,7 @@ ActorAnimation::~ActorAnimation()
     }
 
     mScabbard.reset();
+    mHolsteredShield.reset();
 }
 
 PartHolderPtr ActorAnimation::attachMesh(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor)
@@ -81,6 +82,163 @@ PartHolderPtr ActorAnimation::attachMesh(const std::string& model, const std::st
         mGlowUpdater = SceneUtil::addEnchantedGlow(instance, mResourceSystem, *glowColor);
 
     return PartHolderPtr(new PartHolder(instance));
+}
+
+std::string ActorAnimation::getShieldMesh(MWWorld::ConstPtr shield) const
+{
+    std::string mesh = shield.getClass().getModel(shield);
+    std::string holsteredName = mesh;
+    holsteredName = holsteredName.replace(holsteredName.size()-4, 4, "_sh.nif");
+    if(mResourceSystem->getVFS()->exists(holsteredName))
+    {
+        osg::ref_ptr<osg::Node> shieldTemplate = mResourceSystem->getSceneManager()->getInstance(holsteredName);
+        SceneUtil::FindByNameVisitor findVisitor ("Bip01 Sheath");
+        shieldTemplate->accept(findVisitor);
+        osg::ref_ptr<osg::Node> sheathNode = findVisitor.mFoundNode;
+        if(!sheathNode)
+            return std::string();
+    }
+
+    return mesh;
+}
+
+bool ActorAnimation::updateCarriedLeftVisible(const int weaptype) const
+{
+    static const bool shieldSheathing = Settings::Manager::getBool("shield sheathing", "Game");
+    if (shieldSheathing)
+    {
+        const MWWorld::Class &cls = mPtr.getClass();
+        MWMechanics::CreatureStats &stats = cls.getCreatureStats(mPtr);
+        if (cls.hasInventoryStore(mPtr) && weaptype != ESM::Weapon::Spell)
+        {
+            const MWWorld::InventoryStore& inv = cls.getInventoryStore(mPtr);
+            const MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+            const MWWorld::ConstContainerStoreIterator shield = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
+            if (shield != inv.end() && shield->getTypeName() == typeid(ESM::Armor).name() && !getShieldMesh(*shield).empty())
+            {
+                if(stats.getDrawState() != MWMechanics::DrawState_Weapon)
+                    return false;
+
+                if (weapon != inv.end())
+                {
+                    const std::string &type = weapon->getTypeName();
+                    if(type == typeid(ESM::Weapon).name())
+                    {
+                        const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
+                        ESM::Weapon::Type weaponType = (ESM::Weapon::Type)ref->mBase->mData.mType;
+                        return !(MWMechanics::getWeaponType(weaponType)->mFlags & ESM::WeaponType::TwoHanded);
+                    }
+                    else if (type == typeid(ESM::Lockpick).name() || type == typeid(ESM::Probe).name())
+                        return true;
+                }
+            }
+        }
+    }
+
+    return !(MWMechanics::getWeaponType(weaptype)->mFlags & ESM::WeaponType::TwoHanded);
+}
+
+void ActorAnimation::updateHolsteredShield(bool showCarriedLeft)
+{
+    static const bool shieldSheathing = Settings::Manager::getBool("shield sheathing", "Game");
+    if (!shieldSheathing)
+        return;
+
+    if (!mPtr.getClass().hasInventoryStore(mPtr))
+        return;
+
+    mHolsteredShield.reset();
+
+    if (showCarriedLeft)
+        return;
+
+    const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+    MWWorld::ConstContainerStoreIterator shield = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
+    if (shield == inv.end() || shield->getTypeName() != typeid(ESM::Armor).name())
+        return;
+
+    // Can not show holdstered shields with two-handed weapons at all
+    const MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    if(weapon == inv.end())
+        return;
+
+    const std::string &type = weapon->getTypeName();
+    if(type == typeid(ESM::Weapon).name())
+    {
+        const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
+        ESM::Weapon::Type weaponType = (ESM::Weapon::Type)ref->mBase->mData.mType;
+        if (MWMechanics::getWeaponType(weaponType)->mFlags & ESM::WeaponType::TwoHanded)
+            return;
+    }
+
+    std::string mesh = getShieldMesh(*shield);
+    if (mesh.empty())
+        return;
+
+    std::string boneName = "Bip01 AttachShield";
+    osg::Vec4f glowColor = shield->getClass().getEnchantmentColor(*shield);
+    std::string holsteredName = mesh;
+    holsteredName = holsteredName.replace(holsteredName.size()-4, 4, "_sh.nif");
+    bool isEnchanted = !shield->getClass().getEnchantment(*shield).empty();
+
+    // If we have no dedicated sheath model, use basic shield model as fallback.
+    if (!mResourceSystem->getVFS()->exists(holsteredName))
+        mHolsteredShield = attachMesh(mesh, boneName, isEnchanted, &glowColor);
+    else
+        mHolsteredShield = attachMesh(holsteredName, boneName, isEnchanted, &glowColor);
+
+    if (!mHolsteredShield)
+        return;
+
+    SceneUtil::FindByNameVisitor findVisitor ("Bip01 Sheath");
+    mHolsteredShield->getNode()->accept(findVisitor);
+    osg::Group* shieldNode = findVisitor.mFoundNode;
+
+    // If mesh author declared an empty sheath node, use transformation from this node, but use the common shield mesh.
+    // This approach allows to tweak shield position without need to store the whole shield mesh in the _sh file.
+    if (shieldNode && !shieldNode->getNumChildren())
+    {
+        osg::ref_ptr<osg::Node> fallbackNode = mResourceSystem->getSceneManager()->getInstance(mesh, shieldNode);
+        if (isEnchanted)
+            SceneUtil::addEnchantedGlow(shieldNode, mResourceSystem, glowColor);
+    }
+
+    if (mAlpha != 1.f)
+        mResourceSystem->getSceneManager()->recreateShaders(mHolsteredShield->getNode());
+}
+
+bool ActorAnimation::useShieldAnimations() const
+{
+    static const bool shieldSheathing = Settings::Manager::getBool("shield sheathing", "Game");
+    if (!shieldSheathing)
+        return false;
+
+    const MWWorld::Class &cls = mPtr.getClass();
+    if (!cls.hasInventoryStore(mPtr))
+        return false;
+
+    if (getTextKeyTime("shield: equip attach") < 0 || getTextKeyTime("shield: unequip detach") < 0)
+        return false;
+
+    const MWWorld::InventoryStore& inv = cls.getInventoryStore(mPtr);
+    const MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    const MWWorld::ConstContainerStoreIterator shield = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
+    if (weapon != inv.end() && shield != inv.end() &&
+        shield->getTypeName() == typeid(ESM::Armor).name() &&
+        !getShieldMesh(*shield).empty())
+    {
+        const std::string &type = weapon->getTypeName();
+        if(type == typeid(ESM::Weapon).name())
+        {
+            const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
+            ESM::Weapon::Type weaponType = (ESM::Weapon::Type)ref->mBase->mData.mType;
+            return !(MWMechanics::getWeaponType(weaponType)->mFlags & ESM::WeaponType::TwoHanded);
+        }
+        else if (type == typeid(ESM::Lockpick).name() || type == typeid(ESM::Probe).name())
+            return true;
+    }
+
+    return false;
 }
 
 osg::Group* ActorAnimation::getBoneByName(const std::string& boneName)

--- a/apps/openmw/mwrender/actoranimation.hpp
+++ b/apps/openmw/mwrender/actoranimation.hpp
@@ -38,11 +38,15 @@ class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
         virtual void itemAdded(const MWWorld::ConstPtr& item, int count);
         virtual void itemRemoved(const MWWorld::ConstPtr& item, int count);
         virtual bool isArrowAttached() const { return false; }
+        virtual bool useShieldAnimations() const;
+        bool updateCarriedLeftVisible(const int weaptype) const;
 
     protected:
         osg::Group* getBoneByName(const std::string& boneName);
         virtual void updateHolsteredWeapon(bool showHolsteredWeapons);
+        virtual void updateHolsteredShield(bool showCarriedLeft);
         virtual void updateQuiver();
+        virtual std::string getShieldMesh(MWWorld::ConstPtr shield) const;
         virtual std::string getHolsteredWeaponBoneName(const MWWorld::ConstPtr& weapon);
         virtual PartHolderPtr attachMesh(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor);
         virtual PartHolderPtr attachMesh(const std::string& model, const std::string& bonename)
@@ -52,6 +56,7 @@ class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
         };
 
         PartHolderPtr mScabbard;
+        PartHolderPtr mHolsteredShield;
 
     private:
         void addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM::Light* esmLight);

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -153,6 +153,8 @@ public:
 
     void setTextKeyListener(TextKeyListener* listener);
 
+    virtual bool updateCarriedLeftVisible(const int weaptype) const { return false; };
+
 protected:
     class AnimationTime : public SceneUtil::ControllerSource
     {
@@ -453,6 +455,7 @@ public:
     /// @note The matching is case-insensitive.
     const osg::Node* getNode(const std::string& name) const;
 
+    virtual bool useShieldAnimations() const { return false; }
     virtual void showWeapons(bool showWeapon) {}
     virtual void showCarriedLeft(bool show) {}
     virtual void setWeaponGroup(const std::string& group, bool relativeDuration) {}

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -90,6 +90,7 @@ void CreatureWeaponAnimation::updateParts()
 
     updateHolsteredWeapon(!mShowWeapons);
     updateQuiver();
+    updateHolsteredShield(mShowCarriedLeft);
 
     if (mShowWeapons)
         updatePart(mWeapon, MWWorld::InventoryStore::Slot_CarriedRight);

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -98,6 +98,7 @@ private:
 protected:
     virtual void addControllers();
     virtual bool isArrowAttached() const;
+    virtual std::string getShieldMesh(MWWorld::ConstPtr shield) const;
 
 public:
     /**

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -184,6 +184,22 @@ Otherwise they wait for the enemies or the player to do an attack first.
 Please note this setting has not been extensively tested and could have side effects with certain quests.
 This setting can be toggled in Advanced tab of the launcher.
 
+shield sheathing
+----------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, OpenMW will utilize shield sheathing-compatible assets to display holstered shields.
+
+To make use of this, you need to have an xbase_anim_sh.nif file with weapon bones that will be injected into the skeleton.
+Also you can use additional _sh meshes for more precise shield placement.
+Warning: this feature may conflict with mods that use pseudo-shields to emulate item in actor's hand (e.g. books, baskets, pick axes).
+To avoid conflicts, you can use _sh mesh without "Bip01 Sheath" node for such "shields" meshes, or declare its bodypart as Clothing type, not as Armor.
+Also you can use an _sh node with empty "Bip01 Sheath" node.
+In this case the engine will use basic shield model, but will use transformations from the "Bip01 Sheath" node.
+
 weapon sheathing
 ----------------
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -255,6 +255,9 @@ strength influences hand to hand = 0
 # Render holstered weapons (with quivers and scabbards), requires modded assets
 weapon sheathing = false
 
+# Render holstered shield when it is not in actor's hands, requires modded assets
+shield sheathing = false
+
 # Allow non-standard ammunition solely to bypass normal weapon resistance or weakness
 only appropriate ammunition bypasses resistance = false
 


### PR DESCRIPTION
Implements [feature #5193](https://gitlab.com/OpenMW/openmw/issues/5193).

Custom equipping animations: [Animations.zip](https://github.com/OpenMW/openmw/files/2612491/Animations.zip)

Behaviour is similar to MWSE [Weapon Sheathing](https://www.nexusmods.com/morrowind/mods) mod, but with shield animations support.

Configs:
```
[Game]
weapon sheathing = true
shield sheathing = true
use additional anim sources = true
```

**Requires skeletons from mentioned mod.**

For now there are two ways to keep compatibility with Animated Morrowind and other mods with pseudo-shields:
1. Declare bodyparts for such pseudo-shields as a Clothing, not as Armor.
2. Create an _sh mesh without "Bip01 Sheath" node for pseudo-shield mesh.

Note: by default this PR takes model from shield bodyparts, not from ground models, for NPCs!