### PR TITLE
[Discussion] Make creature/activator screams Voice-type sounds

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -984,7 +984,6 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
     if(evt.compare(0, 7, "sound: ") == 0)
     {
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-        sndMgr->stopSound3D(mPtr, evt.substr(7));
         sndMgr->playSound3D(mPtr, evt.substr(7), 1.0f, 1.0f);
         return;
     }
@@ -1023,9 +1022,12 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
                 sndMgr->playSound3D(mPtr, sound, volume, pitch, MWSound::Type::Foot,
                                     MWSound::PlayMode::NoPlayerLocal);
             }
+            else if (soundgen == "moan" || soundgen == "roar" || soundgen == "scream")
+            {
+                sndMgr->playSound3D(mPtr, sound, volume, pitch, MWSound::Type::Voice);
+            }
             else
             {
-                sndMgr->stopSound3D(mPtr, sound);
                 sndMgr->playSound3D(mPtr, sound, volume, pitch);
             }
         }


### PR DESCRIPTION
Instead of being affected by Effect volume slider, Moan, Roar and Scream sounds that were "generated" by soundgen keys will be affected by Voice volume slider, which makes more sense to me.
I removed redundant stopSound calls, the sounds are already stopped automatically in playSound3D.