### PR TITLE
[Feedback needed] Projectiles collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #1952: Incorrect particle lighting
     Bug #2311: Targeted scripts are not properly supported on non-unique RefIDs
+    Bug #3372: Projectiles and magic bolts go through moving targets
     Bug #3676: NiParticleColorModifier isn't applied properly
     Bug #3714: Savegame fails to load due to conflict between SpellState and MagicEffects
     Bug #4021: Attributes and skills are not stored as floats

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -66,13 +66,13 @@ add_openmw_dir (mwworld
     cells localscripts customdata inventorystore ptr actionopen actionread actionharvest
     actionequip timestamp actionalchemy cellstore actionapply actioneat
     store esmstore recordcmp fallback actionrepair actionsoulgem livecellref actiondoor
-    contentloader esmloader actiontrap cellreflist cellref physicssystem weather projectilemanager
+    contentloader esmloader actiontrap cellreflist cellref weather projectilemanager
     cellpreloader datetimemanager
     )
 
 add_openmw_dir (mwphysics
     physicssystem trace collisiontype actor convert object heightfield closestnotmerayresultcallback
-    contacttestresultcallback deepestnotmecontacttestresultcallback stepper movementsolver
+    contacttestresultcallback deepestnotmecontacttestresultcallback stepper movementsolver projectile
     closestnotmeconvexresultcallback
     )
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -594,6 +594,8 @@ namespace MWBase
 
             virtual bool isPlayerInJail() const = 0;
 
+            virtual void manualProjectileHit(int projectileId, const MWWorld::Ptr& target, const osg::Vec3f& pos) = 0;
+
             virtual void rest(double hours) = 0;
             virtual void rechargeItems(double duration, bool activeOnly) = 0;
 

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -72,7 +72,7 @@ Actor::Actor(const MWWorld::Ptr& ptr, osg::ref_ptr<const Resource::BulletShape> 
     mCollisionObject->setCollisionFlags(btCollisionObject::CF_KINEMATIC_OBJECT);
     mCollisionObject->setActivationState(DISABLE_DEACTIVATION);
     mCollisionObject->setCollisionShape(mShape.get());
-    mCollisionObject->setUserPointer(static_cast<PtrHolder*>(this));
+    mCollisionObject->setUserPointer(this);
 
     updateRotation();
     updateScale();

--- a/apps/openmw/mwphysics/closestnotmerayresultcallback.cpp
+++ b/apps/openmw/mwphysics/closestnotmerayresultcallback.cpp
@@ -6,13 +6,14 @@
 
 #include "../mwworld/class.hpp"
 
+#include "projectile.hpp"
 #include "ptrholder.hpp"
 
 namespace MWPhysics
 {
-    ClosestNotMeRayResultCallback::ClosestNotMeRayResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3& from, const btVector3& to)
+    ClosestNotMeRayResultCallback::ClosestNotMeRayResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3& from, const btVector3& to, int projId)
     : btCollisionWorld::ClosestRayResultCallback(from, to)
-    , mMe(me), mTargets(targets)
+    , mMe(me), mTargets(targets), mProjectileId(projId)
     {
     }
 
@@ -29,6 +30,15 @@ namespace MWPhysics
                     return 1.f;
             }
         }
+
+        if (mProjectileId >= 0)
+        {
+            PtrHolder* holder = static_cast<PtrHolder*>(rayResult.m_collisionObject->getUserPointer());
+            Projectile* projectile = dynamic_cast<Projectile*>(holder);
+            if (projectile && projectile->getProjectileId() == mProjectileId)
+                return 1.f;
+        }
+
         return btCollisionWorld::ClosestRayResultCallback::addSingleResult(rayResult, normalInWorldSpace);
     }
 }

--- a/apps/openmw/mwphysics/closestnotmerayresultcallback.hpp
+++ b/apps/openmw/mwphysics/closestnotmerayresultcallback.hpp
@@ -12,12 +12,13 @@ namespace MWPhysics
     class ClosestNotMeRayResultCallback : public btCollisionWorld::ClosestRayResultCallback
     {
     public:
-        ClosestNotMeRayResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3& from, const btVector3& to);
+        ClosestNotMeRayResultCallback(const btCollisionObject* me, const std::vector<const btCollisionObject*>& targets, const btVector3& from, const btVector3& to, int projId=-1);
 
         virtual btScalar addSingleResult(btCollisionWorld::LocalRayResult& rayResult, bool normalInWorldSpace);
     private:
         const btCollisionObject* mMe;
         const std::vector<const btCollisionObject*> mTargets;
+        const int mProjectileId;
     };
 }
 

--- a/apps/openmw/mwphysics/object.cpp
+++ b/apps/openmw/mwphysics/object.cpp
@@ -23,7 +23,7 @@ namespace MWPhysics
         mCollisionObject.reset(new btCollisionObject);
         mCollisionObject->setCollisionShape(shapeInstance->getCollisionShape());
 
-        mCollisionObject->setUserPointer(static_cast<PtrHolder*>(this));
+        mCollisionObject->setUserPointer(this);
 
         setScale(ptr.getCellRef().getScale());
         setRotation(Misc::Convert::toBullet(ptr.getRefData().getBaseNode()->getAttitude()));

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -50,6 +50,7 @@ namespace MWPhysics
     class HeightField;
     class Object;
     class Actor;
+    class Projectile;
 
     class PhysicsSystem
     {
@@ -68,6 +69,10 @@ namespace MWPhysics
             void addObject (const MWWorld::Ptr& ptr, const std::string& mesh, int collisionType = CollisionType_World);
             void addActor (const MWWorld::Ptr& ptr, const std::string& mesh);
 
+            int addProjectile(const osg::Vec3f& position);
+            void updateProjectile(const int projectileId, const osg::Vec3f &position);
+            void removeProjectile(const int projectileId);
+
             void updatePtr (const MWWorld::Ptr& old, const MWWorld::Ptr& updated);
 
             Actor* getActor(const MWWorld::Ptr& ptr);
@@ -81,7 +86,6 @@ namespace MWPhysics
             void updateScale (const MWWorld::Ptr& ptr);
             void updateRotation (const MWWorld::Ptr& ptr);
             void updatePosition (const MWWorld::Ptr& ptr);
-
 
             void addHeightField (const float* heights, int x, int y, float triSize, float sqrtVerts, float minH, float maxH, const osg::Object* holdObject);
 
@@ -115,12 +119,13 @@ namespace MWPhysics
                 osg::Vec3f mHitPos;
                 osg::Vec3f mHitNormal;
                 MWWorld::Ptr mHitObject;
+                int mProjectileId;
             };
 
             /// @param me Optional, a Ptr to ignore in the list of results. targets are actors to filter for, ignoring all other actors.
             RayResult castRay(const osg::Vec3f &from, const osg::Vec3f &to, const MWWorld::ConstPtr& ignore = MWWorld::ConstPtr(),
                     std::vector<MWWorld::Ptr> targets = std::vector<MWWorld::Ptr>(),
-                    int mask = CollisionType_World|CollisionType_HeightMap|CollisionType_Actor|CollisionType_Door, int group=0xff) const;
+                    int mask = CollisionType_World|CollisionType_HeightMap|CollisionType_Actor|CollisionType_Door, int group=0xff, int projId=-1) const;
 
             RayResult castSphere(const osg::Vec3f& from, const osg::Vec3f& to, float radius);
 
@@ -211,6 +216,9 @@ namespace MWPhysics
             typedef std::map<MWWorld::ConstPtr, Actor*> ActorMap;
             ActorMap mActors;
 
+            typedef std::map<int, Projectile*> ProjectileMap;
+            ProjectileMap mProjectiles;
+
             typedef std::map<std::pair<int, int>, HeightField*> HeightFieldMap;
             HeightFieldMap mHeightFields;
 
@@ -228,6 +236,8 @@ namespace MWPhysics
             PtrVelocityList mMovementResults;
 
             float mTimeAccum;
+
+            int mProjectileId;
 
             float mWaterHeight;
             bool mWaterEnabled;

--- a/apps/openmw/mwphysics/projectile.cpp
+++ b/apps/openmw/mwphysics/projectile.cpp
@@ -1,0 +1,64 @@
+#include "projectile.hpp"
+
+#include <BulletCollision/CollisionShapes/btSphereShape.h>
+#include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
+
+#include <components/sceneutil/positionattitudetransform.hpp>
+#include <components/resource/bulletshape.hpp>
+#include <components/debug/debuglog.hpp>
+#include <components/misc/convert.hpp>
+
+#include "../mwworld/class.hpp"
+
+#include "collisiontype.hpp"
+
+namespace MWPhysics
+{
+Projectile::Projectile(int projectileId, const osg::Vec3f& position, btCollisionWorld* world)
+    : mCollisionWorld(world)
+{
+    mProjectileId = projectileId;
+
+    mShape.reset(new btSphereShape(1.f));
+    mConvexShape = static_cast<btConvexShape*>(mShape.get());
+
+    mCollisionObject.reset(new btCollisionObject);
+    mCollisionObject->setCollisionFlags(btCollisionObject::CF_KINEMATIC_OBJECT);
+    mCollisionObject->setActivationState(DISABLE_DEACTIVATION);
+    mCollisionObject->setCollisionShape(mShape.get());
+    mCollisionObject->setUserPointer(this);
+
+    setPosition(position);
+
+    const int collisionMask = CollisionType_World | CollisionType_HeightMap |
+        CollisionType_Actor | CollisionType_Door | CollisionType_Water;
+    mCollisionWorld->addCollisionObject(mCollisionObject.get(), CollisionType_Projectile, collisionMask);
+}
+
+Projectile::~Projectile()
+{
+    if (mCollisionObject.get())
+        mCollisionWorld->removeCollisionObject(mCollisionObject.get());
+}
+
+void Projectile::updateCollisionObjectPosition()
+{
+    btTransform tr = mCollisionObject->getWorldTransform();
+   // osg::Vec3f scaledTranslation = mRotation * mMeshTranslation;
+   // osg::Vec3f newPosition = scaledTranslation + mPosition;
+    tr.setOrigin(Misc::Convert::toBullet(mPosition));
+    mCollisionObject->setWorldTransform(tr);
+}
+
+void Projectile::setPosition(const osg::Vec3f &position)
+{
+    mPosition = position;
+    updateCollisionObjectPosition();
+}
+
+osg::Vec3f Projectile::getPosition() const
+{
+    return mPosition;
+}
+
+}

--- a/apps/openmw/mwphysics/projectile.hpp
+++ b/apps/openmw/mwphysics/projectile.hpp
@@ -1,0 +1,68 @@
+#ifndef OPENMW_MWPHYSICS_PROJECTILE_H
+#define OPENMW_MWPHYSICS_PROJECTILE_H
+
+#include <memory>
+
+#include "ptrholder.hpp"
+
+#include <osg/Vec3f>
+#include <osg/Quat>
+#include <osg/ref_ptr>
+
+class btCollisionWorld;
+class btCollisionShape;
+class btCollisionObject;
+class btConvexShape;
+
+namespace Resource
+{
+    class BulletShape;
+}
+
+namespace MWPhysics
+{
+    class Projectile : public PtrHolder
+    {
+    public:
+        Projectile(const int projectileId, const osg::Vec3f& position, btCollisionWorld* world);
+        ~Projectile();
+
+        btConvexShape* getConvexShape() const { return mConvexShape; }
+
+        void updateCollisionObjectPosition();
+
+        void setPosition(const osg::Vec3f& position);
+
+        osg::Vec3f getPosition() const;
+
+        btCollisionObject* getCollisionObject() const
+        {
+            return mCollisionObject.get();
+        }
+
+        int getProjectileId() const
+        {
+            return mProjectileId;
+        }
+
+    private:
+
+        std::unique_ptr<btCollisionShape> mShape;
+        btConvexShape* mConvexShape;
+
+        std::unique_ptr<btCollisionObject> mCollisionObject;
+
+        osg::Vec3f mPosition;
+
+        btCollisionWorld* mCollisionWorld;
+
+        Projectile(const Projectile&);
+        Projectile& operator=(const Projectile&);
+
+        int mProjectileId;
+    };
+
+}
+
+
+#endif

--- a/apps/openmw/mwphysics/trace.cpp
+++ b/apps/openmw/mwphysics/trace.cpp
@@ -5,6 +5,9 @@
 #include <BulletCollision/CollisionDispatch/btCollisionWorld.h>
 #include <BulletCollision/CollisionShapes/btConvexShape.h>
 
+#include "../mwbase/world.hpp"
+#include "../mwbase/environment.hpp"
+
 #include "collisiontype.hpp"
 #include "actor.hpp"
 #include "closestnotmeconvexresultcallback.hpp"

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -80,7 +80,6 @@ namespace MWWorld
             int mActorId;
             int mProjectileId;
 
-            bool mHit;
             osg::Vec3f mHitPosition;
 
             // TODO: this will break when the game is saved and reloaded, since there is currently

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -56,6 +56,8 @@ namespace MWWorld
 
         void update(float dt);
 
+        void manualHit(int projectileId, const MWWorld::Ptr& target, const osg::Vec3f& pos);
+
         /// Removes all current projectiles. Should be called when switching to a new worldspace.
         void clear();
 
@@ -76,6 +78,10 @@ namespace MWWorld
             std::shared_ptr<MWRender::EffectAnimationTime> mEffectAnimationTime;
 
             int mActorId;
+            int mProjectileId;
+
+            bool mHit;
+            osg::Vec3f mHitPosition;
 
             // TODO: this will break when the game is saved and reloaded, since there is currently
             // no way to write identifiers for non-actors to a savegame.
@@ -124,6 +130,8 @@ namespace MWWorld
 
         void moveProjectiles(float dt);
         void moveMagicBolts(float dt);
+
+        bool isValidTarget(const MWWorld::Ptr& caster, const MWWorld::Ptr& target);
 
         void createModel (State& state, const std::string& model, const osg::Vec3f& pos, const osg::Quat& orient,
                             bool rotate, bool createLight, osg::Vec4 lightDiffuseColor, std::string texture = "");

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -836,6 +836,11 @@ namespace MWWorld
         }
     }
 
+    void World::manualProjectileHit(int projectileId, const MWWorld::Ptr& target, const osg::Vec3f& pos)
+    {
+        mProjectileManager->manualHit(projectileId, target, pos);
+    }
+
     void World::disable (const Ptr& reference)
     {
         // disable is a no-op for items in containers

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -576,6 +576,8 @@ namespace MWWorld
             RestPermitted canRest() const override;
             ///< check if the player is allowed to rest
 
+            void manualProjectileHit(int projectileId, const MWWorld::Ptr& target, const osg::Vec3f& pos);
+
             void rest(double hours) override;
             void rechargeItems(double duration, bool activeOnly) override;
 


### PR DESCRIPTION
Should fix [bug #3372](https://gitlab.com/OpenMW/openmw/issues/3372).

A current design may be suboptimal, so it would be nice to get a feedback from other developers.
@AnyOldName3, @wareya, @elsid, what do you think?

The main idea:
1. Add collision object to the collision world for every projectile in scene.
2. Use an integer ID since projectiles have no persistent pointers.
3. During sweep tests for actors check if they collide with projectiles. If yes, apply projectile hit immediately and skip collision.