### PR TITLE
Fix raki creatures in Skyrim: Home of the Nords (bug #4810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
     Bug #4803: Stray special characters before begin statement break script compilation
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
+    Bug #4810: Raki creature broken in OpenMW
     Bug #4813: Creatures with known file but no "Sound Gen Creature" assigned use default sounds
     Bug #4815: "Finished" journal entry with lower index doesn't close journal, SetJournalIndex closes journal
     Bug #4820: Spell absorption is broken

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -843,9 +843,9 @@ namespace MWRender
 
         if (!mAccumRoot)
         {
-            NodeMap::const_iterator found = nodeMap.find("root bone");
+            NodeMap::const_iterator found = nodeMap.find("bip01");
             if (found == nodeMap.end())
-                found = nodeMap.find("bip01");
+                found = nodeMap.find("root bone");
 
             if (found != nodeMap.end())
                 mAccumRoot = found->second;


### PR DESCRIPTION
[Bug 4810.](https://gitlab.com/OpenMW/openmw/issues/4810)

So basically raki creature model has a bip01 node under the 'root bone' node and such construction somehow causes movement accumulation not to work properly and subsequently breaks animations. Apparently bip01 needs to have higher priority than root bone in the movement accumulation root node assignment code to make it work, so I switched the node names around and now movement accumulation for dear, sweet, precious rakis works fine without breaking movement accumulation for the original reason why 'root bone' node name was considered - Correct UV Mudcrabs mudcrab model - or any vanilla creature.

'Root bone' node cannot be the root node. Both OpenMW and Morrowind drop it from the model.