### PR TITLE
Update magic effects VFX immediately after effects update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
     Bug #4820: Spell absorption is broken
     Bug #4827: NiUVController is handled incorrectly
+    Bug #4828: Potion looping effects VFX are not shown for NPCs
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1355,6 +1355,14 @@ namespace MWMechanics
                     bool cellChanged = world->hasCellChanged();
                     MWWorld::Ptr actor = iter->first; // make a copy of the map key to avoid it being invalidated when the player teleports
                     updateActor(actor, duration);
+
+                    // Looping magic VFX update
+                    // Note: we need to do this before any of the animations are updated.
+                    // Reaching the text keys may trigger Hit / Spellcast (and as such, particles),
+                    // so updating VFX immediately after that would just remove the particle effects instantly.
+                    // There needs to be a magic effect update in between.
+                    ctrl->updateContinuousVfx();
+
                     if (!cellChanged && world->hasCellChanged())
                     {
                         return; // for now abort update of the old cell when cell changes by teleportation magic effect
@@ -1427,14 +1435,6 @@ namespace MWMechanics
             timerUpdateHeadTrack += duration;
             timerUpdateEquippedLight += duration;
             mTimerDisposeSummonsCorpses += duration;
-
-            // Looping magic VFX update
-            // Note: we need to do this before any of the animations are updated.
-            // Reaching the text keys may trigger Hit / Spellcast (and as such, particles),
-            // so updating VFX immediately after that would just remove the particle effects instantly.
-            // There needs to be a magic effect update in between.
-            for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
-                iter->second->getCharacterController()->updateContinuousVfx();
 
             // Animation/movement update
             CharacterController* playerCharacter = nullptr;


### PR DESCRIPTION
Fixes [bug #4828](https://gitlab.com/OpenMW/openmw/issues/4828).

Currently we update the MagicEffects in the updateActor() and update visual effects itself in the updateContinuousVfx() based on the MagicEffect state, so if there is an effect added between these calls, this effect sometimes is considered as expired and OpenMW removes VFX.

An example - when combat AI uses potions.

A simpliest way to fix this issue is to update VFX immediately after magic effects update.
In this case newly added effects just will be handled in the next frame.


As an alternative solution, we can update MagicEffects in the end of actors update, but in this case combat AI will use old values, so I prefer approach from this PR since it affects only spell VFX.
