### PR TITLE
 Make normal weapon resistance behavior closer to vanilla (bug #4384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     Bug #3733: Normal maps are inverted on mirrored UVs
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
+    Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -80,6 +80,7 @@ bool Launcher::AdvancedPage::loadSettings()
     int unarmedFactorsStrengthIndex = mEngineSettings.getInt("strength influences hand to hand", "Game");
     if (unarmedFactorsStrengthIndex >= 0 && unarmedFactorsStrengthIndex <= 2)
         unarmedFactorsStrengthComboBox->setCurrentIndex(unarmedFactorsStrengthIndex);
+    loadSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
 
     // Input Settings
     loadSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");
@@ -139,6 +140,7 @@ void Launcher::AdvancedPage::saveSettings()
     int unarmedFactorsStrengthIndex = unarmedFactorsStrengthComboBox->currentIndex();
     if (unarmedFactorsStrengthIndex != mEngineSettings.getInt("strength influences hand to hand", "Game"))
         mEngineSettings.setInt("strength influences hand to hand", "Game", unarmedFactorsStrengthIndex);
+    saveSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
 
     // Input Settings
     saveSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -308,6 +308,7 @@ namespace MWClass
             {
                 damage = attack[0] + ((attack[1]-attack[0])*attackStrength);
                 MWMechanics::adjustWeaponDamage(damage, weapon, ptr);
+                MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
                 MWMechanics::reduceWeaponCondition(damage, true, weapon, ptr);
             }
 
@@ -381,9 +382,6 @@ namespace MWClass
 
         if (!object.isEmpty())
             stats.setLastHitObject(object.getCellRef().getRefId());
-
-        if (damage > 0.0f && !object.isEmpty())
-            MWMechanics::resistNormalWeapon(ptr, attacker, object, damage);
 
         if (damage < 0.001f)
             damage = 0;

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -308,7 +308,6 @@ namespace MWClass
             {
                 damage = attack[0] + ((attack[1]-attack[0])*attackStrength);
                 MWMechanics::adjustWeaponDamage(damage, weapon, ptr);
-                MWMechanics::applyWerewolfDamageMult(victim, weapon, damage);
                 MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
                 MWMechanics::reduceWeaponCondition(damage, true, weapon, ptr);
             }

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -308,6 +308,7 @@ namespace MWClass
             {
                 damage = attack[0] + ((attack[1]-attack[0])*attackStrength);
                 MWMechanics::adjustWeaponDamage(damage, weapon, ptr);
+                MWMechanics::applyWerewolfDamageMult(victim, weapon, damage);
                 MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
                 MWMechanics::reduceWeaponCondition(damage, true, weapon, ptr);
             }

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -621,6 +621,7 @@ namespace MWClass
             }
             MWMechanics::adjustWeaponDamage(damage, weapon, ptr);
             resisted = MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
+            MWMechanics::applyWerewolfDamageMult(victim, weapon, damage);
             MWMechanics::reduceWeaponCondition(damage, true, weapon, ptr);
             healthdmg = true;
         }

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -604,6 +604,7 @@ namespace MWClass
         }
 
         bool healthdmg;
+        bool resisted = false;
         float damage = 0.0f;
         if(!weapon.isEmpty())
         {
@@ -619,6 +620,7 @@ namespace MWClass
                 damage  = attack[0] + ((attack[1]-attack[0])*attackStrength);
             }
             MWMechanics::adjustWeaponDamage(damage, weapon, ptr);
+            resisted = MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
             MWMechanics::reduceWeaponCondition(damage, true, weapon, ptr);
             healthdmg = true;
         }
@@ -629,6 +631,8 @@ namespace MWClass
         if(ptr == MWMechanics::getPlayer())
         {
             skillUsageSucceeded(ptr, weapskill, 0);
+            if (resisted)
+                MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicTargetResistsWeapons}");
 
             const MWMechanics::AiSequence& seq = victim.getClass().getCreatureStats(victim).getAiSequence();
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -604,7 +604,6 @@ namespace MWClass
         }
 
         bool healthdmg;
-        bool resisted = false;
         float damage = 0.0f;
         if(!weapon.isEmpty())
         {
@@ -620,7 +619,7 @@ namespace MWClass
                 damage  = attack[0] + ((attack[1]-attack[0])*attackStrength);
             }
             MWMechanics::adjustWeaponDamage(damage, weapon, ptr);
-            resisted = MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
+            MWMechanics::resistNormalWeapon(victim, ptr, weapon, damage);
             MWMechanics::applyWerewolfDamageMult(victim, weapon, damage);
             MWMechanics::reduceWeaponCondition(damage, true, weapon, ptr);
             healthdmg = true;
@@ -632,8 +631,6 @@ namespace MWClass
         if(ptr == MWMechanics::getPlayer())
         {
             skillUsageSucceeded(ptr, weapskill, 0);
-            if (resisted)
-                MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicTargetResistsWeapons}");
 
             const MWMechanics::AiSequence& seq = victim.getClass().getCreatureStats(victim).getAiSequence();
 

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -227,7 +227,7 @@ namespace MWMechanics
             damage += attack[0] + ((attack[1] - attack[0]) * attackStrength);
 
             adjustWeaponDamage(damage, weapon, attacker);
-            if (weapon == projectile || isNormalWeapon(weapon)) // NB: both the weapon and the projectile need to be normal
+            if (weapon == projectile || Settings::Manager::getBool("only appropriate ammunition bypasses resistance", "Game") || isNormalWeapon(weapon))
                 resistNormalWeapon(victim, attacker, projectile, damage);
             applyWerewolfDamageMult(victim, projectile, damage);
 

--- a/apps/openmw/mwmechanics/combat.hpp
+++ b/apps/openmw/mwmechanics/combat.hpp
@@ -12,7 +12,11 @@ bool applyOnStrikeEnchantment(const MWWorld::Ptr& attacker, const MWWorld::Ptr& 
 /// @return can we block the attack?
 bool blockMeleeAttack (const MWWorld::Ptr& attacker, const MWWorld::Ptr& blocker, const MWWorld::Ptr& weapon, float damage, float attackStrength);
 
-void resistNormalWeapon (const MWWorld::Ptr& actor, const MWWorld::Ptr& attacker, const MWWorld::Ptr& weapon, float& damage);
+/// @return does normal weapon resistance and weakness apply to the weapon?
+bool isNormalWeapon (const MWWorld::Ptr& weapon);
+
+/// @return was the damage fully resisted?
+bool resistNormalWeapon (const MWWorld::Ptr& actor, const MWWorld::Ptr& attacker, const MWWorld::Ptr& weapon, float& damage);
 
 /// @note for a thrown weapon, \a weapon == \a projectile, for bows/crossbows, \a projectile is the arrow/bolt
 /// @note \a victim may be empty (e.g. for a hit on terrain), a non-actor (environment objects) or an actor

--- a/apps/openmw/mwmechanics/combat.hpp
+++ b/apps/openmw/mwmechanics/combat.hpp
@@ -18,6 +18,8 @@ bool isNormalWeapon (const MWWorld::Ptr& weapon);
 /// @return was the damage fully resisted?
 bool resistNormalWeapon (const MWWorld::Ptr& actor, const MWWorld::Ptr& attacker, const MWWorld::Ptr& weapon, float& damage);
 
+void applyWerewolfDamageMult (const MWWorld::Ptr& actor, const MWWorld::Ptr& weapon, float &damage);
+
 /// @note for a thrown weapon, \a weapon == \a projectile, for bows/crossbows, \a projectile is the arrow/bolt
 /// @note \a victim may be empty (e.g. for a hit on terrain), a non-actor (environment objects) or an actor
 void projectileHit (const MWWorld::Ptr& attacker, const MWWorld::Ptr& victim, MWWorld::Ptr weapon, const MWWorld::Ptr& projectile,

--- a/apps/openmw/mwmechanics/combat.hpp
+++ b/apps/openmw/mwmechanics/combat.hpp
@@ -15,8 +15,7 @@ bool blockMeleeAttack (const MWWorld::Ptr& attacker, const MWWorld::Ptr& blocker
 /// @return does normal weapon resistance and weakness apply to the weapon?
 bool isNormalWeapon (const MWWorld::Ptr& weapon);
 
-/// @return was the damage fully resisted?
-bool resistNormalWeapon (const MWWorld::Ptr& actor, const MWWorld::Ptr& attacker, const MWWorld::Ptr& weapon, float& damage);
+void resistNormalWeapon (const MWWorld::Ptr& actor, const MWWorld::Ptr& attacker, const MWWorld::Ptr& weapon, float& damage);
 
 void applyWerewolfDamageMult (const MWWorld::Ptr& actor, const MWWorld::Ptr& weapon, float &damage);
 

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -78,7 +78,10 @@ namespace MWMechanics
         adjustWeaponDamage(rating, item, actor);
 
         if (weapon->mData.mType != ESM::Weapon::MarksmanBow && weapon->mData.mType != ESM::Weapon::MarksmanCrossbow)
+        {
             resistNormalWeapon(enemy, actor, item, rating);
+            applyWerewolfDamageMult(enemy, item, rating);
+        }
         else if (weapon->mData.mType == ESM::Weapon::MarksmanBow)
         {
             if (arrowRating <= 0.f)

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -211,3 +211,16 @@ disposition change of merchants caused by trading will be permanent and won't be
 This imitates the option that Morrowind Code Patch offers.
 
 This setting can be toggled in Advanced tab of the launcher.
+
+only appropriate ammunition bypasses resistance
+-----------------------------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+If this setting is true, you will have to use the appropriate ammunition to bypass normal weapon resistance (or weakness).
+An enchanted bow with chitin arrows will no longer be enough for the purpose, while a steel longbow with glass arrows will still work.
+This was previously the default engine behavior that diverged from Morrowind design.
+
+This setting can be toggled in Advanced tab of the launcher.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -242,6 +242,9 @@ strength influences hand to hand = 0
 # Render holstered weapons (with quivers and scabbards), requires modded assets
 weapon sheathing = false
 
+# Allow non-standard ammunition solely to bypass normal weapon resistance or weakness
+only appropriate ammunition bypasses resistance = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -96,6 +96,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="requireAppropriateAmmunitionCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow non-standard ammunition solely to bypass normal weapon resistance or weakness.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Only appropriate ammunition bypasses normal weapon resistance</string>
+            </property>
+           </widget>
+          </item>
           <item alignment="Qt::AlignLeft">
            <widget class="QWidget" name="unarmedFactorsStrengthGroup" native="true">
             <property name="toolTip">


### PR DESCRIPTION
[Bug 4384](https://gitlab.com/OpenMW/openmw/issues/4384).

Previously onHit was the only where normal weapons resistance was applied, and it only checked one weapon to determine whether to modify the damage. In case of ranged weapons, that weapon was the projectile. However, in Morrowind *both* the bow/crossbow *and* the projectile have to be normal weapons for normal weapons resistance to work. The discrepancy caused player complaints, since their daedric bows were considered ineffective for shooting scamps by the game.

To add to that, resistNormalWeapon function applied werewolf silver weapon damage multiplier for some reason (which should really be in a different function) and used a complicated check to determine whether the weapon is normal. I moved both the damage mult functionality and normal weapon check into new functions. Since applyWerewolfDamageMult can only reasonably be used with NPC victims, creature class doesn't need it.

isNormalWeapon could easily be reused in projectileHit so that Morrowind behavior could be followed. 
This has made it a necessity to also move resistNormalWeapon out of onHit methods for its more flexible usage.

Unfortunately I didn't adjust the AI other than for applyWerewolfDamageMult continued usage, because the projectile and ranged weapon combination can be arbitrary in the given frame, we don't keep track of the current ammo in rateWeapon for bows/crossbows, and because it's not really necessary for resolving the bug. Maybe later.