### PR TITLE
Clean up fallback record creation again

### DIFF
--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -140,8 +140,6 @@ void ESMStore::setUp(bool validateRecords)
     mMagicEffects.setUp();
     mAttributes.setUp();
     mDialogs.setUp();
-    mStatics.setUp();
-    mDoors.setUp();
 
     if (validateRecords)
         validate();

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1053,58 +1053,6 @@ namespace MWWorld
         }
     }
 
-    template<>
-    void Store<ESM::Static>::setUp()
-    {
-        // Load default marker definitions, if game files do not have them for some reason
-        std::pair<std::string, std::string> markers[] = {
-            std::make_pair("divinemarker", "marker_divine.nif"),
-            std::make_pair("doormarker", "marker_arrow.nif"),
-            std::make_pair("northmarker", "marker_north.nif"),
-            std::make_pair("templemarker", "marker_temple.nif"),
-            std::make_pair("travelmarker", "marker_travel.nif")
-        };
-
-        for (const std::pair<std::string, std::string> &marker : markers)
-        {
-            if (search(marker.first) == 0)
-            {
-                ESM::Static newMarker;
-                newMarker.mId = marker.first;
-                newMarker.mModel = marker.second;
-                std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(marker.first, newMarker));
-                if (ret.first != mStatic.end())
-                {
-                    mShared.push_back(&ret.first->second);
-                }
-            }
-        }
-    }
-
-    template<>
-    void Store<ESM::Door>::setUp()
-    {
-        // Load default Door type marker definitions
-        std::pair<std::string, std::string> markers[] = {
-            std::make_pair("prisonmarker", "marker_prison.nif")
-        };
-
-        for (const std::pair<std::string, std::string> &marker : markers)
-        {
-            if (search(marker.first) == 0)
-            {
-                ESM::Door newMarker;
-                newMarker.mId = marker.first;
-                newMarker.mModel = marker.second;
-                std::pair<typename Static::iterator, bool> ret = mStatic.insert(std::make_pair(marker.first, newMarker));
-                if (ret.first != mStatic.end())
-                {
-                    mShared.push_back(&ret.first->second);
-                }
-            }
-        }
-    }
-
     template <>
     inline RecordId Store<ESM::Dialogue>::load(ESM::ESMReader &esm) {
         // The original letter case of a dialogue ID is saved, because it's printed

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -494,6 +494,17 @@ namespace MWWorld
         gmst["iWereWolfBounty"] = ESM::Variant(1000);
         gmst["fCombatDistanceWerewolfMod"] = ESM::Variant(0.3f);
 
+        for (const std::pair<std::string, ESM::Variant> &params : gmst)
+        {
+            if (!mStore.get<ESM::GameSetting>().search(params.first))
+            {
+                ESM::GameSetting record;
+                record.mId = params.first;
+                record.mValue = params.second;
+                mStore.insertStatic(record);
+            }
+        }
+
         std::map<std::string, ESM::Variant> globals;
         // vanilla Morrowind does not define dayspassed.
         globals["dayspassed"] = ESM::Variant(1); // but the addons start counting at 1 :(
@@ -513,25 +524,47 @@ namespace MWWorld
         globals["crimegoldturnin"] = ESM::Variant(0);
         globals["pchasturnin"] = ESM::Variant(0);
 
-        for (std::map<std::string, ESM::Variant>::iterator it = gmst.begin(); it != gmst.end(); ++it)
+        for (const std::pair<std::string, ESM::Variant> &params : globals)
         {
-            if (!mStore.get<ESM::GameSetting>().search(it->first))
+            if (!mStore.get<ESM::Global>().search(params.first))
             {
-                ESM::GameSetting setting;
-                setting.mId = it->first;
-                setting.mValue = it->second;
-                mStore.insertStatic(setting);
+                ESM::Global record;
+                record.mId = params.first;
+                record.mValue = params.second;
+                mStore.insertStatic(record);
             }
         }
 
-        for (std::map<std::string, ESM::Variant>::iterator it = globals.begin(); it != globals.end(); ++it)
+        std::map<std::string, std::string> statics;
+        // Total conversions from SureAI lack marker records
+        statics["divinemarker"] = "marker_divine.nif";
+        statics["doormarker"] = "marker_arrow.nif";
+        statics["northmarker"] = "marker_north.nif";
+        statics["templemarker"] = "marker_temple.nif";
+        statics["travelmarker"] = "marker_travel.nif";
+
+        for (const std::pair<std::string, std::string> &params : statics)
         {
-            if (!mStore.get<ESM::Global>().search(it->first))
+            if (!mStore.get<ESM::Static>().search(params.first))
             {
-                ESM::Global setting;
-                setting.mId = it->first;
-                setting.mValue = it->second;
-                mStore.insertStatic(setting);
+                ESM::Static record;
+                record.mId = params.first;
+                record.mModel = params.second;
+                mStore.insertStatic(record);
+            }
+        }
+
+        std::map<std::string, std::string> doors;
+        doors["prisonmarker"] = "marker_prison.nif";
+
+        for (const std::pair<std::string, std::string> &params : doors)
+        {
+            if (!mStore.get<ESM::Door>().search(params.first))
+            {
+                ESM::Door record;
+                record.mId = params.first;
+                record.mModel = params.second;
+                mStore.insertStatic(record);
             }
         }
     }


### PR DESCRIPTION
Move missing markers initialization from store into ensureNeededRecords where it belongs.

ensureNeededRecords is run for any game file with 0 format version (i.e. any ESM game file at the moment).

Arktwend still works OK.