### PR TITLE
Do not allocate empty callbacks in the RigGeometry

### DIFF
--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -40,8 +40,8 @@ RigGeometry::RigGeometry()
     , mLastFrameNumber(0)
     , mBoundsFirstFrame(true)
 {
-    setUpdateCallback(new osg::Callback); // dummy to make sure getNumChildrenRequiringUpdateTraversal() is correct
-                                          // update done in accept(NodeVisitor&)
+    setNumChildrenRequiringUpdateTraversal(1);
+    // update done in accept(NodeVisitor&)
 }
 
 RigGeometry::RigGeometry(const RigGeometry &copy, const osg::CopyOp &copyop)
@@ -54,6 +54,7 @@ RigGeometry::RigGeometry(const RigGeometry &copy, const osg::CopyOp &copyop)
     , mBoundsFirstFrame(true)
 {
     setSourceGeometry(copy.mSourceGeometry);
+    setNumChildrenRequiringUpdateTraversal(1);
 }
 
 void RigGeometry::setSourceGeometry(osg::ref_ptr<osg::Geometry> sourceGeometry)


### PR DESCRIPTION
If the `getNumChildrenRequiringUpdateTraversal()` for node returns 0 and the node has no callbacks, OSG will skip it during update traversal.
As a result, for our RigGeometry objects skeletons will not be initialized properly.
To avoid this issue, we add an empty callback to every RigGeometry object to force OSG to process it during update traversal.

A better way to do it is to use the `setNumChildrenRequiringUpdateTraversal()` function, which is widely used in OSG examples for the same purpose.



