### PR TITLE
Avoid useless read of navmeshes from navigator

### DIFF
--- a/apps/openmw/mwrender/navmesh.hpp
+++ b/apps/openmw/mwrender/navmesh.hpp
@@ -30,6 +30,11 @@ namespace MWRender
 
         void disable();
 
+        bool isEnabled() const
+        {
+            return mEnabled;
+        }
+
     private:
         osg::ref_ptr<osg::Group> mRootNode;
         bool mEnabled;

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -1385,6 +1385,9 @@ namespace MWRender
 
     void RenderingManager::updateNavMesh()
     {
+        if (!mNavMesh->isEnabled())
+            return;
+
         const auto navMeshes = mNavigator.getNavMeshes();
 
         auto it = navMeshes.begin();

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -599,28 +599,8 @@ namespace MWRender
             mWater->update(dt);
         }
 
-        const auto navMeshes = mNavigator.getNavMeshes();
+        updateNavMesh();
 
-        auto it = navMeshes.begin();
-        for (std::size_t i = 0; it != navMeshes.end() && i < mNavMeshNumber; ++i)
-            ++it;
-        if (it == navMeshes.end())
-        {
-            mNavMesh->reset();
-        }
-        else
-        {
-            try
-            {
-                const auto locked = it->second.lockConst();
-                mNavMesh->update(locked->getValue(), mNavMeshNumber, locked->getGeneration(),
-                                 locked->getNavMeshRevision(), mNavigator.getSettings());
-            }
-            catch (const std::exception& e)
-            {
-                Log(Debug::Error) << "NavMesh render update exception: " << e.what();
-            }
-        }
         mCamera->update(dt, paused);
 
         osg::Vec3f focal, cameraPos;
@@ -1401,5 +1381,31 @@ namespace MWRender
     void RenderingManager::setNavMeshNumber(const std::size_t value)
     {
         mNavMeshNumber = value;
+    }
+
+    void RenderingManager::updateNavMesh()
+    {
+        const auto navMeshes = mNavigator.getNavMeshes();
+
+        auto it = navMeshes.begin();
+        for (std::size_t i = 0; it != navMeshes.end() && i < mNavMeshNumber; ++i)
+            ++it;
+        if (it == navMeshes.end())
+        {
+            mNavMesh->reset();
+        }
+        else
+        {
+            try
+            {
+                const auto locked = it->second.lockConst();
+                mNavMesh->update(locked->getValue(), mNavMeshNumber, locked->getGeneration(),
+                                 locked->getNavMeshRevision(), mNavigator.getSettings());
+            }
+            catch (const std::exception& e)
+            {
+                Log(Debug::Error) << "NavMesh render update exception: " << e.what();
+            }
+        }
     }
 }

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -240,6 +240,8 @@ namespace MWRender
 
         void renderCameraToImage(osg::Camera *camera, osg::Image *image, int w, int h);
 
+        void updateNavMesh();
+
         osg::ref_ptr<osgUtil::IntersectionVisitor> getIntersectionVisitor(osgUtil::Intersector* intersector, bool ignorePlayer, bool ignoreActors);
 
         osg::ref_ptr<osgUtil::IntersectionVisitor> mIntersectionVisitor;


### PR DESCRIPTION
Prevents [deadlock](https://gitlab.com/OpenMW/openmw/issues/4777) if navmesh rendering is disabled (but not fixes). Actulally this is a little optimization because of [this](https://github.com/OpenMW/openmw/compare/master...elsid:navmesh_render?expand=1#diff-f1edf5c7ed145cbb380aad92dedbf3bbR1404) lock.