### PR TITLE
Support NiSwitchNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     Feature #3610: Option to invert X axis
     Feature #4673: Weapon sheathing
     Feature #4730: Native animated containers support
+    Feature #4812: Support NiSwitchNode
     Task #4686: Upgrade media decoder to a more current FFmpeg API
 
 0.45.0

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -807,6 +807,13 @@ void Optimizer::RemoveRedundantNodesVisitor::apply(osg::LOD& lod)
         traverse(*lod.getChild(i));
 }
 
+void Optimizer::RemoveRedundantNodesVisitor::apply(osg::Switch& switchNode)
+{
+    // We should keep all switch child nodes since they reflect different switch states.
+    for (unsigned int i=0; i<switchNode.getNumChildren(); ++i)
+        traverse(*switchNode.getChild(i));
+}
+
 void Optimizer::RemoveRedundantNodesVisitor::apply(osg::Group& group)
 {
     if (typeid(group)==typeid(osg::Group) &&
@@ -1860,6 +1867,12 @@ void Optimizer::MergeGroupsVisitor::apply(osg::LOD &lod)
 {
     // don't merge the direct children of the LOD because they are used to define each LOD level.
     traverse(lod);
+}
+
+void Optimizer::MergeGroupsVisitor::apply(osg::Switch &switchNode)
+{
+    // We should keep all switch child nodes since they reflect different switch states.
+    traverse(switchNode);
 }
 
 void Optimizer::MergeGroupsVisitor::apply(osg::Group &group)

--- a/components/sceneutil/optimizer.hpp
+++ b/components/sceneutil/optimizer.hpp
@@ -340,6 +340,7 @@ class Optimizer
                 virtual void apply(osg::Group& group);
                 virtual void apply(osg::Transform& transform);
                 virtual void apply(osg::LOD& lod);
+                virtual void apply(osg::Switch& switchNode);
 
                 bool isOperationPermissible(osg::Node& node);
 
@@ -360,6 +361,7 @@ class Optimizer
 
             virtual void apply(osg::Group& group);
             virtual void apply(osg::LOD& lod);
+            virtual void apply(osg::Switch& switchNode);
         };
 
         class MergeGeometryVisitor : public BaseOptimizerVisitor


### PR DESCRIPTION
Implements [feature #4812](https://gitlab.com/OpenMW/openmw/issues/4812).

In upstream master we handle the NiSwitchNode as a common NiNode (render all children), while vanilla Morrowind renders just its first child (and MGE improves its loading, so it is possible to switch between its children).

This PR creates an osg::Switch for every NiSwitchNode, so it is possible so set current active child:
```
switchNode->setSingleChildOn(index);
```

By default only first children is rendered.

Note: autogenerated collisions still will be based on all node children in both Morrowind and OpenMW, so it is recommended to use either NiRootCollisionNode or NCO for such meshes.

Switch nodes will allow us to implement some extended features (such as native herbalism or glowing windows) and it does not matter if they will be hardcoded or handled via Lua scripting with scene graph access (probably based on existing Lua bindings for OpenSceneGraph).