### PR TITLE
Don't stack scripted items (bug #2969)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.46.0
 ------
 
+    Bug #2969: Scripted items can stack
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
     Bug #4411: Reloading a saved game while falling prevents damage in some cases

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -246,7 +246,9 @@ bool MWWorld::ContainerStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2)
 
         && ptr1.getClass().getRemainingUsageTime(ptr1) == ptr2.getClass().getRemainingUsageTime(ptr2)
 
-        && cls1.getScript(ptr1) == cls2.getScript(ptr2)
+        // Items with scripts never stack
+        && cls1.getScript(ptr1).empty()
+        && cls2.getScript(ptr2).empty()
 
         // item that is already partly used up never stacks
         && (!cls1.hasItemHealth(ptr1) || (
@@ -306,7 +308,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr
     item.getCellRef().unsetRefNum(); // destroy link to content file
 
     std::string script = item.getClass().getScript(item);
-    if(script != "")
+    if (!script.empty())
     {
         if (actorPtr == player)
         {


### PR DESCRIPTION
[Bug 2969](https://gitlab.com/OpenMW/openmw/issues/2969).

Make scripted items not stack, ensure scripted items added with AddItem don't stack and optimize an item name recovery loop in RemoveItem.

Scripted items must not stack because every stack is effectively a single reference which can have non-1 count but still have 1 script, but every script must be per-instance and not per-stack (or shit breaks due to script states being merged). This is something scrawl changed a while ago seemingly for no reason. Even then, ContainerStore::add happily creates stacks of anything added even if the added items shouldn't stack (they simply won't stack with existing instances of the same item ID if they can't stack).

Using a loop for ContainerStore::add is obviously not ideal for performance, but I can't think of something else that doesn't horribly break stacking.