### PR TITLE
Do not restore birthsign abilities upon game load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
-    Bug #4411: Reloading a saved game while falling prevents damage in some cases
+    Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
+    Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4540: Rain delay when exiting water
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4714: Crash upon game load in the repair menu while the "Your repair failed!" message is active

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -414,14 +414,6 @@ namespace MWWorld
                 const ESM::BirthSign* sign = world.getStore().get<ESM::BirthSign>().search (player.mBirthsign);
                 if (!sign)
                     throw std::runtime_error ("invalid player state record (birthsign does not exist)");
-
-                // To handle the case where a birth sign was edited in between play sessions (does not yet handle removing the old spells)
-                // Also needed for ess-imported savegames which do not specify the birtsign spells in the player's spell list.
-                for (std::vector<std::string>::const_iterator iter (sign->mPowers.mList.begin());
-                    iter!=sign->mPowers.mList.end(); ++iter)
-                {
-                    getPlayer().getClass().getCreatureStats(getPlayer()).getSpells().add (*iter);
-                }
             }
 
             mCurrentCrimeId = player.mCurrentCrimeId;


### PR DESCRIPTION
Fixes [bug #4329](https://gitlab.com/OpenMW/openmw/issues/4329).

Morrowind does not have this hack.
As a proper solution, we need to implement import of active effects.