### PR TITLE
Get rid of Boost.Array

### DIFF
--- a/apps/openmw/mwgui/charactercreation.cpp
+++ b/apps/openmw/mwgui/charactercreation.cpp
@@ -554,7 +554,7 @@ namespace MWGui
     {
         if (mGenerateClassStep == 10)
         {
-            static boost::array<ClassPoint, 23> classes = { {
+            static std::array<ClassPoint, 23> classes = { {
                 {"Acrobat",     {6, 2, 2}},
                 {"Agent",       {6, 1, 3}},
                 {"Archer",      {3, 5, 2}},

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -228,11 +228,9 @@ namespace MWGui
         std::set<int> skillSet;
         std::copy(major.begin(), major.end(), std::inserter(skillSet, skillSet.begin()));
         std::copy(minor.begin(), minor.end(), std::inserter(skillSet, skillSet.begin()));
-        boost::array<ESM::Skill::SkillEnum, ESM::Skill::Length>::const_iterator end = ESM::Skill::sSkillIds.end();
         mMiscSkills.clear();
-        for (boost::array<ESM::Skill::SkillEnum, ESM::Skill::Length>::const_iterator it = ESM::Skill::sSkillIds.begin(); it != end; ++it)
+        for (const int skill : ESM::Skill::sSkillIds)
         {
-            int skill = *it;
             if (skillSet.find(skill) == skillSet.end())
                 mMiscSkills.push_back(skill);
         }

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -278,11 +278,9 @@ namespace MWGui
         std::set<int> skillSet;
         std::copy(major.begin(), major.end(), std::inserter(skillSet, skillSet.begin()));
         std::copy(minor.begin(), minor.end(), std::inserter(skillSet, skillSet.begin()));
-        boost::array<ESM::Skill::SkillEnum, ESM::Skill::Length>::const_iterator end = ESM::Skill::sSkillIds.end();
         mMiscSkills.clear();
-        for (boost::array<ESM::Skill::SkillEnum, ESM::Skill::Length>::const_iterator it = ESM::Skill::sSkillIds.begin(); it != end; ++it)
+        for (const int skill : ESM::Skill::sSkillIds)
         {
-            int skill = *it;
             if (skillSet.find(skill) == skillSet.end())
                 mMiscSkills.push_back(skill);
         }

--- a/components/esm/loadskil.cpp
+++ b/components/esm/loadskil.cpp
@@ -97,7 +97,7 @@ namespace ESM
         "stealth_speechcraft.dds",
         "stealth_handtohand.dds",
     };
-    const boost::array<Skill::SkillEnum, Skill::Length> Skill::sSkillIds = {{
+    const std::array<Skill::SkillEnum, Skill::Length> Skill::sSkillIds = {{
         Block,
         Armorer,
         MediumArmor,

--- a/components/esm/loadskil.hpp
+++ b/components/esm/loadskil.hpp
@@ -1,9 +1,8 @@
 #ifndef OPENMW_ESM_SKIL_H
 #define OPENMW_ESM_SKIL_H
 
+#include <array>
 #include <string>
-
-#include <boost/array.hpp>
 
 #include "defs.hpp"
 
@@ -76,7 +75,7 @@ struct Skill
   static const std::string sSkillNames[Length];
   static const std::string sSkillNameIds[Length];
   static const std::string sIconNames[Length];
-  static const boost::array<SkillEnum, Length> sSkillIds;
+  static const std::array<SkillEnum, Length> sSkillIds;
 
   void load(ESMReader &esm, bool &isDeleted);
   void save(ESMWriter &esm, bool isDeleted = false) const;


### PR DESCRIPTION
std::array from C++11 is basically a drop-in replacement for boost::array, so it's possible to get rid of another Boost bit seamlessly.