### PR TITLE
 Handle initial actor's transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
     Bug #4827: NiUVController is handled incorrectly
     Bug #4828: Potion looping effects VFX are not shown for NPCs
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
+    Bug #4860: Actors outside of processing range visible for one frame after spawning
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -26,6 +26,8 @@
 
 #include "../mwmechanics/aibreathe.hpp"
 
+#include "../mwrender/vismask.hpp"
+
 #include "spellcasting.hpp"
 #include "npcstats.hpp"
 #include "creaturestats.hpp"
@@ -1461,7 +1463,7 @@ namespace MWMechanics
                     continue;
                 }
                 else if (!isPlayer)
-                    iter->first.getRefData().getBaseNode()->setNodeMask(1<<3);
+                    iter->first.getRefData().getBaseNode()->setNodeMask(MWRender::Mask_Actor);
 
                 if (iter->first.getClass().getCreatureStats(iter->first).isParalyzed())
                     ctrl->skipAnim();

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -19,6 +19,7 @@ namespace MWWorld
 namespace MWMechanics
 {
     class Actor;
+    class CharacterController;
     class CreatureStats;
 
     class Actors
@@ -169,6 +170,8 @@ namespace MWMechanics
             bool isAttackingOrSpell(const MWWorld::Ptr& ptr) const;
 
     private:
+        void updateVisibility (const MWWorld::Ptr& ptr, CharacterController* ctrl);
+
         PtrActorMap mActors;
         float mTimerDisposeSummonsCorpses;
         float mActorsProcessingRange;


### PR DESCRIPTION
Fixes [bug #4860](https://gitlab.com/OpenMW/openmw/issues/4860).

The main idea:
1. Move visibility update to the separate function
2. Call it after adding actor to scene as well during actor's update.

Note: when we teleport player, we can not check distance to actor since player still has old coordinates.
I do not know how to handle this case - for now I just ignore the visibility check.