### PR TITLE
Add support for NiRollController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
     Feature #3610: Option to invert X axis
     Feature #4209: Editor: Faction rank sub-table
     Feature #4673: Weapon sheathing
+    Feature #4675: Support for NiRollController
     Feature #4730: Native animated containers support
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch

--- a/components/nif/controller.cpp
+++ b/components/nif/controller.cpp
@@ -173,6 +173,18 @@ namespace Nif
         data.post(nif);
     }
 
+    void NiRollController::read(NIFStream *nif)
+    {
+        Controller::read(nif);
+        data.read(nif);
+    }
+
+    void NiRollController::post(NIFFile *nif)
+    {
+        Controller::post(nif);
+        data.post(nif);
+    }
+
     void NiGeomMorpherController::read(NIFStream *nif)
     {
         Controller::read(nif);

--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -136,6 +136,15 @@ public:
     void post(NIFFile *nif);
 };
 
+class NiRollController : public Controller
+{
+public:
+    NiFloatDataPtr data;
+
+    void read(NIFStream *nif);
+    void post(NIFFile *nif);
+};
+
 class NiGeomMorpherController : public Controller
 {
 public:

--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -73,6 +73,7 @@ static std::map<std::string,RecordFactoryEntry> makeFactory()
     newFactory.insert(makeEntry("NiGeomMorpherController",    &construct <NiGeomMorpherController>     , RC_NiGeomMorpherController       ));
     newFactory.insert(makeEntry("NiKeyframeController",       &construct <NiKeyframeController>        , RC_NiKeyframeController          ));
     newFactory.insert(makeEntry("NiAlphaController",          &construct <NiAlphaController>           , RC_NiAlphaController             ));
+    newFactory.insert(makeEntry("NiRollController",           &construct <NiRollController>            , RC_NiRollController              ));
     newFactory.insert(makeEntry("NiUVController",             &construct <NiUVController>              , RC_NiUVController                ));
     newFactory.insert(makeEntry("NiPathController",           &construct <NiPathController>            , RC_NiPathController              ));
     newFactory.insert(makeEntry("NiMaterialColorController",  &construct <NiMaterialColorController>   , RC_NiMaterialColorController     ));

--- a/components/nif/record.hpp
+++ b/components/nif/record.hpp
@@ -60,6 +60,7 @@ enum RecordType
   RC_NiGeomMorpherController,
   RC_NiKeyframeController,
   RC_NiAlphaController,
+  RC_NiRollController,
   RC_NiUVController,
   RC_NiPathController,
   RC_NiMaterialColorController,

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -246,6 +246,22 @@ namespace NifOsg
         virtual void operator() (osg::Node* node, osg::NodeVisitor* nv);
     };
 
+    class RollController : public osg::NodeCallback, public SceneUtil::Controller
+    {
+    private:
+        FloatInterpolator mData;
+        double mStartingTime;
+
+    public:
+        RollController(const Nif::NiFloatData *data);
+        RollController();
+        RollController(const RollController& copy, const osg::CopyOp& copyop);
+
+        virtual void operator() (osg::Node* node, osg::NodeVisitor* nv);
+
+        META_Object(NifOsg, RollController)
+    };
+
     class AlphaController : public SceneUtil::StateSetUpdater, public SceneUtil::Controller
     {
     private:

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -697,6 +697,10 @@ namespace NifOsg
                 {
                     handleVisController(static_cast<const Nif::NiVisController*>(ctrl.getPtr()), transformNode, animflags);
                 }
+                else if (ctrl->recType == Nif::RC_NiRollController)
+                {
+                    handleRollController(static_cast<const Nif::NiRollController*>(ctrl.getPtr()), transformNode, animflags);
+                }
                 else
                     Log(Debug::Info) << "Unhandled controller " << ctrl->recName << " on node " << nifNode->recIndex << " in " << mFilename;
             }
@@ -706,6 +710,13 @@ namespace NifOsg
         {
             osg::ref_ptr<VisController> callback(new VisController(visctrl->data.getPtr()));
             setupController(visctrl, callback, animflags);
+            node->addUpdateCallback(callback);
+        }
+
+        void handleRollController(const Nif::NiRollController* rollctrl, osg::Node* node, int animflags)
+        {
+            osg::ref_ptr<RollController> callback(new RollController(rollctrl->data.getPtr()));
+            setupController(rollctrl, callback, animflags);
             node->addUpdateCallback(callback);
         }
 


### PR DESCRIPTION
Implements [feature #4675](https://gitlab.com/OpenMW/openmw/issues/4675), so the Daedric Crescent mesh from Weapon Sheathing mod should work properly.

Note: from what I can tell, a controller's current value is the per-update rotation, not a per-second speed in Morrowind, so rotation will be faster with high FPS, but in a very tricky way. I see no reason to replicate such behaviour if we really do not need it.

It would be nice to have some meshes for testing.