### PR TITLE
Fix pathfinding when scene is changed by scripts (bug #4763) (2nd try)

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -134,6 +134,7 @@ namespace MWBase
 
             virtual MWWorld::Player& getPlayer() = 0;
             virtual MWWorld::Ptr getPlayerPtr() = 0;
+            virtual MWWorld::ConstPtr getPlayerConstPtr() const = 0;
 
             virtual const MWWorld::ESMStore& getStore() const = 0;
 
@@ -615,6 +616,9 @@ namespace MWBase
             virtual void removeActorPath(const MWWorld::ConstPtr& actor) const = 0;
 
             virtual void setNavMeshNumberToRender(const std::size_t value) = 0;
+
+            /// Return physical half extents of the given actor to be used in pathfinding
+            virtual osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const = 0;
     };
 }
 

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -135,9 +135,9 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
         {
             if (wasShortcutting || doesPathNeedRecalc(dest, actor.getCell())) // if need to rebuild path
             {
-                const osg::Vec3f playerHalfExtents = world->getHalfExtents(getPlayer()); // Using player half extents for better performance
+                const auto halfExtents = world->getPathfindingHalfExtents(actor);
                 mPathFinder.buildPath(actor, position, dest, actor.getCell(), getPathGridGraph(actor.getCell()),
-                    playerHalfExtents, getNavigatorFlags(actor));
+                    halfExtents, getNavigatorFlags(actor));
                 mRotateOnTheRunChecks = 3;
 
                 // give priority to go directly on target if there is minimal opportunity

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -155,9 +155,9 @@ namespace MWMechanics
             }
             else
             {
-                const osg::Vec3f playerHalfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(getPlayer()); // Using player half extents for better performance
+                const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
                 mPathFinder.buildPath(actor, pos.asVec3(), mDestination, actor.getCell(),
-                    getPathGridGraph(actor.getCell()), playerHalfExtents, getNavigatorFlags(actor));
+                    getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
             }
 
             if (mPathFinder.isPathConstructed())
@@ -312,10 +312,9 @@ namespace MWMechanics
             if ((!isWaterCreature && !destinationIsAtWater(actor, mDestination)) ||
                 (isWaterCreature && !destinationThroughGround(currentPosition, mDestination)))
             {
-                // Using player half extents for better performance
-                const osg::Vec3f playerHalfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(getPlayer());
+                const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
                 mPathFinder.buildPath(actor, currentPosition, mDestination, actor.getCell(),
-                    getPathGridGraph(actor.getCell()), playerHalfExtents, getNavigatorFlags(actor));
+                    getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
                 mPathFinder.addPointToPath(mDestination);
 
                 if (mPathFinder.isPathConstructed())

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -201,6 +201,11 @@ osg::Vec3f Actor::getHalfExtents() const
     return osg::componentMultiply(mHalfExtents, mScale);
 }
 
+osg::Vec3f Actor::getOriginalHalfExtents() const
+{
+    return mHalfExtents;
+}
+
 osg::Vec3f Actor::getRenderingHalfExtents() const
 {
     return osg::componentMultiply(mHalfExtents, mRenderingScale);

--- a/apps/openmw/mwphysics/actor.hpp
+++ b/apps/openmw/mwphysics/actor.hpp
@@ -67,6 +67,11 @@ namespace MWPhysics
         osg::Vec3f getHalfExtents() const;
 
         /**
+         * Returns the half extents of the collision body (not scaled)
+         */
+        osg::Vec3f getOriginalHalfExtents() const;
+
+        /**
          * Returns the position of the collision body
          * @note The collision shape's origin is in its center, so the position returned can be described as center of the actor collision box in world space.
          */

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -906,6 +906,14 @@ namespace MWPhysics
             return osg::Vec3f();
     }
 
+    osg::Vec3f PhysicsSystem::getOriginalHalfExtents(const MWWorld::ConstPtr &actor) const
+    {
+        if (const Actor* physactor = getActor(actor))
+            return physactor->getOriginalHalfExtents();
+        else
+            return osg::Vec3f();
+    }
+
     osg::Vec3f PhysicsSystem::getRenderingHalfExtents(const MWWorld::ConstPtr &actor) const
     {
         const Actor* physactor = getActor(actor);

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -136,6 +136,9 @@ namespace MWPhysics
             /// Get physical half extents (scaled) of the given actor.
             osg::Vec3f getHalfExtents(const MWWorld::ConstPtr& actor) const;
 
+            /// Get physical half extents (not scaled) of the given actor.
+            osg::Vec3f getOriginalHalfExtents(const MWWorld::ConstPtr& actor) const;
+
             /// @see MWPhysics::Actor::getRenderingHalfExtents
             osg::Vec3f getRenderingHalfExtents(const MWWorld::ConstPtr& actor) const;
 

--- a/apps/openmw/mwrender/navmesh.cpp
+++ b/apps/openmw/mwrender/navmesh.cpp
@@ -34,7 +34,7 @@ namespace MWRender
     void NavMesh::update(const dtNavMesh& navMesh, const std::size_t id,
         const std::size_t generation, const std::size_t revision, const DetourNavigator::Settings& settings)
     {
-        if (!mEnabled || (mId == id && mGeneration >= generation && mRevision >= revision))
+        if (!mEnabled || (mGroup && mId == id && mGeneration >= generation && mRevision >= revision))
             return;
 
         mId = id;
@@ -53,7 +53,10 @@ namespace MWRender
     void NavMesh::reset()
     {
         if (mGroup)
+        {
             mRootNode->removeChild(mGroup);
+            mGroup = nullptr;
+        }
     }
 
     void NavMesh::enable()
@@ -65,7 +68,8 @@ namespace MWRender
 
     void NavMesh::disable()
     {
-        reset();
+        if (mGroup)
+            mRootNode->removeChild(mGroup);
         mEnabled = false;
     }
 }

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -122,6 +122,12 @@ namespace MWWorld
         return ptr;
     }
 
+    MWWorld::ConstPtr Player::getConstPlayer() const
+    {
+        MWWorld::ConstPtr ptr (&mPlayer, mCellStore);
+        return ptr;
+    }
+
     void Player::setBirthSign (const std::string &sign)
     {
         mSign = sign;

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -27,6 +27,7 @@ namespace Loading
 namespace MWWorld
 {
     class CellStore;
+    class ConstPtr;
 
     /// \brief NPC object representing the player and additional player data
     class Player
@@ -81,6 +82,7 @@ namespace MWWorld
         void setCell (MWWorld::CellStore *cellStore);
 
         MWWorld::Ptr getPlayer();
+        MWWorld::ConstPtr getConstPlayer() const;
 
         void setBirthSign(const std::string &sign);
         const std::string &getBirthSign() const;

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -172,12 +172,9 @@ namespace
                 );
             }
         }
-        else if (const auto actor = physics.getActor(ptr))
+        else if (physics.getActor(ptr))
         {
-            const auto halfExtents = ptr.getCell()->isExterior()
-                ? physics.getHalfExtents(MWBase::Environment::get().getWorld()->getPlayerPtr())
-                : actor->getHalfExtents();
-            navigator.addAgent(halfExtents);
+            navigator.addAgent(MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(ptr));
         }
     }
 
@@ -337,15 +334,14 @@ namespace MWWorld
         ListAndResetObjectsVisitor visitor;
 
         (*iter)->forEach<ListAndResetObjectsVisitor>(visitor);
-        const auto player = MWBase::Environment::get().getWorld()->getPlayerPtr();
-        const auto playerHalfExtents = mPhysics->getHalfExtents(player);
+        const auto world = MWBase::Environment::get().getWorld();
         for (const auto& ptr : visitor.mObjects)
         {
             if (const auto object = mPhysics->getObject(ptr))
                 navigator->removeObject(DetourNavigator::ObjectId(object));
             else if (const auto actor = mPhysics->getActor(ptr))
             {
-                navigator->removeAgent(ptr.getCell()->isExterior() ? playerHalfExtents : actor->getHalfExtents());
+                navigator->removeAgent(world->getPathfindingHalfExtents(ptr));
                 mRendering.removeActorPath(ptr);
             }
             mPhysics->remove(ptr);
@@ -372,6 +368,7 @@ namespace MWWorld
         if ((*iter)->getCell()->hasWater())
             navigator->removeWater(osg::Vec2i(cellX, cellY));
 
+        const auto player = world->getPlayerPtr();
         navigator->update(player.getRefData().getPosition().asVec3());
 
         MWBase::Environment::get().getMechanicsManager()->drop (*iter);
@@ -815,10 +812,7 @@ namespace MWWorld
         }
         else if (const auto actor = mPhysics->getActor(ptr))
         {
-            const auto& halfExtents = ptr.getCell()->isExterior()
-                ? mPhysics->getHalfExtents(MWBase::Environment::get().getWorld()->getPlayerPtr())
-                : actor->getHalfExtents();
-            navigator->removeAgent(halfExtents);
+            navigator->removeAgent(MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(ptr));
         }
         mPhysics->remove(ptr);
         mRendering.removeObject (ptr);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1298,6 +1298,9 @@ namespace MWWorld
             {
                 mPhysics->updatePosition(newPtr);
                 mPhysics->updatePtr(ptr, newPtr);
+
+                if (const auto object = mPhysics->getObject(newPtr))
+                    updateNavigatorObject(object);
             }
         }
         if (isPlayer)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1381,7 +1381,12 @@ namespace MWWorld
         ptr.getRefData().setPosition(pos);
 
         if(ptr.getRefData().getBaseNode() != 0)
+        {
             mWorldScene->updateObjectRotation(ptr, true);
+
+            if (const auto object = mPhysics->getObject(ptr))
+                updateNavigatorObject(object);
+        }
     }
 
     void World::adjustPosition(const Ptr &ptr, bool force)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2443,6 +2443,7 @@ namespace MWWorld
 
         applyLoopingParticles(player);
 
+        mDefaultHalfExtents = mPhysics->getOriginalHalfExtents(getPlayerPtr());
         mNavigator->addAgent(getPathfindingHalfExtents(getPlayerConstPtr()));
     }
 
@@ -3795,7 +3796,7 @@ namespace MWWorld
     osg::Vec3f World::getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const
     {
         if (actor.isInCell() && actor.getCell()->isExterior())
-            return getHalfExtents(getPlayerConstPtr()); // Using player half extents for better performance
+            return mDefaultHalfExtents; // Using default half extents for better performance
         else
             return getHalfExtents(actor);
     }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2408,7 +2408,7 @@ namespace MWWorld
         {
             // Remove the old CharacterController
             MWBase::Environment::get().getMechanicsManager()->remove(getPlayerPtr());
-            mNavigator->removeAgent(mPhysics->getHalfExtents(getPlayerPtr()));
+            mNavigator->removeAgent(getPathfindingHalfExtents(getPlayerConstPtr()));
             mPhysics->remove(getPlayerPtr());
             mRendering->removePlayer(getPlayerPtr());
 
@@ -2443,7 +2443,7 @@ namespace MWWorld
 
         applyLoopingParticles(player);
 
-        mNavigator->addAgent(mPhysics->getHalfExtents(getPlayerPtr()));
+        mNavigator->addAgent(getPathfindingHalfExtents(getPlayerConstPtr()));
     }
 
     World::RestPermitted World::canRest () const
@@ -3418,6 +3418,11 @@ namespace MWWorld
         return mPlayer->getPlayer();
     }
 
+    MWWorld::ConstPtr World::getPlayerConstPtr() const
+    {
+        return mPlayer->getConstPlayer();
+    }
+
     void World::updateDialogueGlobals()
     {
         MWWorld::Ptr player = getPlayerPtr();
@@ -3785,6 +3790,14 @@ namespace MWWorld
     void World::setNavMeshNumberToRender(const std::size_t value)
     {
         mRendering->setNavMeshNumber(value);
+    }
+
+    osg::Vec3f World::getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const
+    {
+        if (actor.isInCell() && actor.getCell()->isExterior())
+            return getHalfExtents(getPlayerConstPtr()); // Using player half extents for better performance
+        else
+            return getHalfExtents(actor);
     }
 
 }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1328,9 +1328,15 @@ namespace MWWorld
 
     void World::scaleObject (const Ptr& ptr, float scale)
     {
+        if (mPhysics->getActor(ptr))
+            mNavigator->removeAgent(getPathfindingHalfExtents(ptr));
+
         ptr.getCellRef().setScale(scale);
 
         mWorldScene->updateObjectScale(ptr);
+
+        if (mPhysics->getActor(ptr))
+            mNavigator->addAgent(getPathfindingHalfExtents(ptr));
     }
 
     void World::rotateObjectImp (const Ptr& ptr, const osg::Vec3f& rot, bool adjust)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -112,6 +112,7 @@ namespace MWWorld
             std::string mUserDataPath;
 
             osg::Vec3f mDefaultHalfExtents;
+            bool mShouldUpdateNavigator = false;
 
             // not implemented
             World (const World&);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -111,6 +111,8 @@ namespace MWWorld
 
             std::string mUserDataPath;
 
+            osg::Vec3f mDefaultHalfExtents;
+
             // not implemented
             World (const World&);
             World& operator= (const World&);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -238,6 +238,7 @@ namespace MWWorld
 
             Player& getPlayer() override;
             MWWorld::Ptr getPlayerPtr() override;
+            MWWorld::ConstPtr getPlayerConstPtr() const override;
 
             const MWWorld::ESMStore& getStore() const override;
 
@@ -717,6 +718,9 @@ namespace MWWorld
             void removeActorPath(const MWWorld::ConstPtr& actor) const override;
 
             void setNavMeshNumberToRender(const std::size_t value) override;
+
+            /// Return physical half extents of the given actor to be used in pathfinding
+            osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const override;
     };
 }
 

--- a/apps/openmw_test_suite/detournavigator/recastmeshobject.cpp
+++ b/apps/openmw_test_suite/detournavigator/recastmeshobject.cpp
@@ -69,4 +69,11 @@ namespace
         object.update(mTransform, AreaType_ground);
         EXPECT_FALSE(object.update(mTransform, AreaType_ground));
     }
+
+    TEST_F(DetourNavigatorRecastMeshObjectTest, update_for_changed_local_scaling_should_return_true)
+    {
+        RecastMeshObject object(mBoxShape, mTransform, AreaType_ground);
+        mBoxShape.setLocalScaling(btVector3(2, 2, 2));
+        EXPECT_TRUE(object.update(mTransform, AreaType_ground));
+    }
 }

--- a/components/detournavigator/recastmeshobject.cpp
+++ b/components/detournavigator/recastmeshobject.cpp
@@ -13,6 +13,7 @@ namespace DetourNavigator
         : mShape(shape)
         , mTransform(transform)
         , mAreaType(areaType)
+        , mLocalScaling(shape.getLocalScaling())
         , mChildren(makeChildrenObjects(shape, mAreaType))
     {
     }
@@ -28,6 +29,11 @@ namespace DetourNavigator
         if (mAreaType != areaType)
         {
             mAreaType = areaType;
+            result = true;
+        }
+        if (!(mLocalScaling == mShape.get().getLocalScaling()))
+        {
+            mLocalScaling = mShape.get().getLocalScaling();
             result = true;
         }
         if (mShape.get().isCompound())

--- a/components/detournavigator/recastmeshobject.hpp
+++ b/components/detournavigator/recastmeshobject.hpp
@@ -39,6 +39,7 @@ namespace DetourNavigator
             std::reference_wrapper<const btCollisionShape> mShape;
             btTransform mTransform;
             AreaType mAreaType;
+            btVector3 mLocalScaling;
             std::vector<RecastMeshObject> mChildren;
 
             static bool updateCompoundObject(const btCompoundShape& shape, const AreaType areaType,


### PR DESCRIPTION
There are several problems fixed:
1. Pathfinding uses player half extents instead of actor in interior cells.
2. Player scaling makes unavailable to find navmesh in exterior cells (also in interior because of 1).
3. Actor scaling makes unvailable to find navmesh in interior cells (bug after 1 is fixed).
4. Local scaling is not checked when object is updated in recast mesh.
5. Scaled, moved, rotated objects by scripts do not trigger navmesh update.
6. Using `setnavmeshnumber` for invalid value than for valid disable navmesh render without getting back.

Update: check is actor in a cell before check is it in an exterior cell