### PR TITLE
Make fallback map static to simplify constructors

### DIFF
--- a/apps/opencs/editor.hpp
+++ b/apps/opencs/editor.hpp
@@ -42,7 +42,6 @@ namespace CS
             Files::ConfigurationManager mCfgMgr;
             CSMPrefs::State mSettingsState;
             CSMDoc::DocumentManager mDocumentManager;
-            CSVDoc::ViewManager mViewManager;
             CSVDoc::StartupDialogue mStartup;
             CSVDoc::NewGameDialogue mNewGame;
             CSVPrefs::Dialogue mSettings;
@@ -54,6 +53,7 @@ namespace CS
             boost::filesystem::ofstream mPidFile;
             bool mFsStrict;
             CSVTools::Merge mMerge;
+            CSVDoc::ViewManager* mViewManager;
 
             void setupDataFiles (const Files::PathContainer& dataDirs);
 

--- a/apps/opencs/model/doc/document.cpp
+++ b/apps/opencs/model/doc/document.cpp
@@ -273,18 +273,16 @@ void CSMDoc::Document::createBase()
 CSMDoc::Document::Document (const Files::ConfigurationManager& configuration,
     const std::vector< boost::filesystem::path >& files,bool new_,
     const boost::filesystem::path& savePath, const boost::filesystem::path& resDir,
-    const Fallback::Map* fallback,
-    ToUTF8::FromType encoding,
-    const std::vector<std::string>& blacklistedScripts,
+    ToUTF8::FromType encoding, const std::vector<std::string>& blacklistedScripts,
     bool fsStrict, const Files::PathContainer& dataPaths, const std::vector<std::string>& archives)
-: mSavePath (savePath), mContentFiles (files), mNew (new_), mData (encoding, fsStrict, dataPaths, archives, fallback, resDir),
+: mSavePath (savePath), mContentFiles (files), mNew (new_), mData (encoding, fsStrict, dataPaths, archives, resDir),
   mTools (*this, encoding),
   mProjectPath ((configuration.getUserDataPath() / "projects") /
   (savePath.filename().string() + ".project")),
   mSavingOperation (*this, mProjectPath, encoding),
   mSaving (&mSavingOperation),
-  mResDir(resDir), mFallbackMap(fallback),
-  mRunner (mProjectPath), mDirty (false), mIdCompletionManager(mData)
+  mResDir(resDir), mRunner (mProjectPath),
+  mDirty (false), mIdCompletionManager(mData)
 {
     if (mContentFiles.empty())
         throw std::runtime_error ("Empty content file sequence");

--- a/apps/opencs/model/doc/document.hpp
+++ b/apps/opencs/model/doc/document.hpp
@@ -69,7 +69,6 @@ namespace CSMDoc
             Saving mSavingOperation;
             OperationHolder mSaving;
             boost::filesystem::path mResDir;
-            const Fallback::Map* mFallbackMap;
             Blacklist mBlacklist;
             Runner mRunner;
             bool mDirty;
@@ -105,8 +104,7 @@ namespace CSMDoc
             Document (const Files::ConfigurationManager& configuration,
                 const std::vector< boost::filesystem::path >& files, bool new_,
                 const boost::filesystem::path& savePath, const boost::filesystem::path& resDir,
-                const Fallback::Map* fallback, ToUTF8::FromType encoding,
-                const std::vector<std::string>& blacklistedScripts,
+                ToUTF8::FromType encoding, const std::vector<std::string>& blacklistedScripts,
                 bool fsStrict, const Files::PathContainer& dataPaths, const std::vector<std::string>& archives);
 
             ~Document();

--- a/apps/opencs/model/doc/documentmanager.cpp
+++ b/apps/opencs/model/doc/documentmanager.cpp
@@ -62,7 +62,7 @@ CSMDoc::Document *CSMDoc::DocumentManager::makeDocument (
     const std::vector< boost::filesystem::path >& files,
     const boost::filesystem::path& savePath, bool new_)
 {
-    return new Document (mConfiguration, files, new_, savePath, mResDir, &mFallbackMap, mEncoding, mBlacklistedScripts, mFsStrict, mDataPaths, mArchives);
+    return new Document (mConfiguration, files, new_, savePath, mResDir, mEncoding, mBlacklistedScripts, mFsStrict, mDataPaths, mArchives);
 }
 
 void CSMDoc::DocumentManager::insertDocument (CSMDoc::Document *document)
@@ -96,11 +96,6 @@ void CSMDoc::DocumentManager::removeDocument (CSMDoc::Document *document)
 void CSMDoc::DocumentManager::setResourceDir (const boost::filesystem::path& parResDir)
 {
     mResDir = boost::filesystem::system_complete(parResDir);
-}
-
-void CSMDoc::DocumentManager::setFallbackMap(const std::map<std::string, std::string>& fallbackMap)
-{
-    mFallbackMap = Fallback::Map(fallbackMap);
 }
 
 void CSMDoc::DocumentManager::setEncoding (ToUTF8::FromType encoding)

--- a/apps/opencs/model/doc/documentmanager.hpp
+++ b/apps/opencs/model/doc/documentmanager.hpp
@@ -41,7 +41,6 @@ namespace CSMDoc
             std::vector<std::string> mBlacklistedScripts;
 
             boost::filesystem::path mResDir;
-            Fallback::Map mFallbackMap;
 
             bool mFsStrict;
             Files::PathContainer mDataPaths;
@@ -71,8 +70,6 @@ namespace CSMDoc
                 const boost::filesystem::path& savePath, bool new_);
 
             void setResourceDir (const boost::filesystem::path& parResDir);
-
-            void setFallbackMap (const std::map<std::string, std::string>& fallbackMap);
 
             void setEncoding (ToUTF8::FromType encoding);
 

--- a/apps/opencs/model/filter/textnode.cpp
+++ b/apps/opencs/model/filter/textnode.cpp
@@ -38,11 +38,11 @@ bool CSMFilter::TextNode::test (const CSMWorld::IdTableBase& table, int row,
     {
         int value = data.toInt();
 
-        std::vector<std::string> enums =
+        std::vector<std::pair<int,std::string>> enums =
             CSMWorld::Columns::getEnums (static_cast<CSMWorld::Columns::ColumnId> (mColumnId));
 
         if (value>=0 && value<static_cast<int> (enums.size()))
-            string = QString::fromUtf8 (enums[value].c_str());
+            string = QString::fromUtf8 (enums[value].second.c_str());
     }
     else if (data.type()==QVariant::Bool)
     {

--- a/apps/opencs/model/tools/search.cpp
+++ b/apps/opencs/model/tools/search.cpp
@@ -75,11 +75,11 @@ void CSMTools::Search::searchRecordStateCell (const CSMWorld::IdTableBase *model
 
     if (data==mValue)
     {
-        std::vector<std::string> states =
+        std::vector<std::pair<int,std::string>> states =
             CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_Modification);
 
         const std::string hint = "r: " + std::to_string(model->getColumnId(index.column()));
-        messages.add (id, states.at(data), hint);
+        messages.add (id, states.at(data).second, hint);
     }
 }
 

--- a/apps/opencs/model/world/columns.cpp
+++ b/apps/opencs/model/world/columns.cpp
@@ -626,19 +626,19 @@ bool CSMWorld::Columns::hasEnums (ColumnId column)
     return getEnumNames (column)!=0 || column==ColumnId_RecordType;
 }
 
-std::vector<std::string> CSMWorld::Columns::getEnums (ColumnId column)
+std::vector<std::pair<int,std::string>>CSMWorld::Columns::getEnums (ColumnId column)
 {
-    std::vector<std::string> enums;
+    std::vector<std::pair<int,std::string>> enums;
 
     if (const char **table = getEnumNames (column))
         for (int i=0; table[i]; ++i)
-            enums.push_back (table[i]);
+            enums.emplace_back(i, table[i]);
     else if (column==ColumnId_RecordType)
     {
-        enums.push_back (""); // none
+        enums.emplace_back(UniversalId::Type_None, ""); // none
 
         for (int i=UniversalId::Type_None+1; i<UniversalId::NumberOfTypes; ++i)
-            enums.push_back (UniversalId (static_cast<UniversalId::Type> (i)).getTypeName());
+            enums.emplace_back (i, UniversalId (static_cast<UniversalId::Type> (i)).getTypeName());
     }
 
     return enums;

--- a/apps/opencs/model/world/columns.hpp
+++ b/apps/opencs/model/world/columns.hpp
@@ -390,7 +390,7 @@ namespace CSMWorld
 
         bool hasEnums (ColumnId column);
 
-        std::vector<std::string> getEnums (ColumnId column);
+        std::vector<std::pair<int,std::string>> getEnums (ColumnId column);
         ///< Returns an empty vector, if \a column isn't an enum type column.
     }
 }

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -64,9 +64,9 @@ int CSMWorld::Data::count (RecordBase::State state, const CollectionBase& collec
 }
 
 CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::PathContainer& dataPaths,
-    const std::vector<std::string>& archives, const Fallback::Map* fallback, const boost::filesystem::path& resDir)
+    const std::vector<std::string>& archives, const boost::filesystem::path& resDir)
 : mEncoder (encoding), mPathgrids (mCells), mRefs (mCells),
-  mFallbackMap(fallback), mReader (0), mDialogue (0), mReaderIndex(1),
+  mReader (0), mDialogue (0), mReaderIndex(1),
   mFsStrict(fsStrict), mDataPaths(dataPaths), mArchives(archives)
 {
     mVFS.reset(new VFS::Manager(mFsStrict));
@@ -1359,9 +1359,4 @@ void CSMWorld::Data::rowsChanged (const QModelIndex& parent, int start, int end)
 const VFS::Manager* CSMWorld::Data::getVFS() const
 {
     return mVFS.get();
-}
-
-const Fallback::Map* CSMWorld::Data::getFallbackMap() const
-{
-    return mFallbackMap;
 }

--- a/apps/opencs/model/world/data.hpp
+++ b/apps/opencs/model/world/data.hpp
@@ -112,7 +112,6 @@ namespace CSMWorld
             IdCollection<ESM::Filter> mFilters;
             Collection<MetaData> mMetaData;
             std::unique_ptr<ActorAdapter> mActorAdapter;
-            const Fallback::Map* mFallbackMap;
             std::vector<QAbstractItemModel *> mModels;
             std::map<UniversalId::Type, QAbstractItemModel *> mModelIndex;
             ESM::ESMReader *mReader;
@@ -151,14 +150,11 @@ namespace CSMWorld
         public:
 
             Data (ToUTF8::FromType encoding, bool fsStrict, const Files::PathContainer& dataPaths,
-                const std::vector<std::string>& archives, const Fallback::Map* fallback,
-                const boost::filesystem::path& resDir);
+                const std::vector<std::string>& archives, const boost::filesystem::path& resDir);
 
             virtual ~Data();
 
             const VFS::Manager* getVFS() const;
-
-            const Fallback::Map* getFallbackMap() const;
 
             std::shared_ptr<Resource::ResourceSystem> getResourceSystem();
 

--- a/apps/opencs/model/world/idtableproxymodel.cpp
+++ b/apps/opencs/model/world/idtableproxymodel.cpp
@@ -6,13 +6,13 @@
 
 namespace
 {
-    std::string getEnumValue(const std::vector<std::string> &values, int index)
+    std::string getEnumValue(const std::vector<std::pair<int,std::string>> &values, int index)
     {
         if (index < 0 || index >= static_cast<int>(values.size()))
         {
             return "";
         }
-        return values[index];
+        return values[index].second;
     }
 }
 

--- a/apps/opencs/model/world/idtableproxymodel.hpp
+++ b/apps/opencs/model/world/idtableproxymodel.hpp
@@ -22,7 +22,7 @@ namespace CSMWorld
 
             // Cache of enum values for enum columns (e.g. Modified, Record Type).
             // Used to speed up comparisons during the sort by such columns.
-            typedef std::map<Columns::ColumnId, std::vector<std::string> > EnumColumnCache;
+            typedef std::map<Columns::ColumnId, std::vector<std::pair<int,std::string>> > EnumColumnCache;
             mutable EnumColumnCache mEnumColumnCache;
 
         protected:

--- a/apps/opencs/view/render/cellwater.cpp
+++ b/apps/opencs/view/render/cellwater.cpp
@@ -164,7 +164,7 @@ namespace CSVRender
         mWaterGeometry->setStateSet(SceneUtil::createSimpleWaterStateSet(Alpha, RenderBin));
 
         // Add water texture
-        std::string textureName = mData.getFallbackMap()->getFallbackString("Water_SurfaceTexture");
+        std::string textureName = Fallback::Map::getString("Water_SurfaceTexture");
         textureName = "textures/water/" + textureName + "00.dds";
 
         Resource::ImageManager* imageManager = mData.getResourceSystem()->getImageManager();

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -140,14 +140,13 @@ void CSVRender::Object::update()
 
     if (light)
     {
-        const Fallback::Map* fallback = mData.getFallbackMap();
-        static bool outQuadInLin = fallback->getFallbackBool("LightAttenuation_OutQuadInLin");
-        static bool useQuadratic = fallback->getFallbackBool("LightAttenuation_UseQuadratic");
-        static float quadraticValue = fallback->getFallbackFloat("LightAttenuation_QuadraticValue");
-        static float quadraticRadiusMult = fallback->getFallbackFloat("LightAttenuation_QuadraticRadiusMult");
-        static bool useLinear = fallback->getFallbackBool("LightAttenuation_UseLinear");
-        static float linearRadiusMult = fallback->getFallbackFloat("LightAttenuation_LinearRadiusMult");
-        static float linearValue = fallback->getFallbackFloat("LightAttenuation_LinearValue");
+        static bool outQuadInLin = Fallback::Map::getBool("LightAttenuation_OutQuadInLin");
+        static bool useQuadratic = Fallback::Map::getBool("LightAttenuation_UseQuadratic");
+        static float quadraticValue = Fallback::Map::getFloat("LightAttenuation_QuadraticValue");
+        static float quadraticRadiusMult = Fallback::Map::getFloat("LightAttenuation_QuadraticRadiusMult");
+        static bool useLinear = Fallback::Map::getBool("LightAttenuation_UseLinear");
+        static float linearRadiusMult = Fallback::Map::getFloat("LightAttenuation_LinearRadiusMult");
+        static float linearValue = Fallback::Map::getFloat("LightAttenuation_LinearValue");
         bool isExterior = false; // FIXME
         SceneUtil::addLight(mBaseNode, light, Mask_ParticleSystem, Mask_Lighting, isExterior, outQuadInLin, useQuadratic,
                             quadraticValue, quadraticRadiusMult, useLinear, linearRadiusMult, linearValue);

--- a/apps/opencs/view/tools/searchbox.cpp
+++ b/apps/opencs/view/tools/searchbox.cpp
@@ -40,13 +40,13 @@ CSVTools::SearchBox::SearchBox (QWidget *parent)
     mLayout = new QGridLayout (this);
 
     // search panel
-    std::vector<std::string> states =
+    std::vector<std::pair<int,std::string>> states =
         CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_Modification);
     states.resize (states.size()-1); // ignore erased state
 
-    for (std::vector<std::string>::const_iterator iter (states.begin()); iter!=states.end();
+    for (std::vector<std::pair<int,std::string>>::const_iterator iter (states.begin()); iter!=states.end();
         ++iter)
-        mRecordState.addItem (QString::fromUtf8 (iter->c_str()));
+        mRecordState.addItem (QString::fromUtf8 (iter->second.c_str()));
         
     mMode.addItem (tr("Text"));
     mMode.addItem (tr("Text (RegEx)"));

--- a/apps/opencs/view/world/dialoguesubview.cpp
+++ b/apps/opencs/view/world/dialoguesubview.cpp
@@ -76,9 +76,9 @@ void CSVWorld::NotEditableSubDelegate::setEditorData (QWidget* editor, const QMo
     else if (CSMWorld::Columns::hasEnums (columnId))
     {
         int data = v.toInt();
-        std::vector<std::string> enumNames (CSMWorld::Columns::getEnums (columnId));
+        std::vector<std::pair<int,std::string>> enumNames (CSMWorld::Columns::getEnums (columnId));
 
-        label->setText(QString::fromUtf8(enumNames.at(data).c_str()));
+        label->setText(QString::fromUtf8(enumNames.at(data).second.c_str()));
     }
     else
     {

--- a/apps/opencs/view/world/enumdelegate.cpp
+++ b/apps/opencs/view/world/enumdelegate.cpp
@@ -155,7 +155,7 @@ CSVWorld::EnumDelegateFactory::EnumDelegateFactory (const char **names, bool all
         add (i, names[i]);
 }
 
-CSVWorld::EnumDelegateFactory::EnumDelegateFactory (const std::vector<std::string>& names,
+CSVWorld::EnumDelegateFactory::EnumDelegateFactory (const std::vector<std::pair<int,std::string>>& names,
     bool allowNone)
 {
     if (allowNone)
@@ -164,7 +164,7 @@ CSVWorld::EnumDelegateFactory::EnumDelegateFactory (const std::vector<std::strin
     int size = static_cast<int> (names.size());
 
     for (int i=0; i<size; ++i)
-        add (i, names[i].c_str());
+        add (names[i].first, names[i].second.c_str());
 }
 
 CSVWorld::CommandDelegate *CSVWorld::EnumDelegateFactory::makeDelegate (

--- a/apps/opencs/view/world/enumdelegate.hpp
+++ b/apps/opencs/view/world/enumdelegate.hpp
@@ -65,7 +65,7 @@ namespace CSVWorld
             ///< \param names Array of char pointer with a 0-pointer as end mark
             /// \param allowNone Use value of -1 for "none selected" (empty string)
 
-            EnumDelegateFactory (const std::vector<std::string>& names, bool allowNone = false);
+            EnumDelegateFactory (const std::vector<std::pair<int,std::string>>& names, bool allowNone = false);
             /// \param allowNone Use value of -1 for "none selected" (empty string)
 
             virtual CommandDelegate *makeDelegate (CSMWorld::CommandDispatcher *dispatcher, CSMDoc::Document& document, QObject *parent) const;

--- a/apps/opencs/view/world/recordstatusdelegate.cpp
+++ b/apps/opencs/view/world/recordstatusdelegate.cpp
@@ -22,7 +22,7 @@ CSVWorld::CommandDelegate *CSVWorld::RecordStatusDelegateFactory::makeDelegate (
 
 CSVWorld::RecordStatusDelegateFactory::RecordStatusDelegateFactory()
 {
-    std::vector<std::string> enums =
+    std::vector<std::pair<int,std::string>> enums =
         CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_Modification);
 
     static const char *sIcons[] =
@@ -31,5 +31,8 @@ CSVWorld::RecordStatusDelegateFactory::RecordStatusDelegateFactory()
     };
 
     for (int i=0; sIcons[i]; ++i)
-        add (i, enums.at (i).c_str(), sIcons[i]);
+    {
+        auto& enumPair = enums.at(i);
+        add (enumPair.first, enumPair.second.c_str(), sIcons[i]);
+    }
 }

--- a/apps/opencs/view/world/vartypedelegate.cpp
+++ b/apps/opencs/view/world/vartypedelegate.cpp
@@ -73,11 +73,11 @@ CSVWorld::CommandDelegate *CSVWorld::VarTypeDelegateFactory::makeDelegate (
 
 void CSVWorld::VarTypeDelegateFactory::add (ESM::VarType type)
 {
-    std::vector<std::string> enums =
+    std::vector<std::pair<int,std::string>> enums =
         CSMWorld::Columns::getEnums (CSMWorld::Columns::ColumnId_ValueType);
 
     if (static_cast<size_t>(type) >= enums.size())
         throw std::logic_error ("Unsupported variable type");
 
-    mValues.push_back (std::make_pair (type, QString::fromUtf8 (enums[type].c_str())));
+    mValues.emplace_back(type, QString::fromUtf8 (enums[type].second.c_str()));
 }

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -534,24 +534,24 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
     rootNode->addChild(guiRoot);
     MWGui::WindowManager* window = new MWGui::WindowManager(mViewer, guiRoot, mResourceSystem.get(), mWorkQueue.get(),
                 mCfgMgr.getLogPath().string() + std::string("/"), myguiResources,
-                mScriptConsoleMode, mTranslationDataStorage, mEncoding, mExportFonts, mFallbackMap,
+                mScriptConsoleMode, mTranslationDataStorage, mEncoding, mExportFonts,
                 Version::getOpenmwVersionDescription(mResDir.string()), mCfgMgr.getUserConfigPath().string());
     mEnvironment.setWindowManager (window);
 
     // Create sound system
-    mEnvironment.setSoundManager (new MWSound::SoundManager(mVFS.get(), mFallbackMap, mUseSound));
+    mEnvironment.setSoundManager (new MWSound::SoundManager(mVFS.get(), mUseSound));
 
     if (!mSkipMenu)
     {
-        std::string logo = mFallbackMap["Movies_Company_Logo"];
+        const std::string& logo = Fallback::Map::getString("Movies_Company_Logo");
         if (!logo.empty())
             window->playVideo(logo, true);
     }
 
     // Create the world
     mEnvironment.setWorld( new MWWorld::World (mViewer, rootNode, mResourceSystem.get(), mWorkQueue.get(),
-        mFileCollections, mContentFiles, mEncoder, mFallbackMap,
-        mActivationDistanceOverride, mCellName, mResDir.string(), mCfgMgr.getUserDataPath().string()));
+        mFileCollections, mContentFiles, mEncoder, mActivationDistanceOverride, mCellName,
+        mStartupScript, mResDir.string(), mCfgMgr.getUserDataPath().string()));
     mEnvironment.getWorld()->setupPlayer();
     input->setPlayer(&mEnvironment.getWorld()->getPlayer());
 
@@ -712,7 +712,7 @@ void OMW::Engine::go()
         // start in main menu
         mEnvironment.getWindowManager()->pushGuiMode (MWGui::GM_MainMenu);
         mEnvironment.getSoundManager()->playTitleMusic();
-        std::string logo = mFallbackMap["Movies_Morrowind_Logo"];
+        const std::string& logo = Fallback::Map::getString("Movies_Morrowind_Logo");
         if (!logo.empty())
             mEnvironment.getWindowManager()->playVideo(logo, true);
     }
@@ -783,11 +783,6 @@ void OMW::Engine::setSoundUsage(bool soundUsage)
 void OMW::Engine::setEncoding(const ToUTF8::FromType& encoding)
 {
     mEncoding = encoding;
-}
-
-void OMW::Engine::setFallbackValues(std::map<std::string,std::string> fallbackMap)
-{
-    mFallbackMap = fallbackMap;
 }
 
 void OMW::Engine::setScriptConsoleMode (bool enabled)

--- a/apps/openmw/engine.hpp
+++ b/apps/openmw/engine.hpp
@@ -91,7 +91,6 @@ namespace OMW
             bool mCompileAllDialogue;
             int mWarningsMode;
             std::string mFocusName;
-            std::map<std::string,std::string> mFallbackMap;
             bool mScriptConsoleMode;
             std::string mStartupScript;
             int mActivationDistanceOverride;
@@ -181,8 +180,6 @@ namespace OMW
 
             /// Font encoding
             void setEncoding(const ToUTF8::FromType& encoding);
-
-            void setFallbackValues(std::map<std::string,std::string> map);
 
             /// Enable console-only script functionality
             void setScriptConsoleMode (bool enabled);

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -1,6 +1,7 @@
 #include <components/version/version.hpp>
 #include <components/files/configurationmanager.hpp>
 #include <components/files/escape.hpp>
+#include <components/fallback/fallback.hpp>
 #include <components/fallback/validate.hpp>
 #include <components/debug/debugging.hpp>
 #include <components/misc/rng.hpp>
@@ -233,8 +234,8 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     engine.setSaveGameFile (variables["load-savegame"].as<Files::EscapeHashString>().toStdString());
 
     // other settings
+    Fallback::Map::init(variables["fallback"].as<FallbackMap>().mMap);
     engine.setSoundUsage(!variables["no-sound"].as<bool>());
-    engine.setFallbackValues(variables["fallback"].as<FallbackMap>().mMap);
     engine.setActivationDistanceOverride (variables["activate-dist"].as<int>());
     engine.enableFontExport(variables["export-fonts"].as<bool>());
     engine.setRandomSeed(variables["random-seed"].as<unsigned int>());

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -72,11 +72,6 @@ namespace MWWorld
     typedef std::vector<std::pair<MWWorld::Ptr,MWMechanics::Movement> > PtrMovementList;
 }
 
-namespace Fallback
-{
-    class Map;
-}
-
 namespace MWBase
 {
     /// \brief Interface for the World (implemented in MWWorld)
@@ -129,8 +124,6 @@ namespace MWBase
             virtual bool toggleBorders() = 0;
 
             virtual void adjustSky() = 0;
-
-            virtual const Fallback::Map *getFallback () const = 0;
 
             virtual MWWorld::Player& getPlayer() = 0;
             virtual MWWorld::Ptr getPlayerPtr() = 0;

--- a/apps/openmw/mwgui/charactercreation.cpp
+++ b/apps/openmw/mwgui/charactercreation.cpp
@@ -33,14 +33,15 @@ namespace
     };
 
     const ESM::Class::Specialization mSpecializations[3]={ESM::Class::Combat, ESM::Class::Magic, ESM::Class::Stealth}; // The specialization for each answer
-    Step sGenerateClassSteps(int number) {
+    Step sGenerateClassSteps(int number)
+    {
         number++;
-        const Fallback::Map* fallback=MWBase::Environment::get().getWorld()->getFallback();
-        Step step = {fallback->getFallbackString("Question_"+MyGUI::utility::toString(number)+"_Question"),
-        {fallback->getFallbackString("Question_"+MyGUI::utility::toString(number)+"_AnswerOne"),
-        fallback->getFallbackString("Question_"+MyGUI::utility::toString(number)+"_AnswerTwo"),
-        fallback->getFallbackString("Question_"+MyGUI::utility::toString(number)+"_AnswerThree")},
-        "vo\\misc\\chargen qa"+MyGUI::utility::toString(number)+".wav"
+        Step step = {
+            Fallback::Map::getString("Question_"+MyGUI::utility::toString(number)+"_Question"),
+            {Fallback::Map::getString("Question_"+MyGUI::utility::toString(number)+"_AnswerOne"),
+            Fallback::Map::getString("Question_"+MyGUI::utility::toString(number)+"_AnswerTwo"),
+            Fallback::Map::getString("Question_"+MyGUI::utility::toString(number)+"_AnswerThree")},
+            "vo\\misc\\chargen qa"+MyGUI::utility::toString(number)+".wav"
         };
         return step;
     }

--- a/apps/openmw/mwgui/levelupdialog.cpp
+++ b/apps/openmw/mwgui/levelupdialog.cpp
@@ -140,10 +140,10 @@ namespace MWGui
         mLevelText->setCaptionWithReplacing("#{sLevelUpMenu1} " + MyGUI::utility::toString(level));
 
         std::string levelupdescription;
-        levelupdescription=world->getFallback()->getFallbackString("Level_Up_Level"+MyGUI::utility::toString(level));
+        levelupdescription = Fallback::Map::getString("Level_Up_Level"+MyGUI::utility::toString(level));
 
         if (levelupdescription == "")
-            levelupdescription=world->getFallback()->getFallbackString("Level_Up_Default");
+            levelupdescription = Fallback::Map::getString("Level_Up_Default");
 
         mLevelDescription->setCaption (levelupdescription);
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -129,7 +129,7 @@ namespace MWGui
     WindowManager::WindowManager(
             osgViewer::Viewer* viewer, osg::Group* guiRoot, Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
             const std::string& logpath, const std::string& resourcePath, bool consoleOnlyScripts, Translation::Storage& translationDataStorage,
-            ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string, std::string>& fallbackMap, const std::string& versionDescription, const std::string& userDataPath)
+            ToUTF8::FromType encoding, bool exportFonts, const std::string& versionDescription, const std::string& userDataPath)
       : mStore(nullptr)
       , mResourceSystem(resourceSystem)
       , mWorkQueue(workQueue)
@@ -189,7 +189,6 @@ namespace MWGui
       , mForceHidden(GW_None)
       , mAllowed(GW_ALL)
       , mRestAllowed(true)
-      , mFallbackMap(fallbackMap)
       , mShowOwned(0)
       , mEncoding(encoding)
       , mFontHeight(16)
@@ -1184,7 +1183,7 @@ namespace MWGui
         {
             _result = mTranslationDataStorage.translateCellName(tag.substr(tokenLength));
         }
-        else if (Gui::replaceTag(tag, _result, mFallbackMap))
+        else if (Gui::replaceTag(tag, _result))
         {
             return;
         }

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -132,7 +132,7 @@ namespace MWGui
 
     WindowManager(osgViewer::Viewer* viewer, osg::Group* guiRoot, Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
                   const std::string& logpath, const std::string& cacheDir, bool consoleOnlyScripts, Translation::Storage& translationDataStorage,
-                  ToUTF8::FromType encoding, bool exportFonts, const std::map<std::string,std::string>& fallbackMap, const std::string& versionDescription, const std::string& localPath);
+                  ToUTF8::FromType encoding, bool exportFonts, const std::string& versionDescription, const std::string& localPath);
     virtual ~WindowManager();
 
     /// Set the ESMStore to use for retrieving of GUI-related strings.
@@ -514,8 +514,6 @@ namespace MWGui
 
     void updateMap();
 
-    std::map<std::string, std::string> mFallbackMap;
-    
     int mShowOwned;
 
     ToUTF8::FromType mEncoding;

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -428,14 +428,13 @@ void ActorAnimation::addHiddenItemLight(const MWWorld::ConstPtr& item, const ESM
     if (mItemLights.find(item) != mItemLights.end())
         return;
 
-    const Fallback::Map* fallback = MWBase::Environment::get().getWorld()->getFallback();
-    static bool outQuadInLin = fallback->getFallbackBool("LightAttenuation_OutQuadInLin");
-    static bool useQuadratic = fallback->getFallbackBool("LightAttenuation_UseQuadratic");
-    static float quadraticValue = fallback->getFallbackFloat("LightAttenuation_QuadraticValue");
-    static float quadraticRadiusMult = fallback->getFallbackFloat("LightAttenuation_QuadraticRadiusMult");
-    static bool useLinear = fallback->getFallbackBool("LightAttenuation_UseLinear");
-    static float linearRadiusMult = fallback->getFallbackFloat("LightAttenuation_LinearRadiusMult");
-    static float linearValue = fallback->getFallbackFloat("LightAttenuation_LinearValue");
+    static bool outQuadInLin = Fallback::Map::getBool("LightAttenuation_OutQuadInLin");
+    static bool useQuadratic = Fallback::Map::getBool("LightAttenuation_UseQuadratic");
+    static float quadraticValue = Fallback::Map::getFloat("LightAttenuation_QuadraticValue");
+    static float quadraticRadiusMult = Fallback::Map::getFloat("LightAttenuation_QuadraticRadiusMult");
+    static bool useLinear = Fallback::Map::getBool("LightAttenuation_UseLinear");
+    static float linearRadiusMult = Fallback::Map::getFloat("LightAttenuation_LinearRadiusMult");
+    static float linearValue = Fallback::Map::getFloat("LightAttenuation_LinearValue");
     bool exterior = mPtr.isInCell() && mPtr.getCell()->getCell()->isExterior();
 
     osg::Vec4f ambient(1,1,1,1);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1628,14 +1628,13 @@ namespace MWRender
 
     void Animation::addExtraLight(osg::ref_ptr<osg::Group> parent, const ESM::Light *esmLight)
     {
-        const Fallback::Map* fallback = MWBase::Environment::get().getWorld()->getFallback();
-        static bool outQuadInLin = fallback->getFallbackBool("LightAttenuation_OutQuadInLin");
-        static bool useQuadratic = fallback->getFallbackBool("LightAttenuation_UseQuadratic");
-        static float quadraticValue = fallback->getFallbackFloat("LightAttenuation_QuadraticValue");
-        static float quadraticRadiusMult = fallback->getFallbackFloat("LightAttenuation_QuadraticRadiusMult");
-        static bool useLinear = fallback->getFallbackBool("LightAttenuation_UseLinear");
-        static float linearRadiusMult = fallback->getFallbackFloat("LightAttenuation_LinearRadiusMult");
-        static float linearValue = fallback->getFallbackFloat("LightAttenuation_LinearValue");
+        static bool outQuadInLin = Fallback::Map::getBool("LightAttenuation_OutQuadInLin");
+        static bool useQuadratic = Fallback::Map::getBool("LightAttenuation_UseQuadratic");
+        static float quadraticValue = Fallback::Map::getFloat("LightAttenuation_QuadraticValue");
+        static float quadraticRadiusMult = Fallback::Map::getFloat("LightAttenuation_QuadraticRadiusMult");
+        static bool useLinear = Fallback::Map::getBool("LightAttenuation_UseLinear");
+        static float linearRadiusMult = Fallback::Map::getFloat("LightAttenuation_LinearRadiusMult");
+        static float linearValue = Fallback::Map::getFloat("LightAttenuation_LinearValue");
         bool exterior = mPtr.isInCell() && mPtr.getCell()->getCell()->isExterior();
 
         SceneUtil::addLight(parent, esmLight, Mask_ParticleSystem, Mask_Lighting, exterior, outQuadInLin,

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -168,16 +168,15 @@ namespace MWRender
         stateset->setAttributeAndModes(lightmodel, osg::StateAttribute::ON);
 
         osg::ref_ptr<osg::Light> light = new osg::Light;
-        const Fallback::Map* fallback = MWBase::Environment::get().getWorld()->getFallback();
-        float diffuseR = fallback->getFallbackFloat("Inventory_DirectionalDiffuseR");
-        float diffuseG = fallback->getFallbackFloat("Inventory_DirectionalDiffuseG");
-        float diffuseB = fallback->getFallbackFloat("Inventory_DirectionalDiffuseB");
-        float ambientR = fallback->getFallbackFloat("Inventory_DirectionalAmbientR");
-        float ambientG = fallback->getFallbackFloat("Inventory_DirectionalAmbientG");
-        float ambientB = fallback->getFallbackFloat("Inventory_DirectionalAmbientB");
-        float azimuth = osg::DegreesToRadians(180.f - fallback->getFallbackFloat("Inventory_DirectionalRotationX"));
-        float altitude = osg::DegreesToRadians(fallback->getFallbackFloat("Inventory_DirectionalRotationY"));
-        float positionX = std::cos(azimuth) * std::sin(altitude);
+        float diffuseR = Fallback::Map::getFloat("Inventory_DirectionalDiffuseR");
+        float diffuseG = Fallback::Map::getFloat("Inventory_DirectionalDiffuseG");
+        float diffuseB = Fallback::Map::getFloat("Inventory_DirectionalDiffuseB");
+        float ambientR = Fallback::Map::getFloat("Inventory_DirectionalAmbientR");
+        float ambientG = Fallback::Map::getFloat("Inventory_DirectionalAmbientG");
+        float ambientB = Fallback::Map::getFloat("Inventory_DirectionalAmbientB");
+        float azimuth = osg::DegreesToRadians(Fallback::Map::getFloat("Inventory_DirectionalRotationX"));
+        float altitude = osg::DegreesToRadians(Fallback::Map::getFloat("Inventory_DirectionalRotationY"));
+        float positionX = -std::cos(azimuth) * std::sin(altitude);
         float positionY = std::sin(azimuth) * std::sin(altitude);
         float positionZ = std::cos(altitude);
         light->setPosition(osg::Vec4(positionX,positionY,positionZ, 0.0));

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -195,8 +195,7 @@ namespace MWRender
 
     RenderingManager::RenderingManager(osgViewer::Viewer* viewer, osg::ref_ptr<osg::Group> rootNode,
                                        Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
-                                       const Fallback::Map* fallback, const std::string& resourcePath,
-                                       DetourNavigator::Navigator& navigator)
+                                       const std::string& resourcePath, DetourNavigator::Navigator& navigator)
         : mViewer(viewer)
         , mRootNode(rootNode)
         , mResourceSystem(resourceSystem)
@@ -207,9 +206,9 @@ namespace MWRender
         , mLandFogEnd(std::numeric_limits<float>::max())
         , mUnderwaterFogStart(0.f)
         , mUnderwaterFogEnd(std::numeric_limits<float>::max())
-        , mUnderwaterColor(fallback->getFallbackColour("Water_UnderwaterColor"))
-        , mUnderwaterWeight(fallback->getFallbackFloat("Water_UnderwaterColorWeight"))
-        , mUnderwaterIndoorFog(fallback->getFallbackFloat("Water_UnderwaterIndoorFog"))
+        , mUnderwaterColor(Fallback::Map::getColour("Water_UnderwaterColor"))
+        , mUnderwaterWeight(Fallback::Map::getFloat("Water_UnderwaterColorWeight"))
+        , mUnderwaterIndoorFog(Fallback::Map::getFloat("Water_UnderwaterIndoorFog"))
         , mNightEyeFactor(0.f)
         , mDistantFog(false)
         , mDistantTerrain(false)
@@ -275,7 +274,7 @@ namespace MWRender
 
         mEffectManager.reset(new EffectManager(sceneRoot, mResourceSystem));
 
-        mWater.reset(new Water(mRootNode, sceneRoot, mResourceSystem, mViewer->getIncrementalCompileOperation(), fallback, resourcePath));
+        mWater.reset(new Water(mRootNode, sceneRoot, mResourceSystem, mViewer->getIncrementalCompileOperation(), resourcePath));
 
         DLLandFogStart = Settings::Manager::getFloat("distant land fog start", "Fog");
         DLLandFogEnd = Settings::Manager::getFloat("distant land fog end", "Fog");

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -86,8 +86,7 @@ namespace MWRender
     public:
         RenderingManager(osgViewer::Viewer* viewer, osg::ref_ptr<osg::Group> rootNode,
                          Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
-                         const Fallback::Map* fallback, const std::string& resourcePath,
-                         DetourNavigator::Navigator& navigator);
+                         const std::string& resourcePath, DetourNavigator::Navigator& navigator);
         ~RenderingManager();
 
         MWRender::Objects& getObjects();

--- a/apps/openmw/mwrender/ripplesimulation.cpp
+++ b/apps/openmw/mwrender/ripplesimulation.cpp
@@ -26,13 +26,13 @@
 
 namespace
 {
-    void createWaterRippleStateSet(Resource::ResourceSystem* resourceSystem, const Fallback::Map* fallback, osg::Node* node)
+    void createWaterRippleStateSet(Resource::ResourceSystem* resourceSystem,osg::Node* node)
     {
-        int rippleFrameCount = fallback->getFallbackInt("Water_RippleFrameCount");
+        int rippleFrameCount = Fallback::Map::getInt("Water_RippleFrameCount");
         if (rippleFrameCount <= 0)
             return;
 
-        std::string tex = fallback->getFallbackString("Water_RippleTexture");
+        const std::string& tex = Fallback::Map::getString("Water_RippleTexture");
 
         std::vector<osg::ref_ptr<osg::Texture2D> > textures;
         for (int i=0; i<rippleFrameCount; ++i)
@@ -81,7 +81,7 @@ namespace
 namespace MWRender
 {
 
-RippleSimulation::RippleSimulation(osg::Group *parent, Resource::ResourceSystem* resourceSystem, const Fallback::Map* fallback)
+RippleSimulation::RippleSimulation(osg::Group *parent, Resource::ResourceSystem* resourceSystem)
     : mParent(parent)
 {
     mParticleSystem = new osgParticle::ParticleSystem;
@@ -94,8 +94,8 @@ RippleSimulation::RippleSimulation(osg::Group *parent, Resource::ResourceSystem*
     particleTemplate.setSizeRange(osgParticle::rangef(15, 180));
     particleTemplate.setColorRange(osgParticle::rangev4(osg::Vec4f(1,1,1,0.7), osg::Vec4f(1,1,1,0.7)));
     particleTemplate.setAlphaRange(osgParticle::rangef(1.f, 0.f));
-    particleTemplate.setAngularVelocity(osg::Vec3f(0,0,fallback->getFallbackFloat("Water_RippleRotSpeed")));
-    particleTemplate.setLifeTime(fallback->getFallbackFloat("Water_RippleLifetime"));
+    particleTemplate.setAngularVelocity(osg::Vec3f(0,0,Fallback::Map::getFloat("Water_RippleRotSpeed")));
+    particleTemplate.setLifeTime(Fallback::Map::getFloat("Water_RippleLifetime"));
 
     osg::ref_ptr<osgParticle::ParticleSystemUpdater> updater (new osgParticle::ParticleSystemUpdater);
     updater->addParticleSystem(mParticleSystem);
@@ -105,7 +105,7 @@ RippleSimulation::RippleSimulation(osg::Group *parent, Resource::ResourceSystem*
     mParticleNode->addChild(mParticleSystem);
     mParticleNode->setNodeMask(Mask_Effect);
 
-    createWaterRippleStateSet(resourceSystem, fallback, mParticleNode);
+    createWaterRippleStateSet(resourceSystem, mParticleNode);
 
     mParent->addChild(mParticleNode);
 }

--- a/apps/openmw/mwrender/ripplesimulation.hpp
+++ b/apps/openmw/mwrender/ripplesimulation.hpp
@@ -40,7 +40,7 @@ namespace MWRender
     class RippleSimulation
     {
     public:
-        RippleSimulation(osg::Group* parent, Resource::ResourceSystem* resourceSystem, const Fallback::Map* fallback);
+        RippleSimulation(osg::Group* parent, Resource::ResourceSystem* resourceSystem);
         ~RippleSimulation();
 
         /// @param dt Time since the last frame

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -828,10 +828,9 @@ private:
             , mTimeOfDayFade(1.f)
             , mGlareView(1.f)
         {
-            const Fallback::Map* fallback = MWBase::Environment::get().getWorld()->getFallback();
-            mColor = fallback->getFallbackColour("Weather_Sun_Glare_Fader_Color");
-            mSunGlareFaderMax = fallback->getFallbackFloat("Weather_Sun_Glare_Fader_Max");
-            mSunGlareFaderAngleMax = fallback->getFallbackFloat("Weather_Sun_Glare_Fader_Angle_Max");
+            mColor = Fallback::Map::getColour("Weather_Sun_Glare_Fader_Color");
+            mSunGlareFaderMax = Fallback::Map::getFloat("Weather_Sun_Glare_Fader_Max");
+            mSunGlareFaderAngleMax = Fallback::Map::getFloat("Weather_Sun_Glare_Fader_Angle_Max");
 
             // Replicating a design flaw in MW. The color was being set on both ambient and emissive properties, which multiplies the result by two,
             // then finally gets clamped by the fixed function pipeline. With the default INI settings, only the red component gets clamped,
@@ -1179,9 +1178,8 @@ void SkyManager::create()
 
     mSun.reset(new Sun(mEarlyRenderBinRoot, *mSceneManager->getImageManager()));
 
-    const Fallback::Map* fallback=MWBase::Environment::get().getWorld()->getFallback();
-    mMasser.reset(new Moon(mEarlyRenderBinRoot, *mSceneManager->getImageManager(), fallback->getFallbackFloat("Moons_Masser_Size")/125, Moon::Type_Masser));
-    mSecunda.reset(new Moon(mEarlyRenderBinRoot, *mSceneManager->getImageManager(), fallback->getFallbackFloat("Moons_Secunda_Size")/125, Moon::Type_Secunda));
+    mMasser.reset(new Moon(mEarlyRenderBinRoot, *mSceneManager->getImageManager(), Fallback::Map::getFloat("Moons_Masser_Size")/125, Moon::Type_Masser));
+    mSecunda.reset(new Moon(mEarlyRenderBinRoot, *mSceneManager->getImageManager(), Fallback::Map::getFloat("Moons_Secunda_Size")/125, Moon::Type_Secunda));
 
     mCloudNode = new osg::PositionAttitudeTransform;
     mEarlyRenderBinRoot->addChild(mCloudNode);
@@ -1205,7 +1203,7 @@ void SkyManager::create()
     mEarlyRenderBinRoot->getOrCreateStateSet()->setMode(GL_BLEND, osg::StateAttribute::ON);
     mEarlyRenderBinRoot->getOrCreateStateSet()->setMode(GL_FOG, osg::StateAttribute::OFF);
 
-    mMoonScriptColor = fallback->getFallbackColour("Moons_Script_Color");
+    mMoonScriptColor = Fallback::Map::getColour("Moons_Script_Color");
 
     mCreated = true;
 }

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -400,19 +400,18 @@ public:
     }
 };
 
-Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem *resourceSystem, osgUtil::IncrementalCompileOperation *ico,
-             const Fallback::Map* fallback, const std::string& resourcePath)
+Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem *resourceSystem,
+             osgUtil::IncrementalCompileOperation *ico, const std::string& resourcePath)
     : mParent(parent)
     , mSceneRoot(sceneRoot)
     , mResourceSystem(resourceSystem)
-    , mFallback(fallback)
     , mResourcePath(resourcePath)
     , mEnabled(true)
     , mToggled(true)
     , mTop(0)
     , mInterior(false)
 {
-    mSimulation.reset(new RippleSimulation(parent, resourceSystem, fallback));
+    mSimulation.reset(new RippleSimulation(parent, resourceSystem));
 
     mWaterGeom = SceneUtil::createWaterGeometry(Constants::CellSizeInUnits*150, 40, 900);
     mWaterGeom->setDrawCallback(new DepthClampCallback);
@@ -428,7 +427,7 @@ Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem
 
     // simple water fallback for the local map
     osg::ref_ptr<osg::Geometry> geom2 (osg::clone(mWaterGeom.get(), osg::CopyOp::DEEP_COPY_NODES));
-    createSimpleWaterStateSet(geom2, mFallback->getFallbackFloat("Water_Map_Alpha"));
+    createSimpleWaterStateSet(geom2, Fallback::Map::getFloat("Water_Map_Alpha"));
     geom2->setNodeMask(Mask_SimpleWater);
     mWaterNode->addChild(geom2);
  
@@ -479,7 +478,7 @@ void Water::updateWaterMaterial()
         createShaderWaterStateSet(mWaterGeom, mReflection, mRefraction);
     }
     else
-        createSimpleWaterStateSet(mWaterGeom, mFallback->getFallbackFloat("Water_World_Alpha"));
+        createSimpleWaterStateSet(mWaterGeom, Fallback::Map::getFloat("Water_World_Alpha"));
 
     updateVisible();
 }
@@ -502,8 +501,8 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
 
     // Add animated textures
     std::vector<osg::ref_ptr<osg::Texture2D> > textures;
-    int frameCount = mFallback->getFallbackInt("Water_SurfaceFrameCount");
-    std::string texture = mFallback->getFallbackString("Water_SurfaceTexture");
+    int frameCount = Fallback::Map::getInt("Water_SurfaceFrameCount");
+    const std::string& texture = Fallback::Map::getString("Water_SurfaceTexture");
     for (int i=0; i<frameCount; ++i)
     {
         std::ostringstream texname;
@@ -517,7 +516,7 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
     if (textures.empty())
         return;
 
-    float fps = mFallback->getFallbackFloat("Water_SurfaceFPS");
+    float fps = Fallback::Map::getFloat("Water_SurfaceFPS");
 
     osg::ref_ptr<NifOsg::FlipController> controller (new NifOsg::FlipController(0, 1.f/fps, textures));
     controller->setSource(std::shared_ptr<SceneUtil::ControllerSource>(new SceneUtil::FrameTimeSource));
@@ -618,8 +617,8 @@ Water::~Water()
 
 void Water::listAssetsToPreload(std::vector<std::string> &textures)
 {
-    int frameCount = mFallback->getFallbackInt("Water_SurfaceFrameCount");
-    std::string texture = mFallback->getFallbackString("Water_SurfaceTexture");
+    int frameCount = Fallback::Map::getInt("Water_SurfaceFrameCount");
+    const std::string& texture = Fallback::Map::getString("Water_SurfaceTexture");
     for (int i=0; i<frameCount; ++i)
     {
         std::ostringstream texname;

--- a/apps/openmw/mwrender/water.hpp
+++ b/apps/openmw/mwrender/water.hpp
@@ -57,7 +57,6 @@ namespace MWRender
         osg::ref_ptr<osg::PositionAttitudeTransform> mWaterNode;
         osg::ref_ptr<osg::Geometry> mWaterGeom;
         Resource::ResourceSystem* mResourceSystem;
-        const Fallback::Map* mFallback;
         osg::ref_ptr<osgUtil::IncrementalCompileOperation> mIncrementalCompileOperation;
 
         std::unique_ptr<RippleSimulation> mSimulation;
@@ -85,7 +84,7 @@ namespace MWRender
 
     public:
         Water(osg::Group* parent, osg::Group* sceneRoot,
-              Resource::ResourceSystem* resourceSystem, osgUtil::IncrementalCompileOperation* ico, const Fallback::Map* fallback,
+              Resource::ResourceSystem* resourceSystem, osgUtil::IncrementalCompileOperation* ico,
               const std::string& resourcePath);
         ~Water();
 

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -33,9 +33,8 @@ namespace MWSound
     // For combining PlayMode and Type flags
     inline int operator|(PlayMode a, Type b) { return static_cast<int>(a) | static_cast<int>(b); }
 
-    SoundManager::SoundManager(const VFS::Manager* vfs, const std::map<std::string, std::string>& fallbackMap, bool useSound)
+    SoundManager::SoundManager(const VFS::Manager* vfs, bool useSound)
         : mVFS(vfs)
-        , mFallback(fallbackMap)
         , mOutput(new DEFAULT_OUTPUT(*this))
         , mMasterVolume(1.0f)
         , mSFXVolume(1.0f)
@@ -66,12 +65,12 @@ namespace MWSound
         mFootstepsVolume = Settings::Manager::getFloat("footsteps volume", "Sound");
         mFootstepsVolume = std::min(std::max(mFootstepsVolume, 0.0f), 1.0f);
 
-        mNearWaterRadius = mFallback.getFallbackInt("Water_NearWaterRadius");
-        mNearWaterPoints = mFallback.getFallbackInt("Water_NearWaterPoints");
-        mNearWaterIndoorTolerance = mFallback.getFallbackFloat("Water_NearWaterIndoorTolerance");
-        mNearWaterOutdoorTolerance = mFallback.getFallbackFloat("Water_NearWaterOutdoorTolerance");
-        mNearWaterIndoorID = Misc::StringUtils::lowerCase(mFallback.getFallbackString("Water_NearWaterIndoorID"));
-        mNearWaterOutdoorID = Misc::StringUtils::lowerCase(mFallback.getFallbackString("Water_NearWaterOutdoorID"));
+        mNearWaterRadius = Fallback::Map::getInt("Water_NearWaterRadius");
+        mNearWaterPoints = Fallback::Map::getInt("Water_NearWaterPoints");
+        mNearWaterIndoorTolerance = Fallback::Map::getFloat("Water_NearWaterIndoorTolerance");
+        mNearWaterOutdoorTolerance = Fallback::Map::getFloat("Water_NearWaterOutdoorTolerance");
+        mNearWaterIndoorID = Misc::StringUtils::lowerCase(Fallback::Map::getString("Water_NearWaterIndoorID"));
+        mNearWaterOutdoorID = Misc::StringUtils::lowerCase(Fallback::Map::getString("Water_NearWaterOutdoorID"));
 
         mBufferCacheMin = std::max(Settings::Manager::getInt("buffer cache min", "Sound"), 1);
         mBufferCacheMax = std::max(Settings::Manager::getInt("buffer cache max", "Sound"), 1);

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -46,7 +46,6 @@ namespace MWSound
     {
         const VFS::Manager* mVFS;
 
-        Fallback::Map mFallback;
         std::unique_ptr<Sound_Output> mOutput;
 
         // Caches available music tracks by <playlist name, (sound files) >
@@ -149,7 +148,7 @@ namespace MWSound
         ///< Stop the given object from playing given sound buffer.
 
     public:
-        SoundManager(const VFS::Manager* vfs, const std::map<std::string, std::string>& fallbackMap, bool useSound);
+        SoundManager(const VFS::Manager* vfs, bool useSound);
         virtual ~SoundManager();
 
         virtual void processChangedSettings(const Settings::CategorySettingVector& settings);

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -115,67 +115,66 @@ template class MWWorld::TimeOfDayInterpolator<float>;
 template class MWWorld::TimeOfDayInterpolator<osg::Vec4f>;
 
 Weather::Weather(const std::string& name,
-                 const Fallback::Map& fallback,
                  float stormWindSpeed,
                  float rainSpeed,
                  float dlFactor,
                  float dlOffset,
                  const std::string& particleEffect)
-    : mCloudTexture(fallback.getFallbackString("Weather_" + name + "_Cloud_Texture"))
-    , mSkyColor(fallback.getFallbackColour("Weather_" + name +"_Sky_Sunrise_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Sky_Day_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Sky_Sunset_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Sky_Night_Color"))
-    , mFogColor(fallback.getFallbackColour("Weather_" + name + "_Fog_Sunrise_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Fog_Day_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Fog_Sunset_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Fog_Night_Color"))
-    , mAmbientColor(fallback.getFallbackColour("Weather_" + name + "_Ambient_Sunrise_Color"),
-                    fallback.getFallbackColour("Weather_" + name + "_Ambient_Day_Color"),
-                    fallback.getFallbackColour("Weather_" + name + "_Ambient_Sunset_Color"),
-                    fallback.getFallbackColour("Weather_" + name + "_Ambient_Night_Color"))
-    , mSunColor(fallback.getFallbackColour("Weather_" + name + "_Sun_Sunrise_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Sun_Day_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Sun_Sunset_Color"),
-                fallback.getFallbackColour("Weather_" + name + "_Sun_Night_Color"))
-    , mLandFogDepth(fallback.getFallbackFloat("Weather_" + name + "_Land_Fog_Day_Depth"),
-                    fallback.getFallbackFloat("Weather_" + name + "_Land_Fog_Day_Depth"),
-                    fallback.getFallbackFloat("Weather_" + name + "_Land_Fog_Day_Depth"),
-                    fallback.getFallbackFloat("Weather_" + name + "_Land_Fog_Night_Depth"))
-    , mSunDiscSunsetColor(fallback.getFallbackColour("Weather_" + name + "_Sun_Disc_Sunset_Color"))
-    , mWindSpeed(fallback.getFallbackFloat("Weather_" + name + "_Wind_Speed"))
-    , mCloudSpeed(fallback.getFallbackFloat("Weather_" + name + "_Cloud_Speed"))
-    , mGlareView(fallback.getFallbackFloat("Weather_" + name + "_Glare_View"))
+    : mCloudTexture(Fallback::Map::getString("Weather_" + name + "_Cloud_Texture"))
+    , mSkyColor(Fallback::Map::getColour("Weather_" + name +"_Sky_Sunrise_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Sky_Day_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Sky_Sunset_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Sky_Night_Color"))
+    , mFogColor(Fallback::Map::getColour("Weather_" + name + "_Fog_Sunrise_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Fog_Day_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Fog_Sunset_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Fog_Night_Color"))
+    , mAmbientColor(Fallback::Map::getColour("Weather_" + name + "_Ambient_Sunrise_Color"),
+                    Fallback::Map::getColour("Weather_" + name + "_Ambient_Day_Color"),
+                    Fallback::Map::getColour("Weather_" + name + "_Ambient_Sunset_Color"),
+                    Fallback::Map::getColour("Weather_" + name + "_Ambient_Night_Color"))
+    , mSunColor(Fallback::Map::getColour("Weather_" + name + "_Sun_Sunrise_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Sun_Day_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Sun_Sunset_Color"),
+                Fallback::Map::getColour("Weather_" + name + "_Sun_Night_Color"))
+    , mLandFogDepth(Fallback::Map::getFloat("Weather_" + name + "_Land_Fog_Day_Depth"),
+                    Fallback::Map::getFloat("Weather_" + name + "_Land_Fog_Day_Depth"),
+                    Fallback::Map::getFloat("Weather_" + name + "_Land_Fog_Day_Depth"),
+                    Fallback::Map::getFloat("Weather_" + name + "_Land_Fog_Night_Depth"))
+    , mSunDiscSunsetColor(Fallback::Map::getColour("Weather_" + name + "_Sun_Disc_Sunset_Color"))
+    , mWindSpeed(Fallback::Map::getFloat("Weather_" + name + "_Wind_Speed"))
+    , mCloudSpeed(Fallback::Map::getFloat("Weather_" + name + "_Cloud_Speed"))
+    , mGlareView(Fallback::Map::getFloat("Weather_" + name + "_Glare_View"))
     , mIsStorm(mWindSpeed > stormWindSpeed)
     , mRainSpeed(rainSpeed)
-    , mRainFrequency(fallback.getFallbackFloat("Weather_" + name + "_Rain_Entrance_Speed"))
+    , mRainFrequency(Fallback::Map::getFloat("Weather_" + name + "_Rain_Entrance_Speed"))
     , mParticleEffect(particleEffect)
-    , mRainEffect(fallback.getFallbackBool("Weather_" + name + "_Using_Precip") ? "meshes\\raindrop.nif" : "")
-    , mTransitionDelta(fallback.getFallbackFloat("Weather_" + name + "_Transition_Delta"))
-    , mCloudsMaximumPercent(fallback.getFallbackFloat("Weather_" + name + "_Clouds_Maximum_Percent"))
-    , mThunderFrequency(fallback.getFallbackFloat("Weather_" + name + "_Thunder_Frequency"))
-    , mThunderThreshold(fallback.getFallbackFloat("Weather_" + name + "_Thunder_Threshold"))
+    , mRainEffect(Fallback::Map::getBool("Weather_" + name + "_Using_Precip") ? "meshes\\raindrop.nif" : "")
+    , mTransitionDelta(Fallback::Map::getFloat("Weather_" + name + "_Transition_Delta"))
+    , mCloudsMaximumPercent(Fallback::Map::getFloat("Weather_" + name + "_Clouds_Maximum_Percent"))
+    , mThunderFrequency(Fallback::Map::getFloat("Weather_" + name + "_Thunder_Frequency"))
+    , mThunderThreshold(Fallback::Map::getFloat("Weather_" + name + "_Thunder_Threshold"))
     , mThunderSoundID()
-    , mFlashDecrement(fallback.getFallbackFloat("Weather_" + name + "_Flash_Decrement"))
+    , mFlashDecrement(Fallback::Map::getFloat("Weather_" + name + "_Flash_Decrement"))
     , mFlashBrightness(0.0f)
 {
     mDL.FogFactor = dlFactor;
     mDL.FogOffset = dlOffset;
-    mThunderSoundID[0] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_0");
-    mThunderSoundID[1] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_1");
-    mThunderSoundID[2] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_2");
-    mThunderSoundID[3] = fallback.getFallbackString("Weather_" + name + "_Thunder_Sound_ID_3");
+    mThunderSoundID[0] = Fallback::Map::getString("Weather_" + name + "_Thunder_Sound_ID_0");
+    mThunderSoundID[1] = Fallback::Map::getString("Weather_" + name + "_Thunder_Sound_ID_1");
+    mThunderSoundID[2] = Fallback::Map::getString("Weather_" + name + "_Thunder_Sound_ID_2");
+    mThunderSoundID[3] = Fallback::Map::getString("Weather_" + name + "_Thunder_Sound_ID_3");
 
     // TODO: support weathers that have both "Ambient Loop Sound ID" and "Rain Loop Sound ID", need to play both sounds at the same time.
 
     if (!mRainEffect.empty()) // NOTE: in vanilla, the weathers with rain seem to be hardcoded; changing Using_Precip has no effect
     {
-        mAmbientLoopSoundID = fallback.getFallbackString("Weather_" + name + "_Rain_Loop_Sound_ID");
+        mAmbientLoopSoundID = Fallback::Map::getString("Weather_" + name + "_Rain_Loop_Sound_ID");
         if (mAmbientLoopSoundID.empty()) // default to "rain" if not set
             mAmbientLoopSoundID = "rain";
     }
     else
-        mAmbientLoopSoundID = fallback.getFallbackString("Weather_" + name + "_Ambient_Loop_Sound_ID");
+        mAmbientLoopSoundID = Fallback::Map::getString("Weather_" + name + "_Ambient_Loop_Sound_ID");
 
     if (Misc::StringUtils::ciEqual(mAmbientLoopSoundID, "None"))
         mAmbientLoopSoundID.clear();
@@ -351,17 +350,17 @@ void RegionWeather::chooseNewWeather()
     mWeather = 0;
 }
 
-MoonModel::MoonModel(const std::string& name, const Fallback::Map& fallback)
-  : mFadeInStart(fallback.getFallbackFloat("Moons_" + name + "_Fade_In_Start"))
-  , mFadeInFinish(fallback.getFallbackFloat("Moons_" + name + "_Fade_In_Finish"))
-  , mFadeOutStart(fallback.getFallbackFloat("Moons_" + name + "_Fade_Out_Start"))
-  , mFadeOutFinish(fallback.getFallbackFloat("Moons_" + name + "_Fade_Out_Finish"))
-  , mAxisOffset(fallback.getFallbackFloat("Moons_" + name + "_Axis_Offset"))
-  , mSpeed(fallback.getFallbackFloat("Moons_" + name + "_Speed"))
-  , mDailyIncrement(fallback.getFallbackFloat("Moons_" + name + "_Daily_Increment"))
-  , mFadeStartAngle(fallback.getFallbackFloat("Moons_" + name + "_Fade_Start_Angle"))
-  , mFadeEndAngle(fallback.getFallbackFloat("Moons_" + name + "_Fade_End_Angle"))
-  , mMoonShadowEarlyFadeAngle(fallback.getFallbackFloat("Moons_" + name + "_Moon_Shadow_Early_Fade_Angle"))
+MoonModel::MoonModel(const std::string& name)
+  : mFadeInStart(Fallback::Map::getFloat("Moons_" + name + "_Fade_In_Start"))
+  , mFadeInFinish(Fallback::Map::getFloat("Moons_" + name + "_Fade_In_Finish"))
+  , mFadeOutStart(Fallback::Map::getFloat("Moons_" + name + "_Fade_Out_Start"))
+  , mFadeOutFinish(Fallback::Map::getFloat("Moons_" + name + "_Fade_Out_Finish"))
+  , mAxisOffset(Fallback::Map::getFloat("Moons_" + name + "_Axis_Offset"))
+  , mSpeed(Fallback::Map::getFloat("Moons_" + name + "_Speed"))
+  , mDailyIncrement(Fallback::Map::getFloat("Moons_" + name + "_Daily_Increment"))
+  , mFadeStartAngle(Fallback::Map::getFloat("Moons_" + name + "_Fade_Start_Angle"))
+  , mFadeEndAngle(Fallback::Map::getFloat("Moons_" + name + "_Fade_End_Angle"))
+  , mMoonShadowEarlyFadeAngle(Fallback::Map::getFloat("Moons_" + name + "_Moon_Shadow_Early_Fade_Angle"))
 {
     // Morrowind appears to have a minimum speed in order to avoid situations where the moon couldn't conceivably
     // complete a rotation in a single 24 hour period. The value of 180/23 was deduced from reverse engineering.
@@ -520,24 +519,24 @@ inline float MoonModel::earlyMoonShadowAlpha(float angle) const
         return 0.0f;
 }
 
-WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, const Fallback::Map& fallback, MWWorld::ESMStore& store)
+WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, MWWorld::ESMStore& store)
     : mStore(store)
     , mRendering(rendering)
-    , mSunriseTime(fallback.getFallbackFloat("Weather_Sunrise_Time"))
-    , mSunsetTime(fallback.getFallbackFloat("Weather_Sunset_Time"))
-    , mSunriseDuration(fallback.getFallbackFloat("Weather_Sunrise_Duration"))
-    , mSunsetDuration(fallback.getFallbackFloat("Weather_Sunset_Duration"))
-    , mSunPreSunsetTime(fallback.getFallbackFloat("Weather_Sun_Pre-Sunset_Time"))
+    , mSunriseTime(Fallback::Map::getFloat("Weather_Sunrise_Time"))
+    , mSunsetTime(Fallback::Map::getFloat("Weather_Sunset_Time"))
+    , mSunriseDuration(Fallback::Map::getFloat("Weather_Sunrise_Duration"))
+    , mSunsetDuration(Fallback::Map::getFloat("Weather_Sunset_Duration"))
+    , mSunPreSunsetTime(Fallback::Map::getFloat("Weather_Sun_Pre-Sunset_Time"))
     , mNightFade(0, 0, 0, 1)
-    , mHoursBetweenWeatherChanges(fallback.getFallbackFloat("Weather_Hours_Between_Weather_Changes"))
-    , mRainSpeed(fallback.getFallbackFloat("Weather_Precip_Gravity"))
-    , mUnderwaterFog(fallback.getFallbackFloat("Water_UnderwaterSunriseFog"),
-                    fallback.getFallbackFloat("Water_UnderwaterDayFog"),
-                    fallback.getFallbackFloat("Water_UnderwaterSunsetFog"),
-                    fallback.getFallbackFloat("Water_UnderwaterNightFog"))
+    , mHoursBetweenWeatherChanges(Fallback::Map::getFloat("Weather_Hours_Between_Weather_Changes"))
+    , mRainSpeed(Fallback::Map::getFloat("Weather_Precip_Gravity"))
+    , mUnderwaterFog(Fallback::Map::getFloat("Water_UnderwaterSunriseFog"),
+                    Fallback::Map::getFloat("Water_UnderwaterDayFog"),
+                    Fallback::Map::getFloat("Water_UnderwaterSunsetFog"),
+                    Fallback::Map::getFloat("Water_UnderwaterNightFog"))
     , mWeatherSettings()
-    , mMasser("Masser", fallback)
-    , mSecunda("Secunda", fallback)
+    , mMasser("Masser")
+    , mSecunda("Secunda")
     , mWindSpeed(0.f)
     , mIsStorm(false)
     , mPrecipitation(false)
@@ -561,15 +560,15 @@ WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, const Fall
     mTimeSettings.mDayStart = mSunriseTime + mSunriseDuration;
     mTimeSettings.mDayEnd = mSunsetTime;
 
-    mTimeSettings.addSetting(fallback, "Sky");
-    mTimeSettings.addSetting(fallback, "Ambient");
-    mTimeSettings.addSetting(fallback, "Fog");
-    mTimeSettings.addSetting(fallback, "Sun");
+    mTimeSettings.addSetting("Sky");
+    mTimeSettings.addSetting("Ambient");
+    mTimeSettings.addSetting("Fog");
+    mTimeSettings.addSetting("Sun");
 
     // Morrowind handles stars settings differently for other ones
-    mTimeSettings.mStarsPostSunsetStart = fallback.getFallbackFloat("Weather_Stars_Post-Sunset_Start");
-    mTimeSettings.mStarsPreSunriseFinish = fallback.getFallbackFloat("Weather_Stars_Pre-Sunrise_Finish");
-    mTimeSettings.mStarsFadingDuration = fallback.getFallbackFloat("Weather_Stars_Fading_Duration");
+    mTimeSettings.mStarsPostSunsetStart = Fallback::Map::getFloat("Weather_Stars_Post-Sunset_Start");
+    mTimeSettings.mStarsPreSunriseFinish = Fallback::Map::getFloat("Weather_Stars_Pre-Sunrise_Finish");
+    mTimeSettings.mStarsFadingDuration = Fallback::Map::getFloat("Weather_Stars_Fading_Duration");
 
     WeatherSetting starSetting = {
         mTimeSettings.mStarsPreSunriseFinish,
@@ -583,16 +582,16 @@ WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, const Fall
     mWeatherSettings.reserve(10);
     // These distant land fog factor and offset values are the defaults MGE XE provides. Should be
     // provided by settings somewhere?
-    addWeather("Clear", fallback, 1.0f, 0.0f); // 0
-    addWeather("Cloudy", fallback, 0.9f, 0.0f); // 1
-    addWeather("Foggy", fallback, 0.2f, 30.0f); // 2
-    addWeather("Overcast", fallback, 0.7f, 0.0f); // 3
-    addWeather("Rain", fallback, 0.5f, 10.0f); // 4
-    addWeather("Thunderstorm", fallback, 0.5f, 20.0f); // 5
-    addWeather("Ashstorm", fallback, 0.2f, 50.0f, "meshes\\ashcloud.nif"); // 6
-    addWeather("Blight", fallback, 0.2f, 60.0f, "meshes\\blightcloud.nif"); // 7
-    addWeather("Snow", fallback, 0.5f, 40.0f, "meshes\\snow.nif"); // 8
-    addWeather("Blizzard", fallback, 0.16f, 70.0f, "meshes\\blizzard.nif"); // 9
+    addWeather("Clear", 1.0f, 0.0f); // 0
+    addWeather("Cloudy", 0.9f, 0.0f); // 1
+    addWeather("Foggy", 0.2f, 30.0f); // 2
+    addWeather("Overcast", 0.7f, 0.0f); // 3
+    addWeather("Rain", 0.5f, 10.0f); // 4
+    addWeather("Thunderstorm", 0.5f, 20.0f); // 5
+    addWeather("Ashstorm", 0.2f, 50.0f, "meshes\\ashcloud.nif"); // 6
+    addWeather("Blight", 0.2f, 60.0f, "meshes\\blightcloud.nif"); // 7
+    addWeather("Snow", 0.5f, 40.0f, "meshes\\snow.nif"); // 8
+    addWeather("Blizzard", 0.16f, 70.0f, "meshes\\blizzard.nif"); // 9
 
     Store<ESM::Region>::iterator it = store.get<ESM::Region>().begin();
     for(; it != store.get<ESM::Region>().end(); ++it)
@@ -924,13 +923,12 @@ void WeatherManager::clear()
 }
 
 inline void WeatherManager::addWeather(const std::string& name,
-                                       const Fallback::Map& fallback,
                                        float dlFactor, float dlOffset,
                                        const std::string& particleEffect)
 {
     static const float fStromWindSpeed = mStore.get<ESM::GameSetting>().find("fStromWindSpeed")->mValue.getFloat();
 
-    Weather weather(name, fallback, fStromWindSpeed, mRainSpeed, dlFactor, dlOffset, particleEffect);
+    Weather weather(name, fStromWindSpeed, mRainSpeed, dlFactor, dlOffset, particleEffect);
 
     mWeatherSettings.push_back(weather);
 }

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -81,13 +81,13 @@ namespace MWWorld
             }
         }
 
-        void addSetting(const Fallback::Map& fallback, const std::string& type)
+        void addSetting(const std::string& type)
         {
             WeatherSetting setting = {
-                fallback.getFallbackFloat("Weather_" + type + "_Pre-Sunrise_Time"),
-                fallback.getFallbackFloat("Weather_" + type + "_Post-Sunrise_Time"),
-                fallback.getFallbackFloat("Weather_" + type + "_Pre-Sunset_Time"),
-                fallback.getFallbackFloat("Weather_" + type + "_Post-Sunset_Time")
+                Fallback::Map::getFloat("Weather_" + type + "_Pre-Sunrise_Time"),
+                Fallback::Map::getFloat("Weather_" + type + "_Post-Sunrise_Time"),
+                Fallback::Map::getFloat("Weather_" + type + "_Pre-Sunset_Time"),
+                Fallback::Map::getFloat("Weather_" + type + "_Post-Sunset_Time")
             };
 
             mSunriseTransitions[type] = setting;
@@ -116,7 +116,6 @@ namespace MWWorld
     {
     public:
         Weather(const std::string& name,
-                const Fallback::Map& fallback,
                 float stormWindSpeed,
                 float rainSpeed,
                 float dlFactor,
@@ -230,7 +229,7 @@ namespace MWWorld
     class MoonModel
     {
     public:
-        MoonModel(const std::string& name, const Fallback::Map& fallback);
+        MoonModel(const std::string& name);
 
         MWRender::MoonState calculateState(const TimeStamp& gameTime) const;
 
@@ -260,9 +259,7 @@ namespace MWWorld
     {
     public:
         // Have to pass fallback and Store, can't use singleton since World isn't fully constructed yet at the time
-        WeatherManager(MWRender::RenderingManager& rendering,
-                       const Fallback::Map& fallback,
-                       MWWorld::ESMStore& store);
+        WeatherManager(MWRender::RenderingManager& rendering, MWWorld::ESMStore& store);
         ~WeatherManager();
 
         /**
@@ -348,7 +345,6 @@ namespace MWWorld
         std::string mPlayingSoundID;
 
         void addWeather(const std::string& name,
-                        const Fallback::Map& fallback,
                         float dlFactor, float dlOffset,
                         const std::string& particleEffect = "");
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -156,10 +156,10 @@ namespace MWWorld
         Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
         const Files::Collections& fileCollections,
         const std::vector<std::string>& contentFiles,
-        ToUTF8::Utf8Encoder* encoder, const std::map<std::string,std::string>& fallbackMap,
-        int activationDistanceOverride, const std::string& startCell,
+        ToUTF8::Utf8Encoder* encoder, int activationDistanceOverride,
+        const std::string& startCell, const std::string& startupScript,
         const std::string& resourcePath, const std::string& userDataPath)
-    : mResourceSystem(resourceSystem), mFallback(fallbackMap), mLocalScripts (mStore),
+    : mResourceSystem(resourceSystem), mLocalScripts (mStore),
       mSky (true), mCells (mStore, mEsm),
       mGodMode(false), mScriptsEnabled(true), mContentFiles (contentFiles), mUserDataPath(userDataPath),
       mActivationDistanceOverride (activationDistanceOverride),
@@ -213,11 +213,11 @@ namespace MWWorld
             mNavigator.reset(new DetourNavigator::NavigatorStub());
         }
 
-        mRendering.reset(new MWRender::RenderingManager(viewer, rootNode, resourceSystem, workQueue, &mFallback, resourcePath, *mNavigator));
+        mRendering.reset(new MWRender::RenderingManager(viewer, rootNode, resourceSystem, workQueue, resourcePath, *mNavigator));
         mProjectileManager.reset(new ProjectileManager(mRendering->getLightRoot(), resourceSystem, mRendering.get(), mPhysics.get()));
         mRendering->preloadCommonAssets();
 
-        mWeatherManager.reset(new MWWorld::WeatherManager(*mRendering, mFallback, mStore));
+        mWeatherManager.reset(new MWWorld::WeatherManager(*mRendering, mStore));
 
         mWorldScene.reset(new Scene(*mRendering.get(), mPhysics.get(), *mNavigator));
     }
@@ -253,7 +253,7 @@ namespace MWWorld
         // we don't want old weather to persist on a new game
         // Note that if reset later, the initial ChangeWeather that the chargen script calls will be lost.
         mWeatherManager.reset();
-        mWeatherManager.reset(new MWWorld::WeatherManager(*mRendering.get(), mFallback, mStore));
+        mWeatherManager.reset(new MWWorld::WeatherManager(*mRendering.get(), mStore));
 
         if (!bypass)
         {
@@ -298,7 +298,7 @@ namespace MWWorld
 
         if (!bypass)
         {
-            std::string video = mFallback.getFallbackString("Movies_New_Game");
+            const std::string& video = Fallback::Map::getString("Movies_New_Game");
             if (!video.empty())
                 MWBase::Environment::get().getWindowManager()->playVideo(video, true);
         }
@@ -568,11 +568,6 @@ namespace MWWorld
         }
 
         return nullptr;
-    }
-
-    const Fallback::Map *World::getFallback() const
-    {
-        return &mFallback;
     }
 
     CellStore *World::getExterior (int x, int y)
@@ -1854,7 +1849,7 @@ namespace MWWorld
         bool isFirstPerson = mRendering->getCamera()->isFirstPerson();
         if (isWerewolf && isFirstPerson)
         {
-            float werewolfFov = mFallback.getFallbackFloat("General_Werewolf_FOV");
+            float werewolfFov = Fallback::Map::getFloat("General_Werewolf_FOV");
             if (werewolfFov != 0)
                 mRendering->overrideFieldOfView(werewolfFov);
             MWBase::Environment::get().getWindowManager()->setWerewolfOverlay(true);
@@ -3588,9 +3583,8 @@ namespace MWWorld
         if (ptr == getPlayerPtr() && Settings::Manager::getBool("hit fader", "GUI"))
             return;
 
-        std::string texture = getFallback()->getFallbackString("Blood_Texture_" + std::to_string(ptr.getClass().getBloodTexture(ptr)));
-        std::string model = "meshes\\" + getFallback()->getFallbackString("Blood_Model_" + std::to_string(Misc::Rng::rollDice(3))); // [0, 2]
-
+        std::string texture = Fallback::Map::getString("Blood_Texture_" + std::to_string(ptr.getClass().getBloodTexture(ptr)));
+        std::string model = "meshes\\" + Fallback::Map::getString("Blood_Model_" + std::to_string(Misc::Rng::rollDice(3))); // [0, 2]
         mRendering->spawnEffect(model, texture, worldPosition, 1.0f, false);
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -78,8 +78,6 @@ namespace MWWorld
     {
             Resource::ResourceSystem* mResourceSystem;
 
-            Fallback::Map mFallback;
-
             std::vector<ESM::ESMReader> mEsm;
             MWWorld::ESMStore mStore;
             LocalScripts mLocalScripts;
@@ -198,8 +196,9 @@ namespace MWWorld
                 Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
                 const Files::Collections& fileCollections,
                 const std::vector<std::string>& contentFiles,
-                ToUTF8::Utf8Encoder* encoder, const std::map<std::string,std::string>& fallbackMap,
-                int activationDistanceOverride, const std::string& startCell, const std::string& resourcePath, const std::string& userDataPath);
+                ToUTF8::Utf8Encoder* encoder, int activationDistanceOverride,
+                const std::string& startCell, const std::string& startupScript,
+                const std::string& resourcePath, const std::string& userDataPath);
 
             virtual ~World();
 
@@ -234,8 +233,6 @@ namespace MWWorld
             bool toggleBorders() override;
 
             void adjustSky() override;
-
-            const Fallback::Map *getFallback() const override;
 
             Player& getPlayer() override;
             MWWorld::Ptr getPlayerPtr() override;

--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -6,10 +6,14 @@
 
 namespace Fallback
 {
-    Map::Map(const std::map<std::string,std::string>& fallback):mFallbackMap(fallback)
-    {}
+    std::map<std::string,std::string> Map::mFallbackMap;
 
-    std::string Map::getFallbackString(const std::string& fall) const
+    void Map::init(const std::map<std::string,std::string>& fallback)
+    {
+        mFallbackMap = fallback;
+    }
+
+    std::string Map::getString(const std::string& fall)
     {
         std::map<std::string,std::string>::const_iterator it;
         if ((it = mFallbackMap.find(fall)) == mFallbackMap.end())
@@ -19,9 +23,9 @@ namespace Fallback
         return it->second;
     }
 
-    float Map::getFallbackFloat(const std::string& fall) const
+    float Map::getFloat(const std::string& fall)
     {
-        std::string fallback = getFallbackString(fall);
+        const std::string& fallback = getString(fall);
         if (!fallback.empty())
         {
             try
@@ -39,9 +43,9 @@ namespace Fallback
         return 0;
     }
 
-    int Map::getFallbackInt(const std::string& fall) const
+    int Map::getInt(const std::string& fall)
     {
-        std::string fallback = getFallbackString(fall);
+        const std::string& fallback = getString(fall);
         if (!fallback.empty())
         {
             try
@@ -61,15 +65,15 @@ namespace Fallback
         return 0;
     }
 
-    bool Map::getFallbackBool(const std::string& fall) const
+    bool Map::getBool(const std::string& fall)
     {
-        std::string fallback = getFallbackString(fall);
+        const std::string& fallback = getString(fall);
         return !fallback.empty() && fallback != "0";
     }
 
-    osg::Vec4f Map::getFallbackColour(const std::string& fall) const
+    osg::Vec4f Map::getColour(const std::string& fall)
     {
-        std::string sum = getFallbackString(fall);
+        const std::string& sum = getString(fall);
         if (!sum.empty())
         {
             try

--- a/components/fallback/fallback.hpp
+++ b/components/fallback/fallback.hpp
@@ -11,16 +11,15 @@ namespace Fallback
     /// @brief contains settings imported from the Morrowind INI file.
     class Map
     {
-            std::map<std::string,std::string> mFallbackMap;
+            static std::map<std::string,std::string> mFallbackMap;
         public:
-            Map(const std::map<std::string,std::string>& fallback);
-            Map() {}
+            static void init(const std::map<std::string,std::string>& fallback);
 
-            std::string getFallbackString(const std::string& fall) const;
-            float getFallbackFloat(const std::string& fall) const;
-            int getFallbackInt(const std::string& fall) const;
-            bool getFallbackBool(const std::string& fall) const;
-            osg::Vec4f getFallbackColour(const std::string& fall) const;
+            static std::string getString(const std::string& fall);
+            static float getFloat(const std::string& fall);
+            static int getInt(const std::string& fall);
+            static bool getBool(const std::string& fall);
+            static osg::Vec4f getColour(const std::string& fall);
     };
 }
 #endif

--- a/components/widgets/tags.cpp
+++ b/components/widgets/tags.cpp
@@ -1,11 +1,13 @@
 #include "tags.hpp"
 
+#include <components/fallback/fallback.hpp>
+
 #include <MyGUI_Colour.h>
 
 namespace Gui
 {
 
-bool replaceTag(const MyGUI::UString& tag, MyGUI::UString& out, const std::map<std::string,std::string>& fallbackSettings)
+bool replaceTag(const MyGUI::UString& tag, MyGUI::UString& out)
 {
     std::string fontcolour = "fontcolour=";
     size_t fontcolourLength = fontcolour.length();
@@ -16,14 +18,14 @@ bool replaceTag(const MyGUI::UString& tag, MyGUI::UString& out, const std::map<s
     if (tag.compare(0, fontcolourLength, fontcolour) == 0)
     {
         std::string fallbackName = "FontColor_color_" + tag.substr(fontcolourLength);
-        std::map<std::string, std::string>::const_iterator it = fallbackSettings.find(fallbackName);
-        if (it == fallbackSettings.end())
+        std::string str = Fallback::Map::getString(fallbackName);
+        if (str.empty())
             throw std::runtime_error("Unknown fallback name: " + fallbackName);
-        std::string str = it->second;
 
         std::string ret[3];
         unsigned int j=0;
-        for(unsigned int i=0;i<str.length();++i){
+        for(unsigned int i=0;i<str.length();++i)
+        {
             if(str[i]==',') j++;
             else if (str[i] != ' ') ret[j]+=str[i];
         }
@@ -34,14 +36,14 @@ bool replaceTag(const MyGUI::UString& tag, MyGUI::UString& out, const std::map<s
     else if (tag.compare(0, fontcolourhtmlLength, fontcolourhtml) == 0)
     {
         std::string fallbackName = "FontColor_color_" + tag.substr(fontcolourhtmlLength);
-        std::map<std::string, std::string>::const_iterator it = fallbackSettings.find(fallbackName);
-        if (it == fallbackSettings.end())
+        std::string str = Fallback::Map::getString(fallbackName);
+        if (str.empty())
             throw std::runtime_error("Unknown fallback name: " + fallbackName);
-        std::string str = it->second;
 
         std::string ret[3];
         unsigned int j=0;
-        for(unsigned int i=0;i<str.length();++i){
+        for(unsigned int i=0;i<str.length();++i)
+        {
             if(str[i]==',') j++;
             else if (str[i] != ' ') ret[j]+=str[i];
         }

--- a/components/widgets/tags.hpp
+++ b/components/widgets/tags.hpp
@@ -9,7 +9,7 @@ namespace Gui
 {
 
 /// Try to replace a tag. Returns true on success and writes the result to \a out.
-bool replaceTag (const MyGUI::UString& tag, MyGUI::UString& out, const std::map<std::string,std::string>& fallbackSettings);
+bool replaceTag (const MyGUI::UString& tag, MyGUI::UString& out);
 
 }
 


### PR DESCRIPTION
The main idea - make the fallback map static as the settings map.
New syntax looks like this:
```
const std::string& value = Fallback::Map::getString(settingName);
```
As a result, a code is a lot cleaner since we do not need to pass the map into every constructor and store it in different places.

Also now we read configs before GUI init in the editor, so we can populate enums and labels by values from openmw.cfg (can be useful for blood types or weapon types).