### PR TITLE
Minor water shader fixes

### DIFF
--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -255,6 +255,7 @@ public:
         attach(osg::Camera::COLOR_BUFFER, mRefractionTexture);
 
         mRefractionDepthTexture = new osg::Texture2D;
+        mRefractionDepthTexture->setTextureSize(rttSize, rttSize);
         mRefractionDepthTexture->setSourceFormat(GL_DEPTH_COMPONENT);
         mRefractionDepthTexture->setInternalFormat(GL_DEPTH_COMPONENT24);
         mRefractionDepthTexture->setWrap(osg::Texture::WRAP_S, osg::Texture::CLAMP_TO_EDGE);
@@ -334,6 +335,7 @@ public:
         setUpdateCallback(new NoTraverseCallback);
 
         mReflectionTexture = new osg::Texture2D;
+        mReflectionTexture->setTextureSize(rttSize, rttSize);
         mReflectionTexture->setInternalFormat(GL_RGB);
         mReflectionTexture->setFilter(osg::Texture::MIN_FILTER, osg::Texture::LINEAR);
         mReflectionTexture->setFilter(osg::Texture::MAG_FILTER, osg::Texture::LINEAR);
@@ -418,9 +420,6 @@ Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem
     mWaterGeom->setDrawCallback(new DepthClampCallback);
     mWaterGeom->setNodeMask(Mask_Water);
 
-    if (ico)
-        ico->add(mWaterGeom);
-
     mWaterNode = new osg::PositionAttitudeTransform;
     mWaterNode->setName("Water Root");
     mWaterNode->addChild(mWaterGeom);
@@ -439,6 +438,9 @@ Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem
     mRainIntensityUniform = new osg::Uniform("rainIntensity",(float) 0.0);
 
     updateWaterMaterial();
+
+    if (ico)
+        ico->add(mWaterNode);
 }
 
 osg::Uniform *Water::getRainIntensityUniform()

--- a/files/shaders/water_fragment.glsl
+++ b/files/shaders/water_fragment.glsl
@@ -6,7 +6,7 @@
 
 // tweakables -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-const float VISIBILITY = 2.5;
+const float VISIBILITY = 2500;
 
 const float BIG_WAVES_X = 0.1; // strength of big waves
 const float BIG_WAVES_Y = 0.1;
@@ -36,7 +36,7 @@ const vec3 SUN_EXT = vec3(0.45, 0.55, 0.68);       //sunlight extinction
 
 const float SPEC_HARDNESS = 256.0;                 // specular highlights hardness
 
-const float BUMP_SUPPRESS_DEPTH = 0.3;             // at what water depth bumpmap will be supressed for reflections and refractions (prevents artifacts at shores)
+const float BUMP_SUPPRESS_DEPTH = 300;             // at what water depth bumpmap will be supressed for reflections and refractions (prevents artifacts at shores)
 
 const vec2 WIND_DIR = vec2(0.5f, -0.8f);
 const float WIND_SPEED = 0.2f;
@@ -151,11 +151,11 @@ uniform float rainIntensity;
 
 float frustumDepth;
 
-float linearizeDepth(float depth)  // takes <0,1> non-linear depth value and returns <0,1> linearized value
+float linearizeDepth(float depth)
   {
     float z_n = 2.0 * depth - 1.0;
     depth = 2.0 * near * far / (far + near - z_n * frustumDepth);
-    return depth / frustumDepth;
+    return depth;
   }
 
 void main(void)
@@ -239,10 +239,9 @@ void main(void)
     fresnel = clamp(fresnel, 0.0, 1.0);
 
 #if REFRACTION
-    float normalization = frustumDepth / 1000;
-    float depthSample = linearizeDepth(texture2D(refractionDepthMap,screenCoords).x) * normalization;
-    float depthSampleDistorted = linearizeDepth(texture2D(refractionDepthMap,screenCoords-(normal.xy*REFR_BUMP)).x) * normalization;
-    float surfaceDepth = linearizeDepth(gl_FragCoord.z) * normalization;
+    float depthSample = linearizeDepth(texture2D(refractionDepthMap,screenCoords).x);
+    float depthSampleDistorted = linearizeDepth(texture2D(refractionDepthMap,screenCoords-(normal.xy*REFR_BUMP)).x);
+    float surfaceDepth = linearizeDepth(gl_FragCoord.z);
     float realWaterDepth = depthSample - surfaceDepth;  // undistorted water depth in view direction, independent of frustum
     float shore = clamp(realWaterDepth / BUMP_SUPPRESS_DEPTH,0,1);
 #else


### PR DESCRIPTION
Based on bzzt's work.
Summary of changes:
1. Cleanup water shader a bit - do not use division by 1000.
2. Use the Incremental Compile Operation for water shader and RTT (now we seems to use it only for water geometry)

@AnyOldName3, can you take a look?