### PR TITLE
Improve compiler messages

### DIFF
--- a/components/compiler/controlparser.cpp
+++ b/components/compiler/controlparser.cpp
@@ -125,7 +125,7 @@ namespace Compiler
 
             if (loop.size()!=loop2.size())
                 throw std::logic_error (
-                    "internal compiler error: failed to generate a while loop");
+                    "Internal compiler error: failed to generate a while loop");
 
             std::copy (loop2.begin(), loop2.end(), std::back_inserter (mCode));
 
@@ -181,7 +181,7 @@ namespace Compiler
         }
         else if (mState==IfElseJunkState)
         {
-            getErrorHandler().warning ("Ignoring extra text after else", loc);
+            getErrorHandler().warning ("Extra text after else", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
             mState = IfElseBodyState;
@@ -227,7 +227,7 @@ namespace Compiler
         }
         else if (mState==IfElseJunkState)
         {
-            getErrorHandler().warning ("Ignoring extra text after else", loc);
+            getErrorHandler().warning ("Extra text after else", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
             mState = IfElseBodyState;
@@ -267,7 +267,7 @@ namespace Compiler
         }
         else if (mState==IfElseJunkState)
         {
-            getErrorHandler().warning ("Ignoring extra text after else", loc);
+            getErrorHandler().warning ("Extra text after else", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
             mState = IfElseBodyState;

--- a/components/compiler/declarationparser.cpp
+++ b/components/compiler/declarationparser.cpp
@@ -22,7 +22,7 @@ bool Compiler::DeclarationParser::parseName (const std::string& name, const Toke
         char type = mLocals.getType (name2);
 
         if (type!=' ')
-            getErrorHandler().warning ("ignoring local variable re-declaration", loc);
+            getErrorHandler().warning ("Local variable re-declaration", loc);
         else
             mLocals.declare (mType, name2);
 
@@ -31,7 +31,7 @@ bool Compiler::DeclarationParser::parseName (const std::string& name, const Toke
     }
     else if (mState==State_End)
     {
-        getErrorHandler().warning ("Ignoring extra text after local variable declaration", loc);
+        getErrorHandler().warning ("Extra text after local variable declaration", loc);
         SkipParser skip (getErrorHandler(), getContext());
         scanner.scan (skip);
         return false;
@@ -65,7 +65,7 @@ bool Compiler::DeclarationParser::parseKeyword (int keyword, const TokenLoc& loc
     }
     else if (mState==State_End)
     {
-        getErrorHandler().warning ("Ignoring extra text after local variable declaration", loc);
+        getErrorHandler().warning ("Extra text after local variable declaration", loc);
         SkipParser skip (getErrorHandler(), getContext());
         scanner.scan (skip);
         return false;
@@ -80,7 +80,7 @@ bool Compiler::DeclarationParser::parseSpecial (int code, const TokenLoc& loc, S
     {
         if (code!=Scanner::S_newline)
         {
-            getErrorHandler().warning ("Ignoring extra text after local variable declaration", loc);
+            getErrorHandler().warning ("Extra text after local variable declaration", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
         }

--- a/components/compiler/exception.hpp
+++ b/components/compiler/exception.hpp
@@ -11,7 +11,7 @@ namespace Compiler
     {
         public:
         
-            virtual const char *what() const throw() { return "compile error";} 
+            virtual const char *what() const throw() { return "Compile error";} 
             ///< Return error message
     };
 
@@ -21,7 +21,7 @@ namespace Compiler
     {
         public:
         
-            virtual const char *what() const throw() { return "can't read file"; }
+            virtual const char *what() const throw() { return "Can't read file"; }
             ///< Return error message
     };
 
@@ -31,7 +31,7 @@ namespace Compiler
     {       
         public:
         
-            virtual const char *what() const throw() { return "end of file"; }
+            virtual const char *what() const throw() { return "End of file"; }
             ///< Return error message
     };
 }

--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -99,7 +99,7 @@ namespace Compiler
         else if (t1=='f' || t2=='f')
             mOperands.push_back ('f');
         else
-            throw std::logic_error ("failed to determine result operand type");
+            throw std::logic_error ("Failed to determine result operand type");
     }
 
     void ExprParser::pop()
@@ -158,7 +158,7 @@ namespace Compiler
 
             default:
 
-                throw std::logic_error ("unknown operator");
+                throw std::logic_error ("Unknown operator");
         }
     }
 
@@ -287,7 +287,7 @@ namespace Compiler
             else
             {
                 mExplicit.clear();
-                getErrorHandler().warning ("Ignoring stray explicit reference", loc);
+                getErrorHandler().warning ("Stray explicit reference", loc);
             }
         }
 
@@ -430,7 +430,7 @@ namespace Compiler
                     {
                         if (!hasExplicit)
                         {
-                            getErrorHandler().warning ("ignoring stray explicit reference", loc);
+                            getErrorHandler().warning ("Stray explicit reference", loc);
                             mExplicit.clear();
                         }
 
@@ -735,13 +735,13 @@ namespace Compiler
     {
         if (mOperands.empty() && mOperators.empty())
         {
-            getErrorHandler().error ("missing expression", mTokenLoc);
+            getErrorHandler().error ("Missing expression", mTokenLoc);
             return 'l';
         }
 
         if (mNextOperand || mOperands.empty())
         {
-            getErrorHandler().error ("syntax error in expression", mTokenLoc);
+            getErrorHandler().error ("Syntax error in expression", mTokenLoc);
             return 'l';
         }
 
@@ -799,7 +799,7 @@ namespace Compiler
                         ++optionalCount;
                 }
                 else
-                    getErrorHandler().warning ("ignoring extra argument",
+                    getErrorHandler().warning ("Extra argument",
                         stringParser.getTokenLoc());
             }
             else if (*iter=='X')
@@ -813,7 +813,7 @@ namespace Compiler
                 if (parser.isEmpty())
                     break;
                 else
-                    getErrorHandler().warning("ignoring extra argument", parser.getTokenLoc());
+                    getErrorHandler().warning("Extra argument", parser.getTokenLoc());
             }
             else if (*iter=='z')
             {
@@ -825,7 +825,7 @@ namespace Compiler
                 if (discardParser.isEmpty())
                     break;
                 else
-                    getErrorHandler().warning("ignoring extra argument", discardParser.getTokenLoc());
+                    getErrorHandler().warning("Extra argument", discardParser.getTokenLoc());
             }
             else if (*iter=='j')
             {

--- a/components/compiler/fileparser.cpp
+++ b/components/compiler/fileparser.cpp
@@ -98,7 +98,7 @@ namespace Compiler
         if (mState == BeginState)
         {
             if (code != Scanner::S_newline)
-                reportWarning ("Ignoring stray special character before begin statement", loc);
+                reportWarning ("Stray special character before begin statement", loc);
             return true;
         }
 

--- a/components/compiler/junkparser.cpp
+++ b/components/compiler/junkparser.cpp
@@ -29,7 +29,7 @@ bool Compiler::JunkParser::parseName (const std::string& name, const TokenLoc& l
 bool Compiler::JunkParser::parseKeyword (int keyword, const TokenLoc& loc, Scanner& scanner)
 {
     if (keyword==mIgnoreKeyword)
-        reportWarning ("ignoring found junk", loc);
+        reportWarning ("Ignoring found junk", loc);
     else
         scanner.putbackKeyword (keyword, loc);
 
@@ -39,7 +39,7 @@ bool Compiler::JunkParser::parseKeyword (int keyword, const TokenLoc& loc, Scann
 bool Compiler::JunkParser::parseSpecial (int code, const TokenLoc& loc, Scanner& scanner)
 {
     if (code==Scanner::S_member)
-        reportWarning ("ignoring found junk", loc);
+        reportWarning ("Ignoring found junk", loc);
     else
         scanner.putbackSpecial (code, loc);
 

--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -48,7 +48,7 @@ namespace Compiler
 
             default:
 
-                throw std::runtime_error ("unknown expression result type");
+                throw std::runtime_error ("Unknown expression result type");
         }
     }
 
@@ -88,7 +88,7 @@ namespace Compiler
     {
         if (mState==PotentialEndState)
         {
-            getErrorHandler().warning ("ignoring stray string argument", loc);
+            getErrorHandler().warning ("Stray string argument", loc);
             mState = EndState;
             return true;
         }
@@ -132,7 +132,7 @@ namespace Compiler
                 return true;
             }
 
-            getErrorHandler().error ("unknown variable", loc);
+            getErrorHandler().error ("Unknown variable", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
             return false;
@@ -233,7 +233,7 @@ namespace Compiler
 
         if (mState==SetPotentialMemberVarState && keyword==Scanner::K_to)
         {
-            getErrorHandler().warning ("unknown variable, ignoring set instruction", loc);
+            getErrorHandler().warning ("Unknown variable", loc);
             SkipParser skip (getErrorHandler(), getContext());
             scanner.scan (skip);
             return false;
@@ -286,7 +286,7 @@ namespace Compiler
                 {
                     if (!hasExplicit && mState==ExplicitState)
                     {
-                        getErrorHandler().warning ("ignoring stray explicit reference", loc);
+                        getErrorHandler().warning ("Stray explicit reference", loc);
                         mExplicit.clear();
                     }
 
@@ -344,7 +344,7 @@ namespace Compiler
                     {
                         if (!hasExplicit && !mExplicit.empty())
                         {
-                            getErrorHandler().warning ("ignoring stray explicit reference", loc);
+                            getErrorHandler().warning ("Stray explicit reference", loc);
                             mExplicit.clear();
                         }
 
@@ -360,7 +360,7 @@ namespace Compiler
         if (mState==ExplicitState)
         {
             // drop stray explicit reference
-            getErrorHandler().warning ("ignoring stray explicit reference", loc);
+            getErrorHandler().warning ("Stray explicit reference", loc);
             mState = BeginState;
             mExplicit.clear();
         }
@@ -375,8 +375,7 @@ namespace Compiler
                 {
                     if (!getContext().canDeclareLocals())
                     {
-                        getErrorHandler().error (
-                            "local variables can't be declared in this context", loc);
+                        getErrorHandler().error("Local variables cannot be declared in this context", loc);
                         SkipParser skip (getErrorHandler(), getContext());
                         scanner.scan (skip);
                         return true;
@@ -412,19 +411,19 @@ namespace Compiler
 
                 case Scanner::K_else:
 
-                    getErrorHandler().warning ("ignoring stray else", loc);
+                    getErrorHandler().warning ("Stray else", loc);
                     mState = EndState;
                     return true;
 
                 case Scanner::K_endif:
 
-                    getErrorHandler().warning ("ignoring stray endif", loc);
+                    getErrorHandler().warning ("Stray endif", loc);
                     mState = EndState;
                     return true;
 
                 case Scanner::K_begin:
 
-                    getErrorHandler().warning ("ignoring stray begin", loc);
+                    getErrorHandler().warning ("Stray begin", loc);
                     mState = EndState;
                     return true;
             }
@@ -491,7 +490,7 @@ namespace Compiler
     {
         if (mState==EndState && code==Scanner::S_open)
         {
-            getErrorHandler().warning ("ignoring stray '[' or '(' at the end of the line",
+            getErrorHandler().warning ("Stray '[' or '(' at the end of the line",
                 loc);
             return true;
         }
@@ -508,7 +507,7 @@ namespace Compiler
 
         if (code==Scanner::S_ref && mState==SetPotentialMemberVarState)
         {
-            getErrorHandler().warning ("Ignoring stray explicit reference", loc);
+            getErrorHandler().warning ("Stray explicit reference", loc);
             mState = SetState;
             return true;
         }

--- a/components/compiler/locals.cpp
+++ b/components/compiler/locals.cpp
@@ -18,7 +18,7 @@ namespace Compiler
             case 'f': return mFloats;
         }
 
-        throw std::logic_error ("unknown variable type");
+        throw std::logic_error ("Unknown variable type");
     }
 
     int Locals::searchIndex (char type, const std::string& name) const
@@ -48,7 +48,7 @@ namespace Compiler
             case 'f': return mFloats;
         }
 
-        throw std::logic_error ("unknown variable type");
+        throw std::logic_error ("Unknown variable type");
     }
 
     char Locals::getType (const std::string& name) const

--- a/components/compiler/scanner.cpp
+++ b/components/compiler/scanner.cpp
@@ -158,7 +158,7 @@ namespace Compiler
         TokenLoc loc (mLoc);
         mLoc.mLiteral.clear();
 
-        mErrorHandler.error ("syntax error", loc);
+        mErrorHandler.error ("Syntax error", loc);
         throw SourceException();
     }
 
@@ -521,7 +521,7 @@ namespace Compiler
                 else if (c == '<' || c == '>') // Treat <> and << as <
                 {
                     special = S_cmpLT;
-                    mErrorHandler.warning (std::string("invalid operator <") + c + ", treating it as <", mLoc);
+                    mErrorHandler.warning ("Invalid operator, treating it as <", mLoc);
                 }
                 else
                 {
@@ -549,7 +549,7 @@ namespace Compiler
                 else if (c == '<' || c == '>') // Treat >< and >> as >
                 {
                     special = S_cmpGT;
-                    mErrorHandler.warning (std::string("invalid operator >") + c + ", treating it as >", mLoc);
+                    mErrorHandler.warning ("Invalid operator, treating it as >", mLoc);
                 }
                 else
                 {


### PR DESCRIPTION
1. Make compiler messages and exceptions start from a capital letter consistently.
2. The fact that the erroneous syntax was ignored was stated far too often, even though it was pretty obvious. Now it's considered implicit.