### PR TITLE
Fix macOS CI build timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ addons:
     build_command: "make VERBOSE=1 -j3"
 matrix:
   include:
-    - name: OpenMW (all) on macOS Xcode 10.1
+    - name: OpenMW (all) on macOS Xcode 10.2
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       if: branch != coverity_scan
     - name: OpenMW (all) on Ubuntu Xenial GCC-5
       os: linux

--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -6,6 +6,7 @@ brew install https://gist.githubusercontent.com/nikolaykasyanov/f36da224bdef4202
 brew switch cmake 3.12.4
 brew outdated pkgconfig || brew upgrade pkgconfig
 brew install qt
+brew install ccache
 
 curl -fSL -R -J https://downloads.openmw.org/osx/dependencies/openmw-deps-110f3d3.zip -o ~/openmw-deps.zip
 unzip -o ~/openmw-deps.zip -d /private/tmp/openmw-deps > /dev/null

--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -1,9 +1,6 @@
 #!/bin/sh -e
 
 brew update
-brew unlink cmake || true
-brew install https://gist.githubusercontent.com/nikolaykasyanov/f36da224bdef42025e480f99fa21a82d/raw/7dd8b5ed2750198757f81c6bc6456e03541999bd/cmake.rb
-brew switch cmake 3.12.4
 brew outdated pkgconfig || brew upgrade pkgconfig
 brew install qt
 brew install ccache

--- a/CI/before_script.osx.sh
+++ b/CI/before_script.osx.sh
@@ -10,6 +10,8 @@ cd build
 
 cmake \
 -D CMAKE_PREFIX_PATH="$DEPENDENCIES_ROOT;$QT_PATH" \
+-D CMAKE_C_COMPILER_LAUNCHER=/usr/local/opt/ccache/bin/ccache \
+-D CMAKE_CXX_COMPILER_LAUNCHER=/usr/local/opt/ccache/bin/ccache \
 -D CMAKE_OSX_DEPLOYMENT_TARGET="10.9" \
 -D CMAKE_OSX_SYSROOT="macosx10.14" \
 -D CMAKE_BUILD_TYPE=Release \

--- a/CI/before_script.osx.sh
+++ b/CI/before_script.osx.sh
@@ -4,14 +4,15 @@ export CXX=clang++
 export CC=clang
 
 DEPENDENCIES_ROOT="/private/tmp/openmw-deps/openmw-deps"
-QT_PATH=`brew --prefix qt`
+QT_PATH=$(brew --prefix qt)
+CCACHE_EXECUTABLE=$(brew --prefix ccache)/bin/ccache
 mkdir build
 cd build
 
 cmake \
 -D CMAKE_PREFIX_PATH="$DEPENDENCIES_ROOT;$QT_PATH" \
--D CMAKE_C_COMPILER_LAUNCHER=/usr/local/opt/ccache/bin/ccache \
--D CMAKE_CXX_COMPILER_LAUNCHER=/usr/local/opt/ccache/bin/ccache \
+-D CMAKE_C_COMPILER_LAUNCHER="$CCACHE_EXECUTABLE" \
+-D CMAKE_CXX_COMPILER_LAUNCHER="$CCACHE_EXECUTABLE" \
 -D CMAKE_OSX_DEPLOYMENT_TARGET="10.9" \
 -D CMAKE_OSX_SYSROOT="macosx10.14" \
 -D CMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
~The recent builds are taking too much time & being terminated by Travis a lot.
I'll look into ccache and if it helps, re-enable the step.~

This PR improves macOS build times by switching to the most recent macOS image & using ccache.