### PR TITLE
Stack items with and without owner if item holder is owner (bug #1933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.46.0
 ------
 
+    Bug #1933: Actors can have few stocks of the same item
     Bug #2969: Scripted items can stack
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3623: Fix HiDPI on Windows

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -58,8 +58,7 @@ namespace MWClass
 
             // setting ownership not needed, since taking items from a container inherits the
             // container's owner automatically
-            data->mContainerStore.fill(
-                ref->mBase->mInventory, "");
+            data->mContainerStore.fill(ref->mBase->mInventory, "", ptr);
 
             // store
             ptr.getRefData().setCustomData (data.release());

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -163,7 +163,7 @@ namespace MWClass
             // store
             ptr.getRefData().setCustomData(data.release());
 
-            getContainerStore(ptr).fill(ref->mBase->mInventory, ptr.getCellRef().getRefId());
+            getContainerStore(ptr).fill(ref->mBase->mInventory, ptr.getCellRef().getRefId(), ptr);
 
             if (hasInventory)
                 getInventoryStore(ptr).autoEquip(ptr);

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -403,7 +403,7 @@ namespace MWClass
 
             // inventory
             // setting ownership is used to make the NPC auto-equip his initial equipment only, and not bartered items
-            data->mInventoryStore.fill(ref->mBase->mInventory, ptr.getCellRef().getRefId());
+            data->mInventoryStore.fill(ref->mBase->mInventory, ptr.getCellRef().getRefId(), ptr);
 
             data->mNpcStats.setGoldPool(gold);
 

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -11,7 +11,8 @@ namespace MWGui
     class ContainerItemModel : public ItemModel
     {
     public:
-        ContainerItemModel (const std::vector<MWWorld::Ptr>& itemSources, const std::vector<MWWorld::Ptr>& worldItems);
+        ContainerItemModel (const std::vector<MWWorld::Ptr>& itemSources, const std::vector<MWWorld::Ptr>& worldItems,
+                            const MWWorld::ConstPtr& owner);
         ///< @note The order of elements \a itemSources matters here. The first element has the highest priority for removal,
         ///  while the last element will be used to add new items to.
 
@@ -36,6 +37,7 @@ namespace MWGui
         std::vector<MWWorld::Ptr> mWorldItems;
 
         std::vector<ItemStack> mItems;
+        MWWorld::ConstPtr mOwner;
     };
 
 }

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -18,6 +18,7 @@ namespace MWGui
 InventoryItemModel::InventoryItemModel(const MWWorld::Ptr &actor)
     : mActor(actor)
 {
+    assert(mActor);
 }
 
 ItemStack InventoryItemModel::getItem (ModelIndex index)
@@ -106,7 +107,7 @@ void InventoryItemModel::update()
         if (!item.getClass().showsInInventory(item))
             continue;
 
-        ItemStack newItem (item, this, item.getRefData().getCount());
+        ItemStack newItem (item, this, item.getRefData().getCount(), mActor);
 
         if (mActor.getClass().hasInventoryStore(mActor))
         {

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -32,26 +32,6 @@ namespace MWGui
     {
     }
 
-    bool ItemStack::stacks(const ItemStack &other)
-    {
-        if(mBase == other.mBase)
-            return true;
-
-        // If one of the items is in an inventory and currently equipped, we need to check stacking both ways to be sure
-        if (mBase.getContainerStore() && other.mBase.getContainerStore())
-            return mBase.getContainerStore()->stacks(mBase, other.mBase)
-                    && other.mBase.getContainerStore()->stacks(mBase, other.mBase);
-
-        if (mBase.getContainerStore())
-            return mBase.getContainerStore()->stacks(mBase, other.mBase);
-        if (other.mBase.getContainerStore())
-            return other.mBase.getContainerStore()->stacks(mBase, other.mBase);
-
-        MWWorld::ContainerStore store;
-        return store.stacks(mBase, other.mBase);
-
-    }
-
     bool operator == (const ItemStack& left, const ItemStack& right)
     {
         if (left.mType != right.mType)

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -10,12 +10,13 @@
 namespace MWGui
 {
 
-    ItemStack::ItemStack(const MWWorld::Ptr &base, ItemModel *creator, size_t count)
+    ItemStack::ItemStack(const MWWorld::Ptr &base, ItemModel *creator, size_t count, const MWWorld::ConstPtr& holder)
         : mType(Type_Normal)
         , mFlags(0)
         , mCreator(creator)
         , mCount(count)
         , mBase(base)
+        , mHolder(holder)
     {
         if (base.getClass().getEnchantment(base) != "")
             mFlags |= Flag_Enchanted;
@@ -40,18 +41,21 @@ namespace MWGui
         if(left.mBase == right.mBase)
             return true;
 
+        if (left.mHolder != right.mHolder)
+            return false;
+
         // If one of the items is in an inventory and currently equipped, we need to check stacking both ways to be sure
         if (left.mBase.getContainerStore() && right.mBase.getContainerStore())
-            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase)
-                    && right.mBase.getContainerStore()->stacks(left.mBase, right.mBase);
+            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase, left.mHolder)
+                    && right.mBase.getContainerStore()->stacks(left.mBase, right.mBase, left.mHolder);
 
         if (left.mBase.getContainerStore())
-            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase);
+            return left.mBase.getContainerStore()->stacks(left.mBase, right.mBase, left.mHolder);
         if (right.mBase.getContainerStore())
-            return right.mBase.getContainerStore()->stacks(left.mBase, right.mBase);
+            return right.mBase.getContainerStore()->stacks(left.mBase, right.mBase, left.mHolder);
 
         MWWorld::ContainerStore store;
-        return store.stacks(left.mBase, right.mBase);
+        return store.stacks(left.mBase, right.mBase, left.mHolder);
     }
 
     ItemModel::ItemModel()

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -13,7 +13,6 @@ namespace MWGui
     {
         ItemStack (const MWWorld::Ptr& base, ItemModel* creator, size_t count);
         ItemStack();
-        bool stacks (const ItemStack& other);
         ///< like operator==, only without checking mType
 
         enum Type

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -11,7 +11,7 @@ namespace MWGui
     /// @brief A single item stack managed by an item model
     struct ItemStack
     {
-        ItemStack (const MWWorld::Ptr& base, ItemModel* creator, size_t count);
+        ItemStack (const MWWorld::Ptr& base, ItemModel* creator, size_t count, const MWWorld::ConstPtr& holder);
         ItemStack();
         ///< like operator==, only without checking mType
 
@@ -33,6 +33,7 @@ namespace MWGui
         ItemModel* mCreator;
         size_t mCount;
         MWWorld::Ptr mBase;
+        MWWorld::ConstPtr mHolder;
     };
 
     bool operator == (const ItemStack& left, const ItemStack& right);

--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -127,7 +127,7 @@ void MerchantRepair::onRepairButtonClick(MyGUI::Widget *sender)
     MWWorld::Ptr item = *sender->getUserData<MWWorld::Ptr>();
     item.getCellRef().setCharge(item.getClass().getItemMaxHealth(item));
 
-    player.getClass().getContainerStore(player).restack(item);
+    player.getClass().getContainerStore(player).restack(item, player);
 
     MWBase::Environment::get().getWindowManager()->playSound("Repair");
 

--- a/apps/openmw/mwgui/recharge.cpp
+++ b/apps/openmw/mwgui/recharge.cpp
@@ -164,7 +164,7 @@ void Recharge::onItemClicked(MyGUI::Widget *sender, const MWWorld::Ptr& item)
 
         MWBase::Environment::get().getWindowManager()->playSound("Enchant Success");
 
-        player.getClass().getContainerStore(player).restack(item);
+        player.getClass().getContainerStore(player).restack(item, player);
     }
     else
     {

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -127,7 +127,7 @@ namespace MWGui
         std::vector<MWWorld::Ptr> worldItems;
         MWBase::Environment::get().getWorld()->getItemsOwnedBy(actor, worldItems);
 
-        mTradeModel = new TradeItemModel(new ContainerItemModel(itemSources, worldItems), mPtr);
+        mTradeModel = new TradeItemModel(new ContainerItemModel(itemSources, worldItems, mPtr), mPtr);
         mSortModel = new SortFilterItemModel(mTradeModel);
         mItemView->setModel (mSortModel);
         mItemView->resetScrollBars();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -212,7 +212,7 @@ namespace MWMechanics
             gem->getCellRef().setSoul(mCreature.getCellRef().getRefId());
 
             // Restack the gem with other gems with the same soul
-            gem->getContainerStore()->restack(*gem);
+            gem->getContainerStore()->restack(*gem, caster);
 
             mTrapped = true;
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -294,7 +294,7 @@ namespace MWMechanics
         if (timeScaleFactor != 0.0f)
             duration /= timeScaleFactor;
         MWWorld::Ptr player = getPlayer();
-        player.getClass().getInventoryStore(player).rechargeItems(duration);
+        player.getClass().getInventoryStore(player).rechargeItems(duration, player);
     }
 
     void MechanicsManager::update(float duration, bool paused)

--- a/apps/openmw/mwmechanics/repair.cpp
+++ b/apps/openmw/mwmechanics/repair.cpp
@@ -55,7 +55,7 @@ void Repair::repair(const MWWorld::Ptr &itemToRepair)
         itemToRepair.getCellRef().setCharge(charge);
 
         // attempt to re-stack item, in case it was fully repaired
-        MWWorld::ContainerStoreIterator stacked = player.getClass().getContainerStore(player).restack(itemToRepair);
+        MWWorld::ContainerStoreIterator stacked = player.getClass().getContainerStore(player).restack(itemToRepair, player);
 
         // set the OnPCRepair variable on the item's script
         std::string script = stacked->getClass().getScript(itemToRepair);

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -479,7 +479,7 @@ namespace MWScript
                     item.getCellRef().setSoul(creature);
 
                     // Restack the gem with other gems with the same soul
-                    item.getContainerStore()->restack(item);
+                    item.getContainerStore()->restack(item, ptr);
                 }
         };
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -92,8 +92,9 @@ namespace MWWorld
 
             mutable float mCachedWeight;
             mutable bool mWeightUpToDate;
-            ContainerStoreIterator addImp (const Ptr& ptr, int count);
-            void addInitialItem (const std::string& id, const std::string& owner, int count, bool topLevel=true, const std::string& levItem = "");
+            ContainerStoreIterator addImp (const Ptr& ptr, int count, const ConstPtr& holder);
+            void addInitialItem (const ConstPtr& holder, const std::string& id, const std::string& owner,
+                                 int count, bool topLevel=true, const std::string& levItem = "");
 
             template<typename T>
             ContainerStoreIterator getState (CellRefList<T>& collection,
@@ -158,7 +159,7 @@ namespace MWWorld
             ///
             /// @return an iterator to the new stack, or end() if no new stack was created.
 
-            MWWorld::ContainerStoreIterator restack (const MWWorld::Ptr& item);
+            MWWorld::ContainerStoreIterator restack (const MWWorld::Ptr& item, const ConstPtr& holder);
             ///< Attempt to re-stack an item in this container.
             /// If a compatible stack is found, the item's count is added to that stack, then the original is deleted.
             /// @return If the item was stacked, return the stack, otherwise return the old (untouched) item.
@@ -181,13 +182,13 @@ namespace MWWorld
 
         public:
 
-            virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2) const;
+            virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2, const ConstPtr& holder) const;
             ///< @return true if the two specified objects can stack with each other
 
-            void fill (const ESM::InventoryList& items, const std::string& owner);
+            void fill (const ESM::InventoryList& items, const std::string& owner, const ConstPtr& holder);
             ///< Insert items into *this.
 
-            void restock (const ESM::InventoryList& items, const MWWorld::Ptr& ptr, const std::string& owner);
+            void restock (const ESM::InventoryList& items, const MWWorld::Ptr& holder, const std::string& owner);
 
             virtual void clear();
             ///< Empty container.

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -724,9 +724,9 @@ void MWWorld::InventoryStore::flagAsModified()
     mRechargingItemsUpToDate = false;
 }
 
-bool MWWorld::InventoryStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2) const
+bool MWWorld::InventoryStore::stacks(const ConstPtr& ptr1, const ConstPtr& ptr2, const ConstPtr& holder) const
 {
-    bool canStack = MWWorld::ContainerStore::stacks(ptr1, ptr2);
+    bool canStack = MWWorld::ContainerStore::stacks(ptr1, ptr2, holder);
     if (!canStack)
         return false;
 
@@ -839,7 +839,7 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::unequipSlot(int slot, c
 
         if (it->getRefData().getCount())
         {
-            retval = restack(*it);
+            retval = restack(*it, actor);
 
             if (actor == MWMechanics::getPlayer())
             {
@@ -892,7 +892,7 @@ MWWorld::ContainerStoreIterator MWWorld::InventoryStore::unequipItemQuantity(con
     // Moving counts manually here, since ContainerStore's restack can't target unequipped stacks.
     for (MWWorld::ContainerStoreIterator iter (begin()); iter != end(); ++iter)
     {
-        if (stacks(*iter, item) && !isEquipped(*iter))
+        if (stacks(*iter, item, actor) && !isEquipped(*iter))
         {
             iter->getRefData().setCount(iter->getRefData().getCount() + count);
             item.getRefData().setCount(item.getRefData().getCount() - count);
@@ -989,7 +989,7 @@ void MWWorld::InventoryStore::updateRechargingItems()
     }
 }
 
-void MWWorld::InventoryStore::rechargeItems(float duration)
+void MWWorld::InventoryStore::rechargeItems(float duration, const ConstPtr& holder)
 {
     if (!mRechargingItemsUpToDate)
     {
@@ -1012,7 +1012,7 @@ void MWWorld::InventoryStore::rechargeItems(float duration)
 
             // attempt to restack when fully recharged
             if (it->first->getCellRef().getEnchantmentCharge() == it->second)
-                it->first = restack(*it->first);
+                it->first = restack(*it->first, holder);
         }
     }
 }

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -175,7 +175,7 @@ namespace MWWorld
             ///< \attention This function is internal to the world model and should not be called from
             /// outside.
 
-            virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2) const;
+            virtual bool stacks (const ConstPtr& ptr1, const ConstPtr& ptr2, const ConstPtr& holder) const;
             ///< @return true if the two specified objects can stack with each other
 
             virtual int remove(const std::string& itemId, int count, const Ptr& actor);
@@ -216,7 +216,7 @@ namespace MWWorld
 
             void visitEffectSources (MWMechanics::EffectSourceVisitor& visitor);
 
-            void rechargeItems (float duration);
+            void rechargeItems (float duration, const ConstPtr& holder);
             ///< Restore charge on enchanted items. Note this should only be done for the player.
 
             void purgeEffect (short effectId);


### PR DESCRIPTION
Holder is an actor in which inventory or container item is placed. If player pick and item or item is sold to NPC, or stolen from NPC, then item owner is set to empty. If actor has other item in the same container and with same parameters but has different owner (actor itself) they can be stacked. At least I don't see why they can't be stacked.

This pr fixes [1933](https://gitlab.com/OpenMW/openmw/issues/1933) and doesn't break [1953](https://gitlab.com/OpenMW/openmw/issues/1953). Sold item is placed into merchant inventory and can be stolen from it. All sold apparel can be bought back.

Also removed some unused code.