### PR TITLE
Don't set scale if argument is less than 0

### DIFF
--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -52,6 +52,8 @@ namespace MWScript
 
                     Interpreter::Type_Float scale = runtime[0].mFloat;
                     runtime.pop();
+                    
+                    if (scale < 0) return;
 
                     MWBase::Environment::get().getWorld()->scaleObject(ptr,scale);
                 }


### PR DESCRIPTION
In cases where an actors scale is set to less than 0, collisions break while in a negative scale and even after reverting to a scale above 0.