### PR TITLE
Delete composite map layers in the background thread

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -314,6 +314,7 @@ namespace MWRender
 
         mTerrain->setDefaultViewer(mViewer->getCamera());
         mTerrain->setTargetFrameRate(Settings::Manager::getFloat("target framerate", "Cells"));
+        mTerrain->setWorkQueue(mWorkQueue.get());
 
         mCamera.reset(new Camera(mViewer->getCamera()));
 

--- a/components/terrain/compositemaprenderer.hpp
+++ b/components/terrain/compositemaprenderer.hpp
@@ -14,6 +14,12 @@ namespace osg
     class Texture2D;
 }
 
+namespace SceneUtil
+{
+    class UnrefQueue;
+    class WorkQueue;
+}
+
 namespace Terrain
 {
 
@@ -34,10 +40,14 @@ namespace Terrain
     {
     public:
         CompositeMapRenderer();
+        ~CompositeMapRenderer();
 
         virtual void drawImplementation(osg::RenderInfo& renderInfo) const;
 
         void compile(CompositeMap& compositeMap, osg::RenderInfo& renderInfo, double* timeLeft) const;
+
+        /// Set a WorkQueue to delete compiled composite map layers in the background thread
+        void setWorkQueue(SceneUtil::WorkQueue* workQueue);
 
         /// Set the available time in seconds for compiling (non-immediate) composite maps each frame
         void setMinimumTimeAvailableForCompile(double time);
@@ -57,6 +67,9 @@ namespace Terrain
         float mTargetFrameRate;
         double mMinimumTimeAvailable;
         mutable osg::Timer mTimer;
+
+        osg::ref_ptr<SceneUtil::UnrefQueue> mUnrefQueue;
+        osg::ref_ptr<SceneUtil::WorkQueue> mWorkQueue;
 
         typedef std::set<osg::ref_ptr<CompositeMap> > CompileSet;
 

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -16,7 +16,7 @@ namespace Terrain
     class RootNode;
     class ViewDataMap;
 
-    /// @brief Terrain implementation that loads cells into a Quad Tree, with geometry LOD and texture LOD. The entire world is displayed at all times.
+    /// @brief Terrain implementation that loads cells into a Quad Tree, with geometry LOD and texture LOD.
     class QuadTreeWorld : public TerrainGrid // note: derived from TerrainGrid is only to render default cells (see loadCell)
     {
     public:

--- a/components/terrain/world.cpp
+++ b/components/terrain/world.cpp
@@ -66,6 +66,11 @@ World::~World()
     delete mStorage;
 }
 
+void World::setWorkQueue(SceneUtil::WorkQueue* workQueue)
+{
+    mCompositeMapRenderer->setWorkQueue(workQueue);
+}
+
 void World::setBordersVisible(bool visible)
 {
     mBorderVisible = visible;

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -24,6 +24,11 @@ namespace Resource
     class ResourceSystem;
 }
 
+namespace SceneUtil
+{
+    class WorkQueue;
+}
+
 namespace Terrain
 {
     class Storage;
@@ -58,6 +63,9 @@ namespace Terrain
         /// @param preCompileMask mask for pre compiling textures
         World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask, int borderMask);
         virtual ~World();
+
+        /// Set a WorkQueue to delete objects in the background thread.
+        void setWorkQueue(SceneUtil::WorkQueue* workQueue);
 
         /// See CompositeMapRenderer::setTargetFrameRate
         void setTargetFrameRate(float rate);


### PR DESCRIPTION
Based on bzzt's changes.
In our recent changes we remove compiled composite map layers immediately.
This PR deletes them in the background thread instead via UnrefQueue.