### PR TITLE
Add creature-with-the-same-model soundgen fallback (bug #4813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
     Bug #4803: Stray special characters before begin statement break script compilation
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
+    Bug #4813: Creatures with known file but no "Sound Gen Creature" assigned use default sounds
     Bug #4820: Spell absorption is broken
     Bug #4827: NiUVController is handled incorrectly
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -625,34 +625,59 @@ namespace MWClass
 
     std::string Creature::getSoundIdFromSndGen(const MWWorld::Ptr &ptr, const std::string &name) const
     {
-        const MWWorld::Store<ESM::SoundGenerator> &store = MWBase::Environment::get().getWorld()->getStore().get<ESM::SoundGenerator>();
-
         int type = getSndGenTypeFromName(ptr, name);
-        if(type >= 0)
+        if (type < 0)
+            return std::string();
+
+        std::vector<const ESM::SoundGenerator*> sounds;
+        std::vector<const ESM::SoundGenerator*> fallbacksounds;
+
+        MWWorld::LiveCellRef<ESM::Creature>* ref = ptr.get<ESM::Creature>();
+
+        const std::string& ourId = (ref->mBase->mOriginal.empty()) ? ptr.getCellRef().getRefId() : ref->mBase->mOriginal;
+
+        const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
+        auto sound = store.get<ESM::SoundGenerator>().begin();
+        while (sound != store.get<ESM::SoundGenerator>().end())
         {
-            std::vector<const ESM::SoundGenerator*> sounds;
-            std::vector<const ESM::SoundGenerator*> fallbacksounds;
-
-            MWWorld::LiveCellRef<ESM::Creature>* ref = ptr.get<ESM::Creature>();
-
-            const std::string& ourId = (ref->mBase->mOriginal.empty()) ? ptr.getCellRef().getRefId() : ref->mBase->mOriginal;
-
-            MWWorld::Store<ESM::SoundGenerator>::iterator sound = store.begin();
-            while (sound != store.end())
-            {
-                if (type == sound->mType && !sound->mCreature.empty() && (Misc::StringUtils::ciEqual(ourId, sound->mCreature)))
-                    sounds.push_back(&*sound);
-                if (type == sound->mType && sound->mCreature.empty())
-                    fallbacksounds.push_back(&*sound);
-                ++sound;
-            }
-            if (!sounds.empty())
-                return sounds[Misc::Rng::rollDice(sounds.size())]->mSound;
-            if (!fallbacksounds.empty())
-                return fallbacksounds[Misc::Rng::rollDice(fallbacksounds.size())]->mSound;
+            if (type == sound->mType && !sound->mCreature.empty() && Misc::StringUtils::ciEqual(ourId, sound->mCreature))
+                sounds.push_back(&*sound);
+            if (type == sound->mType && sound->mCreature.empty())
+                fallbacksounds.push_back(&*sound);
+            ++sound;
         }
 
-        return "";
+        if (sounds.empty())
+        {
+            const std::string model = getModel(ptr);
+            if (!model.empty())
+            {
+                for (const ESM::Creature &creature : store.get<ESM::Creature>())
+                {
+                    if (creature.mId != ourId && creature.mOriginal != ourId && !creature.mModel.empty()
+                     && Misc::StringUtils::ciEqual(model, "meshes\\" + creature.mModel))
+                    {
+                        const std::string& fallbackId = !creature.mOriginal.empty() ? creature.mOriginal : creature.mId;
+                        sound = store.get<ESM::SoundGenerator>().begin();
+                        while (sound != store.get<ESM::SoundGenerator>().end())
+                        {
+                            if (type == sound->mType && !sound->mCreature.empty()
+                             && Misc::StringUtils::ciEqual(fallbackId, sound->mCreature))
+                                sounds.push_back(&*sound);
+                            ++sound;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!sounds.empty())
+            return sounds[Misc::Rng::rollDice(sounds.size())]->mSound;
+        if (!fallbacksounds.empty())
+            return fallbacksounds[Misc::Rng::rollDice(fallbacksounds.size())]->mSound;
+
+        return std::string();
     }
 
     MWWorld::Ptr Creature::copyToCellImpl(const MWWorld::ConstPtr &ptr, MWWorld::CellStore &cell) const


### PR DESCRIPTION
[Bug 4813](https://gitlab.com/OpenMW/openmw/issues/4813).

Creatures will fallback to the sounds of the first creature that has the same model in the record store if the creature couldn't get any specific sounds before falling back to actual creature-independent fallback sounds.