### PR TITLE
Avoid menu button textures vertical cutoff

### DIFF
--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -287,11 +287,10 @@ namespace MWGui
 
             MyGUI::IntSize requested = button->getRequestedSize();
 
+            button->setImageCoord(MyGUI::IntCoord(0, 0, requested.width, requested.height));
             // Trim off some of the excessive padding
             // TODO: perhaps do this within ImageButton?
-            int trim = 8;
-            button->setImageCoord(MyGUI::IntCoord(0, trim, requested.width, requested.height-trim));
-            int height = requested.height-trim*2;
+            int height = requested.height-16;
             button->setImageTile(MyGUI::IntSize(requested.width, height));
             button->setCoord((maxwidth-requested.width) / 2, curH, requested.width, height);
             curH += height;


### PR DESCRIPTION
For some reason button height trimming code in the main menu also trims lower and upper edges of the button textures, which looks pretty bad, especially with button texture replacers.

This makes sure there isn't a cutoff without reintroducing the noticeable padding.