### PR TITLE
Do not pass nullptr to std::memcmp

### DIFF
--- a/components/detournavigator/navmeshtilescache.cpp
+++ b/components/detournavigator/navmeshtilescache.cpp
@@ -179,6 +179,17 @@ namespace DetourNavigator
                 const auto lhsEnd = reinterpret_cast<const char*>(lhs.data() + lhs.size());
                 const auto lhsSize = static_cast<std::ptrdiff_t>(lhsEnd - lhsBegin);
                 const auto rhsSize = static_cast<std::ptrdiff_t>(mRhsEnd - mRhsIt);
+
+                if (lhsBegin == nullptr || mRhsIt == nullptr)
+                {
+                    if (lhsSize < rhsSize)
+                        return -1;
+                    else if (lhsSize > rhsSize)
+                        return 1;
+                    else
+                        return 0;
+                }
+
                 const auto size = std::min(lhsSize, rhsSize);
 
                 if (const auto result = std::memcmp(lhsBegin, mRhsIt, size))


### PR DESCRIPTION
Fixes ubsan warnings:
```
[ RUN      ] DetourNavigatorNavigatorTest.update_remove_and_update_then_find_path_should_return_path
/home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:184:53: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:64:33: note: nonnull attribute specified here
    #0 0x555ad3d2cc1a in int DetourNavigator::(anonymous namespace)::CompareBytes::operator()<DetourNavigator::RecastMesh::Water>(std::vector<DetourNavigator::RecastMesh::Water, std::allocator<DetourNavigator::RecastMesh::Water> > const&) /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:184:41
    #1 0x555ad3d2cc1a in DetourNavigator::NavMeshTilesCache::RecastMeshKeyView::compare(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:210
    #2 0x555ad3d2ea42 in DetourNavigator::NavMeshTilesCache::KeyView::isLess(DetourNavigator::NavMeshTilesCache::KeyView const&) const /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.hpp:132:30
    #3 0x555ad3d30753 in std::_Rb_tree<DetourNavigator::NavMeshTilesCache::KeyView, std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> >, std::_Select1st<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > >, std::less<DetourNavigator::NavMeshTilesCache::KeyView>, std::allocator<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > > >::_M_lower_bound(std::_Rb_tree_node<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > >*, std::_Rb_tree_node_base*, DetourNavigator::NavMeshTilesCache::KeyView const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_tree.h:1888:7
    #4 0x555ad3d3042f in std::_Rb_tree<DetourNavigator::NavMeshTilesCache::KeyView, std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> >, std::_Select1st<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > >, std::less<DetourNavigator::NavMeshTilesCache::KeyView>, std::allocator<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > > >::find(DetourNavigator::NavMeshTilesCache::KeyView const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_tree.h:2539:22
    #5 0x555ad3d29860 in std::map<DetourNavigator::NavMeshTilesCache::KeyView, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item>, std::less<DetourNavigator::NavMeshTilesCache::KeyView>, std::allocator<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > > >::find(DetourNavigator::NavMeshTilesCache::KeyView const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_map.h:1169:21
    #6 0x555ad3d29860 in DetourNavigator::NavMeshTilesCache::get(osg::Vec3f const&, osg::Vec2i const&, DetourNavigator::RecastMesh const&, std::vector<DetourNavigator::OffMeshConnection, std::allocator<DetourNavigator::OffMeshConnection> > const&) /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:66
    #7 0x555ad3d49d3e in DetourNavigator::updateNavMesh(osg::Vec3f const&, DetourNavigator::RecastMesh const*, osg::Vec2i const&, osg::Vec2i const&, std::vector<DetourNavigator::OffMeshConnection, std::allocator<DetourNavigator::OffMeshConnection> > const&, DetourNavigator::Settings const&, std::shared_ptr<Misc::ScopeGuarded<DetourNavigator::NavMeshCacheItem> > const&, DetourNavigator::NavMeshTilesCache&) /home/elsid/dev/openmw/components/detournavigator/makenavmesh.cpp:530:52
    #8 0x555ad3cf3f68 in DetourNavigator::AsyncNavMeshUpdater::processJob(DetourNavigator::AsyncNavMeshUpdater::Job const&) /home/elsid/dev/openmw/components/detournavigator/asyncnavmeshupdater.cpp:141:29
    #9 0x555ad3cf3168 in DetourNavigator::AsyncNavMeshUpdater::process() /home/elsid/dev/openmw/components/detournavigator/asyncnavmeshupdater.cpp:113:26
    #10 0x7f8713295062 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80:18
    #11 0x7f871ac27a9c in start_thread (/usr/lib/libpthread.so.0+0x7a9c)
    #12 0x7f8712f60b22 in __GI___clone (/usr/lib/libc.so.6+0xfbb22)

/home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:184:53: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:64:33: note: nonnull attribute specified here
    #0 0x555ad3d2cd18 in int DetourNavigator::(anonymous namespace)::CompareBytes::operator()<DetourNavigator::OffMeshConnection>(std::vector<DetourNavigator::OffMeshConnection, std::allocator<DetourNavigator::OffMeshConnection> > const&) /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:184:41
    #1 0x555ad3d2cd18 in DetourNavigator::NavMeshTilesCache::RecastMeshKeyView::compare(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:213
    #2 0x555ad3d2ea42 in DetourNavigator::NavMeshTilesCache::KeyView::isLess(DetourNavigator::NavMeshTilesCache::KeyView const&) const /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.hpp:132:30
    #3 0x555ad3d30753 in std::_Rb_tree<DetourNavigator::NavMeshTilesCache::KeyView, std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> >, std::_Select1st<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > >, std::less<DetourNavigator::NavMeshTilesCache::KeyView>, std::allocator<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > > >::_M_lower_bound(std::_Rb_tree_node<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > >*, std::_Rb_tree_node_base*, DetourNavigator::NavMeshTilesCache::KeyView const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_tree.h:1888:7
    #4 0x555ad3d3042f in std::_Rb_tree<DetourNavigator::NavMeshTilesCache::KeyView, std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> >, std::_Select1st<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > >, std::less<DetourNavigator::NavMeshTilesCache::KeyView>, std::allocator<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > > >::find(DetourNavigator::NavMeshTilesCache::KeyView const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_tree.h:2539:22
    #5 0x555ad3d29860 in std::map<DetourNavigator::NavMeshTilesCache::KeyView, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item>, std::less<DetourNavigator::NavMeshTilesCache::KeyView>, std::allocator<std::pair<DetourNavigator::NavMeshTilesCache::KeyView const, std::_List_iterator<DetourNavigator::NavMeshTilesCache::Item> > > >::find(DetourNavigator::NavMeshTilesCache::KeyView const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_map.h:1169:21
    #6 0x555ad3d29860 in DetourNavigator::NavMeshTilesCache::get(osg::Vec3f const&, osg::Vec2i const&, DetourNavigator::RecastMesh const&, std::vector<DetourNavigator::OffMeshConnection, std::allocator<DetourNavigator::OffMeshConnection> > const&) /home/elsid/dev/openmw/components/detournavigator/navmeshtilescache.cpp:66
    #7 0x555ad3d49d3e in DetourNavigator::updateNavMesh(osg::Vec3f const&, DetourNavigator::RecastMesh const*, osg::Vec2i const&, osg::Vec2i const&, std::vector<DetourNavigator::OffMeshConnection, std::allocator<DetourNavigator::OffMeshConnection> > const&, DetourNavigator::Settings const&, std::shared_ptr<Misc::ScopeGuarded<DetourNavigator::NavMeshCacheItem> > const&, DetourNavigator::NavMeshTilesCache&) /home/elsid/dev/openmw/components/detournavigator/makenavmesh.cpp:530:52
    #8 0x555ad3cf3f68 in DetourNavigator::AsyncNavMeshUpdater::processJob(DetourNavigator::AsyncNavMeshUpdater::Job const&) /home/elsid/dev/openmw/components/detournavigator/asyncnavmeshupdater.cpp:141:29
    #9 0x555ad3cf3168 in DetourNavigator::AsyncNavMeshUpdater::process() /home/elsid/dev/openmw/components/detournavigator/asyncnavmeshupdater.cpp:113:26
    #10 0x7f8713295062 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80:18
    #11 0x7f871ac27a9c in start_thread (/usr/lib/libpthread.so.0+0x7a9c)
    #12 0x7f8712f60b22 in __GI___clone (/usr/lib/libc.so.6+0xfbb22)
```