### PR TITLE
Fix an exception when try to load a particle node with empty sizes array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
     Bug #4803: Stray special characters before begin statement break script compilation
+    Bug #4804: Particle system with the "Has Sizes = false" causes an exception
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -822,7 +822,9 @@ namespace NifOsg
                 if (particle.vertex < int(particledata->colors.size()))
                     partcolor = particledata->colors.at(particle.vertex);
 
-                float size = particledata->sizes.at(particle.vertex) * partctrl->size;
+                float size = partctrl->size;
+                if (particle.vertex < int(particledata->sizes.size()))
+                    size *= particledata->sizes.at(particle.vertex);
 
                 created->setSizeRange(osgParticle::rangef(size, size));
                 box.expandBy(osg::BoundingSphere(position, size));


### PR DESCRIPTION
Fixes [bug #4804](https://gitlab.com/OpenMW/openmw/issues/4804).

Just use the same approach as for `colors` array, so OpenMW will load the mesh.

Note: it seems the `partcolor` variable (an initial particle color and alpha, I suppose) is not used at all. Is it a bug or a feature?

In theory, there should be something like 
```
created->setColorRange(osgParticle::rangev4(partcolor, partcolor));
```
to set initial colors at least. Not sure about how the `colors` array should be handled properly, though.