### PR TITLE
Replace Boost format and replace_all where possible

### DIFF
--- a/apps/opencs/view/doc/adjusterwidget.cpp
+++ b/apps/opencs/view/doc/adjusterwidget.cpp
@@ -1,7 +1,8 @@
 #include "adjusterwidget.hpp"
 
+#include <components/misc/stringops.hpp>
+
 #include <boost/filesystem.hpp>
-#include <boost/algorithm/string/case_conv.hpp>
 
 #include <QHBoxLayout>
 #include <QLabel>
@@ -70,8 +71,7 @@ void CSVDoc::AdjusterWidget::setName (const QString& name, bool addon)
     {
         boost::filesystem::path path (name.toUtf8().data());
 
-        std::string extension = path.extension().string();
-        boost::algorithm::to_lower(extension);
+        std::string extension = Misc::StringUtils::lowerCase(path.extension().string());
 
         bool isLegacyPath = (extension == ".esm" ||
                              extension == ".esp");

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -348,8 +348,7 @@ namespace MWGui
                 if (MWBase::Environment::get().getMechanicsManager()->isItemStolenFrom(item.getCellRef().getRefId(), mPtr))
                 {
                     std::string msg = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("sNotifyMessage49")->mValue.getString();
-                    if (msg.find("%s") != std::string::npos)
-                        msg.replace(msg.find("%s"), 2, item.getClass().getName(item));
+                    Misc::StringUtils::replace(msg, "%s", item.getClass().getName(item).c_str(), 2);
                     MWBase::Environment::get().getWindowManager()->messageBox(msg);
 
                     MWBase::Environment::get().getMechanicsManager()->confiscateStolenItemToOwner(player, item, mPtr, 1);

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -9,8 +9,6 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
 
-#include <boost/algorithm/string/replace.hpp>
-
 #include <components/debug/debuglog.hpp>
 #include <components/interpreter/defines.hpp>
 #include <components/misc/stringops.hpp>
@@ -28,7 +26,7 @@ namespace MWGui
             MWScript::InterpreterContext interpreterContext(nullptr, MWWorld::Ptr()); // empty arguments, because there is no locals or actor
             mText = Interpreter::fixDefinesBook(mText, interpreterContext);
 
-            boost::algorithm::replace_all(mText, "\r", "");
+            Misc::StringUtils::replaceAll(mText, "\r", "");
 
             // vanilla game does not show any text after the last EOL tag.
             const std::string lowerText = Misc::StringUtils::lowerCase(mText);

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -1,7 +1,5 @@
 #include "recharge.hpp"
 
-#include <boost/format.hpp>
-
 #include <MyGUI_ScrollView.h>
 #include <MyGUI_Gui.h>
 
@@ -179,7 +177,8 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
     if (gem.getRefData().getCount() == 0)
     {
         std::string message = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("sNotifyMessage51")->mValue.getString();
-        message = boost::str(boost::format(message) % gem.getClass().getName(gem));
+        Misc::StringUtils::replace(message, "%s", gem.getClass().getName(gem).c_str(), 2);
+
         MWBase::Environment::get().getWindowManager()->messageBox(message);
 
         // special case: readd Azura's Star

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -13,6 +13,7 @@
 #include <SDL_video.h>
 
 #include <components/debug/debuglog.hpp>
+#include <components/misc/stringops.hpp>
 #include <components/widgets/sharedstatebutton.hpp>
 #include <components/settings/settings.hpp>
 
@@ -159,7 +160,7 @@ namespace MWGui
             MyGUI::TextBox* textBox;
             getWidget(textBox, labelWidgetName);
             std::string labelCaption = scroller->getUserString("SettingLabelCaption");
-            boost::algorithm::replace_all(labelCaption, "%s", value);
+            Misc::StringUtils::replaceAll(labelCaption, "%s", value.c_str(), 2);
             textBox->setCaptionWithReplacing(labelCaption);
         }
     }

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -1,10 +1,9 @@
 #include "spellwindow.hpp"
 
-#include <boost/format.hpp>
-
 #include <MyGUI_EditBox.h>
 #include <MyGUI_InputManager.h>
 
+#include <components/misc/stringops.hpp>
 #include <components/settings/settings.hpp>
 
 #include "../mwbase/windowmanager.hpp"
@@ -157,7 +156,7 @@ namespace MWGui
             mSpellToDelete = spellId;
             ConfirmationDialog* dialog = MWBase::Environment::get().getWindowManager()->getConfirmationDialog();
             std::string question = MWBase::Environment::get().getWindowManager()->getGameSettingString("sQuestionDeleteSpell", "Delete %s?");
-            question = boost::str(boost::format(question) % spell->mName);
+            Misc::StringUtils::replace(question, "%s", spell->mName.c_str(), 2);
             dialog->askForConfirmation(question);
             dialog->eventOkClicked.clear();
             dialog->eventOkClicked += MyGUI::newDelegate(this, &SpellWindow::onDeleteSpellAccept);

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -311,8 +311,7 @@ namespace MWGui
             if (MWBase::Environment::get().getMechanicsManager()->isItemStolenFrom(it->mBase.getCellRef().getRefId(), mPtr))
             {
                 std::string msg = gmst.find("sNotifyMessage49")->mValue.getString();
-                if (msg.find("%s") != std::string::npos)
-                    msg.replace(msg.find("%s"), 2, it->mBase.getClass().getName(it->mBase));
+                Misc::StringUtils::replace(msg, "%s", it->mBase.getClass().getName(it->mBase).c_str(), 2);
                 MWBase::Environment::get().getWindowManager()->messageBox(msg);
 
                 MWBase::Environment::get().getMechanicsManager()->confiscateStolenItemToOwner(player, it->mBase, mPtr, it->mCount);

--- a/apps/openmw/mwmechanics/disease.hpp
+++ b/apps/openmw/mwmechanics/disease.hpp
@@ -60,8 +60,7 @@ namespace MWMechanics
 
                 std::string msg = "sMagicContractDisease";
                 msg = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(msg)->mValue.getString();
-                if (msg.find("%s") != std::string::npos)
-                    msg.replace(msg.find("%s"), 2, spell->mName);
+                Misc::StringUtils::replace(msg, "%s", spell->mName.c_str(), 2);
                 MWBase::Environment::get().getWindowManager()->messageBox(msg);
             }
         }

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -2,8 +2,6 @@
 
 #include <iomanip>
 
-#include <boost/format.hpp>
-
 #include <components/esm/loadclas.hpp>
 #include <components/esm/loadgmst.hpp>
 #include <components/esm/loadfact.hpp>
@@ -251,16 +249,14 @@ void MWMechanics::NpcStats::increaseSkill(int skillIndex, const ESM::Class &clas
     /// \todo check if character is the player, if levelling is ever implemented for NPCs
     MWBase::Environment::get().getWindowManager()->playSound("skillraise");
 
-    std::stringstream message;
+    std::string message = MWBase::Environment::get().getWindowManager ()->getGameSettingString ("sNotifyMessage39", "");
+    Misc::StringUtils::replace(message, "%s", ("#{" + ESM::Skill::sSkillNameIds[skillIndex] + "}").c_str(), 2);
+    Misc::StringUtils::replace(message, "%d", std::to_string(base).c_str(), 2);
 
     if (readBook)
-        message << std::string("#{sBookSkillMessage}\n");
-
-    message << boost::format(MWBase::Environment::get().getWindowManager ()->getGameSettingString ("sNotifyMessage39", ""))
-               % std::string("#{" + ESM::Skill::sSkillNameIds[skillIndex] + "}")
-               % static_cast<int> (base);
+        message = "#{sBookSkillMessage}\n" + message;
     
-    MWBase::Environment::get().getWindowManager ()->messageBox(message.str(), MWGui::ShowInDialogueMode_Never);
+    MWBase::Environment::get().getWindowManager ()->messageBox(message, MWGui::ShowInDialogueMode_Never);
 
     if (mLevelProgress >= gmst.find("iLevelUpTotal")->mValue.getInteger())
     {

--- a/apps/openmw/mwmechanics/repair.cpp
+++ b/apps/openmw/mwmechanics/repair.cpp
@@ -1,7 +1,5 @@
 #include "repair.hpp"
 
-#include <boost/format.hpp>
-
 #include <components/misc/rng.hpp>
 
 #include "../mwbase/world.hpp"
@@ -85,8 +83,9 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
 
         std::string message = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>()
                 .find("sNotifyMessage51")->mValue.getString();
+        Misc::StringUtils::replace(message, "%s", mTool.getClass().getName(mTool).c_str(), 2);
 
-        MWBase::Environment::get().getWindowManager()->messageBox((boost::format(message) % mTool.getClass().getName(mTool)).str());
+        MWBase::Environment::get().getWindowManager()->messageBox(message);
 
         // try to find a new tool of the same ID
         for (MWWorld::ContainerStoreIterator iter (store.begin());

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -3,8 +3,6 @@
 #include <limits>
 #include <iomanip>
 
-#include <boost/format.hpp>
-
 #include <components/misc/rng.hpp>
 #include <components/settings/settings.hpp>
 
@@ -1015,7 +1013,7 @@ namespace MWMechanics
         {
             // "X has no effect on you"
             std::string message = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("sNotifyMessage50")->mValue.getString();
-            message = boost::str(boost::format(message) % ingredient->mName);
+            Misc::StringUtils::replace(message, "%s", ingredient->mName.c_str(), 2);
             MWBase::Environment::get().getWindowManager()->messageBox(message);
             return false;
         }

--- a/apps/openmw/mwrender/terrainstorage.cpp
+++ b/apps/openmw/mwrender/terrainstorage.cpp
@@ -1,7 +1,5 @@
 #include "terrainstorage.hpp"
 
-#include <boost/algorithm/string.hpp>
-
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwworld/esmstore.hpp"

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -2,8 +2,6 @@
 
 #include <stdexcept>
 
-#include <boost/format.hpp>
-
 #include <MyGUI_LanguageManager.h>
 
 #include <components/debug/debuglog.hpp>
@@ -85,13 +83,13 @@ namespace MWScript
                         if (count == 1)
                         {
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage60}");
-                            msgBox = boost::str(boost::format(msgBox) % itemName);
                         }
                         else
                         {
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage61}");
-                            msgBox = boost::str(boost::format(msgBox) % count % itemName);
+                            Misc::StringUtils::replace(msgBox, "%d", std::to_string(count).c_str(), 2);
                         }
+                        Misc::StringUtils::replace(msgBox, "%s", itemName.c_str(), 2);
                         MWBase::Environment::get().getWindowManager()->messageBox(msgBox, MWGui::ShowInDialogueMode_Only);
                     }
                 }
@@ -170,16 +168,16 @@ namespace MWScript
                         // The two GMST entries below expand to strings informing the player of what, and how many of it has been removed from their inventory
                         std::string msgBox;
 
-                        if(numRemoved > 1)
+                        if (numRemoved > 1)
                         {
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage63}");
-                            msgBox = boost::str (boost::format(msgBox) % numRemoved % itemName);
+                            Misc::StringUtils::replace(msgBox, "%d", std::to_string(numRemoved).c_str(), 2);
                         }
                         else
                         {
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage62}");
-                            msgBox = boost::str (boost::format(msgBox) % itemName);
                         }
+                        Misc::StringUtils::replace(msgBox, "%s", itemName.c_str(), 2);
                         MWBase::Environment::get().getWindowManager()->messageBox(msgBox, MWGui::ShowInDialogueMode_Only);
                     }
                 }

--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -3,8 +3,6 @@
 #include <components/debug/debuglog.hpp>
 #include <components/files/escape.hpp>
 
-#include <boost/algorithm/string/erase.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/fstream.hpp>
 /**
  * \namespace Files

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -240,6 +240,32 @@ public:
         }
         return str;
     }
+
+    /** @brief Replaces the first occurrence of a string in another string.
+     *
+     * @param str The string to operate on.
+     * @param what The string to replace.
+     * @param with The replacement string.
+     * @param whatLen The length of the string to replace.
+     * @param withLen The length of the replacement string.
+     *
+     * @return A reference to the string passed in @p str.
+     */
+    static std::string &replace(std::string &str, const char *what, const char *with,
+                                std::size_t whatLen=std::string::npos, std::size_t withLen=std::string::npos)
+    {
+        if (whatLen == std::string::npos)
+            whatLen = strlen(what);
+
+        if (withLen == std::string::npos)
+            withLen = strlen(with);
+
+        std::size_t found;
+        if ((found = str.find(what)) != std::string::npos)
+            str.replace(found, whatLen, with, withLen);
+
+        return str;
+    }
 };
 
 }


### PR DESCRIPTION
Every time boost/format.hpp is included in a unique file, virtually [the entirety of the freaking Boost.Format module](https://github.com/boostorg/format/blob/develop/include/boost/format.hpp) with all the templates and complex functions gets put into the source to simply copy the name and count of something into a messagebox, which certainly doesn't improve the compilation times and it doesn't even have that good of runtime performance to begin with.

So I replaced boost::format with less complex "replace" alternative which does the same thing in the context to get rid of these dependencies in the engine itself. I used it in all or most instances of %s/%d tag replacement.

esmtool still uses boost::format but it is left alone for the time being.

replace_all from Boost was replaced with our own replaceAll which does the same thing, which also allows to remove some boost dependencies in book formatting.