### PR TITLE
[abandoned] allow more generator setup in ci/msvc

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -313,7 +313,7 @@ if [ ${BITS} -eq 64 ]; then
 fi
 
 if [ -n "$NMAKE" ]; then
-	GENERATOR="NMake Makefiles"
+	GENERATOR="CodeBlocks - NMake Makefiles"
 fi
 
 add_cmake_opts "-G\"$GENERATOR\""

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -32,6 +32,7 @@ KEEP=""
 UNITY_BUILD=""
 VS_VERSION=""
 NMAKE=""
+FORCE_GENERATOR=""
 PLATFORM=""
 CONFIGURATION=""
 
@@ -68,7 +69,12 @@ while [ $# -gt 0 ]; do
 				shift ;;
 
 			n )
-				NMAKE=true ;;
+				FORCE_GENERATOR="CodeBlocks - NMake Makefiles"
+				NMAKE=1 ;;
+
+			G )
+				FORCE_GENERATOR="$1"
+				shift ;;
 
 			p )
 				PLATFORM=$1
@@ -100,6 +106,8 @@ Options:
 		Choose the Visual Studio version to use.
 	-n
 		Produce NMake makefiles instead of a Visual Studio solution.
+	 G
+		Force using a specific CMake generator.
 	-V
 		Run verbosely
 EOF
@@ -312,13 +320,13 @@ if [ ${BITS} -eq 64 ]; then
 	GENERATOR="${GENERATOR} Win64"
 fi
 
-if [ -n "$NMAKE" ]; then
-	GENERATOR="CodeBlocks - NMake Makefiles"
+if test -n "$FORCE_GENERATOR"; then
+	GENERATOR="$FORCE_GENERATOR"
 fi
 
 add_cmake_opts "-G\"$GENERATOR\""
 
-if [ -n "$NMAKE" ]; then
+if [ -n "$FORCE_GENERATOR" ]; then
 	add_cmake_opts "-DCMAKE_BUILD_TYPE=${BUILD_CONFIG}"
 fi
 
@@ -402,7 +410,7 @@ cd .. #/..
 # Set up dependencies
 BUILD_DIR="MSVC${MSVC_DISPLAY_YEAR}_${BITS}"
 
-if [ -n "$NMAKE" ]; then
+if [ -n "$FORCE_GENERATOR" ]; then
 	BUILD_DIR="${BUILD_DIR}_NMake_${BUILD_CONFIG}"
 fi
 
@@ -716,7 +724,7 @@ fi
 #if [ -z $CI ]; then
 	echo "- Copying Runtime DLLs..."
 	DLL_PREFIX=""
-	if [ -z $NMAKE ]; then
+	if [ -z "$FORCE_GENERATOR" ]; then
 		mkdir -p $BUILD_CONFIG
 		DLL_PREFIX="$BUILD_CONFIG/"
 	fi

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -769,3 +769,5 @@ if [ -z $VERBOSE ]; then
 	fi
 fi
 exit $RET
+
+# vim: noet sts=4 ts=4 sw=4


### PR DESCRIPTION
Unconditionally use `CodeBlocks - NMake Makefiles` rather than `NMake Makefiles` since that's required by at least the CLion IDE. It used to be required by old versions of Qt Creator. Any IDE that hasn't yet implemented the "CMake server mode" protocol depends on the CodeBlocks aux generator.

Allow for using any arbitrary generator through the `-G` switch. This helps with IDEs that support arbitrary generators. For one, `Unix Makefiles` is unable to fully saturate the CPU due to forking off unnecessary processes and processing rules suboptimally. With `Ninja` I'm able to keep the cores fully saturated till it's done. This is more directly evident on projects with many trivial targets, but openmw as well.

While at it, add a Vim modeline since `:se noet` gets old after a while.

This affects building inside IDEs like Qt Creator or CLion. I can drop the second (and third) commit from the series but there should be no harm in keeping them.

