### PR TITLE
Support explicit limit of navmesh tiles for scene

### DIFF
--- a/apps/openmw_test_suite/detournavigator/navigator.cpp
+++ b/apps/openmw_test_suite/detournavigator/navigator.cpp
@@ -61,6 +61,7 @@ namespace
             mSettings.mMaxSmoothPathSize = 1024;
             mSettings.mTrianglesPerChunk = 256;
             mSettings.mMaxPolys = 4096;
+            mSettings.mMaxTilesNumber = 512;
             mNavigator.reset(new NavigatorImpl(mSettings));
         }
     };

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -32,11 +32,11 @@ namespace DetourNavigator
     {
         switch (value)
         {
-            case UpdateNavMeshStatus::ignore:
+            case UpdateNavMeshStatus::ignored:
                 return stream << "ignore";
             case UpdateNavMeshStatus::removed:
                 return stream << "removed";
-            case UpdateNavMeshStatus::add:
+            case UpdateNavMeshStatus::added:
                 return stream << "add";
             case UpdateNavMeshStatus::replaced:
                 return stream << "replaced";

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -14,16 +14,6 @@ namespace
     {
         return std::abs(lhs.x() - rhs.x()) + std::abs(lhs.y() - rhs.y());
     }
-
-    std::tuple<ChangeType, int, int> makePriority(const TilePosition& position, const ChangeType changeType,
-                                                    const TilePosition& playerTile)
-    {
-        return std::make_tuple(
-            changeType,
-            getManhattanDistance(position, playerTile),
-            getManhattanDistance(position, TilePosition {0, 0})
-        );
-    }
 }
 
 namespace DetourNavigator
@@ -81,8 +71,18 @@ namespace DetourNavigator
         for (const auto& changedTile : changedTiles)
         {
             if (mPushed[agentHalfExtents].insert(changedTile.first).second)
-                mJobs.push(Job {agentHalfExtents, navMeshCacheItem, changedTile.first,
-                                makePriority(changedTile.first, changedTile.second, playerTile)});
+            {
+                Job job;
+
+                job.mAgentHalfExtents = agentHalfExtents;
+                job.mNavMeshCacheItem = navMeshCacheItem;
+                job.mChangedTile = changedTile.first;
+                job.mChangeType = changedTile.second;
+                job.mDistanceToPlayer = getManhattanDistance(changedTile.first, playerTile);
+                job.mDistanceToOrigin = getManhattanDistance(changedTile.first, TilePosition {0, 0});
+
+                mJobs.push(std::move(job));
+            }
         }
 
         log("posted ", mJobs.size(), " jobs");

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -87,7 +87,8 @@ namespace DetourNavigator
 
         log("posted ", mJobs.size(), " jobs");
 
-        mHasJob.notify_all();
+        if (!mJobs.empty())
+            mHasJob.notify_all();
     }
 
     void AsyncNavMeshUpdater::wait()

--- a/components/detournavigator/asyncnavmeshupdater.hpp
+++ b/components/detournavigator/asyncnavmeshupdater.hpp
@@ -50,11 +50,18 @@ namespace DetourNavigator
             osg::Vec3f mAgentHalfExtents;
             SharedNavMeshCacheItem mNavMeshCacheItem;
             TilePosition mChangedTile;
-            std::tuple<ChangeType, int, int> mPriority;
+            ChangeType mChangeType;
+            int mDistanceToPlayer;
+            int mDistanceToOrigin;
+
+            std::tuple<ChangeType, int, int> getPriority() const
+            {
+                return std::make_tuple(mChangeType, mDistanceToPlayer, mDistanceToOrigin);
+            }
 
             friend inline bool operator <(const Job& lhs, const Job& rhs)
             {
-                return lhs.mPriority > rhs.mPriority;
+                return lhs.getPriority() > rhs.getPriority();
             }
         };
 

--- a/components/detournavigator/asyncnavmeshupdater.hpp
+++ b/components/detournavigator/asyncnavmeshupdater.hpp
@@ -50,13 +50,14 @@ namespace DetourNavigator
             osg::Vec3f mAgentHalfExtents;
             SharedNavMeshCacheItem mNavMeshCacheItem;
             TilePosition mChangedTile;
+            unsigned mTryNumber;
             ChangeType mChangeType;
             int mDistanceToPlayer;
             int mDistanceToOrigin;
 
-            std::tuple<ChangeType, int, int> getPriority() const
+            std::tuple<unsigned, ChangeType, int, int> getPriority() const
             {
-                return std::make_tuple(mChangeType, mDistanceToPlayer, mDistanceToOrigin);
+                return std::make_tuple(mTryNumber, mChangeType, mDistanceToPlayer, mDistanceToOrigin);
             }
 
             friend inline bool operator <(const Job& lhs, const Job& rhs)
@@ -83,13 +84,15 @@ namespace DetourNavigator
 
         void process() throw();
 
-        void processJob(const Job& job);
+        bool processJob(const Job& job);
 
         boost::optional<Job> getNextJob();
 
         void writeDebugFiles(const Job& job, const RecastMesh* recastMesh) const;
 
         std::chrono::steady_clock::time_point setFirstStart(const std::chrono::steady_clock::time_point& value);
+
+        void repost(Job&& job);
     };
 }
 

--- a/components/detournavigator/makenavmesh.cpp
+++ b/components/detournavigator/makenavmesh.cpp
@@ -628,7 +628,7 @@ namespace DetourNavigator
             return removeTile();
         }
 
-        if (!shouldAddTile(changedTile, playerTile, params.maxTiles))
+        if (!shouldAddTile(changedTile, playerTile, std::min(settings.mMaxTilesNumber, params.maxTiles)))
         {
             log("ignore add tile: too far from player");
             return removeTile();

--- a/components/detournavigator/makenavmesh.cpp
+++ b/components/detournavigator/makenavmesh.cpp
@@ -464,6 +464,15 @@ namespace
             return *this;
         }
 
+        UpdateNavMeshStatusBuilder failed(bool value)
+        {
+            if (value)
+                set(UpdateNavMeshStatus::failed);
+            else
+                unset(UpdateNavMeshStatus::failed);
+            return *this;
+        }
+
         UpdateNavMeshStatus getResult() const
         {
             return mResult;
@@ -531,7 +540,7 @@ namespace
             if (removed)
                 locked->removeUsedTile(changedTile);
             log("failed to add tile with status=", WriteDtStatus {addStatus});
-            return UpdateNavMeshStatusBuilder().removed(removed).getResult();
+            return UpdateNavMeshStatusBuilder().removed(removed).failed((addStatus & DT_OUT_OF_MEMORY) != 0).getResult();
         }
     }
 }

--- a/components/detournavigator/makenavmesh.hpp
+++ b/components/detournavigator/makenavmesh.hpp
@@ -26,7 +26,14 @@ namespace DetourNavigator
         removed = 1 << 0,
         added = 1 << 1,
         replaced = removed | added,
+        failed = 1 << 2,
+        lost = removed | failed,
     };
+
+    inline bool isSuccess(UpdateNavMeshStatus value)
+    {
+        return (static_cast<unsigned>(value) & static_cast<unsigned>(UpdateNavMeshStatus::failed)) == 0;
+    }
 
     inline float getLength(const osg::Vec2i& value)
     {
@@ -41,7 +48,7 @@ namespace DetourNavigator
     inline bool shouldAddTile(const TilePosition& changedTile, const TilePosition& playerTile, int maxTiles)
     {
         const auto expectedTilesCount = std::ceil(osg::PI * osg::square(getDistance(changedTile, playerTile)));
-        return expectedTilesCount * 3 <= maxTiles;
+        return expectedTilesCount <= maxTiles;
     }
 
     NavMeshPtr makeEmptyNavMesh(const Settings& settings);

--- a/components/detournavigator/makenavmesh.hpp
+++ b/components/detournavigator/makenavmesh.hpp
@@ -20,12 +20,12 @@ namespace DetourNavigator
     class RecastMesh;
     struct Settings;
 
-    enum class UpdateNavMeshStatus
+    enum class UpdateNavMeshStatus : unsigned
     {
-        ignore,
-        removed,
-        add,
-        replaced
+        ignored = 0,
+        removed = 1 << 0,
+        added = 1 << 1,
+        replaced = removed | added,
     };
 
     inline float getLength(const osg::Vec2i& value)

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -157,7 +157,7 @@ namespace DetourNavigator
                 if (changedTiles->second.empty())
                     mChangedTiles.erase(changedTiles);
             }
-            const auto maxTiles = navMesh.getParams()->maxTiles;
+            const auto maxTiles = std::min(mSettings.mMaxTilesNumber, navMesh.getParams()->maxTiles);
             mRecastMeshManager.forEachTilePosition([&] (const TilePosition& tile)
             {
                 if (tilesToPost.count(tile))

--- a/components/detournavigator/navmeshtilescache.cpp
+++ b/components/detournavigator/navmeshtilescache.cpp
@@ -62,8 +62,8 @@ namespace DetourNavigator
             return Value();
 
         // TODO: use different function to make key to avoid unnecessary std::string allocation
-        const auto tile = tileValues->second.Map.find(makeNavMeshKey(recastMesh, offMeshConnections));
-        if (tile == tileValues->second.Map.end())
+        const auto tile = tileValues->second.mMap.find(makeNavMeshKey(recastMesh, offMeshConnections));
+        if (tile == tileValues->second.mMap.end())
             return Value();
 
         acquireItemUnsafe(tile->second);
@@ -96,7 +96,7 @@ namespace DetourNavigator
 
         const auto iterator = mFreeItems.emplace(mFreeItems.end(), agentHalfExtents, changedTile, navMeshKey);
         // TODO: use std::string_view or some alternative to avoid navMeshKey copy into both mFreeItems and mValues
-        const auto emplaced = mValues[agentHalfExtents][changedTile].Map.emplace(navMeshKey, iterator);
+        const auto emplaced = mValues[agentHalfExtents][changedTile].mMap.emplace(navMeshKey, iterator);
 
         if (!emplaced.second)
         {
@@ -125,16 +125,16 @@ namespace DetourNavigator
         if (tileValues == agentValues->second.end())
             return;
 
-        const auto value = tileValues->second.Map.find(item.mNavMeshKey);
-        if (value == tileValues->second.Map.end())
+        const auto value = tileValues->second.mMap.find(item.mNavMeshKey);
+        if (value == tileValues->second.mMap.end())
             return;
 
         mUsedNavMeshDataSize -= getSize(item);
         mFreeNavMeshDataSize -= getSize(item);
         mFreeItems.pop_back();
 
-        tileValues->second.Map.erase(value);
-        if (!tileValues->second.Map.empty())
+        tileValues->second.mMap.erase(value);
+        if (!tileValues->second.mMap.empty())
             return;
 
         agentValues->second.erase(tileValues);

--- a/components/detournavigator/navmeshtilescache.hpp
+++ b/components/detournavigator/navmeshtilescache.hpp
@@ -108,7 +108,7 @@ namespace DetourNavigator
 
         struct TileMap
         {
-            std::map<std::string, ItemIterator> Map;
+            std::map<std::string, ItemIterator> mMap;
         };
 
         std::mutex mMutex;

--- a/components/detournavigator/settings.cpp
+++ b/components/detournavigator/settings.cpp
@@ -24,6 +24,7 @@ namespace DetourNavigator
         navigatorSettings.mMaxEdgeLen = ::Settings::Manager::getInt("max edge len", "Navigator");
         navigatorSettings.mMaxNavMeshQueryNodes = ::Settings::Manager::getInt("max nav mesh query nodes", "Navigator");
         navigatorSettings.mMaxPolys = ::Settings::Manager::getInt("max polygons per tile", "Navigator");
+        navigatorSettings.mMaxTilesNumber = ::Settings::Manager::getInt("max tiles number", "Navigator");
         navigatorSettings.mMaxVertsPerPoly = ::Settings::Manager::getInt("max verts per poly", "Navigator");
         navigatorSettings.mRegionMergeSize = ::Settings::Manager::getInt("region merge size", "Navigator");
         navigatorSettings.mRegionMinSize = ::Settings::Manager::getInt("region min size", "Navigator");

--- a/components/detournavigator/settings.hpp
+++ b/components/detournavigator/settings.hpp
@@ -26,6 +26,7 @@ namespace DetourNavigator
         int mMaxEdgeLen = 0;
         int mMaxNavMeshQueryNodes = 0;
         int mMaxPolys = 0;
+        int mMaxTilesNumber = 0;
         int mMaxVertsPerPoly = 0;
         int mRegionMergeSize = 0;
         int mRegionMinSize = 0;

--- a/docs/source/reference/modding/settings/navigator.rst
+++ b/docs/source/reference/modding/settings/navigator.rst
@@ -24,6 +24,24 @@ Moving across external world, entering/exiting location produce nav mesh update.
 NPC and creatures may not be able to find path before nav mesh is built around them.
 Try to disable this if you want to have old fashioned AI which doesn't know where to go when you stand behind that stone and casting a firebolt.
 
+max tiles number
+----------------
+
+:Type:		integer
+:Range:		>= 0
+:Default:	512
+
+Number of tiles at nav mesh.
+Nav mesh covers circle area around player.
+This option allows to set an explicit limit for nav mesh size, how many tiles should fit into circle.
+If actor is inside this area it able to find path over nav mesh.
+Increasing this value may decrease performance.
+
+.. note::
+    Don't expect infinite nav mesh size increasing.
+    This condition is always true: ``max tiles number * max polygons per tile <= 4194304``.
+    It's a limitation of `Recastnavigation <https://github.com/recastnavigation/recastnavigation>`_ library.
+
 Advanced settings
 *****************
 
@@ -321,6 +339,12 @@ max polygons per tile
 Maximum number of polygons per nav mesh tile. Maximum number of nav mesh tiles depends on
 this value. 22 bits is a limit to store both tile identifier and polygon identifier (tiles = 2^(22 - log2(polygons))).
 See `recastnavigation <https://github.com/recastnavigation/recastnavigation>`_ for more details.
+
+.. Warning::
+    Lower value may lead to ignored world geometry on nav mesh.
+    Greater value will reduce number of nav mesh tiles.
+    This condition is always true: ``max tiles number * max polygons per tile <= 4194304``.
+    It's a limitation of `Recastnavigation <https://github.com/recastnavigation/recastnavigation>`_ library.
 
 max verts per poly
 ------------------

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -670,6 +670,9 @@ enable nav mesh render = false
 # Render agents paths (true, false)
 enable agents paths render = false
 
+# Max number of navmesh tiles (value >= 0)
+max tiles number = 512
+
 [Shadows]
 
 # Enable or disable shadows. Bear in mind that this will force OpenMW to use shaders as if "[Shaders]/force shaders" was set to true.


### PR DESCRIPTION
To allow player limit number of tiles new option is added. Now it is possible to have number of tiles at scene equal to physical limit without lost tiles.

Condition to check whether tile should be added to navmesh is following:
```c++
std::ceil(osg::PI * osg::square(std::ceil(getDistance(tilePosition, playerTile)))) * 3
   <= maxTiles
```
 `maxTiles`  is a physical limit of navmesh tiles number (1024 with current default settings).
Multiplication by 3 is required to left some space for new tiles. If player is moving and new tile is added before any other is removed, add may fail when there is no more space in navmesh and tile will be lost.  This pr removes multiplication by 3 to avoid wasted space. Instead it adds job reposting to avoid lost tiles. If `dtNavMesh::addTile` rejected new tile because there is no more space, job is reposted into the queue with reduced priority. Number of reposts is limited.
