### PR TITLE
Use std::vector::data method to avoid reference binding to null pointer

### DIFF
--- a/components/esm/loadscpt.cpp
+++ b/components/esm/loadscpt.cpp
@@ -104,7 +104,7 @@ namespace ESM
                     }
 
                     mScriptData.resize(subSize);
-                    esm.getExact(&mScriptData[0], mScriptData.size());
+                    esm.getExact(mScriptData.data(), mScriptData.size());
                     break;
                 }
                 case ESM::FourCC<'S','C','T','X'>::value:
@@ -156,7 +156,7 @@ namespace ESM
         }
 
         esm.startSubRecord("SCDT");
-        esm.write(reinterpret_cast<const char * >(&mScriptData[0]), mData.mScriptDataSize);
+        esm.write(reinterpret_cast<const char *>(mScriptData.data()), mData.mScriptDataSize);
         esm.endRecord("SCDT");
 
         esm.writeHNOString("SCTX", mScriptText);


### PR DESCRIPTION
Fixes ubsan warnings like this:
```
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_vector.h:933:9: runtime error: reference binding to null pointer of type 'unsigned char'
    #0 0x5593c0f0a521 in std::vector<unsigned char, std::allocator<unsigned char> >::operator[](unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_vector.h:933:2
    #1 0x5593c0f08f50 in ESM::Script::load(ESM::ESMReader&, bool&) /home/elsid/dev/openmw/components/esm/loadscpt.cpp:107:35
    #2 0x5593c039ad22 in CSMWorld::IdCollection<ESM::Script, CSMWorld::IdAccessor<ESM::Script> >::load(ESM::ESMReader&, bool) /home/elsid/dev/openmw/apps/opencs/model/world/idcollection.hpp:65:9
    #3 0x5593c037c16e in CSMWorld::Data::continueLoading(CSMDoc::Messages&) /home/elsid/dev/openmw/apps/opencs/model/world/data.cpp:1079:38
    #4 0x5593c02f290a in CSMDoc::Loader::load() /home/elsid/dev/openmw/apps/opencs/model/doc/loader.cpp:65:41
    #5 0x5593c0b93770 in CSMDoc::Loader::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/elsid/dev/openmw/build/clang/ubsan/apps/opencs/model/doc/moc_loader.cpp:115:21
    #6 0x7f3d923ef87b in QMetaObject::activate(QObject*, int, int, void**) (/usr/lib/libQt5Core.so.5+0x2a587b)
    #7 0x7f3d923fbab7 in QTimer::timeout(QTimer::QPrivateSignal) (/usr/lib/libQt5Core.so.5+0x2b1ab7)
    #8 0x7f3d923f010a in QObject::event(QEvent*) (/usr/lib/libQt5Core.so.5+0x2a610a)
    #9 0x7f3d94b89e23 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib/libQt5Widgets.so.5+0x157e23)
    #10 0x7f3d94b916e0 in QApplication::notify(QObject*, QEvent*) (/usr/lib/libQt5Widgets.so.5+0x15f6e0)
    #11 0x5593c025afb4 in Application::notify(QObject*, QEvent*) /home/elsid/dev/openmw/apps/opencs/main.cpp:29:38
    #12 0x7f3d923c4e98 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/usr/lib/libQt5Core.so.5+0x27ae98)
    #13 0x7f3d9241a094 in QTimerInfoList::activateTimers() (/usr/lib/libQt5Core.so.5+0x2d0094)
    #14 0x7f3d9241a959  (/usr/lib/libQt5Core.so.5+0x2d0959)
    #15 0x7f3d903087be in g_main_context_dispatch (/usr/lib/libglib-2.0.so.0+0x6b7be)
    #16 0x7f3d9030a738  (/usr/lib/libglib-2.0.so.0+0x6d738)
    #17 0x7f3d9030a77d in g_main_context_iteration (/usr/lib/libglib-2.0.so.0+0x6d77d)
    #18 0x7f3d9241ace8 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/libQt5Core.so.5+0x2d0ce8)
    #19 0x7f3d923c3b2b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/libQt5Core.so.5+0x279b2b)
    #20 0x7f3d92207568 in QThread::exec() (/usr/lib/libQt5Core.so.5+0xbd568)
    #21 0x7f3d9220896b  (/usr/lib/libQt5Core.so.5+0xbe96b)
    #22 0x7f3d92cc2a9c in start_thread (/usr/lib/libpthread.so.0+0x7a9c)
    #23 0x7f3d91d42b22 in __GI___clone (/usr/lib/libc.so.6+0xfbb22)

/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_vector.h:951:9: runtime error: reference binding to null pointer of type 'const unsigned char'
    #0 0x55e3409768b1 in std::vector<unsigned char, std::allocator<unsigned char> >::operator[](unsigned long) const /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/stl_vector.h:951:2
    #1 0x55e340a4a95d in ESM::Script::save(ESM::ESMWriter&, bool) const /home/elsid/dev/openmw/components/esm/loadscpt.cpp:159:52
    #2 0x55e33fe15aa9 in CSMDoc::WriteCollectionStage<CSMWorld::IdCollection<ESM::Script, CSMWorld::IdAccessor<ESM::Script> > >::perform(int, CSMDoc::Messages&) /home/elsid/dev/openmw/apps/opencs/model/doc/savingstages.hpp:112:20
    #3 0x55e33fe09e96 in CSMDoc::Operation::executeStage() /home/elsid/dev/openmw/apps/opencs/model/doc/operation.cpp:113:39
    #4 0x55e3406cf9e4 in CSMDoc::Operation::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/elsid/dev/openmw/build/clang/ubsan/apps/opencs/model/doc/moc_operation.cpp:107:21
    #5 0x7f4affe4787b in QMetaObject::activate(QObject*, int, int, void**) (/usr/lib/libQt5Core.so.5+0x2a587b)
    #6 0x7f4affe53ab7 in QTimer::timeout(QTimer::QPrivateSignal) (/usr/lib/libQt5Core.so.5+0x2b1ab7)
    #7 0x7f4affe4810a in QObject::event(QEvent*) (/usr/lib/libQt5Core.so.5+0x2a610a)
    #8 0x7f4b025e1e23 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/usr/lib/libQt5Widgets.so.5+0x157e23)
    #9 0x7f4b025e96e0 in QApplication::notify(QObject*, QEvent*) (/usr/lib/libQt5Widgets.so.5+0x15f6e0)
    #10 0x55e33fd9bfb4 in Application::notify(QObject*, QEvent*) /home/elsid/dev/openmw/apps/opencs/main.cpp:29:38
    #11 0x7f4affe1ce98 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/usr/lib/libQt5Core.so.5+0x27ae98)
    #12 0x7f4affe72094 in QTimerInfoList::activateTimers() (/usr/lib/libQt5Core.so.5+0x2d0094)
    #13 0x7f4affe72959  (/usr/lib/libQt5Core.so.5+0x2d0959)
    #14 0x7f4afdd607be in g_main_context_dispatch (/usr/lib/libglib-2.0.so.0+0x6b7be)
    #15 0x7f4afdd62738  (/usr/lib/libglib-2.0.so.0+0x6d738)
    #16 0x7f4afdd6277d in g_main_context_iteration (/usr/lib/libglib-2.0.so.0+0x6d77d)
    #17 0x7f4affe72ce8 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/libQt5Core.so.5+0x2d0ce8)
    #18 0x7f4affe1bb2b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/libQt5Core.so.5+0x279b2b)
    #19 0x7f4affc5f568 in QThread::exec() (/usr/lib/libQt5Core.so.5+0xbd568)
    #20 0x7f4affc6096b  (/usr/lib/libQt5Core.so.5+0xbe96b)
    #21 0x7f4b0071aa9c in start_thread (/usr/lib/libpthread.so.0+0x7a9c)
    #22 0x7f4aff79ab22 in __GI___clone (/usr/lib/libc.so.6+0xfbb22)
```