### PR TITLE
Avoid conflict between SpellState and MagicEffects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
+    Bug #3714: Failed to load saved game: ESM error: Expected subrecord ARG_ but got BASE
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4411: Reloading a saved game while falling prevents damage in some cases

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -5,7 +5,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 5;
+int ESM::SavedGame::sCurrentFormat = 6;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
Fixes [bug #3714](https://gitlab.com/OpenMW/openmw/issues/3714).

**Warning: this PR changes a savegame format!**

The fix has two parts:
1. Apply a fix from mentioned thread to restore old savegames.
1. Use the "PEID" subrecord instead of "EFID" in the SpellState, so in newer savegames this bug should not appear.