### PR TITLE
Small script verifier tweaks

### DIFF
--- a/apps/opencs/model/tools/scriptcheck.cpp
+++ b/apps/opencs/model/tools/scriptcheck.cpp
@@ -30,11 +30,11 @@ void CSMTools::ScriptCheckStage::report (const std::string& message, const Compi
 
     CSMWorld::UniversalId id (CSMWorld::UniversalId::Type_Script, mId);
 
-    stream << "line " << loc.mLine << ", column " << loc.mColumn << ": " << message << " (" << loc.mLiteral << ")";
+    stream << message << " (" << loc.mLiteral  << ")" << " @ line " << loc.mLine+1 << ", column " << loc.mColumn;
 
     std::ostringstream hintStream;
 
-    hintStream << "l:" << loc.mLine << " " << loc.mColumn;
+    hintStream << "l:" << loc.mLine+1 << " " << loc.mColumn;
 
     mMessages->add (id, stream.str(), hintStream.str(), getSeverity (type));
 }

--- a/apps/openmw/mwscript/dialogueextensions.cpp
+++ b/apps/openmw/mwscript/dialogueextensions.cpp
@@ -285,6 +285,7 @@ namespace MWScript
         void installOpcodes (Interpreter::Interpreter& interpreter)
         {
             interpreter.installSegment5 (Compiler::Dialogue::opcodeJournal, new OpJournal<ImplicitRef>);
+            interpreter.installSegment5 (Compiler::Dialogue::opcodeJournalExplicit, new OpJournal<ExplicitRef>);
             interpreter.installSegment5 (Compiler::Dialogue::opcodeSetJournalIndex, new OpSetJournalIndex);
             interpreter.installSegment5 (Compiler::Dialogue::opcodeGetJournalIndex, new OpGetJournalIndex);
             interpreter.installSegment5 (Compiler::Dialogue::opcodeAddTopic, new OpAddTopic);

--- a/apps/openmw/mwscript/docs/vmformat.txt
+++ b/apps/openmw/mwscript/docs/vmformat.txt
@@ -458,5 +458,6 @@ op 0x2000307: ToggleBorders, tb
 op 0x2000308: ToggleNavMesh
 op 0x2000309: ToggleActorsPaths
 op 0x200030a: SetNavMeshNumber
+op 0x200030b: Journal, explicit
 
-opcodes 0x200030b-0x3ffffff unused
+opcodes 0x200030c-0x3ffffff unused

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -175,7 +175,7 @@ namespace Compiler
     {
         void registerExtensions (Extensions& extensions)
         {
-            extensions.registerInstruction ("journal", "cl", opcodeJournal);
+            extensions.registerInstruction ("journal", "cl", opcodeJournal, opcodeJournalExplicit);
             extensions.registerInstruction ("setjournalindex", "cl", opcodeSetJournalIndex);
             extensions.registerFunction ("getjournalindex", 'l', "c", opcodeGetJournalIndex);
             extensions.registerInstruction ("addtopic", "S" , opcodeAddTopic);

--- a/components/compiler/opcodes.hpp
+++ b/components/compiler/opcodes.hpp
@@ -150,6 +150,7 @@ namespace Compiler
     namespace Dialogue
     {
         const int opcodeJournal = 0x2000133;
+        const int opcodeJournalExplicit = 0x200030b;
         const int opcodeSetJournalIndex = 0x2000134;
         const int opcodeGetJournalIndex = 0x2000135;
         const int opcodeAddTopic = 0x200013a;


### PR DESCRIPTION
Changes two minor things:

1. Journal now has an explicit variant. Explicit reference calls for Journal actually matter (in case the scripter wants to use a different actor for %Name and other similar "macros"), parser deciding they're redundant is unfair (though it may have worked fine before). This is mainly to silence the spammy warning about stray explicit references for the instruction.
2. Script verifier messages are restructured again, placing line and column after the message, they didn't get sorted well alphabetically. Also, line number is fixed. Lines start from 1, not 0.