### PR TITLE
Fix shader specular lighting (again)

### DIFF
--- a/files/shaders/lighting.glsl
+++ b/files/shaders/lighting.glsl
@@ -74,9 +74,10 @@ vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, out vec3 shadow
 vec3 getSpecular(vec3 viewNormal, vec3 viewDirection, float shininess, vec3 matSpec)
 {
     vec3 lightDir = normalize(gl_LightSource[0].position.xyz);
-    float NdotL = max(dot(viewNormal, lightDir), 0.0);
-    if (NdotL < 0.0)
+    float NdotL = dot(viewNormal, lightDir);
+    if (NdotL <= 0.0)
         return vec3(0.,0.,0.);
     vec3 halfVec = normalize(lightDir - viewDirection);
-    return pow(max(dot(viewNormal, halfVec), 0.0), shininess) * gl_LightSource[0].specular.xyz * matSpec;
+    float NdotH = dot(viewNormal, halfVec);
+    return pow(max(NdotH, 0.0), max(1e-4, shininess)) * gl_LightSource[0].specular.xyz * matSpec;
 }


### PR DESCRIPTION
1. Actually discard stuff that is unreachable for the sunlight and don't attempt to use specular lighting for it.
2. Avoid undefined behavior for pow function. Shininess is never 0, so that a 0^0 calculation never happens.

A lot of objects in the game have zero shininess, so once it became used and since the angle between the sun and the view normal was over 90 degrees (it wasn't discarded), the angle between the view normal and half vector was also likely to be over 90 degrees, so it became 0. pow(0, 0) leads to undefined behavior, and it became pretty obvious when literal zero didn't cause the following issue for whatever reason (Nvidia shenanigans probably). 

Before these fixes the stuff that was unreachable for light became very dark and the lighting looked broken when shaders were used, which was especially obvious when the object was covered by fog.