### PR TITLE
Account for inverted tangents on normal-mapped objects (bug #3733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows
+    Bug #3733: Normal maps are inverted on mirrored UVs
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4411: Reloading a saved game while falling prevents damage in some cases

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -68,7 +68,7 @@ void main()
 
     vec3 normalizedNormal = normalize(passNormal);
     vec3 normalizedTangent = normalize(passTangent.xyz);
-    vec3 binormal = cross(normalizedTangent, normalizedNormal);
+    vec3 binormal = cross(normalizedTangent, normalizedNormal) * passTangent.w;
     mat3 tbnTranspose = mat3(normalizedTangent, binormal, normalizedNormal);
 
     vec3 viewNormal = gl_NormalMatrix * normalize(tbnTranspose * (normalTex.xyz * 2.0 - 1.0));


### PR DESCRIPTION
[Bug 3733](https://gitlab.com/OpenMW/openmw/issues/3733)

Normal maps didn't look right on objects where UV is mirrored because the shader didn't account for the case when tangents were actually inverted in the model. So I did a thing similar to [what is done in Unity](https://forum.unity.com/threads/symmetric-models-with-mirrored-normal-maps-shader-fix.65859/#post-420888). Now such objects should look fine.

Terrain cannot have inverted tangents.
Before: ![before](https://user-images.githubusercontent.com/21265616/51947204-11ae1a00-2435-11e9-90b0-9f5a285fe4c0.png)

After: ![after](https://user-images.githubusercontent.com/21265616/51947203-11158380-2435-11e9-982e-1cef277ad8ea.png)
Perhaps more apparent:
Before: ![before](https://user-images.githubusercontent.com/21265616/51947375-b3ce0200-2435-11e9-891c-7acf80d67ad5.png)

After: ![after](https://user-images.githubusercontent.com/21265616/51947376-b4669880-2435-11e9-8f86-2a7488cad803.png)

