### PR TITLE
[Trivial] Reuse a previously-saved value

### DIFF
--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -240,8 +240,8 @@ namespace MWClass
         std::string text;
         int lockLevel = ptr.getCellRef().getLockLevel();
         if (lockLevel > 0 && lockLevel != ESM::UnbreakableLock)
-            text += "\n#{sLockLevel}: " + MWGui::ToolTips::toString(ptr.getCellRef().getLockLevel());
-        else if (ptr.getCellRef().getLockLevel() < 0)
+            text += "\n#{sLockLevel}: " + MWGui::ToolTips::toString(lockLevel);
+        else if (lockLevel < 0)
             text += "\n#{sUnlocked}";
         if (ptr.getCellRef().getTrap() != "")
             text += "\n#{sTrapped}";


### PR DESCRIPTION
`ptr.getCellRef().getLockLevel()` was already saved to a variable. Since it cannot change between invocations, reuse its value instead of fetching it again.