### PR TITLE
Weapon types de-hardcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls
+    Feature #3214: Custom weapon animation groups
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
     Feature #3893: Implicit target for "set" function in console

--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -12,6 +12,7 @@
 
 #include "model/doc/document.hpp"
 #include "model/world/data.hpp"
+#include "model/world/columns.hpp"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -106,7 +107,9 @@ std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfi
     ("script-blacklist", boost::program_options::value<Files::EscapeStringVector>()->default_value(Files::EscapeStringVector(), "")
         ->multitoken(), "exclude specified script from the verifier (if the use of the blacklist is enabled)")
     ("script-blacklist-use", boost::program_options::value<bool>()->implicit_value(true)
-        ->default_value(true), "enable script blacklisting");
+        ->default_value(true), "enable script blacklisting")
+    ("weapon-type", boost::program_options::value<Files::EscapeStringVector>()->default_value(Files::EscapeStringVector(), "")
+        ->multitoken(), "override data for given weapon type");
 
     boost::program_options::notify(variables);
 
@@ -123,6 +126,10 @@ std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfi
     if (variables["script-blacklist-use"].as<bool>())
         mDocumentManager.setBlacklistedScripts (
             variables["script-blacklist"].as<Files::EscapeStringVector>().toStdStringVector());
+
+    const std::vector<std::string>& weaponTypes = variables["weapon-type"].as<Files::EscapeStringVector>().toStdStringVector();
+    for (const std::string& type : weaponTypes)
+        CSMWorld::Columns::registerWeaponType(type);
 
     mFsStrict = variables["fs-strict"].as<bool>();
 

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -10,6 +10,8 @@ namespace CSMWorld
 {
     namespace Columns
     {
+        void registerWeaponType(const std::string& type);
+
         enum ColumnId
         {
             ColumnId_Value = 0,

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -83,7 +83,7 @@ add_openmw_dir (mwmechanics
     drawstate spells activespells npcstats aipackage aisequence aipursue alchemy aiwander aitravel aifollow aiavoiddoor aibreathe
     aicast aiescort aiface aiactivate aicombat repair enchanting pathfinding pathgrid security spellsuccess spellcasting
     disease pickpocket levelledlist combat steering obstacle autocalcspell difficultyscaling aicombataction actor summoning
-    character actors objects aistate coordinateconverter trading weaponpriority spellpriority
+    character actors objects aistate coordinateconverter trading weaponpriority spellpriority weapontype
     )
 
 add_openmw_dir (mwstate

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -6,6 +6,8 @@
 #include <components/debug/debugging.hpp>
 #include <components/misc/rng.hpp>
 
+#include "mwmechanics/weapontype.hpp"
+
 #include "engine.hpp"
 
 #if defined(_WIN32)
@@ -102,6 +104,9 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
 
         ("script-blacklist", bpo::value<Files::EscapeStringVector>()->default_value(Files::EscapeStringVector(), "")
             ->multitoken(), "ignore the specified script (if the use of the blacklist is enabled)")
+
+        ("weapon-type", bpo::value<Files::EscapeStringVector>()->default_value(Files::EscapeStringVector(), "")
+            ->multitoken(), "override data for given weapon type")
 
         ("script-blacklist-use", bpo::value<bool>()->implicit_value(true)
             ->default_value(true), "enable script blacklisting")
@@ -222,6 +227,10 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     engine.setSkipMenu (variables["skip-menu"].as<bool>(), variables["new-game"].as<bool>());
     if (!variables["skip-menu"].as<bool>() && variables["new-game"].as<bool>())
         Log(Debug::Warning) << "Warning: new-game used without skip-menu -> ignoring it";
+
+    const std::vector<std::string>& weaponTypes = variables["weapon-type"].as<Files::EscapeStringVector>().toStdStringVector();
+    for (const std::string& type : weaponTypes)
+        MWMechanics::registerWeaponType(type);
 
     // scripts
     engine.setCompileAll(variables["script-all"].as<bool>());

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -336,7 +336,7 @@ namespace MWClass
                 if(weapon != invStore.end() && weapon->getTypeName() == typeid(ESM::Weapon).name())
                 {
                     const MWWorld::LiveCellRef<ESM::Armor> *ref = ptr.get<ESM::Armor>();
-                    if (MWMechanics::getWeaponType(ref->mBase->mData.mType)->mFlags & MWMechanics::WeaponType::TwoHanded)
+                    if (MWMechanics::getWeaponType(ref->mBase->mData.mType)->mFlags & ESM::WeaponType::TwoHanded)
                         return std::make_pair(3,"");
                 }
 

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -20,6 +20,7 @@
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/weapontype.hpp"
 
 #include "../mwgui/tooltips.hpp"
 
@@ -332,21 +333,13 @@ namespace MWClass
             if(*slot == MWWorld::InventoryStore::Slot_CarriedLeft)
             {
                 MWWorld::ConstContainerStoreIterator weapon = invStore.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-
-                if(weapon == invStore.end())
-                    return std::make_pair(1,"");
-
-                if(weapon->getTypeName() == typeid(ESM::Weapon).name() &&
-                        (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::LongBladeTwoHand ||
-                weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::BluntTwoClose ||
-                weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::BluntTwoWide ||
-                weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::SpearTwoWide ||
-                weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::AxeTwoHand ||
-                weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanBow ||
-                weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow))
+                if(weapon != invStore.end() && weapon->getTypeName() == typeid(ESM::Weapon).name())
                 {
-                    return std::make_pair(3,"");
+                    const MWWorld::LiveCellRef<ESM::Armor> *ref = ptr.get<ESM::Armor>();
+                    if (MWMechanics::getWeaponType(ref->mBase->mData.mType)->mFlags & MWMechanics::WeaponType::TwoHanded)
+                        return std::make_pair(3,"");
                 }
+
                 return std::make_pair(1,"");
             }
         }

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -26,7 +26,7 @@
 #include "../mwmechanics/combat.hpp"
 #include "../mwmechanics/autocalcspell.hpp"
 #include "../mwmechanics/difficultyscaling.hpp"
-#include "../mwmechanics/character.hpp"
+#include "../mwmechanics/weapontype.hpp"
 #include "../mwmechanics/actorutil.hpp"
 
 #include "../mwworld/ptr.hpp"
@@ -1227,9 +1227,9 @@ namespace MWClass
                 if (getNpcStats(ptr).isWerewolf()
                         && getCreatureStats(ptr).getStance(MWMechanics::CreatureStats::Stance_Run))
                 {
-                    MWMechanics::WeaponType weaponType = MWMechanics::WeapType_None;
-                    MWMechanics::getActiveWeapon(getCreatureStats(ptr), getInventoryStore(ptr), &weaponType);
-                    if (weaponType == MWMechanics::WeapType_None)
+                    int weaponType = ESM::Weapon::None;
+                    MWMechanics::getActiveWeapon(ptr, &weaponType);
+                    if (weaponType == ESM::Weapon::None)
                         return std::string();
                 }
 

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -66,9 +66,9 @@ namespace MWClass
     bool Weapon::hasItemHealth (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
-        MWMechanics::WeaponClass weapClass = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mWeaponClass;
+        ESM::WeaponType::Class weapClass = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mWeaponClass;
 
-        return (weapClass == MWMechanics::WeaponClass::Melee || weapClass == MWMechanics::WeaponClass::Ranged); // thrown weapons and arrows/bolts don't have health, only quantity
+        return (weapClass == ESM::WeaponType::Melee || weapClass == ESM::WeaponType::Ranged); // thrown weapons and arrows/bolts don't have health, only quantity
     }
 
     int Weapon::getItemMaxHealth (const MWWorld::ConstPtr& ptr) const
@@ -89,17 +89,17 @@ namespace MWClass
     std::pair<std::vector<int>, bool> Weapon::getEquipmentSlots (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
-        MWMechanics::WeaponClass weapClass = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mWeaponClass;
+        ESM::WeaponType::Class weapClass = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mWeaponClass;
 
         std::vector<int> slots_;
         bool stack = false;
 
-        if (weapClass == MWMechanics::WeaponClass::Ammo)
+        if (weapClass == ESM::WeaponType::Ammo)
         {
             slots_.push_back (int (MWWorld::InventoryStore::Slot_Ammunition));
             stack = true;
         }
-        else if (weapClass == MWMechanics::WeaponClass::Thrown)
+        else if (weapClass == ESM::WeaponType::Thrown)
         {
             slots_.push_back (int (MWWorld::InventoryStore::Slot_CarriedRight));
             stack = true;
@@ -165,7 +165,7 @@ namespace MWClass
     MWGui::ToolTipInfo Weapon::getToolTipInfo (const MWWorld::ConstPtr& ptr, int count) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
-        const MWMechanics::WeaponType* weaponType = MWMechanics::getWeaponType(ref->mBase->mData.mType);
+        const ESM::WeaponType* weaponType = MWMechanics::getWeaponType(ref->mBase->mData.mType);
 
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
@@ -176,16 +176,16 @@ namespace MWClass
         std::string text;
 
         // weapon type & damage
-        if (weaponType->mWeaponClass != MWMechanics::WeaponClass::Ammo || Settings::Manager::getBool("show projectile damage", "Game"))
+        if (weaponType->mWeaponClass != ESM::WeaponType::Ammo || Settings::Manager::getBool("show projectile damage", "Game"))
         {
             text += "\n#{sType} ";
 
             int skill = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mSkill;
             const std::string type = ESM::Skill::sSkillNameIds[skill];
             std::string oneOrTwoHanded;
-            if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Melee)
+            if (weaponType->mWeaponClass == ESM::WeaponType::Melee)
             {
-                if (weaponType->mFlags & MWMechanics::WeaponType::TwoHanded)
+                if (weaponType->mFlags & ESM::WeaponType::TwoHanded)
                     oneOrTwoHanded = "sTwoHanded";
                 else
                     oneOrTwoHanded = "sOneHanded";
@@ -195,7 +195,7 @@ namespace MWClass
                 ((oneOrTwoHanded != "") ? ", " + store.get<ESM::GameSetting>().find(oneOrTwoHanded)->mValue.getString() : "");
 
             // weapon damage
-            if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+            if (weaponType->mWeaponClass == ESM::WeaponType::Thrown)
             {
                 // Thrown weapons have 2x real damage applied
                 // as they're both the weapon and the ammo
@@ -203,7 +203,7 @@ namespace MWClass
                     + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[0] * 2))
                     + " - " + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[1] * 2));
             }
-            else if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Melee)
+            else if (weaponType->mWeaponClass == ESM::WeaponType::Melee)
             {
                 // Chop
                 text += "\n#{sChop}: "
@@ -236,7 +236,7 @@ namespace MWClass
 
         const bool verbose = Settings::Manager::getBool("show melee info", "Game");
         // add reach for melee weapon
-        if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Melee && verbose)
+        if (weaponType->mWeaponClass == ESM::WeaponType::Melee && verbose)
         {
             // display value in feet
             const float combatDistance = store.get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat() * ref->mBase->mData.mReach;
@@ -245,7 +245,7 @@ namespace MWClass
         }
 
         // add attack speed for any weapon excepts arrows and bolts
-        if (weaponType->mWeaponClass != MWMechanics::WeaponClass::Ammo && verbose)
+        if (weaponType->mWeaponClass != ESM::WeaponType::Ammo && verbose)
         {
             text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mSpeed, "#{sAttributeSpeed}");
         }
@@ -305,7 +305,7 @@ namespace MWClass
             return std::make_pair (0, "");
 
         int type = ptr.get<ESM::Weapon>()->mBase->mData.mType;
-        if(MWMechanics::getWeaponType(type)->mFlags & MWMechanics::WeaponType::TwoHanded)
+        if(MWMechanics::getWeaponType(type)->mFlags & ESM::WeaponType::TwoHanded)
         {
             return std::make_pair (2, "");
         }

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -17,6 +17,8 @@
 #include "../mwphysics/physicssystem.hpp"
 #include "../mwworld/nullaction.hpp"
 
+#include "../mwmechanics/weapontype.hpp"
+
 #include "../mwgui/tooltips.hpp"
 
 #include "../mwrender/objects.hpp"
@@ -64,8 +66,9 @@ namespace MWClass
     bool Weapon::hasItemHealth (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
+        MWMechanics::WeaponClass weapClass = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mWeaponClass;
 
-        return (ref->mBase->mData.mType < ESM::Weapon::MarksmanThrown); // thrown weapons and arrows/bolts don't have health, only quantity
+        return (weapClass == MWMechanics::WeaponClass::Melee || weapClass == MWMechanics::WeaponClass::Ranged); // thrown weapons and arrows/bolts don't have health, only quantity
     }
 
     int Weapon::getItemMaxHealth (const MWWorld::ConstPtr& ptr) const
@@ -86,16 +89,17 @@ namespace MWClass
     std::pair<std::vector<int>, bool> Weapon::getEquipmentSlots (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
+        MWMechanics::WeaponClass weapClass = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mWeaponClass;
 
         std::vector<int> slots_;
         bool stack = false;
 
-        if (ref->mBase->mData.mType==ESM::Weapon::Arrow || ref->mBase->mData.mType==ESM::Weapon::Bolt)
+        if (weapClass == MWMechanics::WeaponClass::Ammo)
         {
             slots_.push_back (int (MWWorld::InventoryStore::Slot_Ammunition));
             stack = true;
         }
-        else if (ref->mBase->mData.mType==ESM::Weapon::MarksmanThrown)
+        else if (weapClass == MWMechanics::WeaponClass::Thrown)
         {
             slots_.push_back (int (MWWorld::InventoryStore::Slot_CarriedRight));
             stack = true;
@@ -109,30 +113,9 @@ namespace MWClass
     int Weapon::getEquipmentSkill (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
+        int type = ref->mBase->mData.mType;
 
-        const int size = 12;
-
-        static const int sMapping[size][2] =
-        {
-            { ESM::Weapon::ShortBladeOneHand, ESM::Skill::ShortBlade },
-            { ESM::Weapon::LongBladeOneHand, ESM::Skill::LongBlade },
-            { ESM::Weapon::LongBladeTwoHand, ESM::Skill::LongBlade },
-            { ESM::Weapon::BluntOneHand, ESM::Skill::BluntWeapon },
-            { ESM::Weapon::BluntTwoClose, ESM::Skill::BluntWeapon },
-            { ESM::Weapon::BluntTwoWide, ESM::Skill::BluntWeapon },
-            { ESM::Weapon::SpearTwoWide, ESM::Skill::Spear },
-            { ESM::Weapon::AxeOneHand, ESM::Skill::Axe },
-            { ESM::Weapon::AxeTwoHand, ESM::Skill::Axe },
-            { ESM::Weapon::MarksmanBow, ESM::Skill::Marksman },
-            { ESM::Weapon::MarksmanCrossbow, ESM::Skill::Marksman },
-            { ESM::Weapon::MarksmanThrown, ESM::Skill::Marksman }
-        };
-
-        for (int i=0; i<size; ++i)
-            if (sMapping[i][0]==ref->mBase->mData.mType)
-                return sMapping[i][1];
-
-        return -1;
+        return MWMechanics::getWeaponType(type)->mSkill;
     }
 
     int Weapon::getValue (const MWWorld::ConstPtr& ptr) const
@@ -152,89 +135,17 @@ namespace MWClass
     std::string Weapon::getUpSoundId (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
-
         int type = ref->mBase->mData.mType;
-        // Ammo
-        if (type == 12 || type == 13)
-        {
-            return std::string("Item Ammo Up");
-        }
-        // Bow
-        if (type == 9)
-        {
-            return std::string("Item Weapon Bow Up");
-        }
-        // Crossbow
-        if (type == 10)
-        {
-            return std::string("Item Weapon Crossbow Up");
-        }
-        // Longblades, One hand and Two
-        if (type == 1 || type == 2)
-        {
-            return std::string("Item Weapon Longblade Up");
-        }
-        // Shortblade
-        if (type == 0)
-        {
-            return std::string("Item Weapon Shortblade Up");
-        }
-        // Spear
-        if (type == 6)
-        {
-            return std::string("Item Weapon Spear Up");
-        }
-        // Blunts, Axes and Thrown weapons
-        if (type == 3 || type == 4 || type == 5 || type == 7 || type == 8 || type == 11)
-        {
-            return std::string("Item Weapon Blunt Up");
-        }
-
-        return std::string("Item Misc Up");
+        std::string soundId = MWMechanics::getWeaponType(type)->mSoundId;
+        return soundId + " Up";
     }
 
     std::string Weapon::getDownSoundId (const MWWorld::ConstPtr& ptr) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
-
         int type = ref->mBase->mData.mType;
-        // Ammo
-        if (type == 12 || type == 13)
-        {
-            return std::string("Item Ammo Down");
-        }
-        // Bow
-        if (type == 9)
-        {
-            return std::string("Item Weapon Bow Down");
-        }
-        // Crossbow
-        if (type == 10)
-        {
-            return std::string("Item Weapon Crossbow Down");
-        }
-        // Longblades, One hand and Two
-        if (type == 1 || type == 2)
-        {
-            return std::string("Item Weapon Longblade Down");
-        }
-        // Shortblade
-        if (type == 0)
-        {
-            return std::string("Item Weapon Shortblade Down");
-        }
-        // Spear
-        if (type == 6)
-        {
-            return std::string("Item Weapon Spear Down");
-        }
-        // Blunts, Axes and Thrown weapons
-        if (type == 3 || type == 4 || type == 5 || type == 7 || type == 8 || type == 11)
-        {
-            return std::string("Item Weapon Blunt Down");
-        }
-
-        return std::string("Item Misc Down");
+        std::string soundId = MWMechanics::getWeaponType(type)->mSoundId;
+        return soundId + " Down";
     }
 
     std::string Weapon::getInventoryIcon (const MWWorld::ConstPtr& ptr) const
@@ -254,6 +165,7 @@ namespace MWClass
     MWGui::ToolTipInfo Weapon::getToolTipInfo (const MWWorld::ConstPtr& ptr, int count) const
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = ptr.get<ESM::Weapon>();
+        const MWMechanics::WeaponType* weaponType = MWMechanics::getWeaponType(ref->mBase->mData.mType);
 
         MWGui::ToolTipInfo info;
         info.caption = ref->mBase->mName + MWGui::ToolTips::getCountString(count);
@@ -264,37 +176,26 @@ namespace MWClass
         std::string text;
 
         // weapon type & damage
-        if ((ref->mBase->mData.mType < ESM::Weapon::Arrow || Settings::Manager::getBool("show projectile damage", "Game")) && ref->mBase->mData.mType <= ESM::Weapon::Bolt)
+        if (weaponType->mWeaponClass != MWMechanics::WeaponClass::Ammo || Settings::Manager::getBool("show projectile damage", "Game"))
         {
             text += "\n#{sType} ";
 
-            static std::map <int, std::pair <std::string, std::string> > mapping;
-            if (mapping.empty())
+            int skill = MWMechanics::getWeaponType(ref->mBase->mData.mType)->mSkill;
+            const std::string type = ESM::Skill::sSkillNameIds[skill];
+            std::string oneOrTwoHanded;
+            if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Melee)
             {
-                mapping[ESM::Weapon::ShortBladeOneHand] = std::make_pair("sSkillShortblade", "sOneHanded");
-                mapping[ESM::Weapon::LongBladeOneHand] = std::make_pair("sSkillLongblade", "sOneHanded");
-                mapping[ESM::Weapon::LongBladeTwoHand] = std::make_pair("sSkillLongblade", "sTwoHanded");
-                mapping[ESM::Weapon::BluntOneHand] = std::make_pair("sSkillBluntweapon", "sOneHanded");
-                mapping[ESM::Weapon::BluntTwoClose] = std::make_pair("sSkillBluntweapon", "sTwoHanded");
-                mapping[ESM::Weapon::BluntTwoWide] = std::make_pair("sSkillBluntweapon", "sTwoHanded");
-                mapping[ESM::Weapon::SpearTwoWide] = std::make_pair("sSkillSpear", "sTwoHanded");
-                mapping[ESM::Weapon::AxeOneHand] = std::make_pair("sSkillAxe", "sOneHanded");
-                mapping[ESM::Weapon::AxeTwoHand] = std::make_pair("sSkillAxe", "sTwoHanded");
-                mapping[ESM::Weapon::MarksmanBow] = std::make_pair("sSkillMarksman", "");
-                mapping[ESM::Weapon::MarksmanCrossbow] = std::make_pair("sSkillMarksman", "");
-                mapping[ESM::Weapon::MarksmanThrown] = std::make_pair("sSkillMarksman", "");
-                mapping[ESM::Weapon::Arrow] = std::make_pair("sSkillMarksman", "");
-                mapping[ESM::Weapon::Bolt] = std::make_pair("sSkillMarksman", "");
+                if (weaponType->mFlags & MWMechanics::WeaponType::TwoHanded)
+                    oneOrTwoHanded = "sTwoHanded";
+                else
+                    oneOrTwoHanded = "sOneHanded";
             }
-
-            const std::string type = mapping[ref->mBase->mData.mType].first;
-            const std::string oneOrTwoHanded = mapping[ref->mBase->mData.mType].second;
 
             text += store.get<ESM::GameSetting>().find(type)->mValue.getString() +
                 ((oneOrTwoHanded != "") ? ", " + store.get<ESM::GameSetting>().find(oneOrTwoHanded)->mValue.getString() : "");
 
             // weapon damage
-            if (ref->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+            if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Thrown)
             {
                 // Thrown weapons have 2x real damage applied
                 // as they're both the weapon and the ammo
@@ -302,14 +203,7 @@ namespace MWClass
                     + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[0] * 2))
                     + " - " + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[1] * 2));
             }
-            else if (ref->mBase->mData.mType >= ESM::Weapon::MarksmanBow)
-            {
-                // marksman
-                text += "\n#{sAttack}: "
-                    + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[0]))
-                    + " - " + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[1]));
-            }
-            else
+            else if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Melee)
             {
                 // Chop
                 text += "\n#{sChop}: "
@@ -324,6 +218,13 @@ namespace MWClass
                     + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mThrust[0]))
                     + " - " + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mThrust[1]));
             }
+            else
+            {
+                // marksman
+                text += "\n#{sAttack}: "
+                    + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[0]))
+                    + " - " + MWGui::ToolTips::toString(static_cast<int>(ref->mBase->mData.mChop[1]));
+            }
         }
 
         if (hasItemHealth(ptr))
@@ -335,7 +236,7 @@ namespace MWClass
 
         const bool verbose = Settings::Manager::getBool("show melee info", "Game");
         // add reach for melee weapon
-        if (ref->mBase->mData.mType < ESM::Weapon::MarksmanBow && verbose)
+        if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Melee && verbose)
         {
             // display value in feet
             const float combatDistance = store.get<ESM::GameSetting>().find("fCombatDistance")->mValue.getFloat() * ref->mBase->mData.mReach;
@@ -344,7 +245,7 @@ namespace MWClass
         }
 
         // add attack speed for any weapon excepts arrows and bolts
-        if (ref->mBase->mData.mType < ESM::Weapon::Arrow && verbose)
+        if (weaponType->mWeaponClass != MWMechanics::WeaponClass::Ammo && verbose)
         {
             text += MWGui::ToolTips::getPercentString(ref->mBase->mData.mSpeed, "#{sAttributeSpeed}");
         }
@@ -403,13 +304,8 @@ namespace MWClass
         if (slots_.first.empty())
             return std::make_pair (0, "");
 
-        if(ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::LongBladeTwoHand ||
-        ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::BluntTwoClose ||
-        ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::BluntTwoWide ||
-        ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::SpearTwoWide ||
-        ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::AxeTwoHand ||
-        ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanBow ||
-        ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow)
+        int type = ptr.get<ESM::Weapon>()->mBase->mData.mType;
+        if(MWMechanics::getWeaponType(type)->mFlags & MWMechanics::WeaponType::TwoHanded)
         {
             return std::make_pair (2, "");
         }

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -641,7 +641,7 @@ osg::Vec3f AimDirToMovingTarget(const MWWorld::Ptr& actor, const MWWorld::Ptr& t
     const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
 
     // get projectile speed (depending on weapon type)
-    if (MWMechanics::getWeaponType(weapType)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+    if (MWMechanics::getWeaponType(weapType)->mWeaponClass == ESM::WeaponType::Thrown)
     {
         static float fThrownWeaponMinSpeed = gmst.find("fThrownWeaponMinSpeed")->mValue.getFloat();
         static float fThrownWeaponMaxSpeed = gmst.find("fThrownWeaponMaxSpeed")->mValue.getFloat();

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -442,10 +442,9 @@ namespace MWMechanics
 
         if (targetClass.hasInventoryStore(target))
         {
-            MWMechanics::WeaponType weapType = WeapType_None;
-            MWWorld::ContainerStoreIterator weaponSlot =
-                MWMechanics::getActiveWeapon(targetClass.getCreatureStats(target), targetClass.getInventoryStore(target), &weapType);
-            if (weapType != WeapType_PickProbe && weapType != WeapType_Spell && weapType != WeapType_None && weapType != WeapType_HandToHand)
+            int weapType = ESM::Weapon::None;
+            MWWorld::ContainerStoreIterator weaponSlot = MWMechanics::getActiveWeapon(target, &weapType);
+            if (weapType > ESM::Weapon::None)
                 targetWeapon = *weaponSlot;
         }
 
@@ -642,7 +641,7 @@ osg::Vec3f AimDirToMovingTarget(const MWWorld::Ptr& actor, const MWWorld::Ptr& t
     const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
 
     // get projectile speed (depending on weapon type)
-    if (weapType == ESM::Weapon::MarksmanThrown)
+    if (MWMechanics::getWeaponType(weapType)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
     {
         static float fThrownWeaponMinSpeed = gmst.find("fThrownWeaponMinSpeed")->mValue.getFloat();
         static float fThrownWeaponMaxSpeed = gmst.find("fThrownWeaponMaxSpeed")->mValue.getFloat();

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -18,6 +18,7 @@
 #include "combat.hpp"
 #include "weaponpriority.hpp"
 #include "spellpriority.hpp"
+#include "weapontype.hpp"
 
 namespace MWMechanics
 {
@@ -125,8 +126,7 @@ namespace MWMechanics
         }
 
         const ESM::Weapon* weapon = mWeapon.get<ESM::Weapon>()->mBase;
-
-        if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
+        if (MWMechanics::getWeaponType(weapon->mData.mType)->mWeaponClass != MWMechanics::WeaponClass::Melee)
         {
             isRanged = true;
             return fProjectileMaxSpeed;
@@ -194,11 +194,12 @@ namespace MWMechanics
                 if (rating > bestActionRating)
                 {
                     const ESM::Weapon* weapon = it->get<ESM::Weapon>()->mBase;
+                    int ammotype = getWeaponType(weapon->mData.mType)->mAmmoType;
 
                     MWWorld::Ptr ammo;
-                    if (weapon->mData.mType == ESM::Weapon::MarksmanBow)
+                    if (ammotype == ESM::Weapon::Arrow)
                         ammo = bestArrow;
-                    else if (weapon->mData.mType == ESM::Weapon::MarksmanCrossbow)
+                    else if (ammotype == ESM::Weapon::Bolt)
                         ammo = bestBolt;
 
                     bestActionRating = rating;
@@ -367,7 +368,7 @@ namespace MWMechanics
         else if (!activeWeapon.isEmpty())
         {
             const ESM::Weapon* esmWeap = activeWeapon.get<ESM::Weapon>()->mBase;
-            if (esmWeap->mData.mType >= ESM::Weapon::MarksmanBow)
+            if (MWMechanics::getWeaponType(esmWeap->mData.mType)->mWeaponClass != MWMechanics::WeaponClass::Melee)
             {
                 static const float fTargetSpellMaxSpeed = gmst.find("fProjectileMaxSpeed")->mValue.getFloat();
                 dist = fTargetSpellMaxSpeed;

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -126,7 +126,7 @@ namespace MWMechanics
         }
 
         const ESM::Weapon* weapon = mWeapon.get<ESM::Weapon>()->mBase;
-        if (MWMechanics::getWeaponType(weapon->mData.mType)->mWeaponClass != MWMechanics::WeaponClass::Melee)
+        if (MWMechanics::getWeaponType(weapon->mData.mType)->mWeaponClass != ESM::WeaponType::Melee)
         {
             isRanged = true;
             return fProjectileMaxSpeed;
@@ -368,7 +368,7 @@ namespace MWMechanics
         else if (!activeWeapon.isEmpty())
         {
             const ESM::Weapon* esmWeap = activeWeapon.get<ESM::Weapon>()->mBase;
-            if (MWMechanics::getWeaponType(esmWeap->mData.mType)->mWeaponClass != MWMechanics::WeaponClass::Melee)
+            if (MWMechanics::getWeaponType(esmWeap->mData.mType)->mWeaponClass != ESM::WeaponType::Melee)
             {
                 static const float fTargetSpellMaxSpeed = gmst.find("fProjectileMaxSpeed")->mValue.getFloat();
                 dist = fTargetSpellMaxSpeed;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -823,8 +823,8 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
                 mAnimation->showWeapons(true);
                 // Note: controllers for ranged weapon should use time for beginning of animation to play shooting properly,
                 // for other weapons they should use absolute time. Some mods rely on this behaviour (to rotate throwing projectiles, for example)
-                MWMechanics::WeaponClass weaponClass = getWeaponType(mWeaponType)->mWeaponClass;
-                bool useRelativeDuration = weaponClass == WeaponClass::Ranged;
+                ESM::WeaponType::Class weaponClass = getWeaponType(mWeaponType)->mWeaponClass;
+                bool useRelativeDuration = weaponClass == ESM::WeaponType::Ranged;
                 mAnimation->setWeaponGroup(mCurrentWeapon, useRelativeDuration);
             }
 
@@ -1154,7 +1154,7 @@ bool CharacterController::updateCarriedLeftVisible(const int weaptype) const
     // Shields/torches shouldn't be visible during any operation involving two hands
     // There seems to be no text keys for this purpose, except maybe for "[un]equip start/stop",
     // but they are also present in weapon drawing animation.
-    return !(getWeaponType(weaptype)->mFlags & MWMechanics::WeaponType::TwoHanded);
+    return !(getWeaponType(weaptype)->mFlags & ESM::WeaponType::TwoHanded);
 }
 
 bool CharacterController::updateWeaponState(CharacterState& idle)
@@ -1266,8 +1266,8 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 getWeaponGroup(weaptype, weapgroup);
                 // Note: controllers for ranged weapon should use time for beginning of animation to play shooting properly,
                 // for other weapons they should use absolute time. Some mods rely on this behaviour (to rotate throwing projectiles, for example)
-                MWMechanics::WeaponClass weaponClass = getWeaponType(weaptype)->mWeaponClass;
-                bool useRelativeDuration = weaponClass == WeaponClass::Ranged;
+                ESM::WeaponType::Class weaponClass = getWeaponType(weaptype)->mWeaponClass;
+                bool useRelativeDuration = weaponClass == ESM::WeaponType::Ranged;
                 mAnimation->setWeaponGroup(weapgroup, useRelativeDuration);
 
                 if (!isStillWeapon)
@@ -1369,7 +1369,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
 
     float complete;
     bool animPlaying;
-    MWMechanics::WeaponClass weapclass = getWeaponType(mWeaponType)->mWeaponClass;
+    ESM::WeaponType::Class weapclass = getWeaponType(mWeaponType)->mWeaponClass;
     if(mAttackingOrSpell)
     {
         MWWorld::Ptr player = getPlayer();
@@ -1525,7 +1525,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 std::string startKey;
                 std::string stopKey;
 
-                if(weapclass == WeaponClass::Ranged || weapclass == WeaponClass::Thrown)
+                if(weapclass == ESM::WeaponType::Ranged || weapclass == ESM::WeaponType::Thrown)
                 {
                     mAttackType = "shoot";
                     startKey = mAttackType+" start";
@@ -1597,7 +1597,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 attackStrength = std::min(1.f, 0.1f + Misc::Rng::rollClosedProbability());
             }
 
-            if(weapclass != WeaponClass::Ranged && weapclass != WeaponClass::Thrown)
+            if(weapclass != ESM::WeaponType::Ranged && weapclass != ESM::WeaponType::Thrown)
             {
                 MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
 
@@ -1633,7 +1633,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     }
 
     mAnimation->setPitchFactor(0.f);
-    if (weapclass == WeaponClass::Ranged || weapclass == WeaponClass::Thrown)
+    if (weapclass == ESM::WeaponType::Ranged || weapclass == ESM::WeaponType::Thrown)
     {
         switch (mUpperBodyState)
         {

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -650,13 +650,6 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
     refreshIdleAnims(weap, idle, force);
 }
 
-
-void getWeaponGroup(const int weaptype, std::string &group)
-{
-    group = getWeaponType(weaptype)->mLongGroup;
-}
-
-
 void CharacterController::playDeath(float startpoint, CharacterState death)
 {
     // Make sure the character was swimming upon death for forward-compatibility
@@ -815,7 +808,7 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
             if (mWeaponType != ESM::Weapon::None)
             {
                 mUpperBodyState = UpperCharState_WeapEquiped;
-                getWeaponGroup(mWeaponType, mCurrentWeapon);
+                mCurrentWeapon = getWeaponType(mWeaponType)->mLongGroup;
             }
 
             if(mWeaponType != ESM::Weapon::None && mWeaponType != ESM::Weapon::Spell && mWeaponType != ESM::Weapon::HandToHand)
@@ -1234,7 +1227,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             if (!weaponChanged)
             {
                 // Note: we do not disable unequipping animation automatically to avoid body desync
-                getWeaponGroup(mWeaponType, weapgroup);
+                weapgroup = getWeaponType(mWeaponType)->mLongGroup;
                 mAnimation->play(weapgroup, priorityWeapon,
                                 MWRender::Animation::BlendMask_All, false,
                                 1.0f, "unequip start", "unequip stop", 0.0f, 0);
@@ -1263,7 +1256,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 forcestateupdate = true;
                 mAnimation->showCarriedLeft(updateCarriedLeftVisible(weaptype));
 
-                getWeaponGroup(weaptype, weapgroup);
+                weapgroup = getWeaponType(weaptype)->mLongGroup;
                 // Note: controllers for ranged weapon should use time for beginning of animation to play shooting properly,
                 // for other weapons they should use absolute time. Some mods rely on this behaviour (to rotate throwing projectiles, for example)
                 ESM::WeaponType::Class weaponClass = getWeaponType(weaptype)->mWeaponClass;
@@ -1302,7 +1295,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 }
 
                 mWeaponType = weaptype;
-                getWeaponGroup(mWeaponType, mCurrentWeapon);
+                mCurrentWeapon = getWeaponType(mWeaponType)->mLongGroup;
 
                 if(!upSoundId.empty() && !isStillWeapon)
                 {
@@ -1317,7 +1310,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 mUpperBodyState = UpperCharState_Nothing;
                 mAnimation->disable(mCurrentWeapon);
                 mWeaponType = ESM::Weapon::None;
-                getWeaponGroup(mWeaponType, mCurrentWeapon);
+                mCurrentWeapon = getWeaponType(mWeaponType)->mLongGroup;
             }
         }
     }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -877,14 +877,6 @@ CharacterController::~CharacterController()
     }
 }
 
-void split(const std::string &s, char delim, std::vector<std::string> &elems) {
-    std::stringstream ss(s);
-    std::string item;
-    while (std::getline(ss, item, delim)) {
-        elems.push_back(item);
-    }
-}
-
 void CharacterController::handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key, const std::multimap<float, std::string> &map)
 {
     const std::string &evt = key->second;
@@ -905,7 +897,7 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
         if (soundgen.find(" ") != std::string::npos)
         {
             std::vector<std::string> tokens;
-            split(soundgen, ' ', tokens);
+            Misc::StringUtils::split(soundgen, ' ', tokens);
             soundgen = tokens[0];
             if (tokens.size() >= 2)
             {

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -198,33 +198,6 @@ public:
 };
 
 
-static const struct WeaponInfo {
-    WeaponType type;
-    const char shortgroup[16];
-    const char longgroup[16];
-} sWeaponTypeList[] = {
-    { WeapType_HandToHand, "hh", "handtohand" },
-    { WeapType_OneHand, "1h", "weapononehand" },
-    { WeapType_TwoHand, "2c", "weapontwohand" },
-    { WeapType_TwoWide, "2w", "weapontwowide" },
-    { WeapType_BowAndArrow, "1h", "bowandarrow" },
-    { WeapType_Crossbow, "crossbow", "crossbow" },
-    { WeapType_Thrown, "1h", "throwweapon" },
-    { WeapType_PickProbe, "1h", "pickprobe" },
-    { WeapType_Spell, "spell", "spellcast" },
-};
-static const WeaponInfo *sWeaponTypeListEnd = &sWeaponTypeList[sizeof(sWeaponTypeList)/sizeof(sWeaponTypeList[0])];
-
-class FindWeaponType {
-    WeaponType type;
-
-public:
-    FindWeaponType(WeaponType _type) : type(_type) { }
-
-    bool operator()(const WeaponInfo &weap) const
-    { return weap.type == type; }
-};
-
 std::string CharacterController::chooseRandomGroup (const std::string& prefix, int* num) const
 {
     int numAnims=0;
@@ -345,7 +318,7 @@ void CharacterController::refreshHitRecoilAnims(CharacterState& idle)
         idle = CharState_None;
 }
 
-void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, bool force)
+void CharacterController::refreshJumpAnims(const std::string& weapShortGroup, JumpingState jump, CharacterState& idle, bool force)
 {
     if (!force && jump == mJumpState && idle == CharState_None)
         return;
@@ -355,9 +328,9 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
     if (jump != JumpState_None)
     {
         jumpAnimName = "jump";
-        if(weap != sWeaponTypeListEnd)
+        if(!weapShortGroup.empty())
         {
-            jumpAnimName += weap->shortgroup;
+            jumpAnimName += weapShortGroup;
             if(!mAnimation->hasAnimation(jumpAnimName))
             {
                 jumpmask = MWRender::Animation::BlendMask_LowerBody;
@@ -369,7 +342,7 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
                     idle = CharState_Idle;
 
                 // For crossbow animations use 1h ones as fallback
-                if (mWeaponType == WeapType_Crossbow)
+                if (mWeaponType == ESM::Weapon::MarksmanCrossbow)
                     jumpAnimName += "1h";
             }
         }
@@ -444,7 +417,7 @@ void CharacterController::onClose()
     }
 }
 
-void CharacterController::refreshMovementAnims(const WeaponInfo* weap, CharacterState movement, CharacterState& idle, bool force)
+void CharacterController::refreshMovementAnims(const std::string& weapShortGroup, CharacterState movement, CharacterState& idle, bool force)
 {
     if (movement == mMovementState && idle == mIdleState && !force)
         return;
@@ -458,15 +431,15 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
     if(movestate != sMovementListEnd)
     {
         movementAnimName = movestate->groupname;
-        if(weap != sWeaponTypeListEnd)
+        if(!weapShortGroup.empty())
         {
             std::string::size_type swimpos = movementAnimName.find("swim");
             if (swimpos == std::string::npos)
             {
-                if (mWeaponType == WeapType_Spell && (movement == CharState_TurnLeft || movement == CharState_TurnRight)) // Spellcasting stance turning is a special case
-                    movementAnimName = weap->shortgroup + movementAnimName;
+                if (mWeaponType == ESM::Weapon::Spell && (movement == CharState_TurnLeft || movement == CharState_TurnRight)) // Spellcasting stance turning is a special case
+                    movementAnimName = weapShortGroup + movementAnimName;
                 else
-                    movementAnimName += weap->shortgroup;
+                    movementAnimName += weapShortGroup;
             }
 
             if(!mAnimation->hasAnimation(movementAnimName))
@@ -481,7 +454,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
                         idle = CharState_Idle;
 
                     // For crossbow animations use 1h ones as fallback
-                    if (mWeaponType == WeapType_Crossbow)
+                    if (mWeaponType == ESM::Weapon::MarksmanCrossbow)
                         movementAnimName += "1h";
                 }
                 else if (idle == CharState_None)
@@ -519,13 +492,13 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
                 else
                 {
                     // For crossbow animations use 1h ones as fallback
-                    if (mWeaponType == WeapType_Crossbow)
+                    if (mWeaponType == ESM::Weapon::MarksmanCrossbow)
                         movementAnimName += "1h";
 
                     movementAnimName.erase(swimpos, 4);
-                    if (weap != sWeaponTypeListEnd)
+                    if (!weapShortGroup.empty())
                     {
-                        std::string weapMovementAnimName = movementAnimName + weap->shortgroup;
+                        std::string weapMovementAnimName = movementAnimName + weapShortGroup;
                         if(mAnimation->hasAnimation(weapMovementAnimName))
                             movementAnimName = weapMovementAnimName;
                         else
@@ -595,7 +568,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
     }
 }
 
-void CharacterController::refreshIdleAnims(const WeaponInfo* weap, CharacterState idle, bool force)
+void CharacterController::refreshIdleAnims(const std::string& weapShortGroup, CharacterState idle, bool force)
 {
     // FIXME: if one of the below states is close to their last animation frame (i.e. will be disabled in the coming update),
     // the idle animation should be displayed
@@ -627,9 +600,9 @@ void CharacterController::refreshIdleAnims(const WeaponInfo* weap, CharacterStat
         else if(mIdleState != CharState_None)
         {
             idleGroup = "idle";
-            if(weap != sWeaponTypeListEnd)
+            if(!weapShortGroup.empty())
             {
-                idleGroup += weap->shortgroup;
+                idleGroup += weapShortGroup;
                 if(!mAnimation->hasAnimation(idleGroup))
                     idleGroup = "idle";
 
@@ -666,9 +639,9 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
     if (mPtr.getClass().isActor())
         refreshHitRecoilAnims(idle);
 
-    const WeaponInfo *weap = std::find_if(sWeaponTypeList, sWeaponTypeListEnd, FindWeaponType(mWeaponType));
-    if (!mPtr.getClass().hasInventoryStore(mPtr))
-        weap = sWeaponTypeListEnd;
+    std::string weap;
+    if (mPtr.getClass().hasInventoryStore(mPtr))
+        weap = getWeaponType(mWeaponType)->mShortGroup;
 
     refreshJumpAnims(weap, jump, idle, force);
     refreshMovementAnims(weap, movement, idle, force);
@@ -678,75 +651,11 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
 }
 
 
-void getWeaponGroup(WeaponType weaptype, std::string &group)
+void getWeaponGroup(const int weaptype, std::string &group)
 {
-    const WeaponInfo *info = std::find_if(sWeaponTypeList, sWeaponTypeListEnd, FindWeaponType(weaptype));
-    if(info != sWeaponTypeListEnd)
-        group = info->longgroup;
-    else
-        group.clear();
+    group = getWeaponType(weaptype)->mLongGroup;
 }
 
-
-MWWorld::ContainerStoreIterator getActiveWeapon(CreatureStats &stats, MWWorld::InventoryStore &inv, WeaponType *weaptype)
-{
-    if(stats.getDrawState() == DrawState_Spell)
-    {
-        *weaptype = WeapType_Spell;
-        return inv.end();
-    }
-
-    if(stats.getDrawState() == MWMechanics::DrawState_Weapon)
-    {
-        MWWorld::ContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-        if(weapon == inv.end())
-            *weaptype = WeapType_HandToHand;
-        else
-        {
-            const std::string &type = weapon->getTypeName();
-            if(type == typeid(ESM::Lockpick).name() || type == typeid(ESM::Probe).name())
-                *weaptype = WeapType_PickProbe;
-            else if(type == typeid(ESM::Weapon).name())
-            {
-                MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
-                ESM::Weapon::Type weaponType = (ESM::Weapon::Type)ref->mBase->mData.mType;
-                switch(weaponType)
-                {
-                    case ESM::Weapon::ShortBladeOneHand:
-                    case ESM::Weapon::LongBladeOneHand:
-                    case ESM::Weapon::BluntOneHand:
-                    case ESM::Weapon::AxeOneHand:
-                    case ESM::Weapon::Arrow:
-                    case ESM::Weapon::Bolt:
-                        *weaptype = WeapType_OneHand;
-                        break;
-                    case ESM::Weapon::LongBladeTwoHand:
-                    case ESM::Weapon::BluntTwoClose:
-                    case ESM::Weapon::AxeTwoHand:
-                        *weaptype = WeapType_TwoHand;
-                        break;
-                    case ESM::Weapon::BluntTwoWide:
-                    case ESM::Weapon::SpearTwoWide:
-                        *weaptype = WeapType_TwoWide;
-                        break;
-                    case ESM::Weapon::MarksmanBow:
-                        *weaptype = WeapType_BowAndArrow;
-                        break;
-                    case ESM::Weapon::MarksmanCrossbow:
-                        *weaptype = WeapType_Crossbow;
-                        break;
-                    case ESM::Weapon::MarksmanThrown:
-                        *weaptype = WeapType_Thrown;
-                        break;
-                }
-            }
-        }
-
-        return weapon;
-    }
-
-    return inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-}
 
 void CharacterController::playDeath(float startpoint, CharacterState death)
 {
@@ -878,7 +787,7 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
     , mHitState(CharState_None)
     , mUpperBodyState(UpperCharState_Nothing)
     , mJumpState(JumpState_None)
-    , mWeaponType(WeapType_None)
+    , mWeaponType(ESM::Weapon::None)
     , mAttackStrength(0.f)
     , mSkipAnim(false)
     , mSecondsOfSwimming(0)
@@ -902,19 +811,20 @@ CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Anim
 
         if (cls.hasInventoryStore(mPtr))
         {
-            getActiveWeapon(cls.getCreatureStats(mPtr), cls.getInventoryStore(mPtr), &mWeaponType);
-            if (mWeaponType != WeapType_None)
+            getActiveWeapon(mPtr, &mWeaponType);
+            if (mWeaponType != ESM::Weapon::None)
             {
                 mUpperBodyState = UpperCharState_WeapEquiped;
                 getWeaponGroup(mWeaponType, mCurrentWeapon);
             }
 
-            if(mWeaponType != WeapType_None && mWeaponType != WeapType_Spell && mWeaponType != WeapType_HandToHand)
+            if(mWeaponType != ESM::Weapon::None && mWeaponType != ESM::Weapon::Spell && mWeaponType != ESM::Weapon::HandToHand)
             {
                 mAnimation->showWeapons(true);
                 // Note: controllers for ranged weapon should use time for beginning of animation to play shooting properly,
                 // for other weapons they should use absolute time. Some mods rely on this behaviour (to rotate throwing projectiles, for example)
-                bool useRelativeDuration = mWeaponType == WeapType_BowAndArrow || mWeaponType == WeapType_Crossbow;
+                MWMechanics::WeaponClass weaponClass = getWeaponType(mWeaponType)->mWeaponClass;
+                bool useRelativeDuration = weaponClass == WeaponClass::Ranged;
                 mAnimation->setWeaponGroup(mCurrentWeapon, useRelativeDuration);
             }
 
@@ -1161,11 +1071,11 @@ bool CharacterController::updateCreatureState()
     const MWWorld::Class &cls = mPtr.getClass();
     CreatureStats &stats = cls.getCreatureStats(mPtr);
 
-    WeaponType weapType = WeapType_None;
+    int weapType = ESM::Weapon::None;
     if(stats.getDrawState() == DrawState_Weapon)
-        weapType = WeapType_HandToHand;
+        weapType = ESM::Weapon::HandToHand;
     else if (stats.getDrawState() == DrawState_Spell)
-        weapType = WeapType_Spell;
+        weapType = ESM::Weapon::Spell;
 
     if (weapType != mWeaponType)
     {
@@ -1182,7 +1092,7 @@ bool CharacterController::updateCreatureState()
 
             std::string startKey = "start";
             std::string stopKey = "stop";
-            if (weapType == WeapType_Spell)
+            if (weapType == ESM::Weapon::Spell)
             {
                 const std::string spellid = stats.getSpells().getSelectedSpell();
                 bool canCast = mCastingManualSpell || MWBase::Environment::get().getWorld()->startSpellCast(mPtr);
@@ -1218,7 +1128,7 @@ bool CharacterController::updateCreatureState()
                     mCurrentWeapon = "";
             }
 
-            if (weapType != WeapType_Spell || !mAnimation->hasAnimation("spellcast")) // Not all creatures have a dedicated spellcast animation
+            if (weapType != ESM::Weapon::Spell || !mAnimation->hasAnimation("spellcast")) // Not all creatures have a dedicated spellcast animation
             {
                 mCurrentWeapon = chooseRandomAttackAnimation();
             }
@@ -1233,7 +1143,7 @@ bool CharacterController::updateCreatureState()
 
                 mAttackStrength = std::min(1.f, 0.1f + Misc::Rng::rollClosedProbability());
 
-                if (weapType == WeapType_HandToHand)
+                if (weapType == ESM::Weapon::HandToHand)
                     playSwishSound(0.0f);
             }
         }
@@ -1247,34 +1157,23 @@ bool CharacterController::updateCreatureState()
     return false;
 }
 
-bool CharacterController::updateCarriedLeftVisible(WeaponType weaptype) const
+bool CharacterController::updateCarriedLeftVisible(const int weaptype) const
 {
     // Shields/torches shouldn't be visible during any operation involving two hands
     // There seems to be no text keys for this purpose, except maybe for "[un]equip start/stop",
     // but they are also present in weapon drawing animation.
-    switch (weaptype)
-    {
-    case WeapType_Spell:
-    case WeapType_BowAndArrow:
-    case WeapType_Crossbow:
-    case WeapType_HandToHand:
-    case WeapType_TwoHand:
-    case WeapType_TwoWide:
-        return false;
-    default:
-        return true;
-    }
+    return !(getWeaponType(weaptype)->mFlags & MWMechanics::WeaponType::TwoHanded);
 }
 
 bool CharacterController::updateWeaponState(CharacterState& idle)
 {
     const MWWorld::Class &cls = mPtr.getClass();
     CreatureStats &stats = cls.getCreatureStats(mPtr);
-    WeaponType weaptype = WeapType_None;
+    int weaptype = ESM::Weapon::None;
     if(stats.getDrawState() == DrawState_Weapon)
-        weaptype = WeapType_HandToHand;
+        weaptype = ESM::Weapon::HandToHand;
     else if (stats.getDrawState() == DrawState_Spell)
-        weaptype = WeapType_Spell;
+        weaptype = ESM::Weapon::Spell;
 
     const bool isWerewolf = cls.isNpc() && cls.getNpcStats(mPtr).isWerewolf();
 
@@ -1284,18 +1183,18 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     if (mPtr.getClass().hasInventoryStore(mPtr))
     {
         MWWorld::InventoryStore &inv = cls.getInventoryStore(mPtr);
-        MWWorld::ContainerStoreIterator weapon = getActiveWeapon(stats, inv, &weaptype);
+        MWWorld::ContainerStoreIterator weapon = getActiveWeapon(mPtr, &weaptype);
         if(stats.getDrawState() == DrawState_Spell)
             weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
 
-        if(weapon != inv.end() && mWeaponType != WeapType_HandToHand && weaptype > WeapType_HandToHand && weaptype < WeapType_Spell)
+        if(weapon != inv.end() && mWeaponType != ESM::Weapon::HandToHand && weaptype != ESM::Weapon::HandToHand && weaptype != ESM::Weapon::Spell && weaptype != ESM::Weapon::None)
             upSoundId = weapon->getClass().getUpSoundId(*weapon);
 
-        if(weapon != inv.end() && mWeaponType > WeapType_HandToHand && mWeaponType < WeapType_Spell)
+        if(weapon != inv.end() && mWeaponType != ESM::Weapon::HandToHand && mWeaponType != ESM::Weapon::Spell && mWeaponType != ESM::Weapon::None)
             downSoundId = weapon->getClass().getDownSoundId(*weapon);
 
         // weapon->HtH switch: weapon is empty already, so we need to take sound from previous weapon
-        if(weapon == inv.end() && !mWeapon.isEmpty() && weaptype == WeapType_HandToHand && mWeaponType != WeapType_Spell)
+        if(weapon == inv.end() && !mWeapon.isEmpty() && weaptype == ESM::Weapon::HandToHand && mWeaponType != ESM::Weapon::Spell)
             downSoundId = mWeapon.getClass().getDownSoundId(mWeapon);
 
         MWWorld::Ptr newWeapon = weapon != inv.end() ? *weapon : MWWorld::Ptr();
@@ -1316,8 +1215,8 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     bool forcestateupdate = false;
 
     // We should not play equipping animation and sound during weapon->weapon transition
-    bool isStillWeapon = weaptype > WeapType_HandToHand && weaptype < WeapType_Spell &&
-                            mWeaponType > WeapType_HandToHand && mWeaponType < WeapType_Spell;
+    bool isStillWeapon = weaptype != ESM::Weapon::HandToHand && weaptype != ESM::Weapon::Spell && weaptype != ESM::Weapon::None &&
+                            mWeaponType != ESM::Weapon::HandToHand && mWeaponType != ESM::Weapon::Spell && mWeaponType != ESM::Weapon::None;
 
     // If the current weapon type was changed in the middle of attack (e.g. by Equip console command or when bound spell expires),
     // we should force actor to the "weapon equipped" state, interrupt attack and update animations.
@@ -1334,7 +1233,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     if(!isKnockedOut() && !isKnockedDown() && !isRecovery())
     {
         std::string weapgroup;
-        if ((!isWerewolf || mWeaponType != WeapType_Spell)
+        if ((!isWerewolf || mWeaponType != ESM::Weapon::Spell)
             && weaptype != mWeaponType
             && mUpperBodyState != UpperCharState_UnEquipingWeap
             && !isStillWeapon)
@@ -1375,13 +1274,14 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 getWeaponGroup(weaptype, weapgroup);
                 // Note: controllers for ranged weapon should use time for beginning of animation to play shooting properly,
                 // for other weapons they should use absolute time. Some mods rely on this behaviour (to rotate throwing projectiles, for example)
-                bool useRelativeDuration = weaptype == WeapType_BowAndArrow || weaptype == WeapType_Crossbow;
+                MWMechanics::WeaponClass weaponClass = getWeaponType(weaptype)->mWeaponClass;
+                bool useRelativeDuration = weaponClass == WeaponClass::Ranged;
                 mAnimation->setWeaponGroup(weapgroup, useRelativeDuration);
 
                 if (!isStillWeapon)
                 {
                     mAnimation->disable(mCurrentWeapon);
-                    if (weaptype != WeapType_None)
+                    if (weaptype != ESM::Weapon::None)
                     {
                         mAnimation->showWeapons(false);
                         mAnimation->play(weapgroup, priorityWeapon,
@@ -1390,7 +1290,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                         mUpperBodyState = UpperCharState_EquipingWeap;
 
                         // If we do not have the "equip attach" key, show weapon manually.
-                        if (weaptype != WeapType_Spell)
+                        if (weaptype != ESM::Weapon::Spell)
                         {
                             if (mAnimation->getTextKeyTime(weapgroup+": equip attach") < 0)
                                 mAnimation->showWeapons(true);
@@ -1424,7 +1324,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             {
                 mUpperBodyState = UpperCharState_Nothing;
                 mAnimation->disable(mCurrentWeapon);
-                mWeaponType = WeapType_None;
+                mWeaponType = ESM::Weapon::None;
                 getWeaponGroup(mWeaponType, mCurrentWeapon);
             }
         }
@@ -1436,7 +1336,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         if(cls.getCreatureStats(mPtr).getStance(MWMechanics::CreatureStats::Stance_Run)
             && mHasMovedInXY
             && !MWBase::Environment::get().getWorld()->isSwimming(mPtr)
-            && mWeaponType == WeapType_None)
+            && mWeaponType == ESM::Weapon::None)
         {
             if(!sndMgr->getSoundPlaying(mPtr, "WolfRun"))
                 sndMgr->playSound3D(mPtr, "WolfRun", 1.0f, 1.0f, MWSound::Type::Sfx,
@@ -1453,16 +1353,17 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     if (mPtr.getClass().hasInventoryStore(mPtr))
     {
         MWWorld::InventoryStore &inv = cls.getInventoryStore(mPtr);
-        MWWorld::ConstContainerStoreIterator weapon = getActiveWeapon(stats, inv, &weaptype);
+        MWWorld::ConstContainerStoreIterator weapon = getActiveWeapon(mPtr, &weaptype);
         isWeapon = (weapon != inv.end() && weapon->getTypeName() == typeid(ESM::Weapon).name());
-        if(isWeapon)
+        if (isWeapon)
+        {
             weapSpeed = weapon->get<ESM::Weapon>()->mBase->mData.mSpeed;
+            MWWorld::ConstContainerStoreIterator ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
+            int ammotype = getWeaponType(weapon->get<ESM::Weapon>()->mBase->mData.mType)->mAmmoType;
+            if (ammotype != ESM::Weapon::None && (ammo == inv.end() || ammo->get<ESM::Weapon>()->mBase->mData.mType != ammotype))
+                ammunition = false;
+        }
 
-        MWWorld::ConstContainerStoreIterator ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
-        if (mWeaponType == WeapType_Crossbow)
-            ammunition = (ammo != inv.end() && ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Bolt);
-        else if (mWeaponType == WeapType_BowAndArrow)
-            ammunition = (ammo != inv.end() && ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Arrow);
         if (!ammunition && mUpperBodyState > UpperCharState_WeapEquiped)
         {
             mAnimation->disable(mCurrentWeapon);
@@ -1476,6 +1377,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
 
     float complete;
     bool animPlaying;
+    MWMechanics::WeaponClass weapclass = getWeaponType(mWeaponType)->mWeaponClass;
     if(mAttackingOrSpell)
     {
         MWWorld::Ptr player = getPlayer();
@@ -1494,7 +1396,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 mCurrentWeapon = chooseRandomAttackAnimation();
             }
 
-            if(mWeaponType == WeapType_Spell)
+            if(mWeaponType == ESM::Weapon::Spell)
             {
                 // Unset casting flag, otherwise pressing the mouse button down would
                 // continue casting every frame if there is no animation
@@ -1600,7 +1502,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                     resetIdle = false;
                 }
             }
-            else if(mWeaponType == WeapType_PickProbe)
+            else if(mWeaponType == ESM::Weapon::PickProbe)
             {
                 MWWorld::ContainerStoreIterator weapon = mPtr.getClass().getInventoryStore(mPtr).getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
                 MWWorld::Ptr item = *weapon;
@@ -1630,7 +1532,8 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             {
                 std::string startKey;
                 std::string stopKey;
-                if(mWeaponType == WeapType_Crossbow || mWeaponType == WeapType_BowAndArrow || mWeaponType == WeapType_Thrown)
+
+                if(weapclass == WeaponClass::Ranged || weapclass == WeaponClass::Thrown)
                 {
                     mAttackType = "shoot";
                     startKey = mAttackType+" start";
@@ -1702,7 +1605,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 attackStrength = std::min(1.f, 0.1f + Misc::Rng::rollClosedProbability());
             }
 
-            if(mWeaponType != WeapType_Crossbow && mWeaponType != WeapType_BowAndArrow)
+            if(weapclass != WeaponClass::Ranged && weapclass != WeaponClass::Thrown)
             {
                 MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
 
@@ -1738,9 +1641,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
     }
 
     mAnimation->setPitchFactor(0.f);
-    if (mWeaponType == WeapType_BowAndArrow ||
-        mWeaponType == WeapType_Thrown ||
-        mWeaponType == WeapType_Crossbow)
+    if (weapclass == WeaponClass::Ranged || weapclass == WeaponClass::Thrown)
     {
         switch (mUpperBodyState)
         {
@@ -1757,7 +1658,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             {
                 // technically we do not need a pitch for crossbow reload animation,
                 // but we should avoid abrupt repositioning
-                if (mWeaponType == WeapType_Crossbow)
+                if (mWeaponType == ESM::Weapon::MarksmanCrossbow)
                     mAnimation->setPitchFactor(std::max(0.f, 1.f-complete*10.f));
                 else
                     mAnimation->setPitchFactor(1.f-complete);
@@ -1774,7 +1675,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
            mUpperBodyState == UpperCharState_FollowStartToFollowStop ||
            mUpperBodyState == UpperCharState_CastingSpell)
         {
-            if (ammunition && mWeaponType == WeapType_Crossbow)
+            if (ammunition && mWeaponType == ESM::Weapon::MarksmanCrossbow)
                 mAnimation->attachArrow();
 
             mUpperBodyState = UpperCharState_WeapEquiped;
@@ -1851,7 +1752,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         if(!start.empty())
         {
             int mask = MWRender::Animation::BlendMask_All;
-            if (mWeaponType == WeapType_Crossbow)
+            if (mWeaponType == ESM::Weapon::MarksmanCrossbow)
                 mask = MWRender::Animation::BlendMask_UpperBody;
 
             mAnimation->disable(mCurrentWeapon);
@@ -2637,7 +2538,7 @@ void CharacterController::resurrect()
         mAnimation->disable(mCurrentDeath);
     mCurrentDeath.clear();
     mDeathState = CharState_None;
-    mWeaponType = WeapType_None;
+    mWeaponType = ESM::Weapon::None;
 }
 
 void CharacterController::updateContinuousVfx()

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -10,6 +10,8 @@
 
 #include "../mwrender/animation.hpp"
 
+#include "weapontype.hpp"
+
 namespace MWWorld
 {
     class InventoryStore;
@@ -113,21 +115,6 @@ enum CharacterState {
     CharState_Block
 };
 
-enum WeaponType {
-    WeapType_None,
-
-    WeapType_HandToHand,
-    WeapType_OneHand,
-    WeapType_TwoHand,
-    WeapType_TwoWide,
-    WeapType_BowAndArrow,
-    WeapType_Crossbow,
-    WeapType_Thrown,
-    WeapType_PickProbe,
-
-    WeapType_Spell
-};
-
 enum UpperBodyCharacterState {
     UpperCharState_Nothing,
     UpperCharState_EquipingWeap,
@@ -186,7 +173,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     JumpingState mJumpState;
     std::string mCurrentJump;
 
-    WeaponType mWeaponType;
+    int mWeaponType;
     std::string mCurrentWeapon;
 
     float mAttackStrength;
@@ -212,9 +199,9 @@ class CharacterController : public MWRender::Animation::TextKeyListener
 
     void refreshCurrentAnims(CharacterState idle, CharacterState movement, JumpingState jump, bool force=false);
     void refreshHitRecoilAnims(CharacterState& idle);
-    void refreshJumpAnims(const WeaponInfo* weap, JumpingState jump, CharacterState& idle, bool force=false);
-    void refreshMovementAnims(const WeaponInfo* weap, CharacterState movement, CharacterState& idle, bool force=false);
-    void refreshIdleAnims(const WeaponInfo* weap, CharacterState idle, bool force=false);
+    void refreshJumpAnims(const std::string& weapShortGroup, JumpingState jump, CharacterState& idle, bool force=false);
+    void refreshMovementAnims(const std::string& weapShortGroup, CharacterState movement, CharacterState& idle, bool force=false);
+    void refreshIdleAnims(const std::string& weapShortGroup, CharacterState idle, bool force=false);
 
     void clearAnimQueue(bool clearPersistAnims = false);
 
@@ -241,7 +228,7 @@ class CharacterController : public MWRender::Animation::TextKeyListener
     /// @param num if non-nullptr, the chosen animation number will be written here
     std::string chooseRandomGroup (const std::string& prefix, int* num = nullptr) const;
 
-    bool updateCarriedLeftVisible(WeaponType weaptype) const;
+    bool updateCarriedLeftVisible(int weaptype) const;
 
 public:
     CharacterController(const MWWorld::Ptr &ptr, MWRender::Animation *anim);
@@ -312,8 +299,6 @@ public:
 
     void playSwishSound(float attackStrength);
 };
-
-    MWWorld::ContainerStoreIterator getActiveWeapon(CreatureStats &stats, MWWorld::InventoryStore &inv, WeaponType *weaptype);
 }
 
 #endif /* GAME_MWMECHANICS_CHARACTER_HPP */

--- a/apps/openmw/mwmechanics/objects.cpp
+++ b/apps/openmw/mwmechanics/objects.cpp
@@ -9,6 +9,7 @@
 
 #include "character.hpp"
 #include "movement.hpp"
+#include "weapontype.hpp"
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -882,8 +882,8 @@ namespace MWMechanics
         if (item.getTypeName() == typeid(ESM::Weapon).name())
         {
             int type = item.get<ESM::Weapon>()->mBase->mData.mType;
-            MWMechanics::WeaponClass weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
-            isProjectile = (weapclass == MWMechanics::WeaponClass::Thrown || weapclass == MWMechanics::WeaponClass::Ranged);
+            ESM::WeaponType::Class weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
+            isProjectile = (weapclass == ESM::WeaponType::Thrown || weapclass == ESM::WeaponType::Ranged);
         }
 
         if (isProjectile || !mTarget.isEmpty())

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -26,6 +26,7 @@
 #include "npcstats.hpp"
 #include "actorutil.hpp"
 #include "aifollow.hpp"
+#include "weapontype.hpp"
 
 namespace MWMechanics
 {
@@ -880,8 +881,9 @@ namespace MWMechanics
         bool isProjectile = false;
         if (item.getTypeName() == typeid(ESM::Weapon).name())
         {
-            const MWWorld::LiveCellRef<ESM::Weapon> *ref = item.get<ESM::Weapon>();
-            isProjectile = ref->mBase->mData.mType == ESM::Weapon::Arrow || ref->mBase->mData.mType == ESM::Weapon::Bolt || ref->mBase->mData.mType == ESM::Weapon::MarksmanThrown;
+            int type = item.get<ESM::Weapon>()->mBase->mData.mType;
+            MWMechanics::WeaponClass weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
+            isProjectile = (weapclass == MWMechanics::WeaponClass::Thrown || weapclass == MWMechanics::WeaponClass::Ranged);
         }
 
         if (isProjectile || !mTarget.isEmpty())

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -16,6 +16,8 @@
 
 #include "creaturestats.hpp"
 #include "spellcasting.hpp"
+#include "weapontype.hpp"
+#include "combat.hpp"
 
 namespace
 {
@@ -379,7 +381,7 @@ namespace MWMechanics
 
         case ESM::MagicEffect::BoundLongbow:
             // AI should not summon the bow if there is no suitable ammo.
-            if (rateAmmo(actor, enemy, ESM::Weapon::Arrow) <= 0.f)
+            if (rateAmmo(actor, enemy, getWeaponType(ESM::Weapon::MarksmanBow)->mAmmoType) <= 0.f)
                 return 0.f;
             break;
 

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -14,6 +14,7 @@
 #include "aicombataction.hpp"
 #include "spellpriority.hpp"
 #include "spellcasting.hpp"
+#include "weapontype.hpp"
 
 namespace MWMechanics
 {
@@ -34,14 +35,15 @@ namespace MWMechanics
         const MWBase::World* world = MWBase::Environment::get().getWorld();
         const MWWorld::Store<ESM::GameSetting>& gmst = world->getStore().get<ESM::GameSetting>();
 
-        if (type == -1 && (weapon->mData.mType == ESM::Weapon::Arrow || weapon->mData.mType == ESM::Weapon::Bolt))
+        MWMechanics::WeaponClass weapclass = MWMechanics::getWeaponType(weapon->mData.mType)->mWeaponClass;
+        if (type == -1 && weapclass == MWMechanics::WeaponClass::Ammo)
             return 0.f;
 
         float rating=0.f;
         static const float fAIMeleeWeaponMult = gmst.find("fAIMeleeWeaponMult")->mValue.getFloat();
         float ratingMult = fAIMeleeWeaponMult;
 
-        if (weapon->mData.mType >= ESM::Weapon::MarksmanBow && weapon->mData.mType <= ESM::Weapon::MarksmanThrown)
+        if (weapclass != MWMechanics::WeaponClass::Melee)
         {
             // Underwater ranged combat is impossible
             if (world->isUnderwater(MWWorld::ConstPtr(actor), 0.75f)
@@ -59,11 +61,11 @@ namespace MWMechanics
         const float chop = (weapon->mData.mChop[0] + weapon->mData.mChop[1]) / 2.f;
         // We need to account for the fact that thrown weapons have 2x real damage applied to the target
         // as they're both the weapon and the ammo of the hit
-        if (weapon->mData.mType == ESM::Weapon::MarksmanThrown)
+        if (weapclass == MWMechanics::WeaponClass::Thrown)
         {
             rating = chop * 2;
         }
-        else if (weapon->mData.mType >= ESM::Weapon::MarksmanBow)
+        else if (weapclass != MWMechanics::WeaponClass::Melee)
         {
             rating = chop;
         }
@@ -76,7 +78,7 @@ namespace MWMechanics
 
         adjustWeaponDamage(rating, item, actor);
 
-        if (weapon->mData.mType != ESM::Weapon::MarksmanBow && weapon->mData.mType != ESM::Weapon::MarksmanCrossbow)
+        if (weapclass != MWMechanics::WeaponClass::Ranged)
         {
             resistNormalWeapon(enemy, actor, item, rating);
             applyWerewolfDamageMult(enemy, item, rating);
@@ -90,10 +92,21 @@ namespace MWMechanics
         }
         else if (weapon->mData.mType == ESM::Weapon::MarksmanCrossbow)
         {
-            if (boltRating <= 0.f)
-                rating = 0.f;
-            else
-                rating += boltRating;
+            int ammotype = MWMechanics::getWeaponType(weapon->mData.mType)->mAmmoType;
+            if (ammotype == ESM::Weapon::Arrow)
+            {
+                if (arrowRating <= 0.f)
+                    rating = 0.f;
+                else
+                    rating += arrowRating;
+            }
+            else if (ammotype == ESM::Weapon::Bolt)
+            {
+                if (boltRating <= 0.f)
+                    rating = 0.f;
+                else
+                    rating += boltRating;
+            }
         }
 
         if (!weapon->mEnchant.empty())
@@ -131,13 +144,13 @@ namespace MWMechanics
         float chance = getHitChance(actor, enemy, value) / 100.f;
         rating *= std::min(1.f, std::max(0.01f, chance));
 
-        if (weapon->mData.mType < ESM::Weapon::Arrow)
+        if (weapclass != MWMechanics::WeaponClass::Ammo)
             rating *= weapon->mData.mSpeed;
 
         return rating * ratingMult;
     }
 
-    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, ESM::Weapon::Type ammoType)
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, int ammoType)
     {
         float bestAmmoRating = 0.f;
         if (!actor.getClass().hasInventoryStore(actor))
@@ -158,7 +171,7 @@ namespace MWMechanics
         return bestAmmoRating;
     }
 
-    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, ESM::Weapon::Type ammoType)
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, int ammoType)
     {
         MWWorld::Ptr emptyPtr;
         return rateAmmo(actor, enemy, emptyPtr, ammoType);
@@ -180,8 +193,8 @@ namespace MWMechanics
         float bonusDamage = 0.f;
 
         const ESM::Weapon* esmWeap = weapon.get<ESM::Weapon>()->mBase;
-
-        if (esmWeap->mData.mType >= ESM::Weapon::MarksmanBow)
+        int type = esmWeap->mData.mType;
+        if (getWeaponType(type)->mWeaponClass != MWMechanics::WeaponClass::Melee)
         {
             if (!ammo.isEmpty() && !MWBase::Environment::get().getWorld()->isSwimming(enemy))
             {

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -35,15 +35,15 @@ namespace MWMechanics
         const MWBase::World* world = MWBase::Environment::get().getWorld();
         const MWWorld::Store<ESM::GameSetting>& gmst = world->getStore().get<ESM::GameSetting>();
 
-        MWMechanics::WeaponClass weapclass = MWMechanics::getWeaponType(weapon->mData.mType)->mWeaponClass;
-        if (type == -1 && weapclass == MWMechanics::WeaponClass::Ammo)
+        ESM::WeaponType::Class weapclass = MWMechanics::getWeaponType(weapon->mData.mType)->mWeaponClass;
+        if (type == -1 && weapclass == ESM::WeaponType::Ammo)
             return 0.f;
 
         float rating=0.f;
         static const float fAIMeleeWeaponMult = gmst.find("fAIMeleeWeaponMult")->mValue.getFloat();
         float ratingMult = fAIMeleeWeaponMult;
 
-        if (weapclass != MWMechanics::WeaponClass::Melee)
+        if (weapclass != ESM::WeaponType::Melee)
         {
             // Underwater ranged combat is impossible
             if (world->isUnderwater(MWWorld::ConstPtr(actor), 0.75f)
@@ -61,11 +61,11 @@ namespace MWMechanics
         const float chop = (weapon->mData.mChop[0] + weapon->mData.mChop[1]) / 2.f;
         // We need to account for the fact that thrown weapons have 2x real damage applied to the target
         // as they're both the weapon and the ammo of the hit
-        if (weapclass == MWMechanics::WeaponClass::Thrown)
+        if (weapclass == ESM::WeaponType::Thrown)
         {
             rating = chop * 2;
         }
-        else if (weapclass != MWMechanics::WeaponClass::Melee)
+        else if (weapclass != ESM::WeaponType::Melee)
         {
             rating = chop;
         }
@@ -78,7 +78,7 @@ namespace MWMechanics
 
         adjustWeaponDamage(rating, item, actor);
 
-        if (weapclass != MWMechanics::WeaponClass::Ranged)
+        if (weapclass != ESM::WeaponType::Ranged)
         {
             resistNormalWeapon(enemy, actor, item, rating);
             applyWerewolfDamageMult(enemy, item, rating);
@@ -144,7 +144,7 @@ namespace MWMechanics
         float chance = getHitChance(actor, enemy, value) / 100.f;
         rating *= std::min(1.f, std::max(0.01f, chance));
 
-        if (weapclass != MWMechanics::WeaponClass::Ammo)
+        if (weapclass != ESM::WeaponType::Ammo)
             rating *= weapon->mData.mSpeed;
 
         return rating * ratingMult;
@@ -194,7 +194,7 @@ namespace MWMechanics
 
         const ESM::Weapon* esmWeap = weapon.get<ESM::Weapon>()->mBase;
         int type = esmWeap->mData.mType;
-        if (getWeaponType(type)->mWeaponClass != MWMechanics::WeaponClass::Melee)
+        if (getWeaponType(type)->mWeaponClass != ESM::WeaponType::Melee)
         {
             if (!ammo.isEmpty() && !MWBase::Environment::get().getWorld()->isSwimming(enemy))
             {

--- a/apps/openmw/mwmechanics/weaponpriority.hpp
+++ b/apps/openmw/mwmechanics/weaponpriority.hpp
@@ -10,8 +10,8 @@ namespace MWMechanics
     float rateWeapon (const MWWorld::Ptr& item, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy,
                       int type=-1, float arrowRating=0.f, float boltRating=0.f);
 
-    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, ESM::Weapon::Type ammoType);
-    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, ESM::Weapon::Type ammoType);
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, MWWorld::Ptr &bestAmmo, int ammoType);
+    float rateAmmo(const MWWorld::Ptr &actor, const MWWorld::Ptr &enemy, int ammoType);
 
     float vanillaRateWeaponAndAmmo(const MWWorld::Ptr& weapon, const MWWorld::Ptr& ammo, const MWWorld::Ptr& actor, const MWWorld::Ptr& enemy);
 }

--- a/apps/openmw/mwmechanics/weapontype.cpp
+++ b/apps/openmw/mwmechanics/weapontype.cpp
@@ -39,9 +39,9 @@ namespace MWMechanics
         return inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
     }
 
-    const WeaponType* getWeaponType(const int weaponType)
+    const ESM::WeaponType* getWeaponType(const int weaponType)
     {
-        std::map<int, WeaponType>::const_iterator found = sWeaponTypeList.find(weaponType);
+        std::map<int, ESM::WeaponType>::const_iterator found = sWeaponTypeList.find(weaponType);
         if (found == sWeaponTypeList.end())
         {
             // Use one-handed short blades as fallback
@@ -64,7 +64,7 @@ namespace MWMechanics
 
         try
         {
-            WeaponType weapon;
+            ESM::WeaponType weapon;
             weapon.mDisplayName = weaponData[1];
             weapon.mShortGroup = weaponData[2];
             weapon.mLongGroup = weaponData[3];
@@ -72,7 +72,7 @@ namespace MWMechanics
             weapon.mAttachBone = weaponData[5];
             weapon.mSheathingBone = weaponData[6];
             weapon.mSkill = ESM::Skill::SkillEnum(std::stoi(weaponData[7]));
-            weapon.mWeaponClass = MWMechanics::WeaponClass(std::stoi(weaponData[8]));
+            weapon.mWeaponClass = ESM::WeaponType::Class(std::stoi(weaponData[8]));
             weapon.mAmmoType = std::stoi(weaponData[9]);
             weapon.mFlags = std::stoi(weaponData[10]);
 

--- a/apps/openmw/mwmechanics/weapontype.cpp
+++ b/apps/openmw/mwmechanics/weapontype.cpp
@@ -1,0 +1,65 @@
+#include "weapontype.hpp"
+
+#include "../mwworld/class.hpp"
+
+namespace MWMechanics
+{
+    static const WeaponType *sWeaponTypeListEnd = &sWeaponTypeList[sizeof(sWeaponTypeList)/sizeof(sWeaponTypeList[0])];
+
+    class FindWeaponType
+    {
+        int type;
+
+    public:
+        FindWeaponType(int _type) : type(_type) { }
+
+        bool operator()(const WeaponType &weap) const
+        { return weap.mType == type; }
+    };
+
+    MWWorld::ContainerStoreIterator getActiveWeapon(MWWorld::Ptr actor, int *weaptype)
+    {
+        MWWorld::InventoryStore &inv = actor.getClass().getInventoryStore(actor);
+        CreatureStats &stats = actor.getClass().getCreatureStats(actor);
+        if(stats.getDrawState() == MWMechanics::DrawState_Spell)
+        {
+            *weaptype = ESM::Weapon::Spell;
+            return inv.end();
+        }
+
+        if(stats.getDrawState() == MWMechanics::DrawState_Weapon)
+        {
+            MWWorld::ContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+            if(weapon == inv.end())
+                *weaptype = ESM::Weapon::HandToHand;
+            else
+            {
+                const std::string &type = weapon->getTypeName();
+                if(type == typeid(ESM::Weapon).name())
+                {
+                    const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
+                    *weaptype = ref->mBase->mData.mType;
+                }
+                else if (type == typeid(ESM::Lockpick).name() || type == typeid(ESM::Probe).name())
+                    *weaptype = ESM::Weapon::PickProbe;
+            }
+
+            return weapon;
+        }
+
+        return inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    }
+
+    const WeaponType* getWeaponType(const int weaponType)
+    {
+        const WeaponType *weap = std::find_if(sWeaponTypeList, sWeaponTypeListEnd, FindWeaponType(weaponType));
+        if (weap == sWeaponTypeListEnd)
+        {
+            // Use one-handed short blades as fallback
+            const WeaponType *fallback = std::find_if(sWeaponTypeList, sWeaponTypeListEnd, FindWeaponType(ESM::Weapon::ShortBladeOneHand));
+            return fallback;
+        }
+
+        return weap;
+    }
+}

--- a/apps/openmw/mwmechanics/weapontype.hpp
+++ b/apps/openmw/mwmechanics/weapontype.hpp
@@ -3,19 +3,21 @@
 
 #include "../mwworld/inventorystore.hpp"
 
+#include <map>
+
 #include "creaturestats.hpp"
 
 namespace MWMechanics
 {
     enum WeaponClass
     {
-        Melee,
-        Ranged,
-        Thrown,
-        Ammo
+        Melee = 0,
+        Ranged = 1,
+        Thrown = 2,
+        Ammo = 3
     };
 
-    static const struct WeaponType
+    struct WeaponType
     {
         // Only one flag for now, later we can add other ones (e.g. for weapon parry)
         enum Flags
@@ -23,42 +25,45 @@ namespace MWMechanics
             TwoHanded = 0x01
         };
 
-        const int mType;
-        const char mShortGroup[32];
-        const char mLongGroup[32];
-        const char mSoundId[32];
-        const char mAttachBone[32];
-        const char mSheathingBone[32];
-        const ESM::Skill::SkillEnum mSkill;
-        const WeaponClass mWeaponClass;
-        const int mAmmoType;
-        const int mFlags;
-    }
-    sWeaponTypeList[] =
+        std::string mDisplayName;
+        std::string mShortGroup;
+        std::string mLongGroup;
+        std::string mSoundId;
+        std::string mAttachBone;
+        std::string mSheathingBone;
+        ESM::Skill::SkillEnum mSkill;
+        WeaponClass mWeaponClass;
+        int mAmmoType;
+        int mFlags;
+    };
+
+    static std::map<int, WeaponType> sWeaponTypeList =
     {
-        { ESM::Weapon::None, "", "", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, 0 },
-        { ESM::Weapon::PickProbe, "1h", "pickprobe", "", "", "", ESM::Skill::Security, WeaponClass::Melee, ESM::Weapon::None, 0 },
-        { ESM::Weapon::Spell, "spell", "spellcast", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::HandToHand, "hh", "handtohand", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::ShortBladeOneHand, "1h", "weapononehand", "Item Weapon Shortblade", "Weapon Bone", "Bip01 ShortBladeOneHand", ESM::Skill::ShortBlade, WeaponClass::Melee, ESM::Weapon::None, 0 },
-        { ESM::Weapon::LongBladeOneHand, "1h", "weapononehand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, 0 },
-        { ESM::Weapon::BluntOneHand, "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntOneHand", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, 0 },
-        { ESM::Weapon::AxeOneHand, "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, 0 },
-        { ESM::Weapon::LongBladeTwoHand, "2c", "weapontwohand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeTwoClose", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::AxeTwoHand, "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 AxeTwoClose", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::BluntTwoClose, "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoClose", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::BluntTwoWide, "2w", "weapontwowide", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoWide", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::SpearTwoWide, "2w", "weapontwowide", "Item Weapon Spear", "Weapon Bone", "Bip01 SpearTwoWide", ESM::Skill::Spear, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::MarksmanBow, "1h", "bowandarrow", "Item Weapon Bow", "Weapon Bone", "Bip01 MarksmanBow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Arrow, WeaponType::TwoHanded },
-        { ESM::Weapon::MarksmanCrossbow, "crossbow", "crossbow", "Item Weapon Crossbow", "Weapon Bone", "Bip01 MarksmanCrossbow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Bolt, WeaponType::TwoHanded },
-        { ESM::Weapon::MarksmanThrown, "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, WeaponClass::Thrown, ESM::Weapon::None, WeaponType::TwoHanded },
-        { ESM::Weapon::Arrow, "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 },
-        { ESM::Weapon::Bolt, "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }
+        { ESM::Weapon::None, { "", "", "", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::PickProbe, { "", "1h", "pickprobe", "", "", "", ESM::Skill::Security, WeaponClass::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::Spell, { "", "spell", "spellcast", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::HandToHand, { "", "hh", "handtohand", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::ShortBladeOneHand, { "Short Blade 1H", "1h", "weapononehand", "Item Weapon Shortblade", "Weapon Bone", "Bip01 ShortBladeOneHand", ESM::Skill::ShortBlade, WeaponClass::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::LongBladeOneHand, { "Long Blade 1H", "1h", "weapononehand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::BluntOneHand, { "Blunt 1H", "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntOneHand", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::AxeOneHand, { "Axe 1H", "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::LongBladeTwoHand, { "Long Blade 2H", "2c", "weapontwohand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeTwoClose", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::AxeTwoHand, { "Axe 2H", "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 AxeTwoClose", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::BluntTwoClose, { "Blunt 2H Close", "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoClose", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::BluntTwoWide, { "Blunt 2H Wide", "2w", "weapontwowide", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoWide", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::SpearTwoWide, { "Spear 2H", "2w", "weapontwowide", "Item Weapon Spear", "Weapon Bone", "Bip01 SpearTwoWide", ESM::Skill::Spear, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanBow, { "Bow", "1h", "bowandarrow", "Item Weapon Bow", "Weapon Bone", "Bip01 MarksmanBow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Arrow, WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanCrossbow, { "Crossbow", "crossbow", "crossbow", "Item Weapon Crossbow", "Weapon Bone", "Bip01 MarksmanCrossbow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Bolt, WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanThrown, { "Thrown", "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, WeaponClass::Thrown, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::Arrow, { "Arrow", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::Bolt, { "Bolt", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }}
     };
 
     MWWorld::ContainerStoreIterator getActiveWeapon(MWWorld::Ptr actor, int *weaptype);
 
     const WeaponType* getWeaponType(const int weaponType);
+
+    void registerWeaponType(const std::string& type);
 }
 
 #endif

--- a/apps/openmw/mwmechanics/weapontype.hpp
+++ b/apps/openmw/mwmechanics/weapontype.hpp
@@ -9,59 +9,31 @@
 
 namespace MWMechanics
 {
-    enum WeaponClass
+    static std::map<int, ESM::WeaponType> sWeaponTypeList =
     {
-        Melee = 0,
-        Ranged = 1,
-        Thrown = 2,
-        Ammo = 3
-    };
-
-    struct WeaponType
-    {
-        // Only one flag for now, later we can add other ones (e.g. for weapon parry)
-        enum Flags
-        {
-            TwoHanded = 0x01
-        };
-
-        std::string mDisplayName;
-        std::string mShortGroup;
-        std::string mLongGroup;
-        std::string mSoundId;
-        std::string mAttachBone;
-        std::string mSheathingBone;
-        ESM::Skill::SkillEnum mSkill;
-        WeaponClass mWeaponClass;
-        int mAmmoType;
-        int mFlags;
-    };
-
-    static std::map<int, WeaponType> sWeaponTypeList =
-    {
-        { ESM::Weapon::None, { "", "", "", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::PickProbe, { "", "1h", "pickprobe", "", "", "", ESM::Skill::Security, WeaponClass::Melee, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::Spell, { "", "spell", "spellcast", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::HandToHand, { "", "hh", "handtohand", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::ShortBladeOneHand, { "Short Blade 1H", "1h", "weapononehand", "Item Weapon Shortblade", "Weapon Bone", "Bip01 ShortBladeOneHand", ESM::Skill::ShortBlade, WeaponClass::Melee, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::LongBladeOneHand, { "Long Blade 1H", "1h", "weapononehand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::BluntOneHand, { "Blunt 1H", "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntOneHand", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::AxeOneHand, { "Axe 1H", "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::LongBladeTwoHand, { "Long Blade 2H", "2c", "weapontwohand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeTwoClose", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::AxeTwoHand, { "Axe 2H", "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 AxeTwoClose", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::BluntTwoClose, { "Blunt 2H Close", "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoClose", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::BluntTwoWide, { "Blunt 2H Wide", "2w", "weapontwowide", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoWide", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::SpearTwoWide, { "Spear 2H", "2w", "weapontwowide", "Item Weapon Spear", "Weapon Bone", "Bip01 SpearTwoWide", ESM::Skill::Spear, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
-        { ESM::Weapon::MarksmanBow, { "Bow", "1h", "bowandarrow", "Item Weapon Bow", "Weapon Bone", "Bip01 MarksmanBow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Arrow, WeaponType::TwoHanded }},
-        { ESM::Weapon::MarksmanCrossbow, { "Crossbow", "crossbow", "crossbow", "Item Weapon Crossbow", "Weapon Bone", "Bip01 MarksmanCrossbow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Bolt, WeaponType::TwoHanded }},
-        { ESM::Weapon::MarksmanThrown, { "Thrown", "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, WeaponClass::Thrown, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::Arrow, { "Arrow", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }},
-        { ESM::Weapon::Bolt, { "Bolt", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }}
+        { ESM::Weapon::None, { "", "", "", "", "", "", ESM::Skill::HandToHand, ESM::WeaponType::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::PickProbe, { "", "1h", "pickprobe", "", "", "", ESM::Skill::Security, ESM::WeaponType::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::Spell, { "", "spell", "spellcast", "", "", "", ESM::Skill::HandToHand, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::HandToHand, { "", "hh", "handtohand", "", "", "", ESM::Skill::HandToHand, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::ShortBladeOneHand, { "Short Blade 1H", "1h", "weapononehand", "Item Weapon Shortblade", "Weapon Bone", "Bip01 ShortBladeOneHand", ESM::Skill::ShortBlade, ESM::WeaponType::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::LongBladeOneHand, { "Long Blade 1H", "1h", "weapononehand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::LongBlade, ESM::WeaponType::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::BluntOneHand, { "Blunt 1H", "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntOneHand", ESM::Skill::BluntWeapon, ESM::WeaponType::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::AxeOneHand, { "Axe 1H", "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::Axe, ESM::WeaponType::Melee, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::LongBladeTwoHand, { "Long Blade 2H", "2c", "weapontwohand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeTwoClose", ESM::Skill::LongBlade, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::AxeTwoHand, { "Axe 2H", "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 AxeTwoClose", ESM::Skill::Axe, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::BluntTwoClose, { "Blunt 2H Close", "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoClose", ESM::Skill::BluntWeapon, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::BluntTwoWide, { "Blunt 2H Wide", "2w", "weapontwowide", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoWide", ESM::Skill::BluntWeapon, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::SpearTwoWide, { "Spear 2H", "2w", "weapontwowide", "Item Weapon Spear", "Weapon Bone", "Bip01 SpearTwoWide", ESM::Skill::Spear, ESM::WeaponType::Melee, ESM::Weapon::None, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanBow, { "Bow", "1h", "bowandarrow", "Item Weapon Bow", "Weapon Bone", "Bip01 MarksmanBow", ESM::Skill::Marksman, ESM::WeaponType::Ranged, ESM::Weapon::Arrow, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanCrossbow, { "Crossbow", "crossbow", "crossbow", "Item Weapon Crossbow", "Weapon Bone", "Bip01 MarksmanCrossbow", ESM::Skill::Marksman, ESM::WeaponType::Ranged, ESM::Weapon::Bolt, ESM::WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanThrown, { "Thrown", "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, ESM::WeaponType::Thrown, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::Arrow, { "Arrow", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, ESM::WeaponType::Ammo, ESM::Weapon::None, 0 }},
+        { ESM::Weapon::Bolt, { "Bolt", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, ESM::WeaponType::Ammo, ESM::Weapon::None, 0 }}
     };
 
     MWWorld::ContainerStoreIterator getActiveWeapon(MWWorld::Ptr actor, int *weaptype);
 
-    const WeaponType* getWeaponType(const int weaponType);
+    const ESM::WeaponType* getWeaponType(const int weaponType);
 
     void registerWeaponType(const std::string& type);
 }

--- a/apps/openmw/mwmechanics/weapontype.hpp
+++ b/apps/openmw/mwmechanics/weapontype.hpp
@@ -54,7 +54,7 @@ namespace MWMechanics
         { ESM::Weapon::SpearTwoWide, { "Spear 2H", "2w", "weapontwowide", "Item Weapon Spear", "Weapon Bone", "Bip01 SpearTwoWide", ESM::Skill::Spear, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded }},
         { ESM::Weapon::MarksmanBow, { "Bow", "1h", "bowandarrow", "Item Weapon Bow", "Weapon Bone", "Bip01 MarksmanBow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Arrow, WeaponType::TwoHanded }},
         { ESM::Weapon::MarksmanCrossbow, { "Crossbow", "crossbow", "crossbow", "Item Weapon Crossbow", "Weapon Bone", "Bip01 MarksmanCrossbow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Bolt, WeaponType::TwoHanded }},
-        { ESM::Weapon::MarksmanThrown, { "Thrown", "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, WeaponClass::Thrown, ESM::Weapon::None, WeaponType::TwoHanded }},
+        { ESM::Weapon::MarksmanThrown, { "Thrown", "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, WeaponClass::Thrown, ESM::Weapon::None, 0 }},
         { ESM::Weapon::Arrow, { "Arrow", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }},
         { ESM::Weapon::Bolt, { "Bolt", "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }}
     };

--- a/apps/openmw/mwmechanics/weapontype.hpp
+++ b/apps/openmw/mwmechanics/weapontype.hpp
@@ -1,0 +1,64 @@
+#ifndef GAME_MWMECHANICS_WEAPONTYPE_H
+#define GAME_MWMECHANICS_WEAPONTYPE_H
+
+#include "../mwworld/inventorystore.hpp"
+
+#include "creaturestats.hpp"
+
+namespace MWMechanics
+{
+    enum WeaponClass
+    {
+        Melee,
+        Ranged,
+        Thrown,
+        Ammo
+    };
+
+    static const struct WeaponType
+    {
+        // Only one flag for now, later we can add other ones (e.g. for weapon parry)
+        enum Flags
+        {
+            TwoHanded = 0x01
+        };
+
+        const int mType;
+        const char mShortGroup[32];
+        const char mLongGroup[32];
+        const char mSoundId[32];
+        const char mAttachBone[32];
+        const char mSheathingBone[32];
+        const ESM::Skill::SkillEnum mSkill;
+        const WeaponClass mWeaponClass;
+        const int mAmmoType;
+        const int mFlags;
+    }
+    sWeaponTypeList[] =
+    {
+        { ESM::Weapon::None, "", "", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, 0 },
+        { ESM::Weapon::PickProbe, "1h", "pickprobe", "", "", "", ESM::Skill::Security, WeaponClass::Melee, ESM::Weapon::None, 0 },
+        { ESM::Weapon::Spell, "spell", "spellcast", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::HandToHand, "hh", "handtohand", "", "", "", ESM::Skill::HandToHand, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::ShortBladeOneHand, "1h", "weapononehand", "Item Weapon Shortblade", "Weapon Bone", "Bip01 ShortBladeOneHand", ESM::Skill::ShortBlade, WeaponClass::Melee, ESM::Weapon::None, 0 },
+        { ESM::Weapon::LongBladeOneHand, "1h", "weapononehand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, 0 },
+        { ESM::Weapon::BluntOneHand, "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntOneHand", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, 0 },
+        { ESM::Weapon::AxeOneHand, "1h", "weapononehand", "Item Weapon Blunt", "Weapon Bone", "Bip01 LongBladeOneHand", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, 0 },
+        { ESM::Weapon::LongBladeTwoHand, "2c", "weapontwohand", "Item Weapon Longblade", "Weapon Bone", "Bip01 LongBladeTwoClose", ESM::Skill::LongBlade, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::AxeTwoHand, "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 AxeTwoClose", ESM::Skill::Axe, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::BluntTwoClose, "2c", "weapontwohand", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoClose", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::BluntTwoWide, "2w", "weapontwowide", "Item Weapon Blunt", "Weapon Bone", "Bip01 BluntTwoWide", ESM::Skill::BluntWeapon, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::SpearTwoWide, "2w", "weapontwowide", "Item Weapon Spear", "Weapon Bone", "Bip01 SpearTwoWide", ESM::Skill::Spear, WeaponClass::Melee, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::MarksmanBow, "1h", "bowandarrow", "Item Weapon Bow", "Weapon Bone", "Bip01 MarksmanBow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Arrow, WeaponType::TwoHanded },
+        { ESM::Weapon::MarksmanCrossbow, "crossbow", "crossbow", "Item Weapon Crossbow", "Weapon Bone", "Bip01 MarksmanCrossbow", ESM::Skill::Marksman, WeaponClass::Ranged, ESM::Weapon::Bolt, WeaponType::TwoHanded },
+        { ESM::Weapon::MarksmanThrown, "1h", "throwweapon", "Item Weapon Blunt", "Weapon Bone", "Bip01 MarksmanThrown", ESM::Skill::Marksman, WeaponClass::Thrown, ESM::Weapon::None, WeaponType::TwoHanded },
+        { ESM::Weapon::Arrow, "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 },
+        { ESM::Weapon::Bolt, "", "", "Item Weapon Ammo", "ArrowBone", "", ESM::Skill::Marksman, WeaponClass::Ammo, ESM::Weapon::None, 0 }
+    };
+
+    MWWorld::ContainerStoreIterator getActiveWeapon(MWWorld::Ptr actor, int *weaptype);
+
+    const WeaponType* getWeaponType(const int weaponType);
+}
+
+#endif

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -140,7 +140,7 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
 
     // Since throwing weapons stack themselves, do not show such weapon itself
     int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
-    if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+    if (MWMechanics::getWeaponType(type)->mWeaponClass == ESM::WeaponType::Thrown)
         showHolsteredWeapons = false;
 
     std::string mesh = weapon->getClass().getModel(*weapon);
@@ -227,7 +227,7 @@ void ActorAnimation::updateQuiver()
     unsigned int ammoCount = 0;
     int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
     const auto& weaponType = MWMechanics::getWeaponType(type);
-    if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+    if (weaponType->mWeaponClass == ESM::WeaponType::Thrown)
     {
         ammoCount = ammo->getRefData().getCount();
         osg::Group* throwingWeaponNode = getBoneByName(weaponType->mAttachBone);
@@ -301,7 +301,7 @@ void ActorAnimation::itemAdded(const MWWorld::ConstPtr& item, int /*count*/)
 
     MWWorld::ConstContainerStoreIterator ammo = inv.end();
     int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
-    if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+    if (MWMechanics::getWeaponType(type)->mWeaponClass == ESM::WeaponType::Thrown)
         ammo = weapon;
     else
         ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
@@ -335,7 +335,7 @@ void ActorAnimation::itemRemoved(const MWWorld::ConstPtr& item, int /*count*/)
 
     MWWorld::ConstContainerStoreIterator ammo = inv.end();
     int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
-    if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+    if (MWMechanics::getWeaponType(type)->mWeaponClass == ESM::WeaponType::Thrown)
         ammo = weapon;
     else
         ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -28,6 +28,7 @@
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/weapontype.hpp"
 
 #include "vismask.hpp"
 
@@ -51,8 +52,6 @@ ActorAnimation::ActorAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group>
 
     // Make sure we cleaned object from effects, just in cast if we re-use node
     removeEffects();
-
-    mWeaponSheathing = Settings::Manager::getBool("weapon sheathing", "Game");
 }
 
 ActorAnimation::~ActorAnimation()
@@ -84,7 +83,7 @@ PartHolderPtr ActorAnimation::getWeaponPart(const std::string& model, const std:
     return PartHolderPtr(new PartHolder(instance));
 }
 
-osg::Group* ActorAnimation::getBoneByName(std::string boneName)
+osg::Group* ActorAnimation::getBoneByName(const std::string& boneName)
 {
     if (!mObjectRoot)
         return nullptr;
@@ -105,91 +104,11 @@ std::string ActorAnimation::getHolsteredWeaponBoneName(const MWWorld::ConstPtr& 
     if(type == typeid(ESM::Weapon).name())
     {
         const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon.get<ESM::Weapon>();
-        ESM::Weapon::Type weaponType = (ESM::Weapon::Type)ref->mBase->mData.mType;
-        return getHolsteredWeaponBoneName(weaponType);
+        int weaponType = ref->mBase->mData.mType;
+        return MWMechanics::getWeaponType(weaponType)->mSheathingBone;
     }
 
     return boneName;
-}
-
-std::string ActorAnimation::getHolsteredWeaponBoneName(const unsigned int weaponType)
-{
-    std::string boneName;
-
-    switch(weaponType)
-    {
-        case ESM::Weapon::ShortBladeOneHand:
-            boneName = "Bip01 ShortBladeOneHand";
-            break;
-        case ESM::Weapon::LongBladeOneHand:
-            boneName = "Bip01 LongBladeOneHand";
-            break;
-        case ESM::Weapon::BluntOneHand:
-            boneName = "Bip01 BluntOneHand";
-            break;
-        case ESM::Weapon::AxeOneHand:
-            boneName = "Bip01 LongBladeOneHand";
-            break;
-        case ESM::Weapon::LongBladeTwoHand:
-            boneName = "Bip01 LongBladeTwoClose";
-            break;
-        case ESM::Weapon::BluntTwoClose:
-            boneName = "Bip01 BluntTwoClose";
-            break;
-        case ESM::Weapon::AxeTwoHand:
-            boneName = "Bip01 AxeTwoClose";
-            break;
-        case ESM::Weapon::BluntTwoWide:
-            boneName = "Bip01 BluntTwoWide";
-            break;
-        case ESM::Weapon::SpearTwoWide:
-            boneName = "Bip01 SpearTwoWide";
-            break;
-        case ESM::Weapon::MarksmanBow:
-            boneName = "Bip01 MarksmanBow";
-            break;
-        case ESM::Weapon::MarksmanCrossbow:
-            boneName = "Bip01 MarksmanCrossbow";
-            break;
-        case ESM::Weapon::MarksmanThrown:
-            boneName = "Bip01 MarksmanThrown";
-            break;
-        default:
-            break;
-    }
-
-    return boneName;
-}
-
-void ActorAnimation::injectWeaponBones()
-{
-    if (!mResourceSystem->getVFS()->exists("meshes\\xbase_anim_sh.nif"))
-    {
-        mWeaponSheathing = false;
-        return;
-    }
-
-    osg::ref_ptr<osg::Node> sheathSkeleton = mResourceSystem->getSceneManager()->getInstance("meshes\\xbase_anim_sh.nif");
-
-    for (unsigned int type=0; type<=ESM::Weapon::MarksmanThrown; ++type)
-    {
-        const std::string holsteredBoneName = getHolsteredWeaponBoneName(type);
-
-        SceneUtil::FindByNameVisitor findVisitor (holsteredBoneName);
-        sheathSkeleton->accept(findVisitor);
-        osg::ref_ptr<osg::Node> sheathNode = findVisitor.mFoundNode;
-
-        if (sheathNode && sheathNode.get()->getNumParents())
-        {
-            osg::Group* sheathParent = getBoneByName(sheathNode.get()->getParent(0)->getName());
-
-            if (sheathParent)
-            {
-                sheathNode.get()->getParent(0)->removeChild(sheathNode);
-                sheathParent->addChild(sheathNode);
-            }
-        }
-    }
 }
 
 void ActorAnimation::resetControllers(osg::Node* node)
@@ -205,7 +124,8 @@ void ActorAnimation::resetControllers(osg::Node* node)
 
 void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
 {
-    if (!mWeaponSheathing)
+    static const bool weaponSheathing = Settings::Manager::getBool("weapon sheathing", "Game");
+    if (!weaponSheathing)
         return;
 
     if (!mPtr.getClass().hasInventoryStore(mPtr))
@@ -219,7 +139,8 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
         return;
 
     // Since throwing weapons stack themselves, do not show such weapon itself
-    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+    int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
+    if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
         showHolsteredWeapons = false;
 
     std::string mesh = weapon->getClass().getModel(*weapon);
@@ -279,7 +200,8 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
 
 void ActorAnimation::updateQuiver()
 {
-    if (!mWeaponSheathing)
+    static const bool weaponSheathing = Settings::Manager::getBool("weapon sheathing", "Game");
+    if (!weaponSheathing)
         return;
 
     if (!mPtr.getClass().hasInventoryStore(mPtr))
@@ -303,10 +225,12 @@ void ActorAnimation::updateQuiver()
     bool suitableAmmo = false;
     MWWorld::ConstContainerStoreIterator ammo = weapon;
     unsigned int ammoCount = 0;
-    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+    int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
+    const auto& weaponType = MWMechanics::getWeaponType(type);
+    if (weaponType->mWeaponClass == MWMechanics::WeaponClass::Thrown)
     {
         ammoCount = ammo->getRefData().getCount();
-        osg::Group* throwingWeaponNode = getBoneByName("Weapon Bone");
+        osg::Group* throwingWeaponNode = getBoneByName(weaponType->mAttachBone);
         if (throwingWeaponNode && throwingWeaponNode->getNumChildren())
             ammoCount--;
 
@@ -323,10 +247,7 @@ void ActorAnimation::updateQuiver()
         if (arrowAttached)
             ammoCount--;
 
-        if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow)
-            suitableAmmo = ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Bolt;
-        else if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanBow)
-            suitableAmmo = ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Arrow;
+        suitableAmmo = ammo->get<ESM::Weapon>()->mBase->mData.mType == weaponType->mAmmoType;
     }
 
     if (!suitableAmmo)
@@ -379,7 +300,8 @@ void ActorAnimation::itemAdded(const MWWorld::ConstPtr& item, int /*count*/)
         return;
 
     MWWorld::ConstContainerStoreIterator ammo = inv.end();
-    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+    int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
+    if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
         ammo = weapon;
     else
         ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
@@ -412,7 +334,8 @@ void ActorAnimation::itemRemoved(const MWWorld::ConstPtr& item, int /*count*/)
         return;
 
     MWWorld::ConstContainerStoreIterator ammo = inv.end();
-    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+    int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
+    if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
         ammo = weapon;
     else
         ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);

--- a/apps/openmw/mwrender/actoranimation.hpp
+++ b/apps/openmw/mwrender/actoranimation.hpp
@@ -40,13 +40,10 @@ class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
         virtual bool isArrowAttached() const { return false; }
 
     protected:
-        bool mWeaponSheathing;
-        osg::Group* getBoneByName(std::string boneName);
+        osg::Group* getBoneByName(const std::string& boneName);
         virtual void updateHolsteredWeapon(bool showHolsteredWeapons);
-        virtual void injectWeaponBones();
         virtual void updateQuiver();
         virtual std::string getHolsteredWeaponBoneName(const MWWorld::ConstPtr& weapon);
-        virtual std::string getHolsteredWeaponBoneName(const unsigned int weaponType);
         virtual PartHolderPtr getWeaponPart(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor);
         virtual PartHolderPtr getWeaponPart(const std::string& model, const std::string& bonename)
         {

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -249,7 +249,7 @@ namespace
         void apply(osg::Node& node)
         {
             if (SceneUtil::hasUserDescription(&node, "CustomBone"))
-                mFoundBones.push_back(std::make_pair(&node, node.getParent(0)));
+                mFoundBones.emplace_back(&node, node.getParent(0));
 
             traverse(node);
         }

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -300,8 +300,8 @@ namespace MWRender
             {
                 MWWorld::LiveCellRef<ESM::Weapon> *ref = iter->get<ESM::Weapon>();
                 int type = ref->mBase->mData.mType;
-                const MWMechanics::WeaponType* weaponInfo = MWMechanics::getWeaponType(type);
-                showCarriedLeft = !(weaponInfo->mFlags & MWMechanics::WeaponType::TwoHanded);
+                const ESM::WeaponType* weaponInfo = MWMechanics::getWeaponType(type);
+                showCarriedLeft = !(weaponInfo->mFlags & ESM::WeaponType::TwoHanded);
 
                 std::string inventoryGroup = weaponInfo->mLongGroup;
                 inventoryGroup = "inventory" + inventoryGroup;

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -24,6 +24,7 @@
 #include "../mwworld/inventorystore.hpp"
 
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/weapontype.hpp"
 
 #include "npcanimation.hpp"
 #include "vismask.hpp"
@@ -290,55 +291,25 @@ namespace MWRender
 
         MWWorld::InventoryStore &inv = mCharacter.getClass().getInventoryStore(mCharacter);
         MWWorld::ContainerStoreIterator iter = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-        std::string groupname;
+        std::string groupname = "inventoryhandtohand";
         bool showCarriedLeft = true;
-        if(iter == inv.end())
-            groupname = "inventoryhandtohand";
-        else
+        if(iter != inv.end())
         {
-            const std::string &typeName = iter->getTypeName();
-            if(typeName == typeid(ESM::Lockpick).name() || typeName == typeid(ESM::Probe).name())
-                groupname = "inventoryweapononehand";
-            else if(typeName == typeid(ESM::Weapon).name())
+            groupname = "inventoryweapononehand";
+            if(iter->getTypeName() == typeid(ESM::Weapon).name())
             {
                 MWWorld::LiveCellRef<ESM::Weapon> *ref = iter->get<ESM::Weapon>();
-
                 int type = ref->mBase->mData.mType;
-                if(type == ESM::Weapon::ShortBladeOneHand ||
-                   type == ESM::Weapon::LongBladeOneHand ||
-                   type == ESM::Weapon::BluntOneHand ||
-                   type == ESM::Weapon::AxeOneHand ||
-                   type == ESM::Weapon::MarksmanThrown)
-                {
-                    groupname = "inventoryweapononehand";
-                }
-                else if(type == ESM::Weapon::MarksmanCrossbow ||
-                        type == ESM::Weapon::MarksmanBow)
-                {
-                    groupname = "inventoryweapononehand";
-                    showCarriedLeft = false;
-                }
-                else if(type == ESM::Weapon::LongBladeTwoHand ||
-                        type == ESM::Weapon::BluntTwoClose ||
-                        type == ESM::Weapon::AxeTwoHand)
-                {
-                    groupname = "inventoryweapontwohand";
-                    showCarriedLeft = false;
-                }
-                else if(type == ESM::Weapon::BluntTwoWide ||
-                        type == ESM::Weapon::SpearTwoWide)
-                {
-                    groupname = "inventoryweapontwowide";
-                    showCarriedLeft = false;
-                }
-                else
-                {
-                    groupname = "inventoryhandtohand";
-                    showCarriedLeft = false;
-                }
+                const MWMechanics::WeaponType* weaponInfo = MWMechanics::getWeaponType(type);
+                showCarriedLeft = !(weaponInfo->mFlags & MWMechanics::WeaponType::TwoHanded);
+
+                std::string inventoryGroup = weaponInfo->mLongGroup;
+                inventoryGroup = "inventory" + inventoryGroup;
+
+                // We still should use one-handed animation as fallback
+                if (mAnimation->hasAnimation(inventoryGroup))
+                    groupname = inventoryGroup;
            }
-           else
-               groupname = "inventoryhandtohand";
         }
 
         mAnimation->showCarriedLeft(showCarriedLeft);

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -147,7 +147,7 @@ void CreatureWeaponAnimation::updatePart(PartHolderPtr& scene, int slot)
                 item.getTypeName() == typeid(ESM::Weapon).name() &&
                 item.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow)
         {
-            const MWMechanics::WeaponType* weaponInfo = MWMechanics::getWeaponType(ESM::Weapon::MarksmanCrossbow);
+            const ESM::WeaponType* weaponInfo = MWMechanics::getWeaponType(ESM::Weapon::MarksmanCrossbow);
             MWWorld::ConstContainerStoreIterator ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
             if (ammo != inv.end() && ammo->get<ESM::Weapon>()->mBase->mData.mType == weaponInfo->mAmmoType)
                 attachArrow();

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -31,6 +31,7 @@
 
 #include "../mwmechanics/npcstats.hpp"
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/weapontype.hpp"
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -275,7 +276,7 @@ static NpcAnimation::PartBoneMap createPartListMap()
     result.insert(std::make_pair(ESM::PRT_LLeg, "Left Upper Leg"));
     result.insert(std::make_pair(ESM::PRT_RPauldron, "Right Clavicle"));
     result.insert(std::make_pair(ESM::PRT_LPauldron, "Left Clavicle"));
-    result.insert(std::make_pair(ESM::PRT_Weapon, "Weapon Bone"));
+    result.insert(std::make_pair(ESM::PRT_Weapon, "Weapon Bone")); // A fallback value, an actual one will depend on current weapon type
     result.insert(std::make_pair(ESM::PRT_Tail, "Tail"));
     return result;
 }
@@ -317,12 +318,6 @@ void NpcAnimation::setViewMode(NpcAnimation::ViewMode viewMode)
     assert(viewMode != VM_HeadOnly);
     if(mViewMode == viewMode)
         return;
-
-    // Disable weapon sheathing in the 1st-person mode
-    if (viewMode == VM_FirstPerson)
-        mWeaponSheathing = false;
-    else
-        mWeaponSheathing = Settings::Manager::getBool("weapon sheathing", "Game");
 
     mViewMode = viewMode;
     MWBase::Environment::get().getWorld()->scaleObject(mPtr, mPtr.getCellRef().getScale()); // apply race height after view change
@@ -484,9 +479,6 @@ void NpcAnimation::updateNpcBase()
         smodel = Misc::ResourceHelpers::correctActorModelPath("meshes\\" + mNpc->mModel, mResourceSystem->getVFS());
 
     setObjectRoot(smodel, true, true, false);
-
-    if (mWeaponSheathing)
-        injectWeaponBones();
 
     updateParts();
 
@@ -745,7 +737,18 @@ bool NpcAnimation::addOrReplaceIndividualPart(ESM::PartReferenceType type, int g
     mPartPriorities[type] = priority;
     try
     {
-        const std::string& bonename = sPartList.at(type);
+        std::string bonename = sPartList.at(type);
+        if (type == ESM::PRT_Weapon)
+        {
+            const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+            MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+            if(weapon != inv.end() && weapon->getTypeName() == typeid(ESM::Weapon).name())
+            {
+                int weaponType = weapon->get<ESM::Weapon>()->mBase->mData.mType;
+                bonename = MWMechanics::getWeaponType(weaponType)->mAttachBone;
+            }
+        }
+
         // PRT_Hair seems to be the only type that breaks consistency and uses a filter that's different from the attachment bone
         const std::string bonefilter = (type == ESM::PRT_Hair) ? "hair" : bonename;
         mObjectParts[type] = insertBoundedPart(mesh, bonename, bonefilter, enchantedGlow, glowColor);
@@ -906,8 +909,9 @@ void NpcAnimation::showWeapons(bool showWeapon)
             if (weapon->getTypeName() == typeid(ESM::Weapon).name() &&
                     weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanCrossbow)
             {
+                int ammotype = MWMechanics::getWeaponType(ESM::Weapon::MarksmanCrossbow)->mAmmoType;
                 MWWorld::ConstContainerStoreIterator ammo = inv.getSlot(MWWorld::InventoryStore::Slot_Ammunition);
-                if (ammo != inv.end() && ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Bolt)
+                if (ammo != inv.end() && ammo->get<ESM::Weapon>()->mBase->mData.mType == ammotype)
                     attachArrow();
             }
         }
@@ -962,7 +966,15 @@ osg::Group* NpcAnimation::getArrowBone()
     if (!part)
         return nullptr;
 
-    SceneUtil::FindByNameVisitor findVisitor ("ArrowBone");
+    const MWWorld::InventoryStore& inv = mPtr.getClass().getInventoryStore(mPtr);
+    MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+    if(weapon == inv.end() || weapon->getTypeName() != typeid(ESM::Weapon).name())
+        return nullptr;
+
+    int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
+    int ammoType = MWMechanics::getWeaponType(type)->mAmmoType;
+
+    SceneUtil::FindByNameVisitor findVisitor (MWMechanics::getWeaponType(ammoType)->mAttachBone);
     part->getNode()->accept(findVisitor);
 
     return findVisitor.mFoundNode;

--- a/apps/openmw/mwrender/weaponanimation.cpp
+++ b/apps/openmw/mwrender/weaponanimation.cpp
@@ -70,8 +70,8 @@ void WeaponAnimation::attachArrow(MWWorld::Ptr actor)
         return;
 
     int type = weaponSlot->get<ESM::Weapon>()->mBase->mData.mType;
-    MWMechanics::WeaponClass weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
-    if (weapclass == MWMechanics::WeaponClass::Thrown)
+    ESM::WeaponType::Class weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
+    if (weapclass == ESM::WeaponType::Thrown)
     {
         std::string soundid = weaponSlot->getClass().getUpSoundId(*weaponSlot);
         if(!soundid.empty())
@@ -81,7 +81,7 @@ void WeaponAnimation::attachArrow(MWWorld::Ptr actor)
         }
         showWeapon(true);
     }
-    else if (weapclass == MWMechanics::WeaponClass::Ranged)
+    else if (weapclass == ESM::WeaponType::Ranged)
     {
         osg::Group* parent = getArrowBone();
         if (!parent)
@@ -116,7 +116,7 @@ void WeaponAnimation::releaseArrow(MWWorld::Ptr actor, float attackStrength)
 
     MWMechanics::applyFatigueLoss(actor, *weapon, attackStrength);
 
-    if (MWMechanics::getWeaponType(weapon->get<ESM::Weapon>()->mBase->mData.mType)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+    if (MWMechanics::getWeaponType(weapon->get<ESM::Weapon>()->mBase->mData.mType)->mWeaponClass == ESM::WeaponType::Thrown)
     {
         // Thrown weapons get detached now
         osg::Node* weaponNode = getWeaponNode();

--- a/apps/openmw/mwrender/weaponanimation.cpp
+++ b/apps/openmw/mwrender/weaponanimation.cpp
@@ -15,6 +15,7 @@
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/combat.hpp"
+#include "../mwmechanics/weapontype.hpp"
 
 #include "animation.hpp"
 #include "rotatecontroller.hpp"
@@ -67,8 +68,10 @@ void WeaponAnimation::attachArrow(MWWorld::Ptr actor)
         return;
     if (weaponSlot->getTypeName() != typeid(ESM::Weapon).name())
         return;
-    int weaponType = weaponSlot->get<ESM::Weapon>()->mBase->mData.mType;
-    if (weaponType == ESM::Weapon::MarksmanThrown)
+
+    int type = weaponSlot->get<ESM::Weapon>()->mBase->mData.mType;
+    MWMechanics::WeaponClass weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
+    if (weapclass == MWMechanics::WeaponClass::Thrown)
     {
         std::string soundid = weaponSlot->getClass().getUpSoundId(*weaponSlot);
         if(!soundid.empty())
@@ -78,7 +81,7 @@ void WeaponAnimation::attachArrow(MWWorld::Ptr actor)
         }
         showWeapon(true);
     }
-    else if (weaponType == ESM::Weapon::MarksmanBow || weaponType == ESM::Weapon::MarksmanCrossbow)
+    else if (weapclass == MWMechanics::WeaponClass::Ranged)
     {
         osg::Group* parent = getArrowBone();
         if (!parent)
@@ -113,7 +116,7 @@ void WeaponAnimation::releaseArrow(MWWorld::Ptr actor, float attackStrength)
 
     MWMechanics::applyFatigueLoss(actor, *weapon, attackStrength);
 
-    if (weapon->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown)
+    if (MWMechanics::getWeaponType(weapon->get<ESM::Weapon>()->mBase->mData.mType)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
     {
         // Thrown weapons get detached now
         osg::Node* weaponNode = getWeaponNode();

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -371,7 +371,7 @@ void MWWorld::InventoryStore::autoEquipWeapon (const MWWorld::Ptr& actor, TSlots
                 else
                     slots_[Slot_Ammunition] = arrow;
             }
-            else if (type == ESM::Weapon::Bolt)
+            else if (ammotype == ESM::Weapon::Bolt)
             {
                 if (bolt == end())
                     hasAmmo = false;

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -332,7 +332,7 @@ void MWWorld::InventoryStore::autoEquipWeapon (const MWWorld::Ptr& actor, TSlots
 
             const ESM::Weapon* esmWeapon = iter->get<ESM::Weapon>()->mBase;
 
-            if (MWMechanics::getWeaponType(esmWeapon->mData.mType)->mWeaponClass == MWMechanics::WeaponClass::Ammo)
+            if (MWMechanics::getWeaponType(esmWeapon->mData.mType)->mWeaponClass == ESM::WeaponType::Ammo)
                 continue;
 
             if (iter->getClass().getEquipmentSkill(*iter) == weaponSkills[maxWeaponSkill])

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -16,7 +16,7 @@
 #include "../mwmechanics/npcstats.hpp"
 #include "../mwmechanics/spellcasting.hpp"
 #include "../mwmechanics/actorutil.hpp"
-
+#include "../mwmechanics/weapontype.hpp"
 
 #include "esmstore.hpp"
 #include "class.hpp"
@@ -332,7 +332,7 @@ void MWWorld::InventoryStore::autoEquipWeapon (const MWWorld::Ptr& actor, TSlots
 
             const ESM::Weapon* esmWeapon = iter->get<ESM::Weapon>()->mBase;
 
-            if (esmWeapon->mData.mType == ESM::Weapon::Arrow || esmWeapon->mData.mType == ESM::Weapon::Bolt)
+            if (MWMechanics::getWeaponType(esmWeapon->mData.mType)->mWeaponClass == MWMechanics::WeaponClass::Ammo)
                 continue;
 
             if (iter->getClass().getEquipmentSkill(*iter) == weaponSkills[maxWeaponSkill])
@@ -357,31 +357,21 @@ void MWWorld::InventoryStore::autoEquipWeapon (const MWWorld::Ptr& actor, TSlots
             }
         }
 
-        bool isBow = false;
-        bool isCrossbow = false;
-        if (weapon != end())
-        {
-            const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
-            ESM::Weapon::Type type = (ESM::Weapon::Type)ref->mBase->mData.mType;
-
-            if (type == ESM::Weapon::MarksmanBow)
-                isBow = true;
-            else if (type == ESM::Weapon::MarksmanCrossbow)
-                isCrossbow = true;
-        }
-
         if (weapon != end() && weapon->getClass().canBeEquipped(*weapon, actor).first)
         {
             // Do not equip ranged weapons, if there is no suitable ammo
             bool hasAmmo = true;
-            if (isBow == true)
+            const MWWorld::LiveCellRef<ESM::Weapon> *ref = weapon->get<ESM::Weapon>();
+            int type = ref->mBase->mData.mType;
+            int ammotype = MWMechanics::getWeaponType(type)->mAmmoType;
+            if (ammotype == ESM::Weapon::Arrow)
             {
                 if (arrow == end())
                     hasAmmo = false;
                 else
                     slots_[Slot_Ammunition] = arrow;
             }
-            if (isCrossbow == true)
+            else if (type == ESM::Weapon::Bolt)
             {
                 if (bolt == end())
                     hasAmmo = false;
@@ -406,7 +396,7 @@ void MWWorld::InventoryStore::autoEquipWeapon (const MWWorld::Ptr& actor, TSlots
                     int slot = itemsSlots.first.front();
                     slots_[slot] = weapon;
 
-                    if (!isBow && !isCrossbow)
+                    if (ammotype == ESM::Weapon::None)
                         slots_[Slot_Ammunition] = end();
                 }
 

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -32,6 +32,7 @@
 #include "../mwmechanics/spellcasting.hpp"
 #include "../mwmechanics/actorutil.hpp"
 #include "../mwmechanics/aipackage.hpp"
+#include "../mwmechanics/weapontype.hpp"
 
 #include "../mwrender/animation.hpp"
 #include "../mwrender/vismask.hpp"
@@ -317,7 +318,11 @@ namespace MWWorld
         state.mIdArrow = projectile.getCellRef().getRefId();
         state.mCasterHandle = actor;
         state.mAttackStrength = attackStrength;
-        state.mThrown = projectile.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown;
+        state.mThrown = false;
+
+        int type = projectile.get<ESM::Weapon>()->mBase->mData.mType;
+        if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+            state.mThrown = true;
 
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), projectile.getCellRef().getRefId());
         MWWorld::Ptr ptr = ref.getPtr();
@@ -602,7 +607,11 @@ namespace MWWorld
                 MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), esm.mId);
                 MWWorld::Ptr ptr = ref.getPtr();
                 model = ptr.getClass().getModel(ptr);
-                state.mThrown = ptr.get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::MarksmanThrown;
+                state.mThrown = false;
+
+                int weaponType = ptr.get<ESM::Weapon>()->mBase->mData.mType;
+                if (MWMechanics::getWeaponType(weaponType)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+                    state.mThrown = true;
             }
             catch(...)
             {

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -321,7 +321,7 @@ namespace MWWorld
         state.mThrown = false;
 
         int type = projectile.get<ESM::Weapon>()->mBase->mData.mType;
-        if (MWMechanics::getWeaponType(type)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+        if (MWMechanics::getWeaponType(type)->mWeaponClass == ESM::WeaponType::Thrown)
             state.mThrown = true;
 
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), projectile.getCellRef().getRefId());
@@ -610,7 +610,7 @@ namespace MWWorld
                 state.mThrown = false;
 
                 int weaponType = ptr.get<ESM::Weapon>()->mBase->mData.mType;
-                if (MWMechanics::getWeaponType(weaponType)->mWeaponClass == MWMechanics::WeaponClass::Thrown)
+                if (MWMechanics::getWeaponType(weaponType)->mWeaponClass == ESM::WeaponType::Thrown)
                     state.mThrown = true;
             }
             catch(...)

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -386,6 +386,30 @@ namespace MWWorld
         iterator end() const;
     };
 
+    template <>
+    class Store<ESM::WeaponType> : public StoreBase
+    {
+        std::map<int, ESM::WeaponType> mStatic;
+
+    public:
+        typedef std::map<int, ESM::WeaponType>::const_iterator iterator;
+
+        Store();
+
+        const ESM::WeaponType *search(const int id) const;
+        const ESM::WeaponType *find(const int id) const;
+
+        RecordId load(ESM::ESMReader &esm) { return RecordId(0, false); }
+
+        ESM::WeaponType* insert(const ESM::WeaponType &weaponType);
+
+        void setUp();
+
+        size_t getSize() const;
+        iterator begin() const;
+        iterator end() const;
+    };
+
 
 } //end namespace
 

--- a/components/esm/loadweap.hpp
+++ b/components/esm/loadweap.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "loadskil.hpp"
+
 namespace ESM
 {
 
@@ -79,5 +81,34 @@ struct Weapon
     void blank();
     ///< Set record to default state (does not touch the ID).
 };
+
+struct WeaponType
+{
+    // Only one flag for now, later we can add other ones (e.g. for weapon parry)
+    enum Flags
+    {
+        TwoHanded = 0x01
+    };
+
+    enum Class
+    {
+        Melee = 0,
+        Ranged = 1,
+        Thrown = 2,
+        Ammo = 3
+    };
+
+    std::string mDisplayName;
+    std::string mShortGroup;
+    std::string mLongGroup;
+    std::string mSoundId;
+    std::string mAttachBone;
+    std::string mSheathingBone;
+    ESM::Skill::SkillEnum mSkill;
+    Class mWeaponClass;
+    int mAmmoType;
+    int mFlags;
+};
+
 }
 #endif

--- a/components/esm/loadweap.hpp
+++ b/components/esm/loadweap.hpp
@@ -21,6 +21,10 @@ struct Weapon
 
     enum Type
     {
+        PickProbe = -4,
+        HandToHand = -3,
+        Spell = -2,
+        None = -1,
         ShortBladeOneHand = 0,
         LongBladeOneHand = 1,
         LongBladeTwoHand = 2,

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -1,9 +1,11 @@
 #ifndef MISC_STRINGOPS_H
 #define MISC_STRINGOPS_H
 
-#include <cstring>
-#include <string>
 #include <algorithm>
+#include <cstring>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "utf8stream.hpp"
 
@@ -236,6 +238,16 @@ public:
             str.replace(found, whatLen, with, withLen);
 
         return str;
+    }
+
+    static void split(const std::string &s, char delim, std::vector<std::string> &elems)
+    {
+        std::stringstream ss(s);
+        std::string item;
+        while (std::getline(ss, item, delim))
+        {
+            elems.push_back(item);
+        }
     }
 };
 

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -537,6 +537,13 @@ namespace NifOsg
                         // Marker objects. These meshes are only visible in the editor.
                         hasMarkers = true;
                     }
+                    else if(sd->string == "BONE")
+                    {
+                        // Do not allow to optimize custom bones
+                        // TODO: find a better solution
+                        node->getOrCreateUserDataContainer()->addDescription("CustomBone");
+                        node->setDataVariance(osg::Object::DYNAMIC);
+                    }
                 }
             }
 


### PR DESCRIPTION
Changes custom bones loading, so requires new skeleton meshes for weapon sheathing: [Sheath.zip](https://github.com/OpenMW/openmw/files/2775564/Sheath.zip)

Summary of changes:
1. Moves most of weapontype-related logic from a lot of switches and if-s to the table. 
In theory, later we can move this table to ESM or some kind of logic. This approach will allow modders to add new weapon types with new animations (one-handed spears or magic sword which requires Destruction skill instead of Long Blades, for example) or modify existing ones (move bow to the left hand or add a separate set of animations for short blades, for example).

2. Changes custom bones loading.
Instead of hardcoded xbase_anim_sh.nif OpenMW will scan nifs in the Animation folder and will load any node marked with "BONE" NiStringExtraData. Optimizer will not remove such nodes.
This approach allows to tweak new nodes differently for females, beast races, etc.
Here I just rotated sheathing bone for beast races only (left - old behaviour, right - new behaviour):
![screenshot_20190119_171304](https://user-images.githubusercontent.com/26434804/51427507-278c3580-1c12-11e9-8ecc-ab798fcbe46e.png)

Related [forum topic](https://forum.openmw.org/viewtopic.php?f=6&t=5660&p=60730).