### PR TITLE
Ignore extra arguments to PlayLoopSound3D too

### DIFF
--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -356,7 +356,7 @@ namespace Compiler
                 opcodePlaySound3DExplicit);
             extensions.registerInstruction ("playsound3dvp", "cff", opcodePlaySound3DVP,
                 opcodePlaySound3DVPExplicit);
-            extensions.registerInstruction ("playloopsound3d", "c", opcodePlayLoopSound3D,
+            extensions.registerInstruction ("playloopsound3d", "cXX", opcodePlayLoopSound3D,
                 opcodePlayLoopSound3DExplicit);
             extensions.registerInstruction ("playloopsound3dvp", "cff", opcodePlayLoopSound3DVP,
                 opcodePlayLoopSound3DVPExplicit);


### PR DESCRIPTION
scrawl made it so extra arguments to playsound and playsound3d are ignored but left playloopsound3d alone for some reason, this makes argument behavior consistent again.