### PR TITLE
Avoid falling height reset if on-ground state didn't change (bug #4411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
+    Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1339,7 +1339,7 @@ namespace MWPhysics
             float heightDiff = position.z() - oldHeight;
 
             MWMechanics::CreatureStats& stats = iter->first.getClass().getCreatureStats(iter->first);
-            if ((wasOnGround && physicActor->getOnGround()) || flying || world->isSwimming(iter->first) || slowFall < 1)
+            if ((numSteps > 0 && wasOnGround && physicActor->getOnGround()) || flying || world->isSwimming(iter->first) || slowFall < 1)
                 stats.land(iter->first == player);
             else if (heightDiff < 0)
                 stats.addToFallHeight(-heightDiff);


### PR DESCRIPTION
[Bug 4411](https://gitlab.com/OpenMW/openmw/issues/4411).

Falling height was reset even if numSteps was 0. This means that when numSteps is 0 during actor initialization (the number can be inconsistent due to framerate being different, but it's likely always 0 when the save is loaded for the first time), due to mOnGround being true initially falling height will be reset because movement solver is not called and doesn't change the state.

This caused both issues.

I made the on-ground check also check if numSteps is above 0, so now we only reset the falling height if physics were actually updated.