### PR TITLE
Replace boost GCD by the homebrew implementation

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -1,11 +1,5 @@
 #include "graphicspage.hpp"
 
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 106500
-#include <boost/integer/common_factor.hpp>
-#else
-#include <boost/math/common_factor.hpp>
-#endif
 #include <csignal>
 #include <QDesktopWidget>
 #include <QMessageBox>
@@ -20,14 +14,11 @@
 #include <SDL_video.h>
 
 #include <components/files/configurationmanager.hpp>
+#include <components/misc/gcd.hpp>
 
 QString getAspect(int x, int y)
 {
-#if BOOST_VERSION >= 106500
-    int gcd = boost::integer::gcd (x, y);
-#else
-    int gcd = boost::math::gcd (x, y);
-#endif
+    int gcd = Misc::gcd (x, y);
     int xaspect = x / gcd;
     int yaspect = y / gcd;
     // special case: 8 : 5 is usually referred to as 16:10

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -8,16 +8,12 @@
 #include <MyGUI_TabControl.h>
 
 #include <boost/algorithm/string.hpp>
-#if BOOST_VERSION >= 106500
-#include <boost/integer/common_factor.hpp>
-#else
-#include <boost/math/common_factor.hpp>
-#endif
 
 #include <SDL_video.h>
 
 #include <components/debug/debuglog.hpp>
 #include <components/misc/stringops.hpp>
+#include <components/misc/gcd.hpp>
 #include <components/widgets/sharedstatebutton.hpp>
 #include <components/settings/settings.hpp>
 
@@ -63,11 +59,7 @@ namespace
 
     std::string getAspect (int x, int y)
     {
-#if BOOST_VERSION >= 106500
-        int gcd = boost::integer::gcd (x, y);
-#else
-        int gcd = boost::math::gcd (x, y);
-#endif
+        int gcd = Misc::gcd (x, y);
         int xaspect = x / gcd;
         int yaspect = y / gcd;
         // special case: 8 : 5 is usually referred to as 16:10

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -86,7 +86,7 @@ add_component_dir (esmterrain
     )
 
 add_component_dir (misc
-    constants utf8stream stringops resourcehelpers rng messageformatparser weakcache
+    gcd constants utf8stream stringops resourcehelpers rng messageformatparser weakcache
     )
 
 add_component_dir (debug

--- a/components/misc/gcd.hpp
+++ b/components/misc/gcd.hpp
@@ -1,0 +1,13 @@
+#ifndef MISC_GCD_H
+#define MISC_GCD_H
+
+namespace Misc
+{
+    // TODO: replace to the std::gcd() when the C++17 will be available.
+    int gcd(int a, int b)
+    {
+        return b == 0 ? a : gcd(b, a % b);
+    }
+}
+
+#endif


### PR DESCRIPTION
CI showed an another warning about undeclared BOOST_VERSION variable, and preprocessor stuff looks ugly.

Do we really need a boost here? We just need to determine an aspect ratio, so a homebrew implementation will be enough. 

If OpenMW will use the C++17 stuff, we can use the `std::gcd` here.