### PR TITLE
Use recastnavigation 64bit polyref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,9 @@ if (WIN32)
     add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
 endif()
 
+# Use recastnavigation 64bit polygon reference
+add_definitions(-D DT_POLYREF64)
+
 if (NOT WIN32 AND BUILD_WIZARD) # windows users can just run the morrowind installer
     find_package(LIBUNSHIELD REQUIRED) # required only for non win32 when building openmw-wizard
     set(OPENMW_USE_UNSHIELD TRUE)

--- a/apps/openmw_test_suite/detournavigator/navigator.cpp
+++ b/apps/openmw_test_suite/detournavigator/navigator.cpp
@@ -60,8 +60,8 @@ namespace
             mSettings.mMaxPolygonPathSize = 1024;
             mSettings.mMaxSmoothPathSize = 1024;
             mSettings.mTrianglesPerChunk = 256;
-            mSettings.mMaxPolys = 4096;
-            mSettings.mMaxTilesNumber = 512;
+            mSettings.mMaxPolys = 8192;
+            mSettings.mMaxTilesNumber = 4096;
             mNavigator.reset(new NavigatorImpl(mSettings));
         }
     };

--- a/components/detournavigator/makenavmesh.cpp
+++ b/components/detournavigator/makenavmesh.cpp
@@ -549,22 +549,12 @@ namespace DetourNavigator
 {
     NavMeshPtr makeEmptyNavMesh(const Settings& settings)
     {
-        // Max tiles and max polys affect how the tile IDs are caculated.
-        // There are 22 bits available for identifying a tile and a polygon.
-        const int polysAndTilesBits = 22;
-        const auto polysBits = getMinValuableBitsNumber(settings.mMaxPolys);
-
-        if (polysBits >= polysAndTilesBits)
-            throw InvalidArgument("Too many polygons per tile");
-
-        const auto tilesBits = polysAndTilesBits - polysBits;
-
         dtNavMeshParams params;
         std::fill_n(params.orig, 3, 0.0f);
         params.tileWidth = settings.mTileSize * settings.mCellSize;
         params.tileHeight = settings.mTileSize * settings.mCellSize;
-        params.maxTiles = 1 << tilesBits;
-        params.maxPolys = 1 << polysBits;
+        params.maxTiles = settings.mMaxTilesNumber;
+        params.maxPolys = settings.mMaxPolys;
 
         NavMeshPtr navMesh(dtAllocNavMesh(), &dtFreeNavMesh);
         const auto status = navMesh->init(&params);
@@ -628,7 +618,7 @@ namespace DetourNavigator
             return removeTile();
         }
 
-        if (!shouldAddTile(changedTile, playerTile, std::min(settings.mMaxTilesNumber, params.maxTiles)))
+        if (!shouldAddTile(changedTile, playerTile, params.maxTiles))
         {
             log("ignore add tile: too far from player");
             return removeTile();

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -157,7 +157,7 @@ namespace DetourNavigator
                 if (changedTiles->second.empty())
                     mChangedTiles.erase(changedTiles);
             }
-            const auto maxTiles = std::min(mSettings.mMaxTilesNumber, navMesh.getParams()->maxTiles);
+            const auto maxTiles = navMesh.getParams()->maxTiles;
             mRecastMeshManager.forEachTilePosition([&] (const TilePosition& tile)
             {
                 if (tilesToPost.count(tile))

--- a/docs/source/reference/modding/settings/navigator.rst
+++ b/docs/source/reference/modding/settings/navigator.rst
@@ -28,19 +28,14 @@ max tiles number
 ----------------
 
 :Type:		integer
-:Range:		>= 0
-:Default:	512
+:Range:		0 <= ``max tiles number`` < 268435456
+:Default:	4096
 
 Number of tiles at nav mesh.
 Nav mesh covers circle area around player.
 This option allows to set an explicit limit for nav mesh size, how many tiles should fit into circle.
 If actor is inside this area it able to find path over nav mesh.
 Increasing this value may decrease performance.
-
-.. note::
-    Don't expect infinite nav mesh size increasing.
-    This condition is always true: ``max tiles number * max polygons per tile <= 4194304``.
-    It's a limitation of `Recastnavigation <https://github.com/recastnavigation/recastnavigation>`_ library.
 
 Advanced settings
 *****************
@@ -333,18 +328,13 @@ max polygons per tile
 ---------------------
 
 :Type:		integer
-:Range:		2^n, 0 < n < 22
-:Default:	4096
+:Range:		0 <= ``max polygons per tile`` < 1048576
+:Default:	8192
 
-Maximum number of polygons per nav mesh tile. Maximum number of nav mesh tiles depends on
-this value. 22 bits is a limit to store both tile identifier and polygon identifier (tiles = 2^(22 - log2(polygons))).
-See `recastnavigation <https://github.com/recastnavigation/recastnavigation>`_ for more details.
+Maximum number of polygons per nav mesh tile.
 
 .. Warning::
     Lower value may lead to ignored world geometry on nav mesh.
-    Greater value will reduce number of nav mesh tiles.
-    This condition is always true: ``max tiles number * max polygons per tile <= 4194304``.
-    It's a limitation of `Recastnavigation <https://github.com/recastnavigation/recastnavigation>`_ library.
 
 max verts per poly
 ------------------

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -611,10 +611,8 @@ max edge len = 12
 # Maximum number of search nodes. (0 < value <= 65535)
 max nav mesh query nodes = 2048
 
-# Maximum number of polygons per navmesh tile (value = 2^n, 0 < n < 22). Maximum number of navmesh tiles depends on
-# this value. 22 bits is a limit to store both tile identifier and polygon identifier (tiles = 2^(22 - log2(polygons))).
-# See recastnavigation for more details.
-max polygons per tile = 4096
+# Maximum number of polygons per navmesh tile. (0 <= value < 1048576)
+max polygons per tile = 8192
 
 # The maximum number of vertices allowed for polygons generated during the contour to polygon conversion process. (value >= 3)
 max verts per poly = 6
@@ -670,8 +668,8 @@ enable nav mesh render = false
 # Render agents paths (true, false)
 enable agents paths render = false
 
-# Max number of navmesh tiles (value >= 0)
-max tiles number = 512
+# Max number of navmesh tiles (0 <= value < 268435456)
+max tiles number = 4096
 
 [Shadows]
 


### PR DESCRIPTION
This allows to have up to `2**28 = 268435456` navmesh tiles and `2**20 = 1048576` polygons per each tile on scene.

Allow to cover all cells with `exterior cell load distance = 3`: https://streamable.com/2i02r
And with some more tweaks `aitravel` works for large distances: https://streamable.com/td24o