### PR TITLE
Optimize HUD update

### DIFF
--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -417,8 +417,7 @@ namespace MWGui
         icon.insert(slashPos+1, "b_");
         icon = MWBase::Environment::get().getWindowManager()->correctIconPath(icon);
 
-        mSpellImage->setItem(MWWorld::Ptr());
-        mSpellImage->setIcon(icon);
+        mSpellImage->setSpellIcon(icon);
     }
 
     void HUD::setSelectedEnchantItem(const MWWorld::Ptr& item, int chargePercent)

--- a/apps/openmw/mwgui/hud.hpp
+++ b/apps/openmw/mwgui/hud.hpp
@@ -15,6 +15,7 @@ namespace MWGui
     class DragAndDrop;
     class SpellIcons;
     class ItemWidget;
+    class SpellWidget;
 
     class HUD : public WindowBase, public LocalMapBase
     {
@@ -64,7 +65,8 @@ namespace MWGui
         MyGUI::ProgressBar *mHealth, *mMagicka, *mStamina, *mEnemyHealth, *mDrowning;
         MyGUI::Widget* mHealthFrame;
         MyGUI::Widget *mWeapBox, *mSpellBox, *mSneakBox;
-        ItemWidget *mWeapImage, *mSpellImage;
+        ItemWidget *mWeapImage;
+        SpellWidget *mSpellImage;
         MyGUI::ProgressBar *mWeapStatus, *mSpellStatus;
         MyGUI::Widget *mEffectBox, *mMinimapBox;
         MyGUI::Button* mMinimapButton;

--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -43,6 +43,7 @@ namespace MWGui
     void ItemWidget::registerComponents()
     {
         MyGUI::FactoryManager::getInstance().registerFactory<ItemWidget>("Widget");
+        MyGUI::FactoryManager::getInstance().registerFactory<SpellWidget>("Widget");
     }
 
     void ItemWidget::initialiseOverride()
@@ -151,6 +152,16 @@ namespace MWGui
             setFrame(backgroundTex, MyGUI::IntCoord(0,0,42,42));
 
         setIcon(ptr);
+    }
+
+    void SpellWidget::setSpellIcon(const std::string& icon)
+    {
+        if (mFrame)
+            mFrame->setImageTexture("");
+        if (mItemShadow)
+            mItemShadow->setImageTexture(icon);
+        if (mItem)
+            mItem->setImageTexture(icon);
     }
 
 }

--- a/apps/openmw/mwgui/itemwidget.hpp
+++ b/apps/openmw/mwgui/itemwidget.hpp
@@ -40,7 +40,7 @@ namespace MWGui
         void setIcon (const MWWorld::Ptr& ptr);
         void setFrame (const std::string& frame, const MyGUI::IntCoord& coord);
 
-    private:
+    protected:
         virtual void initialiseOverride();
 
         MyGUI::ImageBox* mItem;
@@ -50,6 +50,14 @@ namespace MWGui
 
         std::string mCurrentIcon;
         std::string mCurrentFrame;
+    };
+
+    class SpellWidget : public ItemWidget
+    {
+    MYGUI_RTTI_DERIVED(SpellWidget)
+    public:
+
+        void setSpellIcon (const std::string& icon);
     };
 
 }

--- a/apps/openmw/mwgui/layout.cpp
+++ b/apps/openmw/mwgui/layout.cpp
@@ -58,7 +58,10 @@ namespace MWGui
 
     void Layout::setTitle(const std::string& title)
     {
-        static_cast<MyGUI::Window*>(mMainWidget)->setCaptionWithReplacing(title);
+        MyGUI::Window* window = static_cast<MyGUI::Window*>(mMainWidget);
+
+        if (window->getCaption() != title)
+            window->setCaptionWithReplacing(title);
     }
 
     MyGUI::Widget* Layout::getWidget(const std::string &_name)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -236,7 +236,7 @@ namespace MWMechanics
     // mWatchedTimeToStartDrowning = -1 for correct drowning state check,
     // if stats.getTimeToStartDrowning() == 0 already on game start
     MechanicsManager::MechanicsManager()
-    : mWatchedTimeToStartDrowning(-1), mWatchedStatsEmpty (true), mUpdatePlayer (true), mClassSelected (false),
+    : mWatchedLevel(-1), mWatchedTimeToStartDrowning(-1), mWatchedStatsEmpty (true), mUpdatePlayer (true), mClassSelected (false),
       mRaceSelected (false), mAI(true)
     {
         //buildPlayer no longer here, needs to be done explicitly after all subsystems are up and running
@@ -361,7 +361,11 @@ namespace MWMechanics
                 }
             }
 
-            winMgr->setValue("level", stats.getLevel());
+            if(stats.getLevel() != mWatchedLevel)
+            {
+                mWatchedLevel = stats.getLevel();
+                winMgr->setValue("level", mWatchedLevel);
+            }
 
             mWatchedStatsEmpty = false;
 
@@ -377,10 +381,15 @@ namespace MWMechanics
             MWWorld::ContainerStoreIterator enchantItem = inv.getSelectedEnchantItem();
             if (enchantItem != inv.end())
                 winMgr->setSelectedEnchantItem(*enchantItem);
-            else if (!winMgr->getSelectedSpell().empty())
-                winMgr->setSelectedSpell(winMgr->getSelectedSpell(), int(MWMechanics::getSpellSuccessChance(winMgr->getSelectedSpell(), mWatched)));
             else
-                winMgr->unsetSelectedSpell();
+            {
+                const std::string& spell = winMgr->getSelectedSpell();
+                if (!spell.empty())
+                    winMgr->setSelectedSpell(spell, int(MWMechanics::getSpellSuccessChance(spell, mWatched)));
+                else
+                    winMgr->unsetSelectedSpell();
+            }
+
         }
 
         if (mUpdatePlayer)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -30,6 +30,8 @@ namespace MWMechanics
             DynamicStat<float> mWatchedMagicka;
             DynamicStat<float> mWatchedFatigue;
 
+            int mWatchedLevel;
+
             float mWatchedTimeToStartDrowning;
 
             bool mWatchedStatsEmpty;

--- a/files/mygui/openmw_hud.layout
+++ b/files/mygui/openmw_hud.layout
@@ -72,7 +72,7 @@
         <!-- Selected spell box -->
         <Widget type="Button" position="122 146 36 41" align="Left Bottom" name="SpellBox">
             <Widget type="Widget" skin="HUD_Box" position="0 0 36 36">
-                <Widget type="ItemWidget" skin="MW_ItemIconNoShadow" position="-3 -3 42 42" align="Left Top" name="SpellImage"/>
+                <Widget type="SpellWidget" skin="MW_ItemIconNoShadow" position="-3 -3 42 42" align="Left Top" name="SpellImage"/>
                 <Property key="NeedMouse" value="false"/>
             </Widget>
             <Widget type="ProgressBar" skin="MW_EnergyBar_Magic" position="0 36 36 6" align="Left Bottom" name="SpellStatus">


### PR DESCRIPTION
We update HUD widgets every frame, and in upstream master we spend some time to update windows labels, even if they did not change and even if these windows are not visible (e.g. level widget, inventory window).

With this PR we update titles only when they were actually changed.
On my hardware game mechanics update now takes up to 0.1ms less time per frame.