### PR TITLE
Scalable UI textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
     Feature #4887: Add openmw command option to set initial random seed
     Feature #4890: Make Distant Terrain configurable
     Feature #4962: Add casting animations for magic items
+    Feature #4968: Scalable UI widget skins
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
 

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -32,7 +32,7 @@ add_openmw_dir (mwinput
 add_openmw_dir (mwgui
     layout textinput widgets race class birth review windowmanagerimp console dialogue
     windowbase statswindow messagebox journalwindow charactercreation
-    mapwindow windowpinnablebase tooltips scrollwindow bookwindow
+    mapwindow windowpinnablebase tooltips scrollwindow bookwindow resourceskin
     formatting inventorywindow container hud countdialog tradewindow settingswindow
     confirmationdialog alchemywindow referenceinterface spellwindow mainmenu quickkeysmenu
     itemselection spellbuyingwindow loadingscreen levelupdialog waitdialog spellcreationdialog

--- a/apps/openmw/mwgui/bookwindow.cpp
+++ b/apps/openmw/mwgui/bookwindow.cpp
@@ -20,7 +20,7 @@ namespace MWGui
 {
 
     BookWindow::BookWindow ()
-        : WindowBase("openmw_book.layout")
+        : BookWindowBase("openmw_book.layout")
         , mCurrentPage(0)
         , mTakeButtonShow(true)
         , mTakeButtonAllowed(true)
@@ -43,10 +43,10 @@ namespace MWGui
         getWidget(mLeftPage, "LeftPage");
         getWidget(mRightPage, "RightPage");
 
-        adjustButton(mCloseButton);
-        adjustButton(mTakeButton);
-        adjustButton(mNextPageButton);
-        adjustButton(mPrevPageButton);
+        adjustButton("CloseButton");
+        adjustButton("TakeButton");
+        adjustButton("PrevPageBTN");
+        float scale = adjustButton("NextPageBTN");
 
         mLeftPage->setNeedMouseFocus(true);
         mLeftPage->eventMouseWheel += MyGUI::newDelegate(this, &BookWindow::onMouseWheel);
@@ -62,7 +62,7 @@ namespace MWGui
         {
             // english button has a 7 pixel wide strip of garbage on its right edge
             mNextPageButton->setSize(64-7, mNextPageButton->getSize().height);
-            mNextPageButton->setImageCoord(MyGUI::IntCoord(0,0,64-7,mNextPageButton->getSize().height));
+            mNextPageButton->setImageCoord(MyGUI::IntCoord(0,0,(64-7)*scale,mNextPageButton->getSize().height*scale));
         }
 
         center();
@@ -185,15 +185,6 @@ namespace MWGui
         {
             paper->setVisible(false);
         }
-    }
-
-    void BookWindow::adjustButton (Gui::ImageButton* button)
-    {
-        MyGUI::IntSize diff = button->getSize() - button->getRequestedSize();
-        button->setSize(button->getRequestedSize());
-
-        if (button->getAlign().isRight())
-            button->setPosition(button->getPosition() + MyGUI::IntPoint(diff.width,0));
     }
 
     void BookWindow::nextPage()

--- a/apps/openmw/mwgui/bookwindow.hpp
+++ b/apps/openmw/mwgui/bookwindow.hpp
@@ -9,7 +9,7 @@
 
 namespace MWGui
 {
-    class BookWindow : public WindowBase
+    class BookWindow : public BookWindowBase
     {
         public:
             BookWindow();
@@ -34,7 +34,6 @@ namespace MWGui
 
             void updatePages();
             void clearPages();
-            void adjustButton(Gui::ImageButton* button);
 
         private:
             typedef std::pair<int, int> Page;

--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -2,6 +2,7 @@
 
 #include <MyGUI_FactoryManager.h>
 #include <MyGUI_ImageBox.h>
+#include <MyGUI_RenderManager.h>
 #include <MyGUI_TextBox.h>
 
 // correctIconPath
@@ -30,6 +31,7 @@ namespace
 
 namespace MWGui
 {
+    std::map<std::string, float> ItemWidget::mScales;
 
     ItemWidget::ItemWidget()
         : mItem(nullptr)
@@ -146,10 +148,29 @@ namespace MWGui
         if (backgroundTex != "")
             backgroundTex += ".dds";
 
-        if (state == Barter && !isMagic)
-            setFrame(backgroundTex, MyGUI::IntCoord(2,2,42,42));
-        else
-            setFrame(backgroundTex, MyGUI::IntCoord(0,0,42,42));
+        if (!backgroundTex.empty())
+        {
+            float scale = 1.f;
+            auto found = mScales.find(backgroundTex);
+            if (found == mScales.end())
+            {
+                // By default, background icons are supposed to use the 42x42 part of 64x64 image.
+                // If the image has a different size, we should use a different chunk size
+                // Cache result to do not retrieve background texture every frame.
+                MyGUI::ITexture* texture = MyGUI::RenderManager::getInstance().getTexture(backgroundTex);
+                if (texture)
+                    scale = texture->getHeight() / 64.f;
+
+                mScales[backgroundTex] = scale;
+            }
+            else
+                scale = found->second;
+
+            if (state == Barter && !isMagic)
+                setFrame(backgroundTex, MyGUI::IntCoord(2*scale,2*scale,44*scale,44*scale));
+            else
+                setFrame(backgroundTex, MyGUI::IntCoord(0,0,44*scale,44*scale));
+        }
 
         setIcon(ptr);
     }

--- a/apps/openmw/mwgui/itemwidget.hpp
+++ b/apps/openmw/mwgui/itemwidget.hpp
@@ -50,6 +50,8 @@ namespace MWGui
 
         std::string mCurrentIcon;
         std::string mCurrentFrame;
+
+        static std::map<std::string, float> mScales;
     };
 
     class SpellWidget : public ItemWidget

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -153,7 +153,7 @@ namespace
             }
 
             adjustButton(PrevPageBTN);
-            adjustButton(NextPageBTN);
+            float nextButtonScale = adjustButton(NextPageBTN);
             adjustButton(CloseBTN);
             adjustButton(CancelBTN);
             adjustButton(JournalBTN);
@@ -168,7 +168,7 @@ namespace
             {
                 // english button has a 7 pixel wide strip of garbage on its right edge
                 nextButton->setSize(64-7, nextButton->getSize().height);
-                nextButton->setImageCoord(MyGUI::IntCoord(0,0,64-7,nextButton->getSize().height));
+                nextButton->setImageCoord(MyGUI::IntCoord(0,0,(64-7)*nextButtonScale,nextButton->getSize().height*nextButtonScale));
             }
 
             if (!questList)
@@ -224,17 +224,6 @@ namespace
             mAllQuests = false;
             mOptionsMode = false;
             mTopicsMode = false;
-        }
-
-        void adjustButton (char const * name)
-        {
-            Gui::ImageButton* button = getWidget<Gui::ImageButton>(name);
-
-            MyGUI::IntSize diff = button->getSize() - button->getRequestedSize();
-            button->setSize(button->getRequestedSize());
-
-            if (button->getAlign().isRight())
-                button->setPosition(button->getPosition() + MyGUI::IntPoint(diff.width,0));
         }
 
         void onOpen()
@@ -665,7 +654,7 @@ MWGui::JournalWindow * MWGui::JournalWindow::create (JournalViewModel::Ptr Model
 }
 
 MWGui::JournalWindow::JournalWindow()
-    :WindowBase("openmw_journal.layout")
+    : BookWindowBase("openmw_journal.layout")
 {
 
 }

--- a/apps/openmw/mwgui/journalwindow.hpp
+++ b/apps/openmw/mwgui/journalwindow.hpp
@@ -13,7 +13,7 @@ namespace MWGui
 {
     struct JournalViewModel;
 
-    struct JournalWindow : public WindowBase
+    struct JournalWindow : public BookWindowBase
     {
         JournalWindow();
 

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -285,15 +285,18 @@ namespace MWGui
             Gui::ImageButton* button = mButtons[buttonId];
             button->setVisible(true);
 
+            // By default, assume that all menu buttons textures should have 64 height.
+            // If they have a different resolution, scale them.
             MyGUI::IntSize requested = button->getRequestedSize();
+            float scale = requested.height / 64.f;
 
             button->setImageCoord(MyGUI::IntCoord(0, 0, requested.width, requested.height));
             // Trim off some of the excessive padding
             // TODO: perhaps do this within ImageButton?
-            int height = requested.height-16;
-            button->setImageTile(MyGUI::IntSize(requested.width, height));
-            button->setCoord((maxwidth-requested.width) / 2, curH, requested.width, height);
-            curH += height;
+            int height = requested.height;
+            button->setImageTile(MyGUI::IntSize(requested.width, requested.height-16*scale));
+            button->setCoord((maxwidth-requested.width/scale) / 2, curH, requested.width/scale, height/scale-16);
+            curH += height/scale-16;
         }
 
         if (state == MWBase::StateManager::State_NoGame)

--- a/apps/openmw/mwgui/resourceskin.cpp
+++ b/apps/openmw/mwgui/resourceskin.cpp
@@ -1,0 +1,83 @@
+#include "resourceskin.hpp"
+
+#include <MyGUI_RenderManager.h>
+
+#include <components/misc/stringops.hpp>
+
+namespace MWGui
+{
+    void resizeSkin(MyGUI::xml::ElementPtr _node)
+    {
+        _node->setAttribute("type", "ResourceSkin");
+        const std::string size = _node->findAttribute("size");
+        if (!size.empty())
+            return;
+
+        const std::string textureName = _node->findAttribute("texture");
+        if (textureName.empty())
+            return;
+
+        MyGUI::ITexture* texture = MyGUI::RenderManager::getInstance().getTexture(textureName);
+        if (!texture)
+            return;
+
+        MyGUI::IntCoord coord(0, 0, texture->getWidth(), texture->getHeight());
+        MyGUI::xml::ElementEnumerator basis = _node->getElementEnumerator();
+        const std::string textureSize = std::to_string(coord.width) + " " +  std::to_string(coord.height);
+        _node->addAttribute("size", textureSize);
+        while (basis.next())
+        {
+            if (basis->getName() != "BasisSkin")
+                continue;
+
+            const std::string basisSkinType = basis->findAttribute("type");
+            if (Misc::StringUtils::ciEqual(basisSkinType, "SimpleText"))
+                continue;
+
+            const std::string offset = basis->findAttribute("offset");
+            if (!offset.empty())
+                continue;
+
+            basis->addAttribute("offset", coord);
+
+            MyGUI::xml::ElementEnumerator state = basis->getElementEnumerator();
+            while (state.next())
+            {
+                if (state->getName() == "State")
+                {
+                    const std::string stateOffset = state->findAttribute("offset");
+                    if (!stateOffset.empty())
+                        continue;
+
+                    state->addAttribute("offset", coord);
+                    if (Misc::StringUtils::ciEqual(basisSkinType, "TileRect"))
+                    {
+                        MyGUI::xml::ElementEnumerator property = state->getElementEnumerator();
+                        bool hasTileSize = false;
+                        while (property.next("Property"))
+                        {
+                            const std::string key = property->findAttribute("key");
+                            if (key != "TileSize")
+                                continue;
+
+                            hasTileSize = true;
+                        }
+
+                        if (!hasTileSize)
+                        {
+                            MyGUI::xml::ElementPtr tileSizeProperty = state->createChild("Property");
+                            tileSizeProperty->addAttribute("key", "TileSize");
+                            tileSizeProperty->addAttribute("value", textureSize);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void AutoSizedResourceSkin::deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version)
+    {
+        resizeSkin(_node);
+        Base::deserialization(_node, _version);
+    }
+}

--- a/apps/openmw/mwgui/resourceskin.hpp
+++ b/apps/openmw/mwgui/resourceskin.hpp
@@ -1,0 +1,18 @@
+#ifndef MWGUI_RESOURCESKIN_H
+#define MWGUI_RESOURCESKIN_H
+
+#include <MyGUI_ResourceSkin.h>
+
+namespace MWGui
+{
+    class AutoSizedResourceSkin : public MyGUI::ResourceSkin
+    {
+        MYGUI_RTTI_DERIVED( AutoSizedResourceSkin )
+
+    public:
+        virtual void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version);
+    };
+
+}
+
+#endif

--- a/apps/openmw/mwgui/scrollwindow.cpp
+++ b/apps/openmw/mwgui/scrollwindow.cpp
@@ -16,23 +16,11 @@
 
 #include "formatting.hpp"
 
-namespace
-{
-    void adjustButton (Gui::ImageButton* button)
-    {
-        MyGUI::IntSize diff = button->getSize() - button->getRequestedSize();
-        button->setSize(button->getRequestedSize());
-
-        if (button->getAlign().isRight())
-            button->setPosition(button->getPosition() + MyGUI::IntPoint(diff.width,0));
-    }
-}
-
 namespace MWGui
 {
 
     ScrollWindow::ScrollWindow ()
-        : WindowBase("openmw_scroll.layout")
+        : BookWindowBase("openmw_scroll.layout")
         , mTakeButtonShow(true)
         , mTakeButtonAllowed(true)
     {
@@ -44,8 +32,8 @@ namespace MWGui
         getWidget(mTakeButton, "TakeButton");
         mTakeButton->eventMouseButtonClick += MyGUI::newDelegate(this, &ScrollWindow::onTakeButtonClicked);
 
-        adjustButton(mCloseButton);
-        adjustButton(mTakeButton);
+        adjustButton("CloseButton");
+        adjustButton("TakeButton");
 
         mCloseButton->eventKeyButtonPressed += MyGUI::newDelegate(this, &ScrollWindow::onKeyButtonPressed);
         mTakeButton->eventKeyButtonPressed += MyGUI::newDelegate(this, &ScrollWindow::onKeyButtonPressed);

--- a/apps/openmw/mwgui/scrollwindow.hpp
+++ b/apps/openmw/mwgui/scrollwindow.hpp
@@ -12,7 +12,7 @@ namespace Gui
 
 namespace MWGui
 {
-    class ScrollWindow : public WindowBase
+    class ScrollWindow : public BookWindowBase
     {
         public:
             ScrollWindow ();

--- a/apps/openmw/mwgui/windowbase.cpp
+++ b/apps/openmw/mwgui/windowbase.cpp
@@ -6,6 +6,8 @@
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/environment.hpp"
 
+#include <components/widgets/imagebutton.hpp>
+
 #include "draganddrop.hpp"
 
 using namespace MWGui;
@@ -119,4 +121,31 @@ void NoDrop::setAlpha(float alpha)
 {
     if (mWidget)
         mWidget->setAlpha(alpha);
+}
+
+BookWindowBase::BookWindowBase(const std::string& parLayout)
+  : WindowBase(parLayout)
+{
+}
+
+float BookWindowBase::adjustButton (char const * name)
+{
+    Gui::ImageButton* button;
+    WindowBase::getWidget (button, name);
+    MyGUI::IntSize requested = button->getRequestedSize();
+    float scale = requested.height / button->getSize().height;
+    MyGUI::IntSize newSize = requested;
+    newSize.width /= scale;
+    newSize.height /= scale;
+    button->setSize(newSize);
+
+    if (button->getAlign().isRight())
+    {
+        MyGUI::IntSize diff = (button->getSize() - requested);
+        diff.width /= scale;
+        diff.height /= scale;
+        button->setPosition(button->getPosition() + MyGUI::IntPoint(diff.width,0));
+    }
+
+    return scale;
 }

--- a/apps/openmw/mwgui/windowbase.hpp
+++ b/apps/openmw/mwgui/windowbase.hpp
@@ -82,6 +82,15 @@ namespace MWGui
         DragAndDrop* mDrag;
         bool mTransparent;
     };
+
+    class BookWindowBase : public WindowBase
+    {
+    public:
+        BookWindowBase(const std::string& parLayout);
+
+    protected:
+        float adjustButton (char const * name);
+    };
 }
 
 #endif

--- a/files/mygui/openmw_box.skin.xml
+++ b/files/mygui/openmw_box.skin.xml
@@ -5,60 +5,56 @@ as around the sections of the stats window, or around popup info windows -->
 
 <MyGUI type="Resource" version="1.1">
     <!-- Box borders -->
-    <Resource type="ResourceSkin" name="IB_T" size="512 2" texture="textures\menu_thin_border_top.dds">
-        <BasisSkin type="TileRect" offset="0 0 512 2" align="HStretch">
-            <State name="normal" offset="0 0 512 2">
-                <Property key="TileSize" value="512 2"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_T" texture="textures\menu_thin_border_top.dds">
+        <BasisSkin type="TileRect" align="HStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_B" size="512 2" texture="textures\menu_thin_border_bottom.dds">
-        <BasisSkin type="TileRect" offset="0 0 512 2" align="HStretch">
-            <State name="normal" offset="0 0 512 2">
-                <Property key="TileSize" value="512 2"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_B" texture="textures\menu_thin_border_bottom.dds">
+        <BasisSkin type="TileRect" align="HStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_L" size="2 512" texture="textures\menu_thin_border_left.dds">
-        <BasisSkin type="TileRect" offset="0 0 2 512" align="VStretch">
-            <State name="normal" offset="0 0 2 512">
-                <Property key="TileSize" value="2 512"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_L" texture="textures\menu_thin_border_left.dds">
+        <BasisSkin type="TileRect" align="VStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_R" size="2 512" texture="textures\menu_thin_border_right.dds">
-        <BasisSkin type="TileRect" offset="0 0 2 512" align="VStretch">
-            <State name="normal" offset="0 0 2 512">
-                <Property key="TileSize" value="2 512"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_R" texture="textures\menu_thin_border_right.dds">
+        <BasisSkin type="TileRect" align="VStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_TL" size="2 2" texture="textures\menu_thin_border_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_TL" texture="textures\menu_thin_border_top_left_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_TR" size="2 2" texture="textures\menu_thin_border_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_TR" texture="textures\menu_thin_border_top_right_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_BL" size="2 2" texture="textures\menu_thin_border_bottom_left_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_BL" texture="textures\menu_thin_border_bottom_left_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="IB_BR" size="2 2" texture="textures\menu_thin_border_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="IB_BR" texture="textures\menu_thin_border_bottom_right_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 

--- a/files/mygui/openmw_button.skin.xml
+++ b/files/mygui/openmw_button.skin.xml
@@ -2,68 +2,64 @@
 
 <MyGUI type="Resource" version="1.1">
     <!-- Button graphics -->
-    <Resource type="ResourceSkin" name="BTN_Top" size="128 4" texture="textures\menu_button_frame_top.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_Top" texture="textures\menu_button_frame_top.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="TileRect" offset="0 0 128 4" align="HStretch">
-            <State name="normal" offset="0 0 128 4">
-                <Property key="TileSize" value="128 4"/>
+        <BasisSkin type="TileRect" align="HStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_Bottom" size="128 4" texture="textures\menu_button_frame_bottom.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_Bottom" texture="textures\menu_button_frame_bottom.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="TileRect" offset="0 0 128 4" align="HStretch">
-            <State name="normal" offset="0 0 128 4">
-                <Property key="TileSize" value="128 4"/>
+        <BasisSkin type="TileRect" align="HStretch">
+            <State name="normal" >
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_Left" size="4 16" texture="textures\menu_button_frame_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_Left" texture="textures\menu_button_frame_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="TileRect" offset="0 0 4 16" align="VStretch">
-            <State name="normal" offset="0 0 4 16">
-                <Property key="TileSize" value="4 16"/>
+        <BasisSkin type="TileRect" align="VStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_Right" size="4 16" texture="textures\menu_button_frame_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_Right" texture="textures\menu_button_frame_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="TileRect" offset="0 0 4 16" align="VStretch">
-            <State name="normal" offset="0 0 4 16">
-                <Property key="TileSize" value="4 16"/>
+        <BasisSkin type="TileRect" align="VStretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_TopLeft" size="4 4" texture="textures\menu_button_frame_top_left_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_TopLeft" texture="textures\menu_button_frame_top_left_corner.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_TopRight" size="4 4" texture="textures\menu_button_frame_top_right_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_TopRight" texture="textures\menu_button_frame_top_right_corner.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_BottomLeft" size="4 4" texture="textures\menu_button_frame_bottom_left_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_BottomLeft" texture="textures\menu_button_frame_bottom_left_corner.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="BTN_BottomRight" size="4 4" texture="textures\menu_button_frame_bottom_right_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="BTN_BottomRight" texture="textures\menu_button_frame_bottom_right_corner.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 

--- a/files/mygui/openmw_hud_box.skin.xml
+++ b/files/mygui/openmw_hud_box.skin.xml
@@ -55,19 +55,19 @@
         <Child type="Widget" skin="MW_Box" offset="0 0 40 40" align="Left Stretch"/>
 
     </Resource>
-    
+
     <!-- Defines crosshair color -->
-    <Resource type="ResourceSkin" name="HUD_Crosshair" size="32 32" texture="textures\target.dds">
-        <BasisSkin type="MainSkin" offset="0 0 32 32">
-            <State name="normal" offset="0 0 32 32"/>
+    <Resource type="AutoSizedResourceSkin" name="HUD_Crosshair" texture="textures\target.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    
+
     <!-- Defines owned crosshair color -->
-    <Resource type="ResourceSkin" name="HUD_Crosshair_Owned" size="32 32" texture="textures\target.dds">
+    <Resource type="AutoSizedResourceSkin" name="HUD_Crosshair_Owned" texture="textures\target.dds">
         <Property key="Colour" value="#{setting=GUI,color crosshair owned}"/>
-        <BasisSkin type="MainSkin" offset="0 0 32 32">
-            <State name="normal" offset="0 0 32 32"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 

--- a/files/mygui/openmw_hud_energybar.skin.xml
+++ b/files/mygui/openmw_hud_energybar.skin.xml
@@ -2,60 +2,60 @@
 
 <MyGUI type="Resource" version="1.1">
     <!-- Energy bar frame graphics -->
-    <Resource type="ResourceSkin" name="HUD_Bar_Top" size="64 2" texture="textures\menu_small_energy_bar_top.dds">
-        <BasisSkin type="MainSkin" offset="0 0 64 2">
-            <State name="normal" offset="0 0 64 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HUD_Bar_Top" texture="textures\menu_small_energy_bar_top.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="HUD_Bar_Bottom" size="64 2" texture="textures\menu_small_energy_bar_bottom.dds">
-        <BasisSkin type="MainSkin" offset="0 0 64 2">
-            <State name="normal" offset="0 0 64 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HUD_Bar_Bottom" texture="textures\menu_small_energy_bar_bottom.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="HUD_Bar_Side" size="2 8" texture="textures\menu_small_energy_bar_vert.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 8">
-            <State name="normal" offset="0 0 2 8"/>
+    <Resource type="AutoSizedResourceSkin" name="HUD_Bar_Side" texture="textures\menu_small_energy_bar_vert.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
     <!-- Progress bar track, various colors -->
-    <Resource type="ResourceSkin" name="MW_BarTrack_Red" size="4 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Red" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=health}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_BarTrack_Green" size="4 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Green" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=fatigue}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_BarTrack_Blue" size="4 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Blue" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=magic}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_BarTrack_Yellow" size="4 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Yellow" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="1 1 0"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
 
-    <Resource type="ResourceSkin" name="MW_BarTrack_Magic" size="4 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Magic" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=magic_fill}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="MW_BarTrack_Weapon" size="4 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Weapon" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=weapon_fill}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 

--- a/files/mygui/openmw_journal.layout
+++ b/files/mygui/openmw_journal.layout
@@ -57,13 +57,13 @@
     </Widget>
 
     <!-- "options" -->
-    <Widget type="ImageBox" skin="ImageBox" position="293 0 242 350" name="OptionsOverlay">
+    <Widget type="ImageBox" skin="ImageBox" position="293 0 386 350" name="OptionsOverlay">
       <Property key="ImageTexture" value="textures\tx_menubook_bookmark.dds"/>
-      <Property key="ImageCoord" value="0 0 164 256"/>
 
-      <Widget type="BookPage" skin="MW_BookPage" position="10 10 92 260" name="LeftTopicIndex"/>
-      <Widget type="BookPage" skin="MW_BookPage" position="66 10 92 260" name="CenterTopicIndex"/>
-      <Widget type="BookPage" skin="MW_BookPage" position="122 10 92 260" name="RightTopicIndex"/>
+
+      <Widget type="BookPage" skin="MW_BookPage" position="20 10 92 260" name="LeftTopicIndex"/>
+      <Widget type="BookPage" skin="MW_BookPage" position="75 10 92 260" name="CenterTopicIndex"/>
+      <Widget type="BookPage" skin="MW_BookPage" position="130 10 92 260" name="RightTopicIndex"/>
 
       <Widget type="ImageButton" skin="ImageBox" position="71 15 100 20" Align="Top|Left" name="ShowActiveBTN">
         <!-- Image set at runtime since it may not be available in all versions of the game -->

--- a/files/mygui/openmw_progress.skin.xml
+++ b/files/mygui/openmw_progress.skin.xml
@@ -2,41 +2,41 @@
 
 <MyGUI type="Resource" version="1.1">
     <!-- Progress bar track, various colors -->
-    <Resource type="ResourceSkin" name="MW_Track_Red" size="2 14" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_Track_Red" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=health}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 16" align="Stretch">
-            <State name="normal" offset="0 0 16 16"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_Track_Blue" size="2 14" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_Track_Blue" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=magic}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 16" align="Stretch">
-            <State name="normal" offset="0 0 16 16"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_Track_Green" size="2 14" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_Track_Green" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=fatigue}"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 16" align="Stretch">
-            <State name="normal" offset="0 0 16 16"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
     <!-- Lighter variants (only uses top half of the gradient) -->
-    <Resource type="ResourceSkin" name="MW_BigTrack_Progress_Red_Small" size="16 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BigTrack_Progress_Red_Small" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="1 0 0"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_BigTrack_Progress_Blue_Small" size="16 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BigTrack_Progress_Blue_Small" size="16 8" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="0.3 0.3 1"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="MW_BigTrack_Progress_Green_Small" size="16 8" texture="textures\menu_bar_gray.dds" >
+    <Resource type="AutoSizedResourceSkin" name="MW_BigTrack_Progress_Green_Small" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="0.298 0.784 0.780"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+        <BasisSkin type="MainSkin" align="Stretch">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
     <Resource type="ResourceSkin" name="MW_Progress_Drowning_Full_Small" size="16 8" texture="white" >

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -17,115 +17,128 @@
     </Resource>
 
     <!-- Defines a non-transparent background -->
-    <Resource type="ResourceSkin" name="TransparentBG" size="8 8" texture="transparent">
+     <Resource type="ResourceSkin" name="TransparentBG" size="8 8" texture="transparent">
         <Property key="Colour" value="#{fontcolour=background}"/>
     </Resource>
 
     <!-- Define the borders for pin button (up) -->
-    <Resource type="ResourceSkin" name="PU_B" size="12 2" texture="textures\menu_rightbuttonup_bottom.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_B" texture="textures\menu_rightbuttonup_bottom.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 12 2">
-            <State name="normal" offset="0 0 12 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_BR" size="2 2" texture="textures\menu_rightbuttonup_bottom_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_BR" texture="textures\menu_rightbuttonup_bottom_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_R" size="2 12" texture="textures\menu_rightbuttonup_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_R" texture="textures\menu_rightbuttonup_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 12">
-            <State name="normal" offset="0 0 2 12"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_TR" size="2 2" texture="textures\menu_rightbuttonup_top_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_TR" texture="textures\menu_rightbuttonup_top_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_T" size="12 2" texture="textures\menu_rightbuttonup_top.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_T" texture="textures\menu_rightbuttonup_top.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 12 2">
-            <State name="normal" offset="0 0 12 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_TL" size="2 2" texture="textures\menu_rightbuttonup_top_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_TL" texture="textures\menu_rightbuttonup_top_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_L" size="2 12" texture="textures\menu_rightbuttonup_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_L" texture="textures\menu_rightbuttonup_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 12">
-            <State name="normal" offset="0 0 2 12"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PU_BL" size="2 2" texture="textures\menu_rightbuttonup_bottom_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="PU_BL" texture="textures\menu_rightbuttonup_bottom_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
+        </BasisSkin>
+    </Resource>
+    <Resource type="AutoSizedResourceSkin" name="PU_С" texture="textures\menu_rightbuttonup_center.dds">
+        <Property key="NeedMouse" value="false"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
     <!-- Define the borders for pin button (down) -->
-    <Resource type="ResourceSkin" name="PD_B" size="12 2" texture="textures\menu_rightbuttondown_bottom.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_B" texture="textures\menu_rightbuttondown_bottom.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 12 2">
-            <State name="normal" offset="0 0 12 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_BR" size="2 2" texture="textures\menu_rightbuttondown_bottom_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_BR" texture="textures\menu_rightbuttondown_bottom_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_R" size="2 12" texture="textures\menu_rightbuttondown_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_R" texture="textures\menu_rightbuttondown_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 12">
-            <State name="normal" offset="0 0 2 12"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_TR" size="2 2" texture="textures\menu_rightbuttondown_top_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_TR" texture="textures\menu_rightbuttondown_top_right.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_T" size="12 2" texture="textures\menu_rightbuttondown_top.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_T" texture="textures\menu_rightbuttondown_top.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 12 2">
-            <State name="normal" offset="0 0 12 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_TL" size="2 2" texture="textures\menu_rightbuttondown_top_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_TL" texture="textures\menu_rightbuttondown_top_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_L" size="2 12" texture="textures\menu_rightbuttondown_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_L" texture="textures\menu_rightbuttondown_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 12">
-            <State name="normal" offset="0 0 2 12"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="PD_BL" size="2 2" texture="textures\menu_rightbuttondown_bottom_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="PD_BL" texture="textures\menu_rightbuttondown_bottom_left.dds">
         <Property key="NeedMouse" value="false"/>
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
+        </BasisSkin>
+    </Resource>
+    <Resource type="AutoSizedResourceSkin" name="PD_С" texture="textures\menu_rightbuttondown_center.dds">
+        <Property key="NeedMouse" value="false"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
     <!-- Define the pin button skin -->
-    <Resource type="ResourceSkin" name="PinUp" size="19 19" texture="textures\menu_rightbuttonup_center.dds">
-        <BasisSkin type="MainSkin" offset="0 0 19 19">
-            <State name="normal" offset="0 0 19 19"/>
+    <Resource type="ResourceSkin" name="PinUp" size="19 19">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
+        <Child type="Widget" skin="PU_С" offset="2 2 15 15" align="Stretch"/>
         <Child type="Widget" skin="PU_B" offset="2 17 15 2" align="Stretch"/>
         <Child type="Widget" skin="PU_BR" offset="17 17 2 2" align="Stretch"/>
         <Child type="Widget" skin="PU_R" offset="17 2 2 15" align="Stretch"/>
@@ -135,10 +148,11 @@
         <Child type="Widget" skin="PU_L" offset="0 2 2 15" align="Stretch"/>
         <Child type="Widget" skin="PU_BL" offset="0 17 2 2" align="Stretch"/>
     </Resource>
-    <Resource type="ResourceSkin" name="PinDown" size="19 19" texture="textures\menu_rightbuttondown_center.dds">
-        <BasisSkin type="MainSkin" offset="0 0 19 19">
-            <State name="normal" offset="0 0 19 19"/>
+    <Resource type="ResourceSkin" name="PinDown" size="19 19">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
+        <Child type="Widget" skin="PD_С" offset="2 2 15 15" align="Stretch"/>
         <Child type="Widget" skin="PD_B" offset="2 17 15 2" align="Stretch"/>
         <Child type="Widget" skin="PD_BR" offset="17 17 2 2" align="Stretch"/>
         <Child type="Widget" skin="PD_R" offset="17 2 2 15" align="Stretch"/>
@@ -173,40 +187,36 @@
     </Resource>
 
     <!-- These define the dialog borders -->
-    <Resource type="ResourceSkin" name="DB_B" size="512 4" texture="textures\menu_thick_border_bottom.dds">
-        <BasisSkin type="TileRect" offset="0 0 512 4" align="Stretch">
-            <State name="normal" offset="0 0 512 4">
-                <Property key="TileSize" value="512 4"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_B" texture="textures\menu_thick_border_bottom.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="DB_R" size="4 512" texture="textures\menu_thick_border_right.dds">
-        <BasisSkin type="TileRect" offset="0 0 4 512" align="Stretch">
-            <State name="normal" offset="0 0 4 512">
-                <Property key="TileSize" value="4 512"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_R" texture="textures\menu_thick_border_right.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="DB_T" size="512 4" texture="textures\menu_thick_border_top.dds">
-        <BasisSkin type="TileRect" offset="0 0 512 4" align="Stretch">
-            <State name="normal" offset="0 0 512 4">
-                <Property key="TileSize" value="512 4"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_T" texture="textures\menu_thick_border_top.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="DB_L" size="4 512" texture="textures\menu_thick_border_left.dds">
-        <BasisSkin type="TileRect" offset="0 0 4 512" align="Stretch">
-            <State name="normal" offset="0 0 4 512">
-                <Property key="TileSize" value="4 512"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_L" texture="textures\menu_thick_border_left.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
@@ -214,67 +224,63 @@
     </Resource>
 
     <!-- Dialog border corners -->
-    <Resource type="ResourceSkin" name="DB_BR" size="4 4" texture="textures\menu_thick_border_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_BR" texture="textures\menu_thick_border_bottom_right_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="DB_BL" size="4 4" texture="textures\menu_thick_border_bottom_left_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="DB_BL" texture="textures\menu_thick_border_bottom_left_corner.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="DB_TR" size="4 4" texture="textures\menu_thick_border_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_TR" texture="textures\menu_thick_border_top_right_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="DB_TL" size="4 4" texture="textures\menu_thick_border_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+    <Resource type="AutoSizedResourceSkin" name="DB_TL" texture="textures\menu_thick_border_top_left_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
     <!-- These define the window borders -->
-    <Resource type="ResourceSkin" name="TB_B" size="512 4" texture="textures\menu_thick_border_bottom.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_B" texture="textures\menu_thick_border_bottom.dds">
         <Property key="Pointer" value="vresize"/>
-        <BasisSkin type="TileRect" offset="0 0 512 4" align="Stretch">
-            <State name="normal" offset="0 0 512 4">
-                <Property key="TileSize" value="512 4"/>
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_R" size="4 512" texture="textures\menu_thick_border_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_R" texture="textures\menu_thick_border_right.dds">
         <Property key="Pointer" value="hresize"/>
-        <BasisSkin type="TileRect" offset="0 0 4 512" align="Stretch">
-            <State name="normal" offset="0 0 4 512">
-                <Property key="TileSize" value="4 512"/>
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_T" size="512 4" texture="textures\menu_thick_border_top.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_T" texture="textures\menu_thick_border_top.dds">
         <Property key="Pointer" value="vresize"/>
-        <BasisSkin type="TileRect" offset="0 0 512 4" align="Stretch">
-            <State name="normal" offset="0 0 512 4">
-                <Property key="TileSize" value="512 4"/>
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_L" size="4 512" texture="textures\menu_thick_border_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_L" texture="textures\menu_thick_border_left.dds">
         <Property key="Pointer" value="hresize"/>
-        <BasisSkin type="TileRect" offset="0 0 4 512" align="Stretch">
-            <State name="normal" offset="0 0 4 512">
-                <Property key="TileSize" value="4 512"/>
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
@@ -282,149 +288,146 @@
     </Resource>
 
     <!-- Window border corners -->
-    <Resource type="ResourceSkin" name="TB_BR" size="4 4" texture="textures\menu_thick_border_bottom_right_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_BR" texture="textures\menu_thick_border_bottom_right_corner.dds">
         <Property key="Pointer" value="dresize"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="TB_BL" size="4 4" texture="textures\menu_thick_border_bottom_left_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_BL" texture="textures\menu_thick_border_bottom_left_corner.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="TB_TR" size="4 4" texture="textures\menu_thick_border_top_right_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_TR" texture="textures\menu_thick_border_top_right_corner.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="TB_TL" size="4 4" texture="textures\menu_thick_border_top_left_corner.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_TL" texture="textures\menu_thick_border_top_left_corner.dds">
         <Property key="Pointer" value="dresize"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 4">
-            <State name="normal" offset="0 0 4 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
     <!-- Expanded border corners, to get larger diagonal corner pointer area -->
-    <Resource type="ResourceSkin" name="TB_TL_T" size="10 4" texture="textures\menu_thick_border_top.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_TL_T" texture="textures\menu_thick_border_top.dds">
         <Property key="Pointer" value="dresize"/>
-        <BasisSkin type="MainSkin" offset="0 0 10 4">
-            <State name="normal" offset="0 0 10 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_TL_B" size="4 10" texture="textures\menu_thick_border_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_TL_B" texture="textures\menu_thick_border_left.dds">
         <Property key="Pointer" value="dresize"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 10">
-            <State name="normal" offset="0 0 4 10"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_TR_T" size="10 4" texture="textures\menu_thick_border_top.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_TR_T" texture="textures\menu_thick_border_top.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 10 4">
-            <State name="normal" offset="0 0 10 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_TR_B" size="4 10" texture="textures\menu_thick_border_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_TR_B" texture="textures\menu_thick_border_right.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 10">
-            <State name="normal" offset="0 0 4 10"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_BL_T" size="4 10" texture="textures\menu_thick_border_left.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_BL_T" texture="textures\menu_thick_border_left.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 10">
-            <State name="normal" offset="0 0 4 10"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_BL_B" size="10 4" texture="textures\menu_thick_border_bottom.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_BL_B" texture="textures\menu_thick_border_bottom.dds">
         <Property key="Pointer" value="dresize2"/>
-        <BasisSkin type="MainSkin" offset="0 0 10 4">
-            <State name="normal" offset="0 0 10 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_BR_T" size="4 10" texture="textures\menu_thick_border_right.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_BR_T" texture="textures\menu_thick_border_right.dds">
         <Property key="Pointer" value="dresize"/>
-        <BasisSkin type="MainSkin" offset="0 0 4 10">
-            <State name="normal" offset="0 0 4 10"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="TB_BR_B" size="10 4" texture="textures\menu_thick_border_bottom.dds">
+    <Resource type="AutoSizedResourceSkin" name="TB_BR_B" texture="textures\menu_thick_border_bottom.dds">
         <Property key="Pointer" value="dresize"/>
-        <BasisSkin type="MainSkin" offset="0 0 10 4">
-            <State name="normal" offset="0 0 10 4"/>
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
     <!-- These parts defines the 'blocks' to the left and right of the caption -->
-    <Resource type="ResourceSkin" name="HB_MID" size="256 16" texture="textures\menu_head_block_middle.dds">
-        <BasisSkin type="TileRect" offset="0 0 256 16" align="Stretch">
-            <State name="normal" offset="0 0 256 16">
-                <Property key="TileSize" value="256 16"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_MID" texture="textures\menu_head_block_middle.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="HB_TOP" size="256 2" texture="textures\menu_head_block_top.dds">
-        <BasisSkin type="TileRect" offset="0 0 256 2" align="Stretch">
-            <State name="normal" offset="0 0 256 2">
-                <Property key="TileSize" value="256 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_TOP" texture="textures\menu_head_block_top.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="HB_BOTTOM" size="256 2" texture="textures\menu_head_block_bottom.dds">
-        <BasisSkin type="TileRect" offset="0 0 256 2" align="Stretch">
-            <State name="normal" offset="0 0 256 2">
-                <Property key="TileSize" value="256 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_BOTTOM" texture="textures\menu_head_block_bottom.dds">
+        <BasisSkin type="TileRect" align="Stretch">
+            <State name="normal">
                 <Property key="TileH" value="true"/>
                 <Property key="TileV" value="true"/>
             </State>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="HB_LEFT" size="2 16" texture="textures\menu_head_block_left.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 16">
-            <State name="normal" offset="0 0 2 16"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_LEFT" texture="textures\menu_head_block_left.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="HB_RIGHT" size="2 16" texture="textures\menu_head_block_right.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 16">
-            <State name="normal" offset="0 0 2 16"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_RIGHT" texture="textures\menu_head_block_right.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="ResourceSkin" name="HB_TR" size="2 2" texture="textures\menu_head_block_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_TR" texture="textures\menu_head_block_top_right_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="HB_TL" size="2 2" texture="textures\menu_head_block_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_TL" texture="textures\menu_head_block_top_left_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="HB_BR" size="2 2" texture="textures\menu_head_block_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_BR" texture="textures\menu_head_block_bottom_right_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
-    <Resource type="ResourceSkin" name="HB_BL" size="2 2" texture="textures\menu_head_block_bottom_left_corner.dds">
-        <BasisSkin type="MainSkin" offset="0 0 2 2">
-            <State name="normal" offset="0 0 2 2"/>
+    <Resource type="AutoSizedResourceSkin" name="HB_BL" texture="textures\menu_head_block_bottom_left_corner.dds">
+        <BasisSkin type="MainSkin">
+            <State name="normal"/>
         </BasisSkin>
     </Resource>
 


### PR DESCRIPTION
Currently most of our UI textures can have only fixed size because of MyGUI design.
As a result, such textures look bad if player uses UI scaling. Also Morrowind often does not use textures directly - it uses textured meshes instead. For example, it makes impossible to use HD crosshair replacers, which work in Morrowind.

The main idea here is to implement an autosized texture skin widget, which will use the whole texture indifferently from texture resolution.
What I managed to achive so far:
1. Scalable crosshair.
2. Scalable texture buttions in the main menu and book windows.
3. Scalable skins for most of UI.
4. Scalable background textures for item widgets (we already scale items and spells icons themselves)
5. Scalable bookmark menu in the journal.
6. ~Scalable cursors.~ Removed since may cause driver crashes on some setups.

Unfortunately, I do not know how to handle compound widgets, which do not use the whole texture (e.g. door markers, scrollbars).