### PR TITLE
Optimize map window update

### DIFF
--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -837,22 +837,13 @@ namespace MWGui
 
     void MapWindow::cellExplored(int x, int y)
     {
-        mQueuedToExplore.push_back(std::make_pair(x,y));
+        mGlobalMapRender->cleanupCameras();
+        mGlobalMapRender->exploreCell(x, y, mLocalMapRender->getMapTexture(x, y));
     }
 
     void MapWindow::onFrame(float dt)
     {
         LocalMapBase::onFrame(dt);
-
-        mGlobalMapRender->cleanupCameras();
-
-        for (CellId& cellId : mQueuedToExplore)
-        {
-            mGlobalMapRender->exploreCell(cellId.first, cellId.second, mLocalMapRender->getMapTexture(cellId.first, cellId.second));
-        }
-
-        mQueuedToExplore.clear();
-
         NoDrop::onFrame(dt);
     }
 

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -261,10 +261,6 @@ namespace MWGui
         typedef std::pair<int, int> CellId;
         std::set<CellId> mMarkers;
 
-        // Cells that should be explored in the next frame (i.e. their map revealed on the global map)
-        // We can't do this immediately, because the map update is not immediate either (see mNeedMapUpdate in scene.cpp)
-        std::vector<CellId> mQueuedToExplore;
-
         MyGUI::Button* mEventBoxGlobal;
         MyGUI::Button* mEventBoxLocal;
 

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -126,12 +126,17 @@ namespace MWGui
         // Stores markers that were placed by a player. May be shared between multiple map views.
         CustomMarkerCollection& mCustomMarkers;
 
-        std::vector<MyGUI::ImageBox*> mMapWidgets;
-        std::vector<MyGUI::ImageBox*> mFogWidgets;
+        struct MapEntry
+        {
+            MapEntry(MyGUI::ImageBox* mapWidget, MyGUI::ImageBox* fogWidget)
+                : mMapWidget(mapWidget), mFogWidget(fogWidget) {}
 
-        typedef std::vector<std::shared_ptr<MyGUI::ITexture> > TextureVector;
-        TextureVector mMapTextures;
-        TextureVector mFogTextures;
+            MyGUI::ImageBox* mMapWidget;
+            MyGUI::ImageBox* mFogWidget;
+            std::shared_ptr<MyGUI::ITexture> mMapTexture;
+            std::shared_ptr<MyGUI::ITexture> mFogTexture;
+        };
+        std::vector<MapEntry> mMaps;
 
         // Keep track of created marker widgets, just to easily remove them later.
         std::vector<MyGUI::Widget*> mDoorMarkerWidgets;

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1027,9 +1027,6 @@ namespace MWGui
 
         updateMap();
 
-        if (!mMap->isVisible())
-            mMap->onFrame(frameDuration);
-
         mHud->onFrame(frameDuration);
 
         mDebugWindow->onFrame(frameDuration);

--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -293,7 +293,7 @@ namespace MWRender
         camera->setViewMatrix(osg::Matrix::identity());
         camera->setProjectionMatrix(osg::Matrix::identity());
         camera->setProjectionResizePolicy(osg::Camera::FIXED);
-        camera->setRenderOrder(osg::Camera::PRE_RENDER);
+        camera->setRenderOrder(osg::Camera::PRE_RENDER, 1); // Make sure the global map is rendered after the local map
         y = mHeight - y - height; // convert top-left origin to bottom-left
         camera->setViewport(x, y, width, height);
 

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -613,7 +613,8 @@ void LocalMap::updatePlayer (const osg::Vec3f& position, const osg::Quat& orient
             if (!segment.mFogOfWarImage || !segment.mMapTexture)
                 continue;
 
-            unsigned char* data = segment.mFogOfWarImage->data();
+            uint32_t* data = (uint32_t*)segment.mFogOfWarImage->data();
+            bool changed = false;
             for (int texV = 0; texV<sFogOfWarResolution; ++texV)
             {
                 for (int texU = 0; texU<sFogOfWarResolution; ++texU)
@@ -625,14 +626,22 @@ void LocalMap::updatePlayer (const osg::Vec3f& position, const osg::Quat& orient
                     uint8_t alpha = (clr >> 24);
 
                     alpha = std::min( alpha, (uint8_t) (std::max(0.f, std::min(1.f, (sqrDist/sqrExploreRadius)))*255) );
-                    *(uint32_t*)data = (uint32_t) (alpha << 24);
+                    uint32_t val = (uint32_t) (alpha << 24);
+                    if ( *data != val)
+                    {
+                        *data = val;
+                        changed = true;
+                    }
 
-                    data += 4;
+                    ++data;
                 }
             }
 
-            segment.mHasFogState = true;
-            segment.mFogOfWarImage->dirty();
+            if (changed)
+            {
+                segment.mHasFogState = true;
+                segment.mFogOfWarImage->dirty();
+            }
         }
     }
 }


### PR DESCRIPTION
Based on bzzt's branch.
Summary of changes:
1. Explore cells immediately, so we do not need to update map window when it is not visible.
Originally this delay was added to fix [bug #772](https://gitlab.com/OpenMW/openmw/issues/772) on OGRE version, but it seems this bug is not present with OSG (at least I failed to reproduce it with strongholds).
2. Instead of storing data in 4 differect vectors, define a struct and store a vector of structs.
3. Do not store both sets of new and old textures, replace old textures via `reset()` instead.
4. Update fog texture only if it was changed.

As a result, cell transitions work a bit faster (only fog textures update takes about 50 microseconds less time).