### PR TITLE
Add sort button to item views

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -745,7 +745,7 @@ namespace MWGui
         ItemModel::ModelIndex selected = -1;
         // not using mSortFilterModel as we only need sorting, not filtering
         SortFilterItemModel model(new InventoryItemModel(player));
-        model.setSortByType(false);
+        model.setSort(SortFilterItemModel::Sort_None);
         model.update();
         if (model.getItemCount() == 0)
             return;

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -78,6 +78,21 @@ namespace MWGui
         virtual bool onDropItem(const MWWorld::Ptr &item, int count);
         virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
+        enum Sort
+        {
+            Sort_None,
+            Sort_Name,
+            Sort_Type,
+            Sort_Weight,
+            Sort_Value,
+            Sort_ValuePerWeight,
+            Sort_Last = Sort_ValuePerWeight,
+        };
+
+        virtual bool canSort() { return false; }
+        virtual Sort getSort() { return Sort_None; }
+        virtual void setSort(Sort sort) {}
+
     private:
         ItemModel(const ItemModel&);
         ItemModel& operator=(const ItemModel&);

--- a/apps/openmw/mwgui/itemview.hpp
+++ b/apps/openmw/mwgui/itemview.hpp
@@ -43,9 +43,11 @@ namespace MWGui
         void onSelectedItem (MyGUI::Widget* sender);
         void onSelectedBackground (MyGUI::Widget* sender);
         void onMouseWheelMoved(MyGUI::Widget* _sender, int _rel);
+        void onSort(MyGUI::Widget* _sender);
 
         ItemModel* mModel;
         MyGUI::ScrollView* mScrollView;
+        MyGUI::Button* mSortButton;
 
     };
 

--- a/apps/openmw/mwgui/sortfilteritemmodel.hpp
+++ b/apps/openmw/mwgui/sortfilteritemmodel.hpp
@@ -27,7 +27,9 @@ namespace MWGui
         void setFilter (int filter);
 
         /// Use ItemStack::Type for sorting?
-        void setSortByType(bool sort) { mSortByType = sort; }
+        bool canSort() { return true; }
+        Sort getSort() { return mSort; }
+        void setSort(Sort sort) { mSort = sort; }
 
         void onClose();
         bool onDropItem(const MWWorld::Ptr &item, int count);
@@ -56,7 +58,7 @@ namespace MWGui
 
         int mCategory;
         int mFilter;
-        bool mSortByType;
+        Sort mSort;
     };
 
 }


### PR DESCRIPTION
I was encouraged [on the forum](https://forum.openmw.org/viewtopic.php?f=2&t=5769&p=61812#p61812) to submit this as a pull request.

I'm aware that the contributing guide discourages patches of this sort. I don't have an opinion on whether this functionality should be part of OpenMW or not. But, if the maintainers agree in its favor, I don't mind spending some time polishing this patch for inclusion.

Issues so far:
- [ ] Replace `ItemView` button with layout buttons
- [ ] Replace hard-coded strings with localizable ones
- [ ] Review list of sorting modes
- [ ] Add a way to reverse sorting direction?

This is the original implementation as posted on the forum, for discussion / initial review.