### PR TITLE
Do not scale player's model in the 1st-person view depending on race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
+    Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1172,6 +1172,17 @@ namespace MWClass
         const ESM::Race* race =
                 MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(ref->mBase->mRace);
 
+        // Race weight should not affect 1st-person meshes, otherwise it will change hand proportions and can break aiming.
+        if (ptr == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())
+        {
+            if (ref->mBase->isMale())
+                scale *= race->mData.mHeight.mMale;
+            else
+                scale *= race->mData.mHeight.mFemale;
+
+            return;
+        }
+
         if (ref->mBase->isMale())
         {
             scale.x() *= race->mData.mWeight.mMale;
@@ -1184,7 +1195,6 @@ namespace MWClass
             scale.y() *= race->mData.mWeight.mFemale;
             scale.z() *= race->mData.mHeight.mFemale;
         }
-
     }
 
     int Npc::getServices(const MWWorld::ConstPtr &actor) const

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -317,8 +317,9 @@ void NpcAnimation::setViewMode(NpcAnimation::ViewMode viewMode)
         mWeaponSheathing = Settings::Manager::getBool("weapon sheathing", "Game");
 
     mViewMode = viewMode;
-    rebuild();
+    MWBase::Environment::get().getWorld()->scaleObject(mPtr, mPtr.getCellRef().getScale()); // apply race height after view change
 
+    rebuild();
     setRenderBin();
 }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2438,9 +2438,8 @@ namespace MWWorld
         player.getClass().getInventoryStore(player).setInvListener(anim, player);
         player.getClass().getInventoryStore(player).setContListener(anim);
 
-        scaleObject(getPlayerPtr(), 1.f); // apply race height
-
-        rotateObject(getPlayerPtr(), 0.f, 0.f, 0.f, true);
+        scaleObject(player, player.getCellRef().getScale()); // apply race height
+        rotateObject(player, 0.f, 0.f, 0.f, true);
 
         MWBase::Environment::get().getMechanicsManager()->add(getPlayerPtr());
         MWBase::Environment::get().getMechanicsManager()->watchActor(getPlayerPtr());


### PR DESCRIPTION
Fixes [bug #4383](https://gitlab.com/OpenMW/openmw/issues/4383).

Now Bosmers-archers should be playable.