### PR TITLE
[0.45 regression] Editor: hide hairs when helmet is used

### DIFF
--- a/apps/opencs/model/world/actoradapter.cpp
+++ b/apps/opencs/model/world/actoradapter.cpp
@@ -530,6 +530,10 @@ namespace CSMWorld
         RaceDataPtr raceData = getRaceData(npc.mRace);
         data->reset_data(id, "", false, !npc.isMale(), raceData);
 
+        // Add head and hair
+        data->setPart(ESM::PRT_Head, npc.mHead, 0);
+        data->setPart(ESM::PRT_Hair, npc.mHair, 0);
+
         // Add inventory items
         for (auto& item : npc.mInventory.mList)
         {
@@ -537,10 +541,6 @@ namespace CSMWorld
             std::string itemId = item.mItem.toString();
             addNpcItem(itemId, data);
         }
-
-        // Add head and hair
-        data->setPart(ESM::PRT_Head, npc.mHead, 0);
-        data->setPart(ESM::PRT_Hair, npc.mHair, 0);
     }
 
     void ActorAdapter::addNpcItem(const std::string& itemId, ActorDataPtr data)
@@ -574,6 +574,10 @@ namespace CSMWorld
                     partId = part.mMale;
 
                 data->setPart(partType, partId, priority);
+
+                // An another vanilla quirk: hide hairs if an item replaces Head part
+                if (partType == ESM::PRT_Head)
+                    data->setPart(ESM::PRT_Hair, "", priority);
             }
         };
 


### PR DESCRIPTION
Morrowind has a quirk - when you equip a helmet, it hides hairs even in case if it replaces only Head part.

OpenMW itself takes it in account, but when we added NPC's rendering to the editor, we forgot about it.