### PR TITLE
[macOS, CI] Update dependencies

### DIFF
--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -7,5 +7,5 @@ brew switch cmake 3.12.4
 brew outdated pkgconfig || brew upgrade pkgconfig
 brew install qt
 
-curl -fSL -R -J https://downloads.openmw.org/osx/dependencies/openmw-deps-55c27b1.zip -o ~/openmw-deps.zip
+curl -fSL -R -J https://downloads.openmw.org/osx/dependencies/openmw-deps-110f3d3.zip -o ~/openmw-deps.zip
 unzip -o ~/openmw-deps.zip -d /private/tmp/openmw-deps > /dev/null


### PR DESCRIPTION
They now include boost iostreams for TES 4/5 BSA support.
See https://gitlab.com/OpenMW/openmw/merge_requests/56.