### PR TITLE
Apply UVControllers only for given UV Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     Bug #4803: Stray special characters before begin statement break script compilation
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
     Bug #4820: Spell absorption is broken
+    Bug #4827: NiUVController is handled incorrectly
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/components/nif/controller.cpp
+++ b/components/nif/controller.cpp
@@ -139,7 +139,7 @@ namespace Nif
     {
         Controller::read(nif);
 
-        nif->getUShort(); // always 0
+        uvSet = nif->getUShort();
         data.read(nif);
     }
 

--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -112,6 +112,7 @@ class NiUVController : public Controller
 {
 public:
     NiUVDataPtr data;
+    int uvSet;
 
     void read(NIFStream *nif);
     void post(NIFFile *nif);

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -648,9 +648,14 @@ namespace NifOsg
                 if (ctrl->recType == Nif::RC_NiUVController)
                 {
                     const Nif::NiUVController *niuvctrl = static_cast<const Nif::NiUVController*>(ctrl.getPtr());
+                    const int uvSet = niuvctrl->uvSet;
                     std::set<int> texUnits;
+                    // UVController should work only for textures which use a given UV Set, usually 0.
                     for (unsigned int i=0; i<boundTextures.size(); ++i)
-                        texUnits.insert(i);
+                    {
+                        if (boundTextures[i] == uvSet)
+                            texUnits.insert(i);
+                    }
 
                     osg::ref_ptr<UVController> uvctrl = new UVController(niuvctrl->data.getPtr(), texUnits);
                     setupController(niuvctrl, uvctrl, animflags);


### PR DESCRIPTION
Should fix [bug #4827](https://gitlab.com/OpenMW/openmw/issues/4827).

Just applies UV matrix only to textures which use a given UV Set (usually 0).
You can specify used UV Set index in the NiUVController ("unknown short" in the NifSkope).

Meshes from Glow in the Dahrk should work fine now, but UV Set selection needs testing.