### PR TITLE
Adapt to CMake 3.13's new meaning of OSGDB_LIBRARY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,14 @@ set(USED_OSG_PLUGINS
                     osgdb_tga
                   )
 
-get_filename_component(OSG_LIB_DIR ${OSGDB_LIBRARY} DIRECTORY)
-set(OSGPlugins_LIB_DIR "${OSG_LIB_DIR}/osgPlugins-${OPENSCENEGRAPH_VERSION}")
+set(OSGPlugins_LIB_DIR "")
+foreach(OSGDB_LIB ${OSGDB_LIBRARY})
+	# Skip library type names
+	if(EXISTS ${OSGDB_LIB})
+		get_filename_component(OSG_LIB_DIR ${OSGDB_LIB} DIRECTORY)
+		list(APPEND OSGPlugins_LIB_DIR "${OSG_LIB_DIR}/osgPlugins-${OPENSCENEGRAPH_VERSION}")
+	endif()
+endforeach(OSGDB_LIB)
 
 if(OSG_STATIC)
     add_definitions(-DOSG_LIBRARY_STATIC)
@@ -807,15 +813,24 @@ if (OPENMW_OSX_DEPLOYMENT AND APPLE AND DESIRED_QT_VERSION MATCHES 5)
 
     set(ABSOLUTE_PLUGINS "")
 
+    set(OSGPlugins_DONT_FIND_DEPENDENCIES 1)
+    find_package(OSGPlugins REQUIRED COMPONENTS ${USED_OSG_PLUGINS})
+
     foreach (PLUGIN_NAME ${USED_OSG_PLUGINS})
-      set(PLUGIN_ABS "${OSGPlugins_LIB_DIR}/${PLUGIN_NAME}.so")
-      set(ABSOLUTE_PLUGINS ${PLUGIN_ABS} ${ABSOLUTE_PLUGINS})
+        string(TOUPPER ${PLUGIN_NAME} PLUGIN_NAME_UC)
+        if(${PLUGIN_NAME_UC}_LIBRARY_RELEASE)
+            set(PLUGIN_ABS ${${PLUGIN_NAME_UC}_LIBRARY_RELEASE})
+        elseif(${PLUGIN_NAME_UC}_LIBRARY)
+            set(PLUGIN_ABS ${${PLUGIN_NAME_UC}_LIBRARY})
+        else()
+            message(FATAL_ERROR "Can't find library file for ${PLUGIN_NAME}")
+            # We used to construct the path manually from OSGPlugins_LIB_DIR and the plugin name.
+            # Maybe that could be restored as a fallback?
+        endif()
+        set(ABSOLUTE_PLUGINS ${PLUGIN_ABS} ${ABSOLUTE_PLUGINS})
     endforeach ()
 
-    get_filename_component(OSG_PLUGIN_PREFIX_DIR "${OSGPlugins_LIB_DIR}" NAME)
-    if (NOT OSG_PLUGIN_PREFIX_DIR)
-      message(FATAL_ERROR "Can't get directory name for OSG plugins from '${OSGPlugins_LIB_DIR}'")
-    endif()
+    set(OSG_PLUGIN_PREFIX_DIR "osgPlugins-${OPENSCENEGRAPH_VERSION}")
 
     # installs used plugins in bundle at given path (bundle_path must be relative to ${CMAKE_INSTALL_PREFIX})
     # and returns list of install paths for all installed plugins

--- a/cmake/FindOSGPlugins.cmake
+++ b/cmake/FindOSGPlugins.cmake
@@ -1,5 +1,6 @@
 # This module accepts the following env variable
 #  OSGPlugins_LIB_DIR - <OpenSceneGraph>/lib/osgPlugins-<X.X.X> , path to search plugins
+#  OSGPlugins_DONT_FIND_DEPENDENCIES - Set to skip also finding png, zlib and jpeg
 #
 # Once done this will define
 #  OSGPlugins_FOUND         - System has the all required components.
@@ -27,10 +28,10 @@ foreach(_library ${OSGPlugins_FIND_COMPONENTS})
     set(_component OSGPlugins_${_library})
 
     set(${_library_uc}_DIR ${OSGPlugins_LIB_DIR}) # to help function osg_find_library
-    set(_saved_lib_prefix ${CMAKE_FIND_LIBRARY_PREFIXES}) # save CMAKE_FIND_LIBRARY_PREFIXES
-    set(CMAKE_FIND_LIBRARY_PREFIXES "") # search libraries with no prefix
+    #set(_saved_lib_prefix ${CMAKE_FIND_LIBRARY_PREFIXES}) # save CMAKE_FIND_LIBRARY_PREFIXES
+    #set(CMAKE_FIND_LIBRARY_PREFIXES "") # search libraries with no prefix
     osg_find_library(${_library_uc} ${_library}) # find it into ${_library_uc}_LIBRARIES
-    set(CMAKE_FIND_LIBRARY_PREFIXES ${_saved_lib_prefix}) # restore prefix
+    #set(CMAKE_FIND_LIBRARY_PREFIXES ${_saved_lib_prefix}) # restore prefix
 
     if (${_library_uc}_LIBRARIES)
         set(${_component}_LIBRARY ${${_library_uc}_LIBRARIES}) # fake as if we call find_library
@@ -41,10 +42,12 @@ foreach(_library ${OSGPlugins_FIND_COMPONENTS})
     list(APPEND OSGPlugins_PROCESS_LIBS ${_component}_LIBRARY)
 endforeach()
 
-foreach(_dependency PNG ZLIB JPEG) # needed by osgdb_png or osgdb_jpeg
-    libfind_package(OSGPlugins ${_dependency})
-    set(${_dependency}_LIBRARY_OPTS ${_dependency}_LIBRARY)
-    #list(APPEND OSGPlugins_PROCESS_LIBS ${_dependency}_LIBRARY)
-endforeach()
+if(NOT DEFINED OSGPlugins_DONT_FIND_DEPENDENCIES)
+    foreach(_dependency PNG ZLIB JPEG) # needed by osgdb_png or osgdb_jpeg
+        libfind_package(OSGPlugins ${_dependency})
+        set(${_dependency}_LIBRARY_OPTS ${_dependency}_LIBRARY)
+        #list(APPEND OSGPlugins_PROCESS_LIBS ${_dependency}_LIBRARY)
+    endforeach()
+endif()
 
 libfind_process(OSGPlugins)


### PR DESCRIPTION
Adapt to CMake 3.13's new meaning of OSGDB_LIBRARY (i.e. that it can now be a list) while allowing for the possibility that the found libraries may be in different directories when debug and optimised versions exist.

This is a third attempt at fixing the same thing as https://github.com/OpenMW/openmw/pull/2065 and https://github.com/OpenMW/openmw/pull/2075, but should be more flexible.

This should be backwards compatible with CMake 3.12.3 and earlier, but I've only actually tested it with 3.13.1. Also, the OSX bundling stuff hasn't been tested on a real Mac, but I've tested that the same code does what I expect it to on Windows when I put it in a different bit of the file. I don't know if Travis tests that, but if not, someone with a Mac should.