### PR TITLE
Update jail state once instead of for every single hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     Bug #4813: Creatures with known file but no "Sound Gen Creature" assigned use default sounds
     Bug #4815: "Finished" journal entry with lower index doesn't close journal, SetJournalIndex closes journal
     Bug #4820: Spell absorption is broken
+    Bug #4823: Jail progress bar works incorrectly
     Bug #4827: NiUVController is handled incorrectly
     Bug #4828: Potion looping effects VFX are not shown for NPCs
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -90,9 +90,9 @@ namespace MWBase
             virtual void setPlayerClass (const ESM::Class& class_) = 0;
             ///< Set player class to custom class.
 
-            virtual void restoreDynamicStats(MWWorld::Ptr actor, bool sleep) = 0;
+            virtual void restoreDynamicStats(MWWorld::Ptr actor, double hours, bool sleep) = 0;
 
-            virtual void rest(bool sleep) = 0;
+            virtual void rest(double hours, bool sleep) = 0;
             ///< If the player is sleeping or waiting, this should be called every hour.
             /// @param sleep is the player sleeping or waiting?
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -587,7 +587,7 @@ namespace MWBase
 
             virtual bool isPlayerInJail() const = 0;
 
-            virtual void rest() = 0;
+            virtual void rest(double hours) = 0;
 
             virtual void setPlayerTraveling(bool traveling) = 0;
             virtual bool isPlayerTraveling() const = 0;

--- a/apps/openmw/mwgui/jailscreen.cpp
+++ b/apps/openmw/mwgui/jailscreen.cpp
@@ -78,8 +78,7 @@ namespace MWGui
 
         MWWorld::Ptr player = MWMechanics::getPlayer();
 
-        for (int i=0; i<mDays*24; ++i)
-            MWBase::Environment::get().getMechanicsManager()->rest(true);
+        MWBase::Environment::get().getMechanicsManager()->rest(mDays * 24, true);
         MWBase::Environment::get().getWorld()->advanceTime(mDays * 24);
 
         std::set<int> skills;

--- a/apps/openmw/mwgui/trainingwindow.cpp
+++ b/apps/openmw/mwgui/trainingwindow.cpp
@@ -169,8 +169,7 @@ namespace MWGui
         npcStats.setGoldPool(npcStats.getGoldPool() + price);
 
         // advance time
-        MWBase::Environment::get().getMechanicsManager()->rest(false);
-        MWBase::Environment::get().getMechanicsManager()->rest(false);
+        MWBase::Environment::get().getMechanicsManager()->rest(2, false);
         MWBase::Environment::get().getWorld ()->advanceTime (2);
 
         setVisible(false);

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -174,10 +174,7 @@ namespace MWGui
             ESM::Position playerPos = player.getRefData().getPosition();
             float d = (osg::Vec3f(pos.pos[0], pos.pos[1], 0) - osg::Vec3f(playerPos.pos[0], playerPos.pos[1], 0)).length();
             int hours = static_cast<int>(d /MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fTravelTimeMult")->mValue.getFloat());
-            for(int i = 0;i < hours;i++)
-            {
-                MWBase::Environment::get().getMechanicsManager ()->rest (true);
-            }
+            MWBase::Environment::get().getMechanicsManager ()->rest (hours, true);
             MWBase::Environment::get().getWorld()->advanceTime(hours);
         }
 

--- a/apps/openmw/mwgui/waitdialog.cpp
+++ b/apps/openmw/mwgui/waitdialog.cpp
@@ -232,7 +232,7 @@ namespace MWGui
     void WaitDialog::onWaitingProgressChanged(int cur, int total)
     {
         mProgressBar.setProgress(cur, total);
-        MWBase::Environment::get().getMechanicsManager()->rest(mSleeping);
+        MWBase::Environment::get().getMechanicsManager()->rest(1, mSleeping);
         MWBase::Environment::get().getWorld()->advanceTime(1);
 
         MWWorld::Ptr player = MWBase::Environment::get().getWorld()->getPlayerPtr();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -568,7 +568,7 @@ namespace MWMechanics
         creatureStats.setMagicka(magicka);
     }
 
-    void Actors::restoreDynamicStats (const MWWorld::Ptr& ptr, bool sleep)
+    void Actors::restoreDynamicStats (const MWWorld::Ptr& ptr, double hours, bool sleep)
     {
         MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats (ptr);
         if (stats.isDead())
@@ -582,11 +582,11 @@ namespace MWMechanics
             getRestorationPerHourOfSleep(ptr, health, magicka);
 
             DynamicStat<float> stat = stats.getHealth();
-            stat.setCurrent(stat.getCurrent() + health);
+            stat.setCurrent(stat.getCurrent() + health * hours);
             stats.setHealth(stat);
 
             stat = stats.getMagicka();
-            stat.setCurrent(stat.getCurrent() + magicka);
+            stat.setCurrent(stat.getCurrent() + magicka * hours);
             stats.setMagicka(stat);
         }
 
@@ -610,7 +610,7 @@ namespace MWMechanics
         float x = fFatigueReturnBase + fFatigueReturnMult * (1 - normalizedEncumbrance);
         x *= fEndFatigueMult * endurance;
 
-        fatigue.setCurrent (fatigue.getCurrent() + 3600 * x);
+        fatigue.setCurrent (fatigue.getCurrent() + 3600 * x * hours);
         stats.setFatigue (fatigue);
     }
 
@@ -1685,9 +1685,9 @@ namespace MWMechanics
         }
     }
 
-    void Actors::rest(bool sleep)
+    void Actors::rest(double hours, bool sleep)
     {
-        float duration = 3600.f / MWBase::Environment::get().getWorld()->getTimeScaleFactor();
+        float duration = hours * 3600.f / MWBase::Environment::get().getWorld()->getTimeScaleFactor();
         const MWWorld::Ptr player = MWBase::Environment::get().getWorld()->getPlayerPtr();
         const osg::Vec3f playerPos = player.getRefData().getPosition().asVec3();
 
@@ -1697,7 +1697,7 @@ namespace MWMechanics
                 continue;
 
             if (!sleep || iter->first == player)
-                restoreDynamicStats(iter->first, sleep);
+                restoreDynamicStats(iter->first, hours, sleep);
 
             if ((!iter->first.getRefData().getBaseNode()) ||
                     (playerPos - iter->first.getRefData().getPosition().asVec3()).length2() > mActorsProcessingRange*mActorsProcessingRange)

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -121,13 +121,13 @@ namespace MWMechanics
             void updateHeadTracking(const MWWorld::Ptr& actor, const MWWorld::Ptr& targetActor,
                                             MWWorld::Ptr& headTrackTarget, float& sqrHeadTrackDistance);
 
-            void rest(bool sleep);
-            ///< Update actors while the player is waiting or sleeping. This should be called every hour.
+            void rest(double hours, bool sleep);
+            ///< Update actors while the player is waiting or sleeping.
 
             void updateSneaking(CharacterController* ctrl, float duration);
             ///< Update the sneaking indicator state according to the given player character controller.
 
-            void restoreDynamicStats(const MWWorld::Ptr& actor, bool sleep);
+            void restoreDynamicStats(const MWWorld::Ptr& actor, double hours, bool sleep);
 
             int getHoursToRest(const MWWorld::Ptr& ptr) const;
             ///< Calculate how many hours the given actor needs to rest in order to be fully healed

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -479,17 +479,17 @@ namespace MWMechanics
         return mActors.isSneaking(ptr);
     }
 
-    void MechanicsManager::rest(bool sleep)
+    void MechanicsManager::rest(double hours, bool sleep)
     {
         if (sleep)
-            MWBase::Environment::get().getWorld()->rest();
+            MWBase::Environment::get().getWorld()->rest(hours);
 
-        mActors.rest(sleep);
+        mActors.rest(hours, sleep);
     }
 
-    void MechanicsManager::restoreDynamicStats(MWWorld::Ptr actor, bool sleep)
+    void MechanicsManager::restoreDynamicStats(MWWorld::Ptr actor, double hours, bool sleep)
     {
-        mActors.restoreDynamicStats(actor, sleep);
+        mActors.restoreDynamicStats(actor, hours, sleep);
     }
 
     int MechanicsManager::getHoursToRest() const

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -95,9 +95,9 @@ namespace MWMechanics
             virtual void setPlayerClass (const ESM::Class& class_) override;
             ///< Set player class to custom class.
 
-            virtual void restoreDynamicStats(MWWorld::Ptr actor, bool sleep) override;
+            virtual void restoreDynamicStats(MWWorld::Ptr actor, double hours, bool sleep) override;
 
-            virtual void rest(bool sleep) override;
+            virtual void rest(double hours, bool sleep) override;
             ///< If the player is sleeping or waiting, this should be called every hour.
             /// @param sleep is the player sleeping or waiting?
 

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -151,16 +151,16 @@ MWWorld::CellStore *MWWorld::Cells::getInterior (const std::string& name)
     return &result->second;
 }
 
-void MWWorld::Cells::rest ()
+void MWWorld::Cells::rest (double hours)
 {
     for (auto &interior : mInteriors)
     {
-        interior.second.rest();
+        interior.second.rest(hours);
     }
 
     for (auto &exterior : mExteriors)
     {
-        exterior.second.rest();
+        exterior.second.rest(hours);
     }
 }
 

--- a/apps/openmw/mwworld/cells.hpp
+++ b/apps/openmw/mwworld/cells.hpp
@@ -61,7 +61,7 @@ namespace MWWorld
 
             /// @note name must be lower case
             Ptr getPtr (const std::string& name);
-            void rest ();
+            void rest (double hours);
 
             /// Get all Ptrs referencing \a name in exterior cells
             /// @note Due to the current implementation of getPtr this only supports one Ptr per cell.

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -966,7 +966,7 @@ namespace MWWorld
         }
     }
 
-    void CellStore::rest()
+    void CellStore::rest(double hours)
     {
         if (mState == State_Loaded)
         {
@@ -975,7 +975,7 @@ namespace MWWorld
                 Ptr ptr = getCurrentPtr(&*it);
                 if (!ptr.isEmpty() && ptr.getRefData().getCount() > 0)
                 {
-                    MWBase::Environment::get().getMechanicsManager()->restoreDynamicStats(ptr, true);
+                    MWBase::Environment::get().getMechanicsManager()->restoreDynamicStats(ptr, hours, true);
                 }
             }
             for (CellRefList<ESM::NPC>::List::iterator it (mNpcs.mList.begin()); it!=mNpcs.mList.end(); ++it)
@@ -983,7 +983,7 @@ namespace MWWorld
                 Ptr ptr = getCurrentPtr(&*it);
                 if (!ptr.isEmpty() && ptr.getRefData().getCount() > 0)
                 {
-                    MWBase::Environment::get().getMechanicsManager()->restoreDynamicStats(ptr, true);
+                    MWBase::Environment::get().getMechanicsManager()->restoreDynamicStats(ptr, hours, true);
                 }
             }
         }

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -183,7 +183,7 @@ namespace MWWorld
             /// @return updated MWWorld::Ptr with the new CellStore pointer set.
             MWWorld::Ptr moveTo(const MWWorld::Ptr& object, MWWorld::CellStore* cellToMoveTo);
 
-            void rest();
+            void rest(double hours);
 
             /// Make a copy of the given object and insert it into this cell.
             /// @note If you get a linker error here, this means the given type can not be inserted into a cell.

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3266,9 +3266,9 @@ namespace MWWorld
         return closestMarker;
     }
 
-    void World::rest()
+    void World::rest(double hours)
     {
-        mCells.rest();
+        mCells.rest(hours);
     }
 
     void World::teleportToClosestMarker (const MWWorld::Ptr& ptr,

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -574,7 +574,7 @@ namespace MWWorld
             RestPermitted canRest() const override;
             ///< check if the player is allowed to rest
 
-            void rest() override;
+            void rest(double hours) override;
 
             /// \todo Probably shouldn't be here
             MWRender::Animation* getAnimation(const MWWorld::Ptr &ptr) override;


### PR DESCRIPTION
Fixes [bug #4823](https://gitlab.com/OpenMW/openmw/issues/4823).

Instead of updating world for every single hour in prison in the loop, update world just once with parameter.

Note: a prison progress bar is an artifitial thing without any practical value. In theory, we can completely remove it.