### PR TITLE
Do not store Viewer reference in the ViewData

### DIFF
--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -118,7 +118,6 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer)
     if (found == mViews.end())
     {
         ViewData* vd = createOrReuseView();
-        vd->setViewer(viewer);
         mViews[viewer] = vd;
         return vd;
     }
@@ -148,7 +147,6 @@ void ViewDataMap::clearUnusedViews(unsigned int frame)
         ViewData* vd = it->second;
         if (vd->getFrameLastUsed() + 2 < frame)
         {
-            vd->setViewer(nullptr);
             vd->clear();
             mUnusedViews.push_back(vd);
             mViews.erase(it++);

--- a/components/terrain/viewdata.hpp
+++ b/components/terrain/viewdata.hpp
@@ -44,9 +44,6 @@ namespace Terrain
 
         Entry& getEntry(unsigned int i);
 
-        osg::Object* getViewer() const { return mViewer.get(); }
-        void setViewer(osg::Object* viewer) { mViewer = viewer; }
-
         unsigned int getFrameLastUsed() const { return mFrameLastUsed; }
 
         /// @return Have any nodes changed since the last frame
@@ -62,7 +59,6 @@ namespace Terrain
         unsigned int mNumEntries;
         unsigned int mFrameLastUsed;
         bool mChanged;
-        osg::ref_ptr<osg::Object> mViewer;
         osg::Vec3f mEyePoint;
         bool mHasEyePoint;
     };
@@ -85,7 +81,7 @@ namespace Terrain
     private:
         std::list<ViewData> mViewVector;
 
-        typedef std::map<osg::Object*, ViewData*> Map;
+        typedef std::map<osg::ref_ptr<osg::Object>, ViewData*> Map;
         Map mViews;
 
         std::deque<ViewData*> mUnusedViews;


### PR DESCRIPTION
Based on [MR #51](https://gitlab.com/OpenMW/openmw/merge_requests/51).

Currently the mViewer field is needed only to dispose Viewer object after the related ViewData object was disposed.

The main idea is to store smart pointers in the links map instead of ViewData object, so unused viewer object will be removed once link will be removed from the map.

Can be use such refactoring change or we should tell bzzt to drop it?