### PR TITLE
Option to disable controller (feature #3980)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
+    Feature #3980: In-game option to disable controller
     Feature #4209: Editor: Faction rank sub-table
     Feature #4673: Weapon sheathing
     Feature #4730: Native animated containers support

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -55,6 +55,7 @@ namespace MWInput
         , mInvertX (Settings::Manager::getBool("invert x axis", "Input"))
         , mInvertY (Settings::Manager::getBool("invert y axis", "Input"))
         , mControlsDisabled(false)
+        , mJoystickEnabled (Settings::Manager::getBool("enable controller", "Input"))
         , mCameraSensitivity (Settings::Manager::getFloat("camera sensitivity", "Input"))
         , mCameraYMultiplier (Settings::Manager::getFloat("camera y multiplier", "Input"))
         , mPreviewPOVDelay(0.f)
@@ -659,6 +660,9 @@ namespace MWInput
             if (it->first == "Input" && it->second == "grab cursor")
                 mGrabCursor = Settings::Manager::getBool("grab cursor", "Input");
 
+            if (it->first == "Input" && it->second == "enable controller")
+                mJoystickEnabled = Settings::Manager::getBool("enable controller", "Input");
+
             if (it->first == "Video" && (
                     it->second == "resolution x"
                     || it->second == "resolution y"
@@ -858,6 +862,9 @@ namespace MWInput
 
     void InputManager::buttonPressed(int deviceID, const SDL_ControllerButtonEvent &arg )
     {
+        if (!mJoystickEnabled)
+            return;
+
         mJoystickLastUsed = true;
         bool guiMode = false;
 
@@ -892,6 +899,9 @@ namespace MWInput
 
     void InputManager::buttonReleased(int deviceID, const SDL_ControllerButtonEvent &arg )
     {
+        if (!mJoystickEnabled)
+            return;
+
         mJoystickLastUsed = true;
         if(mInputBinder->detectingBindingState())
             mInputBinder->buttonReleased(deviceID, arg);
@@ -915,7 +925,7 @@ namespace MWInput
 
     void InputManager::axisMoved(int deviceID, const SDL_ControllerAxisEvent &arg )
     {
-        if (!mControlsDisabled)
+        if (!mControlsDisabled && mJoystickEnabled)
             mInputBinder->axisMoved(deviceID, arg);
     }
 

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -179,6 +179,7 @@ namespace MWInput
         bool mInvertY;
 
         bool mControlsDisabled;
+        bool mJoystickEnabled;
 
         float mCameraSensitivity;
         float mCameraYMultiplier;

--- a/docs/source/reference/modding/settings/input.rst
+++ b/docs/source/reference/modding/settings/input.rst
@@ -120,3 +120,16 @@ If this setting is true, moving the mouse away from the player will look down,
 while moving it towards the player will look up. This setting does not affect cursor movement in GUI mode.
 
 This setting can be toggled in game with the Invert Y Axis button in the Controls panel of the Options menu.
+
+enable controller
+-----------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	True
+
+Enable support of controller input — or rather not ignore controller events,
+which are always sent if a controller is present and detected.
+Disabling this setting can be useful for working around controller-related issues or for setting up split-screen gameplay configurations.
+
+This setting can be toggled in game with the Enable Joystick button in the Controls panel of the Options menu.

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -222,21 +222,19 @@
                     <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 78 16" align="Left Bottom">
                         <Property key="Caption" value="Invert X Axis"/>
                     </Widget>
-                </Widget>
-                <Widget type="HBox" skin="" position="4 254 300 24" align="Left Bottom">
-                    <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Bottom">
+                    <Widget type="AutoSizedButton" skin="MW_Button" position="28 0 24 24" align="Left Bottom">
                         <UserString key="SettingCategory" value="Input"/>
                         <UserString key="SettingName" value="invert y axis"/>
                         <UserString key="SettingType" value="CheckButton"/>
                     </Widget>
-                    <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 78 16" align="Left Bottom">
+                    <Widget type="AutoSizedTextBox" skin="SandText" position="56 4 78 16" align="Left Bottom">
                         <Property key="Caption" value="#{sMouseFlip}"/>
                     </Widget>
                 </Widget>
-                <Widget type="TextBox" skin="NormalText" position="4 284 336 18" align="Left Bottom">
+                <Widget type="TextBox" skin="NormalText" position="4 254 336 18" align="Left Bottom">
                     <Property key="Caption" value="Camera Sensitivity"/>
                 </Widget>
-                <Widget type="MWScrollBar" skin="MW_HScroll" position="4 308 336 18" align="HStretch Bottom">
+                <Widget type="MWScrollBar" skin="MW_HScroll" position="4 278 336 18" align="HStretch Bottom">
                     <Property key="Range" value="10000"/>
                     <Property key="Page" value="300"/>
                     <UserString key="SettingType" value="Slider"/>
@@ -246,13 +244,23 @@
                     <UserString key="SettingMin" value="0.2"/>
                     <UserString key="SettingMax" value="5.0"/>
                 </Widget>
-                <Widget type="TextBox" skin="SandText" position="4 332 336 18" align="Left Bottom">
+                <Widget type="TextBox" skin="SandText" position="4 302 336 18" align="Left Bottom">
                     <Property key="Caption" value="#{sLow}"/>
                     <Property key="TextAlign" value="Left"/>
                 </Widget>
-                <Widget type="TextBox" skin="SandText" position="4 332 336 18" align="Right Bottom">
+                <Widget type="TextBox" skin="SandText" position="4 302 336 18" align="Right Bottom">
                     <Property key="Caption" value="#{sHigh}"/>
                     <Property key="TextAlign" value="Right"/>
+                </Widget>
+                <Widget type="HBox" skin="" position="4 324 336 24" align="Left Bottom">
+                    <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Bottom">
+                        <UserString key="SettingCategory" value="Input"/>
+                        <UserString key="SettingName" value="enable controller"/>
+                        <UserString key="SettingType" value="CheckButton"/>
+                    </Widget>
+                    <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 78 16" align="Left Bottom">
+                        <Property key="Caption" value="#{sEnableJoystick}"/>
+                    </Widget>
                 </Widget>
             </Widget>
             <Widget type="TabItem" skin="" position="4 32 360 308">

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -339,6 +339,9 @@ invert x axis = false
 # Invert the vertical axis while not in GUI mode.
 invert y axis = false
 
+# Enable controller support.
+enable controller = true
+
 [Saves]
 
 # Name of last character played, and default for loading save files.


### PR DESCRIPTION
[Feature 3980](https://gitlab.com/OpenMW/openmw/issues/3980).

Adds a button into Controls menu which "toggles" the controller support, the respective option. When it's off, all, or at least most of the controller input events are ignored by the input manager so the detected controller is effectively disabled.

~~The major issue is that I don't have a controller and cannot tell if it works as it should.~~
Independent testing reports that this works as intended.

Controls section of the in-game settings looks like this at the moment. We're tight on space.

Note that in Morrowind the equivalent button is forced off when a joystick is not detected. However:
1. I don't think there's an easy-to-use way to have unique functionality for generic MyGUI-based setting checkboxes
2. While the setting has no effect when there isn't any controller in the system, it might be less confusing for the user when the button state explicitly shows whether controllers are used or not.

![screenshot004](https://user-images.githubusercontent.com/21265616/52867263-9301ee00-3151-11e9-9e7c-3ebd0f2882a3.png)
