### PR TITLE
Fix ODR violation for VDSMCameraCullCallback

### DIFF
--- a/components/sceneutil/mwshadowtechnique.cpp
+++ b/components/sceneutil/mwshadowtechnique.cpp
@@ -25,6 +25,8 @@
 
 #include <sstream>
 
+namespace {
+
 using namespace osgShadow;
 using namespace SceneUtil;
 
@@ -330,6 +332,8 @@ void VDSMCameraCullCallback::operator()(osg::Node* node, osg::NodeVisitor* nv)
 
     _projectionMatrix = cv->getProjectionMatrix();
 }
+
+} // namespace
 
 MWShadowTechnique::ComputeLightSpaceBounds::ComputeLightSpaceBounds(osg::Viewport* viewport, const osg::Matrixd& projectionMatrix, osg::Matrixd& viewMatrix) :
     osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ACTIVE_CHILDREN)


### PR DESCRIPTION
This class is also defined in OpenSceneGraph at global namespace.

ODR violation is an undefined behavior. See https://en.cppreference.com/w/cpp/language/definition .

ASAN report:
```
=================================================================
==14531==ERROR: AddressSanitizer: odr-violation (0x563832d5f620):
  [1] size=624 'vtable for VDSMCameraCullCallback' /home/elsid/dev/openmw/components/sceneutil/mwshadowtechnique.cpp
  [2] size=624 'vtable for VDSMCameraCullCallback' /home/elsid/dev/OpenSceneGraph/src/osgShadow/ViewDependentShadowMap.cpp
These globals were registered at these points:
  [1]:
    #0 0x56383141ecf1 in __asan_register_globals.part.13 (/home/elsid/dev/openmw/build/clang/asan/openmw+0xdffcf1)
    #1 0x56383220cabb in asan.module_ctor (/home/elsid/dev/openmw/build/clang/asan/openmw+0x1bedabb)

  [2]:
    #0 0x56383141ecf1 in __asan_register_globals.part.13 (/home/elsid/dev/openmw/build/clang/asan/openmw+0xdffcf1)
    #1 0x7f2b6636828b in asan.module_ctor (/home/elsid/dev/OpenSceneGraph/build/clang/asan/lib64/libosgShadow.so.130+0x1c228b)

==14531==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'vtable for VDSMCameraCullCallback' at /home/elsid/dev/openmw/components/sceneutil/mwshadowtechnique.cpp
==14531==ABORTING
```

This pr is just a fix for one simple problem. But I think `components/sceneutil/mwshadowtechnique.cpp` should be devided into multiple files and all symbols should be moved into some namespace. 2.5k lines is too much.