### PR TITLE
Fix redundant searchPtr call

### DIFF
--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1190,8 +1190,7 @@ namespace MWMechanics
 
         if (!Misc::StringUtils::ciEqual(item.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
         {
-            const MWWorld::Ptr victimRef = MWBase::Environment::get().getWorld()->searchPtr(ownerCellRef->getOwner(), true);
-            if (victimRef.isEmpty() || !victimRef.getClass().getCreatureStats(victimRef).isDead())
+            if (victim.isEmpty() || (victim.getClass().isActor() && !victim.getClass().getCreatureStats(victim).isDead()))
                 mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
         }
         if (alarm)


### PR DESCRIPTION
searchPtr calls are not cheap. Although this specific call was only checking objects in the current active cells, the same call is already done in isAllowedToUse so the victim is the same thing as victimRef in the context, and it doesn't hurt to reduce the unnecessary overhead when taking items.

Additionally it's made sure that creature stats are not recovered from a non-actor if a non-actor is set as an item/object owner for *whatever* reason.

The intended functionality of the checks is still intact.