### PR TITLE
Update AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -199,6 +199,7 @@ Programmers
     viadanna
     Vincent Heuken
     Vladimir Panteleev (CyberShadow)
+    Wang Ryu (bzzt)
     Will Herrmann (Thunderforge)
     vocollapse
     xyzz

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -26,17 +26,21 @@ Programmers
     Allofich
     Andrei Kortunov (akortunov)
     AnyOldName3
-    Aussiemon
-    Austin Salgat (Salgat)
+    Ardekantur
+    Armin Preiml
     Artem Kotsynyak (greye)
     artemutin
     Arthur Moore (EmperorArthur)
     Assumeru
     athile
+    Aussiemon
+    Austin Salgat (Salgat)
     Ben Shealy (bentsherman)
+    Berulacks
     Bret Curtis (psi29a)
     Britt Mathis (galdor557)
     Capostrophic
+    Carl Maxwell
     cc9cii
     Cédric Mocquillon
     Chris Boyce (slothlife)
@@ -47,6 +51,7 @@ Programmers
     DanielVukelich
     darkf
     David Cernat (davidcernat)
+    Declan Millar (declan-millar)
     devnexen
     Dieho
     Dmitry Shkurskiy (endorph)
@@ -54,10 +59,11 @@ Programmers
     Douglas Mencken (dougmencken)
     dreamer-dead
     David Teviotdale (dteviot)
+    Diggory Hardy
+    Dmitry Marakasov (AMDmi3)
     Edmondo Tommasina (edmondo)
     Eduard Cot (trombonecot)
     Eli2
-    elsid
     Emanuel Guével (potatoesmaster)
     eroen
     escondida
@@ -67,13 +73,19 @@ Programmers
     Finbar Crago (finbar-crago)
     Florian Weber (Florianjw)
     Gašper Sedej
+    Gohan1989
     gugus/gus
+    guidoj
     Hallfaer Tuilinn
     Haoda Wang (h313)
     hristoast
     Internecine
-    Jacob Essex (Yacoby)    
+    Jackerty
+    Jacob Essex (Yacoby)
     Jake Westrip (16bitint)
+    James Carty (MrTopCat)
+    Jan-Peter Nilsson (peppe)
+    Jan Borsodi (am0s)
     Jason Hooks (jhooks)
     jeaye
     Jeffrey Haines (Jyby)
@@ -84,6 +96,7 @@ Programmers
     John Blomberg (fstp)
     Jordan Ayers
     Jordan Milne
+    Josua Grawitter
     Jules Blok (Armada651)
     julianko
     Julien Voisin (jvoisin/ap0)
@@ -95,9 +108,10 @@ Programmers
     lazydev
     Leon Krieg (lkrieg)
     Leon Saunders (emoose)
-    Łukasz Gołębiewski (lukago)
     logzero
     lohikaarme
+    Lordrea
+    Łukasz Gołębiewski (lukago)
     Lukasz Gromanowski (lgro)
     Manuel Edelmann (vorenon)
     Marc Bouvier (CramitDeFrog)
@@ -112,6 +126,7 @@ Programmers
     Michael Hogan (Xethik)
     Michael Mc Donnell
     Michael Papageorgiou (werdanith)
+    Michał Ściubidło (mike-sc)
     Michał Bień (Glorf)
     Michał Moroz (dragonee)
     Miloslav Číž (drummyfish)
@@ -123,15 +138,20 @@ Programmers
     Nathan Jeffords (blunted2night)
     NeveHanter
     Nialsy
+    Nicolay Korslund
     Nikolay Kasyanov (corristo)
     nobrakal
     Nolan Poe (nopoe)
     Oleg Chkan (mrcheko)
     Paul Cercueil (pcercuei)
     Paul McElroy (Greendogo)
+    pchan3
+    Perry Hugh
+    Phillip Andrews (PhillipAnd)
     Pi03k
     Pieter van der Kloet (pvdk)
     pkubik
+    PLkolek
     PlutonicOverkill
     Radu-Marius Popovici (rpopovici)
     Rafael Moura (dhustkoder)
@@ -145,11 +165,12 @@ Programmers
     Roman Proskuryakov (kpp)
     Roman Siromakha (elsid)
     Sandy Carter (bwrsandman)
-    Scott Howard
+    Scott Howard (maqifrnswa)
     scrawl
     Sebastian Wick (swick)
     Sergey Fukanchik
-    Sergey Shambir
+    Sergey Shambir (sergey-shambir)
+    sergoz
     ShadowRadiance
     Siimacore
     sir_herrbatka
@@ -158,24 +179,32 @@ Programmers
     spycrab
     Stefan Galowicz (bogglez)
     Stanislav Bobrov (Jiub)
+    Stanislaw Halik (sthalik)
+    Star-Demon
     stil-t
+    Stomy
     svaante
     Sylvain Thesnieres (Garvek)
     t6
     terrorfisch
     thegriglat
     Thomas Luppi (Digmaster)
+    tlmullis
     tri4ng1e
-    unelsson
-    Will Herrmann (Thunderforge)
+    Thoronador
     Tom Mason (wheybags)
     Torben Leif Carrington (TorbenC)
+    unelsson
+    uramer
     viadanna
     Vincent Heuken
+    Vladimir Panteleev (CyberShadow)
+    Will Herrmann (Thunderforge)
     vocollapse
+    xyzz
     Yohaulticetl
+    Yuri Krupenin
     zelurker
-    James Carty (MrTopCat)
 
 Documentation
 -------------
@@ -184,11 +213,12 @@ Documentation
     Alejandro Sanchez (HiPhish)
     Bodillium
     Bret Curtis (psi29a)
-    David Walley (Loriel)
     Cramal
+    David Walley (Loriel)
+    Diego Crespo
+    Joakim Berg (lysol90)
     Ryan Tucker (Ravenwing)
     sir_herrbatka
-    Diego Crespo
 
 Packagers
 ---------
@@ -207,13 +237,19 @@ Public Relations and Translations
 
     Artem Kotsynyak (greye) - Russian News Writer
     Dawid Lakomy (Vedyimyn) - Polish News Writer
+    ElderTroll - Release Manager
     Jim Clauwaert (Zedd) - Public Outreach
+    juanmnzsk8 - Spanish News Writer
     Julien Voisin (jvoisin/ap0) - French News Writer
+    Kingpix - Italian News Writer
     Lukasz Gromanowski (lgro) - English News Writer
     Martin Otto (Atahualpa) - Podcaster, Public Outreach, German Translator
     Mickey Lyle (raevol) - Release Manager
+    Nekochan - English News Writer
+    penguinroad - Indonesian News Writer
     Pithorn - Chinese News Writer
     sir_herrbatka - Polish News Writer
+    spyboot - German Translator
     Tom Koenderink (Okulo) - English News Writer
 
 Website
@@ -242,34 +278,6 @@ Artwork
     Necrod - OpenMW Logo
     Mickey Lyle (raevol) - Wordpress Theme
     Tom Koenderink (Okulo), SirHerrbatka, crysthala, Shnatsel, Lamoot - OpenMW Editor Icons
-
-Inactive Contributors
----------------------
-
-    Ardekantur
-    Armin Preiml
-    Berulacks
-    Carl Maxwell
-    Diggory Hardy
-    Dmitry Marakasov (AMDmi3)
-    ElderTroll
-    guidoj
-    Jan-Peter Nilsson (peppe)
-    Jan Borsodi
-    Josua Grawitter
-    juanmnzsk8
-    Kingpix
-    Lordrea
-    Michal Sciubidlo
-    Nicolay Korslund
-    Nekochan
-    pchan3
-    penguinroad
-    sergoz
-    spyboot
-    Star-Demon
-    Thoronador
-    Yuri Krupenin
 
 Additional Credits
 ------------------


### PR DESCRIPTION
Summary of changes:
1. Add some missing contributors (Stomy, uramer, Perry Hugh, CyberShadow, xyzz and some others - programmers, lysol90 - doc writer).
2. elsid was added twice, the duplicate entry was removed
3. Fix ordering in some places
4. Move users from "Inactive Contributors" to other sections based on commits history.
In its current state this section is sorely outdated and misleading since 80% of people in other sections are inactive too.