### PR TITLE
Make magic teleportation attempts detectable even when teleportation is disabled (bug #3765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
     Bug #3733: Normal maps are inverted on mirrored UVs
+    Bug #3765: DisableTeleporting makes Mark/Recall/Intervention effects undetectable
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4411: Reloading a saved game while falling prevents damage in some cases


### PR DESCRIPTION
[Bug 3765](https://gitlab.com/OpenMW/openmw/issues/3765)

Add teleportation effects to the list even if they're not going to work due to teleportation being disabled. Disabled teleportation handling was moved from checkEffectTarget to applyInstantEffect. This allows them to be detected by scripting, and also allows teleportation magic VFX to play properly even if teleportation is disabled, which is what I observe in Morrowind.

Also I reduced Intervention effects code duplication.

Works in my testing of a script that simply checks ```player->getEffect sEffectMark``` every frame to show a messagebox:
![screenshot033](https://user-images.githubusercontent.com/21265616/50053953-b9091300-014d-11e9-8182-b9dae57cb0f5.png)