### PR TITLE
 Use selected object local variables in the console (feature #3893) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
+    Feature #3893: Implicit target for "set" function in console
     Feature #3980: In-game option to disable controller
     Feature #4209: Editor: Faction rank sub-table
     Feature #4673: Weapon sheathing

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -11,10 +11,12 @@
 #include "../mwscript/extensions.hpp"
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/scriptmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/world.hpp"
 
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/class.hpp"
 
 namespace MWGui
 {
@@ -173,6 +175,12 @@ namespace MWGui
         print("> " + command + "\n");
 
         Compiler::Locals locals;
+        if (!mPtr.isEmpty())
+        {
+            std::string script = mPtr.getClass().getScript(mPtr);
+            if (!script.empty())
+                locals = MWBase::Environment::get().getScriptManager()->getLocals(script);
+        }
         Compiler::Output output (locals);
 
         if (compile (command + "\n", output))

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -951,7 +951,7 @@ namespace MWScript
 
                 const std::string script = ptr.getClass().getScript(ptr);
                 if(script.empty())
-                    str<< ptr.getCellRef().getRefId()<<"  does not have a script.";
+                    str<< ptr.getCellRef().getRefId()<<" does not have a script.";
                 else
                 {
                     str<< "Local variables for "<<ptr.getCellRef().getRefId();


### PR DESCRIPTION
[Feature 3893](https://gitlab.com/OpenMW/openmw/issues/3893).

This allows to output and change local variables of the selected object without stating the object ID explicitly. The idea is to recover local variables of the script the reference potentially has, then the compiler and interpreter will handle the instance's local variables properly automatically.

Unfortunately the console now depends on script manager and class headers.

Also, I removed an extraneous space in "ID does not have a script" message showvars can output.