### PR TITLE
look for the the OSG plugin directory harder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,25 @@ endif()
 find_package(OpenSceneGraph 3.3.4 REQUIRED osgDB osgViewer osgText osgGA osgParticle osgUtil osgFX)
 include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
 
+function(find_osg_lib_dir var)
+    set(ret "")
+    list(LENGTH "${OSGDB_LIBRARY}" len)
+    if(OSGDB_LIBRARY AND len EQUAL 1)
+        get_filename_component(ret "${OSGDB_LIBRARY}" DIRECTORY)
+    elseif(OSGDB_LIBRARY_DEBUG)
+        get_filename_component(ret "${OSGDB_LIBRARY_DEBUG}" DIRECTORY)
+    elseif(OSGDB_LIBRARY_RELEASE)
+        get_filename_component(ret "${OSGDB_LIBRARY_RELEASE}" DIRECTORY)
+    elseif(OSG_DIR AND DIRECTORY "${OSG_DIR}/lib")
+        set(ret "${OSG_DIR}/lib")
+    else()
+        message(FATAL_ERROR "Can't find OpenSceneGraph library directory")
+    endif()
+    set("${var}" "${ret}" PARENT_SCOPE)
+endfunction()
+
+find_osg_lib_dir(OSG_LIB_DIR)
+
 set(USED_OSG_PLUGINS
                     osgdb_bmp
                     osgdb_dds
@@ -256,7 +275,6 @@ set(USED_OSG_PLUGINS
                     osgdb_tga
                   )
 
-get_filename_component(OSG_LIB_DIR ${OSGDB_LIBRARY} DIRECTORY)
 set(OSGPlugins_LIB_DIR "${OSG_LIB_DIR}/osgPlugins-${OPENSCENEGRAPH_VERSION}")
 
 if(OSG_STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,11 @@ if (DEFINED ENV{TRAVIS_BRANCH} OR DEFINED ENV{APPVEYOR})
     set(REQUIRED_BULLET_VERSION 283) # but for build testing, 283 is fine
 endif()
 
+if(POLICY CMP0074)
+    # don't complain when looking for Bullet
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 find_package(MyGUI 3.2.1 REQUIRED)
 find_package(SDL2 REQUIRED)


### PR DESCRIPTION
This partially unbreaks CMake's incompatible change in the latest version. I'm not aware of what fixes are necessary for migrating from older to newer CMake.

While in CMake land, remove the noisy Bullet warning. This has to be done at toplevel unfortunately. Cherry-pick the first commit if you don't like both changes having been done.

cf. #2065 

