### PR TITLE
Make the default vertical FOV in line with vanilla (bug #4933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4927: Spell effect having both a skill and an attribute assigned is a fatal error
     Bug #4932: Invalid records matching when loading save with edited plugin
+    Bug #4933: Field of View not equal with Morrowind
     Bug #4938: Strings from subrecords with actually empty headers can't be empty
     Bug #4942: Hand-to-Hand attack type is chosen randomly when "always use best attack" is turned off
     Bug #4945: Poor random magic magnitude distribution

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -27,11 +27,11 @@ viewing distance = 6666.0
 
 # Camera field of view in degrees (e.g. 30.0 to 110.0).
 # Does not affect the player's hands in the first person camera.
-field of view = 55.0
+field of view = 60.0
 
 # Field of view for first person meshes (i.e. the player's hands)
 # Best to leave this at the default since vanilla assets are not complete enough to adapt to high FoV's. Too low FoV would clip the hands off screen.
-first person field of view = 55.0
+first person field of view = 60.0
 
 [Cells]
 


### PR DESCRIPTION
[Bug 4933](https://gitlab.com/OpenMW/openmw/issues/4933).

Stating again:
I did some research and I think changing the default vertical FOV to 60 seems reasonable. Since Morrowind uses 75 horizontal FOV by default, which is a standard FOV for 4:3 aspect, the vertical FOV is supposed to be 60, but on widescreen resolutions the scene becomes cut off vertically using the same horizontal FOV. MGE using 91.3 degree FOV corrects the vertical FOV to be 60 again on 16:9, resulting in "wider" portion of the scene becoming visible.
Nicolay Korslund first hardcoded the vertical FOV to be 55 in 2008 based on unknown assumptions.
It was carried over faithfully since then.