### PR TITLE
[WIP] Optimize navmesh update (bug #4785)

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -69,6 +69,8 @@ namespace
 
 void OMW::Engine::executeLocalScripts()
 {
+    const ::ProfileScope profile("Engine::executeLocalScripts");
+
     MWWorld::LocalScripts& localScripts = mEnvironment.getWorld()->getLocalScripts();
 
     localScripts.startIteration();
@@ -85,6 +87,8 @@ bool OMW::Engine::frame(float frametime)
 {
     try
     {
+        const ::ProfileScope profile("Engine::frame");
+
         mStartTick = mViewer->getStartTick();
 
         mEnvironment.setFrameDuration(frametime);
@@ -752,6 +756,8 @@ void OMW::Engine::go()
 
     // Save user settings
     settings.saveUser(settingspath);
+
+    ::Profiler::instance().save();
 
     Log(Debug::Info) << "Quitting peacefully.";
 }

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -412,6 +412,8 @@ namespace MWInput
 
     void InputManager::update(float dt, bool disableControls, bool disableEvents)
     {
+        const ::ProfileScope profile("InputManager::update");
+
         mControlsDisabled = disableControls;
 
         mInputManager->setMouseVisible(MWBase::Environment::get().getWindowManager()->getCursorVisible());

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -27,6 +27,8 @@
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 
+#include <components/debug/debuglog.hpp>
+
 #include "../mwrender/animation.hpp"
 
 #include "../mwbase/environment.hpp"

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -28,6 +28,8 @@
 #include "actorutil.hpp"
 #include "combat.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 namespace
 {
 
@@ -298,6 +300,8 @@ namespace MWMechanics
 
     void MechanicsManager::update(float duration, bool paused)
     {
+        const ::ProfileScope profile("MechanicsManager::update");
+
         if(!mWatched.isEmpty())
         {
             MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1239,6 +1239,8 @@ namespace MWPhysics
 
     const PtrVelocityList& PhysicsSystem::applyQueuedMovement(float dt)
     {
+        const ::ProfileScope profile("PhysicsSystem::applyQueuedMovement");
+
         mMovementResults.clear();
 
         mTimeAccum += dt;

--- a/apps/openmw/mwscript/scriptmanagerimp.cpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.cpp
@@ -91,6 +91,8 @@ namespace MWScript
 
     void ScriptManager::run (const std::string& name, Interpreter::Context& interpreterContext)
     {
+        const ::ProfileScope profile("ScriptManager::run");
+
         // compile script
         ScriptCollection::iterator iter = mScripts.find (name);
 

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -663,6 +663,7 @@ namespace MWSound
                                      float volume, float pitch, Type type, PlayMode mode,
                                      float offset)
     {
+        const ::ProfileScope profile("SoundManager::playSound3D");
         if(!mOutput->isInitialized())
             return nullptr;
 
@@ -718,6 +719,7 @@ namespace MWSound
 
     void SoundManager::stopSound3D(const MWWorld::ConstPtr &ptr, const std::string& soundId)
     {
+        const ::ProfileScope profile("SoundManager::stopSound3D");
         Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
         if (!sfx) return;
 
@@ -1119,6 +1121,8 @@ namespace MWSound
 
     void SoundManager::update(float duration)
     {
+        const ::ProfileScope profile("SoundManager::update");
+
         if(!mOutput->isInitialized())
             return;
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -596,6 +596,8 @@ MWState::StateManager::CharacterIterator MWState::StateManager::characterEnd()
 
 void MWState::StateManager::update (float duration)
 {
+    const ::ProfileScope profile("StateManager::update");
+
     mTimePlayed += duration;
 
     // Note: It would be nicer to trigger this from InputManager, i.e. the very beginning of the frame update.

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -317,6 +317,7 @@ namespace MWWorld
 
     void Scene::update (float duration, bool paused)
     {
+        const ::ProfileScope profile("Scene::update");
         mPreloadTimer += duration;
         if (mPreloadTimer > 0.1f)
         {
@@ -388,6 +389,8 @@ namespace MWWorld
 
     void Scene::loadCell (CellStore *cell, Loading::Listener* loadingListener, bool respawn)
     {
+        const ::ProfileScope profile("Scene::loadCell");
+
         std::pair<CellStoreCollection::iterator, bool> result = mActiveCells.insert(cell);
 
         if(result.second)
@@ -482,6 +485,8 @@ namespace MWWorld
 
     void Scene::playerMoved(const osg::Vec3f &pos)
     {
+        const ::ProfileScope profile("Scene::playerMoved");
+
         const auto navigator = MWBase::Environment::get().getWorld()->getNavigator();
         const auto player = MWBase::Environment::get().getWorld()->getPlayerPtr();
         navigator->update(player.getRefData().getPosition().asVec3());
@@ -506,6 +511,8 @@ namespace MWWorld
 
     void Scene::changeCellGrid (int playerCellX, int playerCellY, bool changeEvent)
     {
+        const ::ProfileScope profile("Scene::changeCellGrid");
+
         Loading::Listener* loadingListener = MWBase::Environment::get().getWindowManager()->getLoadingScreen();
         Loading::ScopedLoad load(loadingListener);
 
@@ -805,6 +812,7 @@ namespace MWWorld
 
     void Scene::removeObjectFromScene (const Ptr& ptr)
     {
+        const ::ProfileScope profile("Scene::removeObjectFromScene");
         MWBase::Environment::get().getMechanicsManager()->remove (ptr);
         MWBase::Environment::get().getSoundManager()->stopSound3D (ptr);
         const auto navigator = MWBase::Environment::get().getWorld()->getNavigator();

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -809,11 +809,7 @@ namespace MWWorld
         MWBase::Environment::get().getSoundManager()->stopSound3D (ptr);
         const auto navigator = MWBase::Environment::get().getWorld()->getNavigator();
         if (const auto object = mPhysics->getObject(ptr))
-        {
             navigator->removeObject(DetourNavigator::ObjectId(object));
-            const auto player = MWBase::Environment::get().getWorld()->getPlayerPtr();
-            navigator->update(player.getRefData().getPosition().asVec3());
-        }
         else if (const auto actor = mPhysics->getActor(ptr))
         {
             const auto& halfExtents = ptr.getCell()->isExterior()

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -848,6 +848,8 @@ namespace MWWorld
 
     void World::disable (const Ptr& reference)
     {
+        const ::ProfileScope profile("World::disable");
+
         // disable is a no-op for items in containers
         if (!reference.isInCell())
             return;
@@ -1160,6 +1162,8 @@ namespace MWWorld
 
     void World::deleteObject (const Ptr& ptr)
     {
+        const ::ProfileScope profile("World::deleteObject");
+
         if (!ptr.getRefData().isDeleted() && ptr.getContainerStore() == nullptr)
         {
             if (ptr == getPlayerPtr())
@@ -1199,6 +1203,8 @@ namespace MWWorld
 
     MWWorld::Ptr World::moveObject(const Ptr &ptr, CellStore* newCell, float x, float y, float z, bool movePhysics)
     {
+        const ::ProfileScope profile("World::moveObject");
+
         ESM::Position pos = ptr.getRefData().getPosition();
 
         pos.pos[0] = x;
@@ -1310,6 +1316,7 @@ namespace MWWorld
 
     MWWorld::Ptr World::moveObjectImp(const Ptr& ptr, float x, float y, float z, bool movePhysics)
     {
+        const ::ProfileScope profile("World::moveObjectImp");
         CellStore *cell = ptr.getCell();
 
         if (cell->isExterior()) {
@@ -1542,6 +1549,8 @@ namespace MWWorld
 
     void World::doPhysics(float duration)
     {
+        const ::ProfileScope profile("World::doPhysics");
+
         mPhysics->stepSimulation(duration);
         processDoors(duration);
 
@@ -1565,6 +1574,7 @@ namespace MWWorld
 
     void World::updateNavigator()
     {
+        const ::ProfileScope profile("World::updateNavigator");
         bool updated = false;
 
         mPhysics->forEachAnimatedObject([&] (const MWPhysics::Object* object)
@@ -1607,6 +1617,7 @@ namespace MWWorld
 
     void World::processDoors(float duration)
     {
+        const ::ProfileScope profile("World::processDoors");
         std::map<MWWorld::Ptr, int>::iterator it = mDoorStates.begin();
         while (it != mDoorStates.end())
         {
@@ -1782,6 +1793,8 @@ namespace MWWorld
 
     void World::update (float duration, bool paused)
     {
+        const ::ProfileScope profile("World::update");
+
         if (mGoToJail && !paused)
             goToJail();
 
@@ -1827,6 +1840,7 @@ namespace MWWorld
 
     void World::updatePlayer()
     {
+        const ::ProfileScope profile("World::updatePlayer");
         MWWorld::Ptr player = getPlayerPtr();
 
         // TODO: move to MWWorld::Player
@@ -1883,6 +1897,7 @@ namespace MWWorld
 
     void World::preloadSpells()
     {
+        const ::ProfileScope profile("World::preloadSpells");
         std::string selectedSpell = MWBase::Environment::get().getWindowManager()->getSelectedSpell();
         if (!selectedSpell.empty())
         {
@@ -1916,6 +1931,7 @@ namespace MWWorld
 
     void World::updateSoundListener()
     {
+        const ::ProfileScope profile("World::updateSoundListener");
         const ESM::Position& refpos = getPlayerPtr().getRefData().getPosition();
         osg::Vec3f listenerPos;
 
@@ -3292,6 +3308,7 @@ namespace MWWorld
 
     void World::updateWeather(float duration, bool paused)
     {
+        const ::ProfileScope profile("World::updateWeather");
         bool isExterior = isCellExterior() || isCellQuasiExterior();
         if (mPlayer->wasTeleported())
         {

--- a/apps/openmw_test_suite/detournavigator/operators.hpp
+++ b/apps/openmw_test_suite/detournavigator/operators.hpp
@@ -29,7 +29,10 @@ namespace testing
         for (const auto& v : value)
         {
             std::ostringstream stream;
-            stream << v;
+            stream << "osg::Vec3f("
+                   << std::setprecision(std::numeric_limits<float>::max_exponent10) << v.x() << ", "
+                   << std::setprecision(std::numeric_limits<float>::max_exponent10) << v.y() << ", "
+                   << std::setprecision(std::numeric_limits<float>::max_exponent10) << v.z() << ")";
             (*this) << stream.str() << ",\n";
         }
         return (*this) << "}";

--- a/components/debug/debuglog.cpp
+++ b/components/debug/debuglog.cpp
@@ -1,8 +1,30 @@
 #include "debuglog.hpp"
 
+#include <boost/filesystem.hpp>
+
+#include <fstream>
+
 namespace Debug
 {
     Level CurrentDebugLevel = Level::NoLevel;
 }
 
 std::mutex Log::sLock;
+
+Profiler::Profiler()
+{
+    mStarts.reserve(100);
+    mRecords.reserve(30000000);
+    mRecords.resize(30000000);
+    mRecords.resize(0);
+}
+
+void Profiler::save(const std::string& path)
+{
+    {
+        std::ofstream file(path);
+        for (const auto& record : mRecords)
+            file << record.mDepth << " " << record.mName << " " << record.mDuration.count() << '\n';
+    }
+    Log(Debug::Verbose) << "profile: " << mRecords.size() << " " << boost::filesystem::canonical(path);
+}

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -80,9 +80,14 @@ namespace DetourNavigator
 
         const std::lock_guard<std::mutex> lock(mMutex);
 
+        auto pushed = mPushed.find(agentHalfExtents);
+
+        if (pushed == mPushed.end())
+            pushed = mPushed.insert(std::make_pair(agentHalfExtents, std::set<TilePosition>())).first;
+
         for (const auto& changedTile : changedTiles)
         {
-            if (mPushed[agentHalfExtents].insert(changedTile.first).second)
+            if (pushed->second.insert(changedTile.first).second)
                 mJobs.push(Job {agentHalfExtents, navMeshCacheItem, changedTile.first,
                                 makePriority(changedTile.first, changedTile.second, playerTile)});
         }

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -153,9 +153,7 @@ namespace DetourNavigator
     boost::optional<AsyncNavMeshUpdater::Job> AsyncNavMeshUpdater::getNextJob()
     {
         std::unique_lock<std::mutex> lock(mMutex);
-        if (mJobs.empty())
-            mHasJob.wait_for(lock, std::chrono::milliseconds(10));
-        if (mJobs.empty())
+        if (!mHasJob.wait_for(lock, std::chrono::milliseconds(10), [&] { return !mJobs.empty(); }))
         {
             mFirstStart.lock()->reset();
             mDone.notify_all();

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -73,6 +73,8 @@ namespace DetourNavigator
         const SharedNavMeshCacheItem& navMeshCacheItem, const TilePosition& playerTile,
         const std::map<TilePosition, ChangeType>& changedTiles)
     {
+        const ::ProfileScope profile("AsyncNavMeshUpdater::post");
+
         *mPlayerTile.lock() = playerTile;
 
         if (changedTiles.empty())

--- a/components/detournavigator/asyncnavmeshupdater.hpp
+++ b/components/detournavigator/asyncnavmeshupdater.hpp
@@ -58,7 +58,7 @@ namespace DetourNavigator
             }
         };
 
-        using Jobs = std::priority_queue<Job, std::deque<Job>>;
+        using Jobs = std::priority_queue<Job, std::vector<Job>>;
 
         std::reference_wrapper<const Settings> mSettings;
         std::reference_wrapper<TileCachedRecastMeshManager> mRecastMeshManager;

--- a/components/detournavigator/cachedrecastmeshmanager.cpp
+++ b/components/detournavigator/cachedrecastmeshmanager.cpp
@@ -1,6 +1,8 @@
 #include "cachedrecastmeshmanager.hpp"
 #include "debug.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 namespace DetourNavigator
 {
     CachedRecastMeshManager::CachedRecastMeshManager(const Settings& settings, const TileBounds& bounds)
@@ -26,6 +28,7 @@ namespace DetourNavigator
 
     boost::optional<RemovedRecastMeshObject> CachedRecastMeshManager::removeObject(const ObjectId id)
     {
+        const ::ProfileScope profile("CachedRecastMeshManager::removeObject");
         const auto object = mImpl.removeObject(id);
         if (object)
             mCached.reset();

--- a/components/detournavigator/findsmoothpath.hpp
+++ b/components/detournavigator/findsmoothpath.hpp
@@ -8,6 +8,8 @@
 #include "settingsutils.hpp"
 #include "debug.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 #include <DetourCommon.h>
 #include <DetourNavMesh.h>
 #include <DetourNavMeshQuery.h>

--- a/components/detournavigator/navigator.hpp
+++ b/components/detournavigator/navigator.hpp
@@ -191,7 +191,7 @@ namespace DetourNavigator
          */
         virtual std::map<osg::Vec3f, SharedNavMeshCacheItem> getNavMeshes() const = 0;
 
-        virtual Settings getSettings() const = 0;
+        virtual const Settings& getSettings() const = 0;
     };
 }
 

--- a/components/detournavigator/navigator.hpp
+++ b/components/detournavigator/navigator.hpp
@@ -7,6 +7,8 @@
 #include "objectid.hpp"
 #include "navmeshcacheitem.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 namespace DetourNavigator
 {
     struct ObjectShapes
@@ -170,6 +172,7 @@ namespace DetourNavigator
                 >::value,
                 "out is not an OutputIterator"
             );
+            const ::ProfileScope profile("Navigator::findPath");
             const auto navMesh = getNavMesh(agentHalfExtents);
             if (!navMesh)
                 return out;

--- a/components/detournavigator/navigatorimpl.cpp
+++ b/components/detournavigator/navigatorimpl.cpp
@@ -2,6 +2,8 @@
 #include "debug.hpp"
 #include "settingsutils.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 #include <Recast.h>
 
 namespace DetourNavigator
@@ -14,12 +16,14 @@ namespace DetourNavigator
 
     void NavigatorImpl::addAgent(const osg::Vec3f& agentHalfExtents)
     {
+        const ::ProfileScope profile("Navigator::addAgent");
         ++mAgents[agentHalfExtents];
         mNavMeshManager.addAgent(agentHalfExtents);
     }
 
     void NavigatorImpl::removeAgent(const osg::Vec3f& agentHalfExtents)
     {
+        const ::ProfileScope profile("Navigator::removeAgent");
         const auto it = mAgents.find(agentHalfExtents);
         if (it == mAgents.end() || --it->second)
             return;
@@ -29,11 +33,13 @@ namespace DetourNavigator
 
     bool NavigatorImpl::addObject(const ObjectId id, const btCollisionShape& shape, const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::addObject1");
         return mNavMeshManager.addObject(id, shape, transform, AreaType_ground);
     }
 
     bool NavigatorImpl::addObject(const ObjectId id, const ObjectShapes& shapes, const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::addObject2");
         bool result = addObject(id, shapes.mShape, transform);
         if (shapes.mAvoid)
         {
@@ -49,6 +55,7 @@ namespace DetourNavigator
 
     bool NavigatorImpl::addObject(const ObjectId id, const DoorShapes& shapes, const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::addObject3");
         if (addObject(id, static_cast<const ObjectShapes&>(shapes), transform))
         {
             mNavMeshManager.addOffMeshConnection(
@@ -63,11 +70,13 @@ namespace DetourNavigator
 
     bool NavigatorImpl::updateObject(const ObjectId id, const btCollisionShape& shape, const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::updateObject1");
         return mNavMeshManager.updateObject(id, shape, transform, AreaType_ground);
     }
 
     bool NavigatorImpl::updateObject(const ObjectId id, const ObjectShapes& shapes, const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::updateObject2");
         bool result = updateObject(id, shapes.mShape, transform);
         if (shapes.mAvoid)
         {
@@ -83,11 +92,13 @@ namespace DetourNavigator
 
     bool NavigatorImpl::updateObject(const ObjectId id, const DoorShapes& shapes, const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::updateObject3");
         return updateObject(id, static_cast<const ObjectShapes&>(shapes), transform);
     }
 
     bool NavigatorImpl::removeObject(const ObjectId id)
     {
+        const ::ProfileScope profile("Navigator::removeObject");
         bool result = mNavMeshManager.removeObject(id);
         const auto avoid = mAvoidIds.find(id);
         if (avoid != mAvoidIds.end())
@@ -102,23 +113,27 @@ namespace DetourNavigator
     bool NavigatorImpl::addWater(const osg::Vec2i& cellPosition, const int cellSize, const btScalar level,
         const btTransform& transform)
     {
+        const ::ProfileScope profile("Navigator::addWater");
         return mNavMeshManager.addWater(cellPosition, cellSize,
             btTransform(transform.getBasis(), btVector3(transform.getOrigin().x(), transform.getOrigin().y(), level)));
     }
 
     bool NavigatorImpl::removeWater(const osg::Vec2i& cellPosition)
     {
+        const ::ProfileScope profile("Navigator::removeWater");
         return mNavMeshManager.removeWater(cellPosition);
     }
 
     void NavigatorImpl::update(const osg::Vec3f& playerPosition)
     {
+        const ::ProfileScope profile("Navigator::update");
         for (const auto& v : mAgents)
             mNavMeshManager.update(playerPosition, v.first);
     }
 
     void NavigatorImpl::wait()
     {
+        const ::ProfileScope profile("Navigator::wait");
         mNavMeshManager.wait();
     }
 
@@ -129,6 +144,7 @@ namespace DetourNavigator
 
     std::map<osg::Vec3f, SharedNavMeshCacheItem> NavigatorImpl::getNavMeshes() const
     {
+        const ::ProfileScope profile("Navigator::getNavMeshes");
         return mNavMeshManager.getNavMeshes();
     }
 
@@ -139,16 +155,19 @@ namespace DetourNavigator
 
     void NavigatorImpl::updateAvoidShapeId(const ObjectId id, const ObjectId avoidId)
     {
+        const ::ProfileScope profile("Navigator::updateAvoidShapeId");
         updateId(id, avoidId, mWaterIds);
     }
 
     void NavigatorImpl::updateWaterShapeId(const ObjectId id, const ObjectId waterId)
     {
+        const ::ProfileScope profile("Navigator::updateWaterShapeId");
         updateId(id, waterId, mWaterIds);
     }
 
     void NavigatorImpl::updateId(const ObjectId id, const ObjectId updateId, std::unordered_map<ObjectId, ObjectId>& ids)
     {
+        const ::ProfileScope profile("Navigator::updateId");
         auto inserted = ids.insert(std::make_pair(id, updateId));
         if (!inserted.second)
         {

--- a/components/detournavigator/navigatorimpl.cpp
+++ b/components/detournavigator/navigatorimpl.cpp
@@ -132,7 +132,7 @@ namespace DetourNavigator
         return mNavMeshManager.getNavMeshes();
     }
 
-    Settings NavigatorImpl::getSettings() const
+    const Settings& NavigatorImpl::getSettings() const
     {
         return mSettings;
     }

--- a/components/detournavigator/navigatorimpl.hpp
+++ b/components/detournavigator/navigatorimpl.hpp
@@ -46,7 +46,7 @@ namespace DetourNavigator
 
         std::map<osg::Vec3f, SharedNavMeshCacheItem> getNavMeshes() const override;
 
-        Settings getSettings() const override;
+        const Settings& getSettings() const override;
 
     private:
         Settings mSettings;

--- a/components/detournavigator/navigatorstub.hpp
+++ b/components/detournavigator/navigatorstub.hpp
@@ -5,8 +5,9 @@
 
 namespace DetourNavigator
 {
-    struct NavigatorStub final : public Navigator
+    class NavigatorStub final : public Navigator
     {
+    public:
         NavigatorStub() = default;
 
         void addAgent(const osg::Vec3f& /*agentHalfExtents*/) override {}
@@ -65,7 +66,7 @@ namespace DetourNavigator
 
         SharedNavMeshCacheItem getNavMesh(const osg::Vec3f& /*agentHalfExtents*/) const override
         {
-            return SharedNavMeshCacheItem();
+            return mEmptyNavMeshCacheItem;
         }
 
         std::map<osg::Vec3f, SharedNavMeshCacheItem> getNavMeshes() const override
@@ -73,10 +74,14 @@ namespace DetourNavigator
             return std::map<osg::Vec3f, SharedNavMeshCacheItem>();
         }
 
-        Settings getSettings() const override
+        const Settings& getSettings() const override
         {
-            return Settings {};
+            return mDefaultSettings;
         }
+
+    private:
+        Settings mDefaultSettings {};
+        SharedNavMeshCacheItem mEmptyNavMeshCacheItem;
     };
 }
 

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -7,6 +7,8 @@
 #include "settings.hpp"
 #include "sharednavmesh.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 #include <DetourNavMesh.h>
 
 #include <BulletCollision/CollisionShapes/btConcaveShape.h>
@@ -54,6 +56,7 @@ namespace DetourNavigator
 
     bool NavMeshManager::removeObject(const ObjectId id)
     {
+        const ::ProfileScope profile("NavMeshManager::removeObject");
         const auto object = mRecastMeshManager.removeObject(id);
         if (!object)
             return false;
@@ -71,6 +74,7 @@ namespace DetourNavigator
 
     bool NavMeshManager::removeWater(const osg::Vec2i& cellPosition)
     {
+        const ::ProfileScope profile("NavMeshManager::removeWater");
         const auto water = mRecastMeshManager.removeWater(cellPosition);
         if (!water)
             return false;
@@ -126,6 +130,7 @@ namespace DetourNavigator
 
     void NavMeshManager::update(osg::Vec3f playerPosition, const osg::Vec3f& agentHalfExtents)
     {
+        const ::ProfileScope profile("NavMeshManager::update");
         const auto playerTile = getTilePosition(mSettings, toNavMeshCoordinates(mSettings, playerPosition));
         auto& lastRevision = mLastRecastMeshManagerRevision[agentHalfExtents];
         auto lastPlayerTile = mPlayerTile.find(agentHalfExtents);
@@ -200,6 +205,7 @@ namespace DetourNavigator
     void NavMeshManager::addChangedTiles(const btCollisionShape& shape, const btTransform& transform,
             const ChangeType changeType)
     {
+        const ::ProfileScope profile("NavMeshManager::addChangedTiles1");
         getTilesPositions(shape, transform, mSettings,
             [&] (const TilePosition& v) { addChangedTile(v, changeType); });
     }
@@ -207,6 +213,7 @@ namespace DetourNavigator
     void NavMeshManager::addChangedTiles(const int cellSize, const btTransform& transform,
             const ChangeType changeType)
     {
+        const ::ProfileScope profile("NavMeshManager::addChangedTiles2");
         if (cellSize == std::numeric_limits<int>::max())
             return;
 

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -157,10 +157,6 @@ namespace DetourNavigator
                         else
                             tileToPost->second = addChangeType(tileToPost->second, tile.second);
                     }
-                for (const auto& tile : tilesToPost)
-                    changedTiles->second.erase(tile.first);
-                if (changedTiles->second.empty())
-                    mChangedTiles.erase(changedTiles);
             }
             const auto maxTiles = navMesh.getParams()->maxTiles;
             mRecastMeshManager.forEachTilePosition([&] (const TilePosition& tile)
@@ -176,6 +172,8 @@ namespace DetourNavigator
             });
         }
         mAsyncNavMeshUpdater.post(agentHalfExtents, cached, playerTile, tilesToPost);
+        if (changedTiles != mChangedTiles.end())
+            changedTiles->second.clear();
         log("cache update posted for agent=", agentHalfExtents,
             " playerTile=", lastPlayerTile->second,
             " recastMeshManagerRevision=", lastRevision);

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -91,6 +91,9 @@ namespace DetourNavigator
     void NavMeshManager::reset(const osg::Vec3f& agentHalfExtents)
     {
         mCache.erase(agentHalfExtents);
+        mChangedTiles.erase(agentHalfExtents);
+        mPlayerTile.erase(agentHalfExtents);
+        mLastRecastMeshManagerRevision.erase(agentHalfExtents);
     }
 
     void NavMeshManager::addOffMeshConnection(const ObjectId id, const osg::Vec3f& start, const osg::Vec3f& end)

--- a/components/detournavigator/recastmeshmanager.cpp
+++ b/components/detournavigator/recastmeshmanager.cpp
@@ -1,5 +1,7 @@
 #include "recastmeshmanager.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 #include <BulletCollision/CollisionShapes/btCompoundShape.h>
 #include <BulletCollision/CollisionShapes/btHeightfieldTerrainShape.h>
 
@@ -37,6 +39,7 @@ namespace DetourNavigator
 
     boost::optional<RemovedRecastMeshObject> RecastMeshManager::removeObject(const ObjectId id)
     {
+        const ::ProfileScope profile("RecastMeshManager::removeObject");
         const auto object = mObjects.find(id);
         if (object == mObjects.end())
             return boost::none;

--- a/components/detournavigator/tilecachedrecastmeshmanager.cpp
+++ b/components/detournavigator/tilecachedrecastmeshmanager.cpp
@@ -3,6 +3,8 @@
 #include "gettilespositions.hpp"
 #include "settingsutils.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 namespace DetourNavigator
 {
     TileCachedRecastMeshManager::TileCachedRecastMeshManager(const Settings& settings)
@@ -72,6 +74,7 @@ namespace DetourNavigator
 
     boost::optional<RemovedRecastMeshObject> TileCachedRecastMeshManager::removeObject(const ObjectId id)
     {
+        const ::ProfileScope profile("TileCachedRecastMeshManager::removeObject");
         const auto object = mObjectsTilesPositions.find(id);
         if (object == mObjectsTilesPositions.end())
             return boost::none;
@@ -206,6 +209,7 @@ namespace DetourNavigator
     boost::optional<RemovedRecastMeshObject> TileCachedRecastMeshManager::removeTile(const ObjectId id,
         const TilePosition& tilePosition, std::map<TilePosition, CachedRecastMeshManager>& tiles)
     {
+        const ::ProfileScope profile("TileCachedRecastMeshManager::removeTile");
         const auto tile = tiles.find(tilePosition);
         if (tile == tiles.end())
             return boost::optional<RemovedRecastMeshObject>();

--- a/components/sceneutil/navmesh.cpp
+++ b/components/sceneutil/navmesh.cpp
@@ -16,7 +16,7 @@ namespace SceneUtil
         dtNavMeshQuery navMeshQuery;
         navMeshQuery.init(&navMesh, settings.mMaxNavMeshQueryNodes);
         duDebugDrawNavMeshWithClosedList(&debugDraw, navMesh, navMeshQuery,
-                                         DU_DRAWNAVMESH_OFFMESHCONS | DU_DRAWNAVMESH_CLOSEDLIST);
+                                         DU_DRAWNAVMESH_OFFMESHCONS | DU_DRAWNAVMESH_CLOSEDLIST | DU_DRAWNAVMESH_HEAT_TILES);
         return group;
     }
 }

--- a/extern/recastnavigation/DebugUtils/Include/DebugDraw.h
+++ b/extern/recastnavigation/DebugUtils/Include/DebugDraw.h
@@ -87,6 +87,7 @@ inline unsigned int duRGBAf(float fr, float fg, float fb, float fa)
 
 unsigned int duIntToCol(int i, int a);
 void duIntToCol(int i, float* col);
+unsigned int duHeatToCol(float heat, int a);
 
 inline unsigned int duMultCol(const unsigned int col, const unsigned int d)
 {
@@ -218,6 +219,5 @@ private:
 	duDisplayList(const duDisplayList&);
 	duDisplayList& operator=(const duDisplayList&);
 };
-
 
 #endif // DEBUGDRAW_H

--- a/extern/recastnavigation/DebugUtils/Include/DetourDebugDraw.h
+++ b/extern/recastnavigation/DebugUtils/Include/DetourDebugDraw.h
@@ -28,6 +28,7 @@ enum DrawNavMeshFlags
 	DU_DRAWNAVMESH_OFFMESHCONS = 0x01,
 	DU_DRAWNAVMESH_CLOSEDLIST = 0x02,
 	DU_DRAWNAVMESH_COLOR_TILES = 0x04,
+	DU_DRAWNAVMESH_HEAT_TILES = 0x08,
 };
 
 void duDebugDrawNavMesh(struct duDebugDraw* dd, const dtNavMesh& mesh, unsigned char flags);

--- a/extern/recastnavigation/DebugUtils/Source/DebugDraw.cpp
+++ b/extern/recastnavigation/DebugUtils/Source/DebugDraw.cpp
@@ -21,6 +21,7 @@
 #include "DebugDraw.h"
 #include "DetourMath.h"
 #include "DetourNavMesh.h"
+#include "DetourCommon.h"
 
 
 duDebugDraw::~duDebugDraw()
@@ -62,6 +63,15 @@ void duIntToCol(int i, float* col)
 	col[0] = 1 - r*63.0f/255.0f;
 	col[1] = 1 - g*63.0f/255.0f;
 	col[2] = 1 - b*63.0f/255.0f;
+}
+
+unsigned int duHeatToCol(float heat, int a)
+{
+	const float ratio = 2 * heat;
+	const int b = static_cast<int>(roundf(dtMax(0.0f, 255 * (1 - ratio))));
+	const int r = static_cast<int>(roundf(dtMax(0.0f, 255 * (ratio - 1))));
+	const int g = 255 - b - r;
+	return duRGBA(r, g, b, a);
 }
 
 void duCalcBoxColors(unsigned int* colors, unsigned int colTop, unsigned int colSide)

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -613,7 +613,7 @@ max nav mesh tiles cache size = 268435456
 max polygon path size = 1024
 
 # Maximum size of smoothed path (value > 0)
-max smooth path size = 1024
+max smooth path size = 128
 
 # Maximum number of triangles in each node of mesh AABB tree (value > 0)
 triangles per chunk = 256


### PR DESCRIPTION
I've tried to do some simple optimization. Got about ~10% performance increase for navmesh update. Then I've added a profiling for `Engine::frame` with detailed report for each frame. All `Navigator` method are profiled. It produces text file when player quits game like [this](https://gist.github.com/elsid/9a393819832378239a7e6718bd2db526). Also I've made a [script](https://gist.github.com/elsid/532e461dfc687975a4d8f71d38a6acd6) to produce [report](https://gist.github.com/elsid/13e3320b36ffdd00a4b3bcb5d63bf45a) with some statistics and detailed profile for each frame with duration greater than 1/60 second exclude all frames with `Scene::loadCell` call.
