### PR TITLE
[0.45.0 regressions] Revert poor animation decisions

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -345,15 +345,14 @@ void CharacterController::refreshHitRecoilAnims(CharacterState& idle)
         idle = CharState_None;
 }
 
-void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, CharacterState& movement, bool force)
+void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, bool force)
 {
-    if (!force && jump == mJumpState && idle == CharState_None && movement == CharState_None)
+    if (!force && jump == mJumpState && idle == CharState_None)
         return;
 
-    if (jump != JumpState_None && !(mPtr == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())) // FIXME
+    if (jump == JumpState_InAir)
     {
         idle = CharState_None;
-        movement = CharState_None;
     }
 
     std::string jumpAnimName;
@@ -384,6 +383,7 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
     if (!force && jump == mJumpState)
         return;
 
+    bool startAtLoop = (jump == mJumpState);
     mJumpState = jump;
 
     if (!mCurrentJump.empty())
@@ -397,7 +397,7 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
         if (mAnimation->hasAnimation(jumpAnimName))
         {
             mAnimation->play(jumpAnimName, Priority_Jump, jumpmask, false,
-                         1.0f, "start", "stop", 0.f, ~0ul);
+                         1.0f, startAtLoop ? "loop start" : "start", "stop", 0.f, ~0ul);
             mCurrentJump = jumpAnimName;
         }
     }
@@ -675,7 +675,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
     if (!mPtr.getClass().hasInventoryStore(mPtr))
         weap = sWeaponTypeListEnd;
 
-    refreshJumpAnims(weap, jump, idle, movement, force);
+    refreshJumpAnims(weap, jump, idle, force);
     refreshMovementAnims(weap, movement, idle, force);
 
     // idle handled last as it can depend on the other states
@@ -2137,12 +2137,6 @@ void CharacterController::update(float duration, bool animationOnly)
 
             inJump = false;
 
-            // Do not play turning animation for player if rotation speed is very slow.
-            // Actual threshold should take framerate in account.
-            float rotationThreshold = 0;
-            if (isPlayer)
-                rotationThreshold = 0.015 * 60 * duration;
-
             if(std::abs(vec.x()/2.0f) > std::abs(vec.y()))
             {
                 if(vec.x() > 0.0f)
@@ -2167,10 +2161,16 @@ void CharacterController::update(float duration, bool animationOnly)
             }
             else if(rot.z() != 0.0f)
             {
+                // Do not play turning animation for player if rotation speed is very slow.
+                // Actual threshold should take framerate in account.
+                float rotationThreshold = 0.f;
+                if (isPlayer)
+                    rotationThreshold = 0.015 * 60 * duration;
+
                 // It seems only bipedal actors use turning animations.
                 // Also do not use turning animations in the first-person view and when sneaking.
                 bool isFirstPlayer = isPlayer && MWBase::Environment::get().getWorld()->isFirstPerson();
-                if (!sneak && !isFirstPlayer && mPtr.getClass().isBipedal(mPtr))
+                if (!sneak && jumpstate == JumpState_None && !isFirstPlayer && mPtr.getClass().isBipedal(mPtr))
                 {
                     if(rot.z() > rotationThreshold)
                         movestate = inwater ? CharState_SwimTurnRight : CharState_TurnRight;
@@ -2183,12 +2183,15 @@ void CharacterController::update(float duration, bool animationOnly)
         if (playLandingSound)
         {
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            std::string sound = "DefaultLand";
+            std::string sound;
             osg::Vec3f pos(mPtr.getRefData().getPosition().asVec3());
             if (world->isUnderwater(mPtr.getCell(), pos) || world->isWalkingOnWater(mPtr))
                 sound = "DefaultLandWater";
+            else if (onground)
+                sound = "DefaultLand";
 
-            sndMgr->playSound3D(mPtr, sound, 1.f, 1.f, MWSound::Type::Foot, MWSound::PlayMode::NoPlayerLocal);
+            if (!sound.empty())
+                sndMgr->playSound3D(mPtr, sound, 1.f, 1.f, MWSound::Type::Foot, MWSound::PlayMode::NoPlayerLocal);
         }
 
         // Player can not use smooth turning as NPCs, so we play turning animation a bit to avoid jittering
@@ -2197,7 +2200,7 @@ void CharacterController::update(float duration, bool animationOnly)
             float threshold = mCurrentMovement.find("swim") == std::string::npos ? 0.4f : 0.8f;
             float complete;
             bool animPlaying = mAnimation->getInfo(mCurrentMovement, &complete);
-            if (movestate == CharState_None && isTurning())
+            if (movestate == CharState_None && jumpstate == JumpState_None && isTurning())
             {
                 if (animPlaying && complete < threshold)
                     movestate = mMovementState;

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -31,10 +31,8 @@ enum Priority {
     Priority_WeaponLowerBody,
     Priority_SneakIdleLowerBody,
     Priority_SwimIdle,
-    Priority_Movement,
-    // Note: in vanilla movement anims have higher priority than jump ones.
-    // It causes issues with landing animations during movement.
     Priority_Jump,
+    Priority_Movement,
     Priority_Hit,
     Priority_Weapon,
     Priority_Block,
@@ -214,7 +212,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
 
     void refreshCurrentAnims(CharacterState idle, CharacterState movement, JumpingState jump, bool force=false);
     void refreshHitRecoilAnims(CharacterState& idle);
-    void refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, CharacterState& movement, bool force=false);
+    void refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, bool force=false);
     void refreshMovementAnims(const WeaponInfo* weap, CharacterState movement, CharacterState& idle, bool force=false);
     void refreshIdleAnims(const WeaponInfo* weap, CharacterState idle, bool force=false);
 


### PR DESCRIPTION
This resolves the two concerns listed in [this bug report](https://gitlab.com/OpenMW/openmw/issues/4782):

a. When the in-air jump animation state is force-updated (such as when the weapon is changed) while it's in progress it's started from the loop start again.
b. Landing animation behavior was reverted to something resembling 0.44.0 behavior again. Jumping animations once again have lower priority than movement animations. This is a big one, and here are my reasons for the revert:
1) Players didn't really like the behavior of landing animation when it "staggered" the character briefly and the subsequent movement was from the wrong point because movement animation was started at the same time as the landing animation was. This behavior is present in TES3MP 0.7.0-alpha which is based on older 0.45.0 revision and there are some mixed opinions about it.
2) My updated behavior introduced weird sliding when the landing animation transitioned into the movement animation, and yet again it looks pretty odd and needs some weird hacks to work properly (first person view doesn't have a landing animation so it was glitchy without the hack).
3) This leads me to the opinion that Morrowind landing animation wasn't really intended to be used during horizontal movement.
4) The change of the behavior is not mentioned in the changelog.

c. Idle is no longer reset during landing animation, so first person view can't suddenly collapse for a frame if jumping and landing in place.

d. Default landing sound is only played when the player is guaranteedly on ground again to prevent spam in certain conditions.

So the behavior resembles 0.44.0 behavior again and thus Morrowind behavior. But: it's not exactly the same. Because akortunov changed the player turning animation behavior the jumping animations conflicted with the turning animation. I had to make the jumping animations have higher priority than turning animation (exact opposite of what drummyfish changed some time ago) to make sure there still isn't any flickering but jumping and landing doesn't look weird due to the turning animation blending with it.

In the result there isn't any landing animation when the character is bunny-hopping again but it's ultimately for the best because any slowdown (either brief or noticeable) during the mentioned tradition of Morrowind gameplay would infuriate the players in 0.45.0.

akortunov stated he doesn't want to mess with animations at the moment and that he has little idea what should the "right" behavior of landing animation be.