### PR TITLE
mingw: add fixes for MinGW static building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,8 +289,8 @@ endif()
 if(QT_STATIC)
    if(WIN32)
       if(DESIRED_QT_VERSION MATCHES 4)
-         # QtCore needs WSAAsyncSelect from Ws2_32.lib
-         set(QT_QTCORE_LIBRARY ${QT_QTCORE_LIBRARY} Ws2_32.lib)
+         # QtCore needs WSAAsyncSelect from ws2_32.lib
+         set(QT_QTCORE_LIBRARY ${QT_QTCORE_LIBRARY} ws2_32.lib)
          message("QT_QTCORE_LIBRARY: ${QT_QTCORE_LIBRARY}")
       endif()
    endif()
@@ -299,8 +299,12 @@ endif()
 
 set(BOOST_COMPONENTS system filesystem program_options iostreams)
 if(WIN32)
-    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} locale zlib)
+    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} locale)
 endif(WIN32)
+
+if (WIN32 AND NOT MINGW)
+    set(BOOST_COMPONENTS ${BOOST_COMPONENTS} zlib)
+endif()
 
 IF(BOOST_STATIC)
     set(Boost_USE_STATIC_LIBS   ON)

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -119,6 +119,7 @@ include_directories(
 )
 
 target_link_libraries(openmw
+    ${OPENMW_CXX_FLAGS}
     ${OSG_LIBRARIES}
     ${OPENTHREADS_LIBRARIES}
     ${OSGPARTICLE_LIBRARIES}
@@ -141,7 +142,33 @@ target_link_libraries(openmw
     components
 )
 
-if (ANDROID)
+if (OPENMW_STATIC AND NOT OPENMW_NO_PKGCONFIG AND (NOT WIN32 OR MINGW))
+    find_package(PkgConfig)
+
+    pkg_check_modules(openmw_pkgconfig REQUIRED
+        libjpeg
+        openal
+        freetype2
+        sdl2
+        gl
+        libavcodec
+        libavdevice
+        libavfilter
+        libavformat
+        libavresample
+        libavutil
+    )
+
+    target_link_libraries(openmw
+        ${openmw_pkgconfig_STATIC_LIBRARIES}
+    )
+
+    target_compile_options(openmw PUBLIC
+        ${openmw_pkgconfig_STATIC_CFLAGS_OTHER}
+    )
+endif()
+
+if (ANDROID OR OPENMW_STATIC)
     set (OSG_PLUGINS
         -Wl,--whole-archive
     )
@@ -154,15 +181,20 @@ if (ANDROID)
     )
 
     target_link_libraries(openmw
-        EGL
-        android
-        log
         dl
         z
         ${OPENSCENEGRAPH_LIBRARIES}
         freetype
         jpeg
-    	png
+        png
+    )
+endif (ANDROID OR OPENMW_STATIC)
+
+if (ANDROID)
+    target_link_libraries(openmw
+        EGL
+        android
+        log
     )
 endif (ANDROID)
 

--- a/cmake/FindOSGPlugins.cmake
+++ b/cmake/FindOSGPlugins.cmake
@@ -28,10 +28,14 @@ foreach(_library ${OSGPlugins_FIND_COMPONENTS})
     set(_component OSGPlugins_${_library})
 
     set(${_library_uc}_DIR ${OSGPlugins_LIB_DIR}) # to help function osg_find_library
-    set(_saved_lib_prefix ${CMAKE_FIND_LIBRARY_PREFIXES}) # save CMAKE_FIND_LIBRARY_PREFIXES
-    set(CMAKE_FIND_LIBRARY_PREFIXES "") # search libraries with no prefix
+    if (NOT MINGW)
+        set(_saved_lib_prefix ${CMAKE_FIND_LIBRARY_PREFIXES}) # save CMAKE_FIND_LIBRARY_PREFIXES
+        set(CMAKE_FIND_LIBRARY_PREFIXES "") # search also libraries with no prefix
+    endif()
     osg_find_library(${_library_uc} ${_library}) # find it into ${_library_uc}_LIBRARIES
-    set(CMAKE_FIND_LIBRARY_PREFIXES ${_saved_lib_prefix}) # restore prefix
+    if (NOT MINGW)
+        set(CMAKE_FIND_LIBRARY_PREFIXES ${_saved_lib_prefix}) # restore prefix
+    endif()
 
     if (${_library_uc}_LIBRARIES)
         set(${_component}_LIBRARY ${${_library_uc}_LIBRARIES}) # fake as if we call find_library

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -6,7 +6,7 @@
 
 #include <shlobj.h>
 #include <shlwapi.h>
-#include <WinReg.h>
+#include <winreg.h>
 
 #include <boost/locale.hpp>
 namespace bconv = boost::locale::conv;


### PR DESCRIPTION
This PR does the following:

- Fixes some paths that are cased wrongly.
- Add an `OPENMW_STATIC` flag, which will add some extra libraries to link with openmw, which are needed to build staticly
- Add an  `OPENMW_NO_PKGCONFIG` to not use pkg config to resolve libraries or cflags
- Add an `OPENMW_CXX_FLAGS` to add CXX_FLAGS if needed only for openmw