### PR TITLE
Ignore extra text after a local variable declaration (bug #4867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
     Bug #4828: Potion looping effects VFX are not shown for NPCs
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
     Bug #4860: Actors outside of processing range visible for one frame after spawning
+    Bug #4867: Arbitrary text after local variable declarations breaks script compilation
     Bug #4876: AI ratings handling inconsistencies
     Bug #4877: Startup script executes only on a new game start
     Bug #4888: Global variable stray explicit reference calls break script compilation

--- a/components/compiler/declarationparser.cpp
+++ b/components/compiler/declarationparser.cpp
@@ -22,19 +22,19 @@ bool Compiler::DeclarationParser::parseName (const std::string& name, const Toke
         char type = mLocals.getType (name2);
 
         if (type!=' ')
-        {
-            /// \todo add option to make re-declared local variables an error
-            getErrorHandler().warning ("ignoring local variable re-declaration",
-                loc);
-
-            mState = State_End;
-            return true;
-        }
-
-        mLocals.declare (mType, name2);
+            getErrorHandler().warning ("ignoring local variable re-declaration", loc);
+        else
+            mLocals.declare (mType, name2);
 
         mState = State_End;
         return true;
+    }
+    else if (mState==State_End)
+    {
+        getErrorHandler().warning ("Ignoring extra text after local variable declaration", loc);
+        SkipParser skip (getErrorHandler(), getContext());
+        scanner.scan (skip);
+        return false;
     }
 
     return Parser::parseName (name, loc, scanner);
@@ -61,8 +61,14 @@ bool Compiler::DeclarationParser::parseKeyword (int keyword, const TokenLoc& loc
     else if (mState==State_Name)
     {
         // allow keywords to be used as local variable names. MW script compiler, you suck!
-        /// \todo option to disable this atrocity.
         return parseName (loc.mLiteral, loc, scanner);
+    }
+    else if (mState==State_End)
+    {
+        getErrorHandler().warning ("Ignoring extra text after local variable declaration", loc);
+        SkipParser skip (getErrorHandler(), getContext());
+        scanner.scan (skip);
+        return false;
     }
 
     return Parser::parseKeyword (keyword, loc, scanner);
@@ -70,8 +76,16 @@ bool Compiler::DeclarationParser::parseKeyword (int keyword, const TokenLoc& loc
 
 bool Compiler::DeclarationParser::parseSpecial (int code, const TokenLoc& loc, Scanner& scanner)
 {
-    if (code==Scanner::S_newline && mState==State_End)
+    if (mState==State_End)
+    {
+        if (code!=Scanner::S_newline)
+        {
+            getErrorHandler().warning ("Ignoring extra text after local variable declaration", loc);
+            SkipParser skip (getErrorHandler(), getContext());
+            scanner.scan (skip);
+        }
         return false;
+    }
 
     return Parser::parseSpecial (code, loc, scanner);
 }


### PR DESCRIPTION
[Bug 4867](https://gitlab.com/OpenMW/openmw/issues/4867).

Special characters, keywords and names are ignored when End state is present and the rest of the line is skipped.