### PR TITLE
Make sure the record hasn't ended in getHString hack (bug #4938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
     Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Bug #4922: Werewolves can not attack if the transformation happens during attack
+    Bug #4938: Strings from subrecords with actually empty headers can't be empty
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -127,7 +127,7 @@ std::string ESMReader::getHString()
     // them. For some reason, they break the rules, and contain a byte
     // (value 0) even if the header says there is no data. If
     // Morrowind accepts it, so should we.
-    if (mCtx.leftSub == 0)
+    if (mCtx.leftSub == 0 && mCtx.leftRec != 0)
     {
         // Skip the following zero byte
         mCtx.leftRec--;


### PR DESCRIPTION
[Bug 4938](https://gitlab.com/OpenMW/openmw/issues/4938).

See the report for description of the issue.
If leftRec is 0, then the record has ended and the following byte must definitely not be skipped.

There might be more cases where "valid" empty strings arise, but this at least allows one specific plugin to load without breaking MultiMark.esp loading.