### PR TITLE
Fix clean unused navmeshes

### DIFF
--- a/components/detournavigator/navmeshmanager.cpp
+++ b/components/detournavigator/navmeshmanager.cpp
@@ -22,7 +22,8 @@ namespace
     template <class T>
     bool resetIfUnique(std::shared_ptr<T>& ptr)
     {
-        const std::weak_ptr<T> weak = std::move(ptr);
+        const std::weak_ptr<T> weak(ptr);
+        ptr.reset();
         if (auto shared = weak.lock())
         {
             ptr = std::move(shared);


### PR DESCRIPTION
`weak_ptr` doesn't have constructor for `shared_ptr&&` type, so ptr wasn't moved, just copied.