### PR TITLE
Fix certain levitation state inconsistencies (bug #4948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4938: Strings from subrecords with actually empty headers can't be empty
     Bug #4942: Hand-to-Hand attack type is chosen randomly when "always use best attack" is turned off
+    Bug #4948: Footstep sounds while levitating on ground level
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -459,8 +459,9 @@ namespace MWBase
             {
                 Rest_Allowed = 0,
                 Rest_OnlyWaiting = 1,
-                Rest_PlayerIsUnderwater = 2,
-                Rest_EnemiesAreNearby = 3
+                Rest_PlayerIsInAir = 2,
+                Rest_PlayerIsUnderwater = 3,
+                Rest_EnemiesAreNearby = 4
             };
 
             /// check if the player is allowed to rest

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -706,6 +706,8 @@ namespace MWClass
         if(name == "left")
         {
             MWBase::World *world = MWBase::Environment::get().getWorld();
+            if(world->isFlying(ptr))
+                return -1;
             osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
             if(world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
                 return ESM::SoundGenerator::SwimLeft;
@@ -716,6 +718,8 @@ namespace MWClass
         if(name == "right")
         {
             MWBase::World *world = MWBase::Environment::get().getWorld();
+            if(world->isFlying(ptr))
+                return -1;
             osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
             if(world->isUnderwater(ptr.getCell(), pos) || world->isWalkingOnWater(ptr))
                 return ESM::SoundGenerator::SwimRight;

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1214,6 +1214,8 @@ namespace MWClass
         if(name == "left" || name == "right")
         {
             MWBase::World *world = MWBase::Environment::get().getWorld();
+            if(world->isFlying(ptr))
+                return std::string();
             osg::Vec3f pos(ptr.getRefData().getPosition().asVec3());
             if(world->isSwimming(ptr))
                 return (name == "left") ? "Swim Left" : "Swim Right";

--- a/apps/openmw/mwgui/waitdialog.hpp
+++ b/apps/openmw/mwgui/waitdialog.hpp
@@ -4,6 +4,7 @@
 #include "timeadvancer.hpp"
 
 #include "windowbase.hpp"
+#include "referenceinterface.hpp"
 
 namespace MWGui
 {
@@ -22,7 +23,7 @@ namespace MWGui
         MyGUI::TextBox* mProgressText;
     };
 
-    class WaitDialog : public WindowBase
+    class WaitDialog : public WindowBase, public ReferenceInterface
     {
     public:
         WaitDialog();
@@ -62,6 +63,8 @@ namespace MWGui
         std::string mInterruptCreatureList;
 
         WaitDialogProgressBar mProgressBar;
+
+        virtual void onReferenceUnavailable();
 
         void onUntilHealedButtonClicked(MyGUI::Widget* sender);
         void onWaitButtonClicked(MyGUI::Widget* sender);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2477,8 +2477,11 @@ namespace MWWorld
         if(mPlayer->enemiesNearby())
             return Rest_EnemiesAreNearby;
 
-        if ((actor->getCollisionMode() && !mPhysics->isOnSolidGround(player)) || isUnderwater(currentCell, playerPos) || isWalkingOnWater(player))
+        if (isUnderwater(currentCell, playerPos) || isWalkingOnWater(player))
             return Rest_PlayerIsUnderwater;
+
+        if ((actor->getCollisionMode() && !mPhysics->isOnSolidGround(player)) || isFlying(player))
+            return Rest_PlayerIsInAir;
 
         if((currentCell->getCell()->mData.mFlags&ESM::Cell::NoSleep) || player.getClass().getNpcStats(player).isWerewolf())
             return Rest_OnlyWaiting;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4948)

This is actually three mostly separate issues, which may need being accounted for in the human-readable changelog.

1. There aren't any footstep sounds while flying. Note that Morrowind doesn't play swimming sounds either, which is odd but I decided to replicate that. Flying checks were added into soundgen handling.
2. Resting is possible while flying in general case. isFlying check was added to canRest.
3. Resting on a bed is not possible while being in air (e.g. jumping). For that a new RestPermitted IsInAir state was added and bed reference handling was added into waiting dialog.