### PR TITLE
Use auto for map value_type in range-based for loops

### DIFF
--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -739,7 +739,7 @@ void Record<ESM::Faction>::print()
             std::cout << "    Faction Reaction: "
                       << mData.mData.mRankData[i].mFactReaction << std::endl;
         }
-    for (const std::pair<std::string, int> &reaction : mData.mReactions)
+    for (const auto &reaction : mData.mReactions)
         std::cout << "  Reaction: " << reaction.second << " = " << reaction.first << std::endl;
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -1006,7 +1006,7 @@ void CSMWorld::Data::loadFallbackEntries()
         std::make_pair("PrisonMarker", "marker_prison.nif")
     };
 
-    for (const std::pair<std::string, std::string> &marker : staticMarkers)
+    for (const auto &marker : staticMarkers)
     {
         if (mReferenceables.searchId (marker.first)==-1)
         {
@@ -1020,7 +1020,7 @@ void CSMWorld::Data::loadFallbackEntries()
         }
     }
 
-    for (const std::pair<std::string, std::string> &marker : doorMarkers)
+    for (const auto &marker : doorMarkers)
     {
         if (mReferenceables.searchId (marker.first)==-1)
         {

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -790,7 +790,7 @@ bool NpcAnimation::addOrReplaceIndividualPart(ESM::PartReferenceType type, int g
                     osg::Object* obj = node->getUserDataContainer()->getUserObject(i);
                     if (NifOsg::TextKeyMapHolder* keys = dynamic_cast<NifOsg::TextKeyMapHolder*>(obj))
                     {
-                        for (const std::pair<float, std::string> &key : keys->mTextKeys)
+                        for (const auto &key : keys->mTextKeys)
                         {
                             if (Misc::StringUtils::ciEqual(key.second, "talk: start"))
                                 mHeadAnimationTime->setTalkStart(key.first);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -470,7 +470,7 @@ namespace MWWorld
         gmst["iWereWolfBounty"] = ESM::Variant(1000);
         gmst["fCombatDistanceWerewolfMod"] = ESM::Variant(0.3f);
 
-        for (const std::pair<std::string, ESM::Variant> &params : gmst)
+        for (const auto &params : gmst)
         {
             if (!mStore.get<ESM::GameSetting>().search(params.first))
             {
@@ -500,7 +500,7 @@ namespace MWWorld
         globals["crimegoldturnin"] = ESM::Variant(0);
         globals["pchasturnin"] = ESM::Variant(0);
 
-        for (const std::pair<std::string, ESM::Variant> &params : globals)
+        for (const auto &params : globals)
         {
             if (!mStore.get<ESM::Global>().search(params.first))
             {
@@ -519,7 +519,7 @@ namespace MWWorld
         statics["templemarker"] = "marker_temple.nif";
         statics["travelmarker"] = "marker_travel.nif";
 
-        for (const std::pair<std::string, std::string> &params : statics)
+        for (const auto &params : statics)
         {
             if (!mStore.get<ESM::Static>().search(params.first))
             {
@@ -533,7 +533,7 @@ namespace MWWorld
         std::map<std::string, std::string> doors;
         doors["prisonmarker"] = "marker_prison.nif";
 
-        for (const std::pair<std::string, std::string> &params : doors)
+        for (const auto &params : doors)
         {
             if (!mStore.get<ESM::Door>().search(params.first))
             {


### PR DESCRIPTION
To avoid implicit call of copy constructor for `pair<const K, V>` to `pair<K, V>` conversion.