### PR TITLE
Get rid of unnecessary string streams

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -3,7 +3,6 @@
 
 #include <stdexcept>
 #include <algorithm>
-#include <sstream>
 
 #include "intsetting.hpp"
 #include "doublesetting.hpp"
@@ -393,9 +392,7 @@ CSMPrefs::IntSetting& CSMPrefs::State::declareInt (const std::string& key,
     if (mCurrentCategory==mCategories.end())
         throw std::logic_error ("no category for setting");
 
-    std::ostringstream stream;
-    stream << default_;
-    setDefault (key, stream.str());
+    setDefault(key, std::to_string(default_));
 
     default_ = mSettings.getInt (key, mCurrentCategory->second.getKey());
 
@@ -414,9 +411,7 @@ CSMPrefs::DoubleSetting& CSMPrefs::State::declareDouble (const std::string& key,
     if (mCurrentCategory==mCategories.end())
         throw std::logic_error ("no category for setting");
 
-    std::ostringstream stream;
-    stream << default_;
-    setDefault (key, stream.str());
+    setDefault(key, std::to_string(default_));
 
     default_ = mSettings.getFloat (key, mCurrentCategory->second.getKey());
 

--- a/apps/opencs/model/tools/search.cpp
+++ b/apps/opencs/model/tools/search.cpp
@@ -77,14 +77,9 @@ void CSMTools::Search::searchRecordStateCell (const CSMWorld::IdTableBase *model
     {
         std::vector<std::string> states =
             CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_Modification);
-    
-        std::ostringstream message;
-        message << states.at (data);
 
-        std::ostringstream hint;
-        hint << "r: " << model->getColumnId (index.column());
-        
-        messages.add (id, message.str(), hint.str());
+        const std::string hint = "r: " + model->getColumnId (index.column());
+        messages.add (id, states.at(data), hint);
     }
 }
 

--- a/apps/opencs/model/world/resources.cpp
+++ b/apps/opencs/model/world/resources.cpp
@@ -77,7 +77,7 @@ int CSMWorld::Resources::getIndex (const std::string& id) const
         std::ostringstream stream;
         stream << "Invalid resource: " << mBaseDirectory << '/' << id;
 
-        throw std::runtime_error (stream.str().c_str());
+        throw std::runtime_error (stream.str());
     }
 
     return index;

--- a/apps/opencs/view/world/scenesubview.cpp
+++ b/apps/opencs/view/world/scenesubview.cpp
@@ -150,10 +150,8 @@ std::string CSVWorld::SceneSubView::getTitle() const
 void CSVWorld::SceneSubView::cellSelectionChanged (const CSMWorld::UniversalId& id)
 {
     setUniversalId(id);
-    std::ostringstream stream;
-    stream << "Scene: " << getUniversalId().getId();
 
-    mTitle = stream.str();
+    mTitle = "Scene: " + getUniversalId().getId();
     setWindowTitle (QString::fromUtf8 (mTitle.c_str()));
     emit updateTitle();
 }

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -125,9 +125,7 @@ namespace MWGui
         for (int i=0; ids[i]; ++i)
             if (ids[i]==id)
             {
-                std::ostringstream valueString;
-                valueString << value.getModified();
-                setText (id, valueString.str());
+                setText (id, std::to_string(value.getModified()));
 
                 MyGUI::TextBox* box;
                 getWidget(box, id);

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -599,9 +599,7 @@ namespace MWGui
 
     std::string ToolTips::toString(const int value)
     {
-        std::ostringstream stream;
-        stream << value;
-        return stream.str();
+        return std::to_string(value);
     }
 
     std::string ToolTips::getWeightString(const float weight, const std::string& prefix)

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -87,10 +87,7 @@ namespace MWGui
         else
             toAdd->setUserString("interior","n");
 
-        std::ostringstream oss;
-        oss << price;
-        toAdd->setUserString("price",oss.str());
-
+        toAdd->setUserString("price", std::to_string(price));
         toAdd->setCaptionWithReplacing("#{sCell=" + name + "}   -   " + MyGUI::utility::toString(price)+"#{sgp}");
         toAdd->setSize(mDestinationsView->getWidth(),lineHeight);
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &TravelWindow::onMouseWheel);

--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -154,9 +154,8 @@ void MWMechanics::Alchemy::updateEffects()
 
         if (magicEffect->mData.mBaseCost<=0)
         {
-            std::ostringstream os;
-            os << "invalid base cost for magic effect " << iter->mId;
-            throw std::runtime_error (os.str());
+            const std::string os = "invalid base cost for magic effect " + iter->mId;
+            throw std::runtime_error (os);
         }
 
         float fPotionT1MagMul =

--- a/apps/openmw/mwrender/landmanager.cpp
+++ b/apps/openmw/mwrender/landmanager.cpp
@@ -2,8 +2,6 @@
 
 #include <osg/Stats>
 
-#include <sstream>
-
 #include <components/resource/objectcache.hpp>
 
 #include "../mwbase/environment.hpp"
@@ -21,9 +19,7 @@ LandManager::LandManager(int loadFlags)
 
 osg::ref_ptr<ESMTerrain::LandObject> LandManager::getLand(int x, int y)
 {
-    std::ostringstream id;
-    id << x << " " << y;
-    std::string idstr = id.str();
+    std::string idstr = std::to_string(x) + " " + std::to_string(y);
 
     osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(idstr);
     if (obj)

--- a/apps/openmw/mwstate/character.cpp
+++ b/apps/openmw/mwstate/character.cpp
@@ -58,10 +58,8 @@ void MWState::Character::addSlot (const ESM::SavedGame& profile)
     int i=0;
     while (boost::filesystem::exists(slot.mPath))
     {
-           std::ostringstream test;
-           test << stream.str();
-           test << " - " << ++i;
-           slot.mPath = mPath / (test.str() + ext);
+        const std::string test = stream.str() + " - " + std::to_string(++i);
+        slot.mPath = mPath / (test + ext);
     }
 
     slot.mProfile = profile;

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -170,19 +170,19 @@ namespace MWWorld
 
         /// Insert a custom record (i.e. with a generated ID that will not clash will pre-existing records)
         template <class T>
-        const T *insert(const T &x) {
-            std::ostringstream id;
-            id << "$dynamic" << mDynamicCount++;
+        const T *insert(const T &x)
+        {
+            const std::string id = "$dynamic" + std::to_string(mDynamicCount++);
 
             Store<T> &store = const_cast<Store<T> &>(get<T>());
-            if (store.search(id.str()) != 0) {
-                std::ostringstream msg;
-                msg << "Try to override existing record '" << id.str() << "'";
-                throw std::runtime_error(msg.str());
+            if (store.search(id) != 0)
+            {
+                const std::string msg = "Try to override existing record '" + id + "'";
+                throw std::runtime_error(msg);
             }
             T record = x;
 
-            record.mId = id.str();
+            record.mId = id;
 
             T *ptr = store.insert(record);
             for (iterator it = mStores.begin(); it != mStores.end(); ++it) {
@@ -208,15 +208,15 @@ namespace MWWorld
         }
 
         template <class T>
-        const T *insertStatic(const T &x) {
-            std::ostringstream id;
-            id << "$dynamic" << mDynamicCount++;
+        const T *insertStatic(const T &x)
+        {
+            const std::string id = "$dynamic" + std::to_string(mDynamicCount++);
 
             Store<T> &store = const_cast<Store<T> &>(get<T>());
-            if (store.search(id.str()) != 0) {
-                std::ostringstream msg;
-                msg << "Try to override existing record '" << id.str() << "'";
-                throw std::runtime_error(msg.str());
+            if (store.search(id) != 0)
+            {
+                const std::string msg = "Try to override existing record '" + id + "'";
+                throw std::runtime_error(msg);
             }
             T record = x;
 
@@ -247,20 +247,22 @@ namespace MWWorld
     }
 
     template <>
-    inline const ESM::NPC *ESMStore::insert<ESM::NPC>(const ESM::NPC &npc) {
-        std::ostringstream id;
-        id << "$dynamic" << mDynamicCount++;
+    inline const ESM::NPC *ESMStore::insert<ESM::NPC>(const ESM::NPC &npc)
+    {
+        const std::string id = "$dynamic" + std::to_string(mDynamicCount++);
 
-        if (Misc::StringUtils::ciEqual(npc.mId, "player")) {
+        if (Misc::StringUtils::ciEqual(npc.mId, "player"))
+        {
             return mNpcs.insert(npc);
-        } else if (mNpcs.search(id.str()) != 0) {
-            std::ostringstream msg;
-            msg << "Try to override existing record '" << id.str() << "'";
-            throw std::runtime_error(msg.str());
+        }
+        else if (mNpcs.search(id) != 0)
+        {
+            const std::string msg = "Try to override existing record '" + id + "'";
+            throw std::runtime_error(msg);
         }
         ESM::NPC record = npc;
 
-        record.mId = id.str();
+        record.mId = id;
 
         ESM::NPC *ptr = mNpcs.insert(record);
         mIds[ptr->mId] = ESM::REC_NPC_;

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -109,11 +109,10 @@ namespace
         
         if (projectileEffects.mList.size() > 1) // insert a VFX_Multiple projectile if there are multiple projectile effects
         {
-            std::ostringstream ID;
-            ID << "VFX_Multiple" << effects->mList.size();
+            const std::string ID = "VFX_Multiple" + std::to_string(effects->mList.size());
             std::vector<std::string>::iterator it;
             it = projectileIDs.begin();
-            it = projectileIDs.insert(it, ID.str());
+            it = projectileIDs.insert(it, ID);
         }
         return projectileEffects;
     }

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -9,7 +9,6 @@
 #include <components/misc/rng.hpp>
 
 #include <stdexcept>
-#include <sstream>
 
 namespace
 {
@@ -102,10 +101,10 @@ namespace MWWorld
     const T *IndexedStore<T>::find(int index) const
     {
         const T *ptr = search(index);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << T::getRecordType() << " with index " << index << " not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = T::getRecordType() + " with index " + std::to_string(index) + " not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
@@ -171,10 +170,10 @@ namespace MWWorld
     const T *Store<T>::find(const std::string &id) const
     {
         const T *ptr = search(id);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << T::getRecordType() << " '" << id << "' not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = T::getRecordType() + " '" + id + "' not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
@@ -184,14 +183,13 @@ namespace MWWorld
         const T *ptr = searchRandom(id);
         if(ptr == 0)
         {
-            std::ostringstream msg;
-            msg << T::getRecordType() << " starting with '"<<id<<"' not found";
-            throw std::runtime_error(msg.str());
+            const std::string msg = T::getRecordType() + " starting with '" + id + "' not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
     template<typename T>
-    RecordId Store<T>::load(ESM::ESMReader &esm) 
+    RecordId Store<T>::load(ESM::ESMReader &esm)
     {
         T record;
         bool isDeleted = false;
@@ -364,10 +362,10 @@ namespace MWWorld
     const ESM::LandTexture *Store<ESM::LandTexture>::find(size_t index, size_t plugin) const
     {
         const ESM::LandTexture *ptr = search(index, plugin);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << "Land texture with index " << index << " not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = "Land texture with index " + std::to_string(index) + " not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
@@ -456,10 +454,10 @@ namespace MWWorld
     const ESM::Land *Store<ESM::Land>::find(int x, int y) const
     {
         const ESM::Land *ptr = search(x, y);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << "Land at (" << x << ", " << y << ") not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = "Land at (" + std::to_string(x) + ", " + std::to_string(y) + ") not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
@@ -591,20 +589,20 @@ namespace MWWorld
     const ESM::Cell *Store<ESM::Cell>::find(const std::string &id) const
     {
         const ESM::Cell *ptr = search(id);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << "Cell '" << id << "' not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = "Cell '" + id + "' not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
     const ESM::Cell *Store<ESM::Cell>::find(int x, int y) const
     {
         const ESM::Cell *ptr = search(x, y);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << "Exterior at (" << x << ", " << y << ") not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = "Exterior at (" + std::to_string(x) + ", " + std::to_string(y) + ") not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }
@@ -784,13 +782,10 @@ namespace MWWorld
     }
     ESM::Cell *Store<ESM::Cell>::insert(const ESM::Cell &cell)
     {
-        if (search(cell) != 0) {
-            std::ostringstream msg;
-            msg << "Failed to create ";
-            msg << ((cell.isExterior()) ? "exterior" : "interior");
-            msg << " cell";
-
-            throw std::runtime_error(msg.str());
+        if (search(cell) != 0)
+        {
+            const std::string cellType = (cell.isExterior()) ? "exterior" : "interior";
+            throw std::runtime_error("Failed to create " + cellType + " cell");
         }
         ESM::Cell *ptr;
         if (cell.isExterior()) {
@@ -931,9 +926,8 @@ namespace MWWorld
         const ESM::Pathgrid* pathgrid = search(x,y);
         if (!pathgrid)
         {
-            std::ostringstream msg;
-            msg << "Pathgrid in cell '" << x << " " << y << "' not found";
-            throw std::runtime_error(msg.str());
+            const std::string msg = "Pathgrid in cell '" + std::to_string(x) + " " + std::to_string(y) + "' not found";
+            throw std::runtime_error(msg);
         }
         return pathgrid;
     }
@@ -942,9 +936,8 @@ namespace MWWorld
         const ESM::Pathgrid* pathgrid = search(name);
         if (!pathgrid)
         {
-            std::ostringstream msg;
-            msg << "Pathgrid in cell '" << name << "' not found";
-            throw std::runtime_error(msg.str());
+            const std::string msg = "Pathgrid in cell '" + name + "' not found";
+            throw std::runtime_error(msg);
         }
         return pathgrid;
     }
@@ -998,10 +991,10 @@ namespace MWWorld
     const ESM::Attribute *Store<ESM::Attribute>::find(size_t index) const
     {
         const ESM::Attribute *ptr = search(index);
-        if (ptr == 0) {
-            std::ostringstream msg;
-            msg << "Attribute with index " << index << " not found";
-            throw std::runtime_error(msg.str());
+        if (ptr == 0)
+        {
+            const std::string msg = "Attribute with index " + std::to_string(index) + " not found";
+            throw std::runtime_error(msg);
         }
         return ptr;
     }

--- a/components/esm/loadcell.cpp
+++ b/components/esm/loadcell.cpp
@@ -1,7 +1,6 @@
 #include "loadcell.hpp"
 
 #include <string>
-#include <sstream>
 #include <list>
 
 #include <boost/concept_check.hpp>
@@ -209,9 +208,7 @@ namespace ESM
         }
         else
         {
-            std::ostringstream stream;
-            stream << mData.mX << ", " << mData.mY;
-            return stream.str();
+            return std::to_string(mData.mX) + ", " + std::to_string(mData.mY);
         }
     }
 

--- a/components/interpreter/interpreter.cpp
+++ b/components/interpreter/interpreter.cpp
@@ -1,7 +1,6 @@
 #include "interpreter.hpp"
 
 #include <cassert>
-#include <sstream>
 #include <stdexcept>
 
 #include "opcodes.hpp"
@@ -116,20 +115,14 @@ namespace Interpreter
 
     void Interpreter::abortUnknownCode (int segment, int opcode)
     {
-        std::ostringstream error;
-
-        error << "unknown opcode " << opcode << " in segment " << segment;
-
-        throw std::runtime_error (error.str());
+        const std::string error = "unknown opcode " + std::to_string(opcode) + " in segment " + std::to_string(segment);
+        throw std::runtime_error (error);
     }
 
     void Interpreter::abortUnknownSegment (Type_Code code)
     {
-        std::ostringstream error;
-
-        error << "opcode outside of the allocated segment range: " << code;
-
-        throw std::runtime_error (error.str());
+        const std::string error = "opcode outside of the allocated segment range: " + std::to_string(code);
+        throw std::runtime_error (error);
     }
 
     void Interpreter::begin()

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -8,48 +8,6 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/algorithm/string.hpp>
 
-namespace
-{
-
-    bool parseBool(const std::string& string)
-    {
-        return (Misc::StringUtils::ciEqual(string, "true"));
-    }
-
-    float parseFloat(const std::string& string)
-    {
-        std::stringstream stream;
-        stream << string;
-        float ret = 0.f;
-        stream >> ret;
-        return ret;
-    }
-
-    int parseInt(const std::string& string)
-    {
-        std::stringstream stream;
-        stream << string;
-        int ret = 0;
-        stream >> ret;
-        return ret;
-    }
-
-    template <typename T>
-    std::string toString(T val)
-    {
-        std::ostringstream stream;
-        stream << val;
-        return stream.str();
-    }
-
-    template <>
-    std::string toString(bool val)
-    {
-        return val ? "true" : "false";
-    }
-
-}
-
 namespace Settings
 {
 
@@ -393,17 +351,36 @@ std::string Manager::getString(const std::string &setting, const std::string &ca
 
 float Manager::getFloat (const std::string& setting, const std::string& category)
 {
-    return parseFloat( getString(setting, category) );
+    const std::string value = getString(setting, category);
+    try
+    {
+        return std::stof(value);
+    }
+    catch(const std::exception& e)
+    {
+        Log(Debug::Warning) << "Cannot parse setting '" << setting << "' (invalid setting value: " << value << ").";
+        return 0;
+    }
 }
 
 int Manager::getInt (const std::string& setting, const std::string& category)
 {
-    return parseInt( getString(setting, category) );
+    const std::string value = getString(setting, category);
+    try
+    {
+        return std::stoi(value);
+    }
+    catch(const std::exception& e)
+    {
+        Log(Debug::Warning) << "Cannot parse setting '" << setting << "' (invalid setting value: " << value << ").";
+        return 0;
+    }
 }
 
 bool Manager::getBool (const std::string& setting, const std::string& category)
 {
-    return parseBool( getString(setting, category) );
+    const std::string& string = getString(setting, category);
+    return Misc::StringUtils::ciEqual(string, "true");
 }
 
 void Manager::setString(const std::string &setting, const std::string &category, const std::string &value)
@@ -424,17 +401,17 @@ void Manager::setString(const std::string &setting, const std::string &category,
 
 void Manager::setInt (const std::string& setting, const std::string& category, const int value)
 {
-    setString(setting, category, toString(value));
+    setString(setting, category, std::to_string(value));
 }
 
 void Manager::setFloat (const std::string &setting, const std::string &category, const float value)
 {
-    setString(setting, category, toString(value));
+    setString(setting, category, std::to_string(value));
 }
 
 void Manager::setBool(const std::string &setting, const std::string &category, const bool value)
 {
-    setString(setting, category, toString(value));
+    setString(setting, category, value ? "true" : "false");
 }
 
 const CategorySettingVector Manager::apply()


### PR DESCRIPTION
In many cases we use string streams to just convert a digit value to string or to concat it with string.

Since now we use the C++11, we can use the std::to_string() to convert digit to string.

Note: most of string strem usages are fine (many arguments or custom formatting), so I did not touch them.