### PR TITLE
Fix "-Wstring-plus-int" warnings

### DIFF
--- a/apps/opencs/model/tools/search.cpp
+++ b/apps/opencs/model/tools/search.cpp
@@ -78,7 +78,7 @@ void CSMTools::Search::searchRecordStateCell (const CSMWorld::IdTableBase *model
         std::vector<std::string> states =
             CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_Modification);
 
-        const std::string hint = "r: " + model->getColumnId (index.column());
+        const std::string hint = "r: " + std::to_string(model->getColumnId(index.column()));
         messages.add (id, states.at(data), hint);
     }
 }

--- a/apps/openmw/mwmechanics/alchemy.cpp
+++ b/apps/openmw/mwmechanics/alchemy.cpp
@@ -154,7 +154,7 @@ void MWMechanics::Alchemy::updateEffects()
 
         if (magicEffect->mData.mBaseCost<=0)
         {
-            const std::string os = "invalid base cost for magic effect " + iter->mId;
+            const std::string os = "invalid base cost for magic effect " + std::to_string(iter->mId);
             throw std::runtime_error (os);
         }
 


### PR DESCRIPTION
Currently we have two such CI build warnings on MacOS:
```
warning: adding 'const int' to a string does not append to the string [-Wstring-plus-int]
```

This PR should fix them.