### PR TITLE
Ignore global variable stray explicit reference calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
     Bug #4860: Actors outside of processing range visible for one frame after spawning
     Bug #4876: AI ratings handling inconsistencies
+    Bug #4888: Global variable stray explicit reference calls break script compilation
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -277,10 +277,18 @@ namespace Compiler
     {
         if (!mExplicit.empty())
         {
-            if (mMemberOp && handleMemberAccess (name))
-                return true;
+            if (!mRefOp)
+            {
+                if (mMemberOp && handleMemberAccess (name))
+                    return true;
 
-            return Parser::parseName (name, loc, scanner);
+                return Parser::parseName (name, loc, scanner);
+            }
+            else
+            {
+                mExplicit.clear();
+                getErrorHandler().warning ("Ignoring stray explicit reference", loc);
+            }
         }
 
         mFirst = false;

--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -506,6 +506,13 @@ namespace Compiler
             return true;
         }
 
+        if (code==Scanner::S_ref && mState==SetPotentialMemberVarState)
+        {
+            getErrorHandler().warning ("Ignoring stray explicit reference", loc);
+            mState = SetState;
+            return true;
+        }
+
         if (code==Scanner::S_ref && mState==PotentialExplicitState)
         {
             mState = ExplicitState;


### PR DESCRIPTION
[Bug 4888](https://gitlab.com/OpenMW/openmw/issues/4888)

This makes the expression parser clear explicit reference calls before names (these can normally only be variables in the expression parser) and makes the line parser reset the state to SetState when a potential member variable modification turns out to be an explicit reference call. So global variables can now "support" explicit reference calls by ignoring them, replicating a quirk one of Sotha Sil Expanded scripts is relying on.

OpenMW-CS will report these mistakes and OpenMW will report them as well.