### PR TITLE
esmtool cleanup

### DIFF
--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -406,13 +406,10 @@ int load(Arguments& info)
     } catch(std::exception &e) {
         std::cout << "\nERROR:\n\n  " << e.what() << std::endl;
 
-        typedef std::deque<EsmTool::RecordBase *> RecStore;
-        RecStore &store = info.data.mRecords;
-        for (RecStore::iterator it = store.begin(); it != store.end(); ++it)
-        {
-            delete *it;
-        }
-        store.clear();
+        for (const EsmTool::RecordBase* record : info.data.mRecords)
+            delete record;
+
+        info.data.mRecords.clear();
         return 1;
     }
 
@@ -444,15 +441,12 @@ int clone(Arguments& info)
     std::cout << "Loaded " << recordCount << " records:" << std::endl << std::endl;
 
     int i = 0;
-    typedef std::map<int, int> Stats;
-    Stats &stats = info.data.mRecordStats;
-    for (Stats::iterator it = stats.begin(); it != stats.end(); ++it)
+    for (std::pair<int, int> stat : info.data.mRecordStats)
     {
         ESM::NAME name;
-        name.intval = it->first;
-        int amount = it->second;
+        name.intval = stat.first;
+        int amount = stat.second;
         std::cout << std::setw(digitCount) << amount << " " << name.toString() << "  ";
-
         if (++i % 3 == 0)
             std::cout << std::endl;
     }
@@ -470,18 +464,18 @@ int clone(Arguments& info)
     esm.setVersion(info.data.version);
     esm.setRecordCount (recordCount);
 
-    for (std::vector<ESM::Header::MasterData>::iterator it = info.data.masters.begin(); it != info.data.masters.end(); ++it)
-        esm.addMaster(it->name, it->size);
+    for (const ESM::Header::MasterData &master : info.data.masters)
+        esm.addMaster(master.name, master.size);
 
     std::fstream save(info.outname.c_str(), std::fstream::out | std::fstream::binary);
     esm.save(save);
 
     int saved = 0;
-    typedef std::deque<EsmTool::RecordBase *> Records;
-    Records &records = info.data.mRecords;
-    for (Records::iterator it = records.begin(); it != records.end() && i > 0; ++it)
+    for (EsmTool::RecordBase* record : info.data.mRecords)
     {
-        EsmTool::RecordBase *record = *it;
+        if (i <= 0)
+            break;
+
         const ESM::NAME& typeName = record->getType();
 
         esm.startRecord(typeName.toString(), record->getFlags());
@@ -489,13 +483,10 @@ int clone(Arguments& info)
         record->save(esm);
         if (typeName.intval == ESM::REC_CELL) {
             ESM::Cell *ptr = &record->cast<ESM::Cell>()->get();
-            if (!info.data.mCellRefs[ptr].empty()) {
-                typedef std::deque<std::pair<ESM::CellRef, bool> > RefList;
-                RefList &refs = info.data.mCellRefs[ptr];
-                for (RefList::iterator refIt = refs.begin(); refIt != refs.end(); ++refIt)
-                {
-                    refIt->first.save(esm, refIt->second);
-                }
+            if (!info.data.mCellRefs[ptr].empty()) 
+            {
+                for (std::pair<ESM::CellRef, bool> &ref : info.data.mCellRefs[ptr])
+                    ref.first.save(esm, ref.second);
             }
         }
 
@@ -557,9 +548,6 @@ int comp(Arguments& info)
         std::cout << "Not equal, different amount of records." << std::endl;
         return 1;
     }
-
-
-
 
     return 0;
 }

--- a/apps/esmtool/labels.cpp
+++ b/apps/esmtool/labels.cpp
@@ -651,7 +651,7 @@ std::string ruleFunction(int idx)
 
 std::string bodyPartFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::BodyPart::BPF_Female) properties += "Female ";
     if (flags & ESM::BodyPart::BPF_NotPlayable) properties += "NotPlayable ";
@@ -665,7 +665,7 @@ std::string bodyPartFlags(int flags)
 
 std::string cellFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::Cell::HasWater) properties += "HasWater ";
     if (flags & ESM::Cell::Interior) properties += "Interior ";
@@ -686,7 +686,7 @@ std::string cellFlags(int flags)
 
 std::string containerFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::Container::Unknown) properties += "Unknown ";
     if (flags & ESM::Container::Organic) properties += "Organic ";
@@ -702,7 +702,7 @@ std::string containerFlags(int flags)
 
 std::string creatureFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::Creature::None) properties += "All ";
     if (flags & ESM::Creature::Walks) properties += "Walks ";
@@ -732,7 +732,7 @@ std::string creatureFlags(int flags)
 
 std::string landFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     // The ESM component says that this first four bits are used, but
     // only the first three bits are used as far as I can tell.
     // There's also no enumeration of the bit in the ESM component.
@@ -747,7 +747,7 @@ std::string landFlags(int flags)
 
 std::string itemListFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::ItemLevList::AllLevels) properties += "AllLevels ";
     if (flags & ESM::ItemLevList::Each) properties += "Each ";
@@ -761,7 +761,7 @@ std::string itemListFlags(int flags)
 
 std::string creatureListFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::CreatureLevList::AllLevels) properties += "AllLevels ";
     int unused = (0xFFFFFFFF ^ ESM::CreatureLevList::AllLevels);
@@ -800,7 +800,7 @@ std::string lightFlags(int flags)
 
 std::string magicEffectFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::MagicEffect::TargetAttribute) properties += "TargetAttribute ";
     if (flags & ESM::MagicEffect::TargetSkill) properties += "TargetSkill ";
@@ -826,7 +826,7 @@ std::string magicEffectFlags(int flags)
 
 std::string npcFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     // Mythicmods and the ESM component differ.  Mythicmods says
     // 0x8=None and 0x10=AutoCalc, while our code previously defined
@@ -860,7 +860,7 @@ std::string npcFlags(int flags)
 
 std::string raceFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     // All races have the playable flag set in Bethesda files.
     if (flags & ESM::Race::Playable) properties += "Playable ";
@@ -875,7 +875,7 @@ std::string raceFlags(int flags)
 
 std::string spellFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::Spell::F_Autocalc) properties += "Autocalc ";
     if (flags & ESM::Spell::F_PCStart) properties += "PCStart ";
@@ -891,7 +891,7 @@ std::string spellFlags(int flags)
 
 std::string weaponFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     // The interpretation of the flags are still unclear to me.
     // Apparently you can't be Silver without being Magical?  Many of

--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -49,7 +49,7 @@ void printAIPackage(ESM::AIPackage p)
         std::cout << "    BadPackage: " << boost::format("0x%08x") % p.mType << std::endl;
     }
 
-    if (p.mCellName != "")
+    if (!p.mCellName.empty())
         std::cout << "    Cell Name: " << p.mCellName << std::endl;
 }
 
@@ -130,43 +130,41 @@ std::string ruleString(ESM::DialInfo::SelectStruct ss)
 void printEffectList(ESM::EffectList effects)
 {
     int i = 0;
-    std::vector<ESM::ENAMstruct>::iterator eit;
-    for (eit = effects.mList.begin(); eit != effects.mList.end(); ++eit)
+    for (const ESM::ENAMstruct& effect : effects.mList)
     {
-        std::cout << "  Effect[" << i << "]: " << magicEffectLabel(eit->mEffectID)
-                  << " (" << eit->mEffectID << ")" << std::endl;
-        if (eit->mSkill != -1)
-            std::cout << "    Skill: " << skillLabel(eit->mSkill)
-                      << " (" << (int)eit->mSkill << ")" << std::endl;
-        if (eit->mAttribute != -1)
-            std::cout << "    Attribute: " << attributeLabel(eit->mAttribute)
-                      << " (" << (int)eit->mAttribute << ")" << std::endl;
-        std::cout << "    Range: " << rangeTypeLabel(eit->mRange)
-                  << " (" << eit->mRange << ")" << std::endl;
+        std::cout << "  Effect[" << i << "]: " << magicEffectLabel(effect.mEffectID)
+                  << " (" << effect.mEffectID << ")" << std::endl;
+        if (effect.mSkill != -1)
+            std::cout << "    Skill: " << skillLabel(effect.mSkill)
+                      << " (" << (int)effect.mSkill << ")" << std::endl;
+        if (effect.mAttribute != -1)
+            std::cout << "    Attribute: " << attributeLabel(effect.mAttribute)
+                      << " (" << (int)effect.mAttribute << ")" << std::endl;
+        std::cout << "    Range: " << rangeTypeLabel(effect.mRange)
+                  << " (" << effect.mRange << ")" << std::endl;
         // Area is always zero if range type is "Self"
-        if (eit->mRange != ESM::RT_Self)
-            std::cout << "    Area: " << eit->mArea << std::endl;
-        std::cout << "    Duration: " << eit->mDuration << std::endl;
-        std::cout << "    Magnitude: " << eit->mMagnMin << "-" << eit->mMagnMax << std::endl;
+        if (effect.mRange != ESM::RT_Self)
+            std::cout << "    Area: " << effect.mArea << std::endl;
+        std::cout << "    Duration: " << effect.mDuration << std::endl;
+        std::cout << "    Magnitude: " << effect.mMagnMin << "-" << effect.mMagnMax << std::endl;
         i++;
     }
 }
 
 void printTransport(const std::vector<ESM::Transport::Dest>& transport)
 {
-    std::vector<ESM::Transport::Dest>::const_iterator dit;
-    for (dit = transport.begin(); dit != transport.end(); ++dit)
+    for (const ESM::Transport::Dest& dest : transport)
     {
         std::cout << "  Destination Position: "
-                  << boost::format("%12.3f") % dit->mPos.pos[0] << ","
-                  << boost::format("%12.3f") % dit->mPos.pos[1] << ","
-                  << boost::format("%12.3f") % dit->mPos.pos[2] << ")" << std::endl;
+                  << boost::format("%12.3f") % dest.mPos.pos[0] << ","
+                  << boost::format("%12.3f") % dest.mPos.pos[1] << ","
+                  << boost::format("%12.3f") % dest.mPos.pos[2] << ")" << std::endl;
         std::cout << "  Destination Rotation: "
-                  << boost::format("%9.6f") % dit->mPos.rot[0] << ","
-                  << boost::format("%9.6f") % dit->mPos.rot[1] << ","
-                  << boost::format("%9.6f") % dit->mPos.rot[2] << ")" << std::endl;
-        if (dit->mCellName != "")
-            std::cout << "  Destination Cell: " << dit->mCellName << std::endl;
+                  << boost::format("%9.6f") % dest.mPos.rot[0] << ","
+                  << boost::format("%9.6f") % dest.mPos.rot[1] << ","
+                  << boost::format("%9.6f") % dest.mPos.rot[2] << ")" << std::endl;
+        if (!dest.mCellName.empty())
+            std::cout << "  Destination Cell: " << dest.mCellName << std::endl;
     }
 }
 
@@ -414,7 +412,7 @@ void Record<ESM::Potion>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -429,9 +427,9 @@ void Record<ESM::Armor>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
-    if (mData.mEnchant != "")
+    if (!mData.mEnchant.empty())
         std::cout << "  Enchantment: " << mData.mEnchant << std::endl;
     std::cout << "  Type: " << armorTypeLabel(mData.mData.mType)
               << " (" << mData.mData.mType << ")" << std::endl;
@@ -440,15 +438,15 @@ void Record<ESM::Armor>::print()
     std::cout << "  Health: " << mData.mData.mHealth << std::endl;
     std::cout << "  Armor: " << mData.mData.mArmor << std::endl;
     std::cout << "  Enchantment Points: " << mData.mData.mEnchant << std::endl;
-    std::vector<ESM::PartReference>::iterator pit;
-    for (pit = mData.mParts.mParts.begin(); pit != mData.mParts.mParts.end(); ++pit)
+    for (const ESM::PartReference &part : mData.mParts.mParts)
     {
-        std::cout << "  Body Part: " << bodyPartLabel(pit->mPart)
-                  << " (" << (int)(pit->mPart) << ")" << std::endl;
-        std::cout << "    Male Name: " << pit->mMale << std::endl;
-        if (pit->mFemale != "")
-            std::cout << "    Female Name: " << pit->mFemale << std::endl;
+        std::cout << "  Body Part: " << bodyPartLabel(part.mPart)
+                  << " (" << (int)(part.mPart) << ")" << std::endl;
+        std::cout << "    Male Name: " << part.mMale << std::endl;
+        if (!part.mFemale.empty())
+            std::cout << "    Female Name: " << part.mFemale << std::endl;
     }
+
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
@@ -487,9 +485,9 @@ void Record<ESM::Book>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
-    if (mData.mEnchant != "")
+    if (!mData.mEnchant.empty())
         std::cout << "  Enchantment: " << mData.mEnchant << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -516,9 +514,8 @@ void Record<ESM::BirthSign>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Texture: " << mData.mTexture << std::endl;
     std::cout << "  Description: " << mData.mDescription << std::endl;
-    std::vector<std::string>::iterator pit;
-    for (pit = mData.mPowers.mList.begin(); pit != mData.mPowers.mList.end(); ++pit)
-        std::cout << "  Power: " << *pit << std::endl;
+    for (const std::string &power : mData.mPowers.mList)
+        std::cout << "  Power: " << power << std::endl;
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
@@ -526,9 +523,9 @@ template<>
 void Record<ESM::Cell>::print()
 {
     // None of the cells have names...
-    if (mData.mName != "")
+    if (!mData.mName.empty())
         std::cout << "  Name: " << mData.mName << std::endl;
-    if (mData.mRegion != "")
+    if (!mData.mRegion.empty())
         std::cout << "  Region: " << mData.mRegion << std::endl;
     std::cout << "  Flags: " << cellFlags(mData.mData.mFlags) << std::endl;
 
@@ -580,23 +577,22 @@ void Record<ESM::Clothing>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
-    if (mData.mEnchant != "")
+    if (!mData.mEnchant.empty())
         std::cout << "  Enchantment: " << mData.mEnchant << std::endl;
     std::cout << "  Type: " << clothingTypeLabel(mData.mData.mType)
               << " (" << mData.mData.mType << ")" << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
     std::cout << "  Enchantment Points: " << mData.mData.mEnchant << std::endl;
-    std::vector<ESM::PartReference>::iterator pit;
-    for (pit = mData.mParts.mParts.begin(); pit != mData.mParts.mParts.end(); ++pit)
+    for (const ESM::PartReference &part : mData.mParts.mParts)
     {
-        std::cout << "  Body Part: " << bodyPartLabel(pit->mPart)
-                  << " (" << (int)(pit->mPart) << ")" << std::endl;
-        std::cout << "    Male Name: " << pit->mMale << std::endl;
-        if (pit->mFemale != "")
-            std::cout << "    Female Name: " << pit->mFemale << std::endl;
+        std::cout << "  Body Part: " << bodyPartLabel(part.mPart)
+                  << " (" << (int)(part.mPart) << ")" << std::endl;
+        std::cout << "    Male Name: " << part.mMale << std::endl;
+        if (!part.mFemale.empty())
+            std::cout << "    Female Name: " << part.mFemale << std::endl;
     }
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
@@ -606,14 +602,13 @@ void Record<ESM::Container>::print()
 {
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Flags: " << containerFlags(mData.mFlags) << std::endl;
     std::cout << "  Weight: " << mData.mWeight << std::endl;
-    std::vector<ESM::ContItem>::iterator cit;
-    for (cit = mData.mInventory.mList.begin(); cit != mData.mInventory.mList.end(); ++cit)
-        std::cout << "  Inventory: Count: " << boost::format("%4d") % cit->mCount
-                  << " Item: " << cit->mItem.toString() << std::endl;
+    for (const ESM::ContItem &item : mData.mInventory.mList)
+        std::cout << "  Inventory: Count: " << boost::format("%4d") % item.mCount
+                  << " Item: " << item.mItem.toString() << std::endl;
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
@@ -656,14 +651,12 @@ void Record<ESM::Creature>::print()
               << "-" <<  mData.mData.mAttack[5] << std::endl;
     std::cout << "  Gold: " << mData.mData.mGold << std::endl;
 
-    std::vector<ESM::ContItem>::iterator cit;
-    for (cit = mData.mInventory.mList.begin(); cit != mData.mInventory.mList.end(); ++cit)
-        std::cout << "  Inventory: Count: " << boost::format("%4d") % cit->mCount
-                  << " Item: " << cit->mItem.toString() << std::endl;
+    for (const ESM::ContItem &item : mData.mInventory.mList)
+        std::cout << "  Inventory: Count: " << boost::format("%4d") % item.mCount
+                  << " Item: " << item.mItem.toString() << std::endl;
 
-    std::vector<std::string>::iterator sit;
-    for (sit = mData.mSpells.mList.begin(); sit != mData.mSpells.mList.end(); ++sit)
-        std::cout << "  Spell: " << *sit << std::endl;
+    for (const std::string &spell : mData.mSpells.mList)
+        std::cout << "  Spell: " << spell << std::endl;
 
     printTransport(mData.getTransport());
 
@@ -678,9 +671,8 @@ void Record<ESM::Creature>::print()
     std::cout << "    AI U4:" << (int)mData.mAiData.mU4 << std::endl;
     std::cout << "    AI Services:" << boost::format("0x%08X") % mData.mAiData.mServices << std::endl;
 
-    std::vector<ESM::AIPackage>::iterator pit;
-    for (pit = mData.mAiPackage.mList.begin(); pit != mData.mAiPackage.mList.end(); ++pit)
-        printAIPackage(*pit);
+    for (const ESM::AIPackage &package : mData.mAiPackage.mList)
+        printAIPackage(package);
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
@@ -693,9 +685,8 @@ void Record<ESM::Dialogue>::print()
     // Sadly, there are no DialInfos, because the loader dumps as it
     // loads, rather than loading and then dumping. :-( Anyone mind if
     // I change this?
-    ESM::Dialogue::InfoContainer::iterator iit;
-    for (iit = mData.mInfo.begin(); iit != mData.mInfo.end(); ++iit)
-        std::cout << "INFO!" << iit->mId << std::endl;
+    for (const ESM::DialInfo &info : mData.mInfo)
+        std::cout << "INFO!" << info.mId << std::endl;
 }
 
 template<>
@@ -735,7 +726,7 @@ void Record<ESM::Faction>::print()
             std::cout << "  Skill: " << skillLabel(mData.mData.mSkills[i])
                       << " (" << mData.mData.mSkills[i] << ")" << std::endl;
     for (int i = 0; i != 10; i++)
-        if (mData.mRanks[i] != "")
+        if (!mData.mRanks[i].empty())
         {
             std::cout << "  Rank: " << mData.mRanks[i] << std::endl;
             std::cout << "    Attribute1 Requirement: "
@@ -749,9 +740,8 @@ void Record<ESM::Faction>::print()
             std::cout << "    Faction Reaction: "
                       << mData.mData.mRankData[i].mFactReaction << std::endl;
         }
-    std::map<std::string, int>::iterator rit;
-    for (rit = mData.mReactions.begin(); rit != mData.mReactions.end(); ++rit)
-        std::cout << "  Reaction: " << rit->second << " = " << rit->first << std::endl;
+    for (const std::pair<std::string, int> &reaction : mData.mReactions)
+        std::cout << "  Reaction: " << reaction.second << " = " << reaction.first << std::endl;
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
@@ -772,34 +762,34 @@ template<>
 void Record<ESM::DialInfo>::print()
 {
     std::cout << "  Id: " << mData.mId << std::endl;
-    if (mData.mPrev != "")
+    if (!mData.mPrev.empty())
         std::cout << "  Previous ID: " << mData.mPrev << std::endl;
-    if (mData.mNext != "")
+    if (!mData.mNext.empty())
         std::cout << "  Next ID: " << mData.mNext << std::endl;
     std::cout << "  Text: " << mData.mResponse << std::endl;
-    if (mData.mActor != "")
+    if (!mData.mActor.empty())
         std::cout << "  Actor: " << mData.mActor << std::endl;
-    if (mData.mRace != "")
+    if (!mData.mRace.empty())
         std::cout << "  Race: " << mData.mRace << std::endl;
-    if (mData.mClass != "")
+    if (!mData.mClass.empty())
         std::cout << "  Class: " << mData.mClass << std::endl;
     std::cout << "  Factionless: " << mData.mFactionLess << std::endl;
-    if (mData.mFaction != "")
+    if (!mData.mFaction.empty())
         std::cout << "  NPC Faction: " << mData.mFaction << std::endl;
     if (mData.mData.mRank != -1)
         std::cout << "  NPC Rank: " << (int)mData.mData.mRank << std::endl;
-    if (mData.mPcFaction != "")
+    if (!mData.mPcFaction.empty())
         std::cout << "  PC Faction: " << mData.mPcFaction << std::endl;
     // CHANGE? non-standard capitalization mPCrank -> mPCRank (mPcRank?)
     if (mData.mData.mPCrank != -1)
         std::cout << "  PC Rank: " << (int)mData.mData.mPCrank << std::endl;
-    if (mData.mCell != "")
+    if (!mData.mCell.empty())
         std::cout << "  Cell: " << mData.mCell << std::endl;
     if (mData.mData.mDisposition > 0)
         std::cout << "  Disposition/Journal index: " << mData.mData.mDisposition << std::endl;
     if (mData.mData.mGender != ESM::DialInfo::NA)
         std::cout << "  Gender: " << mData.mData.mGender << std::endl;
-    if (mData.mSound != "")
+    if (!mData.mSound.empty())
         std::cout << "  Sound File: " << mData.mSound << std::endl;
 
 
@@ -808,11 +798,10 @@ void Record<ESM::DialInfo>::print()
     std::cout << "  Unknown1: " << mData.mData.mUnknown1 << std::endl;
     std::cout << "  Unknown2: " << (int)mData.mData.mUnknown2 << std::endl;
 
-    std::vector<ESM::DialInfo::SelectStruct>::iterator sit;
-    for (sit = mData.mSelects.begin(); sit != mData.mSelects.end(); ++sit)
-        std::cout << "  Select Rule: " << ruleString(*sit) << std::endl;
+    for (const ESM::DialInfo::SelectStruct &rule : mData.mSelects)
+        std::cout << "  Select Rule: " << ruleString(rule) << std::endl;
 
-    if (mData.mResultScript != "")
+    if (!mData.mResultScript.empty())
     {
         if (mPrintPlain)
         {
@@ -835,7 +824,7 @@ void Record<ESM::Ingredient>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -877,10 +866,9 @@ void Record<ESM::CreatureLevList>::print()
     std::cout << "  Chance for None: " << (int)mData.mChanceNone << std::endl;
     std::cout << "  Flags: " << creatureListFlags(mData.mFlags) << std::endl;
     std::cout << "  Number of items: " << mData.mList.size() << std::endl;
-    std::vector<ESM::LevelledListBase::LevelItem>::iterator iit;
-    for (iit = mData.mList.begin(); iit != mData.mList.end(); ++iit)
-        std::cout << "  Creature: Level: " << iit->mLevel
-                  << " Creature: " << iit->mId << std::endl;
+    for (const ESM::LevelledListBase::LevelItem &item : mData.mList)
+        std::cout << "  Creature: Level: " << item.mLevel
+                  << " Creature: " << item.mId << std::endl;
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
@@ -890,23 +878,22 @@ void Record<ESM::ItemLevList>::print()
     std::cout << "  Chance for None: " << (int)mData.mChanceNone << std::endl;
     std::cout << "  Flags: " << itemListFlags(mData.mFlags) << std::endl;
     std::cout << "  Number of items: " << mData.mList.size() << std::endl;
-    std::vector<ESM::LevelledListBase::LevelItem>::iterator iit;
-    for (iit = mData.mList.begin(); iit != mData.mList.end(); ++iit)
-        std::cout << "  Inventory: Level: " << iit->mLevel
-                  << " Item: " << iit->mId << std::endl;
+    for (const ESM::LevelledListBase::LevelItem &item : mData.mList)
+        std::cout << "  Inventory: Level: " << item.mLevel
+                  << " Item: " << item.mId << std::endl;
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
 
 template<>
 void Record<ESM::Light>::print()
 {
-    if (mData.mName != "")
+    if (!mData.mName.empty())
         std::cout << "  Name: " << mData.mName << std::endl;
-    if (mData.mModel != "")
+    if (!mData.mModel.empty())
         std::cout << "  Model: " << mData.mModel << std::endl;
-    if (mData.mIcon != "")
+    if (!mData.mIcon.empty())
         std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Flags: " << lightFlags(mData.mData.mFlags) << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
@@ -924,7 +911,7 @@ void Record<ESM::Lockpick>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -939,7 +926,7 @@ void Record<ESM::Probe>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -954,7 +941,7 @@ void Record<ESM::Repair>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -981,21 +968,21 @@ void Record<ESM::MagicEffect>::print()
     std::cout << "  Icon: " << mData.mIcon << std::endl;
     std::cout << "  Flags: " << magicEffectFlags(mData.mData.mFlags) << std::endl;
     std::cout << "  Particle Texture: " << mData.mParticle << std::endl;
-    if (mData.mCasting != "")
+    if (!mData.mCasting.empty())
         std::cout << "  Casting Static: " << mData.mCasting << std::endl;
-    if (mData.mCastSound != "")
+    if (!mData.mCastSound.empty())
         std::cout << "  Casting Sound: " << mData.mCastSound << std::endl;
-    if (mData.mBolt != "")
+    if (!mData.mBolt.empty())
         std::cout << "  Bolt Static: " << mData.mBolt << std::endl;
-    if (mData.mBoltSound != "")
+    if (!mData.mBoltSound.empty())
         std::cout << "  Bolt Sound: " << mData.mBoltSound << std::endl;
-    if (mData.mHit != "")
+    if (!mData.mHit.empty())
         std::cout << "  Hit Static: " << mData.mHit << std::endl;
-    if (mData.mHitSound != "")
+    if (!mData.mHitSound.empty())
         std::cout << "  Hit Sound: " << mData.mHitSound << std::endl;
-    if (mData.mArea != "")
+    if (!mData.mArea.empty())
         std::cout << "  Area Static: " << mData.mArea << std::endl;
-    if (mData.mAreaSound != "")
+    if (!mData.mAreaSound.empty())
         std::cout << "  Area Sound: " << mData.mAreaSound << std::endl;
     std::cout << "  School: " << schoolLabel(mData.mData.mSchool)
               << " (" << mData.mData.mSchool << ")" << std::endl;
@@ -1015,7 +1002,7 @@ void Record<ESM::Miscellaneous>::print()
     std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
     std::cout << "  Weight: " << mData.mData.mWeight << std::endl;
     std::cout << "  Value: " << mData.mData.mValue << std::endl;
@@ -1032,9 +1019,9 @@ void Record<ESM::NPC>::print()
     std::cout << "  Head Model: " << mData.mHead << std::endl;
     std::cout << "  Race: " << mData.mRace << std::endl;
     std::cout << "  Class: " << mData.mClass << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
-    if (mData.mFaction != "")
+    if (!mData.mFaction.empty())
         std::cout << "  Faction: " << mData.mFaction << std::endl;
     std::cout << "  Flags: " << npcFlags(mData.mFlags) << std::endl;
 
@@ -1083,14 +1070,12 @@ void Record<ESM::NPC>::print()
         std::cout << "  Gold: " << mData.mNpdt.mGold << std::endl;
     }
 
-    std::vector<ESM::ContItem>::iterator cit;
-    for (cit = mData.mInventory.mList.begin(); cit != mData.mInventory.mList.end(); ++cit)
-        std::cout << "  Inventory: Count: " << boost::format("%4d") % cit->mCount
-                  << " Item: " << cit->mItem.toString() << std::endl;
+    for (const ESM::ContItem &item : mData.mInventory.mList)
+        std::cout << "  Inventory: Count: " << boost::format("%4d") % item.mCount
+                  << " Item: " << item.mItem.toString() << std::endl;
 
-    std::vector<std::string>::iterator sit;
-    for (sit = mData.mSpells.mList.begin(); sit != mData.mSpells.mList.end(); ++sit)
-        std::cout << "  Spell: " << *sit << std::endl;
+    for (const std::string &spell : mData.mSpells.mList)
+        std::cout << "  Spell: " << spell << std::endl;
 
     printTransport(mData.getTransport());
 
@@ -1105,9 +1090,8 @@ void Record<ESM::NPC>::print()
     std::cout << "    AI U4:" << (int)mData.mAiData.mU4 << std::endl;
     std::cout << "    AI Services:" << boost::format("0x%08X") % mData.mAiData.mServices << std::endl;
 
-    std::vector<ESM::AIPackage>::iterator pit;
-    for (pit = mData.mAiPackage.mList.begin(); pit != mData.mAiPackage.mList.end(); ++pit)
-        printAIPackage(*pit);
+    for (const ESM::AIPackage &package : mData.mAiPackage.mList)
+        printAIPackage(package);
 
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
@@ -1124,23 +1108,22 @@ void Record<ESM::Pathgrid>::print()
     std::cout << "  Edge Count: " << mData.mEdges.size() << std::endl;
 
     int i = 0;
-    ESM::Pathgrid::PointList::iterator pit;
-    for (pit = mData.mPoints.begin(); pit != mData.mPoints.end(); ++pit)
+    for (const ESM::Pathgrid::Point &point : mData.mPoints)
     {
         std::cout << "  Point[" << i << "]:" << std::endl;
-        std::cout << "    Coordinates: (" << pit->mX << ","
-             << pit->mY << "," << pit->mZ << ")" << std::endl;
-        std::cout << "    Auto-Generated: " << (int)pit->mAutogenerated << std::endl;
-        std::cout << "    Connections: " << (int)pit->mConnectionNum << std::endl;
-        std::cout << "    Unknown: " << pit->mUnknown << std::endl;
+        std::cout << "    Coordinates: (" << point.mX << ","
+             << point.mY << "," << point.mZ << ")" << std::endl;
+        std::cout << "    Auto-Generated: " << (int)point.mAutogenerated << std::endl;
+        std::cout << "    Connections: " << (int)point.mConnectionNum << std::endl;
+        std::cout << "    Unknown: " << point.mUnknown << std::endl;
         i++;
     }
+
     i = 0;
-    ESM::Pathgrid::EdgeList::iterator eit;
-    for (eit = mData.mEdges.begin(); eit != mData.mEdges.end(); ++eit)
+    for (const ESM::Pathgrid::Edge &edge : mData.mEdges)
     {
-        std::cout << "  Edge[" << i << "]: " << eit->mV0 << " -> " << eit->mV1 << std::endl;
-        if (eit->mV0 >= mData.mData.mS2 || eit->mV1 >= mData.mData.mS2)
+        std::cout << "  Edge[" << i << "]: " << edge.mV0 << " -> " << edge.mV1 << std::endl;
+        if (edge.mV0 >= mData.mData.mS2 || edge.mV1 >= mData.mData.mS2)
             std::cout << "  BAD POINT IN EDGE!" << std::endl;
         i++;
     }
@@ -1183,9 +1166,8 @@ void Record<ESM::Race>::print()
                       << " (" << mData.mData.mBonus[i].mSkill << ") = "
                       << mData.mData.mBonus[i].mBonus << std::endl;
 
-    std::vector<std::string>::iterator sit;
-    for (sit = mData.mPowers.mList.begin(); sit != mData.mPowers.mList.end(); ++sit)
-        std::cout << "  Power: " << *sit << std::endl;
+    for (const std::string &power : mData.mPowers.mList)
+        std::cout << "  Power: " << power << std::endl;
 
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }
@@ -1207,11 +1189,10 @@ void Record<ESM::Region>::print()
     std::cout << "    UnknownA: " << (int)mData.mData.mA << std::endl;
     std::cout << "    UnknownB: " << (int)mData.mData.mB << std::endl;
     std::cout << "  Map Color: " << mData.mMapColor << std::endl;
-    if (mData.mSleepList != "")
+    if (!mData.mSleepList.empty())
         std::cout << "  Sleep List: " << mData.mSleepList << std::endl;
-    std::vector<ESM::Region::SoundRef>::iterator sit;
-    for (sit = mData.mSoundList.begin(); sit != mData.mSoundList.end(); ++sit)
-        std::cout << "  Sound: " << (int)sit->mChance << " = " << sit->mSound.toString() << std::endl;
+    for (const ESM::Region::SoundRef &soundref : mData.mSoundList)
+        std::cout << "  Sound: " << (int)soundref.mChance << " = " << soundref.mSound.toString() << std::endl;
 }
 
 template<>
@@ -1225,15 +1206,12 @@ void Record<ESM::Script>::print()
     std::cout << "  Script Data Size: " << mData.mData.mScriptDataSize << std::endl;
     std::cout << "  Table Size: " << mData.mData.mStringTableSize << std::endl;
 
-
-    std::vector<std::string>::iterator vit;
-    for (vit = mData.mVarNames.begin(); vit != mData.mVarNames.end(); ++vit)
-        std::cout << "  Variable: " << *vit << std::endl;
+    for (const std::string &variable : mData.mVarNames)
+        std::cout << "  Variable: " << variable << std::endl;
 
     std::cout << "  ByteCode: ";
-    std::vector<unsigned char>::iterator cit;
-    for (cit = mData.mScriptData.begin(); cit != mData.mScriptData.end(); ++cit)
-        std::cout << boost::format("%02X") % (int)(*cit);
+    for (const unsigned char &byte : mData.mScriptData)
+        std::cout << boost::format("%02X") % (int)(byte);
     std::cout << std::endl;
 
     if (mPrintPlain)
@@ -1268,7 +1246,8 @@ void Record<ESM::Skill>::print()
 template<>
 void Record<ESM::SoundGenerator>::print()
 {
-    std::cout << "  Creature: " << mData.mCreature << std::endl;
+    if (!mData.mCreature.empty())
+        std::cout << "  Creature: " << mData.mCreature << std::endl;
     std::cout << "  Sound: " << mData.mSound << std::endl;
     std::cout << "  Type: " << soundTypeLabel(mData.mType)
               << " (" << mData.mType << ")" << std::endl;
@@ -1316,15 +1295,15 @@ template<>
 void Record<ESM::Weapon>::print()
 {
     // No names on VFX bolts
-    if (mData.mName != "")
+    if (!mData.mName.empty())
         std::cout << "  Name: " << mData.mName << std::endl;
     std::cout << "  Model: " << mData.mModel << std::endl;
     // No icons on VFX bolts or magic bolts
-    if (mData.mIcon != "")
+    if (!mData.mIcon.empty())
         std::cout << "  Icon: " << mData.mIcon << std::endl;
-    if (mData.mScript != "")
+    if (!mData.mScript.empty())
         std::cout << "  Script: " << mData.mScript << std::endl;
-    if (mData.mEnchant != "")
+    if (!mData.mEnchant.empty())
         std::cout << "  Enchantment: " << mData.mEnchant << std::endl;
     std::cout << "  Type: " << weaponTypeLabel(mData.mData.mType)
               << " (" << mData.mData.mType << ")" << std::endl;
@@ -1356,25 +1335,25 @@ std::string Record<ESM::Cell>::getId() const
 template<> 
 std::string Record<ESM::Land>::getId() const
 {
-    return ""; // No ID for Land record
+    return std::string(); // No ID for Land record
 }
 
 template<> 
 std::string Record<ESM::MagicEffect>::getId() const
 {
-    return ""; // No ID for MagicEffect record
+    return std::string(); // No ID for MagicEffect record
 }
 
 template<> 
 std::string Record<ESM::Pathgrid>::getId() const
 {
-    return ""; // No ID for Pathgrid record
+    return std::string(); // No ID for Pathgrid record
 }
 
 template<> 
 std::string Record<ESM::Skill>::getId() const
 {
-    return ""; // No ID for Skill record
+    return std::string(); // No ID for Skill record
 }
 
 } // end namespace


### PR DESCRIPTION
More minor readability improvements like in the PRs I previously have done - like using std::string::empty instead of `""` comparison, range-based for loops instead of many iterators and cleaning up redundant `""` empty string declarations and usage.

I admit I don't fully understand why there were references constructed for working with certain collections. If changing that is horribly wrong, please let me know.