### PR TITLE
fix NMake failure at configure-time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,14 @@ set(USED_OSG_PLUGINS
                     osgdb_tga
                   )
 
-get_filename_component(OSG_LIB_DIR ${OSGDB_LIBRARY} DIRECTORY)
+if(OSGDB_LIBRARY_DEBUG)
+    set(osgdb-libpath "${OSGDB_LIBRARY_DEBUG}")
+elseif(OSGDB_LIBRARY_RELEASE)
+    set(osgdb-libpath "${OSGDB_LIBRARY_RELEASE}")
+else()
+    set(osgdb-libpath "${OSGDB_LIBRARY}")
+endif()
+get_filename_component(OSG_LIB_DIR ${osgdb-libpath} DIRECTORY)
 set(OSGPlugins_LIB_DIR "${OSG_LIB_DIR}/osgPlugins-${OPENSCENEGRAPH_VERSION}")
 
 if(OSG_STATIC)


### PR DESCRIPTION
Fix `OSGDB_LIBRARY` not having a singular path on Windows resulting in CMake configure failure. I'd rather use some elegant solution but there's no `IMPORTED_LOCATION` available under any name. See `share/cmake/Modules` for osg bits.

If there's some elegant solution to extract the correct library path then naturally it should be used instead.
