### PR TITLE
Add resources to path list

### DIFF
--- a/docs/source/reference/modding/paths.rst
+++ b/docs/source/reference/modding/paths.rst
@@ -13,6 +13,13 @@ Configuration files and log files
 :Mac:		``$HOME/Library/Preferences/openmw``
 :Windows:	``C:\Users\Username\Documents\my games\openmw``
 
+Screenshots
+-----------
+
+:Linux:		``/usr/share/games/openmw/resources/``
+:Mac:		``?``
+:Windows:	``?``
+
 Savegames
 ---------
 


### PR DESCRIPTION
The resources folder is required for the fonts section of the wiki, but the path isn't stated anywhere. I'm on linux and don't the paths for other OS'.

Made a typo in the heading, new to github, not sure how to fix without making new request