### PR TITLE
Include osgdb_freetype in builds with statically linked OSG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ include_directories(${OPENSCENEGRAPH_INCLUDE_DIRS})
 set(USED_OSG_PLUGINS
                     osgdb_bmp
                     osgdb_dds
+                    osgdb_freetype
                     osgdb_jpeg
                     osgdb_osg
                     osgdb_png


### PR DESCRIPTION
This makes sure OSG FreeType plugin is included in builds where OSG is linked statically, so the profiler font is loaded correctly. So basically this should only affect official Linux and macOS builds, and it should be up to the packager to include the plugin in a 0.45.0 build -- it shouldn't need cherry-picking.