### PR TITLE
Replace black blendmap layer with blending over black

### DIFF
--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -352,11 +352,6 @@ namespace ESMTerrain
 
     std::string Storage::getTextureName(UniqueTextureId id)
     {
-        // Goes under used terrain blend transitions
-        static const std::string baseTexture = "textures\\tx_black_01.dds";
-        if (id.first == -1)
-            return baseTexture;
-
         static const std::string defaultTexture = "textures\\_land_default.dds";
         if (id.first == 0)
             return defaultTexture; // Not sure if the default texture really is hardcoded?
@@ -391,9 +386,6 @@ namespace ESMTerrain
         // Save the used texture indices so we know the total number of textures
         // and number of required blend maps
         std::set<UniqueTextureId> textureIndices;
-        // Due to the way the blending works, the base layer will bleed between texture transitions so we want it to be a black texture
-        // The subsequent passes are added instead of blended, so this gives the correct result
-        textureIndices.insert(std::make_pair(-1,0)); // -1 goes to tx_black_01
 
         LandCache cache;
 
@@ -415,8 +407,9 @@ namespace ESMTerrain
             layerList.push_back(getLayerInfo(getTextureName(*it)));
         }
 
-        // size-1 since the base layer doesn't need blending
-        int numBlendmaps = textureIndices.size() - 1;
+        int numBlendmaps = textureIndices.size();
+        if (numBlendmaps == 1)
+            return; // There is no need to blend a single texture
 
         // Second iteration - create and fill in the blend maps
         const int blendmapSize = (realTextureSize-1) * chunkSize + 1;

--- a/components/terrain/material.cpp
+++ b/components/terrain/material.cpp
@@ -1,6 +1,5 @@
 #include "material.hpp"
 
-#include <osg/Fog>
 #include <osg/Depth>
 #include <osg/TexEnvCombine>
 #include <osg/Texture2D>
@@ -124,9 +123,26 @@ namespace
         osg::ref_ptr<osg::BlendFunc> mValue;
 
         BlendFunc()
-            : mValue(new osg::BlendFunc)
+            : mValue(new osg::BlendFunc(osg::BlendFunc::SRC_ALPHA, osg::BlendFunc::ONE))
         {
-            mValue->setFunction(osg::BlendFunc::SRC_ALPHA, osg::BlendFunc::ONE);
+        }
+    };
+
+    class BlendFuncFirst
+    {
+    public:
+        static const osg::ref_ptr<osg::BlendFunc>& value()
+        {
+            static BlendFuncFirst instance;
+            return instance.mValue;
+        }
+
+    private:
+        osg::ref_ptr<osg::BlendFunc> mValue;
+
+        BlendFuncFirst()
+            : mValue(new osg::BlendFunc(osg::BlendFunc::SRC_ALPHA, osg::BlendFunc::ZERO))
+        {
         }
     };
 
@@ -166,19 +182,16 @@ namespace Terrain
 
             osg::ref_ptr<osg::StateSet> stateset (new osg::StateSet);
 
+            stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
+
             if (!firstLayer)
             {
-                stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
                 stateset->setAttributeAndModes(BlendFunc::value(), osg::StateAttribute::ON);
                 stateset->setAttributeAndModes(EqualDepth::value(), osg::StateAttribute::ON);
             }
-            // disable fog if we're the first layer of several - supposed to be completely black
-            if (firstLayer && blendmaps.size() > 0)
+            else
             {
-                osg::ref_ptr<osg::Fog> fog (new osg::Fog);
-                fog->setStart(10000000);
-                fog->setEnd(10000000);
-                stateset->setAttributeAndModes(fog, osg::StateAttribute::OFF|osg::StateAttribute::OVERRIDE);
+                stateset->setAttributeAndModes(BlendFuncFirst::value(), osg::StateAttribute::ON);
                 stateset->setAttributeAndModes(LequalDepth::value(), osg::StateAttribute::ON);
             }
 
@@ -193,7 +206,7 @@ namespace Terrain
 
                 stateset->addUniform(new osg::Uniform("diffuseMap", texunit));
 
-                if(!firstLayer)
+                if (!blendmaps.empty())
                 {
                     ++texunit;
                     osg::ref_ptr<osg::Texture2D> blendmap = blendmaps.at(blendmapIndex++);
@@ -212,7 +225,7 @@ namespace Terrain
 
                 Shader::ShaderManager::DefineMap defineMap;
                 defineMap["normalMap"] = (it->mNormalMap) ? "1" : "0";
-                defineMap["blendMap"] = !firstLayer ? "1" : "0";
+                defineMap["blendMap"] = (!blendmaps.empty()) ? "1" : "0";
                 defineMap["specularMap"] = it->mSpecular ? "1" : "0";
                 defineMap["parallax"] = (it->mNormalMap && it->mParallax) ? "1" : "0";
 
@@ -229,7 +242,17 @@ namespace Terrain
             }
             else
             {
-                if(!firstLayer)
+                // Add the actual layer texture
+                osg::ref_ptr<osg::Texture2D> tex = it->mDiffuseMap;
+                stateset->setTextureAttributeAndModes(texunit, tex.get());
+
+                if (layerTileSize != 1.f)
+                    stateset->setTextureAttributeAndModes(texunit, LayerTexMat::value(layerTileSize), osg::StateAttribute::ON);
+
+                ++texunit;
+
+                // Multiply by the alpha map
+                if (!blendmaps.empty())
                 {
                     osg::ref_ptr<osg::Texture2D> blendmap = blendmaps.at(blendmapIndex++);
 
@@ -241,13 +264,6 @@ namespace Terrain
 
                     ++texunit;
                 }
-
-                // Add the actual layer texture multiplied by the alpha map.
-                osg::ref_ptr<osg::Texture2D> tex = it->mDiffuseMap;
-                stateset->setTextureAttributeAndModes(texunit, tex.get());
-
-                if (layerTileSize != 1.f)
-                    stateset->setTextureAttributeAndModes(texunit, LayerTexMat::value(layerTileSize), osg::StateAttribute::ON);
             }
 
             stateset->setRenderBinDetails(passIndex++, "RenderBin");


### PR DESCRIPTION
Another terrain texture blending change from bzzt.

wareya has replaced "default texture" base layer with a black texture base layer earlier, but truth is, such a base layer is not necessary at all, and the layers can be simply blended over black. This further simplifies the terrain texture blending and gets rid of some awkward workarounds in order to keep engine from thinking the black layer is a real blendmap layer.

Needs review.