### PR TITLE
[0.45.0 regression] Fix upside-down night-time lighting

### DIFF
--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -748,7 +748,7 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
         }
         else
         {
-            theta = static_cast<float>(osg::PI) + static_cast<float>(osg::PI) * (adjustedHour - adjustedNightStart) / nightDuration;
+            theta = static_cast<float>(osg::PI) - static_cast<float>(osg::PI) * (adjustedHour - adjustedNightStart) / nightDuration;
         }
 
         osg::Vec3f final(


### PR DESCRIPTION
[The change from June](https://github.com/OpenMW/openmw/pull/1670/files#diff-4fdd9e1b36c1b48bc1294ad5031ffef8R742) was a workaround for sun light source glare being visible at night which was rendered obsolete with [this PR](https://github.com/OpenMW/openmw/pull/1936). It made the sun light source get rotated by an over 180 degree angle during night time so that the glare would only be visible from below the surface of the water, and it messed up the night-time lighting, making the sun light source shine from beneath the ground. 0.44.0 behavior is restored with this small change, which makes the lighting look much less odd.

While not important for 0.45.0 in the specific case, this change is also the cause of the issue with AnyOldName3's shadows looking wrong during night-time, at least more wrong than they were intended to be when the shadows PR was first submitted.

*This is the last non-fatal 0.45.0 regression fix from me I swear psi29a pls*

Edit: comparison of master night time and PR night time
![screenshot080](https://user-images.githubusercontent.com/21265616/52374205-bbad2800-2a6d-11e9-9a50-67510a47cf49.png)
![screenshot081](https://user-images.githubusercontent.com/21265616/52374206-bc45be80-2a6d-11e9-9149-0bc1909dd394.png)
0.44.0 screenshot (the lighting appears different due to the caravaneer's position):
![screenshot082](https://user-images.githubusercontent.com/21265616/52376024-27918f80-2a72-11e9-95e9-31519a857218.png)

It's difficult to tell, but Morrowind's directional light source trajectory appears to follow 0.44.0's.