### PR TITLE
Include cleanup

### DIFF
--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -9,7 +9,10 @@
 #include <components/widgets/list.hpp>
 #include <components/settings/settings.hpp>
 
+#include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/world.hpp"
+
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/esmstore.hpp"

--- a/apps/openmw/mwgui/spellbuyingwindow.hpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.hpp
@@ -4,7 +4,10 @@
 #include "windowbase.hpp"
 #include "referenceinterface.hpp"
 
-#include "../mwworld/esmstore.hpp"
+namespace ESM
+{
+    struct Spell;
+}
 
 namespace MyGUI
 {
@@ -16,7 +19,6 @@ namespace MWGui
 {
     class WindowManager;
 }
-
 
 namespace MWGui
 {

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -54,6 +54,7 @@
 #include "../mwbase/inputmanager.hpp"
 #include "../mwbase/statemanager.hpp"
 #include "../mwbase/soundmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwrender/vismask.hpp"
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1,10 +1,7 @@
 #include "actors.hpp"
 
-#include <typeinfo>
-#include <iostream>
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
-#include <components/esm/loadnpc.hpp>
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 #include <components/debug/debuglog.hpp>
@@ -507,7 +504,7 @@ namespace MWMechanics
 
         MagicEffects now = creatureStats.getSpells().getMagicEffects();
 
-        if (creature.getTypeName()==typeid (ESM::NPC).name())
+        if (creature.getClass().isNpc())
         {
             MWWorld::InventoryStore& store = creature.getClass().getInventoryStore (creature);
             now += store.getMagicEffects();
@@ -1423,7 +1420,7 @@ namespace MWMechanics
                         }
                     }
 
-                    if(iter->first.getTypeName() == typeid(ESM::NPC).name())
+                    if(iter->first.getClass().isNpc())
                     {
                         updateDrowning(iter->first, duration, ctrl->isKnockedOut(), isPlayer);
                         calculateNpcStatModifiers(iter->first, duration);

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -5,10 +5,23 @@
 #include <vector>
 #include <string>
 #include <list>
+#include <map>
 
-#include "../mwbase/world.hpp"
+namespace ESM
+{
+    class ESMReader;
+    class ESMWriter;
+}
 
-#include "movement.hpp"
+namespace osg
+{
+    class Vec3f;
+}
+
+namespace Loading
+{
+    class Listener;
+}
 
 namespace MWWorld
 {

--- a/apps/openmw/mwmechanics/actorutil.hpp
+++ b/apps/openmw/mwmechanics/actorutil.hpp
@@ -1,7 +1,10 @@
 #ifndef OPENMW_MWMECHANICS_ACTORUTIL_H
 #define OPENMW_MWMECHANICS_ACTORUTIL_H
 
-#include "../mwworld/ptr.hpp"
+namespace MWWorld
+{
+    class Ptr;
+}
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/aicast.cpp
+++ b/apps/openmw/mwmechanics/aicast.cpp
@@ -2,6 +2,7 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 

--- a/apps/openmw/mwmechanics/aicast.hpp
+++ b/apps/openmw/mwmechanics/aicast.hpp
@@ -1,9 +1,12 @@
 #ifndef GAME_MWMECHANICS_AICAST_H
 #define GAME_MWMECHANICS_AICAST_H
 
-#include "../mwbase/world.hpp"
-
 #include "aipackage.hpp"
+
+namespace MWWorld
+{
+    class Ptr;
+}
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -5,8 +5,6 @@
 
 #include <string>
 
-#include "pathfinding.hpp"
-
 namespace ESM
 {
 namespace AiSequence

--- a/apps/openmw/mwmechanics/aiface.cpp
+++ b/apps/openmw/mwmechanics/aiface.cpp
@@ -1,6 +1,6 @@
 #include "aiface.hpp"
 
-#include "../mwbase/world.hpp"
+#include "../mwworld/ptr.hpp"
 
 #include "steering.hpp"
 

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -7,8 +7,6 @@
 #include "obstacle.hpp"
 #include "aistate.hpp"
 
-#include <boost/optional.hpp>
-
 namespace MWWorld
 {
     class Ptr;

--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -4,6 +4,7 @@
 #include <components/esm/loadmgef.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/action.hpp"

--- a/apps/openmw/mwmechanics/aipursue.hpp
+++ b/apps/openmw/mwmechanics/aipursue.hpp
@@ -3,10 +3,6 @@
 
 #include "aipackage.hpp"
 
-#include "../mwbase/world.hpp"
-
-#include "pathfinding.hpp"
-
 namespace ESM
 {
 namespace AiSequence

--- a/apps/openmw/mwmechanics/aistate.hpp
+++ b/apps/openmw/mwmechanics/aistate.hpp
@@ -2,7 +2,6 @@
 #define AISTATE_H
 
 #include <typeinfo>
-#include <stdexcept>
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/aitravel.hpp
+++ b/apps/openmw/mwmechanics/aitravel.hpp
@@ -3,8 +3,6 @@
 
 #include "aipackage.hpp"
 
-#include "pathfinding.hpp"
-
 namespace ESM
 {
 namespace AiSequence

--- a/apps/openmw/mwmechanics/autocalcspell.hpp
+++ b/apps/openmw/mwmechanics/autocalcspell.hpp
@@ -1,9 +1,14 @@
 #ifndef OPENMW_AUTOCALCSPELL_H
 #define OPENMW_AUTOCALCSPELL_H
 
-#include <components/esm/loadspel.hpp>
-#include <components/esm/loadskil.hpp>
-#include <components/esm/loadrace.hpp>
+#include <string>
+#include <vector>
+
+namespace ESM
+{
+    struct Spell;
+    struct Race;
+}
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/combat.hpp
+++ b/apps/openmw/mwmechanics/combat.hpp
@@ -1,7 +1,15 @@
 #ifndef OPENMW_MECHANICS_COMBAT_H
 #define OPENMW_MECHANICS_COMBAT_H
 
-#include "../mwworld/ptr.hpp"
+namespace osg
+{
+    class Vec3f;
+}
+
+namespace MWWorld
+{
+    class Ptr;
+}
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -7,6 +7,8 @@
 #include "../mwworld/containerstore.hpp"
 #include "../mwworld/esmstore.hpp"
 
+#include "../mwbase/world.hpp"
+#include "../mwbase/environment.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
 
 #include "creaturestats.hpp"

--- a/apps/openmw/mwmechanics/enchanting.hpp
+++ b/apps/openmw/mwmechanics/enchanting.hpp
@@ -7,9 +7,6 @@
 
 #include "../mwworld/ptr.hpp"
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
-
 namespace MWMechanics
 {
     class Enchanting

--- a/apps/openmw/mwmechanics/objects.cpp
+++ b/apps/openmw/mwmechanics/objects.cpp
@@ -7,6 +7,7 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/world.hpp"
 
+#include "character.hpp"
 #include "movement.hpp"
 
 namespace MWMechanics

--- a/apps/openmw/mwmechanics/objects.hpp
+++ b/apps/openmw/mwmechanics/objects.hpp
@@ -3,8 +3,12 @@
 
 #include <string>
 #include <map>
+#include <vector>
 
-#include "character.hpp"
+namespace osg
+{
+    class Vec3f;
+}
 
 namespace MWWorld
 {
@@ -14,6 +18,8 @@ namespace MWWorld
 
 namespace MWMechanics
 {
+    class CharacterController;
+
     class Objects
     {
         typedef std::map<MWWorld::Ptr,CharacterController*> PtrControllerMap;

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -3,6 +3,7 @@
 
 #include <components/esm/loadench.hpp>
 #include <components/esm/loadmgef.hpp>
+#include <components/esm/loadspel.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"

--- a/apps/openmw/mwmechanics/spellpriority.hpp
+++ b/apps/openmw/mwmechanics/spellpriority.hpp
@@ -1,9 +1,17 @@
 #ifndef OPENMW_SPELL_PRIORITY_H
 #define OPENMW_SPELL_PRIORITY_H
 
-#include <components/esm/loadspel.hpp>
+namespace ESM
+{
+    struct Spell;
+    struct EffectList;
+    struct ENAMstruct;
+}
 
-#include "../mwworld/ptr.hpp"
+namespace MWWorld
+{
+    class Ptr;
+}
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/trading.hpp
+++ b/apps/openmw/mwmechanics/trading.hpp
@@ -1,7 +1,10 @@
 #ifndef OPENMW_MECHANICS_TRADING_H
 #define OPENMW_MECHANICS_TRADING_H
 
-#include "../mwworld/ptr.hpp"
+namespace MWWorld
+{
+    class Ptr;
+}
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwworld/actionalchemy.cpp
+++ b/apps/openmw/mwworld/actionalchemy.cpp
@@ -2,9 +2,7 @@
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
-#include "../mwbase/world.hpp"
 
-#include "../mwworld/player.hpp"
 #include "../mwmechanics/actorutil.hpp"
 
 namespace MWWorld

--- a/apps/openmw/mwworld/actionapply.hpp
+++ b/apps/openmw/mwworld/actionapply.hpp
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/actioneat.cpp
+++ b/apps/openmw/mwworld/actioneat.cpp
@@ -2,9 +2,6 @@
 
 #include <components/esm/loadskil.hpp>
 
-#include "../mwbase/environment.hpp"
-#include "../mwbase/world.hpp"
-
 #include "../mwworld/containerstore.hpp"
 
 #include "../mwmechanics/actorutil.hpp"

--- a/apps/openmw/mwworld/actioneat.hpp
+++ b/apps/openmw/mwworld/actioneat.hpp
@@ -2,7 +2,6 @@
 #define GAME_MWWORLD_ACTIONEAT_H
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/actionequip.cpp
+++ b/apps/openmw/mwworld/actionequip.cpp
@@ -1,7 +1,6 @@
 #include "actionequip.hpp"
 
 #include "../mwbase/environment.hpp"
-#include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
 
 #include "../mwmechanics/actorutil.hpp"

--- a/apps/openmw/mwworld/actionopen.cpp
+++ b/apps/openmw/mwworld/actionopen.cpp
@@ -6,9 +6,6 @@
 
 #include "../mwmechanics/disease.hpp"
 
-#include "class.hpp"
-#include "containerstore.hpp"
-
 namespace MWWorld
 {
     ActionOpen::ActionOpen (const MWWorld::Ptr& container)

--- a/apps/openmw/mwworld/actionopen.hpp
+++ b/apps/openmw/mwworld/actionopen.hpp
@@ -2,8 +2,6 @@
 #define GAME_MWWORLD_ACTIONOPEN_H
 
 #include "action.hpp"
-#include "ptr.hpp"
-
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/actionread.hpp
+++ b/apps/openmw/mwworld/actionread.hpp
@@ -2,7 +2,6 @@
 #define GAME_MWWORLD_ACTIONREAD_H
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/actionsoulgem.cpp
+++ b/apps/openmw/mwworld/actionsoulgem.cpp
@@ -2,8 +2,7 @@
 
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/environment.hpp"
-#include "../mwbase/world.hpp"
-#include "../mwworld/player.hpp"
+
 #include "../mwmechanics/actorutil.hpp"
 
 namespace MWWorld

--- a/apps/openmw/mwworld/actionsoulgem.hpp
+++ b/apps/openmw/mwworld/actionsoulgem.hpp
@@ -2,7 +2,6 @@
 #define GAME_MWWORLD_ACTIONSOULGEM_H
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/actiontake.hpp
+++ b/apps/openmw/mwworld/actiontake.hpp
@@ -2,7 +2,6 @@
 #define GAME_MWWORLD_ACTIONTAKE_H
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/actiontalk.hpp
+++ b/apps/openmw/mwworld/actiontalk.hpp
@@ -1,7 +1,6 @@
 #ifndef GAME_MWWORLD_ACTIONTALK_H
 #define GAME_MWWORLD_ACTIONTALK_H
 
-#include "ptr.hpp"
 #include "action.hpp"
 
 namespace MWWorld

--- a/apps/openmw/mwworld/actiontrap.hpp
+++ b/apps/openmw/mwworld/actiontrap.hpp
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "action.hpp"
-#include "ptr.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/recordcmp.hpp
+++ b/apps/openmw/mwworld/recordcmp.hpp
@@ -1,8 +1,6 @@
 #ifndef OPENMW_MWWORLD_RECORDCMP_H
 #define OPENMW_MWWORLD_RECORDCMP_H
 
-#include <cctype>
-
 #include <components/esm/records.hpp>
 
 #include <components/misc/stringops.hpp>

--- a/apps/openmw/mwworld/refdata.hpp
+++ b/apps/openmw/mwworld/refdata.hpp
@@ -7,7 +7,6 @@
 #include "../mwscript/locals.hpp"
 
 #include <string>
-#include <osg/Vec3f>
 
 namespace SceneUtil
 {


### PR DESCRIPTION
Cut down on includes in header files where possible (in MWWorld and MWMechanics), use forward declarations and move includes into implementation files where necessary.