### PR TITLE
[Regression] Fix missing null check

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -242,7 +242,8 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
         {
             osg::Vec4f glowColor = getEnchantmentColor(*weapon);
             mScabbard = getWeaponPart(mesh, boneName, isEnchanted, &glowColor);
-            resetControllers(mScabbard->getNode());
+            if (mScabbard)
+                resetControllers(mScabbard->getNode());
         }
 
         return;


### PR DESCRIPTION
Should prevent crash if the mScabbard is null (e.g. when we did not find a bone to attach a sheath mesh).