### PR TITLE
Camera-related fixes

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -312,7 +312,6 @@ namespace MWRender
         else
             mTerrain.reset(new Terrain::TerrainGrid(sceneRoot, mRootNode, mResourceSystem, mTerrainStorage, Mask_Terrain, Mask_PreCompile, Mask_Debug));
 
-        mTerrain->setDefaultViewer(mViewer->getCamera());
         mTerrain->setTargetFrameRate(Settings::Manager::getFloat("target framerate", "Cells"));
         mTerrain->setWorkQueue(mWorkQueue.get());
 

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -167,6 +167,44 @@ namespace MWWorld
         std::vector<osg::ref_ptr<const osg::Object> > mPreloadedObjects;
     };
 
+    class TerrainPreloadItem : public SceneUtil::WorkItem
+    {
+    public:
+        TerrainPreloadItem(const std::vector<osg::ref_ptr<Terrain::View> >& views, Terrain::World* world, const std::vector<osg::Vec3f>& preloadPositions)
+            : mAbort(false)
+            , mTerrainViews(views)
+            , mWorld(world)
+            , mPreloadPositions(preloadPositions)
+        {
+        }
+
+        void storeViews(double referenceTime)
+        {
+            for (unsigned int i=0; i<mTerrainViews.size() && i<mPreloadPositions.size(); ++i)
+                mWorld->storeView(mTerrainViews[i], referenceTime);
+        }
+
+        virtual void doWork()
+        {
+            for (unsigned int i=0; i<mTerrainViews.size() && i<mPreloadPositions.size() && !mAbort; ++i)
+            {
+                mTerrainViews[i]->reset();
+                mWorld->preload(mTerrainViews[i], mPreloadPositions[i], mAbort);
+            }
+        }
+
+        virtual void abort()
+        {
+            mAbort = true;
+        }
+
+    private:
+        std::atomic<bool> mAbort;
+        std::vector<osg::ref_ptr<Terrain::View> > mTerrainViews;
+        Terrain::World* mWorld;
+        std::vector<osg::Vec3f> mPreloadPositions;
+    };
+
     /// Worker thread item: update the resource system's cache, effectively deleting unused entries.
     class UpdateCacheItem : public SceneUtil::WorkItem
     {
@@ -288,6 +326,9 @@ namespace MWWorld
             }
 
             mPreloadCells.erase(found);
+
+            if (cell->isExterior() && mTerrainPreloadItem && mTerrainPreloadItem->isDone())
+                mTerrainPreloadItem->storeViews(0.0);
         }
     }
 
@@ -329,6 +370,12 @@ namespace MWWorld
             mWorkQueue->addWorkItem(mUpdateCacheItem, true);
             mLastResourceCacheUpdate = timestamp;
         }
+
+        if (mTerrainPreloadItem && mTerrainPreloadItem->isDone())
+        {
+            mTerrainPreloadItem->storeViews(timestamp);
+            mTerrainPreloadItem = nullptr;
+        }
     }
 
     void CellPreloader::setExpiryDelay(double expiryDelay)
@@ -366,38 +413,6 @@ namespace MWWorld
         mUnrefQueue = unrefQueue;
     }
 
-    class TerrainPreloadItem : public SceneUtil::WorkItem
-    {
-    public:
-        TerrainPreloadItem(const std::vector<osg::ref_ptr<Terrain::View> >& views, Terrain::World* world, const std::vector<osg::Vec3f>& preloadPositions)
-            : mAbort(false)
-            , mTerrainViews(views)
-            , mWorld(world)
-            , mPreloadPositions(preloadPositions)
-        {
-        }
-
-        virtual void doWork()
-        {
-            for (unsigned int i=0; i<mTerrainViews.size() && i<mPreloadPositions.size() && !mAbort; ++i)
-            {
-                mWorld->preload(mTerrainViews[i], mPreloadPositions[i], mAbort);
-                mTerrainViews[i]->reset();
-            }
-        }
-
-        virtual void abort()
-        {
-            mAbort = true;
-        }
-
-    private:
-        std::atomic<bool> mAbort;
-        std::vector<osg::ref_ptr<Terrain::View> > mTerrainViews;
-        Terrain::World* mWorld;
-        std::vector<osg::Vec3f> mPreloadPositions;
-    };
-
     void CellPreloader::setTerrainPreloadPositions(const std::vector<osg::Vec3f> &positions)
     {
         if (mTerrainPreloadItem && !mTerrainPreloadItem->isDone())
@@ -418,8 +433,6 @@ namespace MWWorld
                     mTerrainViews.push_back(mTerrain->createView());
             }
 
-            // TODO: provide some way of giving the preloaded view to the main thread when we enter the cell
-            // right now, we just use it to make sure the resources are preloaded
             mTerrainPreloadPositions = positions;
             mTerrainPreloadItem = new TerrainPreloadItem(mTerrainViews, mTerrain, positions);
             mWorkQueue->addWorkItem(mTerrainPreloadItem);

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -382,7 +382,7 @@ namespace MWWorld
             for (unsigned int i=0; i<mTerrainViews.size() && i<mPreloadPositions.size() && !mAbort; ++i)
             {
                 mWorld->preload(mTerrainViews[i], mPreloadPositions[i], mAbort);
-                mTerrainViews[i]->reset(0);
+                mTerrainViews[i]->reset();
             }
         }
 

--- a/apps/openmw/mwworld/cellpreloader.hpp
+++ b/apps/openmw/mwworld/cellpreloader.hpp
@@ -31,6 +31,7 @@ namespace MWRender
 namespace MWWorld
 {
     class CellStore;
+    class TerrainPreloadItem;
 
     class CellPreloader
     {
@@ -105,7 +106,7 @@ namespace MWWorld
 
         std::vector<osg::ref_ptr<Terrain::View> > mTerrainViews;
         std::vector<osg::Vec3f> mTerrainPreloadPositions;
-        osg::ref_ptr<SceneUtil::WorkItem> mTerrainPreloadItem;
+        osg::ref_ptr<TerrainPreloadItem> mTerrainPreloadItem;
         osg::ref_ptr<SceneUtil::WorkItem> mUpdateCacheItem;
     };
 

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -154,8 +154,6 @@ ViewData* QuadTreeNode::getView(osg::NodeVisitor &nv, bool& needsUpdate)
     else // INTERSECTION_VISITOR
     {
         osg::Vec3f viewPoint = nv.getViewPoint();
-        mViewDataMap->getDefaultViewPoint(viewPoint);
-
         static osg::ref_ptr<osg::Object> dummyObj = new osg::DummyObject;
         vd = mViewDataMap->getViewData(dummyObj.get(), viewPoint, needsUpdate);
         needsUpdate = true;

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -114,9 +114,10 @@ void QuadTreeNode::traverse(osg::NodeVisitor &nv)
     if (!hasValidBounds())
         return;
 
-    ViewData* vd = getView(nv);
+    bool needsUpdate = true;
+    ViewData* vd = getView(nv, needsUpdate);
 
-    if ((mLodCallback && mLodCallback->isSufficientDetail(this, distance(vd->getEyePoint()))) || !getNumChildren())
+    if ((mLodCallback && mLodCallback->isSufficientDetail(this, distance(vd->getViewPoint()))) || !getNumChildren())
         vd->add(this, true);
     else
         osg::Group::traverse(nv);
@@ -142,26 +143,24 @@ ViewDataMap *QuadTreeNode::getViewDataMap()
     return mViewDataMap;
 }
 
-ViewData* QuadTreeNode::getView(osg::NodeVisitor &nv)
+ViewData* QuadTreeNode::getView(osg::NodeVisitor &nv, bool& needsUpdate)
 {
+    ViewData* vd = NULL;
     if (nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
     {
         osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(&nv);
-        ViewData* vd = mViewDataMap->getViewData(cv->getCurrentCamera());
-        vd->setEyePoint(nv.getViewPoint());
-        return vd;
+        vd = mViewDataMap->getViewData(cv->getCurrentCamera(), nv.getViewPoint(), needsUpdate);
     }
     else // INTERSECTION_VISITOR
     {
+        osg::Vec3f viewPoint = nv.getViewPoint();
+        mViewDataMap->getDefaultViewPoint(viewPoint);
+
         static osg::ref_ptr<osg::Object> dummyObj = new osg::DummyObject;
-        ViewData* vd = mViewDataMap->getViewData(dummyObj.get());
-        ViewData* defaultView = mViewDataMap->getDefaultView();
-        if (defaultView->hasEyePoint())
-            vd->setEyePoint(defaultView->getEyePoint());
-        else
-            vd->setEyePoint(nv.getEyePoint());
-        return vd;
+        vd = mViewDataMap->getViewData(dummyObj.get(), viewPoint, needsUpdate);
+        needsUpdate = true;
     }
+    return vd;
 }
 
 void QuadTreeNode::setBoundingBox(const osg::BoundingBox &boundingBox)

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -85,7 +85,7 @@ namespace Terrain
         ViewDataMap* getViewDataMap();
 
         /// Create or retrieve a view for the given traversal.
-        ViewData* getView(osg::NodeVisitor& nv);
+        ViewData* getView(osg::NodeVisitor& nv, bool& needsUpdate);
 
     private:
         QuadTreeNode* mParent;

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -528,11 +528,6 @@ void QuadTreeWorld::reportStats(unsigned int frameNumber, osg::Stats *stats)
     stats->setAttribute(frameNumber, "Composite", mCompositeMapRenderer->getCompileSetSize());
 }
 
-void QuadTreeWorld::setDefaultViewer(osg::Object *obj)
-{
-    mViewDataMap->setDefaultViewer(obj);
-}
-
 void QuadTreeWorld::loadCell(int x, int y)
 {
     // fallback behavior only for undefined cells (every other is already handled in quadtree)

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -247,7 +247,7 @@ QuadTreeWorld::~QuadTreeWorld()
 }
 
 
-void traverse(QuadTreeNode* node, ViewData* vd, osg::NodeVisitor* nv, LodCallback* lodCallback, const osg::Vec3f& eyePoint, bool visible, float maxDist)
+void traverse(QuadTreeNode* node, ViewData* vd, osg::NodeVisitor* nv, LodCallback* lodCallback, const osg::Vec3f& viewPoint, bool visible, float maxDist)
 {
     if (!node->hasValidBounds())
         return;
@@ -255,7 +255,7 @@ void traverse(QuadTreeNode* node, ViewData* vd, osg::NodeVisitor* nv, LodCallbac
     if (nv && nv->getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
         visible = visible && !static_cast<osgUtil::CullVisitor*>(nv)->isCulled(node->getBoundingBox());
 
-    float dist = node->distance(eyePoint);
+    float dist = node->distance(viewPoint);
     if (dist > maxDist)
         return;
 
@@ -266,7 +266,7 @@ void traverse(QuadTreeNode* node, ViewData* vd, osg::NodeVisitor* nv, LodCallbac
     else
     {
         for (unsigned int i=0; i<node->getNumChildren(); ++i)
-            traverse(node->getChild(i), vd, nv, lodCallback, eyePoint, visible, maxDist);
+            traverse(node->getChild(i), vd, nv, lodCallback, viewPoint, visible, maxDist);
     }
 }
 
@@ -367,7 +367,8 @@ void loadRenderingNode(ViewData::Entry& entry, ViewData* vd, int vertexLodMod, C
 
 void QuadTreeWorld::accept(osg::NodeVisitor &nv)
 {
-    if (nv.getVisitorType() != osg::NodeVisitor::CULL_VISITOR && nv.getVisitorType() != osg::NodeVisitor::INTERSECTION_VISITOR)
+    bool isCullVisitor = nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR;
+    if (!isCullVisitor && nv.getVisitorType() != osg::NodeVisitor::INTERSECTION_VISITOR)
     {
         if (nv.getName().find("AcceptedByComponentsTerrainQuadTreeWorld") != std::string::npos)
         {
@@ -382,26 +383,40 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
         return;
     }
 
-    ViewData* vd = mRootNode->getView(nv);
+    bool needsUpdate = false;
+    ViewData* vd = mRootNode->getView(nv, needsUpdate);
 
-    if (nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
+    if (needsUpdate)
     {
-        osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(&nv);
-
-        osg::UserDataContainer* udc = cv->getCurrentCamera()->getUserDataContainer();
-        if (udc && udc->getNumDescriptions() >= 2 && udc->getDescriptions()[0] == "NoTerrainLod")
+        vd->reset();
+        if (isCullVisitor)
         {
-            std::istringstream stream(udc->getDescriptions()[1]);
-            int x,y;
-            stream >> x;
-            stream >> y;
-            traverseToCell(mRootNode.get(), vd, x,y);
+            osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(&nv);
+
+            osg::UserDataContainer* udc = cv->getCurrentCamera()->getUserDataContainer();
+            if (udc && udc->getNumDescriptions() >= 2 && udc->getDescriptions()[0] == "NoTerrainLod")
+            {
+                std::istringstream stream(udc->getDescriptions()[1]);
+                int x,y;
+                stream >> x;
+                stream >> y;
+                traverseToCell(mRootNode.get(), vd, x,y);
+            }
+            else
+                traverse(mRootNode.get(), vd, cv, mRootNode->getLodCallback(), cv->getViewPoint(), true, mViewDistance);
         }
         else
-            traverse(mRootNode.get(), vd, cv, mRootNode->getLodCallback(), cv->getViewPoint(), true, mViewDistance);
+            mRootNode->traverse(nv);
     }
-    else
-        mRootNode->traverse(nv);
+    else if (isCullVisitor)
+    {
+        // view point is the same, but must still update visible status in case the camera has rotated
+        for (unsigned int i=0; i<vd->getNumEntries(); ++i)
+        {
+            ViewData::Entry& entry = vd->getEntry(i);
+            entry.set(entry.mNode, !static_cast<osgUtil::CullVisitor*>(&nv)->isCulled(entry.mNode->getBoundingBox()));
+        }
+    }
 
     for (unsigned int i=0; i<vd->getNumEntries(); ++i)
     {
@@ -416,13 +431,16 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
             {
                 mCompositeMapRenderer->setImmediate(static_cast<CompositeMap*>(udc->getUserData()));
                 udc->setUserData(nullptr);
+
             }
             entry.mRenderingNode->accept(nv);
         }
     }
 
-    vd->reset(nv.getTraversalNumber());
+    if (!isCullVisitor)
+        vd->reset(); // we can't reuse intersection views in the next frame because they only contain what is touched by the intersection ray.
 
+    vd->finishFrame(nv.getTraversalNumber());
     mRootNode->getViewDataMap()->clearUnusedViews(nv.getTraversalNumber());
 }
 
@@ -473,12 +491,13 @@ View* QuadTreeWorld::createView()
     return new ViewData;
 }
 
-void QuadTreeWorld::preload(View *view, const osg::Vec3f &eyePoint, std::atomic<bool> &abort)
+void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, std::atomic<bool> &abort)
 {
     ensureQuadTreeBuilt();
 
     ViewData* vd = static_cast<ViewData*>(view);
-    traverse(mRootNode.get(), vd, nullptr, mRootNode->getLodCallback(), eyePoint, false, mViewDistance);
+    vd->setViewPoint(viewPoint);
+    traverse(mRootNode.get(), vd, nullptr, mRootNode->getLodCallback(), viewPoint, false, mViewDistance);
 
     for (unsigned int i=0; i<vd->getNumEntries() && !abort; ++i)
     {

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -37,7 +37,8 @@ namespace Terrain
         virtual void unloadCell(int x, int y);
 
         View* createView();
-        void preload(View* view, const osg::Vec3f& eyePoint, std::atomic<bool>& abort);
+
+        void preload(View* view, const osg::Vec3f& viewPoint, std::atomic<bool>& abort);
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats);
 

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -37,8 +37,8 @@ namespace Terrain
         virtual void unloadCell(int x, int y);
 
         View* createView();
-
-        void preload(View* view, const osg::Vec3f& viewPoint, std::atomic<bool>& abort);
+        void preload(View* view, const osg::Vec3f& eyePoint, std::atomic<bool>& abort);
+        void storeView(const View* view, double referenceTime);
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats);
 

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -42,8 +42,6 @@ namespace Terrain
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats);
 
-        virtual void setDefaultViewer(osg::Object* obj);
-
     private:
         void ensureQuadTreeBuilt();
 

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -15,7 +15,7 @@ class MyView : public View
 public:
     osg::ref_ptr<osg::Node> mLoaded;
 
-    virtual void reset(unsigned int frame) {}
+    virtual void reset() {}
 };
 
 TerrainGrid::TerrainGrid(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask, int borderMask)

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -132,7 +132,6 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
     if (found == mViews.end())
     {
         vd = createOrReuseView();
-        vd->setViewer(viewer);
         mViews[viewer] = vd;
     }
     else

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -5,7 +5,7 @@ namespace Terrain
 
 ViewData::ViewData()
     : mNumEntries(0)
-    , mFrameLastUsed(0)
+    , mLastUsageTimeStamp(0.0)
     , mChanged(false)
     , mHasViewPoint(false)
 {
@@ -85,7 +85,7 @@ void ViewData::clear()
     for (unsigned int i=0; i<mEntries.size(); ++i)
         mEntries[i].set(nullptr, false);
     mNumEntries = 0;
-    mFrameLastUsed = 0;
+    mLastUsageTimeStamp = 0;
     mChanged = false;
     mHasViewPoint = false;
 }
@@ -173,12 +173,12 @@ ViewData *ViewDataMap::createOrReuseView()
     }
 }
 
-void ViewDataMap::clearUnusedViews(unsigned int frame)
+void ViewDataMap::clearUnusedViews(double referenceTime)
 {
     for (Map::iterator it = mViews.begin(); it != mViews.end(); )
     {
         ViewData* vd = it->second;
-        if (vd->getFrameLastUsed() + 2 < frame)
+        if (vd->getLastUsageTimeStamp() + mExpiryDelay < referenceTime)
         {
             vd->clear();
             mUnusedViews.push_back(vd);

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -195,22 +195,4 @@ void ViewDataMap::clear()
     mViewVector.clear();
 }
 
-void ViewDataMap::setDefaultViewer(osg::Object *viewer)
-{
-    mDefaultViewer = viewer;
-}
-
-bool ViewDataMap::getDefaultViewPoint(osg::Vec3f& viewPoint)
-{
-     Map::const_iterator found = mViews.find(mDefaultViewer);
-     if (found != mViews.end() && found->second->hasViewPoint())
-     {
-        viewPoint = found->second->getViewPoint();
-        return true;
-     }
-     else
-        return false;
-}
-
-
 }

--- a/components/terrain/viewdata.hpp
+++ b/components/terrain/viewdata.hpp
@@ -46,11 +46,12 @@ namespace Terrain
 
         Entry& getEntry(unsigned int i);
 
-        unsigned int getFrameLastUsed() const { return mFrameLastUsed; }
-        void finishFrame(unsigned int frame) { mFrameLastUsed = frame; mChanged = false; }
+        double getLastUsageTimeStamp() const { return mLastUsageTimeStamp; }
+        void setLastUsageTimeStamp(double timeStamp) { mLastUsageTimeStamp = timeStamp; }
 
         /// @return Have any nodes changed since the last frame
         bool hasChanged() const;
+        void markUnchanged() { mChanged = false; }
 
         bool hasViewPoint() const;
 
@@ -60,7 +61,7 @@ namespace Terrain
     private:
         std::vector<Entry> mEntries;
         unsigned int mNumEntries;
-        unsigned int mFrameLastUsed;
+        double mLastUsageTimeStamp;
         bool mChanged;
         osg::Vec3f mViewPoint;
         bool mHasViewPoint;
@@ -71,14 +72,16 @@ namespace Terrain
     {
     public:
         ViewDataMap()
-            : mReuseDistance(100) // large value should be safe because the visibility of each node is still updated individually for each camera even if the base view was reused.
+            : mReuseDistance(300) // large value should be safe because the visibility of each node is still updated individually for each camera even if the base view was reused.
+                                  // this value also serves as a threshold for when a newly loaded LOD gets unloaded again so that if you hover around an LOD transition point the LODs won't keep loading and unloading all the time.
+            , mExpiryDelay(1.f)
         {}
 
         ViewData* getViewData(osg::Object* viewer, const osg::Vec3f& viewPoint, bool& needsUpdate);
 
         ViewData* createOrReuseView();
 
-        void clearUnusedViews(unsigned int frame);
+        void clearUnusedViews(double referenceTime);
 
         void clear();
 
@@ -93,6 +96,7 @@ namespace Terrain
         Map mViews;
 
         float mReuseDistance;
+        float mExpiryDelay; // time in seconds for unused view to be removed
 
         std::deque<ViewData*> mUnusedViews;
 

--- a/components/terrain/viewdata.hpp
+++ b/components/terrain/viewdata.hpp
@@ -85,10 +85,6 @@ namespace Terrain
 
         void clear();
 
-        void setDefaultViewer(osg::Object* viewer);
-
-        bool getDefaultViewPoint(osg::Vec3f& viewPoint);
-
     private:
         std::list<ViewData> mViewVector;
 
@@ -99,8 +95,6 @@ namespace Terrain
         float mExpiryDelay; // time in seconds for unused view to be removed
 
         std::deque<ViewData*> mUnusedViews;
-
-        osg::ref_ptr<osg::Object> mDefaultViewer;
     };
 
 }

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <memory>
 #include <set>
+#include <atomic>
 
 #include "defs.hpp"
 #include "cellborder.hpp"
@@ -48,7 +49,7 @@ namespace Terrain
         virtual ~View() {}
 
         /// Reset internal structure so that the next addition to the view will override the previous frame's contents.
-        virtual void reset(unsigned int frame) = 0;
+        virtual void reset() = 0;
     };
 
     /**
@@ -102,7 +103,8 @@ namespace Terrain
         virtual View* createView() { return nullptr; }
 
         /// @note Thread safe, as long as you do not attempt to load into the same view from multiple threads.
-        virtual void preload(View* view, const osg::Vec3f& eyePoint, std::atomic<bool>& abort) {}
+
+        virtual void preload(View* view, const osg::Vec3f& viewPoint, std::atomic<bool>& abort) {}
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) {}
 

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -82,7 +82,7 @@ namespace Terrain
         /// @note Thread safe.
         virtual void clearAssociatedCaches();
 
-        /// Load a terrain cell at maximum LOD and store it in the View for later use.
+        /// Load a terrain cell and store it in the View for later use.
         /// @note Thread safe.
         virtual void cacheCell(View* view, int x, int y) {}
 
@@ -105,6 +105,10 @@ namespace Terrain
         /// @note Thread safe, as long as you do not attempt to load into the same view from multiple threads.
 
         virtual void preload(View* view, const osg::Vec3f& viewPoint, std::atomic<bool>& abort) {}
+
+        /// Store a preloaded view into the cache with the intent that the next rendering traversal can use it.
+        /// @note Not thread safe.
+        virtual void storeView(const View* view, double referenceTime) {}
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) {}
 

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -112,9 +112,6 @@ namespace Terrain
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) {}
 
-        /// Set the default viewer (usually a Camera), used as viewpoint for any viewers that don't use their own viewpoint.
-        virtual void setDefaultViewer(osg::Object* obj) {}
-
         virtual void setViewDistance(float distance) {}
 
         Storage* getStorage() { return mStorage; }


### PR DESCRIPTION
Let's discuss an another set of changes from bzzt branch.

Summary of changes:
1. Use result of first traversal for other traversals with the same view point
2. Copy preloaded terrain views from the preloading thread to the mViewDataMap in the main thread (there was a relevant TODO in the OpenMW code).
3. Take the view point from main camera for reflection and reflaction cameras, so we will not have to use separate terrain LOD's for them.
4. Remove the DefaultView since we do not need it anymore.

As a result, cell transitions should be a bit faster.

Can we use these changes, or they do not worth it?
Which kind of clarification from bzzt we need here?

Casting @AnyOldName3 here.
