### PR TITLE
Adjust static and constant GMST usage

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -247,7 +247,8 @@ namespace MWClass
 
         MWMechanics::applyFatigueLoss(ptr, weapon, attackStrength);
 
-        float dist = gmst.find("fCombatDistance")->mValue.getFloat();
+        const float fCombatDistance = gmst.find("fCombatDistance")->mValue.getFloat();
+        float dist = fCombatDistance;
         if (!weapon.isEmpty())
             dist *= weapon.get<ESM::Weapon>()->mBase->mData.mReach;
 

--- a/apps/openmw/mwclass/npc.hpp
+++ b/apps/openmw/mwclass/npc.hpp
@@ -38,6 +38,7 @@ namespace MWClass
                 const ESM::GameSetting *iKnockDownOddsMult;
                 const ESM::GameSetting *iKnockDownOddsBase;
                 const ESM::GameSetting *fCombatArmorMinMult;
+                const ESM::GameSetting *iVoiceHitOdds;
             };
 
             static const GMST& getGmst();

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -339,8 +339,8 @@ namespace MWClass
         if (ref->mBase->mData.mType < ESM::Weapon::MarksmanBow && verbose)
         {
             // display value in feet
-            const float combatDistance = store.get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat() * ref->mBase->mData.mReach;
-            text += MWGui::ToolTips::getWeightString(combatDistance / Constants::UnitsPerFoot, "#{sRange}");
+            const float fCombatDistance = store.get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat();
+            text += MWGui::ToolTips::getWeightString(fCombatDistance * ref->mBase->mData.mReach / Constants::UnitsPerFoot, "#{sRange}");
             text += " #{sFeet}";
         }
 

--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -45,6 +45,8 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
 
     MWWorld::ContainerStore& store = player.getClass().getContainerStore(player);
     int categories = MWWorld::ContainerStore::Type_Weapon | MWWorld::ContainerStore::Type_Armor;
+    const float fRepairMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fRepairMult")->mValue.getFloat();
+    const std::string sgp = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("sgp")->mValue.getString();
     for (MWWorld::ContainerStoreIterator iter (store.begin(categories)); iter!=store.end(); ++iter)
     {
         if (iter->getClass().hasItemHealth(*iter))
@@ -55,8 +57,6 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
                 continue;
 
             int basePrice = iter->getClass().getValue(*iter);
-            float fRepairMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                    .find("fRepairMult")->mValue.getFloat();
 
             float p = static_cast<float>(std::max(1, basePrice));
             float r = static_cast<float>(std::max(1, static_cast<int>(maxDurability / p)));
@@ -66,10 +66,7 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
 
             int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mActor, x, true);
 
-            std::string name = iter->getClass().getName(*iter)
-                    + " - " + MyGUI::utility::toString(price)
-                    + MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                    .find("sgp")->mValue.getString();
+            std::string name = iter->getClass().getName(*iter) + " - " + MyGUI::utility::toString(price) + sgp;
 
             MyGUI::Button* button =
                 mList->createWidget<MyGUI::Button>(price <= playerGold ? "SandTextButton" : "SandTextButtonDisabled", // can't use setEnabled since that removes tooltip

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -39,10 +39,10 @@ namespace MWGui
 
     void SpellBuyingWindow::addSpell(const ESM::Spell& spell)
     {
-        const MWWorld::ESMStore &store =
-            MWBase::Environment::get().getWorld()->getStore();
+        const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
 
-        int price = static_cast<int>(spell.mData.mCost*store.get<ESM::GameSetting>().find("fSpellValueMult")->mValue.getFloat());
+        const float fSpellValueMult = store.get<ESM::GameSetting>().find("fSpellValueMult")->mValue.getFloat();
+        int price = static_cast<int>(spell.mData.mCost*fSpellValueMult);
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr,price,true);
 
         MWWorld::Ptr player = MWMechanics::getPlayer();

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -147,9 +147,7 @@ namespace MWGui
 
         mDurationValue->setCaption("1");
         mMagnitudeMinValue->setCaption("1");
-        const std::string to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
-
-        mMagnitudeMaxValue->setCaption(to + " 1");
+        mMagnitudeMaxValue->setCaptionWithReplacing("#{sTo} 1");
         mAreaValue->setCaption("0");
 
         setVisible(true);
@@ -314,9 +312,7 @@ namespace MWGui
         }
 
         mEffect.mMagnMax = pos+1;
-        const std::string to = MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "-");
-
-        mMagnitudeMaxValue->setCaption(to + " " + MyGUI::utility::toString(pos+1));
+        mMagnitudeMaxValue->setCaptionWithReplacing("#{sTo} " + MyGUI::utility::toString(pos+1));
 
         eventEffectModified(mEffect);
     }

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -296,17 +296,16 @@ namespace MWGui
 
         MWWorld::Ptr player = MWMechanics::getPlayer();
         const MWMechanics::NpcStats &PCstats = player.getClass().getNpcStats(player);
-
+        const int iLevelUpTotal = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("iLevelUpTotal")->mValue.getInteger();
         // level progress
         MyGUI::Widget* levelWidget;
         for (int i=0; i<2; ++i)
         {
-            int max = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("iLevelUpTotal")->mValue.getInteger();
             getWidget(levelWidget, i==0 ? "Level_str" : "LevelText");
             levelWidget->setUserString("RangePosition_LevelProgress", MyGUI::utility::toString(PCstats.getLevelProgress()));
-            levelWidget->setUserString("Range_LevelProgress", MyGUI::utility::toString(max));
+            levelWidget->setUserString("Range_LevelProgress", MyGUI::utility::toString(iLevelUpTotal));
             levelWidget->setUserString("Caption_LevelProgressText", MyGUI::utility::toString(PCstats.getLevelProgress()) + "/"
-                                       + MyGUI::utility::toString(max));
+                                       + MyGUI::utility::toString(iLevelUpTotal));
         }
 
         setFactions(PCstats.getFactionRanks());

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -48,21 +48,22 @@ namespace MWGui
     {
         int price;
 
-        const MWWorld::Store<ESM::GameSetting> &gmst =
-            MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
 
         MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
         int playerGold = player.getClass().getContainerStore(player).count(MWWorld::ContainerStore::sGoldId);
 
         if (!mPtr.getCell()->isExterior())
         {
-            price = gmst.find("fMagesGuildTravel")->mValue.getInteger();
+            const int fMagesGuildTravel = gmst.find("fMagesGuildTravel")->mValue.getInteger();
+            price = fMagesGuildTravel;
         }
         else
         {
             ESM::Position PlayerPos = player.getRefData().getPosition();
             float d = sqrt(pow(pos.pos[0] - PlayerPos.pos[0], 2) + pow(pos.pos[1] - PlayerPos.pos[1], 2) + pow(pos.pos[2] - PlayerPos.pos[2], 2));
-            price = static_cast<int>(d / gmst.find("fTravelMult")->mValue.getFloat());
+            const float fTravelMult = gmst.find("fTravelMult")->mValue.getFloat();
+            price = static_cast<int>(d / fTravelMult);
         }
 
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
@@ -173,7 +174,8 @@ namespace MWGui
         {
             ESM::Position playerPos = player.getRefData().getPosition();
             float d = (osg::Vec3f(pos.pos[0], pos.pos[1], 0) - osg::Vec3f(playerPos.pos[0], playerPos.pos[1], 0)).length();
-            int hours = static_cast<int>(d /MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fTravelTimeMult")->mValue.getFloat());
+            const float fTravelTimeMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fTravelTimeMult")->mValue.getFloat();
+            int hours = static_cast<int>(d / fTravelTimeMult);
             for(int i = 0;i < hours;i++)
             {
                 MWBase::Environment::get().getMechanicsManager ()->rest (true);

--- a/apps/openmw/mwgui/waitdialog.cpp
+++ b/apps/openmw/mwgui/waitdialog.cpp
@@ -255,9 +255,9 @@ namespace MWGui
         const MWMechanics::NpcStats &pcstats = player.getClass().getNpcStats(player);
 
         // trigger levelup if possible
-        const MWWorld::Store<ESM::GameSetting> &gmst =
-            MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
-        if (mSleeping && pcstats.getLevelProgress () >= gmst.find("iLevelUpTotal")->mValue.getInteger())
+        const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        const int iLevelUpTotal = gmst.find("iLevelUpTotal")->mValue.getInteger();
+        if (mSleeping && pcstats.getLevelProgress () >= iLevelUpTotal)
         {
             MWBase::Environment::get().getWindowManager()->pushGuiMode (GM_Levelup);
         }

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -550,15 +550,17 @@ namespace MWMechanics
                 mStrength = Misc::Rng::rollClosedProbability();
 
                 const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
+                const float fCombatDelayCreature = store.get<ESM::GameSetting>().find("fCombatDelayCreature")->mValue.getFloat();
 
-                float baseDelay = store.get<ESM::GameSetting>().find("fCombatDelayCreature")->mValue.getFloat();
+                float baseDelay = fCombatDelayCreature;
                 if (actor.getClass().isNpc())
                 {
-                    baseDelay = store.get<ESM::GameSetting>().find("fCombatDelayNPC")->mValue.getFloat();
+                    const float fCombatDelayNPC = store.get<ESM::GameSetting>().find("fCombatDelayNPC")->mValue.getFloat();
+                    baseDelay = fCombatDelayNPC;
 
                     //say a provoking combat phrase
-                    int chance = store.get<ESM::GameSetting>().find("iVoiceAttackOdds")->mValue.getInteger();
-                    if (Misc::Rng::roll0to99() < chance)
+                    const int iVoiceAttackOdds = store.get<ESM::GameSetting>().find("iVoiceAttackOdds")->mValue.getInteger();
+                    if (Misc::Rng::roll0to99() < iVoiceAttackOdds)
                     {
                         MWBase::Environment::get().getDialogueManager()->say(actor, "attack");
                     }
@@ -643,26 +645,19 @@ osg::Vec3f AimDirToMovingTarget(const MWWorld::Ptr& actor, const MWWorld::Ptr& t
 {
     float projSpeed;
     const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+    static const float fThrownWeaponMinSpeed = gmst.find("fThrownWeaponMinSpeed")->mValue.getFloat();
+    static const float fThrownWeaponMaxSpeed = gmst.find("fThrownWeaponMaxSpeed")->mValue.getFloat();
+    static const float fProjectileMinSpeed = gmst.find("fProjectileMinSpeed")->mValue.getFloat();
+    static const float fProjectileMaxSpeed = gmst.find("fProjectileMaxSpeed")->mValue.getFloat();
+    static const float fTargetSpellMaxSpeed = gmst.find("fTargetSpellMaxSpeed")->mValue.getFloat();
 
     // get projectile speed (depending on weapon type)
     if (weapType == ESM::Weapon::MarksmanThrown)
-    {
-        static float fThrownWeaponMinSpeed = gmst.find("fThrownWeaponMinSpeed")->mValue.getFloat();
-        static float fThrownWeaponMaxSpeed = gmst.find("fThrownWeaponMaxSpeed")->mValue.getFloat();
-
         projSpeed = fThrownWeaponMinSpeed + (fThrownWeaponMaxSpeed - fThrownWeaponMinSpeed) * strength;
-    }
     else if (weapType != 0)
-    {
-        static float fProjectileMinSpeed = gmst.find("fProjectileMinSpeed")->mValue.getFloat();
-        static float fProjectileMaxSpeed = gmst.find("fProjectileMaxSpeed")->mValue.getFloat();
-
         projSpeed = fProjectileMinSpeed + (fProjectileMaxSpeed - fProjectileMinSpeed) * strength;
-    }
     else // weapType is 0 ==> it's a target spell projectile
-    {
-        projSpeed = gmst.find("fTargetSpellMaxSpeed")->mValue.getFloat();
-    }
+        projSpeed = fTargetSpellMaxSpeed;
 
     // idea: perpendicular to dir to target speed components of target move vector and projectile vector should be the same
 

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -24,10 +24,10 @@ namespace MWMechanics
     float suggestCombatRange(int rangeTypes)
     {
         static const float fCombatDistance = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat();
-        static float fHandToHandReach = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fHandToHandReach")->mValue.getFloat();
+        static const float fHandToHandReach = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fHandToHandReach")->mValue.getFloat();
 
         // This distance is a possible distance of melee attack
-        static float distance = fCombatDistance * std::max(2.f, fHandToHandReach);
+        static const float distance = fCombatDistance * std::max(2.f, fHandToHandReach);
 
         if (rangeTypes & RangeTypes::Touch)
         {
@@ -114,13 +114,13 @@ namespace MWMechanics
     {
         isRanged = false;
 
-        static const float fCombatDistance = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat();
-        static const float fProjectileMaxSpeed = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fProjectileMaxSpeed")->mValue.getFloat();
+        const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        static const float fCombatDistance = gmst.find("fCombatDistance")->mValue.getFloat();
+        static const float fHandToHandReach = gmst.find("fHandToHandReach")->mValue.getFloat();
+        static const float fProjectileMaxSpeed = gmst.find("fProjectileMaxSpeed")->mValue.getFloat();
 
         if (mWeapon.isEmpty())
         {
-            static float fHandToHandReach =
-                MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fHandToHandReach")->mValue.getFloat();
             return fHandToHandReach * fCombatDistance;
         }
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -527,7 +527,7 @@ namespace MWMechanics
         // Play a random voice greeting if the player gets too close
         int hello = actor.getClass().getCreatureStats(actor).getAiSetting(CreatureStats::AI_Hello).getModified();
         float helloDistance = static_cast<float>(hello);
-        static int iGreetDistanceMultiplier = MWBase::Environment::get().getWorld()->getStore()
+        static const int iGreetDistanceMultiplier = MWBase::Environment::get().getWorld()->getStore()
             .get<ESM::GameSetting>().find("iGreetDistanceMultiplier")->mValue.getInteger();
 
         helloDistance *= iGreetDistanceMultiplier;
@@ -706,7 +706,7 @@ namespace MWMechanics
 
         for(unsigned int counter = 0; counter < mIdle.size(); counter++)
         {
-            static float fIdleChanceMultiplier = MWBase::Environment::get().getWorld()->getStore()
+            static const float fIdleChanceMultiplier = MWBase::Environment::get().getWorld()->getStore()
                 .get<ESM::GameSetting>().find("fIdleChanceMultiplier")->mValue.getFloat();
 
             unsigned short idleChance = static_cast<unsigned short>(fIdleChanceMultiplier * mIdle[counter]);

--- a/apps/openmw/mwmechanics/disease.hpp
+++ b/apps/openmw/mwmechanics/disease.hpp
@@ -26,9 +26,9 @@ namespace MWMechanics
         if (!carrier.getClass().isActor() || actor != getPlayer())
             return;
 
-        float fDiseaseXferChance =
-                MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(
-                    "fDiseaseXferChance")->mValue.getFloat();
+        const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        const float fDiseaseXferChance = gmst.find("fDiseaseXferChance")->mValue.getFloat();
+        const std::string sMagicContractDisease = gmst.find("sMagicContractDisease")->mValue.getString();
 
         MagicEffects& actorEffects = actor.getClass().getCreatureStats(actor).getMagicEffects();
 
@@ -58,8 +58,7 @@ namespace MWMechanics
                 // Contracted disease!
                 actor.getClass().getCreatureStats(actor).getSpells().add(it->first);
 
-                std::string msg = "sMagicContractDisease";
-                msg = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(msg)->mValue.getString();
+                std::string msg = sMagicContractDisease;
                 if (msg.find("%s") != std::string::npos)
                     msg.replace(msg.find("%s"), 2, spell->mName);
                 MWBase::Environment::get().getWindowManager()->messageBox(msg);

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -229,8 +229,8 @@ namespace MWMechanics
         if(mEnchanter.isEmpty())
             return 0;
 
-        float priceMultipler = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find ("fEnchantmentValueMult")->mValue.getFloat();
-        int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mEnchanter, static_cast<int>(getEnchantPoints() * priceMultipler), true);
+        const float fEnchantmentValueMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find ("fEnchantmentValueMult")->mValue.getFloat();
+        int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mEnchanter, static_cast<int>(getEnchantPoints() * fEnchantmentValueMult), true);
         return price;
     }
 

--- a/apps/openmw/mwmechanics/pickpocket.cpp
+++ b/apps/openmw/mwmechanics/pickpocket.cpp
@@ -36,10 +36,9 @@ namespace MWMechanics
         float t = 2*x - y;
 
         float pcSneak = static_cast<float>(mThief.getClass().getSkill(mThief, ESM::Skill::Sneak));
-        int iPickMinChance = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                .find("iPickMinChance")->mValue.getInteger();
-        int iPickMaxChance = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                .find("iPickMaxChance")->mValue.getInteger();
+        const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        const int iPickMinChance = gmst.find("iPickMinChance")->mValue.getInteger();
+        const float iPickMaxChance = floor(gmst.find("iPickMaxChance")->mValue.getFloat());
 
         int roll = Misc::Rng::roll0to99();
         if (t < pcSneak / iPickMinChance)
@@ -48,7 +47,7 @@ namespace MWMechanics
         }
         else
         {
-            t = std::min(float(iPickMaxChance), t);
+            t = std::min(iPickMaxChance, t);
             return (roll > int(t));
         }
     }
@@ -56,8 +55,8 @@ namespace MWMechanics
     bool Pickpocket::pick(MWWorld::Ptr item, int count)
     {
         float stackValue = static_cast<float>(item.getClass().getValue(item) * count);
-        float fPickPocketMod = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                .find("fPickPocketMod")->mValue.getFloat();
+        const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+        const float fPickPocketMod = gmst.find("fPickPocketMod")->mValue.getFloat();
         float valueTerm = 10 * fPickPocketMod * stackValue;
 
         return getDetected(valueTerm);

--- a/apps/openmw/mwmechanics/repair.cpp
+++ b/apps/openmw/mwmechanics/repair.cpp
@@ -39,8 +39,7 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
     int pcLuck = stats.getAttribute(ESM::Attribute::Luck).getModified();
     int armorerSkill = player.getClass().getSkill(player, ESM::Skill::Armorer);
 
-    float fRepairAmountMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-            .find("fRepairAmountMult")->mValue.getFloat();
+    const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
 
     float toolQuality = ref->mBase->mData.mQuality;
 
@@ -49,6 +48,7 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
     int roll = Misc::Rng::roll0to99();
     if (roll <= x)
     {
+        const float fRepairAmountMult = gmst.find("fRepairAmountMult")->mValue.getFloat();
         int y = static_cast<int>(fRepairAmountMult * toolQuality * roll);
         y = std::max(1, y);
 
@@ -84,8 +84,7 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
 
         store.remove(mTool, 1, player);
 
-        std::string message = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                .find("sNotifyMessage51")->mValue.getString();
+        const std::string message = gmst.find("sNotifyMessage51")->mValue.getString();
 
         MWBase::Environment::get().getWindowManager()->messageBox((boost::format(message) % mTool.getClass().getName(mTool)).str());
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -1293,8 +1293,8 @@ namespace MWMechanics
             float timeDiff = std::min(7.f, std::max(0.f, std::abs(time - 13)));
             float damageScale = 1.f - timeDiff / 7.f;
             // When cloudy, the sun damage effect is halved
-            static float fMagicSunBlockedMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(
-                        "fMagicSunBlockedMult")->mValue.getFloat();
+            const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+            static const float fMagicSunBlockedMult = gmst.find("fMagicSunBlockedMult")->mValue.getFloat();
 
             int weather = MWBase::Environment::get().getWorld()->getCurrentWeather();
             if (weather > 1)

--- a/apps/openmw/mwmechanics/trading.cpp
+++ b/apps/openmw/mwmechanics/trading.cpp
@@ -50,12 +50,13 @@ namespace MWMechanics
         float e1 = 0.1f * merchantStats.getAttribute(ESM::Attribute::Luck).getModified();
         float f1 = 0.2f * merchantStats.getAttribute(ESM::Attribute::Personality).getModified();
 
-        float dispositionTerm = gmst.find("fDispositionMod")->mValue.getFloat() * (clampedDisposition - 50);
+        const float fDispositionMod = gmst.find("fDispositionMod")->mValue.getFloat();
+        const float fBargainOfferMulti = gmst.find("fBargainOfferMulti")->mValue.getFloat();
+        const float fBargainOfferBase = gmst.find("fBargainOfferBase")->mValue.getFloat();
+        float dispositionTerm = fDispositionMod * (clampedDisposition - 50);
         float pcTerm = (dispositionTerm + a1 + b1 + c1) * playerStats.getFatigueTerm();
         float npcTerm = (d1 + e1 + f1) * merchantStats.getFatigueTerm();
-        float x = gmst.find("fBargainOfferMulti")->mValue.getFloat() * d
-            + gmst.find("fBargainOfferBase")->mValue.getFloat()
-            + int(pcTerm - npcTerm);
+        float x = fBargainOfferBase + fBargainOfferMulti * d + pcTerm - npcTerm;
 
         int roll = Misc::Rng::rollDice(100) + 1;
 

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -434,8 +434,8 @@ void MWWorld::InventoryStore::autoEquipArmor (const MWWorld::Ptr& actor, TSlots&
     const MWBase::World *world = MWBase::Environment::get().getWorld();
     const MWWorld::Store<ESM::GameSetting> &store = world->getStore().get<ESM::GameSetting>();
 
-    static float fUnarmoredBase1 = store.find("fUnarmoredBase1")->mValue.getFloat();
-    static float fUnarmoredBase2 = store.find("fUnarmoredBase2")->mValue.getFloat();
+    static const float fUnarmoredBase1 = store.find("fUnarmoredBase1")->mValue.getFloat();
+    static const float fUnarmoredBase2 = store.find("fUnarmoredBase2")->mValue.getFloat();
 
     int unarmoredSkill = actor.getClass().getSkill(actor, ESM::Skill::Unarmored);
     float unarmoredRating = (fUnarmoredBase1 * unarmoredSkill) * (fUnarmoredBase2 * unarmoredSkill);
@@ -1003,8 +1003,8 @@ void MWWorld::InventoryStore::rechargeItems(float duration)
                 || it->first->getCellRef().getEnchantmentCharge() == it->second)
             continue;
 
-        static float fMagicItemRechargePerSecond = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(
-                    "fMagicItemRechargePerSecond")->mValue.getFloat();
+        static const float fMagicItemRechargePerSecond = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(
+                          "fMagicItemRechargePerSecond")->mValue.getFloat();
 
         if (it->first->getCellRef().getEnchantmentCharge() <= it->second)
         {

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -385,8 +385,8 @@ namespace MWWorld
         for (std::vector<MagicBoltState>::iterator it = mMagicBolts.begin(); it != mMagicBolts.end();)
         {
             osg::Quat orient = it->mNode->getAttitude();
-            static float fTargetSpellMaxSpeed = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
-                        .find("fTargetSpellMaxSpeed")->mValue.getFloat();
+            static const float fTargetSpellMaxSpeed = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
+                               .find("fTargetSpellMaxSpeed")->mValue.getFloat();
             float speed = fTargetSpellMaxSpeed * it->mSpeed;
             osg::Vec3f direction = orient * osg::Vec3f(0,1,0);
             direction.normalize();

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3432,8 +3432,8 @@ namespace MWWorld
         int bounty = player.getClass().getNpcStats(player).getBounty();
         int playerGold = player.getClass().getContainerStore(player).count(ContainerStore::sGoldId);
 
-        static float fCrimeGoldDiscountMult = mStore.get<ESM::GameSetting>().find("fCrimeGoldDiscountMult")->mValue.getFloat();
-        static float fCrimeGoldTurnInMult = mStore.get<ESM::GameSetting>().find("fCrimeGoldTurnInMult")->mValue.getFloat();
+        const float fCrimeGoldDiscountMult = mStore.get<ESM::GameSetting>().find("fCrimeGoldDiscountMult")->mValue.getFloat();
+        const float fCrimeGoldTurnInMult = mStore.get<ESM::GameSetting>().find("fCrimeGoldTurnInMult")->mValue.getFloat();
 
         int discount = static_cast<int>(bounty * fCrimeGoldDiscountMult);
         int turnIn = static_cast<int>(bounty * fCrimeGoldTurnInMult);
@@ -3498,7 +3498,7 @@ namespace MWWorld
             mPlayer->recordCrimeId();
             confiscateStolenItems(player);
 
-            static int iDaysinPrisonMod = mStore.get<ESM::GameSetting>().find("iDaysinPrisonMod")->mValue.getInteger();
+            int iDaysinPrisonMod = mStore.get<ESM::GameSetting>().find("iDaysinPrisonMod")->mValue.getInteger();
             mDaysInPrison = std::max(1, bounty / iDaysinPrisonMod);
 
             return;
@@ -3556,7 +3556,7 @@ namespace MWWorld
     {
         const ESM::CreatureLevList* list = mStore.get<ESM::CreatureLevList>().find(creatureList);
 
-        static int iNumberCreatures = mStore.get<ESM::GameSetting>().find("iNumberCreatures")->mValue.getInteger();
+        int iNumberCreatures = mStore.get<ESM::GameSetting>().find("iNumberCreatures")->mValue.getInteger();
         int numCreatures = 1 + Misc::Rng::rollDice(iNumberCreatures); // [1, iNumberCreatures]
 
         for (int i=0; i<numCreatures; ++i)


### PR DESCRIPTION
GMSTs are currently static after their records are loaded, so we often use `static const` to make sure the value of the recovered GMST doesn't change at all and is kept in memory for future calls to the function which uses the GMST. However, this isn't the cause for some instances of static GMST declaration, so although std::map::find call time is constant, it is there and presents additional overhead every time the GMST is recovered (because it is still recovered if the variable is static but not constant, it's not marked as read-only and will simply not reset between calls).

So I changed that. It should help slightly in the often used awareness checks which are not cheap.