### PR TITLE
Revert "fix a rig bug visible with OSG_VERTEX_BUFFER_HINT=VAO"

### DIFF
--- a/components/sceneutil/morphgeometry.cpp
+++ b/components/sceneutil/morphgeometry.cpp
@@ -30,7 +30,6 @@ void MorphGeometry::setSourceGeometry(osg::ref_ptr<osg::Geometry> sourceGeom)
     for (unsigned int i=0; i<2; ++i)
     {
         mGeometry[i] = new osg::Geometry(*mSourceGeometry, osg::CopyOp::SHALLOW_COPY);
-        mGeometry[i]->setDataVariance(osg::Object::DYNAMIC);
 
         const osg::Geometry& from = *mSourceGeometry;
         osg::Geometry& to = *mGeometry[i];

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -63,7 +63,6 @@ void RigGeometry::setSourceGeometry(osg::ref_ptr<osg::Geometry> sourceGeometry)
     {
         const osg::Geometry& from = *sourceGeometry;
         mGeometry[i] = new osg::Geometry(from, osg::CopyOp::SHALLOW_COPY);
-        mGeometry[i]->setDataVariance(osg::Object::DYNAMIC);
         osg::Geometry& to = *mGeometry[i];
         to.setSupportsDisplayList(false);
         to.setUseVertexBufferObjects(true);


### PR DESCRIPTION
Reverts OpenMW/openmw#2054

This is temporary to get our nightlies "working" again. The PR might have been correct and it unmasked an underlying problem, but at least saving no longer causes the engine to crash.