### PR TITLE
Vsync tweaks

### DIFF
--- a/components/sdlutil/sdlgraphicswindow.cpp
+++ b/components/sdlutil/sdlgraphicswindow.cpp
@@ -113,7 +113,7 @@ void GraphicsWindowSDL2::init()
         return;
     }
 
-    SDL_GL_SetSwapInterval(_traits->vsync ? 1 : 0);
+    setSwapInterval(_traits->vsync);
 
     SDL_GL_MakeCurrent(oldWin, oldCtx);
 
@@ -194,9 +194,29 @@ void GraphicsWindowSDL2::setSyncToVBlank(bool on)
 
     SDL_GL_MakeCurrent(mWindow, mContext);
 
-    SDL_GL_SetSwapInterval(on ? 1 : 0);
+    setSwapInterval(on);
 
     SDL_GL_MakeCurrent(oldWin, oldCtx);
+}
+
+void GraphicsWindowSDL2::setSwapInterval(bool enable)
+{
+    if (enable)
+    {
+        if (SDL_GL_SetSwapInterval(-1) == -1)
+        {
+            OSG_NOTICE << "Adaptive vsync unsupported" << std::endl;
+            if (SDL_GL_SetSwapInterval(1) == -1)
+            {
+                OSG_NOTICE << "Vertical synchronization unsupported, disabling" << std::endl;
+                SDL_GL_SetSwapInterval(0);
+            }
+        }
+    }
+    else
+    {
+        SDL_GL_SetSwapInterval(0);
+    }
 }
 
 void GraphicsWindowSDL2::raiseWindow()

--- a/components/sdlutil/sdlgraphicswindow.hpp
+++ b/components/sdlutil/sdlgraphicswindow.hpp
@@ -80,6 +80,9 @@ public:
 
         SDL_Window *mWindow;
     };
+
+private:
+    void setSwapInterval(bool enable);
 };
 
 }


### PR DESCRIPTION
* Try to use adaptive vsync if available.
* Don't use vsync if unavailable.

Using adaptive vsync means that the framerate won't be capped to 30 or 15 or whatever if it's too low for the user's display refresh rate, leading to lower input delay and higher framerate, but it requires some OpenGL extension not all cards have (it was introduced to Nvidia and AMD drivers in late 2011).

Not using vsync if unavailable may "fix" visual issues with Intel cards if they really don't support it. I doubt that it will, though.