### PR TITLE
Get rid of some remaining instances of C numeric limits

### DIFF
--- a/apps/opencs/view/world/util.cpp
+++ b/apps/opencs/view/world/util.cpp
@@ -1,5 +1,6 @@
 #include "util.hpp"
 
+#include <limits>
 #include <stdexcept>
 
 #include <QUndoStack>
@@ -214,7 +215,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_UnsignedInteger8:
         {
             DialogueSpinBox *sb = new DialogueSpinBox(parent);
-            sb->setRange(0, UCHAR_MAX);
+            sb->setRange(0, std::numeric_limits<unsigned char>::max());
             return sb;
         }
 
@@ -225,7 +226,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_Float:
         {
             DialogueDoubleSpinBox *dsb = new DialogueDoubleSpinBox(parent);
-            dsb->setRange(-FLT_MAX, FLT_MAX);
+            dsb->setRange(-std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
             dsb->setSingleStep(0.01f);
             dsb->setDecimals(3);
             return dsb;
@@ -234,7 +235,7 @@ QWidget *CSVWorld::CommandDelegate::createEditor (QWidget *parent, const QStyleO
         case CSMWorld::ColumnBase::Display_Double:
         {
             DialogueDoubleSpinBox *dsb = new DialogueDoubleSpinBox(parent);
-            dsb->setRange(-FLT_MAX, FLT_MAX);
+            dsb->setRange(-std::numeric_limits<double>::max(), std::numeric_limits<double>::max());
             dsb->setSingleStep(0.01f);
             dsb->setDecimals(6);
             return dsb;

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -1,6 +1,7 @@
 #include "cellpreloader.hpp"
 
 #include <atomic>
+#include <limits>
 
 #include <components/debug/debuglog.hpp>
 #include <components/resource/scenemanager.hpp>
@@ -251,7 +252,7 @@ namespace MWWorld
         {
             // throw out oldest cell to make room
             PreloadMap::iterator oldestCell = mPreloadCells.begin();
-            double oldestTimestamp = DBL_MAX;
+            double oldestTimestamp = std::numeric_limits<double>::max();
             double threshold = 1.0; // seconds
             for (PreloadMap::iterator it = mPreloadCells.begin(); it != mPreloadCells.end(); ++it)
             {

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -1,5 +1,6 @@
 #include "loadland.hpp"
 
+#include <limits>
 #include <utility>
 
 #include "esmreader.hpp"
@@ -200,9 +201,9 @@ namespace ESM
             mLandData->mTextures[i] = 0;
         for (int i = 0; i < LAND_NUM_VERTS; ++i)
         {
-            mLandData->mColours[i*3+0] = -1;
-            mLandData->mColours[i*3+1] = -1;
-            mLandData->mColours[i*3+2] = -1;
+            mLandData->mColours[i*3+0] = 255;
+            mLandData->mColours[i*3+1] = 255;
+            mLandData->mColours[i*3+2] = 255;
         }
         mLandData->mUnk1 = 0;
         mLandData->mUnk2 = 0;
@@ -252,8 +253,8 @@ namespace ESM
         if (reader.isNextSub("VHGT")) {
             VHGT vhgt;
             if (condLoad(reader, flags, target->mDataLoaded, DATA_VHGT, &vhgt, sizeof(vhgt))) {
-                target->mMinHeight = FLT_MAX;
-                target->mMaxHeight = -FLT_MAX;
+                target->mMinHeight = std::numeric_limits<float>::max();
+                target->mMaxHeight = -std::numeric_limits<float>::max();
                 float rowOffset = vhgt.mHeightOffset;
                 for (int y = 0; y < LAND_SIZE; y++) {
                     rowOffset += vhgt.mHeightData[y * LAND_SIZE];


### PR DESCRIPTION
Yep, why not. I didn't touch recastnavigation and defines in sound system.

Also fixed an intentional unreasonable overflow in land vertex color default values.