### PR TITLE
[Do not merge] Experimental multithreaded physics

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -2,6 +2,7 @@
 #define OPENMW_MWPHYSICS_PHYSICSSYSTEM_H
 
 #include <memory>
+#include <mutex>
 #include <map>
 #include <set>
 #include <algorithm>
@@ -191,6 +192,8 @@ namespace MWPhysics
 
             void updateWater();
 
+            void solveTask(int offset, int module, int numSteps);
+
             osg::ref_ptr<SceneUtil::UnrefQueue> mUnrefQueue;
 
             btBroadphaseInterface* mBroadphase;
@@ -238,9 +241,12 @@ namespace MWPhysics
             osg::ref_ptr<osg::Group> mParentNode;
 
             float mPhysicsDt;
+            int mNumThreads;
 
             PhysicsSystem (const PhysicsSystem&);
             PhysicsSystem& operator= (const PhysicsSystem&);
+
+            mutable std::mutex mMutex;
     };
 }
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -261,6 +261,10 @@ weapon sheathing = false
 # Allow non-standard ammunition solely to bypass normal weapon resistance or weakness
 only appropriate ammunition bypasses resistance = false
 
+[Physics]
+# Number of physics update threads
+num threads = 1
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Do not merge, just a proof of concept!
Requires a Bullet, configured with a -DBULLET2_USE_THREAD_LOCKS=ON.
Indeed improves performance a lot on physics-bounded setups.

Unfortunately, it seems the convexSweepTest() is not fully threadsafe - I get crashes somewhere inside the Bullet code (usually [here](https://github.com/bulletphysics/bullet3/blob/2.87/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp#L1067) or [here](https://github.com/bulletphysics/bullet3/blob/2.87/src/BulletCollision/BroadphaseCollision/btDbvt.h#L1032)) during intensive collisions (e.g. after spawn of many actors in the same position).

Also sometimes I get the
```
System BUS error (signal 7)
Address: (nil)
```
error without log.

Any help to track down these issues would be welcome.