### PR TITLE
Enable light sources directly to avoid virtual calls

### DIFF
--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -245,7 +245,8 @@ namespace SceneUtil
             osg::ref_ptr<LightStateAttribute> attr = new LightStateAttribute(mStartLight, lights);
             // don't use setAttributeAndModes, that does not support light indices!
             stateset->setAttribute(attr, osg::StateAttribute::ON);
-            stateset->setAssociatedModes(attr, osg::StateAttribute::ON);
+            for (unsigned int i=0; i<lightList.size(); ++i)
+                stateset->setMode(GL_LIGHT0 + mStartLight + i, osg::StateAttribute::ON);
 
             // need to push some dummy attributes to ensure proper state tracking
             // lights need to reset to their default when the StateSet is popped


### PR DESCRIPTION
Based on bzzt's changes.
The `setAssociatedModes` is supposed to fill the ModeUsage via `getModeUsage()` and apply specified changes to the stateset.
Currently we use it to enable light sources.
In theory, we can enable light sources directly via a quite common OSG code pattern to avoid overhead.

As a result, every stateset creation in the LightManager takes about 1 microsecond less time.