### PR TITLE
[Regression] Remove looping particles from dead actors

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1350,7 +1350,10 @@ namespace MWMechanics
                         player.getClass().getCreatureStats(player).setHitAttemptActorId(-1);
                 }
 
-                if (!iter->first.getClass().getCreatureStats(iter->first).isDead())
+                // For dead actors we need to remove looping spell particles
+                if (iter->first.getClass().getCreatureStats(iter->first).isDead())
+                    ctrl->updateContinuousVfx();
+                else
                 {
                     bool cellChanged = world->hasCellChanged();
                     MWWorld::Ptr actor = iter->first; // make a copy of the map key to avoid it being invalidated when the player teleports


### PR DESCRIPTION
Related [forum topic](https://forum.openmw.org/viewtopic.php?f=8&t=5713).

Fixes a regression, added by #2150.

We need to update looping particles for dead actors as well.