### PR TITLE
[0.45 regression] Init target for AI packages from old saves

### DIFF
--- a/components/esm/aisequence.cpp
+++ b/components/esm/aisequence.cpp
@@ -48,6 +48,7 @@ namespace AiSequence
     {
         esm.getHNT (mData, "DATA");
         mTargetId = esm.getHNString("TARG");
+        mTargetActorId = -1;
         esm.getHNOT (mTargetActorId, "TAID");
         esm.getHNT (mRemainingDuration, "DURA");
         mCellId = esm.getHNOString ("CELL");
@@ -67,6 +68,7 @@ namespace AiSequence
     {
         esm.getHNT (mData, "DATA");
         mTargetId = esm.getHNString("TARG");
+        mTargetActorId = -1;
         esm.getHNOT (mTargetActorId, "TAID");
         esm.getHNT (mRemainingDuration, "DURA");
         mCellId = esm.getHNOString ("CELL");


### PR DESCRIPTION
Before 0.45, we stored only string target ID for AiFollow and AiEscort, so they did not work properly if target did not have an unique ID, so since 0.45 we also store an integer actor ID.

 But there is a bug - when you read such packages from pre-0.45 saves, "TAID" record does not exist, so mTargetActorId = 0.
An actor with ActorID = 0 is the player character, so any character with AiFollow or AiEscort is considered as player's follower.

A possible solution: init the mTargetActorId by -1. In this case OpenMW will fill mTargetActorId later by actorID found by string mTargetId (as it supposed to be), which exists in old saves.