### PR TITLE
Fix windows CI scripts

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -82,7 +82,7 @@ while [ $# -gt 0 ]; do
 
 			t )
 				TEST_FRAMEWORK=true ;;
-				
+
 			h )
 				cat <<EOF
 Usage: $0 [-cdehkpuvV]
@@ -99,8 +99,8 @@ Options:
 		Keep the old build directory, default is to delete it.
 	-p <Win32/Win64>
 		Set the build platform, can also be set with environment variable PLATFORM.
-	-t 
-		Build unit tests / Google test 	
+	-t
+		Build unit tests / Google test
 	-u
 		Configure for unity builds.
 	-v <2013/2015/2017>
@@ -402,7 +402,7 @@ if [ -z $SKIP_DOWNLOAD ]; then
 	download "SDL 2.0.7" \
 		"https://www.libsdl.org/release/SDL2-devel-2.0.7-VC.zip" \
 		"SDL2-2.0.7.zip"
-		
+
 	# Google test and mock
 	if [ ! -z $TEST_FRAMEWORK ]; then
 		echo "Google test 1.8.1..."
@@ -692,33 +692,33 @@ echo
 # Google Test and Google Mock
 if [ ! -z $TEST_FRAMEWORK ]; then
 	printf "Google test 1.8.1 ..."
-	
+
 	cd googletest
 	if [ ! -d build ]; then
 		mkdir build
 	fi
-	
+
 	cd build
-	
+
 	GOOGLE_INSTALL_ROOT="${DEPS_INSTALL}/GoogleTest"
 	if [ $CONFIGURATION == "Debug" ]; then
 			DEBUG_SUFFIX="d"
 		else
 			DEBUG_SUFFIX=""
 	fi
-		
+
 	if [ ! -d $GOOGLE_INSTALL_ROOT ]; then
-		
+
 		cmake .. -DCMAKE_BUILD_TYPE="${CONFIGURATION}" -DCMAKE_INSTALL_PREFIX="${GOOGLE_INSTALL_ROOT}" -DCMAKE_USE_WIN32_THREADS_INIT=1 -G "${GENERATOR}" -DBUILD_SHARED_LIBS=1
 		cmake --build . --config "${CONFIGURATION}"
 		cmake --build . --target install --config "${CONFIGURATION}"
-		
+
 		add_runtime_dlls "${GOOGLE_INSTALL_ROOT}\bin\gtest_main${DEBUG_SUFFIX}.dll"
 		add_runtime_dlls "${GOOGLE_INSTALL_ROOT}\bin\gtest${DEBUG_SUFFIX}.dll"
 		add_runtime_dlls "${GOOGLE_INSTALL_ROOT}\bin\gmock_main${DEBUG_SUFFIX}.dll"
 		add_runtime_dlls "${GOOGLE_INSTALL_ROOT}\bin\gmock${DEBUG_SUFFIX}.dll"
 	fi
-	
+
 	add_cmake_opts -DBUILD_UNITTESTS=yes
 	# FindGTest and FindGMock do not work perfectly on Windows
 	# but we can help them by telling them everything we know about installation
@@ -730,7 +730,7 @@ if [ ! -z $TEST_FRAMEWORK ]; then
 	add_cmake_opts -DGMOCK_MAIN_LIBRARY="$GOOGLE_INSTALL_ROOT/lib/gmock_main${DEBUG_SUFFIX}.lib"
 	add_cmake_opts -DGTEST_LINKED_AS_SHARED_LIBRARY=True
 	echo Done.
-	
+
 fi
 
 echo

--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -446,7 +446,7 @@ echo
 if [ -z $APPVEYOR ]; then
 	printf "Boost 1.67.0... "
 else
-	if [ $MSVC_VER -eq 12.0 ]; then
+	if [ "${MSVC_VER}" -eq 12.0 ]; then
 		printf "Boost 1.58.0 AppVeyor... "
 	else
 		printf "Boost 1.67.0 AppVeyor... "

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,18 +33,18 @@ configuration:
 clone_depth: 1
 
 cache:
-    - C:\projects\openmw\deps\Bullet-2.83.7-msvc2015-win32.7z
-    - C:\projects\openmw\deps\Bullet-2.83.7-msvc2015-win64.7z
-    - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win64.7z
-    - C:\projects\openmw\deps\MyGUI-3.2.3-git-msvc2015-win64.7z
-    - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2015-win64.7z
-    - C:\projects\openmw\deps\OSG-3.4.0-scrawl-msvc2015-win64.7z
-    - C:\projects\openmw\deps\ffmpeg-3.0.1-dev-win32.7z
-    - C:\projects\openmw\deps\ffmpeg-3.0.1-dev-win64.7z
-    - C:\projects\openmw\deps\ffmpeg-3.0.1-win32.7z
-    - C:\projects\openmw\deps\ffmpeg-3.0.1-win64.7z
-    - C:\projects\openmw\deps\OpenAL-Soft-1.17.2.zip
-    - C:\projects\openmw\deps\SDL2-2.0.4.zip
+    - C:\projects\openmw\deps\Bullet-2.86-msvc2015-win32.7z
+    - C:\projects\openmw\deps\Bullet-2.86-msvc2015-win64.7z
+    - C:\projects\openmw\deps\MyGUI-3.2.2-msvc2015-win32.7z
+    - C:\projects\openmw\deps\MyGUI-3.2.2-msvc2015-win64.7z
+    - C:\projects\openmw\deps\OSG-3.4.1-scrawl-msvc2015-win32.7z
+    - C:\projects\openmw\deps\OSG-3.4.1-scrawl-msvc2015-win64.7z
+    - C:\projects\openmw\deps\ffmpeg-3.2.4-dev-win32.zip
+    - C:\projects\openmw\deps\ffmpeg-3.2.4-dev-win64.zip
+    - C:\projects\openmw\deps\ffmpeg-3.2.4-win32.zip
+    - C:\projects\openmw\deps\ffmpeg-3.2.4-win64.zip
+    - C:\projects\openmw\deps\OpenAL-Soft-1.19.1.zip
+    - C:\projects\openmw\deps\SDL2-2.0.7.zip
 
 clone_folder: C:\projects\openmw
 


### PR DESCRIPTION
1. Cache proper files.
2. Remove annoying white spaces and trailing spaces
3. Fix compare with empty value.
