### PR TITLE
Place QWindow include under Qt version check

### DIFF
--- a/extern/osgQt/GraphicsWindowQt.cpp
+++ b/extern/osgQt/GraphicsWindowQt.cpp
@@ -17,7 +17,10 @@
 #include <osgViewer/ViewerBase>
 #include <QInputEvent>
 #include <QPointer>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QWindow>
+#endif
 
 #if (QT_VERSION>=QT_VERSION_CHECK(4, 6, 0))
 # define USE_GESTURES


### PR DESCRIPTION
QWindow class was added only in the Qt 5.0 release.