### PR TITLE
Fix navigator deadlock (bug #4777)

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -1446,7 +1446,7 @@ namespace MWRender
         {
             try
             {
-                const auto locked = it->second.lockConst();
+                const auto locked = it->second->lockConst();
                 mNavMesh->update(locked->getValue(), mNavMeshNumber, locked->getGeneration(),
                                  locked->getNavMeshRevision(), mNavigator.getSettings());
             }

--- a/apps/openmw_test_suite/detournavigator/navigator.cpp
+++ b/apps/openmw_test_suite/detournavigator/navigator.cpp
@@ -80,14 +80,6 @@ namespace
         EXPECT_THROW(mNavigator->findPath(mAgentHalfExtents, mStepSize, mStart, mEnd, Flag_walk, mOut), NavigatorException);
     }
 
-    TEST_F(DetourNavigatorNavigatorTest, find_path_for_removed_agent_should_return_empty)
-    {
-        mNavigator->addAgent(mAgentHalfExtents);
-        mNavigator->removeAgent(mAgentHalfExtents);
-        mNavigator->findPath(mAgentHalfExtents, mStepSize, mStart, mEnd, Flag_walk, mOut);
-        EXPECT_EQ(mPath, std::deque<osg::Vec3f>());
-    }
-
     TEST_F(DetourNavigatorNavigatorTest, add_agent_should_count_each_agent)
     {
         mNavigator->addAgent(mAgentHalfExtents);

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -129,12 +129,17 @@ namespace DetourNavigator
 
         const auto firstStart = setFirstStart(start);
 
+        const auto navMeshCacheItem = job.mNavMeshCacheItem.lock();
+
+        if (!navMeshCacheItem)
+            return true;
+
         const auto recastMesh = mRecastMeshManager.get().getMesh(job.mChangedTile);
         const auto playerTile = *mPlayerTile.lockConst();
         const auto offMeshConnections = mOffMeshConnectionsManager.get().get(job.mChangedTile);
 
         const auto status = updateNavMesh(job.mAgentHalfExtents, recastMesh.get(), job.mChangedTile, playerTile,
-            offMeshConnections, mSettings, job.mNavMeshCacheItem, mNavMeshTilesCache);
+            offMeshConnections, mSettings, navMeshCacheItem, mNavMeshTilesCache);
 
         const auto finish = std::chrono::steady_clock::now();
 
@@ -143,7 +148,7 @@ namespace DetourNavigator
         using FloatMs = std::chrono::duration<float, std::milli>;
 
         {
-            const auto locked = job.mNavMeshCacheItem->lockConst();
+            const auto locked = navMeshCacheItem->lockConst();
             log("cache updated for agent=", job.mAgentHalfExtents, " status=", status,
                 " generation=", locked->getGeneration(),
                 " revision=", locked->getNavMeshRevision(),
@@ -194,7 +199,8 @@ namespace DetourNavigator
             writeToFile(*recastMesh, mSettings.get().mRecastMeshPathPrefix + std::to_string(job.mChangedTile.x())
                         + "_" + std::to_string(job.mChangedTile.y()) + "_", recastMeshRevision);
         if (mSettings.get().mEnableWriteNavMeshToFile)
-            writeToFile(job.mNavMeshCacheItem->lockConst()->getValue(), mSettings.get().mNavMeshPathPrefix, navMeshRevision);
+            if (const auto shared = job.mNavMeshCacheItem.lock())
+                writeToFile(shared->lockConst()->getValue(), mSettings.get().mNavMeshPathPrefix, navMeshRevision);
     }
 
     std::chrono::steady_clock::time_point AsyncNavMeshUpdater::setFirstStart(const std::chrono::steady_clock::time_point& value)

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -143,7 +143,7 @@ namespace DetourNavigator
         using FloatMs = std::chrono::duration<float, std::milli>;
 
         {
-            const auto locked = job.mNavMeshCacheItem.lockConst();
+            const auto locked = job.mNavMeshCacheItem->lockConst();
             log("cache updated for agent=", job.mAgentHalfExtents, " status=", status,
                 " generation=", locked->getGeneration(),
                 " revision=", locked->getNavMeshRevision(),
@@ -194,7 +194,7 @@ namespace DetourNavigator
             writeToFile(*recastMesh, mSettings.get().mRecastMeshPathPrefix + std::to_string(job.mChangedTile.x())
                         + "_" + std::to_string(job.mChangedTile.y()) + "_", recastMeshRevision);
         if (mSettings.get().mEnableWriteNavMeshToFile)
-            writeToFile(job.mNavMeshCacheItem.lockConst()->getValue(), mSettings.get().mNavMeshPathPrefix, navMeshRevision);
+            writeToFile(job.mNavMeshCacheItem->lockConst()->getValue(), mSettings.get().mNavMeshPathPrefix, navMeshRevision);
     }
 
     std::chrono::steady_clock::time_point AsyncNavMeshUpdater::setFirstStart(const std::chrono::steady_clock::time_point& value)

--- a/components/detournavigator/asyncnavmeshupdater.hpp
+++ b/components/detournavigator/asyncnavmeshupdater.hpp
@@ -48,7 +48,7 @@ namespace DetourNavigator
         struct Job
         {
             osg::Vec3f mAgentHalfExtents;
-            SharedNavMeshCacheItem mNavMeshCacheItem;
+            std::weak_ptr<GuardedNavMeshCacheItem> mNavMeshCacheItem;
             TilePosition mChangedTile;
             unsigned mTryNumber;
             ChangeType mChangeType;

--- a/components/detournavigator/makenavmesh.cpp
+++ b/components/detournavigator/makenavmesh.cpp
@@ -521,7 +521,7 @@ namespace
     UpdateNavMeshStatus replaceTile(const SharedNavMeshCacheItem& navMeshCacheItem,
         const TilePosition& changedTile, T&& navMeshData)
     {
-        const auto locked = navMeshCacheItem.lock();
+        const auto locked = navMeshCacheItem->lock();
         auto& navMesh = locked->getValue();
         const int layer = 0;
         const auto tileRef = navMesh.getTileRefAt(changedTile.x(), changedTile.y(), layer);
@@ -591,14 +591,14 @@ namespace DetourNavigator
             " playerTile=", playerTile,
             " changedTileDistance=", getDistance(changedTile, playerTile));
 
-        const auto params = *navMeshCacheItem.lockConst()->getValue().getParams();
+        const auto params = *navMeshCacheItem->lockConst()->getValue().getParams();
         const osg::Vec3f origin(params.orig[0], params.orig[1], params.orig[2]);
 
         const auto x = changedTile.x();
         const auto y = changedTile.y();
 
         const auto removeTile = [&] {
-            const auto locked = navMeshCacheItem.lock();
+            const auto locked = navMeshCacheItem->lock();
             auto& navMesh = locked->getValue();
             const auto tileRef = navMesh.getTileRefAt(x, y, 0);
             const auto removed = dtStatusSucceed(navMesh.removeTile(tileRef, nullptr, nullptr));

--- a/components/detournavigator/navigator.hpp
+++ b/components/detournavigator/navigator.hpp
@@ -174,7 +174,7 @@ namespace DetourNavigator
             if (!navMesh)
                 return out;
             const auto settings = getSettings();
-            return findSmoothPath(navMesh.lock()->getValue(), toNavMeshCoordinates(settings, agentHalfExtents),
+            return findSmoothPath(navMesh->lockConst()->getValue(), toNavMeshCoordinates(settings, agentHalfExtents),
                 toNavMeshCoordinates(settings, stepSize), toNavMeshCoordinates(settings, start),
                 toNavMeshCoordinates(settings, end), includeFlags, settings, out);
         }

--- a/components/detournavigator/navigatorimpl.cpp
+++ b/components/detournavigator/navigatorimpl.cpp
@@ -21,10 +21,10 @@ namespace DetourNavigator
     void NavigatorImpl::removeAgent(const osg::Vec3f& agentHalfExtents)
     {
         const auto it = mAgents.find(agentHalfExtents);
-        if (it == mAgents.end() || --it->second)
+        if (it == mAgents.end())
             return;
-        mAgents.erase(it);
-        mNavMeshManager.reset(agentHalfExtents);
+        if (it->second > 0)
+            --it->second;
     }
 
     bool NavigatorImpl::addObject(const ObjectId id, const btCollisionShape& shape, const btTransform& transform)
@@ -113,6 +113,7 @@ namespace DetourNavigator
 
     void NavigatorImpl::update(const osg::Vec3f& playerPosition)
     {
+        removeUnusedNavMeshes();
         for (const auto& v : mAgents)
             mNavMeshManager.update(playerPosition, v.first);
     }
@@ -154,6 +155,17 @@ namespace DetourNavigator
         {
             mNavMeshManager.removeObject(inserted.first->second);
             inserted.first->second = updateId;
+        }
+    }
+
+    void NavigatorImpl::removeUnusedNavMeshes()
+    {
+        for (auto it = mAgents.begin(); it != mAgents.end();)
+        {
+            if (it->second == 0 && mNavMeshManager.reset(it->first))
+                it = mAgents.erase(it);
+            else
+                ++it;
         }
     }
 }

--- a/components/detournavigator/navigatorimpl.hpp
+++ b/components/detournavigator/navigatorimpl.hpp
@@ -58,6 +58,7 @@ namespace DetourNavigator
         void updateAvoidShapeId(const ObjectId id, const ObjectId avoidId);
         void updateWaterShapeId(const ObjectId id, const ObjectId waterId);
         void updateId(const ObjectId id, const ObjectId waterId, std::unordered_map<ObjectId, ObjectId>& ids);
+        void removeUnusedNavMeshes();
     };
 }
 

--- a/components/detournavigator/navmeshcacheitem.hpp
+++ b/components/detournavigator/navmeshcacheitem.hpp
@@ -64,7 +64,8 @@ namespace DetourNavigator
         std::map<TilePosition, std::pair<NavMeshTilesCache::Value, NavMeshData>> mUsedTiles;
     };
 
-    using SharedNavMeshCacheItem = Misc::SharedGuarded<NavMeshCacheItem>;
+    using GuardedNavMeshCacheItem = Misc::ScopeGuarded<NavMeshCacheItem>;
+    using SharedNavMeshCacheItem = std::shared_ptr<GuardedNavMeshCacheItem>;
 }
 
 #endif

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -93,7 +93,7 @@ namespace DetourNavigator
         if (cached != mCache.end())
             return;
         mCache.insert(std::make_pair(agentHalfExtents,
-            std::make_shared<NavMeshCacheItem>(makeEmptyNavMesh(mSettings), ++mGenerationCounter)));
+            std::make_shared<GuardedNavMeshCacheItem>(makeEmptyNavMesh(mSettings), ++mGenerationCounter)));
         log("cache add for agent=", agentHalfExtents);
     }
 
@@ -159,7 +159,7 @@ namespace DetourNavigator
         }
         const auto changedTiles = mChangedTiles.find(agentHalfExtents);
         {
-            const auto locked = cached.lock();
+            const auto locked = cached->lockConst();
             const auto& navMesh = locked->getValue();
             if (changedTiles != mChangedTiles.end())
             {

--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -16,6 +16,20 @@ namespace
     {
         return current == add ? current : ChangeType::mixed;
     }
+
+    /// Safely reset shared_ptr with definite underlying object destrutor call.
+    /// Assuming there is another thread holding copy of this shared_ptr or weak_ptr to this shared_ptr.
+    template <class T>
+    bool resetIfUnique(std::shared_ptr<T>& ptr)
+    {
+        const std::weak_ptr<T> weak = std::move(ptr);
+        if (auto shared = weak.lock())
+        {
+            ptr = std::move(shared);
+            return false;
+        }
+        return true;
+    }
 }
 
 namespace DetourNavigator
@@ -83,9 +97,15 @@ namespace DetourNavigator
         log("cache add for agent=", agentHalfExtents);
     }
 
-    void NavMeshManager::reset(const osg::Vec3f& agentHalfExtents)
+    bool NavMeshManager::reset(const osg::Vec3f& agentHalfExtents)
     {
+        const auto it = mCache.find(agentHalfExtents);
+        if (it == mCache.end())
+            return true;
+        if (!resetIfUnique(it->second))
+            return false;
         mCache.erase(agentHalfExtents);
+        return true;
     }
 
     void NavMeshManager::addOffMeshConnection(const ObjectId id, const osg::Vec3f& start, const osg::Vec3f& end)

--- a/components/detournavigator/navmeshmanager.hpp
+++ b/components/detournavigator/navmeshmanager.hpp
@@ -36,7 +36,7 @@ namespace DetourNavigator
 
         bool removeWater(const osg::Vec2i& cellPosition);
 
-        void reset(const osg::Vec3f& agentHalfExtents);
+        bool reset(const osg::Vec3f& agentHalfExtents);
 
         void addOffMeshConnection(const ObjectId id, const osg::Vec3f& start, const osg::Vec3f& end);
 

--- a/components/misc/guarded.hpp
+++ b/components/misc/guarded.hpp
@@ -83,38 +83,6 @@ namespace Misc
             std::mutex mMutex;
             T mValue;
     };
-
-    template <class T>
-    class SharedGuarded
-    {
-        public:
-            SharedGuarded()
-                : mMutex(std::make_shared<std::mutex>()), mValue()
-            {}
-
-            SharedGuarded(std::shared_ptr<T> value)
-                : mMutex(std::make_shared<std::mutex>()), mValue(std::move(value))
-            {}
-
-            Locked<T> lock() const
-            {
-                return Locked<T>(*mMutex, *mValue);
-            }
-
-            Locked<const T> lockConst() const
-            {
-                return Locked<const T>(*mMutex, *mValue);
-            }
-
-            operator bool() const
-            {
-                return static_cast<bool>(mValue);
-            }
-
-        private:
-            std::shared_ptr<std::mutex> mMutex;
-            std::shared_ptr<T> mValue;
-    };
 }
 
 #endif


### PR DESCRIPTION
Spent a lot of time debugging recastnavigation using [this](https://rr-project.org/) recording debugger. Finally find out it was my mistake.

When there is only one actor (player) on a scene and it moving to other cell first it will be removed from navigator then added. Remove cause navmesh removing for its half extents. After it is added navmesh for same half extents is created and added. While this all happens there are still jobs for old navmesh are processing. Old navmesh still exists because it is stored by shared pointer. So jobs take tiles from cache and place them into old navmesh. After that other jobs take same tiles from cache (half extents and coordinates are equal) and place them into other navmesh. dtNavMesh changes tile data on add and remove. Adding tile into two different dtNavMesh corrupts tile in both nameshes.

Basically fix is a more smart garbage collection. We remove namesh only on update method call. When all moved to other cells objects are already removed and added into navigator. And remove only those navmeshes which does not updating by async jobs. This prevents possible issue when all actors with given half extents are removed from scene and then added on next frame and jobs might still be in a queue.

Also to prevent useless navmesh updates jobs queue now contains `weak_ptr` to navmesh instead of `shared_ptr`. This allows to avoid processing for already removed navmeshes.