### PR TITLE
Allow stray special characters before Begin statement (bug #4803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     Bug #4775: Slowfall effect resets player jumping flag
     Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
+    Bug #4803: Stray special characters before begin statement break script compilation
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/components/compiler/fileparser.cpp
+++ b/components/compiler/fileparser.cpp
@@ -94,14 +94,16 @@ namespace Compiler
 
     bool FileParser::parseSpecial (int code, const TokenLoc& loc, Scanner& scanner)
     {
+        // Ignore any junk special characters
+        if (mState == BeginState)
+        {
+            if (code != Scanner::S_newline)
+                reportWarning ("Ignoring stray special character before begin statement", loc);
+            return true;
+        }
+
         if (code==Scanner::S_newline)
         {
-            if (mState==BeginState)
-            {
-                // ignore empty lines
-                return true;
-            }
-
             if (mState==BeginCompleteState)
             {
                 // parse the script body


### PR DESCRIPTION
[Bug 4803](https://gitlab.com/OpenMW/openmw/issues/4803).

A warning is logged for any special character that is not a newline character. Unfortunately OpenMW-CS can't display it in verification log, as with any warnings of file parser, even though the engine itself can log it.