### PR TITLE
Do not allocate eight dummy LightStateAttribute's for every stateset

### DIFF
--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -140,6 +140,8 @@ namespace SceneUtil
         typedef std::map<size_t, osg::ref_ptr<osg::StateSet> > LightStateSetMap;
         LightStateSetMap mStateSetCache[2];
 
+        std::vector<osg::ref_ptr<osg::StateAttribute>> mDummies;
+
         int mStartLight;
 
         unsigned int mLightingMask;


### PR DESCRIPTION
Based on bzzt's work.

If I understand correctly, now we assign LightStateAttribute's for every stateset in the LightManager to reset lights to default when we pop stateset.

bzzt think that it is enough to allocate dummy attributes only once and re-use them for different statesets.
It may be a good idea if the dummies are really dummies, or may be a bad idea if we write data to them.