### PR TITLE
 Use min point tolerance to prevent face wrong direction (bug #4814) 

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -167,7 +167,7 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
         mTimer = 0;
     }
 
-    const float pointTolerance = std::min(actor.getClass().getSpeed(actor), DEFAULT_TOLERANCE);
+    const float pointTolerance = std::max(MIN_TOLERANCE, std::min(actor.getClass().getSpeed(actor), DEFAULT_TOLERANCE));
 
     mPathFinder.update(position, pointTolerance, DEFAULT_TOLERANCE);
 

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -49,6 +49,7 @@ namespace MWMechanics
     // distance after which actor (failed previously to shortcut) will try again
     const float PATHFIND_SHORTCUT_RETRY_DIST = 300.0f;
 
+    const float MIN_TOLERANCE = 1.0f;
     const float DEFAULT_TOLERANCE = 32.0f;
 
     // cast up-down ray with some offset from actor position to check for pits/obstacles on the way to target;

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -46,7 +46,6 @@ namespace MWMechanics
     }
 
     const float PATHFIND_Z_REACH = 50.0f;
-    //static const float sMaxSlope = 49.0f; // duplicate as in physicssystem
     // distance after which actor (failed previously to shortcut) will try again
     const float PATHFIND_SHORTCUT_RETRY_DIST = 300.0f;
 


### PR DESCRIPTION
When next path point is too close to actor and it has speed 0, it can face direction not pointing to path target.