### PR TITLE
Don't interrupt sneak and swim idles in attack ready state in first person view (bug #4750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     Bug #4723: ResetActors command works incorrectly
     Bug #4745: Editor: Interior cell lighting field values are not displayed as colors
     Bug #4746: Non-solid player can't run or sneak
+    Bug #4750: Sneaking doesn't work in first person view if the player is in attack ready state
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1622,11 +1622,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             }
         }
 
-        // We should reset player's idle animation in the first-person mode.
-        if (resetIdle && mPtr == player && MWBase::Environment::get().getWorld()->isFirstPerson())
-            idle = CharState_None;
-
-        // In other cases we should not break swim and sneak animations
+        // We should not break swim and sneak animations
         if (resetIdle &&
             idle != CharState_IdleSneak && idle != CharState_IdleSwim &&
             mIdleState != CharState_IdleSneak && mIdleState != CharState_IdleSwim)


### PR DESCRIPTION
[Bug 4750](https://gitlab.com/OpenMW/openmw/issues/4750).

Apparently Morrowind doesn't do that for a reason. Sneaking breaks otherwise.
As I said in the report, the side effect is that weapon weighing animation is not interrupted by an attack during sneaking and swimming, the same thing happens in Morrowind.