### PR TITLE
Make quest status update handling closer to vanilla (bug #4815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     Bug #4803: Stray special characters before begin statement break script compilation
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
     Bug #4813: Creatures with known file but no "Sound Gen Creature" assigned use default sounds
+    Bug #4815: "Finished" journal entry with lower index doesn't close journal, SetJournalIndex closes journal
     Bug #4820: Spell absorption is broken
     Bug #4827: NiUVController is handled incorrectly
     Bug #4828: Potion looping effects VFX are not shown for NPCs

--- a/apps/openmw/mwdialogue/quest.cpp
+++ b/apps/openmw/mwdialogue/quest.cpp
@@ -41,19 +41,6 @@ namespace MWDialogue
 
     void Quest::setIndex (int index)
     {
-        const ESM::Dialogue *dialogue =
-            MWBase::Environment::get().getWorld()->getStore().get<ESM::Dialogue>().find (mTopic);
-
-        for (ESM::Dialogue::InfoContainer::const_iterator iter (dialogue->mInfo.begin());
-            iter!=dialogue->mInfo.end(); ++iter)
-            if (iter->mData.mDisposition==index && iter->mQuestStatus!=ESM::DialInfo::QS_Name)
-            {
-                if (iter->mQuestStatus==ESM::DialInfo::QS_Finished)
-                    mFinished = true;
-                else if (iter->mQuestStatus==ESM::DialInfo::QS_Restart)
-                    mFinished = false;
-            }
-
         // The index must be set even if no related journal entry was found
         mIndex = index;
     }
@@ -81,8 +68,18 @@ namespace MWDialogue
         if (index==-1)
             throw std::runtime_error ("unknown journal entry for topic " + mTopic);
 
+        for (auto &info : dialogue->mInfo)
+        {
+            if (info.mData.mJournalIndex == index
+            && (info.mQuestStatus == ESM::DialInfo::QS_Finished || info.mQuestStatus == ESM::DialInfo::QS_Restart))
+            {
+                mFinished = (info.mQuestStatus == ESM::DialInfo::QS_Finished);
+                break;
+            }
+        }
+
         if (index > mIndex)
-            setIndex (index);
+            mIndex = index;
 
         for (TEntryIter iter (mEntries.begin()); iter!=mEntries.end(); ++iter)
             if (iter->mInfoId==entry.mInfoId)


### PR DESCRIPTION
[Bug 4815](https://gitlab.com/OpenMW/openmw/issues/4815).

SetJournalIndex in Morrowind simply updates the quest index without doing anything else, so setIndex shouldn't have updated quest status. Journal instruction relied on setIndex to do this, but it can only increase the index when adding an entry, while Morrowind updates quest status regardless of whether the index changed or not. The solution is to move quest status update from setIndex to Quest::addEntry. This is safe to do because the used functions are not used anywhere else other than the script instruction and Journal class implementation.

I'm concerned about Journal::addEntry, though, since its "bailing out" behavior has now changed and I'm not sure what should it actually be.