### PR TITLE
[Regression] Fix incorrect event argument which messed with hidden light pointers

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -150,7 +150,7 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::add(const Ptr& itemPtr,
     }
 
     if (mListener)
-        mListener->itemAdded(itemPtr, count);
+        mListener->itemAdded(*retVal, count);
 
     return retVal;
 }


### PR DESCRIPTION
This fixes a regression in weapon sheathing PR which caused hidden item light list to break. The pointer argument from the itemAdded event is used to determine the item to add into the list but wrong pointer was used in the moved call of the event, causing the added light source to never be removed. Simple test case:
```
additem "blade light" 1
removeitem "blade light" 1
```
`blade light` is the hidden light source Trueflame sword uses in Tribunal. In 0.45.0, the light source does disappear. In master, the light source does not disappear and will in fact duplicate once you try to add the Trueflame hidden light again a couple of times. In PR, the light source can disappear properly again.

In akortunov's brief and my own testing this doesn't appear to break anything else but still fixes the issue.