### PR TITLE
Use loudness data for 2D voiceover (bug #4947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4938: Strings from subrecords with actually empty headers can't be empty
     Bug #4942: Hand-to-Hand attack type is chosen randomly when "always use best attack" is turned off
+    Bug #4947: Player character doesn't use lip animation
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -1247,7 +1247,7 @@ void OpenAL_Output::updateSound(Sound *sound)
 }
 
 
-bool OpenAL_Output::streamSound(DecoderPtr decoder, Stream *sound)
+bool OpenAL_Output::streamSound(DecoderPtr decoder, Stream *sound, bool getLoudnessData)
 {
     if(mFreeSources.empty())
     {
@@ -1265,7 +1265,7 @@ bool OpenAL_Output::streamSound(DecoderPtr decoder, Stream *sound)
         return false;
 
     OpenAL_SoundStream *stream = new OpenAL_SoundStream(source, std::move(decoder));
-    if(!stream->init())
+    if(!stream->init(getLoudnessData))
     {
         delete stream;
         return false;

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -75,7 +75,7 @@ namespace MWSound
         virtual bool isSoundPlaying(Sound *sound);
         virtual void updateSound(Sound *sound);
 
-        virtual bool streamSound(DecoderPtr decoder, Stream *sound);
+        virtual bool streamSound(DecoderPtr decoder, Stream *sound, bool getLoudnessData=false);
         virtual bool streamSound3D(DecoderPtr decoder, Stream *sound, bool getLoudnessData);
         virtual void finishStream(Stream *sound);
         virtual double getStreamDelay(Stream *sound);

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -45,7 +45,7 @@ namespace MWSound
         virtual bool isSoundPlaying(Sound *sound) = 0;
         virtual void updateSound(Sound *sound) = 0;
 
-        virtual bool streamSound(DecoderPtr decoder, Stream *sound) = 0;
+        virtual bool streamSound(DecoderPtr decoder, Stream *sound, bool getLoudnessData=false) = 0;
         virtual bool streamSound3D(DecoderPtr decoder, Stream *sound, bool getLoudnessData) = 0;
         virtual void finishStream(Stream *sound) = 0;
         virtual double getStreamDelay(Stream *sound) = 0;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -319,7 +319,7 @@ namespace MWSound
         if(playlocal)
         {
             sound->init(1.0f, basevol, 1.0f, PlayMode::NoEnv|Type::Voice|Play_2D);
-            played = mOutput->streamSound(decoder, sound);
+            played = mOutput->streamSound(decoder, sound, true);
         }
         else
         {


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4947).

Allows the player character to use lip animation. Seems to work. Granted there's a *lot* of code duplication in sound management, but I better leave such things to kcat.