### PR TITLE
Do not block loading while compiling composite maps

### DIFF
--- a/components/terrain/compositemaprenderer.cpp
+++ b/components/terrain/compositemaprenderer.cpp
@@ -70,14 +70,17 @@ void CompositeMapRenderer::drawImplementation(osg::RenderInfo &renderInfo) const
     while (!mCompileSet.empty() && timeLeft > 0)
     {
         osg::ref_ptr<CompositeMap> node = *mCompileSet.begin();
+        mCompileSet.erase(node);
 
         mMutex.unlock();
         compile(*node, renderInfo, &timeLeft);
         mMutex.lock();
 
-        if (node->mCompiled >= node->mDrawables.size())
+        if (node->mCompiled < node->mDrawables.size())
         {
-            mCompileSet.erase(node);
+            // We did not compile the map fully.
+            // Place it back to queue to continue work in the next time.
+            mCompileSet.insert(node);
         }
     }
     mTimer.setStartTick();

--- a/components/terrain/compositemaprenderer.cpp
+++ b/components/terrain/compositemaprenderer.cpp
@@ -47,8 +47,6 @@ void CompositeMapRenderer::drawImplementation(osg::RenderInfo &renderInfo) const
     double availableTime = std::max((targetFrameTime - dt)*conservativeTimeRatio,
                                     mMinimumTimeAvailable);
 
-    mCompiled.clear();
-
     if (mWorkQueue)
         mUnrefQueue->flush(mWorkQueue.get());
 
@@ -60,7 +58,6 @@ void CompositeMapRenderer::drawImplementation(osg::RenderInfo &renderInfo) const
     while (!mImmediateCompileSet.empty())
     {
         osg::ref_ptr<CompositeMap> node = *mImmediateCompileSet.begin();
-        mCompiled.insert(node);
         mImmediateCompileSet.erase(node);
 
         mMutex.unlock();
@@ -80,7 +77,6 @@ void CompositeMapRenderer::drawImplementation(osg::RenderInfo &renderInfo) const
 
         if (node->mCompiled >= node->mDrawables.size())
         {
-            mCompiled.insert(node);
             mCompileSet.erase(node);
         }
     }

--- a/components/terrain/compositemaprenderer.hpp
+++ b/components/terrain/compositemaprenderer.hpp
@@ -76,8 +76,6 @@ namespace Terrain
         mutable CompileSet mCompileSet;
         mutable CompileSet mImmediateCompileSet;
 
-        mutable CompileSet mCompiled;
-
         mutable OpenThreads::Mutex mMutex;
 
         osg::ref_ptr<osg::FrameBufferObject> mFBO;


### PR DESCRIPTION
Currently we have two queues to compile composite maps in the draw thread:
1. mCompileSet - for low priority maps. Compile while some time left to avoid frame drops. If there is no time left, continue work in the next frame.
2. mImmediateCompileSet - for high priority maps. Compile all of them even if there will be a frame drop.

We manage these queues in the loading thread, so we use a mutex to block access to queues when we work with them.
Since compiling takes some time (about 1ms per map), the draw thread holds the mutex for a while.
As a result, if the background thread wants to add some items to the compile queue (e.g. during cell loading), it should wait for mutex from the draw thread.

The main idea here - since compiling itself does not work with queues, we can release the mutex while compiling (but not when we read data from queues), so the loading thread can push items to queue and continue execution.

If the loading thread moves current map from one queue to another via `setImmediate()`, the draw thread may try to compile the map in the second time, but it will compile only non-compiled drawables in this map, if there are any.

So this PR should increase the loading speed a bit.

Requesting a review from @elsid since he has more experience with threads sync than me - maybe there is a more clean way to do it.