### PR TITLE
Optimize terrain QuadTree build

### DIFF
--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -71,16 +71,6 @@ QuadTreeNode::~QuadTreeNode()
 {
 }
 
-QuadTreeNode* QuadTreeNode::getParent()
-{
-    return mParent;
-}
-
-QuadTreeNode *QuadTreeNode::getChild(unsigned int i)
-{
-    return static_cast<QuadTreeNode*>(Group::getChild(i));
-}
-
 QuadTreeNode *QuadTreeNode::getNeighbour(Direction dir)
 {
     return mNeighbours[dir];

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -35,10 +35,19 @@ namespace Terrain
         QuadTreeNode(QuadTreeNode* parent, ChildDirection dir, float size, const osg::Vec2f& center);
         virtual ~QuadTreeNode();
 
-        QuadTreeNode* getParent();
+        inline QuadTreeNode* getParent() { return mParent; }
+        inline QuadTreeNode* getChild(unsigned int i) { return static_cast<QuadTreeNode*>(Group::getChild(i)); }
+        inline unsigned int getNumChildren() const { return _children.size(); }
 
-        QuadTreeNode* getChild(unsigned int i);
-        using osg::Group::getNumChildren;
+        // osg::Group::addChild() does a lot of unrelated stuff, but we just really want to add a child node.
+        void addChild(QuadTreeNode* child)
+        {
+            // QuadTree node should not contain more than 4 child nodes.
+            // Reserve enough space if this node is supposed to have child nodes.
+            _children.reserve(4);
+            _children.push_back(child);
+            child->addParent(this);
+        };
 
         /// Returns our direction relative to the parent node, or Root if we are the root node.
         ChildDirection getDirection() { return mDirection; }

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -158,9 +158,12 @@ public:
         osg::BoundingBox boundingBox;
         for (unsigned int i=0; i<4; ++i)
         {
-            QuadTreeNode* child = addChild(parent, static_cast<ChildDirection>(i), halfSize);
+            osg::ref_ptr<QuadTreeNode> child = addChild(parent, static_cast<ChildDirection>(i), halfSize);
             if (child)
+            {
                 boundingBox.expandBy(child->getBoundingBox());
+                parent->addChild(child);
+            }
         }
 
         if (!boundingBox.valid())
@@ -169,7 +172,7 @@ public:
             parent->setBoundingBox(boundingBox);
     }
 
-    QuadTreeNode* addChild(QuadTreeNode* parent, ChildDirection direction, float size)
+    osg::ref_ptr<QuadTreeNode> addChild(QuadTreeNode* parent, ChildDirection direction, float size)
     {
         float halfSize = size/2.f;
         osg::Vec2f center;
@@ -194,7 +197,6 @@ public:
         osg::ref_ptr<QuadTreeNode> node = new QuadTreeNode(parent, direction, size, center);
         node->setLodCallback(parent->getLodCallback());
         node->setViewDataMap(mViewDataMap);
-        parent->addChild(node);
 
         if (node->getSize() > mMinSize)
         {


### PR DESCRIPTION
1. QuadTree node can contain either 0 or 4 child nodes, so we can reserve space to make insert faster.
2. `osg::Group::addChild()` does many additional stuff: fixes deprecated data in geometries, checks if child nodes have custom callbacks, etc. In theory, we can just add child nodes without additional stuff.

On my hardware speedup is about 10% with vanilla landmass (0.24-0.25s vs 0.25-0.27s to build the terrain QuadTree).