### PR TITLE
Do not swap buffers for non-exposed windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
     Bug #4876: AI ratings handling inconsistencies
     Bug #4877: Startup script executes only on a new game start
     Bug #4888: Global variable stray explicit reference calls break script compilation
+    Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/extern/osgQt/GraphicsWindowQt.cpp
+++ b/extern/osgQt/GraphicsWindowQt.cpp
@@ -17,6 +17,7 @@
 #include <osgViewer/ViewerBase>
 #include <QInputEvent>
 #include <QPointer>
+#include <QWindow>
 
 #if (QT_VERSION>=QT_VERSION_CHECK(4, 6, 0))
 # define USE_GESTURES
@@ -518,6 +519,12 @@ bool GraphicsWindowQt::releaseContextImplementation()
 
 void GraphicsWindowQt::swapBuffersImplementation()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+    // QOpenGLContext complains if we swap on an non-exposed QWindow
+    if (!_widget || !_widget->windowHandle()->isExposed())
+        return;
+#endif
+
     _widget->swapBuffers();
 
     // FIXME: the processDeferredEvents should really be executed in a GUI (main) thread context but


### PR DESCRIPTION
Fixes [bug #4911](https://gitlab.com/OpenMW/openmw/issues/4911).

The main idea is to do not swap buffers, if the window was not exposed to the window managing system yet.

I took the code from [here](https://github.com/anormann1974/osgviewerQt5/blob/master/GraphicsWindowQt5.cpp) (it is basically a Qt5-version of OSG viewer, take a look at the `swapBuffersImplementation()`).