### PR TITLE
Do not recreate shaders to update transparency

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1798,17 +1798,13 @@ namespace MWRender
                 material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,alpha));
                 material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
                 stateset->setAttributeAndModes(material, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
-
+                stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
                 mObjectRoot->setStateSet(stateset);
-
-                mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
             }
         }
         else
         {
             mObjectRoot->setStateSet(nullptr);
-
-            mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
         }
 
         setRenderBin();

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -649,9 +649,6 @@ void NpcAnimation::updateParts()
 
     if (wasArrowAttached)
         attachArrow();
-
-    if (mAlpha != 1.f)
-        mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
 }
 
 
@@ -918,9 +915,6 @@ void NpcAnimation::showWeapons(bool showWeapon)
                     attachArrow();
             }
         }
-        // Note: we will need to recreate shaders later if we use weapon sheathing anyway, so there is no point to update them here
-        if (mAlpha != 1.f && !mWeaponSheathing)
-            mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
     }
     else
     {
@@ -932,10 +926,6 @@ void NpcAnimation::showWeapons(bool showWeapon)
 
     updateHolsteredWeapon(!mShowWeapons);
     updateQuiver();
-
-    // Recreate shaders for invisible actors, otherwise sheath nodes will be visible
-    if (mAlpha != 1.f && mWeaponSheathing)
-        mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
 }
 
 void NpcAnimation::showCarriedLeft(bool show)
@@ -953,8 +943,6 @@ void NpcAnimation::showCarriedLeft(bool show)
             if (iter->getTypeName() == typeid(ESM::Light).name() && mObjectParts[ESM::PRT_Shield])
                 addExtraLight(mObjectParts[ESM::PRT_Shield]->getNode()->asGroup(), iter->get<ESM::Light>()->mBase);
         }
-        if (mAlpha != 1.f)
-            mResourceSystem->getSceneManager()->recreateShaders(mObjectRoot);
     }
     else
         removeIndividualPart(ESM::PRT_Shield);


### PR DESCRIPTION
Based on bzzt's changes.
Attempt to add a color uniform directly instead of doing the same thing via shader visitor to handle alpha level.
May not be a good idea if other color modes should be used sometimes, so requesting a review from @AnyOldName3. 