### PR TITLE
Clean up fallback record creation

### DIFF
--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -989,23 +989,29 @@ void CSMWorld::Data::loadFallbackEntries()
         std::make_pair("PrisonMarker", "marker_prison.nif")
     };
 
-    for (const std::pair<std::string, std::string> marker : staticMarkers)
+    for (const std::pair<std::string, std::string> &marker : staticMarkers)
     {
         if (mReferenceables.searchId (marker.first)==-1)
         {
+            ESM::Static newMarker;
+            newMarker.mId = marker.first;
+            newMarker.mModel = marker.second;
             CSMWorld::Record<ESM::Static> record;
-            record.mBase = ESM::Static(marker.first, marker.second);
+            record.mBase = newMarker;
             record.mState = CSMWorld::RecordBase::State_BaseOnly;
             mReferenceables.appendRecord (record, CSMWorld::UniversalId::Type_Static);
         }
     }
 
-    for (const std::pair<std::string, std::string> marker : doorMarkers)
+    for (const std::pair<std::string, std::string> &marker : doorMarkers)
     {
         if (mReferenceables.searchId (marker.first)==-1)
         {
+            ESM::Door newMarker;
+            newMarker.mId = marker.first;
+            newMarker.mModel = marker.second;
             CSMWorld::Record<ESM::Door> record;
-            record.mBase = ESM::Door(marker.first, std::string(), marker.second, std::string(), std::string(), std::string());
+            record.mBase = newMarker;
             record.mState = CSMWorld::RecordBase::State_BaseOnly;
             mReferenceables.appendRecord (record, CSMWorld::UniversalId::Type_Door);
         }

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1007,14 +1007,13 @@ namespace MWWorld
     }
     void Store<ESM::Attribute>::setUp()
     {
-        for (int i = 0; i < ESM::Attribute::Length; ++i) {
-            mStatic.push_back(
-                ESM::Attribute(
-                    ESM::Attribute::sAttributeIds[i],
-                    ESM::Attribute::sGmstAttributeIds[i],
-                    ESM::Attribute::sGmstAttributeDescIds[i]
-                )
-            );
+        for (int i = 0; i < ESM::Attribute::Length; ++i) 
+        {
+            ESM::Attribute newAttribute;
+            newAttribute.mId = ESM::Attribute::sAttributeIds[i];
+            newAttribute.mName = ESM::Attribute::sGmstAttributeIds[i];
+            newAttribute.mDescription = ESM::Attribute::sGmstAttributeDescIds[i];
+            mStatic.push_back(newAttribute);
         }
     }
     size_t Store<ESM::Attribute>::getSize() const
@@ -1066,11 +1065,13 @@ namespace MWWorld
             std::make_pair("travelmarker", "marker_travel.nif")
         };
 
-        for (const std::pair<std::string, std::string> marker : markers)
+        for (const std::pair<std::string, std::string> &marker : markers)
         {
             if (search(marker.first) == 0)
             {
-                ESM::Static newMarker = ESM::Static(marker.first, marker.second);
+                ESM::Static newMarker;
+                newMarker.mId = marker.first;
+                newMarker.mModel = marker.second;
                 std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(marker.first, newMarker));
                 if (ret.first != mStatic.end())
                 {
@@ -1088,11 +1089,13 @@ namespace MWWorld
             std::make_pair("prisonmarker", "marker_prison.nif")
         };
 
-        for (const std::pair<std::string, std::string> marker : markers)
+        for (const std::pair<std::string, std::string> &marker : markers)
         {
             if (search(marker.first) == 0)
             {
-                ESM::Door newMarker = ESM::Door(marker.first, std::string(), marker.second, std::string(), std::string(), std::string());
+                ESM::Door newMarker;
+                newMarker.mId = marker.first;
+                newMarker.mModel = marker.second;
                 std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(marker.first, newMarker));
                 if (ret.first != mStatic.end())
                 {

--- a/components/esm/attr.hpp
+++ b/components/esm/attr.hpp
@@ -32,13 +32,6 @@ struct Attribute
     static const std::string sGmstAttributeIds[Length];
     static const std::string sGmstAttributeDescIds[Length];
     static const std::string sAttributeIcons[Length];
-
-    Attribute(AttributeID id, const std::string &name, const std::string &description)
-        : mId(id)
-        , mName(name)
-        , mDescription(description)
-    {
-    }
 };
 }
 #endif

--- a/components/esm/loaddoor.hpp
+++ b/components/esm/loaddoor.hpp
@@ -22,21 +22,6 @@ struct Door
 
     void blank();
     ///< Set record to default state (does not touch the ID).
-
-    Door(const std::string id, const std::string name, const std::string &model,
-         const std::string script, const std::string opensound, const std::string closesound)
-    : mId(id)
-    , mName(name)
-    , mModel(model)
-    , mScript(script)
-    , mOpenSound(opensound)
-    , mCloseSound(closesound)
-    {
-    }
-
-    Door()
-    {
-    }
 };
 }
 #endif

--- a/components/esm/loadstat.hpp
+++ b/components/esm/loadstat.hpp
@@ -33,16 +33,6 @@ struct Static
 
     void blank();
     ///< Set record to default state (does not touch the ID).
-
-    Static(const std::string id, const std::string &model)
-    : mId(id)
-    , mModel(model)
-    {
-    }
-
-    Static()
-    {
-    }
 };
 }
 #endif


### PR DESCRIPTION
Assign fields to the newly created records in a standard way instead of reinventing the wheel in record loading structs and don't make string pair copies during marker map loops.

In my testing of Arktwend fallback markers still appear to work just fine in both the engine and the editor.