### PR TITLE
Don't reset player jumping flag unnecessarily (bug #4775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     Bug #4746: Non-solid player can't run or sneak
     Bug #4750: Sneaking doesn't work in first person view if the player is in attack ready state
     Bug #4768: Fallback numerical value recovery chokes on invalid arguments
+    Bug #4775: Slowfall effect resets player jumping flag
     Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1317,6 +1317,7 @@ namespace MWPhysics
             float slowFall = 1.f - std::max(0.f, std::min(1.f, effects.get(ESM::MagicEffect::SlowFall).getMagnitude() * 0.005f));
 
             bool flying = world->isFlying(iter->first);
+            bool swimming = world->isSwimming(iter->first);
 
             bool wasOnGround = physicActor->getOnGround();
             osg::Vec3f position = physicActor->getPosition();
@@ -1339,8 +1340,9 @@ namespace MWPhysics
             float heightDiff = position.z() - oldHeight;
 
             MWMechanics::CreatureStats& stats = iter->first.getClass().getCreatureStats(iter->first);
-            if ((numSteps > 0 && wasOnGround && physicActor->getOnGround()) || flying || world->isSwimming(iter->first) || slowFall < 1)
-                stats.land(iter->first == player);
+            bool isStillOnGround = (numSteps > 0 && wasOnGround && physicActor->getOnGround());
+            if (isStillOnGround || flying || swimming || slowFall < 1)
+                stats.land(iter->first == player && (flying || swimming));
             else if (heightDiff < 0)
                 stats.addToFallHeight(-heightDiff);
 


### PR DESCRIPTION
[Bug 4775](https://gitlab.com/OpenMW/openmw/issues/4775)

The flag shouldn't be reset in physics if the player simply has a slowfall effect or is still on ground (the flag is reset in the character controller in the actual landing code anyways in the second case).
So the argument to land call is only true if the player is flying or swimming (when the player actually finishes a jump and doesn't just need to have the falling height reset).