### PR TITLE
Minor preloading improvements

### DIFF
--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -381,7 +381,7 @@ namespace MWWorld
         {
             for (unsigned int i=0; i<mTerrainViews.size() && i<mPreloadPositions.size() && !mAbort; ++i)
             {
-                mWorld->preload(mTerrainViews[i], mPreloadPositions[i]);
+                mWorld->preload(mTerrainViews[i], mPreloadPositions[i], mAbort);
                 mTerrainViews[i]->reset(0);
             }
         }

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -531,6 +531,8 @@ namespace Resource
 
             if (mIncrementalCompileOperation)
                 mIncrementalCompileOperation->add(loaded);
+            else
+                loaded->getBound();
 
             mCache->addEntryToObjectCache(normalized, loaded);
             return loaded;
@@ -543,6 +545,12 @@ namespace Resource
         mVFS->normalizeFilename(normalized);
 
         osg::ref_ptr<osg::Node> node = createInstance(normalized);
+
+        // Note: osg::clone() does not calculate bound volumes.
+        // Do it immediately, otherwise we will need to update them for all objects
+        // during first update traversal, what may lead to stuttering during cell transitions
+        node->getBound();
+
         mInstanceCache->addEntryToObjectCache(normalized, node.get());
         return node;
     }

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -478,14 +478,14 @@ View* QuadTreeWorld::createView()
     return new ViewData;
 }
 
-void QuadTreeWorld::preload(View *view, const osg::Vec3f &eyePoint)
+void QuadTreeWorld::preload(View *view, const osg::Vec3f &eyePoint, std::atomic<bool> &abort)
 {
     ensureQuadTreeBuilt();
 
     ViewData* vd = static_cast<ViewData*>(view);
     traverse(mRootNode.get(), vd, nullptr, mRootNode->getLodCallback(), eyePoint, false);
 
-    for (unsigned int i=0; i<vd->getNumEntries(); ++i)
+    for (unsigned int i=0; i<vd->getNumEntries() && !abort; ++i)
     {
         ViewData::Entry& entry = vd->getEntry(i);
         loadRenderingNode(entry, vd, mVertexLodMod, mChunkManager.get());

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -30,7 +30,7 @@ namespace Terrain
         void cacheCell(View *view, int x, int y);
 
         View* createView();
-        void preload(View* view, const osg::Vec3f& eyePoint);
+        void preload(View* view, const osg::Vec3f& eyePoint, std::atomic<bool>& abort);
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats);
 

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -5,6 +5,7 @@
 #include <osg/Referenced>
 #include <osg/Vec3f>
 
+#include <atomic>
 #include <memory>
 #include <set>
 
@@ -93,7 +94,7 @@ namespace Terrain
         virtual View* createView() { return nullptr; }
 
         /// @note Thread safe, as long as you do not attempt to load into the same view from multiple threads.
-        virtual void preload(View* view, const osg::Vec3f& eyePoint) {}
+        virtual void preload(View* view, const osg::Vec3f& eyePoint, std::atomic<bool>& abort) {}
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) {}
 


### PR DESCRIPTION
1. Allow to interrupt terrain preloading if we set an mAbort flag for this cell.
2. Calculate bound volumes immediately when we cache instances to do not do it for all cached instances during first update traversal in the new cell.