### PR TITLE
Remove some redundant code

### DIFF
--- a/apps/opencs/model/world/ref.cpp
+++ b/apps/opencs/model/world/ref.cpp
@@ -1,9 +1,5 @@
 #include "ref.hpp"
 
-#include <cmath>
-
-#include <sstream>
-
 #include "cellcoordinates.hpp"
 
 CSMWorld::CellRef::CellRef() : mNew (true)

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -1,7 +1,5 @@
 #include "aiwander.hpp"
 
-#include <cfloat>
-
 #include <components/debug/debuglog.hpp>
 #include <components/misc/rng.hpp>
 #include <components/esm/aisequence.hpp>

--- a/apps/openmw/mwmechanics/autocalcspell.cpp
+++ b/apps/openmw/mwmechanics/autocalcspell.cpp
@@ -240,19 +240,6 @@ namespace MWMechanics
         return true;
     }
 
-    ESM::Skill::SkillEnum mapSchoolToSkill(int school)
-    {
-        std::map<int, ESM::Skill::SkillEnum> schoolSkillMap; // maps spell school to skill id
-        schoolSkillMap[0] = ESM::Skill::Alteration;
-        schoolSkillMap[1] = ESM::Skill::Conjuration;
-        schoolSkillMap[3] = ESM::Skill::Illusion;
-        schoolSkillMap[2] = ESM::Skill::Destruction;
-        schoolSkillMap[4] = ESM::Skill::Mysticism;
-        schoolSkillMap[5] = ESM::Skill::Restoration;
-        assert(schoolSkillMap.find(school) != schoolSkillMap.end());
-        return schoolSkillMap[school];
-    }
-
     void calcWeakestSchool (const ESM::Spell* spell, const int* actorSkills, int& effectiveSchool, float& skillTerm)
     {
         // Morrowind for some reason uses a formula slightly different from magicka cost calculation
@@ -288,7 +275,7 @@ namespace MWMechanics
             if (effect.mRange == ESM::RT_Target)
                 x *= 1.5f;
 
-            float s = 2.f * actorSkills[mapSchoolToSkill(magicEffect->mData.mSchool)];
+            float s = 2.f * actorSkills[spellSchoolToSkill(magicEffect->mData.mSchool)];
             if (s - x < minChance)
             {
                 minChance = s - x;
@@ -308,7 +295,7 @@ namespace MWMechanics
 
         float skillTerm = 0;
         if (effectiveSchool != -1)
-            skillTerm = 2.f * actorSkills[mapSchoolToSkill(effectiveSchool)];
+            skillTerm = 2.f * actorSkills[spellSchoolToSkill(effectiveSchool)];
         else
             calcWeakestSchool(spell, actorSkills, effectiveSchool, skillTerm); // Note effectiveSchool is unused after this
 

--- a/apps/openmw/mwmechanics/autocalcspell.hpp
+++ b/apps/openmw/mwmechanics/autocalcspell.hpp
@@ -1,9 +1,6 @@
 #ifndef OPENMW_AUTOCALCSPELL_H
 #define OPENMW_AUTOCALCSPELL_H
 
-#include <cfloat>
-#include <set>
-
 #include <components/esm/loadspel.hpp>
 #include <components/esm/loadskil.hpp>
 #include <components/esm/loadrace.hpp>
@@ -21,8 +18,6 @@ std::vector<std::string> autoCalcPlayerSpells(const int* actorSkills, const int*
 // Helpers
 
 bool attrSkillCheck (const ESM::Spell* spell, const int* actorSkills, const int* actorAttributes);
-
-ESM::Skill::SkillEnum mapSchoolToSkill(int school);
 
 void calcWeakestSchool(const ESM::Spell* spell, const int* actorSkills, int& effectiveSchool, float& skillTerm);
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -60,13 +60,6 @@ void wrap(float& rad)
         rad = std::fmod(rad-osg::PI, 2.0f*osg::PI)+osg::PI;
 }
 
-std::string toString(int num)
-{
-    std::ostringstream stream;
-    stream << num;
-    return stream.str();
-}
-
 std::string getBestAttack (const ESM::Weapon* weapon)
 {
     int slash = (weapon->mData.mSlash[0] + weapon->mData.mSlash[1])/2;
@@ -235,13 +228,13 @@ public:
 std::string CharacterController::chooseRandomGroup (const std::string& prefix, int* num) const
 {
     int numAnims=0;
-    while (mAnimation->hasAnimation(prefix + toString(numAnims+1)))
+    while (mAnimation->hasAnimation(prefix + std::to_string(numAnims+1)))
         ++numAnims;
 
     int roll = Misc::Rng::rollDice(numAnims) + 1; // [1, numAnims]
     if (num)
         *num = roll;
-    return prefix + toString(roll);
+    return prefix + std::to_string(roll);
 }
 
 void CharacterController::refreshHitRecoilAnims(CharacterState& idle)
@@ -783,7 +776,7 @@ void CharacterController::playDeath(float startpoint, CharacterState death)
         mCurrentDeath = "deathknockout";
         break;
     default:
-        mCurrentDeath = "death" + toString(death - CharState_Death1 + 1);
+        mCurrentDeath = "death" + std::to_string(death - CharState_Death1 + 1);
     }
     mDeathState = death;
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1,8 +1,5 @@
 #include "mechanicsmanagerimp.hpp"
 
-#include <limits.h>
-#include <set>
-
 #include <components/misc/rng.hpp>
 
 #include <components/esm/esmwriter.hpp>

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -1,6 +1,5 @@
 #include "spellcasting.hpp"
 
-#include <cfloat>
 #include <limits>
 #include <iomanip>
 

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -1,7 +1,5 @@
 #include "objects.hpp"
 
-#include <cmath>
-
 #include <osg/Group>
 #include <osg/UserDataContainer>
 


### PR DESCRIPTION
1. Replace mapSchoolToSkill with its optimized carbon copy spellSchoolToSkill.
2. Replace stream-based toString in character controller with std::to_string, which should have exactly the same performance
3. Purge unnecessary STL includes - for example, autocalcspell uses std::vectors instead of std::sets it used initially so including set is no longer necessary and C limits are no longer used anywhere. Some files which depend on autocalcspell header should compile a little bit faster.