### PR TITLE
Fix enchanted item icon update

### DIFF
--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -156,12 +156,19 @@ namespace MWGui
 
     void SpellWidget::setSpellIcon(const std::string& icon)
     {
-        if (mFrame)
+        if (mFrame && !mCurrentFrame.empty())
+        {
+            mCurrentFrame.clear();
             mFrame->setImageTexture("");
-        if (mItemShadow)
-            mItemShadow->setImageTexture(icon);
-        if (mItem)
-            mItem->setImageTexture(icon);
+        }
+        if (mCurrentIcon != icon)
+        {
+            mCurrentIcon = icon;
+            if (mItemShadow)
+                mItemShadow->setImageTexture(icon);
+            if (mItem)
+                mItem->setImageTexture(icon);
+        }
     }
 
 }


### PR DESCRIPTION
After recent changes to GUI update the current icon and frame for spell widget weren't updating properly and the code which relied on these variables changing like enchanted item's setItem call broke.

This works in my own and akortunov's testing and doesn't seem to cause performance issues.