### PR TITLE
Disallow binding some reserved keys (bug #3282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #2969: Scripted items can stack
     Bug #2987: Editor: some chance and AI data fields can overflow
+    Bug #3282: Unintended behaviour when assigning F3 and Windows keys
     Bug #3623: Fix HiDPI on Windows
     Bug #3733: Normal maps are inverted on mirrored UVs
     Bug #3765: DisableTeleporting makes Mark/Recall/Intervention effects undetectable

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1834,6 +1834,17 @@ namespace MWInput
             MWBase::Environment::get().getWindowManager ()->notifyInputActionBound ();
             return;
         }
+
+        // Disallow binding reserved keys
+        if (key == SDL_SCANCODE_F3 || key == SDL_SCANCODE_F4 || key == SDL_SCANCODE_F10 || key == SDL_SCANCODE_F11)
+            return;
+
+        #ifndef __APPLE__
+        // Disallow binding Windows/Meta keys
+        if (key == SDL_SCANCODE_LGUI || key == SDL_SCANCODE_RGUI)
+            return;
+        #endif
+
         if(!mDetectingKeyboard)
             return;
 


### PR DESCRIPTION
[Bug 3282](https://gitlab.com/OpenMW/openmw/issues/3282)

To prevent unintended behavior, F3, F4, F10 and F11 keys can't be bound to any action because they have special functionality. On non-Apple systems, Windows/Meta keys can't be bound to any action. macOS builds are excluded because Ctrl key which has the respective scancode won't lead to odd behavior.

Attempting to override OSG/system functionality is more trouble than it's worth spending time on.