### PR TITLE
Editor: Implement faction ranks table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
+    Feature #4209: Editor: Faction rank sub-table
     Feature #4673: Weapon sheathing
     Feature #4730: Native animated containers support
     Task #4686: Upgrade media decoder to a more current FFmpeg API

--- a/apps/opencs/model/world/columnbase.cpp
+++ b/apps/opencs/model/world/columnbase.cpp
@@ -30,6 +30,7 @@ bool CSMWorld::ColumnBase::isId (Display display)
         Display_Skill,
         Display_Class,
         Display_Faction,
+        Display_Rank,
         Display_Race,
         Display_Sound,
         Display_Region,

--- a/apps/opencs/model/world/columnbase.hpp
+++ b/apps/opencs/model/world/columnbase.hpp
@@ -46,6 +46,7 @@ namespace CSMWorld
             Display_Skill,
             Display_Class,
             Display_Faction,
+            Display_Rank,
             Display_Race,
             Display_Sound,
             Display_Region,

--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -234,8 +234,16 @@ namespace CSMWorld
             { ColumnId_SoundChance, "Chance" },
 
             { ColumnId_FactionReactions, "Reactions" },
+            { ColumnId_FactionRanks, "Ranks" },
             //{ ColumnId_FactionID, "Faction ID" },
             { ColumnId_FactionReaction, "Reaction" },
+
+            { ColumnId_FactionAttrib1, "Attrib 1" },
+            { ColumnId_FactionAttrib2, "Attrib 2" },
+            { ColumnId_FactionPrimSkill, "Prim Skill" },
+            { ColumnId_FactionFavSkill, "Fav Skill" },
+            { ColumnId_FactionRep, "Fact Rep" },
+            { ColumnId_RankName, "Rank Name" },
 
             { ColumnId_EffectList, "Effects" },
             { ColumnId_EffectId, "Effect" },

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -338,6 +338,14 @@ namespace CSMWorld
             ColumnId_LandColoursIndex = 304,
             ColumnId_LandTexturesIndex = 305,
 
+            ColumnId_RankName = 306,
+            ColumnId_FactionRanks = 307,
+            ColumnId_FactionPrimSkill = 308,
+            ColumnId_FactionFavSkill = 309,
+            ColumnId_FactionRep = 310,
+            ColumnId_FactionAttrib1 = 311,
+            ColumnId_FactionAttrib2 = 312,
+
             // Allocated to a separate value range, so we don't get a collision should we ever need
             // to extend the number of use values.
             ColumnId_UseValue1 = 0x10000,

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -132,6 +132,23 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     mFactions.getNestableColumn(index)->addColumn(
         new NestedChildColumn (Columns::ColumnId_FactionReaction, ColumnBase::Display_Integer));
 
+    // Faction Ranks
+    mFactions.addColumn (new NestedParentColumn<ESM::Faction> (Columns::ColumnId_FactionRanks));
+    index = mFactions.getColumns()-1;
+    mFactions.addAdapter (std::make_pair(&mFactions.getColumn(index), new FactionRanksAdapter ()));
+    mFactions.getNestableColumn(index)->addColumn(
+        new NestedChildColumn (Columns::ColumnId_RankName, ColumnBase::Display_Rank));
+    mFactions.getNestableColumn(index)->addColumn(
+        new NestedChildColumn (Columns::ColumnId_FactionAttrib1, ColumnBase::Display_Integer));
+    mFactions.getNestableColumn(index)->addColumn(
+        new NestedChildColumn (Columns::ColumnId_FactionAttrib2, ColumnBase::Display_Integer));
+    mFactions.getNestableColumn(index)->addColumn(
+        new NestedChildColumn (Columns::ColumnId_FactionPrimSkill, ColumnBase::Display_Integer));
+    mFactions.getNestableColumn(index)->addColumn(
+        new NestedChildColumn (Columns::ColumnId_FactionFavSkill, ColumnBase::Display_Integer));
+    mFactions.getNestableColumn(index)->addColumn(
+        new NestedChildColumn (Columns::ColumnId_FactionRep, ColumnBase::Display_Integer));
+
     mRaces.addColumn (new StringIdColumn<ESM::Race>);
     mRaces.addColumn (new RecordStateColumn<ESM::Race>);
     mRaces.addColumn (new FixedRecordTypeColumn<ESM::Race> (UniversalId::Type_Race));

--- a/apps/opencs/model/world/nestedcoladapterimp.cpp
+++ b/apps/opencs/model/world/nestedcoladapterimp.cpp
@@ -1090,4 +1090,83 @@ namespace CSMWorld
     {
         return 10;
     }
+
+    FactionRanksAdapter::FactionRanksAdapter () {}
+
+    void FactionRanksAdapter::addRow(Record<ESM::Faction>& record, int position) const
+    {
+        throw std::logic_error ("cannot add a row to a fixed table");
+    }
+
+    void FactionRanksAdapter::removeRow(Record<ESM::Faction>& record, int rowToRemove) const
+    {
+        throw std::logic_error ("cannot remove a row from a fixed table");
+    }
+
+    void FactionRanksAdapter::setTable(Record<ESM::Faction>& record,
+            const NestedTableWrapperBase& nestedTable) const
+    {
+        throw std::logic_error ("table operation not supported");
+    }
+
+    NestedTableWrapperBase* FactionRanksAdapter::table(const Record<ESM::Faction>& record) const
+    {
+        throw std::logic_error ("table operation not supported");
+    }
+
+    QVariant FactionRanksAdapter::getData(const Record<ESM::Faction>& record,
+            int subRowIndex, int subColIndex) const
+    {
+        ESM::Faction faction = record.get();
+
+        if (subRowIndex < 0 || subRowIndex >= static_cast<int>(sizeof(faction.mData.mRankData)/sizeof(faction.mData.mRankData[0])))
+            throw std::runtime_error ("index out of range");
+
+        auto& rankData = faction.mData.mRankData[subRowIndex];
+
+        switch (subColIndex)
+        {
+            case 0: return QString(faction.mRanks[subRowIndex].c_str());
+            case 1: return rankData.mAttribute1;
+            case 2: return rankData.mAttribute2;
+            case 3: return rankData.mSkill1;
+            case 4: return rankData.mSkill2;
+            case 5: return rankData.mFactReaction;
+            default: throw std::runtime_error("Rank subcolumn index out of range");
+        }
+    }
+
+    void FactionRanksAdapter::setData(Record<ESM::Faction>& record,
+            const QVariant& value, int subRowIndex, int subColIndex) const
+    {
+        ESM::Faction faction = record.get();
+
+        if (subRowIndex < 0 || subRowIndex >= static_cast<int>(sizeof(faction.mData.mRankData)/sizeof(faction.mData.mRankData[0])))
+            throw std::runtime_error ("index out of range");
+
+        auto& rankData = faction.mData.mRankData[subRowIndex];
+
+        switch (subColIndex)
+        {
+            case 0: faction.mRanks[subRowIndex] = value.toString().toUtf8().constData(); break;
+            case 1: rankData.mAttribute1 = value.toInt(); break;
+            case 2: rankData.mAttribute2 = value.toInt(); break;
+            case 3: rankData.mSkill1 = value.toInt(); break;
+            case 4: rankData.mSkill2 = value.toInt(); break;
+            case 5: rankData.mFactReaction = value.toInt(); break;
+            default: throw std::runtime_error("Rank index out of range");
+        }
+
+        record.setModified (faction);
+    }
+
+    int FactionRanksAdapter::getColumnsCount(const Record<ESM::Faction>& record) const
+    {
+        return 6;
+    }
+
+    int FactionRanksAdapter::getRowsCount(const Record<ESM::Faction>& record) const
+    {
+        return 10;
+    }
 }

--- a/apps/opencs/model/world/nestedcoladapterimp.hpp
+++ b/apps/opencs/model/world/nestedcoladapterimp.hpp
@@ -100,6 +100,31 @@ namespace CSMWorld
         virtual int getRowsCount(const Record<ESM::Faction>& record) const;
     };
 
+    class FactionRanksAdapter : public NestedColumnAdapter<ESM::Faction>
+    {
+    public:
+        FactionRanksAdapter ();
+
+        virtual void addRow(Record<ESM::Faction>& record, int position) const;
+
+        virtual void removeRow(Record<ESM::Faction>& record, int rowToRemove) const;
+
+        virtual void setTable(Record<ESM::Faction>& record,
+                const NestedTableWrapperBase& nestedTable) const;
+
+        virtual NestedTableWrapperBase* table(const Record<ESM::Faction>& record) const;
+
+        virtual QVariant getData(const Record<ESM::Faction>& record,
+                int subRowIndex, int subColIndex) const;
+
+        virtual void setData(Record<ESM::Faction>& record,
+                const QVariant& value, int subRowIndex, int subColIndex) const;
+
+        virtual int getColumnsCount(const Record<ESM::Faction>& record) const;
+
+        virtual int getRowsCount(const Record<ESM::Faction>& record) const;
+    };
+
     class RegionSoundListAdapter : public NestedColumnAdapter<ESM::Region>
     {
     public:


### PR DESCRIPTION
Implements [feature #4209](https://gitlab.com/OpenMW/openmw/issues/4209).
Just adds a sub-table for ranks editing to the faction editor:
![screenshot_20181221_142410](https://user-images.githubusercontent.com/26434804/50337987-3a84ea80-052c-11e9-83c1-ca4395df6059.png)

So faction editing should be completely functional now.