### PR TITLE
Remove unused and unfinished blendmap packing feature

### DIFF
--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -92,14 +92,10 @@ namespace ESMTerrain
         /// @note May be called from background threads.
         /// @param chunkSize size of the terrain chunk in cell units
         /// @param chunkCenter center of the chunk in cell units
-        /// @param pack Whether to pack blend values for up to 4 layers into one texture (one in each channel) -
-        ///        otherwise, each texture contains blend values for one layer only. Shader-based rendering
-        ///        can utilize packing, FFP can't.
         /// @param blendmaps created blendmaps will be written here
         /// @param layerList names of the layer textures used will be written here
-        virtual void getBlendmaps (float chunkSize, const osg::Vec2f& chunkCenter, bool pack,
-                           ImageVector& blendmaps,
-                           std::vector<Terrain::LayerInfo>& layerList);
+        virtual void getBlendmaps (float chunkSize, const osg::Vec2f& chunkCenter, ImageVector& blendmaps,
+                               std::vector<Terrain::LayerInfo>& layerList);
 
         virtual float getHeightAt (const osg::Vec3f& worldPos);
 

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -119,7 +119,7 @@ std::vector<osg::ref_ptr<osg::StateSet> > ChunkManager::createPasses(float chunk
 {
     std::vector<LayerInfo> layerList;
     std::vector<osg::ref_ptr<osg::Image> > blendmaps;
-    mStorage->getBlendmaps(chunkSize, chunkCenter, false, blendmaps, layerList);
+    mStorage->getBlendmaps(chunkSize, chunkCenter, blendmaps, layerList);
 
     bool useShaders = mSceneManager->getForceShaders();
     if (!mSceneManager->getClampLighting())

--- a/components/terrain/storage.hpp
+++ b/components/terrain/storage.hpp
@@ -69,14 +69,10 @@ namespace Terrain
         /// @note May be called from background threads. Make sure to only call thread-safe functions from here!
         /// @param chunkSize size of the terrain chunk in cell units
         /// @param chunkCenter center of the chunk in cell units
-        /// @param pack Whether to pack blend values for up to 4 layers into one texture (one in each channel) -
-        ///        otherwise, each texture contains blend values for one layer only. Shader-based rendering
-        ///        can utilize packing, FFP can't.
         /// @param blendmaps created blendmaps will be written here
         /// @param layerList names of the layer textures used will be written here
-        virtual void getBlendmaps (float chunkSize, const osg::Vec2f& chunkCenter, bool pack,
-                           ImageVector& blendmaps,
-                           std::vector<LayerInfo>& layerList) = 0;
+        virtual void getBlendmaps (float chunkSize, const osg::Vec2f& chunkCenter, ImageVector& blendmaps,
+                               std::vector<LayerInfo>& layerList) = 0;
 
         virtual float getHeightAt (const osg::Vec3f& worldPos) = 0;
 


### PR DESCRIPTION
On Ogre, four layers of blendmaps could be packed into a single texture to save memory if shaders were used (and only with them, fixed function pipeline didn't support it). This feature didn't survive OSG transition and the actual code necessary to support it wasn't written, but scrawl didn't remove the traces of it, and it proceeded to unnecessarily complicate the code of blendmap generation.

bzzt noticed it and removed it (also partially) with the other terrain blending optimizations. While this doesn't really change the performance, it makes the code less complex, and should make the review of his other optimizations a bit easier.