### PR TITLE
Share RigGeometry node data

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1120,7 +1120,7 @@ namespace NifOsg
             const Nif::NodeList &bones = skin->bones;
             for(size_t i = 0;i < bones.length();i++)
             {
-                std::string boneName = bones[i].getPtr()->name;
+                std::string boneName = Misc::StringUtils::lowerCase(bones[i].getPtr()->name);
 
                 SceneUtil::RigGeometry::BoneInfluence influence;
                 const std::vector<Nif::NiSkinData::VertWeight> &weights = data->bones[i].weights;

--- a/components/sceneutil/riggeometry.hpp
+++ b/components/sceneutil/riggeometry.hpp
@@ -6,7 +6,6 @@
 
 namespace SceneUtil
 {
-
     class Skeleton;
     class Bone;
 
@@ -66,20 +65,26 @@ namespace SceneUtil
 
         osg::ref_ptr<InfluenceMap> mInfluenceMap;
 
-        typedef std::pair<Bone*, osg::Matrixf> BoneBindMatrixPair;
+        typedef std::pair<std::string, osg::Matrixf> BoneBindMatrixPair;
 
         typedef std::pair<BoneBindMatrixPair, float> BoneWeight;
 
         typedef std::vector<unsigned short> VertexList;
 
         typedef std::map<std::vector<BoneWeight>, VertexList> Bone2VertexMap;
-        typedef std::vector<std::pair<std::vector<BoneWeight>, VertexList>> Bone2VertexVector;
 
-        Bone2VertexVector mBone2VertexVector;
+        struct Bone2VertexVector : public osg::Referenced
+        {
+            std::vector<std::pair<std::vector<BoneWeight>, VertexList>> mData;
+        };
+        osg::ref_ptr<Bone2VertexVector> mBone2VertexVector;
 
-        typedef std::vector<std::pair<Bone*, osg::BoundingSpheref>> BoneSphereVector;
-
-        BoneSphereVector mBoneSphereVector;
+        struct BoneSphereVector : public osg::Referenced
+        {
+            std::vector<std::pair<std::string, osg::BoundingSpheref>> mData;
+        };
+        osg::ref_ptr<BoneSphereVector> mBoneSphereVector;
+        std::vector<Bone*> mBoneNodesVector;
 
         unsigned int mLastFrameNumber;
         bool mBoundsFirstFrame;


### PR DESCRIPTION
For now we calculate a lot of stuff in the RigGeometry::initFromParentSkeleton(), but most of data is actually static (excepts of link to bone nodes). So I got an idea to calculate data in the NifLoader only once, and then re-use it, but we do not know actual skeleton here.

A basic approach:
1. Store string bone names instead of reference to OSG node.
2. Since data will become static, in theory we can use the same vector for original template and all instances
3. We can load actual bones once they will be available. Probably we can use the "boneName -> osg::Node" map or even just a vector of nodes.

@kcat, @AnyOldName3, what do you think?