### PR TITLE
Update moved object collisions even if the new cell is the same (bug #4800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     Bug #4768: Fallback numerical value recovery chokes on invalid arguments
     Bug #4775: Slowfall effect resets player jumping flag
     Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
+    Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1314,7 +1314,10 @@ namespace MWWorld
         {
             mRendering->moveObject(newPtr, vec);
             if (movePhysics)
+            {
                 mPhysics->updatePosition(newPtr);
+                mPhysics->updatePtr(ptr, newPtr);
+            }
         }
         if (isPlayer)
         {


### PR DESCRIPTION
[Bug 4800](https://gitlab.com/OpenMW/openmw/issues/4800).

Use updatePtr in moveObject like in the cases the cell isn't the same so that the standing collisions map for the object is updated in time. One step closer to Sotha Sil Expanded compatibility.