### PR TITLE
Fixes for werewolf animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
     Bug #4896: Title screen music doesn't loop
     Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
+    Bug #4922: Werewolves can not attack if the transformation happens during attack
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2554,6 +2554,13 @@ void CharacterController::forceStateUpdate()
         return;
     clearAnimQueue();
 
+    // Make sure we canceled the current attack or spellcasting,
+    // because we disabled attack animations anyway.
+    mCastingManualSpell = false;
+    mAttackingOrSpell = false;
+    if (mUpperBodyState != UpperCharState_Nothing)
+        mUpperBodyState = UpperCharState_WeapEquiped;
+
     refreshCurrentAnims(mIdleState, mMovementState, mJumpState, true);
 
     if(mDeathState != CharState_None)

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -238,6 +238,18 @@ void HeadAnimationTime::setBlinkStop(float value)
 
 // ----------------------------------------------------
 
+NpcAnimation::NpcType NpcAnimation::getNpcType()
+{
+    const MWWorld::Class &cls = mPtr.getClass();
+    NpcAnimation::NpcType curType = Type_Normal;
+    if (cls.getCreatureStats(mPtr).getMagicEffects().get(ESM::MagicEffect::Vampirism).getMagnitude() > 0)
+        curType = Type_Vampire;
+    if (cls.getNpcStats(mPtr).isWerewolf())
+        curType = Type_Werewolf;
+
+    return curType;
+}
+
 static NpcAnimation::PartBoneMap createPartListMap()
 {
     NpcAnimation::PartBoneMap result;
@@ -283,7 +295,7 @@ NpcAnimation::NpcAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group> par
     mViewMode(viewMode),
     mShowWeapons(false),
     mShowCarriedLeft(true),
-    mNpcType(Type_Normal),
+    mNpcType(getNpcType()),
     mFirstPersonFieldOfView(firstPersonFieldOfView),
     mSoundsDisabled(disableSounds),
     mAccurateAiming(false),
@@ -431,8 +443,9 @@ void NpcAnimation::updateNpcBase()
 
     const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
     const ESM::Race *race = store.get<ESM::Race>().find(mNpc->mRace);
-    bool isWerewolf = (mNpcType == Type_Werewolf);
-    bool isVampire = (mNpcType == Type_Vampire);
+    NpcType curType = getNpcType();
+    bool isWerewolf = (curType == Type_Werewolf);
+    bool isVampire = (curType == Type_Vampire);
     bool isFemale = !mNpc->isMale();
 
     if (isWerewolf)
@@ -517,14 +530,7 @@ void NpcAnimation::updateParts()
     if (!mObjectRoot.get())
         return;
 
-    const MWWorld::Class &cls = mPtr.getClass();
-
-    NpcType curType = Type_Normal;
-    if (cls.getCreatureStats(mPtr).getMagicEffects().get(ESM::MagicEffect::Vampirism).getMagnitude() > 0)
-        curType = Type_Vampire;
-    if (cls.getNpcStats(mPtr).isWerewolf())
-        curType = Type_Werewolf;
-
+    NpcType curType = getNpcType();
     if (curType != mNpcType)
     {
         mNpcType = curType;
@@ -632,7 +638,7 @@ void NpcAnimation::updateParts()
     showWeapons(mShowWeapons);
     showCarriedLeft(mShowCarriedLeft);
 
-    bool isWerewolf = (mNpcType == Type_Werewolf);
+    bool isWerewolf = (getNpcType() == Type_Werewolf);
     std::string race = (isWerewolf ? "werewolf" : Misc::StringUtils::lowerCase(mNpc->mRace));
 
     const std::vector<const ESM::BodyPart*> &parts = getBodyParts(race, !mNpc->isMale(), mViewMode == VM_FirstPerson, isWerewolf);

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -74,6 +74,8 @@ private:
 
     void updateNpcBase();
 
+    NpcType getNpcType();
+
     PartHolderPtr insertBoundedPart(const std::string &model, const std::string &bonename,
                                         const std::string &bonefilter, bool enchantedGlow, osg::Vec4f* glowColor=nullptr);
 


### PR DESCRIPTION
1. Fixes a 0.46 regression when werewolves sometimes used animations for bipedal actors.
The main idea is to set NPC type properly from beginning, rather than starting to construct a normal NPC and then rebuild him to vampire or werewolf.
2. Fixes [bug #4922](https://gitlab.com/OpenMW/openmw/issues/4922).
Currently we use the forceUpdate() when we rebuild actor from scratch in these cases:
2.1. For player object when we change the view mode
2.2. For all NPCs when we change the NPC type (e.g. from turn him from normal NPC to vampire or werewolf).
In the first case we do not allow to switch mode during attack, so this case is irrelevant here, so in theory it should be safe to reset flags which are responsible for attack state.