### PR TITLE
allow release builds to have a console

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,12 +656,6 @@ if (WIN32)
       set_target_properties(openmw PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/SUBSYSTEM:WINDOWS")
     endif()
 
-    if (BUILD_OPENMW)
-        # Release builds don't use the debug console
-        set_target_properties(openmw PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-        set_target_properties(openmw PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
-    endif()
-
     # Play a bit with the warning levels
 
     set(WARNINGS "/Wall") # Since windows can only disable specific warnings, not enable them


### PR DESCRIPTION
Right now it's possible to have a console after-the-fact using `editbin`. The user ought to be able to control its presence regardless of build type. Otherwise it's necessary to use a debug build type with release-type compiler and linker flags.

It's not typical for CMake projects to dispatch on the build type, which is after all an arbitrary name.