### PR TITLE
Improve AiWander pathfinding for locations without pathgrid

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -298,7 +298,8 @@ namespace MWMechanics
         const auto currentPosition = actor.getRefData().getPosition().asVec3();
 
         std::size_t attempts = 10; // If a unit can't wander out of water, don't want to hang here
-        bool isWaterCreature = actor.getClass().isPureWaterCreature(actor);
+        const bool isWaterCreature = actor.getClass().isPureWaterCreature(actor);
+        const bool isFlyingCreature = actor.getClass().isPureFlyingCreature(actor);
         do {
             // Determine a random location within radius of original position
             const float wanderRadius = (0.2f + Misc::Rng::rollClosedProbability() * 0.8f) * wanderDistance;
@@ -312,7 +313,7 @@ namespace MWMechanics
             if (!isWaterCreature && destinationIsAtWater(actor, mDestination))
                 continue;
 
-            if (isWaterCreature && destinationThroughGround(currentPosition, mDestination))
+            if ((isWaterCreature || isFlyingCreature) && destinationThroughGround(currentPosition, mDestination))
                 continue;
 
             const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -47,6 +47,16 @@ namespace MWMechanics
         std::string("idle9"),
     };
 
+    namespace
+    {
+        inline int getCountBeforeReset(const MWWorld::ConstPtr& actor)
+        {
+            if (actor.getClass().isPureWaterCreature(actor) || actor.getClass().isPureFlyingCreature(actor))
+                return 1;
+            return COUNT_BEFORE_RESET;
+        }
+    }
+
     AiWander::AiWander(int distance, int duration, int timeOfDay, const std::vector<unsigned char>& idle, bool repeat):
         mDistance(distance), mDuration(duration), mRemainingDuration(duration), mTimeOfDay(timeOfDay), mIdle(idle),
         mRepeat(repeat), mStoredInitialActorPosition(false), mInitialActorPosition(osg::Vec3f(0, 0, 0)),
@@ -493,7 +503,7 @@ namespace MWMechanics
         }
 
         // if stuck for sufficiently long, act like current location was the destination
-        if (storage.mStuckCount >= COUNT_BEFORE_RESET) // something has gone wrong, reset
+        if (storage.mStuckCount >= getCountBeforeReset(actor)) // something has gone wrong, reset
         {
             mObstacleCheck.clear();
             stopWalking(actor, storage);

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -325,9 +325,8 @@ namespace MWMechanics
             else
             {
                 const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
-                mPathFinder.buildPath(actor, currentPosition, mDestination, actor.getCell(),
-                    getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
-                mPathFinder.addPointToPath(mDestination);
+                mPathFinder.buildPathByNavMesh(actor, currentPosition, mDestination, halfExtents,
+                    getNavigatorFlags(actor));
             }
 
             if (mPathFinder.isPathConstructed())

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -318,10 +318,17 @@ namespace MWMechanics
             if ((isWaterCreature || isFlyingCreature) && destinationThroughGround(currentPosition, mDestination))
                 continue;
 
-            const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
-            mPathFinder.buildPath(actor, currentPosition, mDestination, actor.getCell(),
-                getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
-            mPathFinder.addPointToPath(mDestination);
+            if (isWaterCreature || isFlyingCreature)
+            {
+                mPathFinder.buildStraightPath(mDestination);
+            }
+            else
+            {
+                const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
+                mPathFinder.buildPath(actor, currentPosition, mDestination, actor.getCell(),
+                    getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
+                mPathFinder.addPointToPath(mDestination);
+            }
 
             if (mPathFinder.isPathConstructed())
             {

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -13,6 +13,8 @@
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/cellstore.hpp"
 
+#include "../mwphysics/collisiontype.hpp"
+
 #include "pathgrid.hpp"
 #include "creaturestats.hpp"
 #include "steering.hpp"
@@ -346,8 +348,10 @@ namespace MWMechanics
      * Returns true if the start to end point travels through a collision point (land).
      */
     bool AiWander::destinationThroughGround(const osg::Vec3f& startPoint, const osg::Vec3f& destination) {
+        const int mask = MWPhysics::CollisionType_World | MWPhysics::CollisionType_HeightMap | MWPhysics::CollisionType_Door;
         return MWBase::Environment::get().getWorld()->castRay(startPoint.x(), startPoint.y(), startPoint.z(),
-                                                              destination.x(), destination.y(), destination.z());
+                                                              destination.x(), destination.y(), destination.z(),
+                                                              mask);
     }
 
     void AiWander::completeManualWalking(const MWWorld::Ptr &actor, AiWanderStorage &storage) {

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -309,22 +309,25 @@ namespace MWMechanics
             mDestination = osg::Vec3f(destinationX, destinationY, destinationZ);
 
             // Check if land creature will walk onto water or if water creature will swim onto land
-            if ((!isWaterCreature && !destinationIsAtWater(actor, mDestination)) ||
-                (isWaterCreature && !destinationThroughGround(currentPosition, mDestination)))
-            {
-                const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
-                mPathFinder.buildPath(actor, currentPosition, mDestination, actor.getCell(),
-                    getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
-                mPathFinder.addPointToPath(mDestination);
+            if (!isWaterCreature && destinationIsAtWater(actor, mDestination))
+                continue;
 
-                if (mPathFinder.isPathConstructed())
-                {
-                    storage.setState(AiWanderStorage::Wander_Walking, true);
-                    mHasDestination = true;
-                    mUsePathgrid = false;
-                }
-                return;
+            if (isWaterCreature && destinationThroughGround(currentPosition, mDestination))
+                continue;
+
+            const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
+            mPathFinder.buildPath(actor, currentPosition, mDestination, actor.getCell(),
+                getPathGridGraph(actor.getCell()), halfExtents, getNavigatorFlags(actor));
+            mPathFinder.addPointToPath(mDestination);
+
+            if (mPathFinder.isPathConstructed())
+            {
+                storage.setState(AiWanderStorage::Wander_Walking, true);
+                mHasDestination = true;
+                mUsePathgrid = false;
             }
+
+            break;
         } while (--attempts);
     }
 

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -121,13 +121,13 @@ namespace MWMechanics
      * u = how long to move sideways
      *
      */
-    void ObstacleCheck::update(const MWWorld::Ptr& actor, float duration, float scaleMinimumDistance)
+    void ObstacleCheck::update(const MWWorld::Ptr& actor, float duration)
     {
         const MWWorld::Class& cls = actor.getClass();
         ESM::Position pos = actor.getRefData().getPosition();
 
         if(mDistSameSpot == -1)
-            mDistSameSpot = DIST_SAME_SPOT * cls.getSpeed(actor) * scaleMinimumDistance;
+            mDistSameSpot = DIST_SAME_SPOT * cls.getSpeed(actor);
 
         float distSameSpot = mDistSameSpot * duration;
 

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -2,6 +2,8 @@
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 
+#include "../mwbase/world.hpp"
+#include "../mwbase/environment.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
 
@@ -123,15 +125,17 @@ namespace MWMechanics
      */
     void ObstacleCheck::update(const MWWorld::Ptr& actor, float duration)
     {
-        const MWWorld::Class& cls = actor.getClass();
-        ESM::Position pos = actor.getRefData().getPosition();
+        const ESM::Position pos = actor.getRefData().getPosition();
 
-        if(mDistSameSpot == -1)
-            mDistSameSpot = DIST_SAME_SPOT * cls.getSpeed(actor);
+        if (mDistSameSpot == -1)
+        {
+            const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(actor);
+            mDistSameSpot = DIST_SAME_SPOT * actor.getClass().getSpeed(actor) + 1.2 * std::max(halfExtents.x(), halfExtents.y());
+        }
 
-        float distSameSpot = mDistSameSpot * duration;
-
-        bool samePosition =  (osg::Vec2f(pos.pos[0], pos.pos[1]) - osg::Vec2f(mPrevX, mPrevY)).length2() <  distSameSpot * distSameSpot;
+        const float distSameSpot = mDistSameSpot * duration;
+        const float squaredMovedDistance = (osg::Vec2f(pos.pos[0], pos.pos[1]) - osg::Vec2f(mPrevX, mPrevY)).length2();
+        const bool samePosition = squaredMovedDistance < distSameSpot * distSameSpot;
 
         // update position
         mPrevX = pos.pos[0];

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -30,7 +30,7 @@ namespace MWMechanics
             bool isEvading() const;
 
             // Updates internal state, call each frame for moving actor
-            void update(const MWWorld::Ptr& actor, float duration, float scaleMinimumDistance = 1.0f);
+            void update(const MWWorld::Ptr& actor, float duration);
 
             // change direction to try to fix "stuck" actor
             void takeEvasiveAction(MWMechanics::Movement& actorMovement) const;

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -287,6 +287,16 @@ namespace MWMechanics
         mConstructed = true;
     }
 
+    void PathFinder::buildPathByNavMesh(const MWWorld::ConstPtr& actor, const osg::Vec3f& startPoint,
+        const osg::Vec3f& endPoint, const osg::Vec3f& halfExtents, const DetourNavigator::Flags flags)
+    {
+        mPath.clear();
+
+        buildPathByNavigatorImpl(actor, startPoint, endPoint, halfExtents, flags, std::back_inserter(mPath));
+
+        mConstructed = true;
+    }
+
     void PathFinder::buildPath(const MWWorld::ConstPtr& actor, const osg::Vec3f& startPoint, const osg::Vec3f& endPoint,
         const MWWorld::CellStore* cell, const PathgridGraph& pathgridGraph, const osg::Vec3f& halfExtents,
         const DetourNavigator::Flags flags)

--- a/apps/openmw/mwmechanics/pathfinding.cpp
+++ b/apps/openmw/mwmechanics/pathfinding.cpp
@@ -269,6 +269,13 @@ namespace MWMechanics
             mPath.pop_front();
     }
 
+    void PathFinder::buildStraightPath(const osg::Vec3f& endPoint)
+    {
+        mPath.clear();
+        mPath.push_back(endPoint);
+        mConstructed = true;
+    }
+
     void PathFinder::buildPathByPathgrid(const osg::Vec3f& startPoint, const osg::Vec3f& endPoint,
         const MWWorld::CellStore* cell, const PathgridGraph& pathgridGraph)
     {

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -72,6 +72,8 @@ namespace MWMechanics
                 mCell = nullptr;
             }
 
+            void buildStraightPath(const osg::Vec3f& endPoint);
+
             void buildPathByPathgrid(const osg::Vec3f& startPoint, const osg::Vec3f& endPoint,
                 const MWWorld::CellStore* cell, const PathgridGraph& pathgridGraph);
 

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -77,6 +77,9 @@ namespace MWMechanics
             void buildPathByPathgrid(const osg::Vec3f& startPoint, const osg::Vec3f& endPoint,
                 const MWWorld::CellStore* cell, const PathgridGraph& pathgridGraph);
 
+            void buildPathByNavMesh(const MWWorld::ConstPtr& actor, const osg::Vec3f& startPoint,
+                const osg::Vec3f& endPoint, const osg::Vec3f& halfExtents, const DetourNavigator::Flags flags);
+
             void buildPath(const MWWorld::ConstPtr& actor, const osg::Vec3f& startPoint, const osg::Vec3f& endPoint,
                 const MWWorld::CellStore* cell, const PathgridGraph& pathgridGraph, const osg::Vec3f& halfExtents,
                 const DetourNavigator::Flags flags);


### PR DESCRIPTION
1. Apply same rules for flying creatures as for water creatures. Basically they are the same. Just use different environment.
2. Disallow collision with height map when check random destination for water and flying creatures. Terrain has this collision mask. I don't know why `WorldImpl::castRay` method doesn't use this mask by default.
3. Change AiWander state after single stuck for water and flying creatures. They can try to reach impassable location, because ray cast doesn't check for creature bounds and there might be just not enought place. Often happens with fish in shallow water.
4. Don't use navmesh and pathgrid for water and flying creatures. Just add single destination point to path. They can move in three dimensions in any direction, there is no point to use pathgrid nor navmesh, because they only help creatures to move along surfaces.
5. Use actor half extents in obstacle check. Actors can try to move into stone going in circles around along surface without any success but with enough position change to pass obstacle check.
6. Try build initial path only by navmesh for actors wandering when choose destination in location without pathgrid. To avoid strange pathgrid path logic.