### PR TITLE
[Discussion, don't merge] Editor: Transient land shape editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,8 @@
     Feature #4784: Launcher: Duplicate Content Lists
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch
+    Feature #4840: Editor: Transient terrain change support
+    Feature #????: Editor: Land shape editing, land selection
     Feature #4859: Make water reflections more configurable
     Feature #4882: Support for NiPalette node
     Feature #4887: Add openmw command option to set initial random seed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
     Feature #3025: Analogue gamepad movement controls
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
+    Feature #3871: Editor: Terrain Selection
     Feature #3893: Implicit target for "set" function in console
     Feature #3980: In-game option to disable controller
     Feature #3999: Shift + Double Click should maximize/restore menu size

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -89,7 +89,7 @@ opencs_units (view/render
     scenewidget worldspacewidget pagedworldspacewidget unpagedworldspacewidget
     previewwidget editmode instancemode instanceselectionmode instancemovemode
     orbitcameramode pathgridmode selectionmode pathgridselectionmode cameracontroller
-    cellwater terraintexturemode actor
+    cellwater terraintexturemode actor terrainselection
     )
 
 opencs_units_noqt (view/render

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -82,14 +82,14 @@ opencs_units_noqt (view/world
 
 opencs_units (view/widget
     scenetoolbar scenetool scenetoolmode pushbutton scenetooltoggle scenetoolrun modebutton
-    scenetooltoggle2 scenetooltexturebrush completerpopup coloreditor colorpickerpopup droplineedit
+    scenetooltoggle2 scenetooltexturebrush scenetoolshapebrush completerpopup coloreditor colorpickerpopup droplineedit
     )
 
 opencs_units (view/render
     scenewidget worldspacewidget pagedworldspacewidget unpagedworldspacewidget
     previewwidget editmode instancemode instanceselectionmode instancemovemode
     orbitcameramode pathgridmode selectionmode pathgridselectionmode cameracontroller
-    cellwater terraintexturemode actor terrainselection
+    cellwater terraintexturemode actor terrainselection terrainshapemode
     )
 
 opencs_units_noqt (view/render

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -170,7 +170,7 @@ void CSMPrefs::State::declare()
         "list go to the first/last item");
 
     declareCategory ("3D Scene Input");
-    
+
     declareDouble ("navi-wheel-factor", "Camera Zoom Sensitivity", 8).setRange(-100.0, 100.0);
     declareDouble ("s-navi-sensitivity", "Secondary Camera Movement Sensitivity", 50.0).setRange(-1000.0, 1000.0);
     declareSeparator();
@@ -178,7 +178,7 @@ void CSMPrefs::State::declare()
     declareDouble ("p-navi-free-sensitivity", "Free Camera Sensitivity", 1/650.).setPrecision(5).setRange(0.0, 1.0);
     declareBool ("p-navi-free-invert", "Invert Free Camera Mouse Input", false);
     declareDouble ("navi-free-lin-speed", "Free Camera Linear Speed", 1000.0).setRange(1.0, 10000.0);
-    declareDouble ("navi-free-rot-speed", "Free Camera Rotational Speed", 3.14 / 2).setRange(0.001, 6.28);    
+    declareDouble ("navi-free-rot-speed", "Free Camera Rotational Speed", 3.14 / 2).setRange(0.001, 6.28);
     declareDouble ("navi-free-speed-mult", "Free Camera Speed Multiplier (from Modifier)", 8).setRange(0.001, 1000.0);
     declareSeparator();
 
@@ -247,6 +247,8 @@ void CSMPrefs::State::declare()
     declareEnum ("outside-visible-landedit", "Handling land edit outside of visible cells", showAndLandEdit).
         addValues (landeditOutsideVisibleCell);
     declareInt ("texturebrush-maximumsize", "Maximum texture brush size", 50).
+        setMin (1);
+    declareInt ("shapebrush-maximumsize", "Maximum texture brush size", 100).
         setMin (1);
     declareBool ("open-list-view", "Open displays list view", false).
         setTooltip ("When opening a reference from the scene view, it will open the"

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -91,19 +91,19 @@ std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(const osg::Vec3d& 
     return std::make_pair(x, y);
 }
 
-float CSMWorld::CellCoordinates::textureSelectionToWorldCoords(int pos)
+float CSMWorld::CellCoordinates::textureGlobalToWorldCoords(int textureGlobal)
 {
-    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / ESM::Land::LAND_TEXTURE_SIZE;
+    return ESM::Land::REAL_SIZE * static_cast<float>(textureGlobal) / ESM::Land::LAND_TEXTURE_SIZE;
 }
 
-float CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(int pos)
+float CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(int vertexGlobal)
 {
-    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1);
+    return ESM::Land::REAL_SIZE * static_cast<float>(vertexGlobal) / (ESM::Land::LAND_SIZE - 1);
 }
 
-int CSMWorld::CellCoordinates::vertexSelectionToInCellCoords(int pos)
+int CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(int vertexGlobal)
 {
-    return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1)) * (ESM::Land::LAND_SIZE - 1));
+    return static_cast<int>(vertexGlobal - std::floor(static_cast<float>(vertexGlobal) / (ESM::Land::LAND_SIZE - 1)) * (ESM::Land::LAND_SIZE - 1));
 }
 
 std::string CSMWorld::CellCoordinates::textureGlobalToCellId(const std::pair<int, int>& textureGlobal)

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -8,13 +8,6 @@
 #include <components/esm/loadland.hpp>
 #include <components/misc/constants.hpp>
 
-namespace
-{
-    const int cellSize {ESM::Land::REAL_SIZE};
-    const int landSize {ESM::Land::LAND_SIZE};
-    const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
-}
-
 CSMWorld::CellCoordinates::CellCoordinates() : mX (0), mY (0) {}
 
 CSMWorld::CellCoordinates::CellCoordinates (int x, int y) : mX (x), mY (y) {}
@@ -76,10 +69,10 @@ std::pair<int, int> CSMWorld::CellCoordinates::coordinatesToCellIndex (float x, 
     return std::make_pair (std::floor (x / Constants::CellSizeInUnits), std::floor (y / Constants::CellSizeInUnits));
 }
 
-std::pair<int, int> CSMWorld::CellCoordinates::toTextureCoords(osg::Vec3d worldPos)
+std::pair<int, int> CSMWorld::CellCoordinates::toTextureCoords(const osg::Vec3d& worldPos)
 {
-    const auto xd = static_cast<float>(worldPos.x() * landTextureSize / cellSize - 0.25f);
-    const auto yd = static_cast<float>(worldPos.y() * landTextureSize / cellSize + 0.25f);
+    const auto xd = static_cast<float>(worldPos.x() * ESM::Land::LAND_TEXTURE_SIZE / ESM::Land::REAL_SIZE - 0.25f);
+    const auto yd = static_cast<float>(worldPos.y() * ESM::Land::LAND_TEXTURE_SIZE / ESM::Land::REAL_SIZE + 0.25f);
 
     const auto x = static_cast<int>(std::floor(xd));
     const auto y = static_cast<int>(std::floor(yd));
@@ -87,10 +80,10 @@ std::pair<int, int> CSMWorld::CellCoordinates::toTextureCoords(osg::Vec3d worldP
     return std::make_pair(x, y);
 }
 
-std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(osg::Vec3d worldPos)
+std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(const osg::Vec3d& worldPos)
 {
-    const auto xd = static_cast<float>(worldPos.x() * (landSize - 1) / cellSize + 0.5f);
-    const auto yd = static_cast<float>(worldPos.y() * (landSize - 1) / cellSize + 0.5f);
+    const auto xd = static_cast<float>(worldPos.x() * (ESM::Land::LAND_SIZE - 1) / ESM::Land::REAL_SIZE + 0.5f);
+    const auto yd = static_cast<float>(worldPos.y() * (ESM::Land::LAND_SIZE - 1) / ESM::Land::REAL_SIZE + 0.5f);
 
     const auto x = static_cast<int>(std::floor(xd));
     const auto y = static_cast<int>(std::floor(yd));
@@ -100,30 +93,30 @@ std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(osg::Vec3d worldPo
 
 float CSMWorld::CellCoordinates::textureSelectionToWorldCoords(int pos)
 {
-    return cellSize * static_cast<float>(pos) / landTextureSize;
+    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / ESM::Land::LAND_TEXTURE_SIZE;
 }
 
 float CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(int pos)
 {
-    return cellSize * static_cast<float>(pos) / (landSize - 1);
+    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1);
 }
 
 int CSMWorld::CellCoordinates::vertexSelectionToInCellCoords(int pos)
 {
-    return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (landSize - 1)) * (landSize - 1));
+    return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1)) * (ESM::Land::LAND_SIZE - 1));
 }
 
-std::string CSMWorld::CellCoordinates::textureGlobalToCellId(std::pair<int, int> textureGlobal)
+std::string CSMWorld::CellCoordinates::textureGlobalToCellId(const std::pair<int, int>& textureGlobal)
 {
-    int x = std::floor(static_cast<float>(textureGlobal.first) / landTextureSize);
-    int y = std::floor(static_cast<float>(textureGlobal.second) / landTextureSize);
+    int x = std::floor(static_cast<float>(textureGlobal.first) / ESM::Land::LAND_TEXTURE_SIZE);
+    int y = std::floor(static_cast<float>(textureGlobal.second) / ESM::Land::LAND_TEXTURE_SIZE);
     return generateId(x, y);
 }
 
-std::string CSMWorld::CellCoordinates::vertexGlobalToCellId(std::pair<int, int> vertexGlobal)
+std::string CSMWorld::CellCoordinates::vertexGlobalToCellId(const std::pair<int, int>& vertexGlobal)
 {
-    int x = std::floor(static_cast<float>(vertexGlobal.first) / (landSize - 1));
-    int y = std::floor(static_cast<float>(vertexGlobal.second) / (landSize - 1));
+    int x = std::floor(static_cast<float>(vertexGlobal.first) / (ESM::Land::LAND_SIZE - 1));
+    int y = std::floor(static_cast<float>(vertexGlobal.second) / (ESM::Land::LAND_SIZE - 1));
     return generateId(x, y);
 }
 

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -113,6 +113,13 @@ int CSMWorld::CellCoordinates::vertexSelectionToInCellCoords(int pos)
     return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (landSize - 1)) * (landSize - 1));
 }
 
+std::string CSMWorld::CellCoordinates::textureGlobalToCellId(std::pair<int, int> textureGlobal)
+{
+    int x = std::floor(static_cast<float>(textureGlobal.first) / landTextureSize);
+    int y = std::floor(static_cast<float>(textureGlobal.second) / landTextureSize);
+    return generateId(x, y);
+}
+
 std::string CSMWorld::CellCoordinates::vertexGlobalToCellId(std::pair<int, int> vertexGlobal)
 {
     int x = std::floor(static_cast<float>(vertexGlobal.first) / (landSize - 1));

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -49,10 +49,10 @@ namespace CSMWorld
             static std::pair<int, int> coordinatesToCellIndex (float x, float y);
 
             ///Converts worldspace coordinates to global texture selection, taking in account the texture offset.
-            static std::pair<int, int> toTextureCoords(osg::Vec3d worldPos);
+            static std::pair<int, int> toTextureCoords(const osg::Vec3d& worldPos);
 
             ///Converts worldspace coordinates to global vertex selection.
-            static std::pair<int, int> toVertexCoords(osg::Vec3d worldPos);
+            static std::pair<int, int> toVertexCoords(const osg::Vec3d& worldPos);
 
             ///Converts global texture coordinate to worldspace coordinate that is at the upper left corner of the selected texture.
             static float textureSelectionToWorldCoords(int);
@@ -63,10 +63,10 @@ namespace CSMWorld
             ///Converts local cell's heightmap coordinates from the global vertex coordinate
             static int vertexSelectionToInCellCoords(int);
 
-            static std::string textureGlobalToCellId(std::pair<int, int>);
+            static std::string textureGlobalToCellId(const std::pair<int, int>&);
 
             ///Converts global vertex coordinates to cell id
-            static std::string vertexGlobalToCellId(std::pair<int, int>);
+            static std::string vertexGlobalToCellId(const std::pair<int, int>&);
     };
 
     bool operator== (const CellCoordinates& left, const CellCoordinates& right);

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -63,6 +63,8 @@ namespace CSMWorld
             ///Converts local cell's heightmap coordinates from the global vertex coordinate
             static int vertexSelectionToInCellCoords(int);
 
+            static std::string textureGlobalToCellId(std::pair<int, int>);
+
             ///Converts global vertex coordinates to cell id
             static std::string vertexGlobalToCellId(std::pair<int, int>);
     };

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -55,18 +55,19 @@ namespace CSMWorld
             static std::pair<int, int> toVertexCoords(const osg::Vec3d& worldPos);
 
             ///Converts global texture coordinate to worldspace coordinate that is at the upper left corner of the selected texture.
-            static float textureSelectionToWorldCoords(int);
+            static float textureGlobalToWorldCoords(int textureGlobal);
 
             ///Converts global vertex coordinate to worldspace coordinate
-            static float vertexSelectionToWorldCoords(int);
+            static float vertexGlobalToWorldCoords(int vertexGlobal);
 
-            ///Converts local cell's heightmap coordinates from the global vertex coordinate
-            static int vertexSelectionToInCellCoords(int);
+            ///Converts global vertex coordinate to local cell's heightmap coordinates
+            static int vertexGlobalToInCellCoords(int vertexGlobal);
 
-            static std::string textureGlobalToCellId(const std::pair<int, int>&);
+            ///Converts global texture coordinates to cell id
+            static std::string textureGlobalToCellId(const std::pair<int, int>& textureGlobal);
 
             ///Converts global vertex coordinates to cell id
-            static std::string vertexGlobalToCellId(const std::pair<int, int>&);
+            static std::string vertexGlobalToCellId(const std::pair<int, int>& vertexGlobal);
     };
 
     bool operator== (const CellCoordinates& left, const CellCoordinates& right);

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -134,7 +134,7 @@ void CSVRender::Cell::updateLand()
             else
             {
                 mTerrain.reset(new Terrain::TerrainGrid(mCellNode, mCellNode,
-                    mData.getResourceSystem().get(), new TerrainStorage(mData), Mask_Terrain));
+                    mData.getResourceSystem().get(), mTerrainStorage, Mask_Terrain));
             }
 
             mTerrain->loadCell(esmLand.mX, esmLand.mY);
@@ -168,6 +168,8 @@ CSVRender::Cell::Cell (CSMWorld::Data& data, osg::Group* rootNode, const std::st
   mSubModeElementMask (0), mUpdateLand(true), mLandDeleted(false)
 {
     std::pair<CSMWorld::CellCoordinates, bool> result = CSMWorld::CellCoordinates::fromId (id);
+
+    mTerrainStorage = new TerrainStorage(mData);
 
     if (result.second)
         mCoordinates = result.first;
@@ -345,6 +347,33 @@ bool CSVRender::Cell::referenceAdded (const QModelIndex& parent, int start, int 
         return false;
 
     return addObjects (start, end);
+}
+
+void CSVRender::Cell::setAlteredHeight(int inCellX, int inCellY, float height)
+{
+    mTerrainStorage->setAlteredHeight(inCellX, inCellY, height);
+    mUpdateLand = true;
+}
+
+float CSVRender::Cell::getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY)
+{
+    return mTerrainStorage->getSumOfAlteredAndTrueHeight(cellX, cellY, inCellX, inCellY);
+}
+
+float* CSVRender::Cell::getAlteredHeights()
+{
+    return mTerrainStorage->getAlteredHeights();
+}
+
+float* CSVRender::Cell::getAlteredHeight(int inCellX, int inCellY)
+{
+    return mTerrainStorage->getAlteredHeight(inCellX, inCellY);
+}
+
+void CSVRender::Cell::resetAlteredHeights()
+{
+    mTerrainStorage->resetHeights();
+    mUpdateLand = true;
 }
 
 void CSVRender::Cell::pathgridModified()

--- a/apps/opencs/view/render/cell.hpp
+++ b/apps/opencs/view/render/cell.hpp
@@ -9,6 +9,7 @@
 #include <osg/ref_ptr>
 
 #include "../../model/world/cellcoordinates.hpp"
+#include "terrainstorage.hpp"
 
 class QModelIndex;
 
@@ -58,6 +59,7 @@ namespace CSVRender
             int mSubMode;
             unsigned int mSubModeElementMask;
             bool mUpdateLand, mLandDeleted;
+            TerrainStorage *mTerrainStorage;
 
             /// Ignored if cell does not have an object with the given ID.
             ///
@@ -117,6 +119,16 @@ namespace CSVRender
             /// \return Did this call result in a modification of the visual representation of
             /// this cell?
             bool referenceAdded (const QModelIndex& parent, int start, int end);
+
+            void setAlteredHeight(int inCellX, int inCellY, float height);
+
+            float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
+
+            float* getAlteredHeights();
+
+            float* getAlteredHeight(int inCellX, int inCellY);
+
+            void resetAlteredHeights();
 
             void pathgridModified();
 

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -140,7 +140,7 @@ void CSVRender::PagedWorldspaceWidget::addEditModeSelectorButtons (
         new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain shape editing"),
         "terrain-shape");
     tool->addButton (
-        new TerrainTextureMode (this, tool),
+        new TerrainTextureMode (this, mRootNode, tool),
         "terrain-texture");
     tool->addButton (
         new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain vertex paint editing"),

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -25,6 +25,7 @@
 #include "cameracontroller.hpp"
 #include "cellarrow.hpp"
 #include "terraintexturemode.hpp"
+#include "terrainshapemode.hpp"
 
 bool CSVRender::PagedWorldspaceWidget::adjustCells()
 {
@@ -137,11 +138,9 @@ void CSVRender::PagedWorldspaceWidget::addEditModeSelectorButtons (
 
     /// \todo replace EditMode with suitable subclasses
     tool->addButton (
-        new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain shape editing"),
-        "terrain-shape");
+        new TerrainShapeMode (this, mRootNode, tool), "terrain-shape");
     tool->addButton (
-        new TerrainTextureMode (this, mRootNode, tool),
-        "terrain-texture");
+        new TerrainTextureMode (this, mRootNode, tool), "terrain-texture");
     tool->addButton (
         new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain vertex paint editing"),
         "terrain-vertex");
@@ -789,6 +788,46 @@ CSVRender::Cell* CSVRender::PagedWorldspaceWidget::getCell(const osg::Vec3d& poi
         return searchResult->second;
     else
         return 0;
+}
+
+CSVRender::Cell* CSVRender::PagedWorldspaceWidget::getCell(const CSMWorld::CellCoordinates& coords) const
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::const_iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end())
+        return searchResult->second;
+    else
+        return 0;
+}
+
+void CSVRender::PagedWorldspaceWidget::setCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY, float height)
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end()) searchResult->second->setAlteredHeight(inCellX, inCellY, height);
+}
+
+float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeights(const CSMWorld::CellCoordinates& coords)
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end()) return searchResult->second->getAlteredHeights();
+    return nullptr;
+}
+
+float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY)
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end()) return searchResult->second->getAlteredHeight(inCellX, inCellY);
+    return nullptr;
+}
+
+void CSVRender::PagedWorldspaceWidget::resetAllAlteredHeights()
+{
+    std::map<CSMWorld::CellCoordinates, Cell *>::iterator iter (mCells.begin());
+
+    while (iter!=mCells.end())
+    {
+        iter->second->resetAlteredHeights();
+        ++iter;
+    }
 }
 
 std::vector<osg::ref_ptr<CSVRender::TagBase> > CSVRender::PagedWorldspaceWidget::getSelection (

--- a/apps/opencs/view/render/pagedworldspacewidget.hpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.hpp
@@ -124,6 +124,16 @@ namespace CSVRender
 
             virtual Cell* getCell(const osg::Vec3d& point) const;
 
+            virtual Cell* getCell(const CSMWorld::CellCoordinates& coords) const;
+
+            void setCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY, float height);
+
+            float* getCellAlteredHeights(const CSMWorld::CellCoordinates& coords);
+
+            float* getCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY);
+
+            void resetAllAlteredHeights();
+
             virtual std::vector<osg::ref_ptr<TagBase> > getSelection (unsigned int elementMask)
                 const;
 

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -249,13 +249,11 @@ int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global ver
     int localX = x - cellX * (ESM::Land::LAND_SIZE - 1);
     int localY = y - cellY * (ESM::Land::LAND_SIZE - 1);
 
-    std::string cellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
+    CSMWorld::CellCoordinates coords (cellX, cellY);
 
-    CSMDoc::Document& document = mWorldspaceWidget->getDocument();
-    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
-        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
-    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
-    const CSMWorld::LandHeightsColumn::DataType mPointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+    float landHeight = 0.f;
+    if (CSVRender::Cell* cell = dynamic_cast<CSVRender::Cell*>(mWorldspaceWidget->getCell(coords)))
+        landHeight = cell->getSumOfAlteredAndTrueHeight(cellX, cellY, localX, localY);
 
-    return mPointer[localY*ESM::Land::LAND_SIZE + localX];
+    return landHeight;
 }

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -66,12 +66,12 @@ void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, 
     {
         for(auto const& localPos: localPositions)
         {
-            auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
-            auto itertemp = std::find(mTemporarySelection.begin(), mTemporarySelection.end(), localPos);
+            auto iterTemp = std::find(mTemporarySelection.begin(), mTemporarySelection.end(), localPos);
             mDraggedOperationFlag = true;
 
-            if (itertemp == mTemporarySelection.end())
+            if (iterTemp == mTemporarySelection.end())
             {
+                auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
                 if (iter != mSelection.end())
                 {
                     mSelection.erase(iter);

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -127,7 +127,7 @@ void CSVRender::TerrainSelection::update()
     mGeometry->setVertexArray(vertices);
     osg::ref_ptr<osg::DrawArrays> drawArrays = new osg::DrawArrays(osg::PrimitiveSet::LINES);
     drawArrays->setCount(vertices->size());
-    mGeometry->addPrimitiveSet(drawArrays);
+    if (vertices->size() != 0) mGeometry->addPrimitiveSet(drawArrays);
     mSelectionNode->addChild(mGeometry);
 }
 

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -56,8 +56,10 @@ void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, in
 void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
 {
     if (std::find(mSelection.begin(), mSelection.end(), localPos) == mSelection.end())
-            mSelection.emplace_back(localPos);
-    update();
+    {
+        mSelection.emplace_back(localPos);
+        update();
+    }
 }
 
 void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool toggleInProgress)
@@ -115,7 +117,7 @@ void CSVRender::TerrainSelection::activate()
 
 void CSVRender::TerrainSelection::deactivate()
 {
-    if (mParentNode->containsNode(mSelectionNode)) mParentNode->removeChild(mSelectionNode);
+    mParentNode->removeChild(mSelectionNode);
 }
 
 void CSVRender::TerrainSelection::update()

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -110,12 +110,12 @@ void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, 
 
 void CSVRender::TerrainSelection::activate()
 {
-    mParentNode->addChild(mSelectionNode);
+    if (!mParentNode->containsNode(mSelectionNode)) mParentNode->addChild(mSelectionNode);
 }
 
 void CSVRender::TerrainSelection::deactivate()
 {
-    mParentNode->removeChild(mSelectionNode);
+    if (mParentNode->containsNode(mSelectionNode)) mParentNode->removeChild(mSelectionNode);
 }
 
 void CSVRender::TerrainSelection::update()

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -15,13 +15,6 @@
 #include "cell.hpp"
 #include "worldspacewidget.hpp"
 
-namespace
-{
-    const int cellSize {ESM::Land::REAL_SIZE};
-    const int landSize {ESM::Land::LAND_SIZE};
-    const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
-}
-
 CSVRender::TerrainSelection::TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type):
 mParentNode(parentNode), mWorldspaceWidget (worldspaceWidget), mDraggedOperationFlag(false), mSelectionType(type)
 {
@@ -180,10 +173,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
     {
         // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
         const float nudgePercentage = 0.25f;
-        const int nudgeOffset = (cellSize / landTextureSize) * nudgePercentage;
-        const int landHeightsNudge = (cellSize / landSize) / (landSize - 1); // Does this work with all land size configurations?
+        const int nudgeOffset = (ESM::Land::REAL_SIZE / ESM::Land::LAND_TEXTURE_SIZE) * nudgePercentage;
+        const int landHeightsNudge = (ESM::Land::REAL_SIZE / ESM::Land::LAND_SIZE) / (ESM::Land::LAND_SIZE - 1); // Does this work with all land size configurations?
 
-        const int textureSizeToLandSizeModifier = (landSize - 1) / landTextureSize;
+        const int textureSizeToLandSizeModifier = (ESM::Land::LAND_SIZE - 1) / ESM::Land::LAND_TEXTURE_SIZE;
 
         for (std::pair<int, int> &localPos : mSelection)
         {
@@ -203,8 +196,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
                     vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
                 }
@@ -215,8 +208,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
                     vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
                 }
@@ -227,8 +220,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
                 }
@@ -239,8 +232,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
                 }
@@ -251,10 +244,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 
 int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global vertex coordinates
 {
-    int cellX = std::floor((1.0f*x / (landSize - 1)));
-    int cellY = std::floor((1.0f*y / (landSize - 1)));
-    int localX = x - cellX * (landSize - 1);
-    int localY = y - cellY * (landSize - 1);
+    int cellX = std::floor((1.0f*x / (ESM::Land::LAND_SIZE - 1)));
+    int cellY = std::floor((1.0f*y / (ESM::Land::LAND_SIZE - 1)));
+    int localX = x - cellX * (ESM::Land::LAND_SIZE - 1);
+    int localY = y - cellY * (ESM::Land::LAND_SIZE - 1);
 
     std::string cellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
 
@@ -264,5 +257,5 @@ int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global ver
     int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
     const CSMWorld::LandHeightsColumn::DataType mPointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
 
-    return mPointer[localY*landSize + localX];
+    return mPointer[localY*ESM::Land::LAND_SIZE + localX];
 }

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -43,17 +43,13 @@ std::vector<std::pair<int, int>> CSVRender::TerrainSelection::getTerrainSelectio
     return mSelection;
 }
 
-void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, int>> localPositions)
+void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, int>> &localPositions)
 {
-    mSelection.clear();
-    for(auto const& value: localPositions)
-    {
-        mSelection.emplace_back(value);
-    }
+    mSelection = localPositions;
     update();
 }
 
-void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
+void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> &localPos)
 {
     if (std::find(mSelection.begin(), mSelection.end(), localPos) == mSelection.end())
     {
@@ -62,7 +58,7 @@ void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
     }
 }
 
-void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool toggleInProgress)
+void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool toggleInProgress)
 {
     if (toggleInProgress == true)
     {
@@ -146,7 +142,7 @@ void CSVRender::TerrainSelection::drawShapeSelection(const osg::ref_ptr<osg::Vec
 {
     if (!mSelection.empty())
     {
-        for (std::pair<int, int> localPos : mSelection)
+        for (std::pair<int, int> &localPos : mSelection)
         {
             int x (localPos.first);
             int y (localPos.second);
@@ -189,7 +185,7 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 
         const int textureSizeToLandSizeModifier = (landSize - 1) / landTextureSize;
 
-        for (std::pair<int, int> localPos : mSelection)
+        for (std::pair<int, int> &localPos : mSelection)
         {
             int x (localPos.first);
             int y (localPos.second);

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -60,7 +60,7 @@ void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> &localPos)
 
 void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool toggleInProgress)
 {
-    if (toggleInProgress == true)
+    if (toggleInProgress)
     {
         for(auto const& localPos: localPositions)
         {

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -1,0 +1,271 @@
+#include "terrainselection.hpp"
+
+#include <algorithm>
+
+#include <osg/Group>
+#include <osg/Geometry>
+#include <osg/PositionAttitudeTransform>
+
+#include <components/esm/loadland.hpp>
+
+#include "../../model/world/cellcoordinates.hpp"
+#include "../../model/world/columnimp.hpp"
+#include "../../model/world/idtable.hpp"
+
+#include "cell.hpp"
+#include "worldspacewidget.hpp"
+
+namespace
+{
+    const int cellSize {ESM::Land::REAL_SIZE};
+    const int landSize {ESM::Land::LAND_SIZE};
+    const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
+}
+
+CSVRender::TerrainSelection::TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type):
+mParentNode(parentNode), mWorldspaceWidget (worldspaceWidget), mDraggedOperationFlag(false), mSelectionType(type)
+{
+    mGeometry = new osg::Geometry();
+
+    mSelectionNode = new osg::Group();
+    mSelectionNode->addChild(mGeometry);
+
+    activate();
+}
+
+CSVRender::TerrainSelection::~TerrainSelection()
+{
+    deactivate();
+}
+
+std::vector<std::pair<int, int>> CSVRender::TerrainSelection::getTerrainSelection() const
+{
+    return mSelection;
+}
+
+void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, int>> localPositions)
+{
+    mSelection.clear();
+    for(auto const& value: localPositions)
+    {
+        mSelection.emplace_back(value);
+    }
+    update();
+}
+
+void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
+{
+    if (std::find(mSelection.begin(), mSelection.end(), localPos) == mSelection.end())
+            mSelection.emplace_back(localPos);
+    update();
+}
+
+void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool toggleInProgress)
+{
+    if (toggleInProgress == true)
+    {
+        for(auto const& localPos: localPositions)
+        {
+            auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
+            auto itertemp = std::find(mTemporarySelection.begin(), mTemporarySelection.end(), localPos);
+            mDraggedOperationFlag = true;
+
+            if (itertemp == mTemporarySelection.end())
+            {
+                if (iter != mSelection.end())
+                {
+                    mSelection.erase(iter);
+                }
+                else
+                {
+                    mSelection.emplace_back(localPos);
+                }
+            }
+
+            mTemporarySelection.push_back(localPos);
+        }
+    }
+    else if (mDraggedOperationFlag == false)
+    {
+        for(auto const& localPos: localPositions)
+        {
+            const auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
+            if (iter != mSelection.end())
+            {
+                mSelection.erase(iter);
+            }
+            else
+            {
+                mSelection.emplace_back(localPos);
+            }
+        }
+    }
+    else
+    {
+        mDraggedOperationFlag = false;
+        mTemporarySelection.clear();
+    }
+    update();
+}
+
+void CSVRender::TerrainSelection::activate()
+{
+    mParentNode->addChild(mSelectionNode);
+}
+
+void CSVRender::TerrainSelection::deactivate()
+{
+    mParentNode->removeChild(mSelectionNode);
+}
+
+void CSVRender::TerrainSelection::update()
+{
+    mSelectionNode->removeChild(mGeometry);
+    mGeometry = new osg::Geometry();
+
+    const osg::ref_ptr<osg::Vec3Array> vertices (new osg::Vec3Array);
+
+    switch (mSelectionType)
+    {
+        case TerrainSelectionType::Texture : drawTextureSelection(vertices);
+        break;
+        case TerrainSelectionType::Shape : drawShapeSelection(vertices);
+        break;
+    }
+
+    mGeometry->setVertexArray(vertices);
+    osg::ref_ptr<osg::DrawArrays> drawArrays = new osg::DrawArrays(osg::PrimitiveSet::LINES);
+    drawArrays->setCount(vertices->size());
+    mGeometry->addPrimitiveSet(drawArrays);
+    mSelectionNode->addChild(mGeometry);
+}
+
+void CSVRender::TerrainSelection::drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices)
+{
+    if (!mSelection.empty())
+    {
+        for (std::pair<int, int> localPos : mSelection)
+        {
+            int x (localPos.first);
+            int y (localPos.second);
+
+            float xWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x));
+            float yWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y));
+
+            osg::Vec3f pointXY(xWorldCoord, yWorldCoord, calculateLandHeight(x, y) + 2);
+
+            vertices->push_back(pointXY);
+            vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y - 1), calculateLandHeight(x, y - 1) + 2));
+            vertices->push_back(pointXY);
+            vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x - 1), yWorldCoord, calculateLandHeight(x - 1, y) + 2));
+
+            const auto north = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y + 1));
+            if (north == mSelection.end())
+            {
+                vertices->push_back(pointXY);
+                vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y + 1), calculateLandHeight(x, y + 1) + 2));
+            }
+
+            const auto east = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x + 1, y));
+            if (east == mSelection.end())
+            {
+                vertices->push_back(pointXY);
+                vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x + 1), yWorldCoord, calculateLandHeight(x + 1, y) + 2));
+            }
+        }
+    }
+}
+
+void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::Vec3Array> vertices)
+{
+    if (!mSelection.empty())
+    {
+
+        // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
+        const float nudgePercentage = 0.25f;
+        const int nudgeOffset = (cellSize / landTextureSize) * nudgePercentage;
+        const int landHeightsNudge = (cellSize / landSize) / (landSize - 1); // Does this work with all land size configurations?
+
+        const int textureSizeToLandSizeModifier = (landSize - 1) / landTextureSize;
+
+        for (std::pair<int, int> localPos : mSelection)
+        {
+            int x (localPos.first);
+            int y (localPos.second);
+
+            // convert texture selection to global vertex coordinates at selection box corners
+            int x1 = x * textureSizeToLandSizeModifier + landHeightsNudge;
+            int x2 = x * textureSizeToLandSizeModifier + textureSizeToLandSizeModifier + landHeightsNudge;
+            int y1 = y * textureSizeToLandSizeModifier - landHeightsNudge;
+            int y2 = y * textureSizeToLandSizeModifier + textureSizeToLandSizeModifier - landHeightsNudge;
+
+            // Draw edges (check all sides, draw lines between vertices, +1 height to keep lines above ground)
+            // Check adjancent selections, draw lines only to edges of the selection
+            const auto north = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y + 1));
+            if (north == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
+                }
+            }
+
+            const auto south = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y - 1));
+            if (south == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
+                }
+            }
+
+            const auto east = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x + 1, y));
+            if (east == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
+                }
+            }
+
+            const auto west = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x - 1, y));
+            if (west == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
+                }
+            }
+        }
+    }
+}
+
+int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global vertex coordinates
+{
+    int cellX = std::floor((1.0f*x / (landSize - 1)));
+    int cellY = std::floor((1.0f*y / (landSize - 1)));
+    int localX = x - cellX * (landSize - 1);
+    int localY = y - cellY * (landSize - 1);
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
+
+    CSMDoc::Document& document = mWorldspaceWidget->getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+    const CSMWorld::LandHeightsColumn::DataType mPointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+    return mPointer[localY*landSize + localX];
+}

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -182,7 +182,6 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 {
     if (!mSelection.empty())
     {
-
         // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
         const float nudgePercentage = 0.25f;
         const int nudgeOffset = (cellSize / landTextureSize) * nudgePercentage;

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -140,28 +140,28 @@ void CSVRender::TerrainSelection::drawShapeSelection(const osg::ref_ptr<osg::Vec
             int x (localPos.first);
             int y (localPos.second);
 
-            float xWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x));
-            float yWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y));
+            float xWorldCoord(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(x));
+            float yWorldCoord(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(y));
 
             osg::Vec3f pointXY(xWorldCoord, yWorldCoord, calculateLandHeight(x, y) + 2);
 
             vertices->push_back(pointXY);
-            vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y - 1), calculateLandHeight(x, y - 1) + 2));
+            vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(y - 1), calculateLandHeight(x, y - 1) + 2));
             vertices->push_back(pointXY);
-            vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x - 1), yWorldCoord, calculateLandHeight(x - 1, y) + 2));
+            vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(x - 1), yWorldCoord, calculateLandHeight(x - 1, y) + 2));
 
             const auto north = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y + 1));
             if (north == mSelection.end())
             {
                 vertices->push_back(pointXY);
-                vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y + 1), calculateLandHeight(x, y + 1) + 2));
+                vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(y + 1), calculateLandHeight(x, y + 1) + 2));
             }
 
             const auto east = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x + 1, y));
             if (east == mSelection.end())
             {
                 vertices->push_back(pointXY);
-                vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x + 1), yWorldCoord, calculateLandHeight(x + 1, y) + 2));
+                vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(x + 1), yWorldCoord, calculateLandHeight(x + 1, y) + 2));
             }
         }
     }
@@ -196,10 +196,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
-                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
                 }
             }
 
@@ -208,10 +208,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
-                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
                 }
             }
 
@@ -220,10 +220,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
                 }
             }
 
@@ -232,10 +232,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
                 }
             }
         }

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -30,7 +30,6 @@ namespace CSVRender
     /// \brief Class handling the terrain selection data and rendering
     class TerrainSelection
     {
-
         public:
 
             TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type);

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -46,10 +46,6 @@ namespace CSVRender
 
         protected:
 
-            void addToSelection(osg::Vec3d worldPos);
-            void toggleSelection(osg::Vec3d worldPos);
-            void deselect();
-
             void update();
 
             void drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices);

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -35,9 +35,9 @@ namespace CSVRender
             TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type);
             ~TerrainSelection();
 
-            void onlySelect(const std::vector<std::pair<int, int>> localPositions);
-            void addSelect(const std::pair<int, int> localPos);
-            void toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool);
+            void onlySelect(const std::vector<std::pair<int, int>> &localPositions);
+            void addSelect(const std::pair<int, int> &localPos);
+            void toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool);
 
             void activate();
             void deactivate();

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -1,0 +1,75 @@
+#ifndef CSV_RENDER_TERRAINSELECTION_H
+#define CSV_RENDER_TERRAINSELECTION_H
+
+#include <utility>
+#include <vector>
+
+#include <osg/Vec3d>
+#include <osg/ref_ptr>
+#include <osg/PositionAttitudeTransform>
+
+#include <components/esm/loadland.hpp>
+#include "../../model/world/cellcoordinates.hpp"
+
+namespace osg
+{
+    class Group;
+}
+
+namespace CSVRender
+{
+    struct WorldspaceHitResult;
+    class WorldspaceWidget;
+
+    enum class TerrainSelectionType
+    {
+        Texture,
+        Shape
+    };
+
+    /// \brief Class handling the terrain selection data and rendering
+    class TerrainSelection
+    {
+
+        public:
+
+            TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type);
+            ~TerrainSelection();
+
+            void onlySelect(const std::vector<std::pair<int, int>> localPositions);
+            void addSelect(const std::pair<int, int> localPos);
+            void toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool);
+
+            void activate();
+            void deactivate();
+
+            std::vector<std::pair<int, int>> getTerrainSelection() const;
+
+        protected:
+
+            void addToSelection(osg::Vec3d worldPos);
+            void toggleSelection(osg::Vec3d worldPos);
+            void deselect();
+
+            void update();
+
+            void drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices);
+            void drawTextureSelection(const osg::ref_ptr<osg::Vec3Array> vertices);
+
+            int calculateLandHeight(int x, int y);
+
+        private:
+
+            osg::Group* mParentNode;
+            WorldspaceWidget *mWorldspaceWidget;
+            osg::ref_ptr<osg::PositionAttitudeTransform> mBaseNode;
+            osg::ref_ptr<osg::Geometry> mGeometry;
+            osg::ref_ptr<osg::Group> mSelectionNode;
+            std::vector<std::pair<int, int>> mSelection; // Global terrain selection coordinate in either vertex or texture units
+            std::vector<std::pair<int, int>> mTemporarySelection; // Used during toggle to compare the most recent drag operation
+            bool mDraggedOperationFlag; //true during drag operation, false when click-operation
+            TerrainSelectionType mSelectionType;
+    };
+}
+
+#endif

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -37,7 +37,7 @@ namespace CSVRender
 
             void onlySelect(const std::vector<std::pair<int, int>> &localPositions);
             void addSelect(const std::pair<int, int> &localPos);
-            void toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool);
+            void toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool toggleInProgress);
 
             void activate();
             void deactivate();

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -352,6 +352,7 @@ void CSVRender::TerrainShapeMode::dragWheel (int diff, double speedFactor)
 void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>& vertexCoords, bool dragOperation)
 {
     int r = mBrushSize / 2;
+    if (r == 0) r = 1; // Prevent division by zero later, which might happen when mBrushSize == 1
 
     std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
     CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
@@ -409,7 +410,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                     float smoothedByDistance = 0.0f;
                     if (mShapeEditTool == 0) smoothedByDistance = mTotalDiffY - mTotalDiffY * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
                     if (mShapeEditTool == 1 || mShapeEditTool == 2) smoothedByDistance = (r + mShapeEditToolStrength) - (r + mShapeEditToolStrength) * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
-                    if (distance < r)
+                    if (distance <= r)
                     {
                         if (mShapeEditTool >= 0 && mShapeEditTool < 3) alterHeight(cellCoords, x, y, smoothedByDistance);
                         if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
@@ -978,7 +979,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
                 int distanceX = abs(i - vertexCoords.first);
                 int distanceY = abs(j - vertexCoords.second);
                 int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
-                if (distance < r) selections.emplace_back(std::make_pair(i, j));
+                if (distance <= r) selections.emplace_back(std::make_pair(i, j));
             }
         }
     }

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1,0 +1,1156 @@
+#include "terrainshapemode.hpp"
+
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <QWidget>
+#include <QIcon>
+#include <QEvent>
+#include <QDropEvent>
+#include <QDragEnterEvent>
+#include <QDrag>
+
+#include <osg/Group>
+
+#include <components/esm/loadland.hpp>
+
+#include "../widget/modebutton.hpp"
+#include "../widget/scenetoolbar.hpp"
+#include "../widget/scenetoolshapebrush.hpp"
+
+#include "../../model/doc/document.hpp"
+#include "../../model/prefs/state.hpp"
+#include "../../model/world/columnbase.hpp"
+#include "../../model/world/commandmacro.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/data.hpp"
+#include "../../model/world/idtable.hpp"
+#include "../../model/world/idtree.hpp"
+#include "../../model/world/land.hpp"
+#include "../../model/world/resourcetable.hpp"
+#include "../../model/world/tablemimedata.hpp"
+#include "../../model/world/universalid.hpp"
+
+#include "editmode.hpp"
+#include "pagedworldspacewidget.hpp"
+#include "mask.hpp"
+#include "object.hpp" // Something small needed regarding pointers from here ()
+#include "terrainselection.hpp"
+#include "worldspacewidget.hpp"
+
+CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidget, osg::Group* parentNode, QWidget *parent)
+: EditMode (worldspaceWidget, QIcon {":scenetoolbar/editing-terrain-shape"}, Mask_Terrain | Mask_Reference, "Terrain land editing", parent),
+    mBrushSize(0),
+    mBrushShape(0),
+    mShapeBrushScenetool(0),
+    mDragMode(InteractionType_None),
+    mParentNode(parentNode),
+    mIsEditing(false),
+    mTotalDiffY(0),
+    mShapeEditTool(0),
+    mShapeEditToolStrength(0),
+    mTargetHeight(0)
+{
+}
+
+void CSVRender::TerrainShapeMode::activate(CSVWidget::SceneToolbar* toolbar)
+{
+    if (!mTerrainShapeSelection)
+    {
+        mTerrainShapeSelection.reset(new TerrainSelection(mParentNode, &getWorldspaceWidget(), TerrainSelectionType::Shape));
+    }
+
+    if(!mShapeBrushScenetool)
+    {
+        mShapeBrushScenetool = new CSVWidget::SceneToolShapeBrush (toolbar, "scenetoolshapebrush", getWorldspaceWidget().getDocument());
+        connect(mShapeBrushScenetool, SIGNAL (clicked()), mShapeBrushScenetool, SLOT (activate()));
+        connect(mShapeBrushScenetool->mShapeBrushWindow, SIGNAL(passBrushSize(int)), this, SLOT(setBrushSize(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow, SIGNAL(passBrushShape(int)), this, SLOT(setBrushShape(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow->mSizeSliders->mBrushSizeSlider, SIGNAL(valueChanged(int)), this, SLOT(setBrushSize(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow->mToolSelector, SIGNAL(currentIndexChanged(int)), this, SLOT(setShapeEditTool(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow->mToolStrengthSlider, SIGNAL(valueChanged(int)), this, SLOT(setShapeEditToolStrength(int)));
+    }
+
+    EditMode::activate(toolbar);
+    toolbar->addTool (mShapeBrushScenetool);
+}
+
+void CSVRender::TerrainShapeMode::deactivate(CSVWidget::SceneToolbar* toolbar)
+{
+    if(mShapeBrushScenetool)
+    {
+        toolbar->removeTool (mShapeBrushScenetool);
+        delete mShapeBrushScenetool;
+        mShapeBrushScenetool = 0;
+    }
+    EditMode::deactivate(toolbar);
+}
+
+void CSVRender::TerrainShapeMode::primaryOpenPressed (const WorldspaceHitResult& hit) // Apply changes here
+{
+}
+
+void CSVRender::TerrainShapeMode::primaryEditPressed(const WorldspaceHitResult& hit)
+{
+    mCellId = getWorldspaceWidget().getCellId (hit.worldPos);
+
+    if (hit.hit && hit.tag == 0)
+    {
+    }
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        paged->resetAllAlteredHeights();
+        mTotalDiffY = 0;
+    }
+}
+
+void CSVRender::TerrainShapeMode::primarySelectPressed(const WorldspaceHitResult& hit)
+{
+    if(hit.hit && hit.tag == 0)
+    {
+        selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 0, false);
+    }
+}
+
+void CSVRender::TerrainShapeMode::secondarySelectPressed(const WorldspaceHitResult& hit)
+{
+    if(hit.hit && hit.tag == 0)
+    {
+        selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 1, false);
+    }
+}
+
+bool CSVRender::TerrainShapeMode::primaryEditStartDrag (const QPoint& pos)
+{
+    WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+
+    mCellId = getWorldspaceWidget().getCellId (hit.worldPos);
+
+    mDragMode = InteractionType_PrimaryEdit;
+
+    if (hit.hit && hit.tag == 0)
+    {
+        mEditingPos = hit.worldPos;
+        mIsEditing = true;
+        if (mShapeEditTool == 4)
+        {
+            std::pair<int, int> vertexCoords = CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos);
+            std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
+            int inCellX = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
+            int inCellY = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
+
+            CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+            CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+                *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+            int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+                landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+            mTargetHeight = landShapePointer[inCellY * landSize + inCellX];
+        }
+    }
+
+    return true;
+}
+
+bool CSVRender::TerrainShapeMode::secondaryEditStartDrag (const QPoint& pos)
+{
+    return false;
+}
+
+bool CSVRender::TerrainShapeMode::primarySelectStartDrag (const QPoint& pos)
+{
+    WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+    mDragMode = InteractionType_PrimarySelect;
+    if (!hit.hit || hit.tag != 0)
+    {
+        mDragMode = InteractionType_None;
+        return false;
+    }
+    selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 0, true);
+    return false;
+}
+
+bool CSVRender::TerrainShapeMode::secondarySelectStartDrag (const QPoint& pos)
+{
+    WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+    mDragMode = InteractionType_SecondarySelect;
+    if (!hit.hit || hit.tag != 0)
+    {
+        mDragMode = InteractionType_None;
+        return false;
+    }
+    selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 1, true);
+    return false;
+}
+
+void CSVRender::TerrainShapeMode::drag (const QPoint& pos, int diffX, int diffY, double speedFactor)
+{
+    if (mDragMode == InteractionType_PrimaryEdit)
+    {
+        WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+        std::string cellId = getWorldspaceWidget().getCellId (hit.worldPos);
+        mTotalDiffY += diffY;
+        if (mIsEditing == true && mShapeEditTool == 0) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(mEditingPos), true);
+        if (mIsEditing == true && mShapeEditTool > 0) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), true);
+    }
+
+    if (mDragMode == InteractionType_PrimarySelect)
+    {
+        WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+        if (hit.hit && hit.tag == 0) selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 0, true);
+    }
+
+    if (mDragMode == InteractionType_SecondarySelect)
+    {
+        WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+        if (hit.hit && hit.tag == 0) selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 1, true);
+    }
+}
+
+void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
+{
+    if (mDragMode == InteractionType_PrimaryEdit)
+    {
+        if (mIsEditing == true)
+        {
+            mTotalDiffY = 0;
+            mIsEditing = false;
+        }
+
+        std::sort(mAlteredCells.begin(), mAlteredCells.end());
+        std::set<CSMWorld::CellCoordinates> removeDuplicates(mAlteredCells.begin(), mAlteredCells.end());
+        mAlteredCells.assign(removeDuplicates.begin(), removeDuplicates.end());
+
+        CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+        CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+        CSMWorld::IdTable& ltexTable = dynamic_cast<CSMWorld::IdTable&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_LandTextures));
+
+        int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+        int landnormalsColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandNormalsIndex);
+
+        QUndoStack& undoStack = document.getUndoStack();
+
+        undoStack.beginMacro ("Edit shape and normal records");
+
+        for(CSMWorld::CellCoordinates cellCoordinates: mAlteredCells)
+        {
+            std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY());
+            undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, cellId));
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            CSMWorld::LandHeightsColumn::DataType landShapeNew(landShapePointer);
+            for(int i = 0; i < landSize; ++i)
+            {
+                for(int j = 0; j < landSize; ++j)
+                {
+                    if (CSVRender::PagedWorldspaceWidget *paged =
+                        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+                    {
+                        if (paged->getCellAlteredHeight(cellCoordinates, i, j))
+                            landShapeNew[j * landSize + i] = landShapePointer[j * landSize + i] + *paged->getCellAlteredHeight(cellCoordinates, i, j);
+                        else
+                            landShapeNew[j * landSize + i] = 0;
+                    }
+                }
+            }
+            if (allowLandShapeEditing(cellId) == true) pushEditToCommand(landShapeNew, document, landTable, cellId);
+        }
+
+        for(CSMWorld::CellCoordinates cellCoordinates: mAlteredCells)
+        {
+            std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY());
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            const CSMWorld::LandHeightsColumn::DataType landRightShapePointer = landTable.data(landTable.getModelIndex(CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY()), landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            const CSMWorld::LandHeightsColumn::DataType landDownShapePointer = landTable.data(landTable.getModelIndex(CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1), landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            const CSMWorld::LandNormalsColumn::DataType landNormalsPointer = landTable.data(landTable.getModelIndex(cellId, landnormalsColumn)).value<CSMWorld::LandNormalsColumn::DataType>();
+            CSMWorld::LandNormalsColumn::DataType landNormalsNew(landNormalsPointer);
+
+            for(int i = 0; i < landSize; ++i)
+            {
+                for(int j = 0; j < landSize; ++j)
+                {
+                    float v1[3];
+                    float v2[3];
+                    float normal[3];
+                    float hyp;
+
+                    v1[0] = 128;
+                    v1[1] = 0;
+                    if (i < landSize - 1) v1[2] = landShapePointer[j*landSize+i+1] - landShapePointer[j*landSize+i];
+                    else
+                    {
+                        bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
+                        bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
+                        if (!noLand && !noCell)
+                            v1[2] = landRightShapePointer[j*landSize+1] - landShapePointer[j*landSize+i];
+                        else
+                            v1[2] = 0;
+                    }
+
+                    v2[0] = 0;
+                    v2[1] = 128;
+                    if (j < landSize - 1) v2[2] = landShapePointer[(j+1)*landSize+i] - landShapePointer[j*landSize+i];
+                    else
+                    {
+                        bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
+                        bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
+                        if (!noLand && !noCell)
+                            v2[2] = landDownShapePointer[landSize+i] - landShapePointer[j*landSize+i];
+                        else
+                            v2[2] = 0;
+                    }
+
+                    normal[1] = v1[2]*v2[0] - v1[0]*v2[2];
+                    normal[0] = v1[1]*v2[2] - v1[2]*v2[1];
+                    normal[2] = v1[0]*v2[1] - v1[1]*v2[0];
+
+                    hyp = sqrt(normal[0]*normal[0] + normal[1]*normal[1] + normal[2]*normal[2]) / 127.0f;
+
+                    normal[0] /= hyp;
+                    normal[1] /= hyp;
+                    normal[2] /= hyp;
+
+                    landNormalsNew[(j*landSize+i)*3+0] = normal[0];
+                    landNormalsNew[(j*landSize+i)*3+1] = normal[1];
+                    landNormalsNew[(j*landSize+i)*3+2] = normal[2];
+                }
+            }
+            if (allowLandShapeEditing(cellId) == true) pushNormalsEditToCommand(landNormalsNew, document, landTable, cellId);
+        }
+        undoStack.endMacro();
+        mAlteredCells.clear();
+
+        if (CSVRender::PagedWorldspaceWidget *paged =
+            dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+        {
+            paged->resetAllAlteredHeights();
+            mTotalDiffY = 0;
+        }
+    }
+}
+
+
+void CSVRender::TerrainShapeMode::dragAborted()
+{
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        paged->resetAllAlteredHeights();
+        mTotalDiffY = 0;
+    }
+}
+
+void CSVRender::TerrainShapeMode::dragWheel (int diff, double speedFactor)
+{
+}
+
+void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>& vertexCoords, bool dragOperation)
+{
+    int r = mBrushSize / 2;
+
+    std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
+    CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        if (mShapeEditTool == 0) paged->resetAllAlteredHeights();
+    }
+
+    if(allowLandShapeEditing(cellId)==true)
+    {
+        if (mBrushShape == 0)
+        {
+            int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
+            int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
+            if (mShapeEditTool == 0) alterHeight(cellCoords, x, y, mTotalDiffY);
+            if (mShapeEditTool == 1 || mShapeEditTool == 2) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+            if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+            if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+        }
+
+        if (mBrushShape == 1)
+        {
+            for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+            {
+                for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+                {
+                    cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
+                    cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                    int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
+                    int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
+                    if (mShapeEditTool == 0) alterHeight(cellCoords, x, y, mTotalDiffY);
+                    if (mShapeEditTool == 1 || mShapeEditTool == 2) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+                }
+            }
+        }
+
+        if (mBrushShape == 2)
+        {
+            for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+            {
+                for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+                {
+                    cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
+                    cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                    int distanceX = abs(i - vertexCoords.first);
+                    int distanceY = abs(j - vertexCoords.second);
+                    int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                    int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
+                    int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
+                    float distancePerRadius = 1.0f * distance / r;
+                    float smoothedByDistance = 0.0f;
+                    if (mShapeEditTool == 0) smoothedByDistance = mTotalDiffY - mTotalDiffY * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
+                    if (mShapeEditTool == 1 || mShapeEditTool == 2) smoothedByDistance = (r + mShapeEditToolStrength) - (r + mShapeEditToolStrength) * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
+                    if (distance < r)
+                    {
+                        if (mShapeEditTool >= 0 && mShapeEditTool < 3) alterHeight(cellCoords, x, y, smoothedByDistance);
+                        if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+                        if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+                    }
+                }
+            }
+        }
+        if (mBrushShape == 3)
+        {
+            if(!mCustomBrushShape.empty())
+            {
+                for(auto const& value: mCustomBrushShape)
+                {
+                    cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(vertexCoords.first + value.first, vertexCoords.second + value.second));
+                    cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                    int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first + value.first);
+                    int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second + value.second);
+                    if (mShapeEditTool == 0) alterHeight(cellCoords, x, y, mTotalDiffY);
+                    if (mShapeEditTool == 1 || mShapeEditTool == 2) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+                }
+            }
+        }
+
+    }
+}
+
+void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float alteredHeight, bool useTool)
+{
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+    std::string cellRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
+    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+    std::string cellDownId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
+    std::string cellUpLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() - 1);
+    std::string cellUpRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY() - 1);
+    std::string cellDownLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() + 1);
+    std::string cellDownRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY() + 1);
+
+    if(allowLandShapeEditing(cellId)==true)
+    {
+        if (useTool) mAlteredCells.emplace_back(cellCoords);
+        if (CSVRender::PagedWorldspaceWidget *paged =
+            dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+        {
+            if (useTool)
+            {
+                if (mShapeEditTool == 0)
+                {
+                    // Get distance from modified land, alter land change based on zoom
+                    osg::Vec3d eye, center, up;
+                    paged->getCamera()->getViewMatrixAsLookAt(eye, center, up);
+                    osg::Vec3d distance = eye - mEditingPos;
+                    alteredHeight = alteredHeight * (distance.length() / 500);
+                }
+                if (mShapeEditTool == 1) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) + alteredHeight;
+                if (mShapeEditTool == 2) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) - alteredHeight;
+                if (mShapeEditTool == 3) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) + alteredHeight;
+            }
+
+            paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
+
+            // Change values of cornering cells
+            if (inCellX == 0 && inCellY == 0)
+            {
+                if(allowLandShapeEditing(cellUpLeftId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(-1, -1));
+                    paged->setCellAlteredHeight(cellCoords.move(-1, -1), landSize - 1, landSize - 1, alteredHeight);
+                }
+            }
+            else if (inCellX == 0 && inCellY == landSize - 1)
+            {
+                if(allowLandShapeEditing(cellDownLeftId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(-1, 1));
+                    paged->setCellAlteredHeight(cellCoords.move(-1, 1), landSize - 1, 0, alteredHeight);
+                }
+            }
+            else if (inCellX == landSize - 1 && inCellY == 0)
+            {
+                if(allowLandShapeEditing(cellUpRightId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(1, -1));
+                    paged->setCellAlteredHeight(cellCoords.move(1, -1), 0, landSize - 1, alteredHeight);
+                }
+            }
+            else if (inCellX == landSize - 1 && inCellY == landSize -1)
+            {
+                if(allowLandShapeEditing(cellDownRightId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(1, 1));
+                    paged->setCellAlteredHeight(cellCoords.move(1, 1), 0, 0, alteredHeight);
+                }
+            }
+
+            // Change values of edging cells
+            if (inCellX == 0)
+            {
+                if(allowLandShapeEditing(cellLeftId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(-1, 0));
+                    paged->setCellAlteredHeight(cellCoords.move(-1, 0), landSize - 1, inCellY, alteredHeight);
+                }
+            }
+            if (inCellY == 0)
+            {
+                if(allowLandShapeEditing(cellUpId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(0, -1));
+                    paged->setCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 1, alteredHeight);
+                }
+            }
+
+            if (inCellX == landSize - 1)
+            {
+                if(allowLandShapeEditing(cellRightId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(1, 0));
+                    paged->setCellAlteredHeight(cellCoords.move(1, 0), 0, inCellY, alteredHeight);
+                }
+            }
+            if (inCellY == landSize - 1)
+            {
+                if(allowLandShapeEditing(cellUpId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(0, 1));
+                    paged->setCellAlteredHeight(cellCoords.move(0, 1), inCellX, 0, alteredHeight);
+                }
+            }
+
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::smoothHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength)
+{
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+        CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+        int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+        std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+        const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+        // ### Variable naming key ###
+        // Variables here hold either the real value, or the altered value of current edit.
+        // this = this Cell
+        // left = x - 1, up = y - 1, right = x + 1, down = y + 1
+        // Altered = transient edit (in current edited)
+        float thisAlteredHeight = 0.0f;
+        if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) != nullptr)
+            thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
+        float thisHeight = landShapePointer[inCellY * landSize + inCellX];
+        float leftHeight = 0.0f;
+        float leftAlteredHeight = 0.0f;
+        float upAlteredHeight = 0.0f;
+        float rightHeight = 0.0f;
+        float rightAlteredHeight = 0.0f;
+        float downHeight = 0.0f;
+        float downAlteredHeight = 0.0f;
+        float upHeight = 0.0f;
+
+        if(allowLandShapeEditing(cellId)==true)
+        {
+            //Get key values for calculating average, handle cell edges, check for null pointers
+            if (inCellX == 0)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+                const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                leftHeight = landLeftShapePointer[inCellY * landSize + (landSize - 2)];
+                if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), inCellX, landSize - 2))
+                    leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY);
+            }
+            if (inCellY == 0)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+                const CSMWorld::LandHeightsColumn::DataType landUpShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                upHeight = landUpShapePointer[(landSize - 2) * landSize + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2))
+                    upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2);
+            }
+            if (inCellX > 0)
+            {
+                leftHeight = landShapePointer[inCellY * landSize + inCellX - 1];
+                leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY);
+            }
+            if (inCellY > 0)
+            {
+                upHeight = landShapePointer[(inCellY - 1) * landSize + inCellX];
+                upAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1);
+            }
+            if (inCellX == landSize - 1)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
+                const CSMWorld::LandHeightsColumn::DataType landRightShapePointer =
+                    landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                rightHeight = landRightShapePointer[inCellY * landSize + 1];
+                if (paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY))
+                {
+                    rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY);
+                }
+            }
+            if (inCellY == landSize - 1)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
+                const CSMWorld::LandHeightsColumn::DataType landDownShapePointer =
+                    landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                downHeight = landDownShapePointer[1 * landSize + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1))
+                {
+                    downAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1);
+                }
+            }
+            if (inCellX < landSize - 1)
+            {
+                rightHeight = landShapePointer[inCellY * landSize + inCellX + 1];
+                if(paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY))
+                    rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY);
+            }
+            if (inCellY < landSize - 1)
+            {
+                downHeight = landShapePointer[(inCellY + 1) * landSize + inCellX];
+                if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1))
+                    downAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1);
+            }
+
+            float averageHeight = (upHeight + downHeight + rightHeight + leftHeight +
+                upAlteredHeight + downAlteredHeight + rightAlteredHeight + leftAlteredHeight) / 4;
+            if ((thisHeight + thisAlteredHeight) != averageHeight) mAlteredCells.emplace_back(cellCoords);
+            if (toolStrength > abs(thisHeight + thisAlteredHeight - averageHeight) && toolStrength > 8.0f) toolStrength =
+                abs(thisHeight + thisAlteredHeight - averageHeight); //Cut down excessive changes
+            if (thisHeight + thisAlteredHeight > averageHeight) alterHeight(cellCoords, inCellX, inCellY, -toolStrength);
+            if (thisHeight + thisAlteredHeight < averageHeight) alterHeight(cellCoords, inCellX, inCellY, +toolStrength);
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::flattenHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength, int targetHeight)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+    float thisHeight = 0.0f;
+    float thisAlteredHeight = 0.0f;
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    bool noCell = document.getData().getCells().searchId (cellId) == -1;
+    bool noLand = document.getData().getLand().searchId (cellId) == -1;
+
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        if (!noCell && !noLand)
+        {
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+                landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+            if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY))
+                thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
+            thisHeight = landShapePointer[inCellY * landSize + inCellX];
+        }
+    }
+
+    if (toolStrength > abs(thisHeight - targetHeight) && toolStrength > 8.0f) toolStrength =
+        abs(thisHeight - targetHeight); //Cut down excessive changes
+    if (thisHeight + thisAlteredHeight > targetHeight) alterHeight(cellCoords, inCellX, inCellY, -toolStrength);
+    if (thisHeight + thisAlteredHeight < targetHeight) alterHeight(cellCoords, inCellX, inCellY, +toolStrength);
+}
+
+void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* thisHeight,
+    float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+    std::string cellUpLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() - 1);
+    bool noCell = document.getData().getCells().searchId (cellId) == -1;
+    bool noLand = document.getData().getLand().searchId (cellId) == -1;
+    bool noLeftCell = document.getData().getCells().searchId (cellLeftId) == -1;
+    bool noLeftLand = document.getData().getLand().searchId (cellLeftId) == -1;
+    bool noUpCell = document.getData().getCells().searchId (cellUpId) == -1;
+    bool noUpLand = document.getData().getLand().searchId (cellUpId) == -1;
+
+    *thisHeight = 0.0f; // real + altered height
+    *thisAlteredHeight = 0.0f;  // only altered height
+    *leftHeight = 0.0f;
+    *leftAlteredHeight = 0.0f;
+    *upHeight = 0.0f;
+    *upAlteredHeight = 0.0f;
+
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        if (!noCell && !noLand)
+        {
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+                landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+            if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY))
+                *thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
+            *thisHeight = landShapePointer[inCellY * landSize + inCellX] + *thisAlteredHeight;
+
+            // In case of cell edge, and touching cell/land is not found, assume that left and up -heights would be the same
+            // This is to prevent unnecessary action at limitHeightChange()
+            *leftHeight = *thisHeight;
+            *upHeight = *thisHeight;
+
+            if (inCellX == 0)
+            {
+                if(!noLeftCell && !noLeftLand)
+                {
+                    const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer =
+                        landTable.data(landTable.getModelIndex(cellLeftId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                    *leftHeight = landLeftShapePointer[inCellY * landSize + (landSize - 2)];
+                    if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY))
+                    {
+                        *leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY);
+                        *leftHeight += *leftAlteredHeight;
+                    }
+                }
+            }
+            if (inCellY == 0)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+                if(!noUpCell && !noUpLand)
+                {
+                    const CSMWorld::LandHeightsColumn::DataType landUpShapePointer =
+                        landTable.data(landTable.getModelIndex(cellUpId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                    *upHeight = landUpShapePointer[(landSize - 2) * landSize + inCellX];
+                    if (paged->getCellAlteredHeight(cellCoords.move(0,-1), inCellX, landSize - 2))
+                    {
+                        *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2);
+                        *upHeight += *upAlteredHeight;
+                    }
+                }
+            }
+            if (inCellX != 0)
+            {
+                *leftHeight = landShapePointer[inCellY * landSize + inCellX - 1];
+                if (paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY))
+                    *leftAlteredHeight += *paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY);
+                *leftHeight += *leftAlteredHeight;
+            }
+            if (inCellY != 0)
+            {
+                *upHeight = landShapePointer[(inCellY - 1) * landSize + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1))
+                    *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1);
+                *upHeight += *upAlteredHeight;
+            }
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::fixEdges(const CSMWorld::CellCoordinates& cellCoords)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+    std::string cellRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
+    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+    std::string cellDownId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
+    if (allowLandShapeEditing(cellId) == true)
+    {
+        const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer = landTable.data(landTable.getModelIndex(cellLeftId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landRightShapePointer = landTable.data(landTable.getModelIndex(cellRightId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landUpShapePointer = landTable.data(landTable.getModelIndex(cellUpId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landDownShapePointer = landTable.data(landTable.getModelIndex(cellDownId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        CSMWorld::LandHeightsColumn::DataType landShapeNew(landShapePointer);
+        for(int i = 0; i < landSize; ++i)
+        {
+            if(document.getData().getCells().searchId (cellLeftId) != -1 && document.getData().getLand().searchId (cellLeftId) != -1 && landShapePointer[i * landSize] != landLeftShapePointer[i * landSize + landSize - 1]) landShapeNew[i * landSize] = landLeftShapePointer[i * landSize + landSize - 1];
+            if(document.getData().getCells().searchId (cellRightId) != -1 && document.getData().getLand().searchId (cellRightId) != -1 && landShapePointer[i * landSize + landSize - 1] != landRightShapePointer[i * landSize]) landShapeNew[i * landSize + landSize - 1] = landRightShapePointer[i * landSize];
+            if(document.getData().getCells().searchId (cellUpId) != -1 && document.getData().getLand().searchId (cellUpId) != -1 && landShapePointer[i] != landUpShapePointer[(landSize - 1) * landSize + i]) landShapeNew[i] = landUpShapePointer[(landSize - 1) * landSize + i];
+            if(document.getData().getCells().searchId (cellDownId) != -1 && document.getData().getLand().searchId (cellDownId) != -1 && landShapePointer[(landSize - 1) * landSize + i] != landDownShapePointer[i]) landShapeNew[(landSize - 1) * landSize + i] = landDownShapePointer[i];
+        }
+        pushEditToCommand(landShapeNew, document, landTable, cellId);
+    }
+}
+
+void CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+
+    int limitHeightChange = 1024.0f; // Limited by save format
+    bool noCell = document.getData().getCells().searchId (cellId) == -1;
+    bool noLand = document.getData().getLand().searchId (cellId) == -1;
+    bool dataAlteredAtThisCell = false;
+    int maxPasses = 5; //Multiple passes are needed if there are consecutive height differences over the limit
+
+    if (!noCell && !noLand)
+    {
+        const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+            landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+        for (int passes = 0; passes < maxPasses; ++passes)
+        {
+            for(int inCellX = 0; inCellX < landSize; ++inCellX)
+            {
+                for(int inCellY = 0; inCellY < landSize; ++inCellY)
+                {
+                    // ### Variable naming key ###
+                    // Variables here aim to hold the final value, which is (real_value + altered_value)
+                    // this = this Cell
+                    // left = x - 1, up = y - 1
+                    // Altered = transient edit (in current edited)
+                    // Binding = the last row or column, the one that binds cell land together
+
+                    float thisHeight = 0.0f;
+                    float thisAlteredHeight = 0.0f;
+                    float leftHeight = 0.0f;
+                    float leftAlteredHeight = 0.0f;
+                    float upHeight = 0.0f;
+                    float upAlteredHeight = 0.0f;
+
+                    updateKeyHeightValues(cellCoords, inCellX, inCellY, &thisHeight, &thisAlteredHeight, &leftHeight, &leftAlteredHeight,
+                        &upHeight, &upAlteredHeight);
+
+                    bool doChange = false;
+
+                    // Check for height limits, prioritize left over up, except in left-right -cell edges
+                    if (thisHeight - upHeight >= limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight + (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - upHeight <= -limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight - (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight >= limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight + (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight <= -limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight - (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+
+                    // Apply limits
+                    if (doChange == true)
+                    {
+                        alterHeight(cellCoords, inCellX, inCellY, thisAlteredHeight, false);
+                        dataAlteredAtThisCell = true;
+                    }
+                }
+            }
+
+            //Skip unneeded extra passes
+            if (dataAlteredAtThisCell == false)
+            {
+                passes = maxPasses;
+                continue;
+            }
+
+            //Inverse check (implement properly after default check works)
+            for(int inCellX = landSize - 1; inCellX >= 0; --inCellX)
+            {
+                for(int inCellY = landSize - 1; inCellY >= 0; --inCellY)
+                {
+                    // ### Variable naming key ###
+                    // Variables here aim to hold the final value, which is (real_value + altered_value)
+                    // this = this Cell
+                    // left = x - 1, up = y - 1
+                    // Altered = transient edit (in current edited)
+                    // Binding = the last row or column, the one that binds cell land together
+
+                    float thisHeight = 0.0f;
+                    float thisAlteredHeight = 0.0f;
+                    float leftHeight = 0.0f;
+                    float leftAlteredHeight = 0.0f;
+                    float upHeight = 0.0f;
+                    float upAlteredHeight = 0.0f;
+
+                    updateKeyHeightValues(cellCoords, inCellX, inCellY, &thisHeight, &thisAlteredHeight, &leftHeight, &leftAlteredHeight,
+                        &upHeight, &upAlteredHeight);
+
+                    bool doChange = false;
+
+                    // Check for height limits, prioritize left over up, except in left-right -cell edges
+                    if (thisHeight - upHeight >= limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight + limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - upHeight <= -limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight - limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight >= limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight + limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight <= -limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight - limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+
+                    // Apply limits
+                    if (doChange == true)
+                    {
+                        alterHeight(cellCoords, inCellX, inCellY, thisAlteredHeight, false);
+                        dataAlteredAtThisCell = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation)
+{
+    int r = mBrushSize / 2;
+    std::vector<std::pair<int, int>> selections;
+
+    if (mBrushShape == 0)
+    {
+        selections.emplace_back(vertexCoords);
+    }
+
+    if (mBrushShape == 1)
+    {
+        for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+        {
+            for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+            {
+                selections.emplace_back(std::make_pair(i, j));
+            }
+        }
+    }
+
+    if (mBrushShape == 2)
+    {
+        for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+        {
+            for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+            {
+                int distanceX = abs(i - vertexCoords.first);
+                int distanceY = abs(j - vertexCoords.second);
+                int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                if (distance < r) selections.emplace_back(std::make_pair(i, j));
+            }
+        }
+    }
+
+    if (mBrushShape == 3)
+    {
+        if(!mCustomBrushShape.empty())
+        {
+            for(auto const& value: mCustomBrushShape)
+            {
+                selections.emplace_back(std::make_pair(vertexCoords.first + value.first, vertexCoords.second + value.second));
+            }
+        }
+    }
+
+    if(selectMode == 0) mTerrainShapeSelection->onlySelect(selections);
+    if(selectMode == 1) mTerrainShapeSelection->toggleSelect(selections, dragOperation);
+
+}
+
+void CSVRender::TerrainShapeMode::pushEditToCommand(const CSMWorld::LandHeightsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+    CSMWorld::IdTable& landTable, std::string cellId)
+{
+    QVariant changedLand;
+    changedLand.setValue(newLandGrid);
+
+    QModelIndex index(landTable.getModelIndex (cellId, landTable.findColumnIndex (CSMWorld::Columns::ColumnId_LandHeightsIndex)));
+
+    QUndoStack& undoStack = document.getUndoStack();
+    undoStack.push (new CSMWorld::ModifyCommand(landTable, index, changedLand));
+}
+
+void CSVRender::TerrainShapeMode::pushNormalsEditToCommand(const CSMWorld::LandNormalsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+    CSMWorld::IdTable& landTable, std::string cellId)
+{
+    QVariant changedLand;
+    changedLand.setValue(newLandGrid);
+
+    QModelIndex index(landTable.getModelIndex (cellId, landTable.findColumnIndex (CSMWorld::Columns::ColumnId_LandNormalsIndex)));
+
+    QUndoStack& undoStack = document.getUndoStack();
+    undoStack.push (new CSMWorld::ModifyCommand(landTable, index, changedLand));
+}
+
+bool CSVRender::TerrainShapeMode::allowLandShapeEditing(std::string cellId)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    CSMWorld::IdTree& cellTable = dynamic_cast<CSMWorld::IdTree&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_Cells));
+
+    bool noCell = document.getData().getCells().searchId (cellId)==-1;
+    bool noLand = document.getData().getLand().searchId (cellId)==-1;
+
+    if (noCell)
+    {
+        std::string mode = CSMPrefs::get()["3D Scene Editing"]["outside-landedit"].toString();
+
+        // target cell does not exist
+        if (mode=="Discard")
+            return false;
+
+        if (mode=="Create cell and land, then edit")
+        {
+            std::unique_ptr<CSMWorld::CreateCommand> createCommand (
+                new CSMWorld::CreateCommand (cellTable, cellId));
+            int parentIndex = cellTable.findColumnIndex (CSMWorld::Columns::ColumnId_Cell);
+            int index = cellTable.findNestedColumnIndex (parentIndex, CSMWorld::Columns::ColumnId_Interior);
+            createCommand->addNestedValue (parentIndex, index, false);
+            document.getUndoStack().push (createCommand.release());
+
+            if (CSVRender::PagedWorldspaceWidget *paged =
+                dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+            {
+                CSMWorld::CellSelection selection = paged->getCellSelection();
+                selection.add (CSMWorld::CellCoordinates::fromId (cellId).first);
+                paged->setCellSelection (selection);
+            }
+        }
+    }
+    else if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        CSMWorld::CellSelection selection = paged->getCellSelection();
+        if (!selection.has (CSMWorld::CellCoordinates::fromId (cellId).first))
+        {
+            // target cell exists, but is not shown
+            std::string mode =
+                CSMPrefs::get()["3D Scene Editing"]["outside-visible-landedit"].toString();
+
+            if (mode=="Discard")
+                return false;
+
+            if (mode=="Show cell and edit")
+            {
+                selection.add (CSMWorld::CellCoordinates::fromId (cellId).first);
+                paged->setCellSelection (selection);
+            }
+        }
+    }
+
+    if (noLand)
+    {
+        std::string mode = CSMPrefs::get()["3D Scene Editing"]["outside-landedit"].toString();
+
+        // target cell does not exist
+        if (mode=="Discard")
+            return false;
+
+        if (mode=="Create cell and land, then edit")
+        {
+            document.getUndoStack().push (new CSMWorld::CreateCommand (landTable, cellId));
+            fixEdges(CSMWorld::CellCoordinates::fromId (cellId).first);
+        }
+    }
+
+    return true;
+}
+
+void CSVRender::TerrainShapeMode::dragMoveEvent (QDragMoveEvent *event)
+{
+}
+
+void CSVRender::TerrainShapeMode::setBrushSize(int brushSize)
+{
+    mBrushSize = brushSize;
+}
+
+void CSVRender::TerrainShapeMode::setBrushShape(int brushShape)
+{
+    mBrushShape = brushShape;
+
+    //Set custom brush shape
+    if (mBrushShape == 3 && !mTerrainShapeSelection->getTerrainSelection().empty())
+    {
+        auto terrainSelection = mTerrainShapeSelection->getTerrainSelection();
+        int selectionCenterX = 0;
+        int selectionCenterY = 0;
+        int selectionAmount = 0;
+
+        for(auto const& value: terrainSelection)
+        {
+            selectionCenterX = selectionCenterX + value.first;
+            selectionCenterY = selectionCenterY + value.second;
+            ++selectionAmount;
+        }
+        selectionCenterX = selectionCenterX / selectionAmount;
+        selectionCenterY = selectionCenterY / selectionAmount;
+
+        mCustomBrushShape.clear();
+        std::pair<int, int> differentialPos {};
+        for(auto const& value: terrainSelection)
+        {
+            differentialPos.first = value.first - selectionCenterX;
+            differentialPos.second = value.second - selectionCenterY;
+            mCustomBrushShape.push_back(differentialPos);
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::setShapeEditTool(int shapeEditTool)
+{
+    mShapeEditTool = shapeEditTool;
+}
+
+void CSVRender::TerrainShapeMode::setShapeEditToolStrength(int shapeEditToolStrength)
+{
+    mShapeEditToolStrength = shapeEditToolStrength;
+}
+
+CSVRender::PagedWorldspaceWidget& CSVRender::TerrainShapeMode::getPagedWorldspaceWidget()
+{
+    return dynamic_cast<PagedWorldspaceWidget&>(getWorldspaceWidget());
+}

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -1,0 +1,157 @@
+#ifndef CSV_RENDER_TERRAINSHAPEMODE_H
+#define CSV_RENDER_TERRAINSHAPEMODE_H
+
+#include "editmode.hpp"
+
+#include <string>
+#include <memory>
+
+#include <QWidget>
+#include <QEvent>
+
+#ifndef Q_MOC_RUN
+#include "../../model/world/data.hpp"
+#include "../../model/world/land.hpp"
+
+#include "../../model/doc/document.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/idtable.hpp"
+#include "../../model/world/landtexture.hpp"
+#endif
+
+#include "terrainselection.hpp"
+
+namespace CSVWidget
+{
+    class SceneToolShapeBrush;
+}
+
+namespace CSVRender
+{
+    class PagedWorldspaceWidget;
+
+    /// \brief EditMode for handling the terrain shape editing
+    class TerrainShapeMode : public EditMode
+    {
+        Q_OBJECT
+
+        public:
+
+            enum InteractionType
+            {
+                InteractionType_PrimaryEdit,
+                InteractionType_PrimarySelect,
+                InteractionType_SecondaryEdit,
+                InteractionType_SecondarySelect,
+                InteractionType_None
+            };
+
+            /// Editmode for terrain shape grid
+            TerrainShapeMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
+
+            void primaryOpenPressed (const WorldspaceHitResult& hit);
+
+            /// Create single command for one-click shape editing
+            void primaryEditPressed (const WorldspaceHitResult& hit);
+
+            /// Open brush settings window
+            void primarySelectPressed(const WorldspaceHitResult&);
+
+            void secondarySelectPressed(const WorldspaceHitResult&);
+
+            void activate(CSVWidget::SceneToolbar*);
+            void deactivate(CSVWidget::SceneToolbar*);
+
+            /// Start shape editing command macro
+            virtual bool primaryEditStartDrag (const QPoint& pos);
+
+            virtual bool secondaryEditStartDrag (const QPoint& pos);
+            virtual bool primarySelectStartDrag (const QPoint& pos);
+            virtual bool secondarySelectStartDrag (const QPoint& pos);
+
+            /// Handle shape edit behavior during dragging
+            virtual void drag (const QPoint& pos, int diffX, int diffY, double speedFactor);
+
+            /// End shape editing command macro
+            virtual void dragCompleted(const QPoint& pos);
+
+            /// Cancel shape editing, and reset all pending changes
+            virtual void dragAborted();
+
+            virtual void dragWheel (int diff, double speedFactor);
+            virtual void dragMoveEvent (QDragMoveEvent *event);
+
+            /// Handle brush mechanics for shape editing
+            void editTerrainShapeGrid (const std::pair<int, int>& vertexCoords, bool dragOperation);
+
+            /// Do a single height alteration for transient shape edit map
+            void alterHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float alteredHeight, bool useTool = true);
+
+            /// Do a single smoothing height alteration for transient shape edit map
+            void smoothHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength);
+
+            /// Do a single flattening height alteration for transient shape edit map
+            void flattenHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength, int targetHeight);
+
+            /// Update the key values used in height calculations
+            void updateKeyHeightValues(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* thisHeight,
+                float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight);
+
+            /// Bind edge vertices to next cells
+            void fixEdges(const CSMWorld::CellCoordinates& cellCoords);
+
+            /// Check that the edit doesn't break save format limits, fix if necessary
+            void limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords);
+
+            /// Handle brush mechanics for terrain shape selection
+            void selectTerrainShapes (const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation);
+
+            /// Push terrain shape edits to command macro
+            void pushEditToCommand (const CSMWorld::LandHeightsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+                CSMWorld::IdTable& landTable, std::string cellId);
+
+            /// Push land normals edits to command macro
+            void pushNormalsEditToCommand(const CSMWorld::LandNormalsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+                CSMWorld::IdTable& landTable, std::string cellId);
+
+            /// Create new cell and land if needed
+            bool allowLandShapeEditing(std::string textureFileName);
+
+        private:
+            std::string mCellId;
+            std::string mBrushTexture;
+            int mBrushSize;
+            int mBrushShape;
+            std::vector<std::pair<int, int>> mCustomBrushShape;
+            CSVWidget::SceneToolShapeBrush *mShapeBrushScenetool;
+            int mDragMode;
+            osg::Group* mParentNode;
+            bool mIsEditing;
+            std::unique_ptr<TerrainSelection> mTerrainShapeSelection;
+            int mTotalDiffY;
+            std::vector<CSMWorld::CellCoordinates> mAlteredCells;
+            osg::Vec3d mEditingPos;
+            int mShapeEditTool;
+            int mShapeEditToolStrength;
+            int mTargetHeight;
+
+            const int cellSize {ESM::Land::REAL_SIZE};
+            const int landSize {ESM::Land::LAND_SIZE};
+            const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
+
+            PagedWorldspaceWidget& getPagedWorldspaceWidget();
+
+        signals:
+            void passBrushTexture(std::string brushTexture);
+
+        public slots:
+            //void handleDropEvent(QDropEvent *event);
+            void setBrushSize(int brushSize);
+            void setBrushShape(int brushShape);
+            void setShapeEditTool(int shapeEditTool);
+            void setShapeEditToolStrength(int shapeEditToolStrength);
+    };
+}
+
+
+#endif

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -1,15 +1,25 @@
 #include "terrainstorage.hpp"
 
+#include <set>
+#include <memory>
+
 #include "../../model/world/land.hpp"
 #include "../../model/world/landtexture.hpp"
 
+#include <components/esmterrain/storage.hpp>
+#include <components/debug/debuglog.hpp>
+#include <components/misc/resourcehelpers.hpp>
+#include <components/vfs/manager.hpp>
+
 namespace CSVRender
 {
+    const float defaultHeight = ESM::Land::DEFAULT_HEIGHT;
 
     TerrainStorage::TerrainStorage(const CSMWorld::Data &data)
         : ESMTerrain::Storage(data.getResourceSystem()->getVFS())
         , mData(data)
     {
+        resetHeights();
     }
 
     osg::ref_ptr<const ESMTerrain::LandObject> TerrainStorage::getLand(int cellX, int cellY)
@@ -31,6 +41,209 @@ namespace CSVRender
             return nullptr;
 
         return &mData.getLandTextures().getRecord(row).get();
+    }
+
+    void TerrainStorage::setAlteredHeight(int inCellX, int inCellY, float height)
+    {
+        mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX] = height - fmod(height, 8); //Limit to divisible by 8 to avoid cell seam breakage
+    }
+
+    void TerrainStorage::resetHeights()
+    {
+        for (int x = 0; x < ESM::Land::LAND_SIZE; ++x)
+        {
+            for (int y = 0; y < ESM::Land::LAND_SIZE; ++y)
+            {
+                mAlteredHeight[y*ESM::Land::LAND_SIZE + x] = 0;
+            }
+        }
+    }
+
+    float TerrainStorage::getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY)
+    {
+        float height = 0.f;
+        osg::ref_ptr<const ESMTerrain::LandObject> land = getLand (cellX, cellY);
+        if (land)
+        {
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VHGT) : 0;
+            if (data) height = getVertexHeight(data, inCellX, inCellY);
+        }
+        else return height;
+        return mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX] + height;
+
+    }
+
+    float* TerrainStorage::getAlteredHeights()
+    {
+        return mAlteredHeight;
+    }
+
+    float* TerrainStorage::getAlteredHeight(int inCellX, int inCellY)
+    {
+        return &mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX];
+    }
+
+    void TerrainStorage::fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
+                                            osg::ref_ptr<osg::Vec3Array> positions,
+                                            osg::ref_ptr<osg::Vec3Array> normals,
+                                            osg::ref_ptr<osg::Vec4ubArray> colours)
+    {
+        // LOD level n means every 2^n-th vertex is kept
+        size_t increment = static_cast<size_t>(1) << lodLevel;
+
+        osg::Vec2f origin = center - osg::Vec2f(size/2.f, size/2.f);
+
+        int startCellX = static_cast<int>(std::floor(origin.x()));
+        int startCellY = static_cast<int>(std::floor(origin.y()));
+
+        size_t numVerts = static_cast<size_t>(size*(ESM::Land::LAND_SIZE - 1) / increment + 1);
+
+        positions->resize(numVerts*numVerts);
+        normals->resize(numVerts*numVerts);
+        colours->resize(numVerts*numVerts);
+
+        osg::Vec3f normal;
+        osg::Vec4ub color;
+
+        float vertY = 0;
+        float vertX = 0;
+
+        ESMTerrain::LandCache cache;
+
+        float vertY_ = 0; // of current cell corner
+        for (int cellY = startCellY; cellY < startCellY + std::ceil(size); ++cellY)
+        {
+            float vertX_ = 0; // of current cell corner
+            for (int cellX = startCellX; cellX < startCellX + std::ceil(size); ++cellX)
+            {
+                const ESMTerrain::LandObject* land = ESMTerrain::Storage::getLand(cellX, cellY, cache);
+                const ESM::Land::LandData *heightData = 0;
+                const ESM::Land::LandData *normalData = 0;
+                const ESM::Land::LandData *colourData = 0;
+                if (land)
+                {
+                    heightData = land->getData(ESM::Land::DATA_VHGT);
+                    normalData = land->getData(ESM::Land::DATA_VNML);
+                    colourData = land->getData(ESM::Land::DATA_VCLR);
+                }
+
+                int rowStart = 0;
+                int colStart = 0;
+                // Skip the first row / column unless we're at a chunk edge,
+                // since this row / column is already contained in a previous cell
+                // This is only relevant if we're creating a chunk spanning multiple cells
+                if (vertY_ != 0)
+                    colStart += increment;
+                if (vertX_ != 0)
+                    rowStart += increment;
+
+                // Only relevant for chunks smaller than (contained in) one cell
+                rowStart += (origin.x() - startCellX) * ESM::Land::LAND_SIZE;
+                colStart += (origin.y() - startCellY) * ESM::Land::LAND_SIZE;
+                int rowEnd = std::min(static_cast<int>(rowStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
+                int colEnd = std::min(static_cast<int>(colStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
+
+                vertY = vertY_;
+                for (int col=colStart; col<colEnd; col += increment)
+                {
+                    vertX = vertX_;
+                    for (int row=rowStart; row<rowEnd; row += increment)
+                    {
+                        int srcArrayIndex = col*ESM::Land::LAND_SIZE*3+row*3;
+
+                        assert(row >= 0 && row < ESM::Land::LAND_SIZE);
+                        assert(col >= 0 && col < ESM::Land::LAND_SIZE);
+
+                        assert (vertX < numVerts);
+                        assert (vertY < numVerts);
+
+                        float height = defaultHeight;
+                        if (heightData)
+                            height = heightData->mHeights[col*ESM::Land::LAND_SIZE + row];
+
+                        (*positions)[static_cast<unsigned int>(vertX*numVerts + vertY)]
+                            = osg::Vec3f((vertX / float(numVerts - 1) - 0.5f) * size * Constants::CellSizeInUnits,
+                                         (vertY / float(numVerts - 1) - 0.5f) * size * Constants::CellSizeInUnits,
+                                         height + mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)]);
+
+                        if (normalData)
+                        {
+                            for (int i=0; i<3; ++i)
+                                normal[i] = normalData->mNormals[srcArrayIndex+i];
+
+                            normal.normalize();
+                        }
+                        else
+                            normal = osg::Vec3f(0,0,1);
+
+                        // Normals apparently don't connect seamlessly between cells
+                        if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
+                            fixNormal(normal, cellX, cellY, col, row, cache);
+
+                        // some corner normals appear to be complete garbage (z < 0)
+                        if ((row == 0 || row == ESM::Land::LAND_SIZE-1) && (col == 0 || col == ESM::Land::LAND_SIZE-1))
+                            averageNormal(normal, cellX, cellY, col, row, cache);
+
+                        assert(normal.z() > 0);
+
+                        (*normals)[static_cast<unsigned int>(vertX*numVerts + vertY)] = normal;
+
+                        if (colourData)
+                        {
+                            for (int i=0; i<3; ++i)
+                                color[i] = colourData->mColours[srcArrayIndex+i];
+                        }
+                        else
+                        {
+                            color.r() = 255;
+                            color.g() = 255;
+                            color.b() = 255;
+                        }
+
+                        // Highlight broken height changes
+                        if ( ((col > 0 && row > 0) &&
+                            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row - 1] +
+                            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row - 1)])) >= 1024 ) ||
+                            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col - 1)*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>((col - 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )) ||
+                            ((col < ESM::Land::LAND_SIZE - 1 && row < ESM::Land::LAND_SIZE - 1) &&
+                            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row + 1] +
+                            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row + 1)])) >= 1024 ) ||
+                            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col + 1)*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>((col + 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )))
+                        {
+                            color.r() = 255;
+                            color.g() = 0;
+                            color.b() = 0;
+                        }
+
+                        // Unlike normals, colors mostly connect seamlessly between cells, but not always...
+                        if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
+                            fixColour(color, cellX, cellY, col, row, cache);
+
+                        color.a() = 255;
+
+                        (*colours)[static_cast<unsigned int>(vertX*numVerts + vertY)] = color;
+
+                        ++vertX;
+                    }
+                    ++vertY;
+                }
+                vertX_ = vertX;
+            }
+            vertY_ = vertY;
+
+            assert(vertX_ == numVerts); // Ensure we covered whole area
+        }
+        assert(vertY_ == numVerts);  // Ensure we covered whole area*/
     }
 
     void TerrainStorage::getBounds(float &minX, float &maxX, float &minY, float &maxY)

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -7,6 +7,7 @@
 
 namespace CSVRender
 {
+    class LandCache;
 
     /**
      * @brief A bridge between the terrain component and OpenCS's terrain data storage.
@@ -15,11 +16,24 @@ namespace CSVRender
     {
     public:
         TerrainStorage(const CSMWorld::Data& data);
+        float mAlteredHeight[ESM::Land::LAND_SIZE * ESM::Land::LAND_SIZE + ESM::Land::LAND_SIZE];
+        void setAlteredHeight(int inCellX, int inCellY, float heightMap);
+        void resetHeights();
+        float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
+        float* getAlteredHeights();
+        float* getAlteredHeight(int inCellX, int inCellY);
+
     private:
         const CSMWorld::Data& mData;
 
         virtual osg::ref_ptr<const ESMTerrain::LandObject> getLand (int cellX, int cellY) override;
         virtual const ESM::LandTexture* getLandTexture(int index, short plugin) override;
+
+        /// Draws temporarily altered land (transient change support)
+        void fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
+                        osg::ref_ptr<osg::Vec3Array> positions,
+                        osg::ref_ptr<osg::Vec3Array> normals,
+                        osg::ref_ptr<osg::Vec4ubArray> colours) override;
 
         virtual void getBounds(float& minX, float& maxX, float& minY, float& maxY) override;
     };

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -112,7 +112,7 @@ void CSVRender::TerrainTextureMode::primaryEditPressed(const WorldspaceHitResult
     CSMWorld::IdCollection<CSMWorld::LandTexture>& landtexturesCollection = document.getData().getLandTextures();
     int index = landtexturesCollection.searchId(mBrushTexture);
 
-    if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted() &&  hit.hit && hit.tag == 0)
+    if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted() && hit.hit && hit.tag == 0)
     {
         undoStack.beginMacro ("Edit texture records");
         if(allowLandTextureEditing(mCellId)==true)
@@ -505,25 +505,24 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(std::pair<int, int> te
 
     if (mBrushShape == 1)
     {
-        for(int i = texCoords.first - r; i <= texCoords.first + r; ++i)
+        for (int i = -r; i <= r; i++)
         {
-            for(int j = texCoords.second - r; j <= texCoords.second + r; ++j)
+            for (int j = -r; j <= r; j++)
             {
-                selections.emplace_back(std::make_pair(i, j));
+                selections.emplace_back(i + texCoords.first, j + texCoords.second);
             }
         }
     }
 
     if (mBrushShape == 2)
     {
-        for(int i = texCoords.first - r; i <= texCoords.first + r; ++i)
+        for (int i = -r; i <= r; i++)
         {
-            for(int j = texCoords.second - r; j <= texCoords.second + r; ++j)
+            for (int j = -r; j <= r; j++)
             {
-                int distanceX = abs(i - texCoords.first);
-                int distanceY = abs(j - texCoords.second);
-                int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
-                if (distance < r) selections.emplace_back(std::make_pair(i, j));
+                osg::Vec2f coords(i,j);
+                if (std::round(coords.length()) < r)
+                    selections.emplace_back(i + texCoords.first, j + texCoords.second);
             }
         }
     }
@@ -534,7 +533,7 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(std::pair<int, int> te
         {
             for(auto const& value: mCustomBrushShape)
             {
-                selections.emplace_back(std::make_pair(texCoords.first + value.first, texCoords.second + value.second));
+                selections.emplace_back(texCoords.first + value.first, texCoords.second + value.second);
             }
         }
     }
@@ -585,8 +584,7 @@ void CSVRender::TerrainTextureMode::createTexture(std::string textureFileName)
             newId = CSMWorld::LandTexture::createUniqueRecordId(0, counter);
             freeIndexFound = true;
         }
-    }
-    while (freeIndexFound == false);
+    } while (freeIndexFound == false);
 
     std::size_t idlocation = textureFileName.find("Texture: ");
     textureFileName = textureFileName.substr (idlocation + 9);
@@ -711,22 +709,12 @@ void CSVRender::TerrainTextureMode::setBrushShape(int brushShape)
         selectionCenterY = selectionCenterY / selectionAmount;
 
         mCustomBrushShape.clear();
-        std::pair<int, int> differentialPos {};
-        for(auto const& value: terrainSelection)
-        {
-            differentialPos.first = value.first - selectionCenterX;
-            differentialPos.second = value.second - selectionCenterY;
-            mCustomBrushShape.push_back(differentialPos);
-        }
+        for (auto const& value: terrainSelection)
+            mCustomBrushShape.emplace_back(value.first - selectionCenterX, value.second - selectionCenterY);
     }
 }
 
 void CSVRender::TerrainTextureMode::setBrushTexture(std::string brushTexture)
 {
     mBrushTexture = brushTexture;
-}
-
-CSVRender::PagedWorldspaceWidget& CSVRender::TerrainTextureMode::getPagedWorldspaceWidget()
-{
-    return dynamic_cast<PagedWorldspaceWidget&>(getWorldspaceWidget());
 }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -496,12 +496,9 @@ bool CSVRender::TerrainTextureMode::isInCellSelection(int globalSelectionX, int 
 {
     if (CSVRender::PagedWorldspaceWidget *paged = dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
     {
-        CSMWorld::CellSelection selection = paged->getCellSelection();
-        if (selection.has (CSMWorld::CellCoordinates::fromId(
-            CSMWorld::CellCoordinates::textureGlobalToCellId(std::make_pair(globalSelectionX, globalSelectionY))).first))
-        {
-            return true;
-        }
+        std::pair<int, int> textureCoords = std::make_pair(globalSelectionX, globalSelectionY);
+        std::string cellId = CSMWorld::CellCoordinates::textureGlobalToCellId(textureCoords);
+        return paged->getCellSelection().has(CSMWorld::CellCoordinates::fromId(cellId).first);
     }
     return false;
 }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -493,6 +493,21 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 }
 
+bool CSVRender::TerrainTextureMode::isInCellSelection(const int& globalSelectionX, const int& globalSelectionY)
+{
+    if (CSVRender::PagedWorldspaceWidget *paged = dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        CSMWorld::CellSelection selection = paged->getCellSelection();
+        if (selection.has (CSMWorld::CellCoordinates::fromId(
+            CSMWorld::CellCoordinates::textureGlobalToCellId(std::make_pair(globalSelectionX, globalSelectionY))).first))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+
 void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation)
 {
     int r = mBrushSize / 2;
@@ -500,7 +515,7 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
 
     if (mBrushShape == 0)
     {
-        selections.emplace_back(texCoords);
+        if (isInCellSelection(texCoords.first, texCoords.second)) selections.emplace_back(texCoords);
     }
 
     if (mBrushShape == 1)
@@ -509,7 +524,12 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
         {
             for (int j = -r; j <= r; j++)
             {
-                selections.emplace_back(i + texCoords.first, j + texCoords.second);
+                int x = i + texCoords.first;
+                int y = j + texCoords.second;
+                if (isInCellSelection(x, y))
+                {
+                    selections.emplace_back(x, y);
+                }
             }
         }
     }
@@ -522,7 +542,14 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
             {
                 osg::Vec2f coords(i,j);
                 if (std::round(coords.length()) < r)
-                    selections.emplace_back(i + texCoords.first, j + texCoords.second);
+                {
+                    int x = i + texCoords.first;
+                    int y = j + texCoords.second;
+                    if (isInCellSelection(x, y))
+                    {
+                        selections.emplace_back(x, y);
+                    }
+                }
             }
         }
     }
@@ -533,7 +560,12 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
         {
             for(auto const& value: mCustomBrushShape)
             {
-                selections.emplace_back(texCoords.first + value.first, texCoords.second + value.second);
+                int x = texCoords.first + value.first;
+                int y = texCoords.second + value.second;
+                if (isInCellSelection(x, y))
+                {
+                    selections.emplace_back(x, y);
+                }
             }
         }
     }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -493,7 +493,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 }
 
-void CSVRender::TerrainTextureMode::selectTerrainTextures(std::pair<int, int> texCoords, unsigned char selectMode, bool dragOperation)
+void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation)
 {
     int r = mBrushSize / 2;
     std::vector<std::pair<int, int>> selections;

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -114,7 +114,7 @@ void CSVRender::TerrainTextureMode::primaryEditPressed(const WorldspaceHitResult
     if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted() && hit.hit && hit.tag == 0)
     {
         undoStack.beginMacro ("Edit texture records");
-        if(allowLandTextureEditing(mCellId)==true)
+        if(allowLandTextureEditing(mCellId))
         {
             undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, mCellId));
             editTerrainTextureGrid(hit);
@@ -162,7 +162,7 @@ bool CSVRender::TerrainTextureMode::primaryEditStartDrag (const QPoint& pos)
     {
         undoStack.beginMacro ("Edit texture records");
         mIsEditing = true;
-        if(allowLandTextureEditing(mCellId)==true)
+        if(allowLandTextureEditing(mCellId))
         {
             undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, mCellId));
             editTerrainTextureGrid(hit);
@@ -245,7 +245,7 @@ void CSVRender::TerrainTextureMode::dragCompleted(const QPoint& pos)
 
         if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted())
         {
-             if (mIsEditing == true)
+             if (mIsEditing)
              {
                  undoStack.endMacro();
                  mIsEditing = false;
@@ -299,7 +299,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
         *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
 
     mCellId = getWorldspaceWidget().getCellId (hit.worldPos);
-    if(allowLandTextureEditing(mCellId)==true) {}
+    if(allowLandTextureEditing(mCellId)) {}
 
     std::pair<CSMWorld::CellCoordinates, bool> cellCoordinates_pair = CSMWorld::CellCoordinates::fromId (mCellId);
 
@@ -321,7 +321,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 
     mCellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
-    if(allowLandTextureEditing(mCellId)==true) {}
+    if(allowLandTextureEditing(mCellId)) {}
 
     std::string iteratedCellId;
 
@@ -340,7 +340,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
         CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(mCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
         CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
 
-        if(allowLandTextureEditing(mCellId)==true)
+        if(allowLandTextureEditing(mCellId))
         {
             newTerrain[yHitInCell*landTextureSize+xHitInCell] = brushInt;
             pushEditToCommand(newTerrain, document, landTable, mCellId);
@@ -364,7 +364,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
             for(int j_cell = upperLeftCellY; j_cell <= lowerrightCellY; j_cell++)
             {
                 iteratedCellId = CSMWorld::CellCoordinates::generateId(i_cell, j_cell);
-                if(allowLandTextureEditing(iteratedCellId)==true)
+                if(allowLandTextureEditing(iteratedCellId))
                 {
                     CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(iteratedCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
                     CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
@@ -414,7 +414,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
             for(int j_cell = upperLeftCellY; j_cell <= lowerrightCellY; j_cell++)
             {
                 iteratedCellId = CSMWorld::CellCoordinates::generateId(i_cell, j_cell);
-                if(allowLandTextureEditing(iteratedCellId)==true)
+                if(allowLandTextureEditing(iteratedCellId))
                 {
                     CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(iteratedCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
                     CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
@@ -462,7 +462,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
         CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(mCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
         CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
 
-        if(allowLandTextureEditing(mCellId)==true && !mCustomBrushShape.empty())
+        if(allowLandTextureEditing(mCellId) && !mCustomBrushShape.empty())
         {
             for(auto const& value: mCustomBrushShape)
             {
@@ -478,7 +478,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
                     int yInOtherCell = yHitInCell + value.second - cellYDifference * landTextureSize;
 
                     std::string cellId = CSMWorld::CellCoordinates::generateId(cellX+cellXDifference, cellY+cellYDifference);
-                    if (allowLandTextureEditing(cellId)==true)
+                    if (allowLandTextureEditing(cellId))
                     {
                         CSMWorld::LandTexturesColumn::DataType newTerrainPointerOtherCell = landTable.data(landTable.getModelIndex(cellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
                         CSMWorld::LandTexturesColumn::DataType newTerrainOtherCell(newTerrainPointerOtherCell);

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -235,7 +235,7 @@ void CSVRender::TerrainTextureMode::drag (const QPoint& pos, int diffX, int diff
 
 void CSVRender::TerrainTextureMode::dragCompleted(const QPoint& pos)
 {
-    if (mDragMode == InteractionType_PrimaryEdit)
+    if (mDragMode == InteractionType_PrimaryEdit && mIsEditing)
     {
         CSMDoc::Document& document = getWorldspaceWidget().getDocument();
         QUndoStack& undoStack = document.getUndoStack();
@@ -245,11 +245,8 @@ void CSVRender::TerrainTextureMode::dragCompleted(const QPoint& pos)
 
         if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted())
         {
-             if (mIsEditing)
-             {
-                 undoStack.endMacro();
-                 mIsEditing = false;
-             }
+             undoStack.endMacro();
+             mIsEditing = false;
         }
     }
 }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -492,7 +492,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 }
 
-bool CSVRender::TerrainTextureMode::isInCellSelection(const int& globalSelectionX, const int& globalSelectionY)
+bool CSVRender::TerrainTextureMode::isInCellSelection(int globalSelectionX, int globalSelectionY)
 {
     if (CSVRender::PagedWorldspaceWidget *paged = dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
     {
@@ -732,12 +732,12 @@ void CSVRender::TerrainTextureMode::setBrushShape(int brushShape)
 
         for(auto const& value: terrainSelection)
         {
-            selectionCenterX = selectionCenterX + value.first;
-            selectionCenterY = selectionCenterY + value.second;
+            selectionCenterX += value.first;
+            selectionCenterY += value.second;
             ++selectionAmount;
         }
-        selectionCenterX = selectionCenterX / selectionAmount;
-        selectionCenterY = selectionCenterY / selectionAmount;
+        selectionCenterX /= selectionAmount;
+        selectionCenterY /= selectionAmount;
 
         mCustomBrushShape.clear();
         for (auto const& value: terrainSelection)

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -36,7 +36,6 @@
 #include "pagedworldspacewidget.hpp"
 #include "mask.hpp"
 #include "object.hpp" // Something small needed regarding pointers from here ()
-#include "terrainselection.hpp"
 #include "worldspacewidget.hpp"
 
 CSVRender::TerrainTextureMode::TerrainTextureMode (WorldspaceWidget *worldspaceWidget, osg::Group* parentNode, QWidget *parent)

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <memory>
 
-#include <osg/Group>
-
 #include <QWidget>
 #include <QEvent>
 
@@ -22,6 +20,11 @@
 #endif
 
 #include "terrainselection.hpp"
+
+namespace osg
+{
+    class Group;
+}
 
 namespace CSVWidget
 {
@@ -82,7 +85,7 @@ namespace CSVRender
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
             /// \brief Handle brush mechanics for texture selection
-            void selectTerrainTextures (std::pair<int, int>, unsigned char, bool);
+            void selectTerrainTextures (const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation);
 
             /// \brief Push texture edits to command macro
             void pushEditToCommand (CSMWorld::LandTexturesColumn::DataType& newLandGrid, CSMDoc::Document& document,

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -85,7 +85,7 @@ namespace CSVRender
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
             /// \brief Check if global selection coordinate belongs to cell in view
-            bool isInCellSelection(const int& globalSelectionX, const int& globalSelectionY);
+            bool isInCellSelection(int globalSelectionX, int globalSelectionY);
 
             /// \brief Handle brush mechanics for texture selection
             void selectTerrainTextures (const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation);

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -110,8 +110,6 @@ namespace CSVRender
             const int landSize {ESM::Land::LAND_SIZE};
             const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
 
-            PagedWorldspaceWidget& getPagedWorldspaceWidget();
-
         signals:
             void passBrushTexture(std::string brushTexture);
 

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -4,6 +4,7 @@
 #include "editmode.hpp"
 
 #include <string>
+#include <memory>
 
 #include <QWidget>
 #include <QEvent>
@@ -18,6 +19,8 @@
 #include "../../model/world/landtexture.hpp"
 #endif
 
+#include "terrainselection.hpp"
+
 namespace CSVWidget
 {
     class SceneToolTextureBrush;
@@ -25,6 +28,7 @@ namespace CSVWidget
 
 namespace CSVRender
 {
+    class PagedWorldspaceWidget;
 
     class TerrainTextureMode : public EditMode
     {
@@ -32,8 +36,17 @@ namespace CSVRender
 
         public:
 
+            enum InteractionType
+            {
+                InteractionType_PrimaryEdit,
+                InteractionType_PrimarySelect,
+                InteractionType_SecondaryEdit,
+                InteractionType_SecondarySelect,
+                InteractionType_None
+            };
+
             /// \brief Editmode for terrain texture grid
-            TerrainTextureMode(WorldspaceWidget*, QWidget* parent = nullptr);
+            TerrainTextureMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
 
             void primaryOpenPressed (const WorldspaceHitResult& hit);
 
@@ -68,6 +81,9 @@ namespace CSVRender
             /// \brief Handle brush mechanics, maths regarding worldspace hit etc.
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
+            /// \brief Handle brush mechanics for texture selection
+            void selectTerrainTextures (std::pair<int, int>, unsigned char, bool);
+
             /// \brief Push texture edits to command macro
             void pushEditToCommand (CSMWorld::LandTexturesColumn::DataType& newLandGrid, CSMDoc::Document& document,
                 CSMWorld::IdTable& landTable, std::string cellId);
@@ -83,11 +99,18 @@ namespace CSVRender
             std::string mBrushTexture;
             int mBrushSize;
             int mBrushShape;
+            std::vector<std::pair<int, int>> mCustomBrushShape;
             CSVWidget::SceneToolTextureBrush *mTextureBrushScenetool;
+            int mDragMode;
+            osg::Group* mParentNode;
+            bool mIsEditing;
+            std::unique_ptr<TerrainSelection> mTerrainTextureSelection;
 
             const int cellSize {ESM::Land::REAL_SIZE};
             const int landSize {ESM::Land::LAND_SIZE};
             const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
+
+            PagedWorldspaceWidget& getPagedWorldspaceWidget();
 
         signals:
             void passBrushTexture(std::string brushTexture);

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <memory>
 
+#include <osg/Group>
+
 #include <QWidget>
 #include <QEvent>
 
@@ -28,8 +30,6 @@ namespace CSVWidget
 
 namespace CSVRender
 {
-    class PagedWorldspaceWidget;
-
     class TerrainTextureMode : public EditMode
     {
         Q_OBJECT

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -84,6 +84,9 @@ namespace CSVRender
             /// \brief Handle brush mechanics, maths regarding worldspace hit etc.
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
+            /// \brief Check if global selection coordinate belongs to cell in view
+            bool isInCellSelection(const int& globalSelectionX, const int& globalSelectionY);
+
             /// \brief Handle brush mechanics for texture selection
             void selectTerrainTextures (const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation);
 

--- a/apps/opencs/view/render/unpagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/unpagedworldspacewidget.cpp
@@ -150,6 +150,11 @@ CSVRender::Cell* CSVRender::UnpagedWorldspaceWidget::getCell(const osg::Vec3d& p
     return mCell.get();
 }
 
+CSVRender::Cell* CSVRender::UnpagedWorldspaceWidget::getCell(const CSMWorld::CellCoordinates& coords) const
+{
+    return mCell.get();
+}
+
 std::vector<osg::ref_ptr<CSVRender::TagBase> > CSVRender::UnpagedWorldspaceWidget::getSelection (
     unsigned int elementMask) const
 {

--- a/apps/opencs/view/render/unpagedworldspacewidget.hpp
+++ b/apps/opencs/view/render/unpagedworldspacewidget.hpp
@@ -17,6 +17,7 @@ namespace CSMDoc
 namespace CSMWorld
 {
     class IdTable;
+    class CellCoordinates;
 }
 
 namespace CSVRender
@@ -62,6 +63,8 @@ namespace CSVRender
             virtual std::string getCellId (const osg::Vec3f& point) const;
 
             virtual Cell* getCell(const osg::Vec3d& point) const;
+
+            virtual Cell* getCell(const CSMWorld::CellCoordinates& coords) const;
 
             virtual std::vector<osg::ref_ptr<TagBase> > getSelection (unsigned int elementMask)
                 const;

--- a/apps/opencs/view/render/worldspacewidget.hpp
+++ b/apps/opencs/view/render/worldspacewidget.hpp
@@ -17,6 +17,7 @@ namespace CSMPrefs
 
 namespace CSMWorld
 {
+    class CellCoordinates;
     class UniversalId;
 }
 
@@ -169,6 +170,8 @@ namespace CSVRender
 
             /// \note Returns the cell if it exists, otherwise a null pointer
             virtual Cell* getCell(const osg::Vec3d& point) const = 0;
+
+            virtual Cell* getCell(const CSMWorld::CellCoordinates& coords) const = 0;
 
             virtual std::vector<osg::ref_ptr<TagBase> > getSelection (unsigned int elementMask)
                 const = 0;

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -1,0 +1,265 @@
+#include "scenetoolshapebrush.hpp"
+
+#include <QFrame>
+#include <QIcon>
+#include <QTableWidget>
+#include <QHBoxLayout>
+
+#include <QWidget>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QGroupBox>
+#include <QSlider>
+#include <QEvent>
+#include <QDropEvent>
+#include <QButtonGroup>
+#include <QVBoxLayout>
+#include <QDragEnterEvent>
+#include <QDrag>
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QApplication>
+#include <QSizePolicy>
+
+#include "scenetool.hpp"
+
+#include "../../model/doc/document.hpp"
+#include "../../model/prefs/state.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/data.hpp"
+#include "../../model/world/idcollection.hpp"
+#include "../../model/world/idtable.hpp"
+#include "../../model/world/landtexture.hpp"
+#include "../../model/world/universalid.hpp"
+
+
+CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, QWidget *parent)
+    : QGroupBox(title, parent)
+{
+    mBrushSizeSlider = new QSlider(Qt::Horizontal);
+    mBrushSizeSlider->setTickPosition(QSlider::TicksBothSides);
+    mBrushSizeSlider->setTickInterval(10);
+    mBrushSizeSlider->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mBrushSizeSlider->setSingleStep(1);
+
+    mBrushSizeSpinBox = new QSpinBox;
+    mBrushSizeSpinBox->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mBrushSizeSpinBox->setSingleStep(1);
+
+    mLayoutSliderSize = new QHBoxLayout;
+    mLayoutSliderSize->addWidget(mBrushSizeSlider);
+    mLayoutSliderSize->addWidget(mBrushSizeSpinBox);
+
+    connect(mBrushSizeSlider, SIGNAL(valueChanged(int)), mBrushSizeSpinBox, SLOT(setValue(int)));
+    connect(mBrushSizeSpinBox, SIGNAL(valueChanged(int)), mBrushSizeSlider, SLOT(setValue(int)));
+
+    setLayout(mLayoutSliderSize);
+}
+
+CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent)
+    : QFrame(parent, Qt::Popup),
+    mBrushShape(0),
+    mBrushSize(0),
+    mDocument(document)
+{
+    mButtonPoint = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-point")), "", this);
+    mButtonSquare = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-square")), "", this);
+    mButtonCircle = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-circle")), "", this);
+    mButtonCustom = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-custom")), "", this);
+
+    mSizeSliders = new ShapeBrushSizeControls("Brush size", this);
+
+    QVBoxLayout *layoutMain = new QVBoxLayout;
+    layoutMain->setSpacing(0);
+    layoutMain->setContentsMargins(4,0,4,4);
+
+    QHBoxLayout *layoutHorizontal = new QHBoxLayout;
+    layoutHorizontal->setSpacing(0);
+    layoutHorizontal->setContentsMargins (QMargins (0, 0, 0, 0));
+
+    configureButtonInitialSettings(mButtonPoint);
+    configureButtonInitialSettings(mButtonSquare);
+    configureButtonInitialSettings(mButtonCircle);
+    configureButtonInitialSettings(mButtonCustom);
+
+    mButtonPoint->setToolTip (toolTipPoint);
+    mButtonSquare->setToolTip (toolTipSquare);
+    mButtonCircle->setToolTip (toolTipCircle);
+    mButtonCustom->setToolTip (toolTipCustom);
+
+    QButtonGroup* brushButtonGroup = new QButtonGroup(this);
+    brushButtonGroup->addButton(mButtonPoint);
+    brushButtonGroup->addButton(mButtonSquare);
+    brushButtonGroup->addButton(mButtonCircle);
+    brushButtonGroup->addButton(mButtonCustom);
+
+    brushButtonGroup->setExclusive(true);
+
+    layoutHorizontal->addWidget(mButtonPoint, 0, Qt::AlignTop);
+    layoutHorizontal->addWidget(mButtonSquare, 0, Qt::AlignTop);
+    layoutHorizontal->addWidget(mButtonCircle, 0, Qt::AlignTop);
+    layoutHorizontal->addWidget(mButtonCustom, 0, Qt::AlignTop);
+
+    mHorizontalGroupBox = new QGroupBox(tr(""));
+    mHorizontalGroupBox->setLayout(layoutHorizontal);
+
+    mToolSelector = new QComboBox(this);
+    mToolSelector->addItem(tr("Height (drag)"));
+    mToolSelector->addItem(tr("Height, raise (paint)"));
+    mToolSelector->addItem(tr("Height, lower (paint)"));
+    mToolSelector->addItem(tr("Smooth (paint)"));
+    mToolSelector->addItem(tr("Flatten (paint)"));
+
+    QLabel *brushStrengthLabel = new QLabel(this);
+    brushStrengthLabel->setText("Brush strength:");
+
+    mToolStrengthSlider = new QSlider(Qt::Horizontal);
+    mToolStrengthSlider->setTickPosition(QSlider::TicksBothSides);
+    mToolStrengthSlider->setTickInterval(8);
+    mToolStrengthSlider->setRange(8, 128);
+    mToolStrengthSlider->setSingleStep(8);
+
+    layoutMain->addWidget(mHorizontalGroupBox);
+    layoutMain->addWidget(mSizeSliders);
+    layoutMain->addWidget(mToolSelector);
+    layoutMain->addWidget(brushStrengthLabel);
+    layoutMain->addWidget(mToolStrengthSlider);
+
+    setLayout(layoutMain);
+
+    connect(mButtonPoint, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+    connect(mButtonSquare, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+    connect(mButtonCircle, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+    connect(mButtonCustom, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+}
+
+void CSVWidget::ShapeBrushWindow::configureButtonInitialSettings(QPushButton *button)
+{
+  button->setSizePolicy (QSizePolicy (QSizePolicy::Fixed, QSizePolicy::Fixed));
+  button->setContentsMargins (QMargins (0, 0, 0, 0));
+  button->setIconSize (QSize (48-6, 48-6));
+  button->setFixedSize (48, 48);
+  button->setCheckable(true);
+}
+
+void CSVWidget::ShapeBrushWindow::setBrushSize(int brushSize)
+{
+    mBrushSize = brushSize;
+    emit passBrushSize(mBrushSize);
+}
+
+void CSVWidget::ShapeBrushWindow::setBrushShape()
+{
+    if(mButtonPoint->isChecked()) mBrushShape = 0;
+    if(mButtonSquare->isChecked()) mBrushShape = 1;
+    if(mButtonCircle->isChecked()) mBrushShape = 2;
+    if(mButtonCustom->isChecked()) mBrushShape = 3;
+    emit passBrushShape(mBrushShape);
+}
+
+void CSVWidget::SceneToolShapeBrush::adjustToolTips()
+{
+}
+
+CSVWidget::SceneToolShapeBrush::SceneToolShapeBrush (SceneToolbar *parent, const QString& toolTip, CSMDoc::Document& document)
+: SceneTool (parent, Type_TopAction),
+    mToolTip (toolTip),
+    mDocument (document),
+    mShapeBrushWindow(new ShapeBrushWindow(document, this))
+{
+    setAcceptDrops(true);
+    connect(mShapeBrushWindow, SIGNAL(passBrushShape(int)), this, SLOT(setButtonIcon(int)));
+    setButtonIcon(mShapeBrushWindow->mBrushShape);
+
+    mPanel = new QFrame (this, Qt::Popup);
+
+    QHBoxLayout *layout = new QHBoxLayout (mPanel);
+
+    layout->setContentsMargins (QMargins (0, 0, 0, 0));
+
+    mTable = new QTableWidget (0, 2, this);
+
+    mTable->setShowGrid (true);
+    mTable->verticalHeader()->hide();
+    mTable->horizontalHeader()->hide();
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    mTable->horizontalHeader()->setSectionResizeMode (0, QHeaderView::Stretch);
+    mTable->horizontalHeader()->setSectionResizeMode (1, QHeaderView::Stretch);
+#else
+    mTable->horizontalHeader()->setResizeMode (0, QHeaderView::Stretch);
+    mTable->horizontalHeader()->setResizeMode (1, QHeaderView::Stretch);
+#endif
+    mTable->setSelectionMode (QAbstractItemView::NoSelection);
+
+    layout->addWidget (mTable);
+
+    connect (mTable, SIGNAL (clicked (const QModelIndex&)),
+        this, SLOT (clicked (const QModelIndex&)));
+
+}
+
+void CSVWidget::SceneToolShapeBrush::setButtonIcon (int brushShape)
+{
+    QString tooltip = "Change brush settings <p>Currently selected: ";
+
+    switch (brushShape)
+    {
+        case 0:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-point")));
+            tooltip += mShapeBrushWindow->toolTipPoint;
+            break;
+
+        case 1:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-square")));
+            tooltip += mShapeBrushWindow->toolTipSquare;
+            break;
+
+        case 2:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-circle")));
+            tooltip += mShapeBrushWindow->toolTipCircle;
+            break;
+
+        case 3:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-custom")));
+            tooltip += mShapeBrushWindow->toolTipCustom;
+            break;
+    }
+
+    setToolTip (tooltip);
+}
+
+void CSVWidget::SceneToolShapeBrush::showPanel (const QPoint& position)
+{
+}
+
+void CSVWidget::SceneToolShapeBrush::updatePanel ()
+{
+}
+
+void CSVWidget::SceneToolShapeBrush::clicked (const QModelIndex& index)
+{
+}
+
+void CSVWidget::SceneToolShapeBrush::activate ()
+{
+    QPoint position = QCursor::pos();
+    mShapeBrushWindow->mSizeSliders->mBrushSizeSlider->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mShapeBrushWindow->mSizeSliders->mBrushSizeSpinBox->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mShapeBrushWindow->move (position);
+    mShapeBrushWindow->show();
+}
+
+void CSVWidget::SceneToolShapeBrush::dragEnterEvent (QDragEnterEvent *event)
+{
+    emit passEvent(event);
+    event->accept();
+}
+void CSVWidget::SceneToolShapeBrush::dropEvent (QDropEvent *event)
+{
+    emit passEvent(event);
+    event->accept();
+}

--- a/apps/opencs/view/widget/scenetoolshapebrush.hpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.hpp
@@ -1,0 +1,130 @@
+#ifndef CSV_WIDGET_SCENETOOLSHAPEBRUSH_H
+#define CSV_WIDGET_SCENETOOLSHAPEBRUSH_H
+
+#include <QIcon>
+#include <QFrame>
+#include <QModelIndex>
+
+#include <QWidget>
+#include <QLabel>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QGroupBox>
+#include <QSlider>
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QPushButton>
+
+#ifndef Q_MOC_RUN
+#include "scenetool.hpp"
+
+#include "../../model/doc/document.hpp"
+#endif
+
+class QTableWidget;
+
+namespace CSVRender
+{
+    class TerrainShapeMode;
+}
+
+namespace CSVWidget
+{
+    class SceneToolShapeBrush;
+
+    /// \brief Layout-box for some brush button settings
+    class ShapeBrushSizeControls : public QGroupBox
+    {
+        Q_OBJECT
+
+        public:
+            ShapeBrushSizeControls(const QString &title, QWidget *parent);
+
+        private:
+            QHBoxLayout *mLayoutSliderSize;
+            QSlider *mBrushSizeSlider;
+            QSpinBox *mBrushSizeSpinBox;
+
+        friend class SceneToolShapeBrush;
+        friend class CSVRender::TerrainShapeMode;
+    };
+
+    class SceneToolShapeBrush;
+
+    /// \brief Brush settings window
+    class ShapeBrushWindow : public QFrame
+    {
+        Q_OBJECT
+
+        public:
+            ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent = 0);
+            void configureButtonInitialSettings(QPushButton *button);
+
+            const QString toolTipPoint = "Paint single point";
+            const QString toolTipSquare = "Paint with square brush";
+            const QString toolTipCircle = "Paint with circle brush";
+            const QString toolTipCustom = "Paint custom selection (not implemented yet)";
+
+        private:
+            int mBrushShape;
+            int mBrushSize;
+            CSMDoc::Document& mDocument;
+            QGroupBox *mHorizontalGroupBox;
+            QComboBox *mToolSelector;
+            QSlider *mToolStrengthSlider;
+            QPushButton *mButtonPoint;
+            QPushButton *mButtonSquare;
+            QPushButton *mButtonCircle;
+            QPushButton *mButtonCustom;
+            ShapeBrushSizeControls* mSizeSliders;
+
+        friend class SceneToolShapeBrush;
+        friend class CSVRender::TerrainShapeMode;
+
+        public slots:
+            void setBrushShape();
+            void setBrushSize(int brushSize);
+
+        signals:
+            void passBrushSize (int brushSize);
+            void passBrushShape(int brushShape);
+    };
+
+    class SceneToolShapeBrush : public SceneTool
+    {
+            Q_OBJECT
+
+            QString mToolTip;
+            CSMDoc::Document& mDocument;
+            QFrame *mPanel;
+            QTableWidget *mTable;
+            ShapeBrushWindow *mShapeBrushWindow;
+
+        private:
+
+            void adjustToolTips();
+
+        public:
+
+            SceneToolShapeBrush (SceneToolbar *parent, const QString& toolTip, CSMDoc::Document& document);
+
+            virtual void showPanel (const QPoint& position);
+            void updatePanel ();
+
+            void dropEvent (QDropEvent *event);
+            void dragEnterEvent (QDragEnterEvent *event);
+
+        friend class CSVRender::TerrainShapeMode;
+
+        public slots:
+            void setButtonIcon(int brushShape);
+            void clicked (const QModelIndex& index);
+            virtual void activate();
+
+        signals:
+            void passEvent(QDropEvent *event);
+            void passEvent(QDragEnterEvent *event);
+    };
+}
+
+#endif

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -1,7 +1,12 @@
 #ifndef COMPONENTS_ESM_TERRAIN_STORAGE_H
 #define COMPONENTS_ESM_TERRAIN_STORAGE_H
 
+#include <cassert>
+
 #include <OpenThreads/Mutex>
+
+#include <osg/Image>
+#include <osg/Plane>
 
 #include <components/terrain/storage.hpp>
 
@@ -13,10 +18,13 @@ namespace VFS
     class Manager;
 }
 
+namespace CSVRender
+{
+    class TerrainStorage;
+}
+
 namespace ESMTerrain
 {
-
-    class LandCache;
 
     /// @brief Wrapper around Land Data with reference counting. The wrapper needs to be held as long as the data is still in use
     class LandObject : public osg::Object
@@ -48,6 +56,13 @@ namespace ESMTerrain
         ESM::Land::LandData mData;
     };
 
+    class LandCache
+    {
+    public:
+        typedef std::map<std::pair<int, int>, osg::ref_ptr<const LandObject> > Map;
+        Map mMap;
+    };
+    
     /// @brief Feeds data from ESM terrain records (ESM::Land, ESM::LandTexture)
     ///        into the terrain component, converting it on the fly as needed.
     class Storage : public Terrain::Storage
@@ -110,14 +125,6 @@ namespace ESMTerrain
     private:
         const VFS::Manager* mVFS;
 
-        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
-        inline void fixColour (osg::Vec4ub& colour, int cellX, int cellY, int col, int row, LandCache& cache);
-        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
-
-        inline float getVertexHeight (const ESM::Land::LandData* data, int x, int y);
-
-        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache);
-
         // Since plugins can define new texture palettes, we need to know the plugin index too
         // in order to retrieve the correct texture name.
         // pair  <texture id, plugin id>
@@ -137,6 +144,103 @@ namespace ESMTerrain
         bool mAutoUseSpecularMaps;
 
         Terrain::LayerInfo getLayerInfo(const std::string& texture);
+
+    protected:
+
+        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache)
+        {
+            while (col >= ESM::Land::LAND_SIZE-1)
+            {
+                ++cellY;
+                col -= ESM::Land::LAND_SIZE-1;
+            }
+            while (row >= ESM::Land::LAND_SIZE-1)
+            {
+                ++cellX;
+                row -= ESM::Land::LAND_SIZE-1;
+            }
+            while (col < 0)
+            {
+                --cellY;
+                col += ESM::Land::LAND_SIZE-1;
+            }
+            while (row < 0)
+            {
+                --cellX;
+                row += ESM::Land::LAND_SIZE-1;
+            }
+
+            const LandObject* land = getLand(cellX, cellY, cache);
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VNML) : 0;
+            if (data)
+            {
+                normal.x() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3];
+                normal.y() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3+1];
+                normal.z() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3+2];
+                normal.normalize();
+            }
+            else
+                normal = osg::Vec3f(0,0,1);
+        };
+
+        inline void fixColour (osg::Vec4ub& color, int cellX, int cellY, int col, int row, LandCache& cache)
+        {
+            if (col == ESM::Land::LAND_SIZE-1)
+            {
+                ++cellY;
+                col = 0;
+            }
+            if (row == ESM::Land::LAND_SIZE-1)
+            {
+                ++cellX;
+                row = 0;
+            }
+
+            const LandObject* land = getLand(cellX, cellY, cache);
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VCLR) : 0;
+            if (data)
+            {
+                color.r() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3];
+                color.g() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+1];
+                color.b() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+2];
+            }
+            else
+            {
+                color.r() = 255;
+                color.g() = 255;
+                color.b() = 255;
+            }
+        };
+
+        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache)
+        {
+            osg::Vec3f n1,n2,n3,n4;
+            fixNormal(n1, cellX, cellY, col+1, row, cache);
+            fixNormal(n2, cellX, cellY, col-1, row, cache);
+            fixNormal(n3, cellX, cellY, col, row+1, cache);
+            fixNormal(n4, cellX, cellY, col, row-1, cache);
+            normal = (n1+n2+n3+n4);
+            normal.normalize();
+        };
+
+        inline float getVertexHeight (const ESM::Land::LandData* data, int x, int y)
+        {
+            assert(x < ESM::Land::LAND_SIZE);
+            assert(y < ESM::Land::LAND_SIZE);
+            return data->mHeights[y * ESM::Land::LAND_SIZE + x];
+        };
+
+        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache)
+        {
+            LandCache::Map::iterator found = cache.mMap.find(std::make_pair(cellX, cellY));
+            if (found != cache.mMap.end())
+                return found->second;
+            else
+            {
+                found = cache.mMap.insert(std::make_pair(std::make_pair(cellX, cellY), getLand(cellX, cellY))).first;
+                return found->second;
+            }
+        };
     };
 
 }


### PR DESCRIPTION
Based on Terrain texture selection (https://github.com/OpenMW/openmw/pull/2517).

This PR edits ESMterrain::Storage on component-level. I'm not too sure how it should work, so reviewing especially the changes on the components would be helpful. Probably should be thoroughly reviewed and tested before even thinking of merging.

Additionally, terrain editing feature allows editing outside of the range of ESM file format. This PR now implements a workaround that highlights the broken land heights as red whenever the edit goes out of range. This is a workaround as it tells the user that editing is going too far, and saving would then corrupt the terrain data, but I'd really like to find another way to solve this.

Features:
- Terrain vertex selection.
- Terrain shape editing
- Transient land shape editing (press esc to undo). Changes made to land are held in float array until the drag end. Memory is not allocated runtime, but rather all cells constantly hold an extra float array. This feature overrides a function from Storage, shouldn't affect OpenMW game engine.

TODO:
- [x] Fix cell edges breaking, when cells are not pre-loaded.
- [x] Add drag-amount to heights change
- [x] Proper naming of variables and functions in alterheights and heightmap to alterheight and height
- [x] Limit land edits to steps of +-8, in order to avoid land tearing because of rounding when saving.
- [x] Limit slopes to fit land format (extreme changes will break the save)
- [x] Develop basic tools for land editing
- [x] Fix bug: saves break, investigate when and why (reason: missing ltex records)
- [x] Fix bug: limitHeightChanges function breaks land, remove duplicated code
- [x] Fix bug: limitHeightChanges still rarely breaks land corners and edges
- [x] Fix bug: Out-of-limits land-edits, strange hit values?
- [x] Fix bug: Land normals command is issued after land shape command (resulting in wrong normals)
- [ ] Fix bug: Tool size 1 doesn't do anything with circle/square brush
- [ ] Fix bug: Smooth next to a broken cell edge doesn't calculate average properly. Note: Other fixes made the land break less, and function fixEdges can sometimes be used as workaround.
- [x] Improve: Make smooth-tool properly paintable
- [x] Improve: limitHeightChanges follows strange logic, and it's unknown if it always works, it shouldn't have to fix cell edges. -> Fixed the logic, but still breaks some corners in special cases. Removed the whole limit feature, opting for broken land highlight and manual edit.
- [ ] Improve: Some cells (e.g. -1, -17 in Morrowind) seems to have land record, but no land is visible, even and terrain heights set to zero. They should also be editable in the future.
- [x] Improve: Highlight excessive height changes/broken land in view window
- [x] Improve: Add label to toolstrength-slider
- [ ] Improve: Ability to re-attach broken cell edges (already done: function fixEdges)
- [x] Improve: When creating new land next to existing land, seam cell edge propely
- [x] Improve: Painting height on empty cell (no land) or non-existing cell should create new land. Note: Fundamentally works, but some cells (e.g. -1, -17) still refuse to be visible.
- [ ] Extra: Bump -tool
- [x] Extra: Plateau/flatten -tool
- [x] Check, and then uncomment or remove commented stuff at terrain and terrainstorage.
- [ ] Testing and further design, planning of advanced tools
- [x] Fix changelog (no hurry with this one though, merge conflict prevents useless builds while updating this)

Planning/feedback needed for:
1) UI/UX, feedback on tools and general usability.
2) Transient land change implementation (terrainstorage.cpp), any objections or better ideas?
3)  C++ style in general
4) Memory management (I've tried to make it as automatic as possible). Should transient edits allocate memory dynamically, use std::vector instead of float[]?
5) Terrain vertex selection drawing, how does it look, tips on optimization
6) Limits and how they are implemented, currently limits are at terrainstorage (always steps of +-8 per change), and max height change is limited at command-phase (end of drag), limiting cuts extreme land edits to those that shouldn't break during mod save.
7) Currently circle brush is the only tool with soft edges, all other tools have hard edges. Hardness/softness can both be useful at times. Should there also be a user option for brush hardness, or some other default setting? Implementing hardness/softness for custom brush could be based on the distance from the center of the custom brush, or a gaussian blur on top of selection shape (using a gaussian blurred "opacity map" to determine the tool strength in any vertex).

https://youtu.be/YtEL6MMvw9w (old video, bugs seen here should be fixed by now)