### PR TITLE
Loop title screen music (bug #4896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
     Bug #4876: AI ratings handling inconsistencies
     Bug #4877: Startup script executes only on a new game start
     Bug #4888: Global variable stray explicit reference calls break script compilation
+    Bug #4896: Title screen music doesn't loop
     Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -706,16 +706,10 @@ void OMW::Engine::go()
     {
         // start in main menu
         mEnvironment.getWindowManager()->pushGuiMode (MWGui::GM_MainMenu);
-        try
-        {
-            // Is there an ini setting for this filename or something?
-            mEnvironment.getSoundManager()->streamMusic("Special/morrowind title.mp3");
-
-            std::string logo = mFallbackMap["Movies_Morrowind_Logo"];
-            if (!logo.empty())
-                mEnvironment.getWindowManager()->playVideo(logo, true);
-        }
-        catch (...) {}
+        mEnvironment.getSoundManager()->playTitleMusic();
+        std::string logo = mFallbackMap["Movies_Morrowind_Logo"];
+        if (!logo.empty())
+            mEnvironment.getWindowManager()->playVideo(logo, true);
     }
     else
     {

--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -89,6 +89,9 @@ namespace MWBase
             ///< Start playing music from the selected folder
             /// \param name of the folder that contains the playlist
 
+            virtual void playTitleMusic() = 0;
+            ///< Start playing title music
+
             virtual void say(const MWWorld::ConstPtr &reference, const std::string& filename) = 0;
             ///< Make an actor say some text.
             /// \param filename name of a sound file in "Sound/" in the data directory.

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -471,6 +471,36 @@ namespace MWSound
         startRandomTitle();
     }
 
+    void SoundManager::playTitleMusic()
+    {
+        if (mCurrentPlaylist == "Title")
+            return;
+
+        if (mMusicFiles.find("Title") == mMusicFiles.end())
+        {
+            std::vector<std::string> filelist;
+            const std::map<std::string, VFS::File*>& index = mVFS->getIndex();
+            // Is there an ini setting for this filename or something?
+            std::string filename = "music/special/morrowind title.mp3";
+            auto found = index.find(filename);
+            if (found != index.end())
+            {
+                filelist.emplace_back(found->first);
+                mMusicFiles["Title"] = filelist;
+            }
+            else
+            {
+                Log(Debug::Warning) << "Title music not found";
+                return;
+            }
+        }
+
+        if (mMusicFiles["Title"].empty())
+            return;
+
+        mCurrentPlaylist = "Title";
+        startRandomTitle();
+    }
 
     void SoundManager::say(const MWWorld::ConstPtr &ptr, const std::string &filename)
     {
@@ -1122,10 +1152,10 @@ namespace MWSound
         if(!mOutput->isInitialized())
             return;
 
+        updateSounds(duration);
         if (MWBase::Environment::get().getStateManager()->getState()!=
             MWBase::StateManager::State_NoGame)
         {
-            updateSounds(duration);
             updateRegionSound(duration);
             updateWaterSound(duration);
         }

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -168,6 +168,9 @@ namespace MWSound
         ///< Start playing music from the selected folder
         /// \param name of the folder that contains the playlist
 
+        virtual void playTitleMusic();
+        ///< Start playing title music
+
         virtual void say(const MWWorld::ConstPtr &reference, const std::string& filename);
         ///< Make an actor say some text.
         /// \param filename name of a sound file in "Sound/" in the data directory.


### PR DESCRIPTION
[Bug 4896](https://gitlab.com/OpenMW/openmw/issues/4896)

Fixes two issues:
1. If title music file was missing, then the logo video (the one after bethesda softworks intro video) wouldn't play due to the exception. Since the exception caused by the video file being missing would actually be catched in VideoWidget playVideo, it's unnecessary to have a try-catch block for that.
2. The titular one. I've added a new hardcoded Title playlist with a single track in it which will play in the main menu.