### PR TITLE
[0.45 regression] Fix AI regressions

### DIFF
--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -170,7 +170,7 @@ namespace MWMechanics
 
             float rating = rateEffects(enchantment->mEffects, actor, enemy);
 
-            rating *= 2; // prefer rechargable magic items over spells
+            rating *= 1.25f; // prefer rechargable magic items over spells
             return rating;
         }
 

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -127,7 +127,9 @@ namespace MWMechanics
             value = ref->mBase->mData.mCombat;
         }
 
-        rating *= getHitChance(actor, enemy, value) / 100.f;
+        // Take hit chance in account, but do not allow rating become negative.
+        float chance = getHitChance(actor, enemy, value) / 100.f;
+        rating *= std::min(1.f, std::max(0.01f, chance));
 
         if (weapon->mData.mType < ESM::Weapon::Arrow)
             rating *= weapon->mData.mSpeed;


### PR DESCRIPTION
1. Decrease artifitial multiplier for rechargable magic items ([bug #4830](https://gitlab.com/OpenMW/openmw/issues/4830)).
2. Normalize chance to hit when calculate current weapon priority, otherwise rating can become too high or negative.

Since mentioned bug affects quest from clean game, I suppose it should not be present in the upcoming release.