### PR TITLE
Print SDL version at startup

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -651,6 +651,9 @@ void OMW::Engine::go()
     assert (!mContentFiles.empty());
 
     Log(Debug::Info) << "OSG version: " << osgGetVersion();
+    SDL_version sdlVersion;
+    SDL_GetVersion(&sdlVersion);
+    Log(Debug::Info) << "SDL version: " << (int)sdlVersion.major << "." << (int)sdlVersion.minor << "." << (int)sdlVersion.patch;
 
     Misc::Rng::init(mRandomSeed);
 


### PR DESCRIPTION
This is put in the logs and can be useful for figuring out if something is actually an SDL issue in user reports.

e.g.:
```
Using Cyrillic font encoding.
OSG version: 3.4.1
SDL version: 2.0.9
Loading settings file: ./settings-default.cfg
```