### PR TITLE
Split physics update from world update in the profiler

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -154,14 +154,23 @@ bool OMW::Engine::frame(float frametime)
                 mEnvironment.getStateManager()->endGame();
         }
 
+        // update physics
+        osg::Timer_t beforePhysicsTick = osg::Timer::instance()->tick();
+        if (mEnvironment.getStateManager()->getState()!=
+            MWBase::StateManager::State_NoGame)
+        {
+            mEnvironment.getWorld()->updatePhysics(frametime, guiActive);
+        }
+        osg::Timer_t afterPhysicsTick = osg::Timer::instance()->tick();
+
         // update world
-        osg::Timer_t beforePhysicsTick = osg::Timer::instance()->tick();;
+        osg::Timer_t beforeWorldTick = osg::Timer::instance()->tick();
         if (mEnvironment.getStateManager()->getState()!=
             MWBase::StateManager::State_NoGame)
         {
             mEnvironment.getWorld()->update(frametime, guiActive);
         }
-        osg::Timer_t afterPhysicsTick = osg::Timer::instance()->tick();
+        osg::Timer_t afterWorldTick = osg::Timer::instance()->tick();
 
         // update GUI
         mEnvironment.getWindowManager()->onFrame(frametime);
@@ -179,6 +188,10 @@ bool OMW::Engine::frame(float frametime)
         stats->setAttribute(frameNumber, "physics_time_begin", osg::Timer::instance()->delta_s(mStartTick, beforePhysicsTick));
         stats->setAttribute(frameNumber, "physics_time_taken", osg::Timer::instance()->delta_s(beforePhysicsTick, afterPhysicsTick));
         stats->setAttribute(frameNumber, "physics_time_end", osg::Timer::instance()->delta_s(mStartTick, afterPhysicsTick));
+
+        stats->setAttribute(frameNumber, "world_time_begin", osg::Timer::instance()->delta_s(mStartTick, beforeWorldTick));
+        stats->setAttribute(frameNumber, "world_time_taken", osg::Timer::instance()->delta_s(beforeWorldTick, afterWorldTick));
+        stats->setAttribute(frameNumber, "world_time_end", osg::Timer::instance()->delta_s(mStartTick, afterWorldTick));
 
         if (stats->collectStats("resource"))
         {
@@ -667,10 +680,12 @@ void OMW::Engine::go()
 
     statshandler->addUserStatsLine("Script", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
                                    "script_time_taken", 1000.0, true, false, "script_time_begin", "script_time_end", 10000);
-    statshandler->addUserStatsLine("Mechanics", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
+    statshandler->addUserStatsLine("Mech", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
                                    "mechanics_time_taken", 1000.0, true, false, "mechanics_time_begin", "mechanics_time_end", 10000);
-    statshandler->addUserStatsLine("Physics", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
+    statshandler->addUserStatsLine("Phys", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
                                    "physics_time_taken", 1000.0, true, false, "physics_time_begin", "physics_time_end", 10000);
+    statshandler->addUserStatsLine("World", osg::Vec4f(1.f, 1.f, 1.f, 1.f), osg::Vec4f(1.f, 1.f, 1.f, 1.f),
+                                   "world_time_taken", 1000.0, true, false, "world_time_begin", "world_time_end", 10000);
 
     mViewer->addEventHandler(statshandler);
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -371,6 +371,7 @@ namespace MWBase
             /// \return pointer to created record
 
             virtual void update (float duration, bool paused) = 0;
+            virtual void updatePhysics (float duration, bool paused) = 0;
 
             virtual void updateWindowManager () = 0;
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1817,7 +1817,6 @@ namespace MWWorld
 
         if (!paused)
         {
-            doPhysics (duration);
             updateNavigator();
         }
 
@@ -1834,6 +1833,14 @@ namespace MWWorld
         {
             mSpellPreloadTimer = 0.1f;
             preloadSpells();
+        }
+    }
+
+    void World::updatePhysics (float duration, bool paused)
+    {
+        if (!paused)
+        {
+            doPhysics (duration);
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -480,6 +480,7 @@ namespace MWWorld
             /// \return pointer to created record
 
             void update (float duration, bool paused) override;
+            void updatePhysics (float duration, bool paused) override;
 
             void updateWindowManager () override;
 


### PR DESCRIPTION
Currently "Physics" tab measures time of the whole world update, including weather, navigator and scene update. Technically, such behaviour is not entirely corrent.
So I decided to split physics update from world update and measure its time separately.

Notes:
1. I had to update physics before weather, but it should be harmless.
2. I use short "Phys" and "Mech" labels since otherwise digits can be over timing bar, what makes digits not readable.