### PR TITLE
Always include <memory> for smart pointers in MWGui

### DIFF
--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -3,6 +3,7 @@
 #include <MyGUI_Gui.h>
 #include <MyGUI_Button.h>
 #include <MyGUI_EditBox.h>
+#include <MyGUI_ControllerManager.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"

--- a/apps/openmw/mwgui/alchemywindow.hpp
+++ b/apps/openmw/mwgui/alchemywindow.hpp
@@ -1,11 +1,8 @@
 #ifndef MWGUI_ALCHEMY_H
 #define MWGUI_ALCHEMY_H
 
+#include <memory>
 #include <vector>
-
-#include <MyGUI_ControllerManager.h>
-
-#include "../mwmechanics/alchemy.hpp"
 
 #include <components/widgets/numericeditbox.hpp>
 

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -6,6 +6,7 @@
 #include "MyGUI_FontManager.h"
 
 #include <functional>
+#include <memory>
 #include <stdint.h>
 
 #include <components/settings/settings.hpp>

--- a/apps/openmw/mwgui/jailscreen.cpp
+++ b/apps/openmw/mwgui/jailscreen.cpp
@@ -103,24 +103,18 @@ namespace MWGui
         else
             message = gmst.find("sNotifyMessage43")->mValue.getString();
 
-        std::stringstream dayStr;
-        dayStr << mDays;
-        if (message.find("%d") != std::string::npos)
-            message.replace(message.find("%d"), 2, dayStr.str());
+        Misc::StringUtils::replace(message, "%d", std::to_string(mDays).c_str(), 2);
 
         for (std::set<int>::iterator it = skills.begin(); it != skills.end(); ++it)
         {
             std::string skillName = gmst.find(ESM::Skill::sSkillNameIds[*it])->mValue.getString();
-            std::stringstream skillValue;
-            skillValue << player.getClass().getNpcStats(player).getSkill(*it).getBase();
+            int skillValue = player.getClass().getNpcStats(player).getSkill(*it).getBase();
             std::string skillMsg = gmst.find("sNotifyMessage44")->mValue.getString();
             if (*it == ESM::Skill::Sneak || *it == ESM::Skill::Security)
                 skillMsg = gmst.find("sNotifyMessage39")->mValue.getString();
 
-            if (skillMsg.find("%s") != std::string::npos)
-                skillMsg.replace(skillMsg.find("%s"), 2, skillName);
-            if (skillMsg.find("%d") != std::string::npos)
-                skillMsg.replace(skillMsg.find("%d"), 2, skillValue.str());
+            Misc::StringUtils::replace(skillMsg, "%s", skillName.c_str(), 2);
+            Misc::StringUtils::replace(skillMsg, "%d", std::to_string(skillValue).c_str(), 2);
             message += "\n" + skillMsg;
         }
 

--- a/apps/openmw/mwgui/loadingscreen.hpp
+++ b/apps/openmw/mwgui/loadingscreen.hpp
@@ -1,6 +1,8 @@
 #ifndef MWGUI_LOADINGSCREEN_H
 #define MWGUI_LOADINGSCREEN_H
 
+#include <memory>
+
 #include <osg/Timer>
 #include <osg/ref_ptr>
 

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -2,6 +2,7 @@
 #define MWGUI_MAPWINDOW_H
 
 #include <stdint.h>
+#include <memory>
 
 #include "windowpinnablebase.hpp"
 

--- a/apps/openmw/mwgui/race.hpp
+++ b/apps/openmw/mwgui/race.hpp
@@ -1,6 +1,8 @@
 #ifndef MWGUI_RACE_H
 #define MWGUI_RACE_H
 
+#include <memory>
+
 #include "windowbase.hpp"
 #include <MyGUI_RenderManager.h>
 

--- a/apps/openmw/mwgui/savegamedialog.hpp
+++ b/apps/openmw/mwgui/savegamedialog.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENMW_MWGUI_SAVEGAMEDIALOG_H
 #define OPENMW_MWGUI_SAVEGAMEDIALOG_H
 
+#include <memory>
+
 #include "windowbase.hpp"
 
 namespace MWState

--- a/apps/openmw/mwgui/screenfader.hpp
+++ b/apps/openmw/mwgui/screenfader.hpp
@@ -2,6 +2,7 @@
 #define OPENMW_MWGUI_SCREENFADER_H
 
 #include <deque>
+#include <memory>
 
 #include "windowbase.hpp"
 

--- a/apps/openmw/mwgui/spellview.hpp
+++ b/apps/openmw/mwgui/spellview.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENMW_GUI_SPELLVIEW_H
 #define OPENMW_GUI_SPELLVIEW_H
 
+#include <memory>
 #include <tuple>
 
 #include <MyGUI_Widget.h>

--- a/apps/openmw/mwgui/videowidget.hpp
+++ b/apps/openmw/mwgui/videowidget.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENMW_MWGUI_VIDEOWIDGET_H
 #define OPENMW_MWGUI_VIDEOWIDGET_H
 
+#include <memory>
+
 #include <MyGUI_Widget.h>
 
 namespace Video


### PR DESCRIPTION
This should fix or at least improve the situation in [this report](https://gitlab.com/OpenMW/openmw/issues/4874).

Here I've put <memory> header to all (or most) MWGui headers that needed it so they build fine on RPi. Hopefully.

Also I used the new replace idiom in jail finish message.