### PR TITLE
Don't apply effects when spell absorption is successful (bug #4820)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
     Bug #4803: Stray special characters before begin statement break script compilation
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
+    Bug #4820: Spell absorption is broken
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -501,8 +501,11 @@ namespace MWMechanics
 
             float magnitudeMult = 1;
 
-            if (!absorbed && target.getClass().isActor())
+            if (target.getClass().isActor())
             {
+                if (absorbed)
+                    continue;
+
                 bool isHarmful = magicEffect->mData.mFlags & ESM::MagicEffect::Harmful;
                 // Reflect harmful effects
                 if (isHarmful && !reflected && !caster.isEmpty() && caster != target && !(magicEffect->mData.mFlags & ESM::MagicEffect::Unreflectable))


### PR DESCRIPTION
[Bug 4820](https://gitlab.com/OpenMW/openmw/issues/4820).
This reverts an erroneous change by noob me from the time of 0.44.0 development so absorbed effects will be again skipped instead of being applied for whatever reason sometimes. Unlike 0.43.0, however, neither harmful nor beneficial effects will be applied - which actually follows Morrowind behavior.

The whole inflict implementation is messy but it's not the time to refurnish it.