### PR TITLE
Reduce default composite map distance to decrease GPU loading

### DIFF
--- a/docs/source/reference/modding/settings/terrain.rst
+++ b/docs/source/reference/modding/settings/terrain.rst
@@ -68,7 +68,7 @@ composite map level
 
 :Type:		integer
 :Range:		>= -3
-:Default:	0
+:Default:	-2
 
 Controls at which minimum size (in 2^value cell units) terrain chunks will start to use a composite map instead of the high-detail textures.
 With value -3 composite maps are used everywhere.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -98,7 +98,7 @@ vertex lod mod = 0
 
 # Controls when the distant terrain will flip to composited textures instead of high-detail textures, should be >= -3.
 # Higher value is more detailed textures.
-composite map level = 0
+composite map level = -2
 
 # Controls the resolution of composite maps.
 composite map resolution = 512


### PR DESCRIPTION
A visual difference is not noticable for me,  but profiler shows about 2ms lesser time under GPU section.
Especially noticable when shadows are enabled.