### PR TITLE
Rework the viewing distance slider

### DIFF
--- a/docs/source/reference/modding/settings/camera.rst
+++ b/docs/source/reference/modding/settings/camera.rst
@@ -46,7 +46,7 @@ viewing distance
 
 :Type:		floating point
 :Range:		> 0
-:Default:	6666.0
+:Default:	6656.0
 
 This value controls the maximum visible distance (also called the far clipping plane).
 Larger values significantly improve rendering in exterior spaces,
@@ -87,7 +87,7 @@ Enabling the distant terrain setting is an alternative to increasing exterior ce
 Note that the distant land setting does not include rendering of distant static objects,
 so the resulting visual effect is not the same.
 
-This setting can be adjusted in game from the ridiculously low value of 2000.0 to a maximum of 6666.0
+This setting can be adjusted in game from the ridiculously low value of 2048.0 to a maximum of 81920.0
 using the View Distance slider in the Detail tab of the Video panel of the Options menu.
 
 field of view

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -376,17 +376,29 @@
                         <Widget type="TextBox" skin="NormalText" position="4 130 322 18" align="Left Top" name="RenderDistanceLabel">
                             <Property key="Caption" value="#{sRender_Distance}"/>
                         </Widget>
-                        <Widget type="MWScrollBar" skin="MW_HScroll" position="4 154 322 18" align="Left Top">
-                            <Property key="Range" value="4667"/>
-                            <Property key="Page" value="300"/>
+                        <Widget type="MWScrollBar" skin="MW_HScroll" position="4 154 322 18" align="Left Top" name="RenderingDistanceSlider">
+                            <Property key="Range" value="4609"/>
+                            <Property key="Page" value="128"/>
                             <UserString key="SettingType" value="Slider"/>
                             <UserString key="SettingCategory" value="Camera"/>
                             <UserString key="SettingName" value="viewing distance"/>
                             <UserString key="SettingValueType" value="Integer"/>
-                            <UserString key="SettingMin" value="2000"/>
-                            <UserString key="SettingMax" value="6666"/>
+                            <UserString key="SettingMin" value="2048"/>
+                            <UserString key="SettingMax" value="6656"/>
                             <UserString key="SettingLabelWidget" value="RenderDistanceLabel"/>
                             <UserString key="SettingLabelCaption" value="#{sRender_Distance} (%s)"/>
+                        </Widget>
+                        <Widget type="MWScrollBar" skin="MW_HScroll" position="4 154 322 18" align="Left Top" name="LargeRenderingDistanceSlider">
+                            <Property key="Range" value="79873"/>
+                            <Property key="Page" value="2048"/>
+                            <UserString key="SettingType" value="Slider"/>
+                            <UserString key="SettingCategory" value="Camera"/>
+                            <UserString key="SettingName" value="viewing distance"/>
+                            <UserString key="SettingValueType" value="Cell"/>
+                            <UserString key="SettingMin" value="2048"/>
+                            <UserString key="SettingMax" value="81920"/>
+                            <UserString key="SettingLabelWidget" value="RenderDistanceLabel"/>
+                            <UserString key="SettingLabelCaption" value="#{sRender_Distance} (x%s)"/>
                         </Widget>
                         <Widget type="TextBox" skin="SandText" position="4 178 332 18" align="Left Top">
                             <Property key="Caption" value="#{sNear}"/>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -21,9 +21,9 @@ small feature culling = true
 
 small feature culling pixel size = 2.0
 
-# Maximum visible distance (e.g. 2000.0 to 6666.0).  Caution: this setting
+# Maximum visible distance. Caution: this setting
 # can dramatically affect performance, see documentation for details.
-viewing distance = 6666.0
+viewing distance = 6656.0
 
 # Camera field of view in degrees (e.g. 30.0 to 110.0).
 # Does not affect the player's hands in the first person camera.


### PR DESCRIPTION
EDIT:

Just increases a maximum value for visiblity slider and display output value in cells.
I still think that it is a quite stupid idea since short and long viewing distances should be handled completely differently (shadows, fog, etc.) and in-game settings should not provide graphics artifacts with any combinations.