### PR TITLE
Editor: avoid overflows in certain fields (bug #2987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.46.0
 ------
 
+    Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers

--- a/apps/opencs/model/tools/referenceablecheck.cpp
+++ b/apps/opencs/model/tools/referenceablecheck.cpp
@@ -470,6 +470,13 @@ void CSMTools::ReferenceableCheckStage::creatureCheck (
     if (creature.mData.mSoul < 0)
         messages.add(id, "Soul value is negative", "", CSMDoc::Message::Severity_Error);
 
+    if (creature.mAiData.mAlarm > 100)
+        messages.add(id, "Alarm rating is over 100", "", CSMDoc::Message::Severity_Warning);
+    if (creature.mAiData.mFight > 100)
+        messages.add(id, "Fight rating is over 100", "", CSMDoc::Message::Severity_Warning);
+    if (creature.mAiData.mFlee > 100)
+        messages.add(id, "Flee rating is over 100", "", CSMDoc::Message::Severity_Warning);
+
     for (int i = 0; i < 6; ++i)
     {
         if (creature.mData.mAttack[i] < 0)
@@ -699,6 +706,13 @@ void CSMTools::ReferenceableCheckStage::npcCheck (
 
     if (level <= 0)
         messages.add(id, "Level is non-positive", "", CSMDoc::Message::Severity_Warning);
+
+    if (npc.mAiData.mAlarm > 100)
+        messages.add(id, "Alarm rating is over 100", "", CSMDoc::Message::Severity_Warning);
+    if (npc.mAiData.mFight > 100)
+        messages.add(id, "Fight rating is over 100", "", CSMDoc::Message::Severity_Warning);
+    if (npc.mAiData.mFlee > 100)
+        messages.add(id, "Flee rating is over 100", "", CSMDoc::Message::Severity_Warning);
 
     if (gold < 0)
         messages.add(id, "Gold count is negative", "", CSMDoc::Message::Severity_Error);
@@ -1014,6 +1028,11 @@ template<typename Tool> void CSMTools::ReferenceableCheckStage::toolCheck (
 template<typename List> void CSMTools::ReferenceableCheckStage::listCheck (
     const List& someList, CSMDoc::Messages& messages, const std::string& someID)
 {
+    if (someList.mChanceNone > 100)
+    {
+        messages.add(someID, "Chance that no object is used is over 100 percent", "", CSMDoc::Message::Severity_Warning);
+    }
+
     for (unsigned i = 0; i < someList.mList.size(); ++i)
     {
         if (mReferencables.searchId(someList.mList[i].mId).first == -1)

--- a/apps/opencs/model/tools/regioncheck.cpp
+++ b/apps/opencs/model/tools/regioncheck.cpp
@@ -42,5 +42,11 @@ void CSMTools::RegionCheckStage::perform (int stage, CSMDoc::Messages& messages)
     if (chances != 100)
         messages.add(id, "Weather chances do not add up to 100", "", CSMDoc::Message::Severity_Error);
 
+    for (const ESM::Region::SoundRef& sound : region.mSoundList)
+    {
+        if (sound.mChance > 100)
+            messages.add(id, "Chance of '" + sound.mSound.toString() + "' sound to play is over 100 percent", "", CSMDoc::Message::Severity_Warning);
+    }
+
     /// \todo check data members that can't be edited in the table view
 }

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -205,7 +205,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     mRegions.getNestableColumn(index)->addColumn(
         new NestedChildColumn (Columns::ColumnId_SoundName, ColumnBase::Display_Sound));
     mRegions.getNestableColumn(index)->addColumn(
-        new NestedChildColumn (Columns::ColumnId_SoundChance, ColumnBase::Display_Integer));
+        new NestedChildColumn (Columns::ColumnId_SoundChance, ColumnBase::Display_UnsignedInteger8));
 
     mBirthsigns.addColumn (new StringIdColumn<ESM::BirthSign>);
     mBirthsigns.addColumn (new RecordStateColumn<ESM::BirthSign>);

--- a/apps/opencs/model/world/refidcollection.cpp
+++ b/apps/opencs/model/world/refidcollection.cpp
@@ -128,13 +128,13 @@ CSMWorld::RefIdCollection::RefIdCollection()
 
     ActorColumns actorsColumns (nameColumns);
 
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiHello, ColumnBase::Display_Integer));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiHello, ColumnBase::Display_UnsignedInteger8));
     actorsColumns.mHello = &mColumns.back();
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiFlee, ColumnBase::Display_Integer));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiFlee, ColumnBase::Display_UnsignedInteger8));
     actorsColumns.mFlee = &mColumns.back();
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiFight, ColumnBase::Display_Integer));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiFight, ColumnBase::Display_UnsignedInteger8));
     actorsColumns.mFight = &mColumns.back();
-    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiAlarm, ColumnBase::Display_Integer));
+    mColumns.push_back (RefIdColumn (Columns::ColumnId_AiAlarm, ColumnBase::Display_UnsignedInteger8));
     actorsColumns.mAlarm = &mColumns.back();
 
     // Nested table
@@ -645,7 +645,7 @@ CSMWorld::RefIdCollection::RefIdCollection()
     mColumns.back().addColumn(
         new RefIdColumn (Columns::ColumnId_LevelledItemType, CSMWorld::ColumnBase::Display_Boolean));
     mColumns.back().addColumn(
-        new RefIdColumn (Columns::ColumnId_LevelledItemChanceNone, CSMWorld::ColumnBase::Display_Integer));
+        new RefIdColumn (Columns::ColumnId_LevelledItemChanceNone, CSMWorld::ColumnBase::Display_UnsignedInteger8));
 
     mAdapters.insert (std::make_pair (UniversalId::Type_Activator,
         new NameRefIdAdapter<ESM::Activator> (UniversalId::Type_Activator, nameColumns)));


### PR DESCRIPTION
[Bug 2987](https://gitlab.com/OpenMW/openmw/issues/2987)

Changes the display type of AI data, regional sound chance and levelled list "chance none" chance fields to one for unsigned 8-bit integers (which was previously only used once, for another chance field) which allows the input to work properly without overflowing. I decided to do that instead of adding a new "percentage" display type with new set limits (Zini doesn't seem to like such kind of thing).

The practical effect is that you can't input a value above 255 or lower than 0 into the fields.

Verifier therefore checks if most of those fields are above 100 and logs warnings of occurrences of such. Hello rating is not handled as a percentage because it's not handled as a chance in the engine and controls the distance of AI greetings instead.

akortunov suggested to think about how we could dehardcode number limits in field creation and allow to set them on per-situation basis instead.