### PR TITLE
Some more improvements from bzzt's branch

### DIFF
--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -158,7 +158,7 @@ namespace ESMTerrain
         normal.normalize();
     }
 
-    void Storage::fixColour (osg::Vec4f& color, int cellX, int cellY, int col, int row, LandCache& cache)
+    void Storage::fixColour (osg::Vec4ub& color, int cellX, int cellY, int col, int row, LandCache& cache)
     {
         if (col == ESM::Land::LAND_SIZE-1)
         {
@@ -175,22 +175,22 @@ namespace ESMTerrain
         const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VCLR) : 0;
         if (data)
         {
-            color.r() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3] / 255.f;
-            color.g() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+1] / 255.f;
-            color.b() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+2] / 255.f;
+            color.r() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3];
+            color.g() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+1];
+            color.b() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+2];
         }
         else
         {
-            color.r() = 1;
-            color.g() = 1;
-            color.b() = 1;
+            color.r() = 255;
+            color.g() = 255;
+            color.b() = 255;
         }
     }
 
     void Storage::fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
                                             osg::ref_ptr<osg::Vec3Array> positions,
                                             osg::ref_ptr<osg::Vec3Array> normals,
-                                            osg::ref_ptr<osg::Vec4Array> colours)
+                                            osg::ref_ptr<osg::Vec4ubArray> colours)
     {
         // LOD level n means every 2^n-th vertex is kept
         size_t increment = static_cast<size_t>(1) << lodLevel;
@@ -207,7 +207,7 @@ namespace ESMTerrain
         colours->resize(numVerts*numVerts);
 
         osg::Vec3f normal;
-        osg::Vec4f color;
+        osg::Vec4ub color;
 
         float vertY = 0;
         float vertX = 0;
@@ -295,20 +295,20 @@ namespace ESMTerrain
                         if (colourData)
                         {
                             for (int i=0; i<3; ++i)
-                                color[i] = colourData->mColours[srcArrayIndex+i] / 255.f;
+                                color[i] = colourData->mColours[srcArrayIndex+i];
                         }
                         else
                         {
-                            color.r() = 1;
-                            color.g() = 1;
-                            color.b() = 1;
+                            color.r() = 255;
+                            color.g() = 255;
+                            color.b() = 255;
                         }
 
                         // Unlike normals, colors mostly connect seamlessly between cells, but not always...
                         if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
                             fixColour(color, cellX, cellY, col, row, cache);
 
-                        color.a() = 1;
+                        color.a() = 255;
 
                         (*colours)[static_cast<unsigned int>(vertX*numVerts + vertY)] = color;
 

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -46,19 +46,6 @@ namespace ESMTerrain
     {
     }
 
-    const ESM::Land::LandData *LandObject::getData(int flags) const
-    {
-        if ((mData.mDataLoaded & flags) != flags)
-            return nullptr;
-        return &mData;
-    }
-
-    int LandObject::getPlugin() const
-    {
-        return mLand->mPlugin;
-    }
-
-
     const float defaultHeight = ESM::Land::DEFAULT_HEIGHT;
 
     Storage::Storage(const VFS::Manager *vfs, const std::string& normalMapPattern, const std::string& normalHeightMapPattern, bool autoUseNormalMaps, const std::string& specularMapPattern, bool autoUseSpecularMaps)

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -29,8 +29,17 @@ namespace ESMTerrain
 
         META_Object(ESMTerrain, LandObject)
 
-        const ESM::Land::LandData* getData(int flags) const;
-        int getPlugin() const;
+        inline const ESM::Land::LandData* getData(int flags) const
+        {
+            if ((mData.mDataLoaded & flags) != flags)
+                return nullptr;
+            return &mData;
+        }
+
+        inline int getPlugin() const
+        {
+            return mLand->mPlugin;
+        }
 
     private:
         const ESM::Land* mLand;
@@ -105,21 +114,20 @@ namespace ESMTerrain
     private:
         const VFS::Manager* mVFS;
 
-        void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
-        void fixColour (osg::Vec4ub& colour, int cellX, int cellY, int col, int row, LandCache& cache);
-        void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
+        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
+        inline void fixColour (osg::Vec4ub& colour, int cellX, int cellY, int col, int row, LandCache& cache);
+        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
 
-        float getVertexHeight (const ESM::Land::LandData* data, int x, int y);
+        inline float getVertexHeight (const ESM::Land::LandData* data, int x, int y);
 
-        const LandObject* getLand(int cellX, int cellY, LandCache& cache);
+        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache);
 
         // Since plugins can define new texture palettes, we need to know the plugin index too
         // in order to retrieve the correct texture name.
         // pair  <texture id, plugin id>
         typedef std::pair<short, short> UniqueTextureId;
 
-        UniqueTextureId getVtexIndexAt(int cellX, int cellY,
-                                               int x, int y, LandCache&);
+        inline UniqueTextureId getVtexIndexAt(int cellX, int cellY, int x, int y, LandCache&);
         std::string getTextureName (UniqueTextureId id);
 
         std::map<std::string, Terrain::LayerInfo> mLayerInfoMap;

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -75,7 +75,7 @@ namespace ESMTerrain
         virtual void fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
                                 osg::ref_ptr<osg::Vec3Array> positions,
                                 osg::ref_ptr<osg::Vec3Array> normals,
-                                osg::ref_ptr<osg::Vec4Array> colours);
+                                osg::ref_ptr<osg::Vec4ubArray> colours);
 
         /// Create textures holding layer blend values for a terrain chunk.
         /// @note The terrain chunk shouldn't be larger than one cell since otherwise we might
@@ -106,7 +106,7 @@ namespace ESMTerrain
         const VFS::Manager* mVFS;
 
         void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
-        void fixColour (osg::Vec4f& colour, int cellX, int cellY, int col, int row, LandCache& cache);
+        void fixColour (osg::Vec4ub& colour, int cellX, int cellY, int col, int row, LandCache& cache);
         void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
 
         float getVertexHeight (const ESM::Land::LandData* data, int x, int y);

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -172,7 +172,8 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
 
     osg::ref_ptr<osg::Vec3Array> positions (new osg::Vec3Array);
     osg::ref_ptr<osg::Vec3Array> normals (new osg::Vec3Array);
-    osg::ref_ptr<osg::Vec4Array> colors (new osg::Vec4Array);
+    osg::ref_ptr<osg::Vec4ubArray> colors (new osg::Vec4ubArray);
+    colors->setNormalize(true);
 
     osg::ref_ptr<osg::VertexBufferObject> vbo (new osg::VertexBufferObject);
     positions->setVertexBufferObject(vbo);

--- a/components/terrain/storage.hpp
+++ b/components/terrain/storage.hpp
@@ -52,7 +52,7 @@ namespace Terrain
         virtual void fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
                                 osg::ref_ptr<osg::Vec3Array> positions,
                                 osg::ref_ptr<osg::Vec3Array> normals,
-                                osg::ref_ptr<osg::Vec4Array> colours) = 0;
+                                osg::ref_ptr<osg::Vec4ubArray> colours) = 0;
 
         typedef std::vector<osg::ref_ptr<osg::Image> > ImageVector;
         /// Create textures holding layer blend values for a terrain chunk.


### PR DESCRIPTION
I've grabbed some more mostly no-brainer stuff from bzzt's branch that is mainly related to esmterrain/storage.cpp file.

1. Vertex colors data type matches the source data. Right now they are expressed in floating point numbers in [0, 1] range even though the input is 4 bytes, one per each channel. Through OpenGL normalization byte array can be used instead.
2. A bunch of functions was inlined. According to bzzt it leads to 17% faster filling of vertex buffers (important in terrain chunk creation).