### PR TITLE
Port minor fixes from bzzt's branch

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1436,7 +1436,7 @@ namespace MWRender
                 return sceneMgr->createInstance(found->second);
         }
         else
-            return sceneMgr->createInstance(model);
+            return sceneMgr->getInstance(model);
     }
 
     void Animation::setObjectRoot(const std::string &model, bool forceskeleton, bool baseonly, bool isCreature)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -409,7 +409,8 @@ namespace MWWorld
                 if (getPlayerPtr().isInCell())
                 {
                     mWorldScene->preloadCell(getPlayerPtr().getCell(), true);
-                    mWorldScene->preloadTerrain(getPlayerPtr().getRefData().getPosition().asVec3());
+                    if (getPlayerPtr().getCell()->isExterior())
+                        mWorldScene->preloadTerrain(getPlayerPtr().getRefData().getPosition().asVec3());
                 }
                 break;
             default:

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -244,10 +244,8 @@ namespace NifOsg
                 osg::ref_ptr<NifOsg::KeyframeController> callback(new NifOsg::KeyframeController(key->data.getPtr()));
                 callback->setFunction(std::shared_ptr<NifOsg::ControllerFunction>(new NifOsg::ControllerFunction(key)));
 
-                if (target.mKeyframeControllers.find(strdata->string) != target.mKeyframeControllers.end())
+                if (!target.mKeyframeControllers.emplace(strdata->string, callback).second)
                     Log(Debug::Verbose) << "Controller " << strdata->string << " present more than once in " << nif->getFilename() << ", ignoring later version";
-                else
-                    target.mKeyframeControllers[strdata->string] = callback;
             }
         }
 

--- a/components/resource/objectcache.cpp
+++ b/components/resource/objectcache.cpp
@@ -75,10 +75,11 @@ void ObjectCache::updateTimeStampOfObjectsInCacheWithExternalReferences(double r
         itr!=_objectCache.end();
         ++itr)
     {
-        // if ref count is greater the 1 the object has an external reference.
-        if (itr->second.first->referenceCount()>1)
+        // If ref count is greater than 1, the object has an external reference.
+        // If the timestamp is yet to be initialized, it needs to be updated too.
+        if (itr->second.first->referenceCount()>1 || itr->second.second == 0.0)
         {
-            // so update it time stamp.
+            // So update it.
             itr->second.second = referenceTime;
         }
     }

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -729,6 +729,7 @@ namespace Resource
 
     void SceneManager::reportStats(unsigned int frameNumber, osg::Stats *stats) const
     {
+        if (mIncrementalCompileOperation)
         {
             OpenThreads::ScopedLock<OpenThreads::Mutex> lock(*mIncrementalCompileOperation->getToCompiledMutex());
             stats->setAttribute(frameNumber, "Compiling", mIncrementalCompileOperation->getToCompile().size());

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -234,6 +234,7 @@ namespace SceneUtil
         {
             osg::ref_ptr<osg::StateSet> stateset = new osg::StateSet;
             std::vector<osg::ref_ptr<osg::Light> > lights;
+            lights.reserve(lightList.size());
             for (unsigned int i=0; i<lightList.size();++i)
             {
                 lights.push_back(lightList[i]->mLightSource->getLight(frameNum));

--- a/components/sceneutil/visitor.cpp
+++ b/components/sceneutil/visitor.cpp
@@ -61,10 +61,7 @@ namespace SceneUtil
     {
         // Take transformation for first found node in file
         const std::string nodeName = Misc::StringUtils::lowerCase(trans.getName());
-        if (mMap.find(nodeName) == mMap.end())
-        {
-            mMap[nodeName] = &trans;
-        }
+        mMap.emplace(nodeName, &trans);
 
         traverse(trans);
     }

--- a/components/terrain/cellborder.cpp
+++ b/components/terrain/cellborder.cpp
@@ -7,7 +7,7 @@
 #include "world.hpp"
 #include "../esm/loadland.hpp"
 
-namespace MWRender
+namespace Terrain
 {
 
 CellBorder::CellBorder(Terrain::World *world, osg::Group *root, int borderMask):

--- a/components/terrain/cellborder.hpp
+++ b/components/terrain/cellborder.hpp
@@ -7,10 +7,7 @@
 namespace Terrain
 {
     class World;
-}
 
-namespace MWRender
-{
     /**
      * @Brief Handles the debug cell borders.
      */

--- a/components/terrain/compositemaprenderer.cpp
+++ b/components/terrain/compositemaprenderer.cpp
@@ -122,6 +122,8 @@ void CompositeMapRenderer::compile(CompositeMap &compositeMap, osg::RenderInfo &
 
         ++compositeMap.mCompiled;
 
+        compositeMap.mDrawables[i] = nullptr;
+
         if (timeLeft)
         {
             *timeLeft -= timer.time_s();
@@ -131,6 +133,8 @@ void CompositeMapRenderer::compile(CompositeMap &compositeMap, osg::RenderInfo &
                 break;
         }
     }
+    if (compositeMap.mCompiled == compositeMap.mDrawables.size())
+        compositeMap.mDrawables = std::vector<osg::ref_ptr<osg::Drawable>>();
 
     state.haveAppliedAttribute(osg::StateAttribute::VIEWPORT);
 

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -171,20 +171,21 @@ public:
 
     QuadTreeNode* addChild(QuadTreeNode* parent, ChildDirection direction, float size)
     {
+        float halfSize = size/2.f;
         osg::Vec2f center;
         switch (direction)
         {
         case SW:
-            center = parent->getCenter() + osg::Vec2f(-size/2.f,-size/2.f);
+            center = parent->getCenter() + osg::Vec2f(-halfSize,-halfSize);
             break;
         case SE:
-            center = parent->getCenter() + osg::Vec2f(size/2.f, -size/2.f);
+            center = parent->getCenter() + osg::Vec2f(halfSize, -halfSize);
             break;
         case NW:
-            center = parent->getCenter() + osg::Vec2f(-size/2.f, size/2.f);
+            center = parent->getCenter() + osg::Vec2f(-halfSize, halfSize);
             break;
         case NE:
-            center = parent->getCenter() + osg::Vec2f(size/2.f, size/2.f);
+            center = parent->getCenter() + osg::Vec2f(halfSize, halfSize);
             break;
         default:
             break;
@@ -206,8 +207,8 @@ public:
         mStorage->getMinMaxHeights(size, center, minZ, maxZ);
 
         float cellWorldSize = mStorage->getCellWorldSize();
-        osg::BoundingBox boundingBox(osg::Vec3f((center.x()-size)*cellWorldSize, (center.y()-size)*cellWorldSize, minZ),
-                                osg::Vec3f((center.x()+size)*cellWorldSize, (center.y()+size)*cellWorldSize, maxZ));
+        osg::BoundingBox boundingBox(osg::Vec3f((center.x()-halfSize)*cellWorldSize, (center.y()-halfSize)*cellWorldSize, minZ),
+                                osg::Vec3f((center.x()+halfSize)*cellWorldSize, (center.y()+halfSize)*cellWorldSize, maxZ));
         node->setBoundingBox(boundingBox);
 
         return node;

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -163,7 +163,10 @@ public:
                 boundingBox.expandBy(child->getBoundingBox());
         }
 
-        parent->setBoundingBox(boundingBox);
+        if (!boundingBox.valid())
+            parent->removeChildren(0, 4);
+        else
+            parent->setBoundingBox(boundingBox);
     }
 
     QuadTreeNode* addChild(QuadTreeNode* parent, ChildDirection direction, float size)

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -84,7 +84,7 @@ void TerrainGrid::loadCell(int x, int y)
 
 void TerrainGrid::unloadCell(int x, int y)
 {
-    MWRender::CellBorder::CellGrid::iterator it = mGrid.find(std::make_pair(x,y));
+    CellBorder::CellGrid::iterator it = mGrid.find(std::make_pair(x,y));
     if (it == mGrid.end())
         return;
 

--- a/components/terrain/terraingrid.hpp
+++ b/components/terrain/terraingrid.hpp
@@ -33,7 +33,7 @@ namespace Terrain
         // split each ESM::Cell into mNumSplits*mNumSplits terrain chunks
         unsigned int mNumSplits;
 
-        MWRender::CellBorder::CellGrid mGrid;
+        CellBorder::CellGrid mGrid;
     };
 }
 

--- a/components/terrain/world.cpp
+++ b/components/terrain/world.cpp
@@ -47,7 +47,7 @@ World::World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSyst
 
     mTextureManager.reset(new TextureManager(mResourceSystem->getSceneManager()));
     mChunkManager.reset(new ChunkManager(mStorage, mResourceSystem->getSceneManager(), mTextureManager.get(), mCompositeMapRenderer));
-    mCellBorder.reset(new MWRender::CellBorder(this,mTerrainRoot.get(),borderMask));
+    mCellBorder.reset(new CellBorder(this,mTerrainRoot.get(),borderMask));
 
     mResourceSystem->addResourceManager(mChunkManager.get());
     mResourceSystem->addResourceManager(mTextureManager.get());

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -116,7 +116,7 @@ namespace Terrain
         std::unique_ptr<TextureManager> mTextureManager;
         std::unique_ptr<ChunkManager> mChunkManager;
 
-        std::unique_ptr<MWRender::CellBorder> mCellBorder;
+        std::unique_ptr<CellBorder> mCellBorder;
 
         bool mBorderVisible;
 


### PR DESCRIPTION
While large-scale additions appear in bzzt's branch in hopes to bring the performance in the best shape it can be, there also are much smaller improvements, that, despite their laconity, can be quite effective. So while bzzt disagrees with the notion that his MR can't be viewed upon not as a whole, I took the liberty of being a crow I've been criticized as being and picking out some very small stuff that deserves to be merged straightaway without waiting for the rest of the MR to get reviewed (somehow) in the following decade.

The commits were cherry-picked, which retains the author and his email intact, even though committeer changes, and GitLab and GitHub will count these as his own commits.

But we want some actual documentation to the commits, right?

1. Don't preload terrain when loading an interior save.
Terrain is preloaded based on the player's position when loading saves. However, said position will be near 0, 0, 0 if the player is in an interior, so terrain in that Ashlands daedric ruins cell (you know the one) will be preloaded redundantly. This should improve interior save loading performance somewhat.

2. Don't use MWRender namespace in common terrain components.
It was used there for some reason even though MW%stuff% namespaces are specific to the engine app itself. 

3. Use emplace instead of find-assign in some places.
std::map::emplace/std::map::insert check for duplicates automatically and doesn't insert anything if the key is used, so making a search is inefficient. The second element of the returned pair gives information whether the insert was successful. The commit was slightly modified; originally it used insert(std::make_pair()) which is slightly more verbose and less efficient.

4. Don't reallocate light list vector unnecessarily.
It is perfectly fine to assume a scene has a maximum of 8 lights at any time, so it doesn't make sense to reallocate the vector which contains light sources every time it gets an element before that point.

5. Fix creature model instance preloading.
The instance wasn't actually used according to bzzt, so he replaced the call.

6. Fix crash when incremental compile operation is not used.
The code in the scope assumes mIncrementalCompileOperation is always available. It may not be, and if it's null then bad things will happen.

7. Prune empty quad tree nodes.
If the assumed bounding box of a distant terrain node is invalid, it means that there aren't any valid children added. So all possible children are removed, with an assumption made that a QuadTreeNode can't have more than four children (obviously).

8. Delete composite map layers on demand.
Composite map layers were previously removed all at once, which wasn't really good for performance. Now they are removed at the moment they are compiled so getting rid of them is gradual instead of being sudden. This fixes the initial ridiculous freeze upon being outside when Tamriel Rebuilt is used and reduces the fatality of frame drops upon turning as akortunov has observed and is actually quite a game-changer.

9. Fix quad tree node bounding box dimensions.
scrawl made a mistake so they used the full size of the quad tree node as a radius/dimension (starting from the center) instead of a half of the size. Bounding boxes affect culling so reducing the size of the bounding box allows to reduce the amount of terrain rendered at a single time. According to bzzt, this leads to about 20% less terrain being rendered (the terrain which was outside of the camera viewport).

10. Don't discard object cache with uninitialized timestamp.
While this is a divergence from OSG, objects with cache timestamp being 0 could have never gotten the real timestamp initialized so the cache could get dropped in an instant. This could happen when the terrain was being loaded.