### PR TITLE
Do not check if additional animation sources are supported for every animation object

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -641,8 +641,6 @@ namespace MWRender
             mAnimationTimePtr[i].reset(new AnimationTime);
 
         mLightListCallback = new SceneUtil::LightListCallback;
-
-        mUseAdditionalSources = Settings::Manager::getBool ("use additional anim sources", "Game");
     }
 
     Animation::~Animation()
@@ -754,7 +752,8 @@ namespace MWRender
 
         addSingleAnimSource(kfname, baseModel);
 
-        if (mUseAdditionalSources)
+        static const bool useAdditionalSources = Settings::Manager::getBool ("use additional anim sources", "Game");
+        if (useAdditionalSources)
             loadAllAnimationsInFolder(kfname, baseModel);
     }
 

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -273,8 +273,6 @@ protected:
 
     osg::ref_ptr<SceneUtil::LightListCallback> mLightListCallback;
 
-    bool mUseAdditionalSources;
-
     const NodeMap& getNodeMap() const;
 
     /* Sets the appropriate animations on the bone groups based on priority.


### PR DESCRIPTION
Just a little optimization. Since the `mUseAdditionalSources` variable is used only in one place and we do not change the `use additional anim sources` setting during runtime, I suggest just to use a static const local variable.
It should be safe bacause:
1. We create animation objects only in the main thread.
2. Since C++11 static local variables allocation should be threadsafe.