### PR TITLE
Make limit of max move steps depending on queue size (bug #4881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
     Bug #4860: Actors outside of processing range visible for one frame after spawning
     Bug #4876: AI ratings handling inconsistencies
+    Bug #4881: Slow PhysicsSystem::applyQueuedMovement for large multiplication of queue size and number of steps
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1226,7 +1226,7 @@ namespace MWPhysics
 
         mTimeAccum += dt;
 
-        const int maxAllowedSteps = 20;
+        const int maxAllowedSteps = std::min(20, std::max(1, 40 / std::max(1, static_cast<int>(mMovementQueue.size()))));
         int numSteps = mTimeAccum / (mPhysicsDt);
         numSteps = std::min(numSteps, maxAllowedSteps);
 


### PR DESCRIPTION
See https://gitlab.com/OpenMW/openmw/issues/4881 for more deails.