### PR TITLE
Merge upstream osgQt changes

### DIFF
--- a/extern/osgQt/GraphicsWindowQt
+++ b/extern/osgQt/GraphicsWindowQt
@@ -14,8 +14,6 @@
 #ifndef OSGVIEWER_GRAPHICSWINDOWQT
 #define OSGVIEWER_GRAPHICSWINDOWQT
 
-#include <QGLWidget>
-
 #include <osgViewer/GraphicsWindow>
 
 #include <QMutex>

--- a/extern/osgQt/GraphicsWindowQt.cpp
+++ b/extern/osgQt/GraphicsWindowQt.cpp
@@ -22,12 +22,6 @@
 #include <QWindow>
 #endif
 
-#if (QT_VERSION>=QT_VERSION_CHECK(4, 6, 0))
-# define USE_GESTURES
-# include <QGestureEvent>
-# include <QGesture>
-#endif
-
 using namespace osgQt;
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 2, 0))
@@ -132,6 +126,8 @@ bool GLWidget::event( QEvent* event )
 
 void GLWidget::resizeEvent( QResizeEvent* event )
 {
+    if (_gw == nullptr || !_gw->valid())
+        return;
     const QSize& size = event->size();
 
     int scaled_width = static_cast<int>(size.width()*_devicePixelRatio);
@@ -143,6 +139,8 @@ void GLWidget::resizeEvent( QResizeEvent* event )
 
 void GLWidget::moveEvent( QMoveEvent* event )
 {
+    if (_gw == nullptr || !_gw->valid())
+        return;
     const QPoint& pos = event->pos();
     int scaled_width = static_cast<int>(width()*_devicePixelRatio);
     int scaled_height = static_cast<int>(height()*_devicePixelRatio);
@@ -527,9 +525,6 @@ void GraphicsWindowQt::swapBuffersImplementation()
     if (!_widget || !_widget->windowHandle()->isExposed())
         return;
 #endif
-
-    _widget->swapBuffers();
-
     // FIXME: the processDeferredEvents should really be executed in a GUI (main) thread context but
     // I couln't find any reliable way to do this. For now, lets hope non of *GUI thread only operations* will
     // be executed in a QGLWidget::event handler. On the other hand, calling GUI only operations in the
@@ -539,8 +534,8 @@ void GraphicsWindowQt::swapBuffersImplementation()
 
     // We need to call makeCurrent here to restore our previously current context
     // which may be changed by the processDeferredEvents function.
-    if (QGLContext::currentContext() != _widget->context())
-        _widget->makeCurrent();
+    _widget->makeCurrent();
+    _widget->swapBuffers();
 }
 
 void GraphicsWindowQt::requestWarpPointer( float x, float y )


### PR DESCRIPTION
There uh, weren't actually that many of them, mainly due to how our osgQt is stripped down.
Upstream changes:
* Remove extraneous QGLWidget include
* Fix *a different* Qt5 threading issue (see [6e4de176](https://github.com/openscenegraph/osgQt/commit/6e4de176c7c2b4aeb4547fa5dc48d29d92b9d1ca))
* Make sure the window is valid before handling movement and resizing events.

My own changes:
* NULL is replaced with nullptr in the added lines (only in them).
* Removed unnecessary QGesture includes. They can't be used anyway due to how Aesylwinn purged the entirety of osgQt input stuff.

I think they should be fine.

Edit: apparently it doesn't fix **the** multithreaded model issue.