### PR TITLE
Do not build path by navigator for pure water and flying creatures

### DIFF
--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -286,7 +286,8 @@ namespace MWMechanics
         mPath.clear();
         mCell = cell;
 
-        buildPathByNavigatorImpl(actor, startPoint, endPoint, halfExtents, flags, std::back_inserter(mPath));
+        if (!actor.getClass().isPureWaterCreature(actor) && !actor.getClass().isPureFlyingCreature(actor))
+            buildPathByNavigatorImpl(actor, startPoint, endPoint, halfExtents, flags, std::back_inserter(mPath));
 
         if (mPath.empty())
             buildPathByPathgridImpl(startPoint, endPoint, pathgridGraph, std::back_inserter(mPath));

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -407,7 +407,7 @@ namespace MWWorld
         return false;
     }
 
-    bool Class::isPureWaterCreature(const MWWorld::Ptr& ptr) const
+    bool Class::isPureWaterCreature(const ConstPtr& ptr) const
     {
         return canSwim(ptr)
                 && !isBipedal(ptr)
@@ -415,7 +415,7 @@ namespace MWWorld
                 && !canWalk(ptr);
     }
 
-    bool Class::isPureFlyingCreature(const Ptr& ptr) const
+    bool Class::isPureFlyingCreature(const ConstPtr& ptr) const
     {
         return canFly(ptr)
                 && !isBipedal(ptr)

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -324,8 +324,8 @@ namespace MWWorld
             virtual bool canFly(const MWWorld::ConstPtr& ptr) const;
             virtual bool canSwim(const MWWorld::ConstPtr& ptr) const;
             virtual bool canWalk(const MWWorld::ConstPtr& ptr) const;
-            bool isPureWaterCreature(const MWWorld::Ptr& ptr) const;
-            bool isPureFlyingCreature(const MWWorld::Ptr& ptr) const;
+            bool isPureWaterCreature(const MWWorld::ConstPtr& ptr) const;
+            bool isPureFlyingCreature(const MWWorld::ConstPtr& ptr) const;
             bool isPureLandCreature(const MWWorld::Ptr& ptr) const;
             bool isMobile(const MWWorld::Ptr& ptr) const;
 


### PR DESCRIPTION
They don't need to move by surfaces and to open/close doors. Also prevents spam to log because of failure to find path.