### PR TITLE
Allow to override texture records in the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     Bug #4720: Inventory avatar has shield with two-handed weapon during [un]equipping animation
     Bug #4723: ResetActors command works incorrectly
     Bug #4745: Editor: Interior cell lighting field values are not displayed as colors
+    Bug #4736: LandTexture records overrides do not work
     Bug #4746: Non-solid player can't run or sneak
     Bug #4747: Bones are not read from X.NIF file for NPC animation
     Bug #4750: Sneaking doesn't work in first person view if the player is in attack ready state

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -387,6 +387,21 @@ namespace MWWorld
 
         assert(plugin < mStatic.size());
 
+        // Replace texture for records with given ID and index from all plugins.
+        for (unsigned int i=0; i<mStatic.size(); i++)
+        {
+            ESM::LandTexture* tex = const_cast<ESM::LandTexture*>(search(lt.mIndex, i));
+            if (tex)
+            {
+                const std::string texId = Misc::StringUtils::lowerCase(tex->mId);
+                const std::string ltId = Misc::StringUtils::lowerCase(lt.mId);
+                if (texId == ltId)
+                {
+                    tex->mTexture = lt.mTexture;
+                }
+            }
+        }
+
         LandTextureList &ltexl = mStatic[plugin];
         if(lt.mIndex + 1 > (int)ltexl.size())
             ltexl.resize(lt.mIndex+1);

--- a/components/esm/loadltex.hpp
+++ b/components/esm/loadltex.hpp
@@ -11,18 +11,9 @@ class ESMWriter;
 
 /*
  * Texture used for texturing landscape.
- *
- * They are probably indexed by 'num', not 'id', but I don't know for
- * sure. And num is not unique between files, so one option is to keep
- * a separate list for each input file (that has LTEX records, of
- * course.) We also need to resolve references to already existing
- * land textures to save space.
-
- * I'm not sure if it is even possible to override existing land
- * textures, probably not. I'll have to try it, and have to mimic the
- * behaviour of morrowind. First, check what you are allowed to do in
- * the editor. Then make an esp which changes a commonly used land
- * texture, and see if it affects the game.
+ * They are indexed by 'num', but still use 'id' to override base records.
+ * Original editor even does not allow to create new records with existing ID's.
+ * TODO: currently OpenMW-CS does not allow to override LTEX records at all.
  */
 
 struct LandTexture


### PR DESCRIPTION
Fixes [bug #4736](https://gitlab.com/OpenMW/openmw/issues/4736).

The main idea:
1. Currently every plugin has its own index set for LandTexture records.
2. If the new plugin declares a texture record with existing index and ID, consider it as an override for base record.
3. If either ID or index differs, consider record from plugin as a new record.

Notes: 
1. It does not fix the [#4904](https://gitlab.com/OpenMW/openmw/issues/4904) - it requires a lot of work on the editor.
2. It would be nice to have a cleaner solution, but it would require to rewrite a lot of legacy stuff. I'd prefer to do not touch it.