### PR TITLE
Option to set specific random seed for random number generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
     Feature #4730: Native animated containers support
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch
+    Feature #4887: Add openmw command option to set initial random seed
     Task #4686: Upgrade media decoder to a more current FFmpeg API
 
 0.45.0

--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ Command line options
       --export-fonts [=arg(=1)] (=0)        Export Morrowind .fnt fonts to PNG
                                             image and XML file in current directory
       --activate-dist arg (=-1)             activation distance override
+      --random-seed arg (=<impl defined>)   seed value for random number generator

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -228,7 +228,6 @@ OMW::Engine::Engine(Files::ConfigurationManager& configurationManager)
   , mNewGame (false)
   , mCfgMgr(configurationManager)
 {
-    Misc::Rng::init();
     MWClass::registerClasses();
 
     Uint32 flags = SDL_INIT_VIDEO|SDL_INIT_NOPARACHUTE|SDL_INIT_GAMECONTROLLER|SDL_INIT_JOYSTICK;
@@ -653,6 +652,8 @@ void OMW::Engine::go()
 
     Log(Debug::Info) << "OSG version: " << osgGetVersion();
 
+    Misc::Rng::init(mRandomSeed);
+
     // Load settings
     Settings::Manager settings;
     std::string settingspath;
@@ -820,4 +821,9 @@ void OMW::Engine::enableFontExport(bool exportFonts)
 void OMW::Engine::setSaveGameFile(const std::string &savegame)
 {
     mSaveGameFile = savegame;
+}
+
+void OMW::Engine::setRandomSeed(unsigned int seed)
+{
+    mRandomSeed = seed;
 }

--- a/apps/openmw/engine.hpp
+++ b/apps/openmw/engine.hpp
@@ -100,6 +100,7 @@ namespace OMW
             bool mGrab;
 
             bool mExportFonts;
+            unsigned int mRandomSeed;
 
             Compiler::Extensions mExtensions;
             Compiler::Context *mScriptContext;
@@ -202,6 +203,8 @@ namespace OMW
 
             /// Set the save game file to load after initialising the engine.
             void setSaveGameFile(const std::string& savegame);
+
+            void setRandomSeed(unsigned int seed);
 
         private:
             Files::ConfigurationManager& mCfgMgr;

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -3,6 +3,7 @@
 #include <components/files/escape.hpp>
 #include <components/fallback/validate.hpp>
 #include <components/debug/debugging.hpp>
+#include <components/misc/rng.hpp>
 
 #include "engine.hpp"
 
@@ -131,7 +132,12 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
         ("export-fonts", bpo::value<bool>()->implicit_value(true)
             ->default_value(false), "Export Morrowind .fnt fonts to PNG image and XML file in current directory")
 
-        ("activate-dist", bpo::value <int> ()->default_value (-1), "activation distance override");
+        ("activate-dist", bpo::value <int> ()->default_value (-1), "activation distance override")
+
+        ("random-seed", bpo::value <unsigned int> ()
+            ->default_value(Misc::Rng::generateDefaultSeed()),
+            "seed value for random number generator")
+    ;
 
     bpo::parsed_options valid_opts = bpo::command_line_parser(argc, argv)
         .options(desc).allow_unregistered().run();
@@ -231,6 +237,7 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     engine.setFallbackValues(variables["fallback"].as<FallbackMap>().mMap);
     engine.setActivationDistanceOverride (variables["activate-dist"].as<int>());
     engine.enableFontExport(variables["export-fonts"].as<bool>());
+    engine.setRandomSeed(variables["random-seed"].as<unsigned int>());
 
     return true;
 }

--- a/components/misc/rng.cpp
+++ b/components/misc/rng.cpp
@@ -8,9 +8,9 @@ namespace Misc
 
     std::mt19937 Rng::generator = std::mt19937();
 
-    void Rng::init()
+    void Rng::init(unsigned int seed)
     {
-        generator.seed(static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+        generator.seed(seed);
     }
 
     float Rng::rollProbability()
@@ -28,4 +28,8 @@ namespace Misc
         return max > 0 ? std::uniform_int_distribution<int>(0, max - 1)(generator) : 0;
     }
 
+    unsigned int Rng::generateDefaultSeed()
+    {
+        return static_cast<unsigned int>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    }
 }

--- a/components/misc/rng.hpp
+++ b/components/misc/rng.hpp
@@ -18,7 +18,7 @@ public:
     static std::mt19937 generator;
 
     /// seed the RNG
-    static void init();
+    static void init(unsigned int seed = generateDefaultSeed());
 
     /// return value in range [0.0f, 1.0f)  <- note open upper range.
     static float rollProbability();
@@ -31,6 +31,9 @@ public:
 
     /// return value in range [0, 99]
     static int roll0to99() { return rollDice(100); }
+
+    /// returns default seed for RNG
+    static unsigned int generateDefaultSeed();
 };
 
 }


### PR DESCRIPTION
This one is more like debugging feature. It would be nice to have reproducible game situations. When random seed depends on time and engine makes a lot of decisions by rolling a dice this option can help. Probably it is not the best way to do it. I will listen other suggestions.