### PR TITLE
[Regression] Fix magic glow update for sheathing weapons

### DIFF
--- a/apps/openmw/mwrender/actoranimation.hpp
+++ b/apps/openmw/mwrender/actoranimation.hpp
@@ -59,6 +59,7 @@ class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
     private:
         void addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM::Light* esmLight);
         void removeHiddenItemLight(const MWWorld::ConstPtr& item);
+        void resetControllers(osg::Node* node);
 
         typedef std::map<MWWorld::ConstPtr, osg::ref_ptr<SceneUtil::LightSource> > ItemLightMap;
         ItemLightMap mItemLights;


### PR DESCRIPTION
When there is a no dedicated _sh mesh for weapon, a Weapon Sheathing feature will attach a generic weapon mesh to the sheathing bone. 
If the weapon mesh contains controllers, they will be copied as well. It may lead to weird side effects (such as bow playing attack animation repeatedly because of morph controller).
So I used a workaround to disable update traversal for sheathed weapons. As a result, I accidentally broke the magic glow update for autogenerated holstered nodes. Also it **may** be related to black textures for enchanted sheathed weapons which a couple of users have (no one bothered to create a bugreport with their hardware specs, though).

In this PR I use an another approach - since it is hard to tell how to interpret current controller's time, disable controllers for autogenerated sheathed weapons at all.
It seems we use the same approach for non-weapon bodyparts for NPCs.

Are there better ways to do it? Maybe limit this workaround only for KeyFrame and GeomMorpher controllers?