### PR TITLE
Make Interiors of Illusion puzzle of Sotha Sil Expanded work (bug #4778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     Bug #4746: Non-solid player can't run or sneak
     Bug #4750: Sneaking doesn't work in first person view if the player is in attack ready state
     Bug #4768: Fallback numerical value recovery chokes on invalid arguments
+    Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -431,6 +431,12 @@ namespace MWScript
                     std::string effect = runtime.getStringLiteral(runtime[0].mInteger);
                     runtime.pop();
 
+                    if (!ptr.getClass().isActor())
+                    {
+                        runtime.push(0);
+                        return;
+                    }
+
                     char *end;
                     long key = strtol(effect.c_str(), &end, 10);
                     if(key < 0 || key > 32767 || *end != '\0')
@@ -658,6 +664,12 @@ namespace MWScript
                     MWWorld::Ptr ptr = R()(runtime);
                     std::string id = runtime.getStringLiteral(runtime[0].mInteger);
                     runtime.pop();
+
+                    if (!ptr.getClass().isActor())
+                    {
+                        runtime.push(0);
+                        return;
+                    }
 
                     const MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
                     runtime.push(stats.getActiveSpells().isSpellActive(id) || stats.getSpells().isSpellActive(id));

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -536,7 +536,7 @@ namespace MWScript
 
                     Interpreter::Type_Integer value = 0;
 
-                    if (ptr.getClass().getCreatureStats(ptr).getSpells().hasSpell(id))
+                    if (ptr.getClass().isActor() && ptr.getClass().getCreatureStats(ptr).getSpells().hasSpell(id))
                         value = 1;
 
                     runtime.push (value);

--- a/components/esm/loadcrea.cpp
+++ b/components/esm/loadcrea.cpp
@@ -23,6 +23,7 @@ namespace ESM {
 
         mScale = 1.f;
         mHasAI = false;
+        mAiData.blank();
 
         bool hasName = false;
         bool hasNpdt = false;
@@ -160,7 +161,6 @@ namespace ESM {
         mSpells.mList.clear();
         mHasAI = false;
         mAiData.blank();
-        mAiData.mServices = 0;
         mAiPackage.mList.clear();
         mTransport.mList.clear();
     }

--- a/components/esm/loadnpc.cpp
+++ b/components/esm/loadnpc.cpp
@@ -18,6 +18,7 @@ namespace ESM
         mInventory.mList.clear();
         mTransport.mList.clear();
         mAiPackage.mList.clear();
+        mAiData.blank();
         mHasAI = false;
 
         bool hasName = false;


### PR DESCRIPTION
[Bug 4778](https://gitlab.com/OpenMW/openmw/issues/4778)

1. GetSpellEffects, GetEffect and GetSpell return 0 if they're called on non-actors instead of throwing an exception due to non-actor objects lacking a magic effect list and creature stats. This allows the puzzle script to compile properly.
2. Actor AI data is `blank`ed when loading to make sure it consists of zeroes if there isn't an AIDT subrecord in the actor record instead of something weird.

In my experience the puzze is now solvable.

Cleaned up one unnecessary line from Creature record blank method.