### PR TITLE
Only set hand-to-hand attack type randomly if "always use best attack" is on (bug #4942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4938: Strings from subrecords with actually empty headers can't be empty
+    Bug #4942: Hand-to-Hand attack type is chosen randomly when "always use best attack" is turned off
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1631,20 +1631,22 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                 {
                     if(mPtr == getPlayer())
                     {
-                        if (isWeapon)
+                        if (Settings::Manager::getBool("best attack", "Game"))
                         {
-                            if (Settings::Manager::getBool("best attack", "Game"))
+                            if (isWeapon)
                             {
                                 MWWorld::ConstContainerStoreIterator weapon = mPtr.getClass().getInventoryStore(mPtr).getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
                                 mAttackType = getBestAttack(weapon->get<ESM::Weapon>()->mBase);
                             }
                             else
-                                setAttackTypeBasedOnMovement();
+                            {
+                                // There is no "best attack" for Hand-to-Hand
+                                setAttackTypeRandomly(mAttackType);
+                            }
                         }
                         else
                         {
-                            // There is no "best attack" for Hand-to-Hand
-                            setAttackTypeRandomly(mAttackType);
+                            setAttackTypeBasedOnMovement();
                         }
                     }
                     // else if (mPtr != getPlayer()) use mAttackType set by AiCombat


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4942)

Now OpenMW behaves like Morrowind in my testing.