### PR TITLE
Reset old record, if its ID does not match with ID of new record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4927: Spell effect having both a skill and an attribute assigned is a fatal error
+    Bug #4932: Invalid records matching when loading save with edited plugin
     Bug #4938: Strings from subrecords with actually empty headers can't be empty
     Bug #4942: Hand-to-Hand attack type is chosen randomly when "always use best attack" is turned off
     Bug #4947: Player character doesn't use lip animation

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -133,7 +133,7 @@ namespace
         {
             for (typename MWWorld::CellRefList<T>::List::iterator iter (collection.mList.begin());
                 iter!=collection.mList.end(); ++iter)
-                if (iter->mRef.getRefNum()==state.mRef.mRefNum)
+                if (iter->mRef.getRefNum()==state.mRef.mRefNum && iter->mRef.getRefId() == state.mRef.mRefID)
                 {
                     // overwrite existing reference
                     iter->load (state);


### PR DESCRIPTION
Fixes [bug #4932](https://gitlab.com/OpenMW/openmw/issues/4932).

Unfortunately, TES CS likes to shuffle RefNums, so we will have to reset most of records anyway if some  instance records were removed from plugin, but at least we will avoid false matches.

OpenMW-CS seems to do not have this issue - it just removes instance records from omwaddon files ithout shuffling RefNums.