### PR TITLE
Fix compressed BSA loading on non-Windows systems

### DIFF
--- a/components/bsa/compressedbsafile.cpp
+++ b/components/bsa/compressedbsafile.cpp
@@ -285,10 +285,15 @@ void CompressedBSAFile::readHeader()
 
 CompressedBSAFile::FileRecord CompressedBSAFile::getFileRecord(const std::string& str) const
 {
-    boost::filesystem::path p(str);
+    // Force-convert the path into something both Windows and UNIX can handle first
+    // to make sure Boost doesn't think the entire path is the filename on Linux
+    // and subsequently purge it to determine the file folder.
+    std::string path = str;
+    std::replace(path.begin(), path.end(), '\\', '/');
+
+    boost::filesystem::path p(path);
     std::string stem = p.stem().string();
     std::string ext = p.extension().string();
-    std::string filename = p.filename().string();
     p.remove_filename();
 
     std::string folder = p.string();


### PR DESCRIPTION
On Linux, in most BSAs - that used Windows (backslash) filepath format - the files couldn't be found during uncompression because when the file folder was determined and the filename was removed from the path the backslashes confused Boost and it thought the entirety of the path is the filename, subsequently purging it. So the hash generation returned zero hash because the used stem was empty and BSA loader threw an exception.

My solution: force-convert the given path into forward slash format first. Both Windows and UNIX can handle it properly according to [this](https://theboostcpplibraries.com/boost.filesystem-paths) article:

>If Example 35.5 is executed on Linux, the returned values are different. Most of the member functions return an empty string, except relative_path() and filename(), which return "C:\Windows\System". This means that the string “C:\\Windows\\System” is interpreted as a file name on Linux, which is understandable given that it is neither a portable encoding of a path nor a platform-dependent encoding on Linux. Therefore, Boost.Filesystem has no choice but to interpret it as a file name.

>Even though the backslash is used as the separator for files and directories by default, Windows still accepts the slash. “C:/Windows/System” is therefore a valid native path.

so the Boost can pick the right part of the filename to purge when determining the folder on any system.
