### PR TITLE
Fix hiding three-column (Cyrillic) topic index

### DIFF
--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -554,7 +554,7 @@ namespace
             mQuestMode = true;
 
             setVisible (LeftTopicIndex, false);
-            setVisible (CenterTopicIndex, true);
+            setVisible (CenterTopicIndex, false);
             setVisible (RightTopicIndex, false);
             setVisible (TopicsList, false);
             setVisible (QuestsList, true);


### PR DESCRIPTION
Ok, I lied about the last non-fatal regression fix thing. ~~But I think it is pretty major for Russian users OpenMW has.~~ This only affects three-column indexes which have been generated with a font size larger than the default 17, and these can only be cyrillic.

I accidentally noticed this today when I changed my encoding to Cyrillic recently to try and test some Russian mod:
![default](https://user-images.githubusercontent.com/21265616/52465563-176fd200-2b90-11e9-83d0-da97088625b5.png)
It happens when you click on Quests button in the journal bookmark.

akortunov has pointed out a copy-paste mistake in his GUI scaling PR in response and asked me to submit the PR myself because he has been busy working on a different issue. This allows the center topic index to be hidden properly.

Update: ok, looks like it's too late for non-fatal regression fixes.