### PR TITLE
[Regression] Improve sound decoding (bug #4906, bug #4909)

### DIFF
--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -96,25 +96,28 @@ bool FFmpeg_Decoder::getAVAudioData()
         return false;
 
     do {
-        if(mPacket.size == 0 && !getNextPacket())
-            return false;
-
         /* Decode some data, and check for errors */
         int ret = 0;
         ret = avcodec_receive_frame(mCodecCtx, mFrame);
-        if (ret == 0)
-            got_frame = true;
-        if (ret == AVERROR(EAGAIN))
-            ret = 0;
-        if (ret == 0)
+        if(ret == AVERROR(EAGAIN))
+        {
+            /* Need more data */
+            if(mPacket.size == 0 && !getNextPacket())
+                return false;
             ret = avcodec_send_packet(mCodecCtx, &mPacket);
-        if (ret < 0 && ret != AVERROR(EAGAIN))
+            av_packet_unref(&mPacket);
+            if(ret == 0)
+                continue;
+        }
+        if(ret != 0)
+        {
+            /* Unknown/unrecoverable error while receiving or sending */
             return false;
+        }
 
-        av_packet_unref(&mPacket);
-
-        if (!got_frame || mFrame->nb_samples == 0)
+        if(mFrame->nb_samples == 0)
             continue;
+        got_frame = true;
 
         if(mSwr)
         {
@@ -138,7 +141,7 @@ bool FFmpeg_Decoder::getAVAudioData()
         else
             mFrameData = &mFrame->data[0];
 
-    } while(!got_frame || mFrame->nb_samples == 0);
+    } while(!got_frame);
     mNextPts += (double)mFrame->nb_samples / mCodecCtx->sample_rate;
 
     return true;


### PR DESCRIPTION
Fixes [bug #4906](https://gitlab.com/OpenMW/openmw/issues/4906) and [bug #4909](https://gitlab.com/OpenMW/openmw/issues/4909).

The main idea:
1. Handle a case when there are several frames in the sound packet.
2. Do not lose a last sound packet (it caused issues for short sounds, especially for files with single sound packet).

Thanks to @kcat.