### PR TITLE
[WIP] Make OpenMW version information easily available in-game (feature #2780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Feature #2229: Improve pathfinding AI
+    Feature #2780: Make OpenMW version information easily available in-game
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
     Feature #3893: Implicit target for "set" function in console

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -226,8 +226,6 @@ namespace MWGui
 
         MWBase::StateManager::State state = MWBase::Environment::get().getStateManager()->getState();
 
-        mVersionText->setVisible(state == MWBase::StateManager::State_NoGame);
-
         std::vector<std::string> buttons;
 
         if (state==MWBase::StateManager::State_Running)


### PR DESCRIPTION
[Feature 2780](https://gitlab.com/OpenMW/openmw/issues/2780).

The request is not for a script command that returns version information specifically (which we shouldn't need to implement anyway), but for a way to easily find openmw version information in the game in general. So the elegant solution I propose is to always show the version text normally available in the "main" main menu in the in-game main menu. Morrowind does this exact thing (note 1.6.1820 appearing in the lower left corner) and it works fine there.

This version text can be copied and pasted as usual.