### PR TITLE
Use the skeleton from the NPC's set model (bug #4747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     Bug #4723: ResetActors command works incorrectly
     Bug #4745: Editor: Interior cell lighting field values are not displayed as colors
     Bug #4746: Non-solid player can't run or sneak
+    Bug #4747: Bones are not read from X.NIF file for NPC animation
     Bug #4750: Sneaking doesn't work in first person view if the player is in attack ready state
     Bug #4768: Fallback numerical value recovery chokes on invalid arguments
     Bug #4775: Slowfall effect resets player jumping flag

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -465,8 +465,12 @@ void NpcAnimation::updateNpcBase()
     bool is1stPerson = mViewMode == VM_FirstPerson;
     bool isBeast = (race->mData.mFlags & ESM::Race::Beast) != 0;
 
-    std::string smodel = SceneUtil::getActorSkeleton(is1stPerson, isFemale, isBeast, isWerewolf);
-    smodel = Misc::ResourceHelpers::correctActorModelPath(smodel, mResourceSystem->getVFS());
+    std::string defaultSkeleton = SceneUtil::getActorSkeleton(is1stPerson, isFemale, isBeast, isWerewolf);
+    defaultSkeleton = Misc::ResourceHelpers::correctActorModelPath(defaultSkeleton, mResourceSystem->getVFS());
+
+    std::string smodel = defaultSkeleton;
+    if (!is1stPerson && !isWerewolf & !mNpc->mModel.empty())
+        smodel = Misc::ResourceHelpers::correctActorModelPath("meshes\\" + mNpc->mModel, mResourceSystem->getVFS());
 
     setObjectRoot(smodel, true, true, false);
 
@@ -481,15 +485,13 @@ void NpcAnimation::updateNpcBase()
         if (smodel != base)
             addAnimSource(base, smodel);
 
+        if (smodel != defaultSkeleton && base != defaultSkeleton)
+            addAnimSource(defaultSkeleton, smodel);
+
         addAnimSource(smodel, smodel);
 
-        if(!isWerewolf)
-        {
-            if(mNpc->mModel.length() > 0)
-                addAnimSource(Misc::ResourceHelpers::correctActorModelPath("meshes\\" + mNpc->mModel, mResourceSystem->getVFS()), smodel);
-            if(Misc::StringUtils::lowerCase(mNpc->mRace).find("argonian") != std::string::npos)
-                addAnimSource("meshes\\xargonian_swimkna.nif", smodel);
-        }
+        if(!isWerewolf && Misc::StringUtils::lowerCase(mNpc->mRace).find("argonian") != std::string::npos)
+            addAnimSource("meshes\\xargonian_swimkna.nif", smodel);
     }
     else
     {


### PR DESCRIPTION
[Bug 4747](https://gitlab.com/OpenMW/openmw/issues/4747).

Previously only the animations and not the skeleton were used from the mModel field in NPC record. This caused NPCs with changed model often lack the nodes necessary to perform the animations from the models or use set body parts of their race.

Now non-werewolf NPCs will use the skeleton of the model set in their record and fallback to their default skeleton otherwise; animations of the default skeleton will be added too, "just in case". As I said under the report, rot has confirmed this should be fine.

This is Teleri Helvi with Khajiit race with Beast flag unchecked. rot's files allow NPCs with it assigned to have tail if it's assigned to their race.
![screenshot024](https://user-images.githubusercontent.com/21265616/49690981-3c24da80-fb4a-11e8-8de4-6b1f0df59223.png)

In master, furry Teleri lacks a tail and there are multiple errors and warnings logged:
```
Error: RigGeometry did not find bone Bip01 L Toe0                                                                                                                                                                                            
Error adding NPC part: Can't find attachment node Tail                                                                                                                                                                                       
Warning: addAnimSource: can't find bone 'bip01 l toe0' in meshes\xbase_anim_female.nif (referenced by meshes\xbase_animkna_importable.kf)
Warning: addAnimSource: can't find bone 'bip01 r toe0' in meshes\xbase_anim_female.nif (referenced by meshes\xbase_animkna_importable.kf)                                                                                                    
Warning: addAnimSource: can't find bone 'bip01 tail' in meshes\xbase_anim_female.nif (referenced by meshes\xbase_animkna_importable.kf)                                                                                                      
Warning: addAnimSource: can't find bone 'bip01 tail1' in meshes\xbase_anim_female.nif (referenced by meshes\xbase_animkna_importable.kf)                                                                                                     
Warning: addAnimSource: can't find bone 'bip01 tail2' in meshes\xbase_anim_female.nif (referenced by meshes\xbase_animkna_importable.kf)                                                                                                     
Warning: addAnimSource: can't find bone 'bip01 tail3' in meshes\xbase_anim_female.nif (referenced by meshes\xbase_animkna_importable.kf)       
```
With these changes they are no more.