### PR TITLE
Cherry-pick cc9cii's minor editor improvements

### DIFF
--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -221,7 +221,11 @@ std::string CSMWorld::IdTable::getId(int row) const
 ///This method can return only indexes to the top level table cells
 QModelIndex CSMWorld::IdTable::getModelIndex (const std::string& id, int column) const
 {
-    return index(mIdCollection->getIndex (id), column);
+    int row = mIdCollection->searchId (id);
+    if (row != -1)
+        return index(row, column);
+
+    return QModelIndex();
 }
 
 void CSMWorld::IdTable::setRecord (const std::string& id, const RecordBase& record, CSMWorld::UniversalId::Type type)

--- a/apps/opencs/model/world/resourcetable.cpp
+++ b/apps/opencs/model/world/resourcetable.cpp
@@ -110,7 +110,11 @@ QModelIndex CSMWorld::ResourceTable::parent (const QModelIndex& index) const
 
 QModelIndex CSMWorld::ResourceTable::getModelIndex (const std::string& id, int column) const
 {
-    return index (mResources->getIndex (id), column);
+    int row = mResources->searchId(id);
+    if (row != -1)
+        return index (row, column);
+
+    return QModelIndex();
 }
 
 int CSMWorld::ResourceTable::searchColumnIndex (Columns::ColumnId id) const


### PR DESCRIPTION
This is an adaptation of certain minor editor improvements from cc9cii's branch (the one with support of new ESM/BSA formats) that can be used separately.

1. getModelIndex no longer throws an "object doesn't exist" exception if the ID doesn't exist in the table which could happen when you delete a record while its editing subview is open
2. Use std::to_string instead of ostringstream in refcollection. According to cc9cii it leads to a minor performance improvement.
3. Use internal message system instead of common logging system for a warning during exterior moved reference loading.

Not sure if all of these are valid.