### PR TITLE
Do not create a redundant parent node for LOD and Switch nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     Bug #4820: Spell absorption is broken
     Bug #4827: NiUVController is handled incorrectly
     Bug #4828: Potion looping effects VFX are not shown for NPCs
+    Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis


### PR DESCRIPTION
Should fix [bug #4837](https://gitlab.com/OpenMW/openmw/issues/4837), which affects a recent (6.0) version of Morrowind Optimization patch.

Currently when we handle a NiLODNode, we create an osg::Node and attach an osg::LOD as its child node. If the NILODNode is a root node in the mesh, we consider the osg::LOD as a root node, which is not true. For some reason in can lead to memory corruption (reference to the root node becomes invalid) and crash. The same thing for NiSwitchNode since I took the NiLODNode handling as a basis.

Possible solution: do not add a redundant osg::Node for such nodes, so reference to the root node should stay valid.

We need a someone to check if these objects do not cause a crash with MOP, especially on Windows:
1. active_bubbles00
2. furn_mist512
3. furn_mist256

These models should have particles, a first one should disappear when distance to player is > 1000, mist meshes should replace particles to billboards on distances > 2000 and disappear on distances > 5000.

Also you can test meshes from Glow in the Dahrk (since I touched NiSwitchNode handling). They still should be fine.
