### PR TITLE
[0.45.0 regression] Editor: Fix color picker oddities

### DIFF
--- a/apps/opencs/view/widget/coloreditor.cpp
+++ b/apps/opencs/view/widget/coloreditor.cpp
@@ -82,6 +82,7 @@ void CSVWidget::ColorEditor::setColor(const int colorInt)
 void CSVWidget::ColorEditor::showPicker()
 {
     mColorPicker->showPicker(calculatePopupPosition(), mColor);
+    emit pickingFinished();
 }
 
 void CSVWidget::ColorEditor::pickerColorChanged(const QColor &color)

--- a/apps/opencs/view/widget/colorpickerpopup.cpp
+++ b/apps/opencs/view/widget/colorpickerpopup.cpp
@@ -39,7 +39,8 @@ void CSVWidget::ColorPickerPopup::showPicker(const QPoint &position, const QColo
 
     // Calling getColor() creates a blocking dialog that will continue execution once the user chooses OK or Cancel
     QColor color = mColorPicker->getColor(initialColor);
-    mColorPicker->setCurrentColor(color);
+    if (color.isValid())
+        mColorPicker->setCurrentColor(color);
 }
 
 void CSVWidget::ColorPickerPopup::mousePressEvent(QMouseEvent *event)


### PR DESCRIPTION
The "color picking finished" signal was accidentally removed without adding an equivalent by Thunderforge in his summer color picker changes so the values of fields with Color display type weren't saved anymore.

Qt's getColor returns invalid color (literally invalid QColor, intended behavior) in reaction to cancel button press and that invalid color was assigned as the new color (black in practice), which could look very odd. Now the color simply doesn't change when Cancel is pressed - there's a check that the new color is valid.