### PR TITLE
Move forcePPL and clamp to global shader defines (task #4869)

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -220,8 +220,8 @@ namespace MWRender
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
         resourceSystem->getSceneManager()->setShaderPath(resourcePath + "/shaders");
         resourceSystem->getSceneManager()->setForceShaders(Settings::Manager::getBool("force shaders", "Shaders") || Settings::Manager::getBool("enable shadows", "Shadows")); // Shadows have problems with fixed-function mode
+        // FIXME: calling dummy method because terrain needs to know whether lighting is clamped
         resourceSystem->getSceneManager()->setClampLighting(Settings::Manager::getBool("clamp lighting", "Shaders"));
-        resourceSystem->getSceneManager()->setForcePerPixelLighting(Settings::Manager::getBool("force per pixel lighting", "Shaders"));
         resourceSystem->getSceneManager()->setAutoUseNormalMaps(Settings::Manager::getBool("auto use object normal maps", "Shaders"));
         resourceSystem->getSceneManager()->setNormalMapPattern(Settings::Manager::getString("normal map pattern", "Shaders"));
         resourceSystem->getSceneManager()->setNormalHeightMapPattern(Settings::Manager::getString("normal height map pattern", "Shaders"));
@@ -252,6 +252,9 @@ namespace MWRender
 
         for (auto itr = shadowDefines.begin(); itr != shadowDefines.end(); itr++)
             globalDefines[itr->first] = itr->second;
+
+        globalDefines["forcePPL"] = Settings::Manager::getBool("force per pixel lighting", "Shaders") ? "1" : "0";
+        globalDefines["clamp"] = Settings::Manager::getBool("clamp lighting", "Shaders") ? "1" : "0";
 
         // It is unnecessary to stop/start the viewer as no frames are being rendered yet.
         mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(globalDefines);

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -218,7 +218,6 @@ namespace Resource
         , mShaderManager(new Shader::ShaderManager)
         , mForceShaders(false)
         , mClampLighting(true)
-        , mForcePerPixelLighting(false)
         , mAutoUseNormalMaps(false)
         , mAutoUseSpecularMaps(false)
         , mInstanceCache(new MultiObjectCache)
@@ -258,16 +257,6 @@ namespace Resource
     bool SceneManager::getClampLighting() const
     {
         return mClampLighting;
-    }
-
-    void SceneManager::setForcePerPixelLighting(bool force)
-    {
-        mForcePerPixelLighting = force;
-    }
-
-    bool SceneManager::getForcePerPixelLighting() const
-    {
-        return mForcePerPixelLighting;
     }
 
     void SceneManager::setAutoUseNormalMaps(bool use)
@@ -749,8 +738,6 @@ namespace Resource
     {
         Shader::ShaderVisitor* shaderVisitor = new Shader::ShaderVisitor(*mShaderManager.get(), *mImageManager, "objects_vertex.glsl", "objects_fragment.glsl");
         shaderVisitor->setForceShaders(mForceShaders);
-        shaderVisitor->setClampLighting(mClampLighting);
-        shaderVisitor->setForcePerPixelLighting(mForcePerPixelLighting);
         shaderVisitor->setAutoUseNormalMaps(mAutoUseNormalMaps);
         shaderVisitor->setNormalMapPattern(mNormalMapPattern);
         shaderVisitor->setNormalHeightMapPattern(mNormalHeightMapPattern);

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -56,13 +56,8 @@ namespace Resource
         void setForceShaders(bool force);
         bool getForceShaders() const;
 
-        /// @see ShaderVisitor::setClampLighting
         void setClampLighting(bool clamp);
         bool getClampLighting() const;
-
-        /// @see ShaderVisitor::setForcePerPixelLighting
-        void setForcePerPixelLighting(bool force);
-        bool getForcePerPixelLighting() const;
 
         /// @see ShaderVisitor::setAutoUseNormalMaps
         void setAutoUseNormalMaps(bool use);
@@ -155,7 +150,6 @@ namespace Resource
         std::unique_ptr<Shader::ShaderManager> mShaderManager;
         bool mForceShaders;
         bool mClampLighting;
-        bool mForcePerPixelLighting;
         bool mAutoUseNormalMaps;
         std::string mNormalMapPattern;
         std::string mNormalHeightMapPattern;

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -37,8 +37,6 @@ namespace Shader
     ShaderVisitor::ShaderVisitor(ShaderManager& shaderManager, Resource::ImageManager& imageManager, const std::string &defaultVsTemplate, const std::string &defaultFsTemplate)
         : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
         , mForceShaders(false)
-        , mClampLighting(true)
-        , mForcePerPixelLighting(false)
         , mAllowedToModifyStateSets(true)
         , mAutoUseNormalMaps(false)
         , mAutoUseSpecularMaps(false)
@@ -53,16 +51,6 @@ namespace Shader
     void ShaderVisitor::setForceShaders(bool force)
     {
         mForceShaders = force;
-    }
-
-    void ShaderVisitor::setClampLighting(bool clamp)
-    {
-        mClampLighting = clamp;
-    }
-
-    void ShaderVisitor::setForcePerPixelLighting(bool force)
-    {
-        mForcePerPixelLighting = force;
     }
 
     void ShaderVisitor::apply(osg::Node& node)
@@ -296,9 +284,6 @@ namespace Shader
             defineMap[texIt->second] = "1";
             defineMap[texIt->second + std::string("UV")] = std::to_string(texIt->first);
         }
-
-        defineMap["forcePPL"] = mForcePerPixelLighting ? "1" : "0";
-        defineMap["clamp"] = mClampLighting ? "1" : "0";
 
         defineMap["parallax"] = reqs.mNormalHeight ? "1" : "0";
 

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -23,13 +23,6 @@ namespace Shader
         /// Setting force = true will cause all objects to render using shaders, regardless of having a bump map.
         void setForceShaders(bool force);
 
-        /// Set whether lighting is clamped for visual compatibility with the fixed function pipeline.
-        void setClampLighting(bool clamp);
-
-        /// By default, only bump mapped objects use per-pixel lighting.
-        /// Setting force = true will cause all shaders to use per-pixel lighting, regardless of having a bump map.
-        void setForcePerPixelLighting(bool force);
-
         /// Set if we are allowed to modify StateSets encountered in the graph (default true).
         /// @par If set to false, then instead of modifying, the StateSet will be cloned and this new StateSet will be assigned to the node.
         /// @par This option is useful when the ShaderVisitor is run on a "live" subgraph that may have already been submitted for rendering.
@@ -57,8 +50,6 @@ namespace Shader
 
     private:
         bool mForceShaders;
-        bool mClampLighting;
-        bool mForcePerPixelLighting;
         bool mAllowedToModifyStateSets;
 
         bool mAutoUseNormalMaps;

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -161,8 +161,7 @@ std::vector<osg::ref_ptr<osg::StateSet> > ChunkManager::createPasses(float chunk
 
     float blendmapScale = mStorage->getBlendmapScale(chunkSize);
 
-    return ::Terrain::createPasses(useShaders, mSceneManager->getForcePerPixelLighting(),
-                                     mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), layers, blendmapTextures, blendmapScale, blendmapScale);
+    return ::Terrain::createPasses(useShaders, &mSceneManager->getShaderManager(), layers, blendmapTextures, blendmapScale, blendmapScale);
 }
 
 osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Vec2f &chunkCenter, int lod, unsigned int lodFlags)
@@ -217,8 +216,7 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
         layer.mDiffuseMap = compositeMap->mTexture;
         layer.mParallax = false;
         layer.mSpecular = false;
-        geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getClampLighting(), mSceneManager->getForcePerPixelLighting(),
-                                                    mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
+        geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
     }
     else
     {

--- a/components/terrain/material.cpp
+++ b/components/terrain/material.cpp
@@ -153,7 +153,7 @@ namespace
 
 namespace Terrain
 {
-    std::vector<osg::ref_ptr<osg::StateSet> > createPasses(bool useShaders, bool forcePerPixelLighting, bool clampLighting, Shader::ShaderManager* shaderManager, const std::vector<TextureLayer> &layers,
+    std::vector<osg::ref_ptr<osg::StateSet> > createPasses(bool useShaders, Shader::ShaderManager* shaderManager, const std::vector<TextureLayer> &layers,
                                                            const std::vector<osg::ref_ptr<osg::Texture2D> > &blendmaps, int blendmapScale, float layerTileSize)
     {
         std::vector<osg::ref_ptr<osg::StateSet> > passes;
@@ -211,8 +211,6 @@ namespace Terrain
                 }
 
                 Shader::ShaderManager::DefineMap defineMap;
-                defineMap["forcePPL"] = forcePerPixelLighting ? "1" : "0";
-                defineMap["clamp"] = clampLighting ? "1" : "0";
                 defineMap["normalMap"] = (it->mNormalMap) ? "1" : "0";
                 defineMap["blendMap"] = !firstLayer ? "1" : "0";
                 defineMap["specularMap"] = it->mSpecular ? "1" : "0";
@@ -223,7 +221,7 @@ namespace Terrain
                 if (!vertexShader || !fragmentShader)
                 {
                     // Try again without shader. Error already logged by above
-                    return createPasses(false, forcePerPixelLighting, clampLighting, shaderManager, layers, blendmaps, blendmapScale, layerTileSize);
+                    return createPasses(false, shaderManager, layers, blendmaps, blendmapScale, layerTileSize);
                 }
 
                 stateset->setAttributeAndModes(shaderManager->getProgram(vertexShader, fragmentShader));

--- a/components/terrain/material.hpp
+++ b/components/terrain/material.hpp
@@ -26,7 +26,7 @@ namespace Terrain
         bool mSpecular;
     };
 
-    std::vector<osg::ref_ptr<osg::StateSet> > createPasses(bool useShaders, bool forcePerPixelLighting, bool clampLighting, Shader::ShaderManager* shaderManager,
+    std::vector<osg::ref_ptr<osg::StateSet> > createPasses(bool useShaders, Shader::ShaderManager* shaderManager,
                                                            const std::vector<TextureLayer>& layers,
                                                            const std::vector<osg::ref_ptr<osg::Texture2D> >& blendmaps, int blendmapScale, float layerTileSize);
 


### PR DESCRIPTION
[Bug 4869](https://gitlab.com/OpenMW/openmw/issues/4869).

This makes use of the recently added global shader defines to clean up some unnecessary code. I had to leave scene manager get/set methods for lighting clamping in because the terrain needs it to decide whether to use shaders anyway. Maybe something more clever could be figured out later.

Looks like AnyOldName3 gave his blessing to this commit.