### PR TITLE
Improve fallback numerical value handling (bug #4768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     Bug #4745: Editor: Interior cell lighting field values are not displayed as colors
     Bug #4746: Non-solid player can't run or sneak
     Bug #4750: Sneaking doesn't work in first person view if the player is in attack ready state
+    Bug #4768: Fallback numerical value recovery chokes on invalid arguments
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -1,70 +1,86 @@
 #include "fallback.hpp"
 
-#include <boost/lexical_cast.hpp>
-
+#include <components/debug/debuglog.hpp>
 
 namespace Fallback
 {
-    bool stob(std::string const& s) {
-        return s != "0";
-    }
-
     Map::Map(const std::map<std::string,std::string>& fallback):mFallbackMap(fallback)
     {}
 
     std::string Map::getFallbackString(const std::string& fall) const
     {
         std::map<std::string,std::string>::const_iterator it;
-        if((it = mFallbackMap.find(fall)) == mFallbackMap.end())
+        if ((it = mFallbackMap.find(fall)) == mFallbackMap.end())
         {
-            return "";
+            return std::string();
         }
         return it->second;
     }
 
     float Map::getFallbackFloat(const std::string& fall) const
     {
-        std::string fallback=getFallbackString(fall);
-        if (fallback.empty())
-            return 0;
-        else
-            return boost::lexical_cast<float>(fallback);
+        std::string fallback = getFallbackString(fall);
+        if (!fallback.empty())
+        {
+            try
+            {
+                return std::stof(fallback);
+            }
+            catch (const std::invalid_argument&)
+            {
+                Log(Debug::Error) << "Error: '" << fall << "' setting value (" << fallback << ") is not a valid number, using 0 as a fallback";
+            }
+        }
+
+        return 0;
     }
 
     int Map::getFallbackInt(const std::string& fall) const
     {
-        std::string fallback=getFallbackString(fall);
-        if (fallback.empty())
-            return 0;
-        else
-            return std::stoi(fallback);
+        std::string fallback = getFallbackString(fall);
+        if (!fallback.empty())
+        {
+            try
+            {
+                return std::stoi(fallback);
+            }
+            catch (const std::invalid_argument&)
+            {
+                Log(Debug::Error) << "Error: '" << fall << "' setting value (" << fallback << ") is not a valid number, using 0 as a fallback";
+            }
+        }
+
+        return 0;
     }
 
     bool Map::getFallbackBool(const std::string& fall) const
     {
-        std::string fallback=getFallbackString(fall);
-        if (fallback.empty())
-            return false;
-        else
-            return stob(fallback);
+        return getFallbackString(fall) != "0";
     }
 
     osg::Vec4f Map::getFallbackColour(const std::string& fall) const
     {
-        std::string sum=getFallbackString(fall);
-        if (sum.empty())
-            return osg::Vec4f(0.5f,0.5f,0.5f,1.f);
-        else
+        std::string sum = getFallbackString(fall);
+        if (!sum.empty())
         {
-            std::string ret[3];
-            unsigned int j=0;
-            for(unsigned int i=0;i<sum.length();++i){
-                if(sum[i]==',') j++;
-                else if (sum[i] != ' ') ret[j]+=sum[i];
+            try
+            {
+                std::string ret[3];
+                unsigned int j = 0;
+                for (unsigned int i = 0; i < sum.length(); ++i)
+                {
+                    if(sum[i]==',') j++;
+                    else if (sum[i] != ' ') ret[j]+=sum[i];
+                }
+                return osg::Vec4f(std::stoi(ret[0])/255.f,std::stoi(ret[1])/255.f,std::stoi(ret[2])/255.f, 1.f);    
             }
-
-            return osg::Vec4f(std::stoi(ret[0])/255.f,std::stoi(ret[1])/255.f,std::stoi(ret[2])/255.f, 1.f);
+            catch (const std::invalid_argument&)
+            {
+                Log(Debug::Error) << "Error: '" << fall << "' setting value (" << sum << ") is not a valid color, using middle gray as a fallback";
+            }
         }
+
+        return osg::Vec4f(0.5f,0.5f,0.5f,1.f);
     }
 
 }


### PR DESCRIPTION
[Bug 4768](https://gitlab.com/OpenMW/openmw/issues/4768).

Fallback setting recovery is now:
1. Using C++11 `stof` instead of boost lexical cast so it doesn't break if there's random stuff after the numerical value; lessening boost dependency is always nice too
2. Catching invalid argument exceptions: it's logging an error and using 0 as a value instead of breaking the stuff the fallback setting was going to be used for completely

Boolean setting recovery was simplified.