### PR TITLE
Do not re-render maps for all active cells during cell transitions

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -350,6 +350,7 @@ namespace MWBase
             virtual std::string correctTexturePath(const std::string& path) = 0;
             virtual bool textureExists(const std::string& path) = 0;
 
+            virtual void addCell(MWWorld::CellStore* cell) = 0;
             virtual void removeCell(MWWorld::CellStore* cell) = 0;
             virtual void writeFog(MWWorld::CellStore* cell) = 0;
 

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -129,12 +129,14 @@ namespace MWGui
         struct MapEntry
         {
             MapEntry(MyGUI::ImageBox* mapWidget, MyGUI::ImageBox* fogWidget)
-                : mMapWidget(mapWidget), mFogWidget(fogWidget) {}
+                : mMapWidget(mapWidget), mFogWidget(fogWidget), mCellX(0), mCellY(0) {}
 
             MyGUI::ImageBox* mMapWidget;
             MyGUI::ImageBox* mFogWidget;
             std::shared_ptr<MyGUI::ITexture> mMapTexture;
             std::shared_ptr<MyGUI::ITexture> mFogTexture;
+            int mCellX;
+            int mCellY;
         };
         std::vector<MapEntry> mMaps;
 
@@ -154,6 +156,8 @@ namespace MWGui
 
         virtual void customMarkerCreated(MyGUI::Widget* marker) {}
         virtual void doorMarkerCreated(MyGUI::Widget* marker) {}
+
+        void updateRequiredMaps();
 
         void updateMagicMarkers();
         void addDetectionMarkers(int type);

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -976,6 +976,12 @@ namespace MWGui
 
     void WindowManager::onFrame (float frameDuration)
     {
+        bool gameRunning = MWBase::Environment::get().getStateManager()->getState()!=
+            MWBase::StateManager::State_NoGame;
+
+        if (gameRunning)
+            updateMap();
+
         if (!mGuiModes.empty())
         {
             GuiModeState& state = mGuiModeStates[mGuiModes.back()];
@@ -1019,13 +1025,10 @@ namespace MWGui
         if (mLocalMapRender)
             mLocalMapRender->cleanupCameras();
 
-        if (MWBase::Environment::get().getStateManager()->getState()==
-            MWBase::StateManager::State_NoGame)
+        if (!gameRunning)
             return;
 
         mDragAndDrop->onFrame();
-
-        updateMap();
 
         mHud->onFrame(frameDuration);
 
@@ -2161,6 +2164,11 @@ namespace MWGui
                 *(data++) = static_cast<unsigned char>(value*255);
             }
         tex->unlock();
+    }
+
+    void WindowManager::addCell(MWWorld::CellStore* cell)
+    {
+        mLocalMapRender->addCell(cell);
     }
 
     void WindowManager::removeCell(MWWorld::CellStore *cell)

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -378,6 +378,7 @@ namespace MWGui
     virtual std::string correctTexturePath(const std::string& path);
     virtual bool textureExists(const std::string& path);
 
+    void addCell(MWWorld::CellStore* cell);
     void removeCell(MWWorld::CellStore* cell);
     void writeFog(MWWorld::CellStore* cell);
 

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -256,36 +256,30 @@ bool needUpdate(std::set<std::pair<int, int> >& renderedGrid, std::set<std::pair
     return false;
 }
 
-void LocalMap::requestMap(std::set<const MWWorld::CellStore*> cells)
+void LocalMap::requestMap(const MWWorld::CellStore* cell)
 {
-    std::set<std::pair<int, int> > grid;
-    for (const MWWorld::CellStore* cell : cells)
+    if (cell->isExterior())
     {
-        if (cell->isExterior())
-            grid.insert(std::make_pair(cell->getCell()->getGridX(), cell->getCell()->getGridY()));
-    }
+        int cellX = cell->getCell()->getGridX();
+        int cellY = cell->getCell()->getGridY();
 
-    for (const MWWorld::CellStore* cell : cells)
-    {
-        if (cell->isExterior())
-        {
-            int cellX = cell->getCell()->getGridX();
-            int cellY = cell->getCell()->getGridY();
-
-            MapSegment& segment = mSegments[std::make_pair(cellX, cellY)];
-            if (!needUpdate(segment.mGrid, grid, cellX, cellY))
-            {
-                continue;
-            }
-            else
-            {
-                segment.mGrid = grid;
-                requestExteriorMap(cell);
-            }
-        }
+        MapSegment& segment = mSegments[std::make_pair(cellX, cellY)];
+        if (!needUpdate(segment.mGrid, mCurrentGrid, cellX, cellY))
+            return;
         else
-            requestInteriorMap(cell);
+        {
+            segment.mGrid = mCurrentGrid;
+            requestExteriorMap(cell);
+        }
     }
+    else
+        requestInteriorMap(cell);
+}
+
+void LocalMap::addCell(MWWorld::CellStore *cell)
+{
+    if (cell->isExterior())
+        mCurrentGrid.emplace(cell->getCell()->getGridX(), cell->getCell()->getGridY());
 }
 
 void LocalMap::removeCell(MWWorld::CellStore *cell)
@@ -293,7 +287,11 @@ void LocalMap::removeCell(MWWorld::CellStore *cell)
     saveFogOfWar(cell);
 
     if (cell->isExterior())
-        mSegments.erase(std::make_pair(cell->getCell()->getGridX(), cell->getCell()->getGridY()));
+    {
+        std::pair<int, int> coords = std::make_pair(cell->getCell()->getGridX(), cell->getCell()->getGridY());
+        mSegments.erase(coords);
+        mCurrentGrid.erase(coords);
+    }
     else
         mSegments.clear();
 }

--- a/apps/openmw/mwrender/localmap.hpp
+++ b/apps/openmw/mwrender/localmap.hpp
@@ -45,13 +45,12 @@ namespace MWRender
         void clear();
 
         /**
-         * Request a map render for the given cells. Render textures will be immediately created and can be retrieved with the getMapTexture function.
+         * Request a map render for the given cell. Render textures will be immediately created and can be retrieved with the getMapTexture function.
          */
-        void requestMap (std::set<const MWWorld::CellStore*> cells);
+        void requestMap (const MWWorld::CellStore* cell);
 
-        /**
-         * Remove map and fog textures for the given cell.
-         */
+        void addCell(MWWorld::CellStore* cell);
+
         void removeCell (MWWorld::CellStore* cell);
 
         osg::ref_ptr<osg::Texture2D> getMapTexture (int x, int y);
@@ -110,6 +109,9 @@ namespace MWRender
 
         CameraVector mCamerasPendingRemoval;
 
+        typedef std::set<std::pair<int, int> > Grid;
+        Grid mCurrentGrid;
+
         struct MapSegment
         {
             MapSegment();
@@ -124,7 +126,7 @@ namespace MWRender
             osg::ref_ptr<osg::Texture2D> mFogOfWarTexture;
             osg::ref_ptr<osg::Image> mFogOfWarImage;
 
-            std::set<std::pair<int, int> > mGrid; // the grid that was active at the time of rendering this segment
+            Grid mGrid; // the grid that was active at the time of rendering this segment
 
             bool mHasFogState;
         };

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -431,6 +431,7 @@ namespace MWWorld
             insertCell (*cell, true, loadingListener);
 
             mRendering.addCell(cell);
+            MWBase::Environment::get().getWindowManager()->addCell(cell);
             bool waterEnabled = cell->getCell()->hasWater() || cell->isExterior();
             float waterLevel = cell->getWaterLevel();
             mRendering.setWaterEnabled(waterEnabled);

--- a/docs/source/reference/modding/settings/map.rst
+++ b/docs/source/reference/modding/settings/map.rst
@@ -112,5 +112,5 @@ local map cell distance
 :Default:	1
 
 Similar to "exterior cell load distance" in the Cells section, controls how many cells are rendered on the local map. 
-Values higher than the default may result in longer loading times. Please note that only loaded cells can be rendered, 
+Please note that only loaded cells can be rendered,
 so this setting must be lower or equal to "exterior cell load distance" to work properly.


### PR DESCRIPTION
Based on bzzt's changes.

Currently during cell transitions we try to re-render local maps for all active cells, what is a bit redundant since we need to load local maps only for new cells.

With this PR we will re-render only cells, visible after transition.