### PR TITLE
Update paths.rst - Windows paths, shell friendly paths

### DIFF
--- a/docs/source/reference/modding/paths.rst
+++ b/docs/source/reference/modding/paths.rst
@@ -9,20 +9,50 @@ The following describes the locations for the various OpenMW file paths for diff
 Configuration files and log files
 ---------------------------------
 
-:Linux:		``$HOME/.config/openmw``
-:Mac:		``$HOME/Library/Preferences/openmw``
-:Windows:	``C:\Users\Username\Documents\my games\openmw``
++--------------+------------------------------------------------------------------+
+| OS           | Location                                                         |
++==============+==================================================================+
+| Linux        | ``$HOME/.config/openmw``                                         |
++--------------+------------------------------------------------------------------+
+| Mac          | ``$HOME/Library/Preferences/openmw``                             |
++--------------+---------------+--------------------------------------------------+
+| Windows      | File Explorer | ``%USERPROFILE%\Documents\My Games\OpenMW``      |
+|              |               |                                                  |
+|              | PowerShell    | ``"$env:USERPROFILE\Documents\My Games\OpenMW"`` |
+|              |               |                                                  |
+|              | Example       | ``C:\Users\Username\Documents\My Games\OpenMW``  |
++--------------+---------------+--------------------------------------------------+
 
 Savegames
 ---------
 
-:Linux:		``$HOME/.local/share/openmw/saves``
-:Mac:		``$HOME/Library/Application Support/openmw/saves``
-:Windows:	``C:\Users\Username\Documents\my games\openmw\saves``
++--------------+------------------------------------------------------------------------+
+| OS           | Location                                                               |
++==============+========================================================================+
+| Linux        | ``$HOME/.config/openmw/saves``                                         |
++--------------+------------------------------------------------------------------------+
+| Mac          | ``$HOME/Library/Application\ Support/openmw/saves``                    |
++--------------+---------------+--------------------------------------------------------+
+| Windows      | File Explorer | ``%USERPROFILE%\Documents\My Games\OpenMW\saves``      |
+|              |               |                                                        |
+|              | PowerShell    | ``"$env:USERPROFILE\Documents\My Games\OpenMW\saves"`` |
+|              |               |                                                        |
+|              | Example       | ``C:\Users\Username\Documents\My Games\OpenMW\saves``  |
++--------------+---------------+--------------------------------------------------------+
 
 Screenshots
 -----------
 
-:Linux:		``$HOME/.local/share/openmw``
-:Mac:		``$HOME/Library/Application Support/openmw``
-:Windows:	``C:\Users\Username\Documents\my games\openmw``
++--------------+-------------------------------------------------------------------------+
+| OS           | Location                                                                |
++==============+=========================================================================+
+| Linux        | ``$HOME/.local/share/openmw``                                           |
++--------------+-------------------------------------------------------------------------+
+| Mac          | ``$HOME/Library/Application\ Support/openmw``                           |
++--------------+---------------+---------------------------------------------------------+
+| Windows      | File Explorer | ``%USERPROFILE%\Documents\My Games\OpenMW\OpenMW``      |
+|              |               |                                                         |
+|              | PowerShell    | ``"$env:USERPROFILE\Documents\My Games\OpenMW\OpenMW"`` |
+|              |               |                                                         |
+|              | Example       | ``C:\Users\Username\Documents\My Games\OpenMW\OpenMW``  |
++--------------+---------------+---------------------------------------------------------+


### PR DESCRIPTION
This is a change to the Paths documentation to generally make paths easier to copy/paste and use within a terminal or the Go menu.

If this sort of change makes things too weird/complicated or is otherwise undesired, my apologies! In particular throwing RST tables around can make this harder to edit in the future, but I think the information needed tables when presented this way.

I'm also worried that this might make the docs more complicated for non-technical users, but I also thought it was something of a problem that users couldn't just copy and paste directories.

- Adds path expansion based paths for Windows for easier copying and pasting
- Edited Windows paths with proper case (even though Windows is case-insensitive)
- Escapes Application Support in Mac to make the paths terminal and Finder Go menu friendly
- Places paths in tables

I have done zero testing beyond previewing the results in GitHub. I'm not incredibly familiar with how ReadTheDocs generates its pages. I did some reading but in the end didn't get my environment fully set up.