### PR TITLE
Optimize skinning, part 2

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1092,8 +1092,7 @@ namespace NifOsg
                 const std::vector<Nif::NiSkinData::VertWeight> &weights = data->bones[i].weights;
                 for(size_t j = 0;j < weights.size();j++)
                 {
-                    std::pair<unsigned short, float> indexWeight = std::make_pair(weights[j].vertex, weights[j].weight);
-                    influence.mWeights.insert(indexWeight);
+                    influence.mWeights.emplace_back(weights[j].vertex, weights[j].weight);
                 }
                 influence.mInvBindMatrix = data->bones[i].trafo.toMatrix();
                 influence.mBoundSphere = osg::BoundingSpheref(data->bones[i].boundSphereCenter, data->bones[i].boundSphereRadius);

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1098,7 +1098,7 @@ namespace NifOsg
                 influence.mInvBindMatrix = data->bones[i].trafo.toMatrix();
                 influence.mBoundSphere = osg::BoundingSpheref(data->bones[i].boundSphereCenter, data->bones[i].boundSphereRadius);
 
-                map->mMap.insert(std::make_pair(boneName, influence));
+                map->mData.emplace_back(boneName, influence);
             }
             rig->setInfluenceMap(map);
 

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -146,18 +146,14 @@ bool RigGeometry::initFromParentSkeleton(osg::NodeVisitor* nv)
             continue;
         }
 
-        mBoneSphereVector.emplace_back(bone, influencePair.second.mBoundSphere);
-
         const BoneInfluence& bi = influencePair.second;
+        mBoneSphereVector.emplace_back(bone, bi.mBoundSphere);
 
-        const std::map<unsigned short, float>& weights = influencePair.second.mWeights;
-        for (std::map<unsigned short, float>::const_iterator weightIt = weights.begin(); weightIt != weights.end(); ++weightIt)
+        for (auto& weightPair: bi.mWeights)
         {
-            std::vector<BoneWeight>& vec = vertex2BoneMap[weightIt->first];
+            std::vector<BoneWeight>& vec = vertex2BoneMap[weightPair.first];
 
-            BoneWeight b = std::make_pair(std::make_pair(bone, bi.mInvBindMatrix), weightIt->second);
-
-            vec.push_back(b);
+            vec.emplace_back(std::make_pair(bone, bi.mInvBindMatrix), weightPair.second);
         }
     }
 

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -136,20 +136,21 @@ bool RigGeometry::initFromParentSkeleton(osg::NodeVisitor* nv)
 
     typedef std::map<unsigned short, std::vector<BoneWeight> > Vertex2BoneMap;
     Vertex2BoneMap vertex2BoneMap;
-    for (std::map<std::string, BoneInfluence>::const_iterator it = mInfluenceMap->mMap.begin(); it != mInfluenceMap->mMap.end(); ++it)
+    mBoneSphereVector.clear();
+    for (auto& influencePair : mInfluenceMap->mData)
     {
-        Bone* bone = mSkeleton->getBone(it->first);
+        Bone* bone = mSkeleton->getBone(influencePair.first);
         if (!bone)
         {
-            Log(Debug::Error) << "Error: RigGeometry did not find bone " << it->first ;
+            Log(Debug::Error) << "Error: RigGeometry did not find bone " << influencePair.first;
             continue;
         }
 
-        mBoneSphereMap[bone] = it->second.mBoundSphere;
+        mBoneSphereVector.emplace_back(bone, influencePair.second.mBoundSphere);
 
-        const BoneInfluence& bi = it->second;
+        const BoneInfluence& bi = influencePair.second;
 
-        const std::map<unsigned short, float>& weights = it->second.mWeights;
+        const std::map<unsigned short, float>& weights = influencePair.second.mWeights;
         for (std::map<unsigned short, float>::const_iterator weightIt = weights.begin(); weightIt != weights.end(); ++weightIt)
         {
             std::vector<BoneWeight>& vec = vertex2BoneMap[weightIt->first];
@@ -160,10 +161,13 @@ bool RigGeometry::initFromParentSkeleton(osg::NodeVisitor* nv)
         }
     }
 
+    Bone2VertexMap bone2VertexMap;
     for (Vertex2BoneMap::iterator it = vertex2BoneMap.begin(); it != vertex2BoneMap.end(); ++it)
     {
-        mBone2VertexMap[it->second].push_back(it->first);
+        bone2VertexMap[it->second].push_back(it->first);
     }
+
+    mBone2VertexVector.assign(bone2VertexMap.begin(), bone2VertexMap.end());
 
     return true;
 }
@@ -201,7 +205,7 @@ void RigGeometry::cull(osg::NodeVisitor* nv)
     osg::Vec3Array* normalDst = static_cast<osg::Vec3Array*>(geom.getNormalArray());
     osg::Vec4Array* tangentDst = static_cast<osg::Vec4Array*>(geom.getTexCoordArray(7));
 
-    for (auto &pair : mBone2VertexMap)
+    for (auto &pair : mBone2VertexVector)
     {
         osg::Matrixf resultMat (0, 0, 0, 0,
                                 0, 0, 0, 0,
@@ -263,10 +267,10 @@ void RigGeometry::updateBounds(osg::NodeVisitor *nv)
     updateGeomToSkelMatrix(nv->getNodePath());
 
     osg::BoundingBox box;
-    for (BoneSphereMap::const_iterator it = mBoneSphereMap.begin(); it != mBoneSphereMap.end(); ++it)
+    for (auto& boundPair : mBoneSphereVector)
     {
-        Bone* bone = it->first;
-        osg::BoundingSpheref bs = it->second;
+        Bone* bone = boundPair.first;
+        osg::BoundingSpheref bs = boundPair.second;
         if (mGeomToSkelMatrix)
             transformBoundingSphere(bone->mMatrixInSkeletonSpace * (*mGeomToSkelMatrix), bs);
         else

--- a/components/sceneutil/riggeometry.hpp
+++ b/components/sceneutil/riggeometry.hpp
@@ -31,7 +31,7 @@ namespace SceneUtil
             osg::Matrixf mInvBindMatrix;
             osg::BoundingSpheref mBoundSphere;
             // <vertex index, weight>
-            std::map<unsigned short, float> mWeights;
+            std::vector<std::pair<unsigned short, float>> mWeights;
         };
 
         struct InfluenceMap : public osg::Referenced

--- a/components/sceneutil/riggeometry.hpp
+++ b/components/sceneutil/riggeometry.hpp
@@ -36,7 +36,7 @@ namespace SceneUtil
 
         struct InfluenceMap : public osg::Referenced
         {
-            std::map<std::string, BoneInfluence> mMap;
+            std::vector<std::pair<std::string, BoneInfluence>> mData;
         };
 
         void setInfluenceMap(osg::ref_ptr<InfluenceMap> influenceMap);
@@ -73,12 +73,13 @@ namespace SceneUtil
         typedef std::vector<unsigned short> VertexList;
 
         typedef std::map<std::vector<BoneWeight>, VertexList> Bone2VertexMap;
+        typedef std::vector<std::pair<std::vector<BoneWeight>, VertexList>> Bone2VertexVector;
 
-        Bone2VertexMap mBone2VertexMap;
+        Bone2VertexVector mBone2VertexVector;
 
-        typedef std::map<Bone*, osg::BoundingSpheref> BoneSphereMap;
+        typedef std::vector<std::pair<Bone*, osg::BoundingSpheref>> BoneSphereVector;
 
-        BoneSphereMap mBoneSphereMap;
+        BoneSphereVector mBoneSphereVector;
 
         unsigned int mLastFrameNumber;
         bool mBoundsFirstFrame;


### PR DESCRIPTION
For now we do not use key lookups in the mBone2VertexMap during skinning calcualtions. Instead we just iterate over the whole map.

So I decided to replace map to vector since it stores elements contiguously and accessing the next element is much cheaper.

As a result, culling phase now takes about 0.5-1ms less time per frame when there are some actors in scene with skinned bodyparts (noticable in the profiler under Cull line).

The same thing for mBoneSphereMap, but the difference is a lot smaller - about 0.1ms (noticable in the profiler under Update line).