### PR TITLE
Replace volatile bools with std::atomic<bool>

### DIFF
--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <atomic>
 
 #include <stdint.h>
 
@@ -279,7 +280,7 @@ private:
 
     std::unique_ptr<Sound_Loudness> mLoudnessAnalyzer;
 
-    volatile bool mIsFinished;
+    std::atomic<bool> mIsFinished;
 
     void updateAll(bool local);
 
@@ -313,7 +314,7 @@ struct OpenAL_Output::StreamThread : public OpenThreads::Thread {
     typedef std::vector<OpenAL_SoundStream*> StreamVec;
     StreamVec mStreams;
 
-    volatile bool mQuitNow;
+    std::atomic<bool> mQuitNow;
     OpenThreads::Mutex mMutex;
     OpenThreads::Condition mCondVar;
 

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -1,5 +1,7 @@
 #include "cellpreloader.hpp"
 
+#include <atomic>
+
 #include <components/debug/debuglog.hpp>
 #include <components/resource/scenemanager.hpp>
 #include <components/resource/resourcesystem.hpp>
@@ -159,7 +161,7 @@ namespace MWWorld
         MWRender::LandManager* mLandManager;
         bool mPreloadInstances;
 
-        volatile bool mAbort;
+        std::atomic<bool> mAbort;
 
         osg::ref_ptr<Terrain::View> mTerrainView;
 
@@ -392,7 +394,7 @@ namespace MWWorld
         }
 
     private:
-        volatile bool mAbort;
+        std::atomic<bool> mAbort;
         std::vector<osg::ref_ptr<Terrain::View> > mTerrainViews;
         Terrain::World* mWorld;
         std::vector<osg::Vec3f> mPreloadPositions;

--- a/components/sceneutil/workqueue.hpp
+++ b/components/sceneutil/workqueue.hpp
@@ -9,6 +9,7 @@
 #include <osg/Referenced>
 #include <osg/ref_ptr>
 
+#include <atomic>
 #include <queue>
 
 namespace SceneUtil
@@ -87,7 +88,7 @@ namespace SceneUtil
 
     private:
         WorkQueue* mWorkQueue;
-        volatile bool mActive;
+        std::atomic<bool> mActive;
     };
 
 

--- a/extern/osg-ffmpeg-videoplayer/videostate.hpp
+++ b/extern/osg-ffmpeg-videoplayer/videostate.hpp
@@ -2,6 +2,7 @@
 #define VIDEOPLAYER_VIDEOSTATE_H
 
 #include <stdint.h>
+#include <atomic>
 #include <vector>
 #include <memory>
 #include <string>
@@ -78,7 +79,7 @@ struct PacketQueue {
     { clear(); }
 
     AVPacketList *first_pkt, *last_pkt;
-    volatile bool flushing;
+    std::atomic<bool> flushing;
     int nb_packets;
     int size;
 
@@ -169,12 +170,12 @@ struct VideoState {
     std::unique_ptr<ParseThread> parse_thread;
     std::unique_ptr<VideoThread> video_thread;
 
-    volatile bool mSeekRequested;
+    std::atomic<bool> mSeekRequested;
     uint64_t mSeekPos;
 
-    volatile bool mVideoEnded;
-    volatile bool mPaused;
-    volatile bool mQuit;
+    std::atomic<bool> mVideoEnded;
+    std::atomic<bool> mPaused;
+    std::atomic<bool> mQuit;
 };
 
 }


### PR DESCRIPTION
Volatiles shouldn't be used for thread synchronization.