### PR TITLE
Use C++11-style loops in the GUI instead of iterators

### DIFF
--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -238,15 +238,15 @@ namespace MWGui
         std::set<MWMechanics::EffectKey> effectIds = mAlchemy->listEffects();
         Widgets::SpellEffectList list;
         unsigned int effectIndex=0;
-        for (std::set<MWMechanics::EffectKey>::iterator it2 = effectIds.begin(); it2 != effectIds.end(); ++it2)
+        for (const MWMechanics::EffectKey& effectKey : effectIds)
         {
             Widgets::SpellEffectParams params;
-            params.mEffectID = it2->mId;
-            const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(it2->mId);
+            params.mEffectID = effectKey.mId;
+            const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectKey.mId);
             if (magicEffect->mData.mFlags & ESM::MagicEffect::TargetSkill)
-                params.mSkill = it2->mArg;
+                params.mSkill = effectKey.mArg;
             else if (magicEffect->mData.mFlags & ESM::MagicEffect::TargetAttribute)
-                params.mAttribute = it2->mArg;
+                params.mAttribute = effectKey.mArg;
             params.mIsConstant = true;
             params.mNoTarget = true;
 

--- a/apps/openmw/mwgui/birth.cpp
+++ b/apps/openmw/mwgui/birth.cpp
@@ -145,35 +145,35 @@ namespace MWGui
         // sort by name
         std::vector < std::pair<std::string, const ESM::BirthSign*> > birthSigns;
 
-        MWWorld::Store<ESM::BirthSign>::iterator it = signs.begin();
-        for (; it != signs.end(); ++it)
+        for (const ESM::BirthSign& sign : signs)
         {
-            birthSigns.push_back(std::make_pair(it->mId, &(*it)));
+            birthSigns.push_back(std::make_pair(sign.mId, &sign));
         }
         std::sort(birthSigns.begin(), birthSigns.end(), sortBirthSigns);
 
         int index = 0;
-        for (std::vector<std::pair<std::string, const ESM::BirthSign*> >::const_iterator it2 = birthSigns.begin();
-             it2 != birthSigns.end(); ++it2, ++index)
+        for (auto& birthsignPair : birthSigns)
         {
-            mBirthList->addItem(it2->second->mName, it2->first);
+            mBirthList->addItem(birthsignPair.second->mName, birthsignPair.first);
             if (mCurrentBirthId.empty())
             {
                 mBirthList->setIndexSelected(index);
-                mCurrentBirthId = it2->first;
+                mCurrentBirthId = birthsignPair.first;
             }
-            else if (Misc::StringUtils::ciEqual(it2->first, mCurrentBirthId))
+            else if (Misc::StringUtils::ciEqual(birthsignPair.first, mCurrentBirthId))
             {
                 mBirthList->setIndexSelected(index);
             }
+
+            index++;
         }
     }
 
     void BirthDialog::updateSpells()
     {
-        for (std::vector<MyGUI::Widget*>::iterator it = mSpellItems.begin(); it != mSpellItems.end(); ++it)
+        for (MyGUI::Widget* widget : mSpellItems)
         {
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         }
         mSpellItems.clear();
 

--- a/apps/openmw/mwgui/charactercreation.cpp
+++ b/apps/openmw/mwgui/charactercreation.cpp
@@ -257,19 +257,17 @@ namespace MWGui
 
                     {
                         std::map<int, MWMechanics::AttributeValue > attributes = MWBase::Environment::get().getWindowManager()->getPlayerAttributeValues();
-                        for (std::map<int, MWMechanics::AttributeValue >::iterator it = attributes.begin();
-                            it != attributes.end(); ++it)
+                        for (auto& attributePair : attributes)
                         {
-                            mReviewDialog->setAttribute(static_cast<ESM::Attribute::AttributeID> (it->first), it->second);
+                            mReviewDialog->setAttribute(static_cast<ESM::Attribute::AttributeID> (attributePair.first), attributePair.second);
                         }
                     }
 
                     {
                         std::map<int, MWMechanics::SkillValue > skills = MWBase::Environment::get().getWindowManager()->getPlayerSkillValues();
-                        for (std::map<int, MWMechanics::SkillValue >::iterator it = skills.begin();
-                            it != skills.end(); ++it)
+                        for (auto& skillPair : skills)
                         {
-                            mReviewDialog->setSkillValue(static_cast<ESM::Skill::SkillEnum> (it->first), it->second);
+                            mReviewDialog->setSkillValue(static_cast<ESM::Skill::SkillEnum> (skillPair.first), skillPair.second);
                         }
                         mReviewDialog->configureSkills(MWBase::Environment::get().getWindowManager()->getPlayerMajorSkills(), MWBase::Environment::get().getWindowManager()->getPlayerMinorSkills());
                     }

--- a/apps/openmw/mwgui/class.cpp
+++ b/apps/openmw/mwgui/class.cpp
@@ -207,25 +207,25 @@ namespace MWGui
 
         const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
 
-        std::vector<std::pair<std::string, std::string> > items; // class id, class name       
-        for (MWWorld::Store<ESM::Class>::iterator it = store.get<ESM::Class>().begin(); it != store.get<ESM::Class>().end(); ++it)
+        std::vector<std::pair<std::string, std::string> > items; // class id, class name
+        for (const ESM::Class& classInfo : store.get<ESM::Class>())
         {
-            bool playable = (it->mData.mIsPlayable != 0);
+            bool playable = (classInfo.mData.mIsPlayable != 0);
             if (!playable) // Only display playable classes
                 continue;
 
-            if (store.get<ESM::Class>().isDynamic(it->mId))
+            if (store.get<ESM::Class>().isDynamic(classInfo.mId))
                 continue; // custom-made class not relevant for this dialog
 
-            items.push_back(std::make_pair(it->mId, it->mName));
+            items.push_back(std::make_pair(classInfo.mId, classInfo.mName));
         }
         std::sort(items.begin(), items.end(), sortClasses);
 
         int index = 0;
-        for (std::vector<std::pair<std::string, std::string> >::const_iterator it = items.begin(); it != items.end(); ++it)
+        for (auto& itemPair : items)
         {
-            const std::string &id = it->first;
-            mClassList->addItem(it->second, id);
+            const std::string &id = itemPair.first;
+            mClassList->addItem(itemPair.second, id);
             if (mCurrentClassId.empty())
             {
                 mCurrentClassId = id;
@@ -332,19 +332,17 @@ namespace MWGui
 
     void InfoBoxDialog::setButtons(ButtonList &buttons)
     {
-        for (std::vector<MyGUI::Button*>::iterator it = this->mButtons.begin(); it != this->mButtons.end(); ++it)
+        for (MyGUI::Button* button : this->mButtons)
         {
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+            MyGUI::Gui::getInstance().destroyWidget(button);
         }
         this->mButtons.clear();
 
         // TODO: The buttons should be generated from a template in the layout file, ie. cloning an existing widget
         MyGUI::Button* button;
         MyGUI::IntCoord coord = MyGUI::IntCoord(0, 0, mButtonBar->getWidth(), 10);
-        ButtonList::const_iterator end = buttons.end();
-        for (ButtonList::const_iterator it = buttons.begin(); it != end; ++it)
+        for (const std::string &text : buttons)
         {
-            const std::string &text = *it;
             button = mButtonBar->createWidget<MyGUI::Button>("MW_Button", coord, MyGUI::Align::Top | MyGUI::Align::HCenter, "");
             button->getSubWidgetText()->setWordWrap(true);
             button->setCaption(text);
@@ -368,11 +366,10 @@ namespace MWGui
 
     void InfoBoxDialog::onButtonClicked(MyGUI::Widget* _sender)
     {
-        std::vector<MyGUI::Button*>::const_iterator end = mButtons.end();
         int i = 0;
-        for (std::vector<MyGUI::Button*>::const_iterator it = mButtons.begin(); it != end; ++it)
+        for (MyGUI::Button* button : mButtons)
         {
-            if (*it == _sender)
+            if (button == _sender)
             {
                 eventButtonSelected(i);
                 return;
@@ -430,10 +427,9 @@ namespace MWGui
             mSkills.push_back(mMinorSkill[i]);
         }
 
-        std::vector<Widgets::MWSkillPtr>::const_iterator end = mSkills.end();
-        for (std::vector<Widgets::MWSkillPtr>::const_iterator it = mSkills.begin(); it != end; ++it)
+        for (Widgets::MWSkillPtr& skill : mSkills)
         {
-            (*it)->eventClicked += MyGUI::newDelegate(this, &CreateClassDialog::onSkillClicked);
+            skill->eventClicked += MyGUI::newDelegate(this, &CreateClassDialog::onSkillClicked);
         }
 
         setText("LabelT", MWBase::Environment::get().getWindowManager()->getGameSettingString("sName", ""));
@@ -642,14 +638,13 @@ namespace MWGui
         ESM::Skill::SkillEnum id = mSkillDialog->getSkillId();
 
         // Avoid duplicate skills by swapping any skill field that matches the selected one
-        std::vector<Widgets::MWSkillPtr>::const_iterator end = mSkills.end();
-        for (std::vector<Widgets::MWSkillPtr>::const_iterator it = mSkills.begin(); it != end; ++it)
+        for (Widgets::MWSkillPtr& skill : mSkills)
         {
-            if (*it == mAffectedSkill)
+            if (skill == mAffectedSkill)
                 continue;
-            if ((*it)->getSkillId() == id)
+            if (skill->getSkillId() == id)
             {
-                (*it)->setSkillId(mAffectedSkill->getSkillId());
+                skill->setSkillId(mAffectedSkill->getSkillId());
                 break;
             }
         }

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -231,11 +231,13 @@ namespace MWGui
             {
                 int i = 0;
                 printOK("");
-                for(std::vector<std::string>::iterator it=matches.begin(); it < matches.end(); ++it,++i )
+                for(std::string& match : matches)
                 {
-                    printOK( *it );
-                    if( i == 50 )
+                    if(i == 50)
                         break;
+
+                    printOK(match);
+                    i++;
                 }
             }
         }
@@ -352,15 +354,16 @@ namespace MWGui
         }
 
         /* Iterate through the vector. */
-        for(std::vector<std::string>::iterator it=mNames.begin(); it < mNames.end();++it) {
+        for(std::string& name : mNames)
+        {
             bool string_different=false;
 
             /* Is the string shorter than the input string? If yes skip it. */
-            if( (*it).length() < tmp.length() )
+            if(name.length() < tmp.length())
                 continue;
 
             /* Is the beginning of the string different from the input string? If yes skip it. */
-            for( std::string::iterator iter=tmp.begin(), iter2=(*it).begin(); iter < tmp.end();++iter, ++iter2) {
+            for( std::string::iterator iter=tmp.begin(), iter2=name.begin(); iter < tmp.end();++iter, ++iter2) {
                 if( Misc::StringUtils::toLower(*iter) != Misc::StringUtils::toLower(*iter2) ) {
                     string_different=true;
                     break;
@@ -371,7 +374,7 @@ namespace MWGui
                 continue;
 
             /* The beginning of the string matches the input string, save it for the next test. */
-            matches.push_back(*it);
+            matches.push_back(name);
         }
 
         /* There are no matches. Return the unchanged input. */
@@ -399,11 +402,14 @@ namespace MWGui
         /* Check if all matching strings match further than input. If yes complete to this match. */
         int i = tmp.length();
 
-        for(std::string::iterator iter=matches.front().begin()+tmp.length(); iter < matches.front().end(); ++iter, ++i) {
-            for(std::vector<std::string>::iterator it=matches.begin(); it < matches.end();++it) {
-                if( Misc::StringUtils::toLower((*it)[i]) != Misc::StringUtils::toLower(*iter) ) {
+        for(std::string::iterator iter=matches.front().begin()+tmp.length(); iter < matches.front().end(); ++iter, ++i)
+        {
+            for(std::string& match : matches)
+            {
+                if(Misc::StringUtils::toLower(match[i]) != Misc::StringUtils::toLower(*iter))
+                {
                     /* Append the longest match to the end of the output string*/
-                    output.append(matches.front().substr( 0, i));
+                    output.append(matches.front().substr(0, i));
                     return output;
                 }
             }

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -82,9 +82,9 @@ size_t ContainerItemModel::getItemCount()
 ItemModel::ModelIndex ContainerItemModel::getIndex (ItemStack item)
 {
     size_t i = 0;
-    for (std::vector<ItemStack>::iterator it = mItems.begin(); it != mItems.end(); ++it)
+    for (ItemStack& itemStack : mItems)
     {
-        if (*it == item)
+        if (itemStack == item)
             return i;
         ++i;
     }
@@ -103,29 +103,29 @@ void ContainerItemModel::removeItem (const ItemStack& item, size_t count)
 {
     int toRemove = count;
 
-    for (std::vector<MWWorld::Ptr>::iterator source = mItemSources.begin(); source != mItemSources.end(); ++source)
+    for (MWWorld::Ptr& source : mItemSources)
     {
-        MWWorld::ContainerStore& store = source->getClass().getContainerStore(*source);
+        MWWorld::ContainerStore& store = source.getClass().getContainerStore(source);
 
         for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
         {
             if (stacks(*it, item.mBase))
             {
-                toRemove -= store.remove(*it, toRemove, *source);
+                toRemove -= store.remove(*it, toRemove, source);
                 if (toRemove <= 0)
                     return;
             }
         }
     }
-    for (std::vector<MWWorld::Ptr>::iterator source = mWorldItems.begin(); source != mWorldItems.end(); ++source)
+    for (MWWorld::Ptr& source : mWorldItems)
     {
-        if (stacks(*source, item.mBase))
+        if (stacks(source, item.mBase))
         {
-            int refCount = source->getRefData().getCount();
+            int refCount = source.getRefData().getCount();
             if (refCount - toRemove <= 0)
-                MWBase::Environment::get().getWorld()->deleteObject(*source);
+                MWBase::Environment::get().getWorld()->deleteObject(source);
             else
-                source->getRefData().setCount(std::max(0, refCount - toRemove));
+                source.getRefData().setCount(std::max(0, refCount - toRemove));
             toRemove -= refCount;
             if (toRemove <= 0)
                 return;
@@ -138,27 +138,28 @@ void ContainerItemModel::removeItem (const ItemStack& item, size_t count)
 void ContainerItemModel::update()
 {
     mItems.clear();
-    for (std::vector<MWWorld::Ptr>::iterator source = mItemSources.begin(); source != mItemSources.end(); ++source)
+    for (MWWorld::Ptr& source : mItemSources)
     {
-        MWWorld::ContainerStore& store = source->getClass().getContainerStore(*source);
+        MWWorld::ContainerStore& store = source.getClass().getContainerStore(source);
 
         for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)
         {
             if (!(*it).getClass().showsInInventory(*it))
                 continue;
 
-            std::vector<ItemStack>::iterator itemStack = mItems.begin();
-            for (; itemStack != mItems.end(); ++itemStack)
+            bool found = false;
+            for (ItemStack& itemStack : mItems)
             {
-                if (stacks(*it, itemStack->mBase))
+                if (stacks(*it, itemStack.mBase))
                 {
                     // we already have an item stack of this kind, add to it
-                    itemStack->mCount += it->getRefData().getCount();
+                    itemStack.mCount += it->getRefData().getCount();
+                    found = true;
                     break;
                 }
             }
 
-            if (itemStack == mItems.end())
+            if (!found)
             {
                 // no stack yet, create one
                 ItemStack newItem (*it, this, it->getRefData().getCount());
@@ -166,23 +167,24 @@ void ContainerItemModel::update()
             }
         }
     }
-    for (std::vector<MWWorld::Ptr>::iterator source = mWorldItems.begin(); source != mWorldItems.end(); ++source)
+    for (MWWorld::Ptr& source : mWorldItems)
     {
-        std::vector<ItemStack>::iterator itemStack = mItems.begin();
-        for (; itemStack != mItems.end(); ++itemStack)
+        bool found = false;
+        for (ItemStack& itemStack : mItems)
         {
-            if (stacks(*source, itemStack->mBase))
+            if (stacks(source, itemStack.mBase))
             {
                 // we already have an item stack of this kind, add to it
-                itemStack->mCount += source->getRefData().getCount();
+                itemStack.mCount += source.getRefData().getCount();
+                found = true;
                 break;
             }
         }
 
-        if (itemStack == mItems.end())
+        if (!found)
         {
             // no stack yet, create one
-            ItemStack newItem (*source, this, source->getRefData().getCount());
+            ItemStack newItem (source, this, source.getRefData().getCount());
             mItems.push_back(newItem);
         }
     }

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -184,16 +184,16 @@ namespace MWGui
 
             BookTypesetter::Style* style = typesetter->createStyle("", textColours.normal, false);
             size_t formatted = 0; // points to the first character that is not laid out yet
-            for (std::map<Range, intptr_t>::iterator it = hyperLinks.begin(); it != hyperLinks.end(); ++it)
+            for (auto& hyperLink : hyperLinks)
             {
-                intptr_t topicId = it->second;
+                intptr_t topicId = hyperLink.second;
                 BookTypesetter::Style* hotStyle = typesetter->createHotStyle (style, textColours.link,
                                                                               textColours.linkOver, textColours.linkPressed,
                                                                               topicId);
-                if (formatted < it->first.first)
-                    typesetter->write(style, formatted, it->first.first);
-                typesetter->write(hotStyle, it->first.first, it->first.second);
-                formatted = it->first.second;
+                if (formatted < hyperLink.first.first)
+                    typesetter->write(style, formatted, hyperLink.first.first);
+                typesetter->write(hotStyle, hyperLink.first.first, hyperLink.first.second);
+                formatted = hyperLink.first.second;
             }
             if (formatted < text.size())
                 typesetter->write(style, formatted, text.size());
@@ -204,9 +204,8 @@ namespace MWGui
             keywordSearch->highlightKeywords(text.begin(), text.end(), matches);
 
             std::string::const_iterator i = text.begin ();
-            for (std::vector<KeywordSearchT::Match>::iterator it = matches.begin(); it != matches.end(); ++it)
+            for (KeywordSearchT::Match& match : matches)
             {
-                KeywordSearchT::Match match = *it;
                 if (i != match.mBeg)
                     addTopicLink (typesetter, 0, i - text.begin (), match.mBeg - text.begin ());
 
@@ -419,13 +418,13 @@ namespace MWGui
         bool sameActor = (mPtr == actor);
         if (!sameActor)
         {
-            for (std::vector<DialogueText*>::iterator it = mHistoryContents.begin(); it != mHistoryContents.end(); ++it)
-                delete (*it);
+            for (DialogueText* text : mHistoryContents)
+                delete text;
             mHistoryContents.clear();
             mKeywords.clear();
             mTopicsList->clear();
-            for (std::vector<Link*>::iterator it = mLinks.begin(); it != mLinks.end(); ++it)
-                mDeleteLater.push_back(*it); // Links are not deleted right away to prevent issues with event handlers
+            for (Link* link : mLinks)
+                mDeleteLater.push_back(link); // Links are not deleted right away to prevent issues with event handlers
             mLinks.clear();
         }
 
@@ -489,8 +488,8 @@ namespace MWGui
     void DialogueWindow::updateTopicsPane()
     {
         mTopicsList->clear();
-        for (std::map<std::string, Link*>::iterator it = mTopicLinks.begin(); it != mTopicLinks.end(); ++it)
-            mDeleteLater.push_back(it->second);
+        for (auto& linkPair : mTopicLinks)
+            mDeleteLater.push_back(linkPair.second);
         mTopicLinks.clear();
         mKeywordSearch.clear();
 
@@ -533,15 +532,15 @@ namespace MWGui
             mTopicsList->addSeparator();
 
 
-        for(std::list<std::string>::iterator it = mKeywords.begin(); it != mKeywords.end(); ++it)
+        for(std::string& keyword : mKeywords)
         {
-            mTopicsList->addItem(*it);
+            mTopicsList->addItem(keyword);
 
-            Topic* t = new Topic(*it);
+            Topic* t = new Topic(keyword);
             t->eventTopicActivated += MyGUI::newDelegate(this, &DialogueWindow::onTopicActivated);
-            mTopicLinks[Misc::StringUtils::lowerCase(*it)] = t;
+            mTopicLinks[Misc::StringUtils::lowerCase(keyword)] = t;
 
-            mKeywordSearch.seed(Misc::StringUtils::lowerCase(*it), intptr_t(t));
+            mKeywordSearch.seed(Misc::StringUtils::lowerCase(keyword), intptr_t(t));
         }
         mTopicsList->adjustSize();
 
@@ -563,9 +562,8 @@ namespace MWGui
 
         BookTypesetter::Ptr typesetter = BookTypesetter::create (mHistory->getWidth(), std::numeric_limits<int>::max());
 
-        for (std::vector<DialogueText*>::iterator it = mHistoryContents.begin(); it != mHistoryContents.end(); ++it)
-            (*it)->write(typesetter, &mKeywordSearch, mTopicLinks);
-
+        for (DialogueText* text : mHistoryContents)
+            text->write(typesetter, &mKeywordSearch, mTopicLinks);
 
         BookTypesetter::Style* body = typesetter->createStyle("", MyGUI::Colour::White, false);
 
@@ -573,9 +571,9 @@ namespace MWGui
         // choices
         const TextColours& textColours = MWBase::Environment::get().getWindowManager()->getTextColours();
         mChoices = MWBase::Environment::get().getDialogueManager()->getChoices();
-        for (std::vector<std::pair<std::string, int> >::const_iterator it = mChoices.begin(); it != mChoices.end(); ++it)
+        for (std::pair<std::string, int>& choice : mChoices)
         {
-            Choice* link = new Choice(it->second);
+            Choice* link = new Choice(choice.second);
             link->eventChoiceActivated += MyGUI::newDelegate(this, &DialogueWindow::onChoiceActivated);
             mLinks.push_back(link);
 
@@ -583,7 +581,7 @@ namespace MWGui
             BookTypesetter::Style* questionStyle = typesetter->createHotStyle(body, textColours.answer, textColours.answerOver,
                                                                               textColours.answerPressed,
                                                                               TypesetBook::InteractiveId(link));
-            typesetter->write(questionStyle, to_utf8_span(it->first.c_str()));
+            typesetter->write(questionStyle, to_utf8_span(choice.first.c_str()));
         }
 
         mGoodbye = MWBase::Environment::get().getDialogueManager()->isGoodbye();

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -37,9 +37,9 @@ size_t InventoryItemModel::getItemCount()
 ItemModel::ModelIndex InventoryItemModel::getIndex (ItemStack item)
 {
     size_t i = 0;
-    for (std::vector<ItemStack>::iterator it = mItems.begin(); it != mItems.end(); ++it)
+    for (ItemStack& itemStack : mItems)
     {
-        if (*it == item)
+        if (itemStack == item)
             return i;
         ++i;
     }

--- a/apps/openmw/mwgui/itemchargeview.cpp
+++ b/apps/openmw/mwgui/itemchargeview.cpp
@@ -130,13 +130,13 @@ namespace MWGui
     {
         int currentY = 0;
 
-        for (Lines::const_iterator iter = mLines.begin(); iter != mLines.end(); ++iter)
+        for (Line& line : mLines)
         {
-            iter->mText->setCoord(8, currentY, mScrollView->getWidth()-8, 18);
+            line.mText->setCoord(8, currentY, mScrollView->getWidth()-8, 18);
             currentY += 19;
 
-            iter->mIcon->setCoord(16, currentY, 32, 32);
-            iter->mCharge->setCoord(72, currentY+2, std::max(199, mScrollView->getWidth()-72-38), 20);
+            line.mIcon->setCoord(16, currentY, 32, 32);
+            line.mCharge->setCoord(72, currentY+2, std::max(199, mScrollView->getWidth()-72-38), 20);
             currentY += 32 + 4;
         }
 

--- a/apps/openmw/mwgui/jailscreen.cpp
+++ b/apps/openmw/mwgui/jailscreen.cpp
@@ -105,12 +105,12 @@ namespace MWGui
 
         Misc::StringUtils::replace(message, "%d", std::to_string(mDays).c_str(), 2);
 
-        for (std::set<int>::iterator it = skills.begin(); it != skills.end(); ++it)
+        for (const int& skill : skills)
         {
-            std::string skillName = gmst.find(ESM::Skill::sSkillNameIds[*it])->mValue.getString();
-            int skillValue = player.getClass().getNpcStats(player).getSkill(*it).getBase();
+            std::string skillName = gmst.find(ESM::Skill::sSkillNameIds[skill])->mValue.getString();
+            int skillValue = player.getClass().getNpcStats(player).getSkill(skill).getBase();
             std::string skillMsg = gmst.find("sNotifyMessage44")->mValue.getString();
-            if (*it == ESM::Skill::Sneak || *it == ESM::Skill::Security)
+            if (skill == ESM::Skill::Sneak || skill == ESM::Skill::Security)
                 skillMsg = gmst.find("sNotifyMessage39")->mValue.getString();
 
             Misc::StringUtils::replace(skillMsg, "%s", skillName.c_str(), 2);

--- a/apps/openmw/mwgui/layout.cpp
+++ b/apps/openmw/mwgui/layout.cpp
@@ -21,11 +21,11 @@ namespace MWGui
             mListWindowRoot = MyGUI::LayoutManager::getInstance().loadLayout(mLayoutName, mPrefix, _parent);
 
             const std::string main_name = mPrefix + MAIN_WINDOW;
-            for (MyGUI::VectorWidgetPtr::iterator iter=mListWindowRoot.begin(); iter!=mListWindowRoot.end(); ++iter)
+            for (MyGUI::Widget* widget : mListWindowRoot)
             {
-                if ((*iter)->getName() == main_name)
+                if (widget->getName() == main_name)
                 {
-                    mMainWidget = (*iter);
+                    mMainWidget = widget;
                     break;
                 }
             }
@@ -66,10 +66,9 @@ namespace MWGui
 
     MyGUI::Widget* Layout::getWidget(const std::string &_name)
     {
-        for (MyGUI::VectorWidgetPtr::iterator iter=mListWindowRoot.begin();
-        iter!=mListWindowRoot.end(); ++iter)
+        for (MyGUI::Widget* widget : mListWindowRoot)
         {
-            MyGUI::Widget* find = (*iter)->findWidget(mPrefix + _name);
+            MyGUI::Widget* find = widget->findWidget(mPrefix + _name);
             if (nullptr != find)
             {
                 return find;

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -253,36 +253,36 @@ namespace MWGui
 
         // Create new buttons if needed
         std::vector<std::string> allButtons { "return", "newgame", "savegame", "loadgame", "options", "credits", "exitgame"};
-        for (std::vector<std::string>::iterator it = allButtons.begin(); it != allButtons.end(); ++it)
+        for (std::string& buttonId : allButtons)
         {
-            if (mButtons.find(*it) == mButtons.end())
+            if (mButtons.find(buttonId) == mButtons.end())
             {
                 Gui::ImageButton* button = mButtonBox->createWidget<Gui::ImageButton>
                         ("ImageBox", MyGUI::IntCoord(0, curH, 0, 0), MyGUI::Align::Default);
-                button->setProperty("ImageHighlighted", "textures\\menu_" + *it + "_over.dds");
-                button->setProperty("ImageNormal", "textures\\menu_" + *it + ".dds");
-                button->setProperty("ImagePushed", "textures\\menu_" + *it + "_pressed.dds");
+                button->setProperty("ImageHighlighted", "textures\\menu_" + buttonId + "_over.dds");
+                button->setProperty("ImageNormal", "textures\\menu_" + buttonId + ".dds");
+                button->setProperty("ImagePushed", "textures\\menu_" + buttonId + "_pressed.dds");
                 button->eventMouseButtonClick += MyGUI::newDelegate(this, &MainMenu::onButtonClicked);
-                button->setUserData(std::string(*it));
-                mButtons[*it] = button;
+                button->setUserData(std::string(buttonId));
+                mButtons[buttonId] = button;
             }
         }
 
         // Start by hiding all buttons
         int maxwidth = 0;
-        for (std::map<std::string, Gui::ImageButton*>::iterator it = mButtons.begin(); it != mButtons.end(); ++it)
+        for (auto& buttonPair : mButtons)
         {
-            it->second->setVisible(false);
-            MyGUI::IntSize requested = it->second->getRequestedSize();
+            buttonPair.second->setVisible(false);
+            MyGUI::IntSize requested = buttonPair.second->getRequestedSize();
             if (requested.width > maxwidth)
                 maxwidth = requested.width;
         }
 
         // Now show and position the ones we want
-        for (std::vector<std::string>::iterator it = buttons.begin(); it != buttons.end(); ++it)
+        for (std::string& buttonId : buttons)
         {
-            assert(mButtons.find(*it) != mButtons.end());
-            Gui::ImageButton* button = mButtons[*it];
+            assert(mButtons.find(buttonId) != mButtons.end());
+            Gui::ImageButton* button = mButtons[buttonId];
             button->setVisible(true);
 
             MyGUI::IntSize requested = button->getRequestedSize();

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -312,8 +312,8 @@ namespace MWGui
 
     void LocalMapBase::updateCustomMarkers()
     {
-        for (std::vector<MyGUI::Widget*>::iterator it = mCustomMarkerWidgets.begin(); it != mCustomMarkerWidgets.end(); ++it)
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+        for (MyGUI::Widget* widget : mCustomMarkerWidgets)
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         mCustomMarkerWidgets.clear();
 
         for (int dX = -mCellDistance; dX <= mCellDistance; ++dX)
@@ -487,9 +487,9 @@ namespace MWGui
         }
 
         int counter = 0;
-        for (std::vector<MWWorld::Ptr>::iterator it = markers.begin(); it != markers.end(); ++it)
+        for (const MWWorld::Ptr& ptr : markers)
         {
-            const ESM::Position& worldPos = it->getRefData().getPosition();
+            const ESM::Position& worldPos = ptr.getRefData().getPosition();
             MarkerUserData markerPos (mLocalMapRender);
             MyGUI::IntPoint widgetPos = getMarkerPosition(worldPos.pos[0], worldPos.pos[1], markerPos);
             MyGUI::IntCoord widgetCoord(widgetPos.left - 4,
@@ -526,8 +526,8 @@ namespace MWGui
     void LocalMapBase::updateDoorMarkers()
     {
         // clear all previous door markers
-        for (std::vector<MyGUI::Widget*>::iterator it = mDoorMarkerWidgets.begin(); it != mDoorMarkerWidgets.end(); ++it)
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+        for (MyGUI::Widget* widget : mDoorMarkerWidgets)
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         mDoorMarkerWidgets.clear();
 
         MWBase::World* world = MWBase::Environment::get().getWorld();
@@ -553,10 +553,8 @@ namespace MWGui
 
         // Create a widget for each marker
         int counter = 0;
-        for (std::vector<MWBase::World::DoorMarker>::iterator it = doors.begin(); it != doors.end(); ++it)
+        for (MWBase::World::DoorMarker& marker : doors)
         {
-            MWBase::World::DoorMarker marker = *it;
-
             std::vector<std::string> destNotes;
             CustomMarkerCollection::RangeType markers = mCustomMarkers.getMarkers(marker.dest);
             for (CustomMarkerCollection::ContainerType::const_iterator iter = markers.first; iter != markers.second; ++iter)
@@ -589,8 +587,8 @@ namespace MWGui
     void LocalMapBase::updateMagicMarkers()
     {
         // clear all previous markers
-        for (std::vector<MyGUI::Widget*>::iterator it = mMagicMarkerWidgets.begin(); it != mMagicMarkerWidgets.end(); ++it)
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+        for (MyGUI::Widget* widget : mMagicMarkerWidgets)
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         mMagicMarkerWidgets.clear();
 
         addDetectionMarkers(MWBase::World::Detect_Creature);
@@ -848,9 +846,9 @@ namespace MWGui
 
         mGlobalMapRender->cleanupCameras();
 
-        for (std::vector<CellId>::iterator it = mQueuedToExplore.begin(); it != mQueuedToExplore.end(); ++it)
+        for (CellId& cellId : mQueuedToExplore)
         {
-            mGlobalMapRender->exploreCell(it->first, it->second, mLocalMapRender->getMapTexture(it->first, it->second));
+            mGlobalMapRender->exploreCell(cellId.first, cellId.second, mLocalMapRender->getMapTexture(cellId.first, cellId.second));
         }
 
         mQueuedToExplore.clear();
@@ -888,11 +886,11 @@ namespace MWGui
     {
         LocalMapBase::updateCustomMarkers();
 
-        for (std::map<std::pair<int, int>, MyGUI::Widget*>::iterator widgetIt = mGlobalMapMarkers.begin(); widgetIt != mGlobalMapMarkers.end(); ++widgetIt)
+        for (auto& widgetPair : mGlobalMapMarkers)
         {
-            int x = widgetIt->first.first;
-            int y = widgetIt->first.second;
-            MyGUI::Widget* markerWidget = widgetIt->second;
+            int x = widgetPair.first.first;
+            int y = widgetPair.first.second;
+            MyGUI::Widget* markerWidget = widgetPair.second;
             setGlobalMapMarkerTooltip(markerWidget, x, y);
         }
     }
@@ -1017,8 +1015,8 @@ namespace MWGui
         mGlobalMapRender->clear();
         mChanged = true;
 
-        for (std::map<std::pair<int, int>, MyGUI::Widget*>::iterator it = mGlobalMapMarkers.begin(); it != mGlobalMapMarkers.end(); ++it)
-            MyGUI::Gui::getInstance().destroyWidget(it->second);
+        for (auto& widgetPair : mGlobalMapMarkers)
+            MyGUI::Gui::getInstance().destroyWidget(widgetPair.second);
         mGlobalMapMarkers.clear();
     }
 
@@ -1043,11 +1041,11 @@ namespace MWGui
 
             mGlobalMapRender->read(map);
 
-            for (std::set<ESM::GlobalMap::CellId>::iterator it = map.mMarkers.begin(); it != map.mMarkers.end(); ++it)
+            for (const ESM::GlobalMap::CellId& cellId : map.mMarkers)
             {
-                const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Cell>().search(it->first, it->second);
+                const ESM::Cell* cell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Cell>().search(cellId.first, cellId.second);
                 if (cell && !cell->mName.empty())
-                    addVisitedLocation(cell->mName, it->first, it->second);
+                    addVisitedLocation(cell->mName, cellId.first, cellId.second);
             }
         }
     }
@@ -1057,8 +1055,8 @@ namespace MWGui
         NoDrop::setAlpha(alpha);
         // can't allow showing map with partial transparency, as the fog of war will also go transparent
         // and reveal parts of the map you shouldn't be able to see
-        for (std::vector<MyGUI::ImageBox*>::iterator it = mMapWidgets.begin(); it != mMapWidgets.end(); ++it)
-            (*it)->setVisible(alpha == 1);
+        for (MyGUI::ImageBox* widget : mMapWidgets)
+            widget->setVisible(alpha == 1);
     }
 
     void MapWindow::customMarkerCreated(MyGUI::Widget *marker)

--- a/apps/openmw/mwgui/messagebox.cpp
+++ b/apps/openmw/mwgui/messagebox.cpp
@@ -28,10 +28,9 @@ namespace MWGui
 
     MessageBoxManager::~MessageBoxManager ()
     {
-        std::vector<MessageBox*>::iterator it(mMessageBoxes.begin());
-        for (; it != mMessageBoxes.end(); ++it)
+        for (MessageBox* messageBox : mMessageBoxes)
         {
-            delete *it;
+            delete messageBox;
         }
     }
 
@@ -50,12 +49,11 @@ namespace MWGui
             mInterMessageBoxe = nullptr;
         }
 
-        std::vector<MessageBox*>::iterator it(mMessageBoxes.begin());
-        for (; it != mMessageBoxes.end(); ++it)
+        for (MessageBox* messageBox : mMessageBoxes)
         {
-            if (*it == mStaticMessageBox)
+            if (messageBox == mStaticMessageBox)
                 mStaticMessageBox = nullptr;
-            delete *it;
+            delete messageBox;
         }
         mMessageBoxes.clear();
 
@@ -81,9 +79,9 @@ namespace MWGui
         it = mMessageBoxes.begin();
         while(it != mMessageBoxes.end())
         {
-                (*it)->update(static_cast<int>(height));
-                height += (*it)->getHeight();
-                ++it;
+            (*it)->update(static_cast<int>(height));
+            height += (*it)->getHeight();
+            ++it;
         }
 
         if(mInterMessageBoxe != nullptr && mInterMessageBoxe->mMarkedToDelete) {
@@ -114,10 +112,10 @@ namespace MWGui
         }
 
         int height = 0;
-        for(std::vector<MessageBox*>::iterator it = mMessageBoxes.begin(); it != mMessageBoxes.end(); ++it)
+        for (MessageBox* messageBox : mMessageBoxes)
         {
-            (*it)->update(height);
-            height += (*it)->getHeight();
+            messageBox->update(height);
+            height += messageBox->getHeight();
         }
     }
 
@@ -240,14 +238,14 @@ namespace MWGui
         int buttonHeight = 0;
         MyGUI::IntCoord dummyCoord(0, 0, 0, 0);
 
-        for(std::vector<std::string>::const_iterator it = buttons.begin(); it != buttons.end(); ++it)
+        for(const std::string& buttonId : buttons)
         {
             MyGUI::Button* button = mButtonsWidget->createWidget<MyGUI::Button>(
                 MyGUI::WidgetStyle::Child,
                 std::string("MW_Button"),
                 dummyCoord,
                 MyGUI::Align::Default);
-            button->setCaptionWithReplacing(*it);
+            button->setCaptionWithReplacing(buttonId);
 
             button->eventMouseButtonClick += MyGUI::newDelegate(this, &InteractiveMessageBox::mousePressed);
 
@@ -300,16 +298,16 @@ namespace MWGui
             MyGUI::IntSize buttonSize(0, buttonHeight);
             int left = (mainWidgetSize.width - buttonsWidth)/2;
 
-            for(std::vector<MyGUI::Button*>::const_iterator button = mButtons.begin(); button != mButtons.end(); ++button)
+            for(MyGUI::Button* button : mButtons)
             {
                 buttonCord.left = left;
                 buttonCord.top = messageWidgetCoord.top + textSize.height + textButtonPadding;
 
-                buttonSize.width = (*button)->getTextSize().width + 2*buttonLabelLeftPadding;
-                buttonSize.height = (*button)->getTextSize().height + 2*buttonLabelTopPadding;
+                buttonSize.width = button->getTextSize().width + 2*buttonLabelLeftPadding;
+                buttonSize.height = button->getTextSize().height + 2*buttonLabelTopPadding;
 
-                (*button)->setCoord(buttonCord);
-                (*button)->setSize(buttonSize);
+                button->setCoord(buttonCord);
+                button->setSize(buttonSize);
 
                 left += buttonSize.width + buttonLeftPadding;
             }
@@ -329,16 +327,16 @@ namespace MWGui
 
             int top = textPadding + textSize.height + textButtonPadding;
 
-            for(std::vector<MyGUI::Button*>::const_iterator button = mButtons.begin(); button != mButtons.end(); ++button)
+            for(MyGUI::Button* button : mButtons)
             {
-                buttonSize.width = (*button)->getTextSize().width + buttonLabelLeftPadding*2;
-                buttonSize.height = (*button)->getTextSize().height + buttonLabelTopPadding*2;
+                buttonSize.width = button->getTextSize().width + buttonLabelLeftPadding*2;
+                buttonSize.height = button->getTextSize().height + buttonLabelTopPadding*2;
 
                 buttonCord.top = top;
                 buttonCord.left = (mainWidgetSize.width - buttonSize.width)/2;
 
-                (*button)->setCoord(buttonCord);
-                (*button)->setSize(buttonSize);
+                button->setCoord(buttonCord);
+                button->setSize(buttonSize);
 
                 top += buttonSize.height + buttonTopPadding;
             }
@@ -368,13 +366,13 @@ namespace MWGui
     MyGUI::Widget* InteractiveMessageBox::getDefaultKeyFocus()
     {
         std::vector<std::string> keywords { "sOk", "sYes" };
-        for(std::vector<MyGUI::Button*>::const_iterator button = mButtons.begin(); button != mButtons.end(); ++button)
+        for(MyGUI::Button* button : mButtons)
         {
             for (const std::string& keyword : keywords)
             {
-                if(Misc::StringUtils::ciEqual(MyGUI::LanguageManager::getInstance().replaceTags("#{" + keyword + "}"), (*button)->getCaption()))
+                if(Misc::StringUtils::ciEqual(MyGUI::LanguageManager::getInstance().replaceTags("#{" + keyword + "}"), button->getCaption()))
                 {
-                    return *button;
+                    return button;
                 }
             }
         }
@@ -390,10 +388,9 @@ namespace MWGui
     {
         mMarkedToDelete = true;
         int index = 0;
-        std::vector<MyGUI::Button*>::const_iterator button;
-        for(button = mButtons.begin(); button != mButtons.end(); ++button)
+        for(const MyGUI::Button* button : mButtons)
         {
-            if(*button == pressed)
+            if(button == pressed)
             {
                 mButtonPressed = index;
                 mMessageBoxManager.onButtonPressed(mButtonPressed);

--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -540,32 +540,32 @@ namespace MWGui
         MWWorld::InventoryStore& store = player.getClass().getInventoryStore(player);
 
         int i=0;
-        for (std::vector<ESM::QuickKeys::QuickKey>::const_iterator it = keys.mKeys.begin(); it != keys.mKeys.end(); ++it)
+        for (ESM::QuickKeys::QuickKey& quickKey : keys.mKeys)
         {
             if (i >= 10)
                 return;
 
             mSelected = &mKey[i];
 
-            switch (it->mType)
+            switch (quickKey.mType)
             {
             case Type_Magic:
-                if (MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(it->mId))
-                    onAssignMagic(it->mId);
+                if (MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(quickKey.mId))
+                    onAssignMagic(quickKey.mId);
                 break;
             case Type_Item:
             case Type_MagicItem:
             {
                 // Find the item by id
-                MWWorld::Ptr item = store.findReplacement(it->mId);
+                MWWorld::Ptr item = store.findReplacement(quickKey.mId);
 
                 if (item.isEmpty())
                     unassign(mSelected);
                 else
                 {
-                    if (it->mType == Type_Item)
+                    if (quickKey.mType == Type_Item)
                         onAssignItem(item);
-                    else // if (it->mType == Type_MagicItem)
+                    else // if (quickKey.mType == Type_MagicItem)
                         onAssignMagicItem(item);
                 }
 

--- a/apps/openmw/mwgui/race.cpp
+++ b/apps/openmw/mwgui/race.cpp
@@ -290,9 +290,8 @@ namespace MWGui
         const MWWorld::Store<ESM::BodyPart> &store =
             MWBase::Environment::get().getWorld()->getStore().get<ESM::BodyPart>();
 
-        for (MWWorld::Store<ESM::BodyPart>::iterator it = store.begin(); it != store.end(); ++it)
+        for (const ESM::BodyPart& bodypart : store)
         {
-            const ESM::BodyPart& bodypart = *it;
             if (bodypart.mData.mFlags & ESM::BodyPart::BPF_NotPlayable)
                 continue;
             if (bodypart.mData.mType != ESM::BodyPart::MT_Skin)
@@ -353,22 +352,21 @@ namespace MWGui
             MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>();
 
         std::vector<std::pair<std::string, std::string> > items; // ID, name
-        MWWorld::Store<ESM::Race>::iterator it = races.begin();
-        for (; it != races.end(); ++it)
+        for (const ESM::Race& race : races)
         {
-            bool playable = it->mData.mFlags & ESM::Race::Playable;
+            bool playable = race.mData.mFlags & ESM::Race::Playable;
             if (!playable) // Only display playable races
                 continue;
 
-            items.push_back(std::make_pair(it->mId, it->mName));
+            items.push_back(std::make_pair(race.mId, race.mName));
         }
         std::sort(items.begin(), items.end(), sortRaces);
 
         int index = 0;
-        for (std::vector<std::pair<std::string, std::string> >::const_iterator iter = items.begin(); iter != items.end(); ++iter)
+        for (auto& item : items)
         {
-            mRaceList->addItem(iter->second, iter->first);
-            if (Misc::StringUtils::ciEqual(iter->first, mCurrentRaceId))
+            mRaceList->addItem(item.second, item.first);
+            if (Misc::StringUtils::ciEqual(item.first, mCurrentRaceId))
                 mRaceList->setIndexSelected(index);
             ++index;
         }
@@ -376,9 +374,9 @@ namespace MWGui
 
     void RaceDialog::updateSkills()
     {
-        for (std::vector<MyGUI::Widget*>::iterator it = mSkillItems.begin(); it != mSkillItems.end(); ++it)
+        for (MyGUI::Widget* widget : mSkillItems)
         {
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         }
         mSkillItems.clear();
 
@@ -413,9 +411,9 @@ namespace MWGui
 
     void RaceDialog::updateSpellPowers()
     {
-        for (std::vector<MyGUI::Widget*>::iterator it = mSpellPowerItems.begin(); it != mSpellPowerItems.end(); ++it)
+        for (MyGUI::Widget* widget : mSpellPowerItems)
         {
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         }
         mSpellPowerItems.clear();
 
@@ -428,11 +426,9 @@ namespace MWGui
         const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
         const ESM::Race *race = store.get<ESM::Race>().find(mCurrentRaceId);
 
-        std::vector<std::string>::const_iterator it = race->mPowers.mList.begin();
-        std::vector<std::string>::const_iterator end = race->mPowers.mList.end();
-        for (int i = 0; it != end; ++it)
+        int i = 0;
+        for (const std::string& spellpower : race->mPowers.mList)
         {
-            const std::string &spellpower = *it;
             Widgets::MWSpellPtr spellPowerWidget = mSpellPowerList->createWidget<Widgets::MWSpell>("MW_StatName", coord, MyGUI::Align::Default, std::string("SpellPower") + MyGUI::utility::toString(i));
             spellPowerWidget->setSpellId(spellpower);
             spellPowerWidget->setUserString("ToolTipType", "Spell");

--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -353,9 +353,9 @@ namespace MWGui
 
     void ReviewDialog::updateSkillArea()
     {
-        for (std::vector<MyGUI::Widget*>::iterator it = mSkillWidgets.begin(); it != mSkillWidgets.end(); ++it)
+        for (MyGUI::Widget* skillWidget : mSkillWidgets)
         {
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+            MyGUI::Gui::getInstance().destroyWidget(skillWidget);
         }
         mSkillWidgets.clear();
 
@@ -388,19 +388,18 @@ namespace MWGui
             attributes[i] = mAttributeWidgets[i]->getAttributeValue().getBase();
 
         std::vector<std::string> selectedSpells = MWMechanics::autoCalcPlayerSpells(skills, attributes, race);
-        for (std::vector<std::string>::iterator iter = selectedSpells.begin(); iter != selectedSpells.end(); ++iter)
+        for (std::string& spellId : selectedSpells)
         {
-            std::string lower = Misc::StringUtils::lowerCase(*iter);
+            std::string lower = Misc::StringUtils::lowerCase(spellId);
             if (std::find(spells.begin(), spells.end(), lower) == spells.end())
                 spells.push_back(lower);
         }
 
         if (race)
         {
-            for (std::vector<std::string>::const_iterator iter = race->mPowers.mList.begin();
-                 iter != race->mPowers.mList.end(); ++iter)
+            for (const std::string& spellId : race->mPowers.mList)
             {
-                std::string lower = Misc::StringUtils::lowerCase(*iter);
+                std::string lower = Misc::StringUtils::lowerCase(spellId);
                 if (std::find(spells.begin(), spells.end(), lower) == spells.end())
                     spells.push_back(lower);
             }
@@ -409,10 +408,9 @@ namespace MWGui
         if (!mBirthSignId.empty())
         {
             const ESM::BirthSign* sign = MWBase::Environment::get().getWorld()->getStore().get<ESM::BirthSign>().find(mBirthSignId);
-            for (std::vector<std::string>::const_iterator iter = sign->mPowers.mList.begin();
-                 iter != sign->mPowers.mList.end(); ++iter)
+            for (const std::string& spellId : sign->mPowers.mList)
             {
-                std::string lower = Misc::StringUtils::lowerCase(*iter);
+                std::string lower = Misc::StringUtils::lowerCase(spellId);
                 if (std::find(spells.begin(), spells.end(), lower) == spells.end())
                     spells.push_back(lower);
             }
@@ -421,27 +419,27 @@ namespace MWGui
         if (!mSkillWidgets.empty())
             addSeparator(coord1, coord2);
         addGroup(MWBase::Environment::get().getWindowManager()->getGameSettingString("sTypeAbility", "Abilities"), coord1, coord2);
-        for (std::vector<std::string>::const_iterator iter = spells.begin(); iter != spells.end(); ++iter)
+        for (std::string& spellId : spells)
         {
-            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(*iter);
+            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(spellId);
             if (spell->mData.mType == ESM::Spell::ST_Ability)
                 addItem(spell, coord1, coord2);
         }
 
         addSeparator(coord1, coord2);
         addGroup(MWBase::Environment::get().getWindowManager()->getGameSettingString("sTypePower", "Powers"), coord1, coord2);
-        for (std::vector<std::string>::const_iterator iter = spells.begin(); iter != spells.end(); ++iter)
+        for (std::string& spellId : spells)
         {
-            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(*iter);
+            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(spellId);
             if (spell->mData.mType == ESM::Spell::ST_Power)
                 addItem(spell, coord1, coord2);
         }
 
         addSeparator(coord1, coord2);
         addGroup(MWBase::Environment::get().getWindowManager()->getGameSettingString("sTypeSpell", "Spells"), coord1, coord2);
-        for (std::vector<std::string>::const_iterator iter = spells.begin(); iter != spells.end(); ++iter)
+        for (std::string& spellId : spells)
         {
-            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(*iter);
+            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(spellId);
             if (spell->mData.mType == ESM::Spell::ST_Spell)
                 addItem(spell, coord1, coord2);
         }

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -235,11 +235,10 @@ namespace MWGui
             resolutions.push_back(std::make_pair(mode.w, mode.h));
         }
         std::sort(resolutions.begin(), resolutions.end(), sortResolutions);
-        for (std::vector < std::pair<int, int> >::const_iterator it=resolutions.begin();
-             it!=resolutions.end(); ++it)
+        for (std::pair<int, int>& resolution : resolutions)
         {
-            std::string str = MyGUI::utility::toString(it->first) + " x " + MyGUI::utility::toString(it->second)
-                    + " (" + getAspect(it->first,it->second) + ")";
+            std::string str = MyGUI::utility::toString(resolution.first) + " x " + MyGUI::utility::toString(resolution.second)
+                    + " (" + getAspect(resolution.first, resolution.second) + ")";
 
             if (mResolutionList->findItemIndexWith(str) == MyGUI::ITEM_NONE)
                 mResolutionList->addItem(str);
@@ -484,17 +483,17 @@ namespace MWGui
         else
             actions = MWBase::Environment::get().getInputManager()->getActionControllerSorting();
 
-        for (std::vector<int>::const_iterator it = actions.begin(); it != actions.end(); ++it)
+        for (const int& action : actions)
         {
-            std::string desc = MWBase::Environment::get().getInputManager()->getActionDescription (*it);
+            std::string desc = MWBase::Environment::get().getInputManager()->getActionDescription (action);
             if (desc == "")
                 continue;
 
             std::string binding;
             if(mKeyboardMode)
-                binding = MWBase::Environment::get().getInputManager()->getActionKeyBindingName(*it);
+                binding = MWBase::Environment::get().getInputManager()->getActionKeyBindingName(action);
             else
-                binding = MWBase::Environment::get().getInputManager()->getActionControllerBindingName(*it);
+                binding = MWBase::Environment::get().getInputManager()->getActionControllerBindingName(action);
 
             Gui::SharedStateButton* leftText = mControlsBox->createWidget<Gui::SharedStateButton>("SandTextButton", MyGUI::IntCoord(), MyGUI::Align::Default);
             leftText->setCaptionWithReplacing(desc);
@@ -502,7 +501,7 @@ namespace MWGui
             Gui::SharedStateButton* rightText = mControlsBox->createWidget<Gui::SharedStateButton>("SandTextButton", MyGUI::IntCoord(), MyGUI::Align::Default);
             rightText->setCaptionWithReplacing(binding);
             rightText->setTextAlign (MyGUI::Align::Right);
-            rightText->setUserData(*it); // save the action id for callbacks
+            rightText->setUserData(action); // save the action id for callbacks
             rightText->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onRebindAction);
             rightText->eventMouseWheel += MyGUI::newDelegate(this, &SettingsWindow::onInputTabMouseWheel);
 

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -122,9 +122,9 @@ namespace MWGui
 
         std::stable_sort(spellsToSort.begin(), spellsToSort.end(), sortSpells);
 
-        for (std::vector<const ESM::Spell*>::iterator it = spellsToSort.begin() ; it != spellsToSort.end(); ++it)
+        for (const ESM::Spell* spell : spellsToSort)
         {
-            addSpell(**it);
+            addSpell(*spell);
         }
 
         spellsToSort.clear();

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -455,10 +455,8 @@ namespace MWGui
         const MWWorld::ESMStore &store =
             MWBase::Environment::get().getWorld()->getStore();
 
-        for (std::vector<ESM::ENAMstruct>::const_iterator it = mEffects.begin(); it != mEffects.end(); ++it)
+        for (const ESM::ENAMstruct& effect : mEffects)
         {
-            const ESM::ENAMstruct& effect = *it;
-
             y += std::max(1.f, MWMechanics::calcEffectCost(effect));
 
             if (effect.mRange == ESM::RT_Target)
@@ -530,18 +528,17 @@ namespace MWGui
             if (spell->mData.mType != ESM::Spell::ST_Spell)
                 continue;
 
-            const std::vector<ESM::ENAMstruct>& list = spell->mEffects.mList;
-            for (std::vector<ESM::ENAMstruct>::const_iterator it2 = list.begin(); it2 != list.end(); ++it2)
+            for (const ESM::ENAMstruct& effectInfo : spell->mEffects.mList)
             {
-                const ESM::MagicEffect * effect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(it2->mEffectID);
+                const ESM::MagicEffect * effect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectInfo.mEffectID);
 
                 // skip effects that do not allow spellmaking/enchanting
                 int requiredFlags = (mType == Spellmaking) ? ESM::MagicEffect::AllowSpellmaking : ESM::MagicEffect::AllowEnchanting;
                 if (!(effect->mData.mFlags & requiredFlags))
                     continue;
 
-                if (std::find(knownEffects.begin(), knownEffects.end(), it2->mEffectID) == knownEffects.end())
-                    knownEffects.push_back(it2->mEffectID);
+                if (std::find(knownEffects.begin(), knownEffects.end(), effectInfo.mEffectID) == knownEffects.end())
+                    knownEffects.push_back(effectInfo.mEffectID);
             }
         }
 
@@ -550,23 +547,23 @@ namespace MWGui
         mAvailableEffectsList->clear ();
 
         int i=0;
-        for (std::vector<short>::const_iterator it = knownEffects.begin(); it != knownEffects.end(); ++it)
+        for (const short effectId : knownEffects)
         {
             mAvailableEffectsList->addItem(MWBase::Environment::get().getWorld ()->getStore ().get<ESM::GameSetting>().find(
-                                               ESM::MagicEffect::effectIdToString  (*it))->mValue.getString());
-            mButtonMapping[i] = *it;
+                                               ESM::MagicEffect::effectIdToString(effectId))->mValue.getString());
+            mButtonMapping[i] = effectId;
             ++i;
         }
         mAvailableEffectsList->adjustSize ();
         mAvailableEffectsList->scrollToTop();
 
-        for (std::vector<short>::const_iterator it = knownEffects.begin(); it != knownEffects.end(); ++it)
+        for (const short effectId : knownEffects)
         {
             std::string name = MWBase::Environment::get().getWorld ()->getStore ().get<ESM::GameSetting>().find(
-                                               ESM::MagicEffect::effectIdToString  (*it))->mValue.getString();
+                                               ESM::MagicEffect::effectIdToString(effectId))->mValue.getString();
             MyGUI::Widget* w = mAvailableEffectsList->getItemWidget(name);
 
-            ToolTips::createMagicEffectToolTip (w, *it);
+            ToolTips::createMagicEffectToolTip (w, effectId);
         }
 
         mEffects.clear();
@@ -646,9 +643,9 @@ namespace MWGui
         }
         else
         {
-            for (std::vector<ESM::ENAMstruct>::const_iterator it = mEffects.begin(); it != mEffects.end(); ++it)
+            for (const ESM::ENAMstruct& effectInfo : mEffects)
             {
-                if (it->mEffectID == mSelectedKnownEffectId)
+                if (effectInfo.mEffectID == mSelectedKnownEffectId)
                 {
                     MWBase::Environment::get().getWindowManager()->messageBox ("#{sOnetypeEffectMessage}");
                     return;
@@ -680,17 +677,17 @@ namespace MWGui
         MyGUI::IntSize size(0,0);
 
         int i = 0;
-        for (std::vector<ESM::ENAMstruct>::const_iterator it = mEffects.begin(); it != mEffects.end(); ++it)
+        for (const ESM::ENAMstruct& effectInfo : mEffects)
         {
             Widgets::SpellEffectParams params;
-            params.mEffectID = it->mEffectID;
-            params.mSkill = it->mSkill;
-            params.mAttribute = it->mAttribute;
-            params.mDuration = it->mDuration;
-            params.mMagnMin = it->mMagnMin;
-            params.mMagnMax = it->mMagnMax;
-            params.mRange = it->mRange;
-            params.mArea = it->mArea;
+            params.mEffectID = effectInfo.mEffectID;
+            params.mSkill = effectInfo.mSkill;
+            params.mAttribute = effectInfo.mAttribute;
+            params.mDuration = effectInfo.mDuration;
+            params.mMagnMin = effectInfo.mMagnMin;
+            params.mMagnMax = effectInfo.mMagnMax;
+            params.mRange = effectInfo.mRange;
+            params.mArea = effectInfo.mArea;
             params.mIsConstant = mConstantEffect;
 
             MyGUI::Button* button = mUsedEffectsView->createWidget<MyGUI::Button>("", MyGUI::IntCoord(0, size.height, 0, 24), MyGUI::Align::Default);

--- a/apps/openmw/mwgui/spellview.cpp
+++ b/apps/openmw/mwgui/spellview.cpp
@@ -149,13 +149,13 @@ namespace MWGui
         mModel->update();
         bool fullUpdateRequired = false;
         SpellModel::ModelIndex maxSpellIndexFound = -1;
-        for (std::vector< LineInfo >::iterator it = mLines.begin(); it != mLines.end(); ++it)
+        for (LineInfo& line : mLines)
         {
             // only update the lines that are "updateable"
-            SpellModel::ModelIndex spellIndex(it->mSpellIndex);
+            SpellModel::ModelIndex spellIndex(line.mSpellIndex);
             if (spellIndex != NoSpellIndex)
             {
-                Gui::SharedStateButton* nameButton = reinterpret_cast<Gui::SharedStateButton*>(it->mLeftWidget);
+                Gui::SharedStateButton* nameButton = reinterpret_cast<Gui::SharedStateButton*>(line.mLeftWidget);
 
                 // match model against line
                 // if don't match, then major change has happened, so do a full update
@@ -176,7 +176,7 @@ namespace MWGui
                 else
                 {
                     maxSpellIndexFound = spellIndex;
-                    Gui::SharedStateButton* costButton = reinterpret_cast<Gui::SharedStateButton*>(it->mRightWidget);
+                    Gui::SharedStateButton* costButton = reinterpret_cast<Gui::SharedStateButton*>(line.mRightWidget);
                     if ((costButton != nullptr) && (costButton->getCaption() != spell.mCostColumn))
                     {
                         costButton->setCaption(spell.mCostColumn);
@@ -198,27 +198,25 @@ namespace MWGui
     void SpellView::layoutWidgets()
     {
         int height = 0;
-        for (std::vector< LineInfo >::iterator it = mLines.begin();
-             it != mLines.end(); ++it)
+        for (LineInfo& line : mLines)
         {
-            height += (it->mLeftWidget)->getHeight();
+            height += line.mLeftWidget->getHeight();
         }
 
         bool scrollVisible = height > mScrollView->getHeight();
         int width = mScrollView->getWidth() - (scrollVisible ? 18 : 0);
 
         height = 0;
-        for (std::vector< LineInfo >::iterator it = mLines.begin();
-             it != mLines.end(); ++it)
+        for (LineInfo& line : mLines)
         {
-            int lineHeight = (it->mLeftWidget)->getHeight();
-            (it->mLeftWidget)->setCoord(4, height, width - 8, lineHeight);
-            if (it->mRightWidget)
+            int lineHeight = line.mLeftWidget->getHeight();
+            line.mLeftWidget->setCoord(4, height, width - 8, lineHeight);
+            if (line.mRightWidget)
             {
-                (it->mRightWidget)->setCoord(4, height, width - 8, lineHeight);
-                MyGUI::TextBox* second = (it->mRightWidget)->castType<MyGUI::TextBox>(false);
+                line.mRightWidget->setCoord(4, height, width - 8, lineHeight);
+                MyGUI::TextBox* second = line.mRightWidget->castType<MyGUI::TextBox>(false);
                 if (second)
-                    (it->mLeftWidget)->setSize(width - 8 - second->getTextSize().width, lineHeight);
+                    line.mLeftWidget->setSize(width - 8 - second->getTextSize().width, lineHeight);
             }
 
             height += lineHeight;

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -433,10 +433,8 @@ namespace MWGui
 
         addGroup(MWBase::Environment::get().getWindowManager()->getGameSettingString(titleId, titleDefault), coord1, coord2);
 
-        SkillList::const_iterator end = skills.end();
-        for (SkillList::const_iterator it = skills.begin(); it != end; ++it)
+        for (const int skillId : skills)
         {
-            int skillId = *it;
             if (skillId < 0 || skillId >= ESM::Skill::Length) // Skip unknown skill indexes
                 continue;
             const std::string &skillNameId = ESM::Skill::sSkillNameIds[skillId];
@@ -499,9 +497,9 @@ namespace MWGui
     {
         mChanged = false;
 
-        for (std::vector<MyGUI::Widget*>::iterator it = mSkillWidgets.begin(); it != mSkillWidgets.end(); ++it)
+        for (MyGUI::Widget* widget : mSkillWidgets)
         {
-            MyGUI::Gui::getInstance().destroyWidget(*it);
+            MyGUI::Gui::getInstance().destroyWidget(widget);
         }
         mSkillWidgets.clear();
 
@@ -550,11 +548,11 @@ namespace MWGui
             const std::set<std::string> &expelled = PCstats.getExpelled();
 
             bool firstFaction=true;
-            FactionList::const_iterator end = mFactions.end();
-            for (FactionList::const_iterator it = mFactions.begin(); it != end; ++it)
+            for (auto& factionPair : mFactions)
             {
+                const std::string& factionId = factionPair.first;
                 const ESM::Faction *faction =
-                    store.get<ESM::Faction>().find(it->first);
+                    store.get<ESM::Faction>().find(factionId);
                 if (faction->mData.mIsHidden == 1)
                     continue;
 
@@ -575,11 +573,11 @@ namespace MWGui
 
                 text += std::string("#{fontcolourhtml=header}") + faction->mName;
 
-                if (expelled.find(it->first) != expelled.end())
+                if (expelled.find(factionId) != expelled.end())
                     text += "\n#{fontcolourhtml=normal}#{sExpelled}";
                 else
                 {
-                    int rank = it->second;
+                    int rank = factionPair.second;
                     rank = std::max(0, std::min(9, rank));
                     text += std::string("\n#{fontcolourhtml=normal}") + faction->mRanks[rank];
 

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -226,18 +226,17 @@ namespace MWGui
                         MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(focus->getUserString("Spell"));
                     info.caption = spell->mName;
                     Widgets::SpellEffectList effects;
-                    std::vector<ESM::ENAMstruct>::const_iterator end = spell->mEffects.mList.end();
-                    for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != end; ++it)
+                    for (const ESM::ENAMstruct& spellEffect : spell->mEffects.mList)
                     {
                         Widgets::SpellEffectParams params;
-                        params.mEffectID = it->mEffectID;
-                        params.mSkill = it->mSkill;
-                        params.mAttribute = it->mAttribute;
-                        params.mDuration = it->mDuration;
-                        params.mMagnMin = it->mMagnMin;
-                        params.mMagnMax = it->mMagnMax;
-                        params.mRange = it->mRange;
-                        params.mArea = it->mArea;
+                        params.mEffectID = spellEffect.mEffectID;
+                        params.mSkill = spellEffect.mSkill;
+                        params.mAttribute = spellEffect.mAttribute;
+                        params.mDuration = spellEffect.mDuration;
+                        params.mMagnMin = spellEffect.mMagnMin;
+                        params.mMagnMax = spellEffect.mMagnMax;
+                        params.mRange = spellEffect.mRange;
+                        params.mArea = spellEffect.mArea;
                         params.mIsConstant = (spell->mData.mType == ESM::Spell::ST_Ability);
                         params.mNoTarget = false;
                         effects.push_back(params);
@@ -260,14 +259,13 @@ namespace MWGui
                     tooltip->setVisible(true);
 
                     std::map<std::string, std::string> userStrings = focus->getUserStrings();
-                    for (std::map<std::string, std::string>::iterator it = userStrings.begin();
-                        it != userStrings.end(); ++it)
+                    for (auto& userStringPair : userStrings)
                     {
-                        size_t underscorePos = it->first.find("_");
+                        size_t underscorePos = userStringPair.first.find("_");
                         if (underscorePos == std::string::npos)
                             continue;
-                        std::string key = it->first.substr(0, underscorePos);
-                        std::string widgetName = it->first.substr(underscorePos+1, it->first.size()-(underscorePos+1));
+                        std::string key = userStringPair.first.substr(0, underscorePos);
+                        std::string widgetName = userStringPair.first.substr(underscorePos+1, userStringPair.first.size()-(underscorePos+1));
 
                         type = "Property";
                         size_t caretPos = key.find("^");
@@ -280,9 +278,9 @@ namespace MWGui
                         MyGUI::Widget* w;
                         getWidget(w, widgetName);
                         if (type == "Property")
-                            w->setProperty(key, it->second);
+                            w->setProperty(key, userStringPair.second);
                         else if (type == "UserData")
-                            w->setUserString(key, it->second);
+                            w->setUserString(key, userStringPair.second);
                     }
 
                     tooltipSize = tooltip->getSize();
@@ -458,7 +456,7 @@ namespace MWGui
         MyGUI::IntSize totalSize = MyGUI::IntSize( std::min(std::max(textSize.width,captionSize.width + ((image != "") ? imageCaptionHPadding : 0)),maximumWidth),
             ((text != "") ? textSize.height + imageCaptionVPadding : 0) + captionHeight );
 
-        for (std::vector<std::string>::const_iterator it = info.notes.begin(); it != info.notes.end(); ++it)
+        for (const std::string& note : info.notes)
         {
             MyGUI::ImageBox* icon = mDynamicToolTipBox->createWidget<MyGUI::ImageBox>("MarkerButton",
                 MyGUI::IntCoord(padding.left, totalSize.height+padding.top, 8, 8), MyGUI::Align::Default);
@@ -468,7 +466,7 @@ namespace MWGui
                                                                                     MyGUI::Align::Default);
             edit->setEditMultiLine(true);
             edit->setEditWordWrap(true);
-            edit->setCaption(*it);
+            edit->setCaption(note);
             edit->setSize(edit->getWidth(), edit->getTextSize().height);
             icon->setPosition(icon->getLeft(),(edit->getTop()+edit->getBottom())/2-icon->getHeight()/2);
             totalSize.height += std::max(edit->getHeight(), icon->getHeight());
@@ -653,12 +651,12 @@ namespace MWGui
         std::vector<std::pair<std::string, int> > itemOwners =
                 MWBase::Environment::get().getMechanicsManager()->getStolenItemOwners(cellref.getRefId());
 
-        for (std::vector<std::pair<std::string, int> >::const_iterator it = itemOwners.begin(); it != itemOwners.end(); ++it)
+        for (std::pair<std::string, int>& owner : itemOwners)
         {
-            if (it->second == std::numeric_limits<int>::max())
-                ret += std::string("\nStolen from ") + it->first; // for legacy (ESS) savegames
+            if (owner.second == std::numeric_limits<int>::max())
+                ret += std::string("\nStolen from ") + owner.first; // for legacy (ESS) savegames
             else
-                ret += std::string("\nStolen ") + MyGUI::utility::toString(it->second) + " from " + it->first;
+                ret += std::string("\nStolen ") + MyGUI::utility::toString(owner.second) + " from " + owner.first;
         }
 
         ret += getMiscString(cellref.getGlobalVariable(), "Global");
@@ -732,17 +730,16 @@ namespace MWGui
             MWBase::Environment::get().getWorld()->getStore().get<ESM::Skill>();
 
         bool isFirst = true;
-        MWWorld::Store<ESM::Skill>::iterator it = skills.begin();
-        for (; it != skills.end(); ++it)
+        for (auto& skillPair : skills)
         {
-            if (it->second.mData.mSpecialization == specId)
+            if (skillPair.second.mData.mSpecialization == specId)
             {
                 if (isFirst)
                     isFirst = false;
                 else
                     specText += "\n";
 
-                specText += std::string("#{") + ESM::Skill::sSkillNameIds[it->first] + "}";
+                specText += std::string("#{") + ESM::Skill::sSkillNameIds[skillPair.first] + "}";
             }
         }
         widget->setUserString("Caption_ColumnText", specText);
@@ -767,9 +764,8 @@ namespace MWGui
 
         std::vector<std::string> abilities, powers, spells;
 
-        for (std::vector<std::string>::const_iterator it = sign->mPowers.mList.begin(); it != sign->mPowers.mList.end(); ++it)
+        for (const std::string& spellId : sign->mPowers.mList)
         {
-            const std::string &spellId = *it;
             const ESM::Spell *spell = store.get<ESM::Spell>().search(spellId);
             if (!spell)
                 continue; // Skip spells which cannot be found
@@ -797,14 +793,14 @@ namespace MWGui
 
         for (int category = 0; category < 3; ++category)
         {
-            for (std::vector<std::string>::const_iterator it = categories[category].spells.begin(); it != categories[category].spells.end(); ++it)
+            bool addHeader = true;
+            for (const std::string& spellId : categories[category].spells)
             {
-                if (it == categories[category].spells.begin())
+                if (addHeader)
                 {
                     text += std::string("\n\n#{fontcolourhtml=header}") + std::string("#{") + categories[category].label + "}";
+                    addHeader = false;
                 }
-
-                const std::string &spellId = *it;
 
                 const ESM::Spell *spell = store.get<ESM::Spell>().find(spellId);
                 text += "\n#{fontcolourhtml=normal}" + spell->mName;

--- a/apps/openmw/mwgui/tradeitemmodel.cpp
+++ b/apps/openmw/mwgui/tradeitemmodel.cpp
@@ -36,13 +36,12 @@ namespace MWGui
 
     void TradeItemModel::borrowImpl(const ItemStack &item, std::vector<ItemStack> &out)
     {
-        std::vector<ItemStack>::iterator it = out.begin();
         bool found = false;
-        for (; it != out.end(); ++it)
+        for (ItemStack& itemStack : out)
         {
-            if (it->mBase == item.mBase)
+            if (itemStack.mBase == item.mBase)
             {
-                it->mCount += item.mCount;
+                itemStack.mCount += item.mCount;
                 found = true;
                 break;
             }
@@ -100,15 +99,15 @@ namespace MWGui
 
     void TradeItemModel::adjustEncumbrance(float &encumbrance)
     {
-        for (std::vector<ItemStack>::iterator it = mBorrowedToUs.begin(); it != mBorrowedToUs.end(); ++it)
+        for (ItemStack& itemStack : mBorrowedToUs)
         {
-            MWWorld::Ptr item = it->mBase;
-            encumbrance += item.getClass().getWeight(item) * it->mCount;
+            MWWorld::Ptr& item = itemStack.mBase;
+            encumbrance += item.getClass().getWeight(item) * itemStack.mCount;
         }
-        for (std::vector<ItemStack>::iterator it = mBorrowedFromUs.begin(); it != mBorrowedFromUs.end(); ++it)
+        for (ItemStack& itemStack : mBorrowedFromUs)
         {
-            MWWorld::Ptr item = it->mBase;
-            encumbrance -= item.getClass().getWeight(item) * it->mCount;
+            MWWorld::Ptr& item = itemStack.mBase;
+            encumbrance -= item.getClass().getWeight(item) * itemStack.mCount;
         }
         encumbrance = std::max(0.f, encumbrance);
     }
@@ -126,15 +125,14 @@ namespace MWGui
 
     void TradeItemModel::transferItems()
     {
-        std::vector<ItemStack>::iterator it = mBorrowedToUs.begin();
-        for (; it != mBorrowedToUs.end(); ++it)
+        for (ItemStack& itemStack : mBorrowedToUs)
         {
             // get index in the source model
-            ItemModel* sourceModel = it->mCreator;
+            ItemModel* sourceModel = itemStack.mCreator;
             size_t i=0;
             for (; i<sourceModel->getItemCount(); ++i)
             {
-                if (it->mBase == sourceModel->getItem(i).mBase)
+                if (itemStack.mBase == sourceModel->getItem(i).mBase)
                     break;
             }
             if (i == sourceModel->getItemCount())
@@ -142,9 +140,9 @@ namespace MWGui
 
             const ItemStack& item = sourceModel->getItem(i);
             // copy the borrowed items to our model
-            copyItem(item, it->mCount);
+            copyItem(item, itemStack.mCount);
             // then remove them from the source model
-            sourceModel->removeItem(item, it->mCount);
+            sourceModel->removeItem(item, itemStack.mCount);
         }
         mBorrowedToUs.clear();
         mBorrowedFromUs.clear();
@@ -189,14 +187,13 @@ namespace MWGui
             }
 
             // don't show items that we borrowed to someone else
-            std::vector<ItemStack>::iterator it = mBorrowedFromUs.begin();
-            for (; it != mBorrowedFromUs.end(); ++it)
+            for (ItemStack& itemStack : mBorrowedFromUs)
             {
-                if (it->mBase == item.mBase)
+                if (itemStack.mBase == item.mBase)
                 {
-                    if (item.mCount < it->mCount)
+                    if (item.mCount < itemStack.mCount)
                         throw std::runtime_error("Lent more items than present");
-                    item.mCount -= it->mCount;
+                    item.mCount -= itemStack.mCount;
                 }
             }
 
@@ -205,12 +202,10 @@ namespace MWGui
         }
 
         // add items borrowed to us
-        std::vector<ItemStack>::iterator it = mBorrowedToUs.begin();
-        for (; it != mBorrowedToUs.end(); ++it)
+        for (ItemStack& itemStack : mBorrowedToUs)
         {
-            ItemStack item = *it;
-            item.mType = ItemStack::Type_Barter;
-            mItems.push_back(item);
+            itemStack.mType = ItemStack::Type_Barter;
+            mItems.push_back(itemStack);
         }
     }
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -106,9 +106,9 @@ namespace MWGui
         // Also restock any containers owned by this merchant, which are also available to buy in the trade window
         std::vector<MWWorld::Ptr> itemSources;
         MWBase::Environment::get().getWorld()->getContainersOwnedBy(mPtr, itemSources);
-        for (std::vector<MWWorld::Ptr>::iterator it = itemSources.begin(); it != itemSources.end(); ++it)
+        for (MWWorld::Ptr& source : itemSources)
         {
-            it->getClass().restock(*it);
+            source.getClass().restock(source);
         }
     }
 
@@ -306,15 +306,15 @@ namespace MWGui
         }
 
         // check if the player is attempting to sell back an item stolen from this actor
-        for (std::vector<ItemStack>::iterator it = merchantBought.begin(); it != merchantBought.end(); ++it)
+        for (ItemStack& itemStack : merchantBought)
         {
-            if (MWBase::Environment::get().getMechanicsManager()->isItemStolenFrom(it->mBase.getCellRef().getRefId(), mPtr))
+            if (MWBase::Environment::get().getMechanicsManager()->isItemStolenFrom(itemStack.mBase.getCellRef().getRefId(), mPtr))
             {
                 std::string msg = gmst.find("sNotifyMessage49")->mValue.getString();
-                Misc::StringUtils::replace(msg, "%s", it->mBase.getClass().getName(it->mBase).c_str(), 2);
+                Misc::StringUtils::replace(msg, "%s", itemStack.mBase.getClass().getName(itemStack.mBase).c_str(), 2);
                 MWBase::Environment::get().getWindowManager()->messageBox(msg);
 
-                MWBase::Environment::get().getMechanicsManager()->confiscateStolenItemToOwner(player, it->mBase, mPtr, it->mCount);
+                MWBase::Environment::get().getMechanicsManager()->confiscateStolenItemToOwner(player, itemStack.mBase, mPtr, itemStack.mCount);
 
                 onCancelButtonClicked(mCancelButton);
                 MWBase::Environment::get().getWindowManager()->exitCurrentGuiMode();
@@ -469,15 +469,15 @@ namespace MWGui
         int merchantOffer = 0;
 
         std::vector<ItemStack> playerBorrowed = playerTradeModel->getItemsBorrowedToUs();
-        for (std::vector<ItemStack>::const_iterator it = playerBorrowed.begin(); it != playerBorrowed.end(); ++it)
+        for (const ItemStack& itemStack : playerBorrowed)
         {
-            merchantOffer -= MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, getEffectiveValue(it->mBase, it->mCount), true);
+            merchantOffer -= MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, getEffectiveValue(itemStack.mBase, itemStack.mCount), true);
         }
 
         std::vector<ItemStack> merchantBorrowed = mTradeModel->getItemsBorrowedToUs();
-        for (std::vector<ItemStack>::const_iterator it = merchantBorrowed.begin(); it != merchantBorrowed.end(); ++it)
+        for (const ItemStack& itemStack : merchantBorrowed)
         {
-            merchantOffer += MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, getEffectiveValue(it->mBase, it->mCount), false);
+            merchantOffer += MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, getEffectiveValue(itemStack.mBase, itemStack.mCount), false);
         }
 
         int diff = merchantOffer - mCurrentMerchantOffer;

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -222,18 +222,17 @@ namespace MWGui
             const ESM::Spell *spell = store.get<ESM::Spell>().search(mId);
             MYGUI_ASSERT(spell, "spell with id '" << mId << "' not found");
 
-            std::vector<ESM::ENAMstruct>::const_iterator end = spell->mEffects.mList.end();
-            for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != end; ++it)
+            for (const ESM::ENAMstruct& effectInfo : spell->mEffects.mList)
             {
                 MWSpellEffectPtr effect = creator->createWidget<MWSpellEffect>("MW_EffectImage", coord, MyGUI::Align::Default);
                 SpellEffectParams params;
-                params.mEffectID = it->mEffectID;
-                params.mSkill = it->mSkill;
-                params.mAttribute = it->mAttribute;
-                params.mDuration = it->mDuration;
-                params.mMagnMin = it->mMagnMin;
-                params.mMagnMax = it->mMagnMax;
-                params.mRange = it->mRange;
+                params.mEffectID = effectInfo.mEffectID;
+                params.mSkill = effectInfo.mSkill;
+                params.mAttribute = effectInfo.mAttribute;
+                params.mDuration = effectInfo.mDuration;
+                params.mMagnMin = effectInfo.mMagnMin;
+                params.mMagnMax = effectInfo.mMagnMax;
+                params.mRange = effectInfo.mRange;
                 params.mIsConstant = (flags & MWEffectList::EF_Constant) != 0;
                 params.mNoTarget = (flags & MWEffectList::EF_NoTarget);
                 effect->setSpellEffect(params);
@@ -289,13 +288,12 @@ namespace MWGui
             MWSpellEffectPtr effect = nullptr;
             int maxwidth = coord.width;
 
-            for (SpellEffectList::iterator it=mEffectList.begin();
-                it != mEffectList.end(); ++it)
+            for (auto& effectInfo : mEffectList)
             {
                 effect = creator->createWidget<MWSpellEffect>("MW_EffectImage", coord, MyGUI::Align::Default);
-                it->mIsConstant = (flags & EF_Constant) || it->mIsConstant;
-                it->mNoTarget = (flags & EF_NoTarget) || it->mNoTarget;
-                effect->setSpellEffect(*it);
+                effectInfo.mIsConstant = (flags & EF_Constant) || effectInfo.mIsConstant;
+                effectInfo.mNoTarget = (flags & EF_NoTarget) || effectInfo.mNoTarget;
+                effect->setSpellEffect(effectInfo);
                 effects.push_back(effect);
                 if (effect->getRequestedWidth() > maxwidth)
                     maxwidth = effect->getRequestedWidth();
@@ -304,9 +302,9 @@ namespace MWGui
             }
 
             // ... then adjust the size for all widgets
-            for (std::vector<MyGUI::Widget*>::iterator it = effects.begin(); it != effects.end(); ++it)
+            for (MyGUI::Widget* effectWidget : effects)
             {
-                effect = (*it)->castType<MWSpellEffect>();
+                effect = effectWidget->castType<MWSpellEffect>();
                 bool needcenter = center && (maxwidth > effect->getRequestedWidth());
                 int diff = maxwidth - effect->getRequestedWidth();
                 if (needcenter)
@@ -339,18 +337,17 @@ namespace MWGui
         SpellEffectList MWEffectList::effectListFromESM(const ESM::EffectList* effects)
         {
             SpellEffectList result;
-            std::vector<ESM::ENAMstruct>::const_iterator end = effects->mList.end();
-            for (std::vector<ESM::ENAMstruct>::const_iterator it = effects->mList.begin(); it != end; ++it)
+            for (const ESM::ENAMstruct& effectInfo : effects->mList)
             {
                 SpellEffectParams params;
-                params.mEffectID = it->mEffectID;
-                params.mSkill = it->mSkill;
-                params.mAttribute = it->mAttribute;
-                params.mDuration = it->mDuration;
-                params.mMagnMin = it->mMagnMin;
-                params.mMagnMax = it->mMagnMax;
-                params.mRange = it->mRange;
-                params.mArea = it->mArea;
+                params.mEffectID = effectInfo.mEffectID;
+                params.mSkill = effectInfo.mSkill;
+                params.mAttribute = effectInfo.mAttribute;
+                params.mDuration = effectInfo.mDuration;
+                params.mMagnMin = effectInfo.mMagnMin;
+                params.mMagnMax = effectInfo.mMagnMax;
+                params.mRange = effectInfo.mRange;
+                params.mArea = effectInfo.mArea;
                 result.push_back(params);
             }
             return result;

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -670,9 +670,9 @@ namespace MWGui
         // Delete any dialogs which are no longer in use
         if (!mGarbageDialogs.empty())
         {
-            for (std::vector<Layout*>::iterator it = mGarbageDialogs.begin(); it != mGarbageDialogs.end(); ++it)
+            for (Layout* widget : mGarbageDialogs)
             {
-                delete *it;
+                delete widget;
             }
             mGarbageDialogs.clear();
         }
@@ -1211,14 +1211,13 @@ namespace MWGui
     {
         mToolTips->setDelay(Settings::Manager::getFloat("tooltip delay", "GUI"));
 
-        for (Settings::CategorySettingVector::const_iterator it = changed.begin();
-            it != changed.end(); ++it)
+        for (const auto& setting : changed)
         {
-            if (it->first == "HUD" && it->second == "crosshair")
+            if (setting.first == "HUD" && setting.second == "crosshair")
                 mCrosshairEnabled = Settings::Manager::getBool ("crosshair", "HUD");
-            else if (it->first == "GUI" && it->second == "subtitles")
+            else if (setting.first == "GUI" && setting.second == "subtitles")
                 mSubtitlesEnabled = Settings::Manager::getBool ("subtitles", "GUI");
-            else if (it->first == "GUI" && it->second == "menu transparency")
+            else if (setting.first == "GUI" && setting.second == "menu transparency")
                 setMenuTransparency(Settings::Manager::getFloat("menu transparency", "GUI"));
         }
     }

--- a/apps/openmw/mwgui/windowpinnablebase.cpp
+++ b/apps/openmw/mwgui/windowpinnablebase.cpp
@@ -16,10 +16,10 @@ namespace MWGui
 
         MyGUI::Button* button = nullptr;
         MyGUI::VectorWidgetPtr widgets = window->getSkinWidgetsByName("Action");
-        for (MyGUI::VectorWidgetPtr::iterator it = widgets.begin(); it != widgets.end(); ++it)
+        for (MyGUI::Widget* widget : widgets)
         {
-            if ((*it)->isUserString("HideWindowOnDoubleClick"))
-                button = (*it)->castType<MyGUI::Button>();
+            if (widget->isUserString("HideWindowOnDoubleClick"))
+                button = widget->castType<MyGUI::Button>();
         }
 
         if (button)


### PR DESCRIPTION
Currently despite we migrated to the C++11, most of our codebase still uses old-school iterators.

This PR replaces iterators in our GUI code to C++11-style loops to make code more readable.