### PR TITLE
Fix some issues, found by PVS-Studio

### DIFF
--- a/apps/essimporter/importercontext.hpp
+++ b/apps/essimporter/importercontext.hpp
@@ -84,6 +84,8 @@ namespace ESSImport
             mGlobalMapState.mBounds.mMaxX = 0;
             mGlobalMapState.mBounds.mMinY = 0;
             mGlobalMapState.mBounds.mMaxY = 0;
+
+            mPlayerBase.blank();
         }
 
         int generateActorId()

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -258,6 +258,9 @@ OMW::Engine::~Engine()
 
     mViewer = nullptr;
 
+    delete mEncoder;
+    mEncoder = nullptr;
+
     if (mWindow)
     {
         SDL_DestroyWindow(mWindow);
@@ -657,8 +660,7 @@ void OMW::Engine::go()
     settingspath = loadSettings (settings);
 
     // Create encoder
-    ToUTF8::Utf8Encoder encoder (mEncoding);
-    mEncoder = &encoder;
+    mEncoder = new ToUTF8::Utf8Encoder(mEncoding);
 
     // Setup viewer
     mViewer = new osgViewer::Viewer;

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -780,7 +780,7 @@ namespace MWClass
                 MWWorld::Ptr armor = ((armorslot != inv.end()) ? *armorslot : MWWorld::Ptr());
                 if(!armor.isEmpty() && armor.getTypeName() == typeid(ESM::Armor).name())
                 {
-                    if (attacker.isEmpty() || (!attacker.isEmpty() && !(object.isEmpty() && !attacker.getClass().isNpc()))) // Unarmed creature attacks don't affect armor condition
+                    if (!object.isEmpty() || attacker.isEmpty() || attacker.getClass().isNpc()) // Unarmed creature attacks don't affect armor condition
                     {
                         int armorhealth = armor.getClass().getItemHealth(armor);
                         armorhealth -= std::min(damageDiff, armorhealth);

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -262,7 +262,7 @@ namespace MWGui
 
             if (mode == GM_Console)
                 MWBase::Environment::get().getWindowManager()->setConsoleSelectedObject(object);
-            else if ((mode == GM_Container) || (mode == GM_Inventory))
+            else //if ((mode == GM_Container) || (mode == GM_Inventory))
             {
                 // pick up object
                 if (!object.isEmpty())

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -631,7 +631,7 @@ namespace
 
                 if (page+2 < book->pageCount())
                 {
-                    MWBase::Environment::get().getWindowManager()->playSound("book page", true);
+                    MWBase::Environment::get().getWindowManager()->playSound("book page");
 
                     page += 2;
                     updateShowingPages ();
@@ -649,7 +649,7 @@ namespace
 
                 if(page >= 2)
                 {
-                    MWBase::Environment::get().getWindowManager()->playSound("book page", true);
+                    MWBase::Environment::get().getWindowManager()->playSound("book page");
 
                     page -= 2;
                     updateShowingPages ();

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -327,11 +327,9 @@ namespace MWGui
 
         addGroup(MWBase::Environment::get().getWindowManager()->getGameSettingString(titleId, titleDefault), coord1, coord2);
 
-        SkillList::const_iterator end = skills.end();
-        for (SkillList::const_iterator it = skills.begin(); it != end; ++it)
+        for (const int& skillId : skills)
         {
-            int skillId = *it;
-            if (skillId < 0 || skillId > ESM::Skill::Length) // Skip unknown skill indexes
+            if (skillId < 0 || skillId >= ESM::Skill::Length) // Skip unknown skill indexes
                 continue;
             assert(skillId >= 0 && skillId < ESM::Skill::Length);
             const std::string &skillNameId = ESM::Skill::sSkillNameIds[skillId];

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -41,7 +41,7 @@ namespace MWGui
             else if (skill < ESM::Skill::Length)
                 setSkillId(static_cast<ESM::Skill::SkillEnum>(skill));
             else
-                throw new std::runtime_error("Skill number out of range");
+                throw std::runtime_error("Skill number out of range");
         }
 
         void MWSkill::setSkillValue(const SkillValue& value)

--- a/apps/openmw/mwmechanics/aiavoiddoor.cpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.cpp
@@ -12,7 +12,7 @@
 #include "steering.hpp"
 
 MWMechanics::AiAvoidDoor::AiAvoidDoor(const MWWorld::ConstPtr& doorPtr)
-: AiPackage(), mDuration(1), mDoorPtr(doorPtr), mAdjAngle(0)
+: AiPackage(), mDuration(1), mDoorPtr(doorPtr), mLastPos(ESM::Position()), mAdjAngle(0)
 {
 
 }

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -328,32 +328,32 @@ void ActorAnimation::updateQuiver()
             suitableAmmo = ammo->get<ESM::Weapon>()->mBase->mData.mType == ESM::Weapon::Arrow;
     }
 
-    if (ammoNode && suitableAmmo)
+    if (!suitableAmmo)
+        return;
+
+    // We should not show more ammo than equipped and more than quiver mesh has
+    ammoCount = std::min(ammoCount, ammoNode->getNumChildren());
+
+    // Remove existing ammo nodes
+    for (unsigned int i=0; i<ammoNode->getNumChildren(); ++i)
     {
-        // We should not show more ammo than equipped and more than quiver mesh has
-        ammoCount = std::min(ammoCount, ammoNode->getNumChildren());
+        osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
+        if (!arrowNode->getNumChildren())
+            continue;
 
-        // Remove existing ammo nodes
-        for (unsigned int i=0; i<ammoNode->getNumChildren(); ++i)
-        {
-            osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
-            if (!arrowNode->getNumChildren())
-                continue;
+        osg::ref_ptr<osg::Node> arrowChildNode = arrowNode->getChild(0);
+        arrowNode->removeChild(arrowChildNode);
+    }
 
-            osg::ref_ptr<osg::Node> arrowChildNode = arrowNode->getChild(0);
-            arrowNode->removeChild(arrowChildNode);
-        }
-
-        // Add new ones
-        osg::Vec4f glowColor = getEnchantmentColor(*ammo);
-        std::string model = ammo->getClass().getModel(*ammo);
-        for (unsigned int i=0; i<ammoCount; ++i)
-        {
-            osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
-            osg::ref_ptr<osg::Node> arrow = mResourceSystem->getSceneManager()->getInstance(model, arrowNode);
-            if (!ammo->getClass().getEnchantment(*ammo).empty())
-                addGlow(arrow, glowColor);
-        }
+    // Add new ones
+    osg::Vec4f glowColor = getEnchantmentColor(*ammo);
+    std::string model = ammo->getClass().getModel(*ammo);
+    for (unsigned int i=0; i<ammoCount; ++i)
+    {
+        osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
+        osg::ref_ptr<osg::Node> arrow = mResourceSystem->getSceneManager()->getInstance(model, arrowNode);
+        if (!ammo->getClass().getEnchantment(*ammo).empty())
+            addGlow(arrow, glowColor);
     }
 }
 

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -30,6 +30,7 @@ namespace MWWorld
     Player::Player (const ESM::NPC *player)
       : mCellStore(0),
         mLastKnownExteriorPosition(0,0,0),
+        mMarkedPosition(ESM::Position()),
         mMarkedCell(nullptr),
         mAutoMove(false),
         mForwardBackward(0),

--- a/apps/wizard/unshield/unshieldworker.cpp
+++ b/apps/wizard/unshield/unshieldworker.cpp
@@ -876,7 +876,7 @@ QStringList Wizard::UnshieldWorker::findFiles(const QString &fileName, const QSt
                     result.append(info.absoluteFilePath());
                 break;
             case Qt::MatchEndsWith:
-                if (info.fileName().endsWith(fileName), Qt::CaseInsensitive)
+                if (info.fileName().endsWith(fileName, Qt::CaseInsensitive))
                     result.append(info.absoluteFilePath());
                 break;
             }

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -368,7 +368,7 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
         }
         else
         {
-            throw new std::runtime_error("Tried to package non-motion event!");
+            throw std::runtime_error("Tried to package non-motion event!");
         }
 
         return pack_evt;


### PR DESCRIPTION
1. Do not throw by reference ([V1022](https://www.viva64.com/en/w/v1022/)).
2. Simplify some checks where we already check the same condition above.
3. Qt::CaseInsensitive is supposed to be an argument of endsWith() call for case-insensitive search.
4. Fix possible overrun of the ESM::Skill::sSkillNameIds array with skillId = 27 (could happen only in Release mode because of correct assert), simplify loop.
5. Init some missing variables
6. Previously the `playSound` function in the WindowsManager had the bool argument, now it has two optional float arguments instead, but I forgot to change a couple of calls. Fixed.
7. Since we init the `encoder` variable in the stack and pass reference to it to the mEncoder field, it can become invalid outside the Engine::go() call. A suggested solution: init encoder object in the heap and destroy it in the engine destructor.