### PR TITLE
[WIP/Testing needed] Get rid of out-of-range actor collision shenanigans

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -312,7 +312,6 @@ namespace MWBase
 
             virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) = 0;
 
-            virtual void setActorCollisionMode(const MWWorld::Ptr& ptr, bool internal, bool external) = 0;
             virtual bool isActorCollisionEnabled(const MWWorld::Ptr& ptr) = 0;
 
             virtual bool toggleCollisionMode() = 0;

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1457,7 +1457,6 @@ namespace MWMechanics
                 if (!inRange)
                 {
                     iter->first.getRefData().getBaseNode()->setNodeMask(0);
-                    world->setActorCollisionMode(iter->first, false, false);
                     continue;
                 }
                 else if (!isPlayer)
@@ -1474,7 +1473,6 @@ namespace MWMechanics
                     continue;
                 }
 
-                world->setActorCollisionMode(iter->first, true, !iter->first.getClass().getCreatureStats(iter->first).isDeathAnimationFinished());
                 ctrl->update(duration);
 
                 // Fade away actors on large distance (>90% of actor's processing distance)

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -413,5 +413,5 @@ DetourNavigator::Flags MWMechanics::AiPackage::getNavigatorFlags(const MWWorld::
 bool MWMechanics::AiPackage::canActorMoveByZAxis(const MWWorld::Ptr& actor) const
 {
     MWBase::World* world = MWBase::Environment::get().getWorld();
-    return (actor.getClass().canSwim(actor) && world->isSwimming(actor)) || world->isFlying(actor) || !world->isActorCollisionEnabled(actor);
+    return (actor.getClass().canSwim(actor) && world->isSwimming(actor)) || world->isFlying(actor);
 }

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -207,8 +207,7 @@ namespace MWMechanics
         }
 
         bool actorCanMoveByZ = (actor.getClass().canSwim(actor) && MWBase::Environment::get().getWorld()->isSwimming(actor))
-            || MWBase::Environment::get().getWorld()->isFlying(actor)
-            || !MWBase::Environment::get().getWorld()->isActorCollisionEnabled(actor);
+            || MWBase::Environment::get().getWorld()->isFlying(actor);
 
         if(actorCanMoveByZ && mDistance > 0) {
             // Typically want to idle for a short time before the next wander

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -421,7 +421,6 @@ namespace MWWorld
 
             bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
 
-            void setActorCollisionMode(const Ptr& ptr, bool internal, bool external) override;
             bool isActorCollisionEnabled(const Ptr& ptr) override;
 
             bool toggleCollisionMode() override;


### PR DESCRIPTION
Something more in-depth than the previous regression fix attempt. This, however, is not intended for 0.45.0.
While this is very "raw" and needs some cleanup, I decided to submit it so that it haunts me for the following week and I don't forget to finish it.
This is something (arguably) better than the current awkward workaround for the original issue actor processing rework tried to avoid.

Original behavior: when an actor first gets in range and gets out of range after that, its collision modes are toggled off to prevent the player being able to hit them with magic and ranged combat projectiles, and there are some checks in place to prevent actors out of range getting hit by exploding spells. When the actor gets into the processing range again, the collisions are turned on again, *even if it's a dead actor which shouldn't have collisions*.
Current behavior: same thing but the collisions are not reenabled for actors with death animation finished.
PR behavior: collisions are not touched at all, instead projectiles go through actors when their distance to the player is beyond actor processing range and exploding spells similarly don't affect out-of-range actors purely based on their distance to the player.
As a reminder, out-of-range actors are invisible so it doesn't look that weird anyway. What I currently have now worked in my testing, but there may have been some cases messing with collision modes worked around some more issues I missed. Even then, I think it's more universal, will allow to avoid issues similar to the one that was fixed recently and that the current behavior (where collision modes are turned off and on) is something openmw shouldn't really do.

This doesn't need a changelog entry because there shouldn't be any visible difference to the end user, it's just a change of approach.

I have written too much.
tl;dr I don't like how we mess with actor collisions, this is a different, less laconic but more universal approach to avoiding the original issue but I may have missed something, needs testing.