### PR TITLE
Fix Boost version check in the launcher

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -1,5 +1,6 @@
 #include "graphicspage.hpp"
 
+#include <boost/version.hpp>
 #if BOOST_VERSION >= 106500
 #include <boost/integer/common_factor.hpp>
 #else


### PR DESCRIPTION
```
apps/launcher/graphicspage.cpp:5 BOOST_VERSION is not defined
```

I suppose it is because of recent changes in the GCD headers.

This PR just adds an include which defines this variable.