### PR TITLE
Add Invert X Axis option (feature #3610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     Bug #4723: ResetActors command works incorrectly
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
+    Feature #3610: Option to invert X axis
     Feature #4673: Weapon sheathing
     Task #4686: Upgrade media decoder to a more current FFmpeg API
 

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -52,6 +52,7 @@ namespace MWInput
         , mUserFile(userFile)
         , mDragDrop(false)
         , mGrabCursor (Settings::Manager::getBool("grab cursor", "Input"))
+        , mInvertX (Settings::Manager::getBool("invert x axis", "Input"))
         , mInvertY (Settings::Manager::getBool("invert y axis", "Input"))
         , mControlsDisabled(false)
         , mCameraSensitivity (Settings::Manager::getFloat("camera sensitivity", "Input"))
@@ -467,7 +468,7 @@ namespace MWInput
                 float rot[3];
                 rot[0] = yAxis * (dt * 100.0f) * 10.0f * mCameraSensitivity * (1.0f/256.f) * (mInvertY ? -1 : 1) * mCameraYMultiplier;
                 rot[1] = 0.0f;
-                rot[2] = xAxis * (dt * 100.0f) * 10.0f * mCameraSensitivity * (1.0f/256.f);
+                rot[2] = xAxis * (dt * 100.0f) * 10.0f * mCameraSensitivity * (1.0f/256.f) * (mInvertX ? -1 : 1);
 
                 // Only actually turn player when we're not in vanity mode
                 if(!MWBase::Environment::get().getWorld()->vanityRotateCamera(rot))
@@ -646,6 +647,9 @@ namespace MWInput
         for (Settings::CategorySettingVector::const_iterator it = changed.begin();
         it != changed.end(); ++it)
         {
+            if (it->first == "Input" && it->second == "invert x axis")
+                mInvertX = Settings::Manager::getBool("invert x axis", "Input");
+
             if (it->first == "Input" && it->second == "invert y axis")
                 mInvertY = Settings::Manager::getBool("invert y axis", "Input");
 
@@ -827,7 +831,7 @@ namespace MWInput
         {
             resetIdleTime();
 
-            float x = arg.xrel * mCameraSensitivity * (1.0f/256.f);
+            float x = arg.xrel * mCameraSensitivity * (1.0f/256.f) * (mInvertX ? -1 : 1);
             float y = arg.yrel * mCameraSensitivity * (1.0f/256.f) * (mInvertY ? -1 : 1) * mCameraYMultiplier;
 
             float rot[3];

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -175,6 +175,7 @@ namespace MWInput
 
         bool mGrabCursor;
 
+        bool mInvertX;
         bool mInvertY;
 
         bool mControlsDisabled;

--- a/docs/source/reference/modding/settings/input.rst
+++ b/docs/source/reference/modding/settings/input.rst
@@ -94,6 +94,20 @@ meaning that it should remain set at 1.0 unless the player desires to have diffe
 
 This setting can only be configured by editing the settings configuration file.
 
+invert x axis
+-------------
+
+:Type:      boolean
+:Range:     True/False
+:Default:   False
+
+
+Invert the horizontal axis while not in GUI mode.
+If this setting is true, moving the mouse to the left will cause the view to rotate counter-clockwise,
+while moving it to the right will cause the view to rotate clockwise. This setting does not affect cursor movement in GUI mode.
+
+This setting can be toggled in game with the Invert X Axis button in the Controls panel of the Options menu.
+
 invert y axis
 -------------
 

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -216,6 +216,16 @@
                 <Widget type="HBox" skin="" position="4 224 300 24" align="Left Bottom">
                     <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Bottom">
                         <UserString key="SettingCategory" value="Input"/>
+                        <UserString key="SettingName" value="invert x axis"/>
+                        <UserString key="SettingType" value="CheckButton"/>
+                    </Widget>
+                    <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 78 16" align="Left Bottom">
+                        <Property key="Caption" value="Invert X Axis"/>
+                    </Widget>
+                </Widget>
+                <Widget type="HBox" skin="" position="4 254 300 24" align="Left Bottom">
+                    <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Bottom">
+                        <UserString key="SettingCategory" value="Input"/>
                         <UserString key="SettingName" value="invert y axis"/>
                         <UserString key="SettingType" value="CheckButton"/>
                     </Widget>
@@ -223,10 +233,10 @@
                         <Property key="Caption" value="#{sMouseFlip}"/>
                     </Widget>
                 </Widget>
-                <Widget type="TextBox" skin="NormalText" position="4 254 336 18" align="Left Bottom">
+                <Widget type="TextBox" skin="NormalText" position="4 284 336 18" align="Left Bottom">
                     <Property key="Caption" value="Camera Sensitivity"/>
                 </Widget>
-                <Widget type="MWScrollBar" skin="MW_HScroll" position="4 278 336 18" align="HStretch Bottom">
+                <Widget type="MWScrollBar" skin="MW_HScroll" position="4 308 336 18" align="HStretch Bottom">
                     <Property key="Range" value="10000"/>
                     <Property key="Page" value="300"/>
                     <UserString key="SettingType" value="Slider"/>
@@ -236,11 +246,11 @@
                     <UserString key="SettingMin" value="0.2"/>
                     <UserString key="SettingMax" value="5.0"/>
                 </Widget>
-                <Widget type="TextBox" skin="SandText" position="4 302 336 18" align="Left Bottom">
+                <Widget type="TextBox" skin="SandText" position="4 332 336 18" align="Left Bottom">
                     <Property key="Caption" value="#{sLow}"/>
                     <Property key="TextAlign" value="Left"/>
                 </Widget>
-                <Widget type="TextBox" skin="SandText" position="4 302 336 18" align="Right Bottom">
+                <Widget type="TextBox" skin="SandText" position="4 332 336 18" align="Right Bottom">
                     <Property key="Caption" value="#{sHigh}"/>
                     <Property key="TextAlign" value="Right"/>
                 </Widget>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -333,6 +333,9 @@ camera sensitivity = 1.0
 # (>0.0, Because it's a multiplier values should be near 1.0)
 camera y multiplier = 1.0
 
+# Invert the horizontal axis while not in GUI mode.
+invert x axis = false
+
 # Invert the vertical axis while not in GUI mode.
 invert y axis = false
 


### PR DESCRIPTION
[Feature 3610](https://gitlab.com/OpenMW/openmw/issues/3610).

Adds another button to Controls section of the in-game settings. When it's on, the horizontal axis of the camera are inverted. It works very similar to how invert Y option works, so although I don't have a controller it should work fine for controllers too.

The button caption is not localized, so it obviously may look out of place on non-English localizations. 