### PR TITLE
Add an option to use casting animations for magic items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
     Feature #4859: Make water reflections more configurable
     Feature #4887: Add openmw command option to set initial random seed
     Feature #4890: Make Distant Terrain configurable
+    Feature #4962: Add casting animations for magic items
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -972,7 +972,7 @@ namespace MWMechanics
     
         // A non-actor doesn't play its spell cast effects from a character controller, so play them here
         if (!mCaster.getClass().isActor())
-            playSpellCastingEffects(mId);
+            playSpellCastingEffects(mId, false);
 
         inflict(mCaster, mCaster, spell->mEffects, ESM::RT_Self);
 
@@ -1047,15 +1047,27 @@ namespace MWMechanics
         return true;
     }
 
-    void CastSpell::playSpellCastingEffects(const std::string &spellid)
+    void CastSpell::playSpellCastingEffects(const std::string &spellid, bool enchantment)
     {
         const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
-        const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);
+        if (enchantment)
+        {
+            const ESM::Enchantment *spell = store.get<ESM::Enchantment>().find(spellid);
+            playSpellCastingEffects(spell->mEffects.mList);
 
+        }
+        else
+        {
+            const ESM::Spell *spell = store.get<ESM::Spell>().find(spellid);
+            playSpellCastingEffects(spell->mEffects.mList);
+        }
+    }
+
+    void CastSpell::playSpellCastingEffects(const std::vector<ESM::ENAMstruct>& effects)
+    {
+        const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
         std::vector<std::string> addedEffects;
-
-        for (std::vector<ESM::ENAMstruct>::const_iterator iter = spell->mEffects.mList.begin();
-            iter != spell->mEffects.mList.end(); ++iter)
+        for (std::vector<ESM::ENAMstruct>::const_iterator iter = effects.begin(); iter != effects.end(); ++iter)
         {
             const ESM::MagicEffect *effect;
             effect = store.get<ESM::MagicEffect>().find(iter->mEffectID);

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -83,6 +83,9 @@ namespace MWMechanics
     private:
         MWWorld::Ptr mCaster; // May be empty
         MWWorld::Ptr mTarget; // May be empty
+
+        void playSpellCastingEffects(const std::vector<ESM::ENAMstruct>& effects);
+
     public:
         bool mStack;
         std::string mId; // ID of spell, potion, item etc
@@ -109,7 +112,7 @@ namespace MWMechanics
         /// @note Auto detects if spell, ingredient or potion
         bool cast (const std::string& id);
 
-        void playSpellCastingEffects(const std::string &spellid);
+        void playSpellCastingEffects(const std::string &spellid, bool enchantment);
 
         bool spellIncreasesSkill();
 

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1098,7 +1098,7 @@ namespace MWScript
                 MWWorld::Ptr target = MWBase::Environment::get().getWorld()->getPtr (targetId, false);
 
                 MWMechanics::CastSpell cast(ptr, target, false, true);
-                cast.playSpellCastingEffects(spell->mId);
+                cast.playSpellCastingEffects(spell->mId, false);
                 cast.mHitPosition = target.getRefData().getPosition().asVec3();
                 cast.mAlwaysSucceed = true;
                 cast.cast(spell);

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -126,6 +126,18 @@ This is how Morrowind behaves.
 
 This setting can be toggled in Advanced tab of the launcher.
 
+use magic item animations
+-------------------------
+
+:Type:		boolean
+:Range: 	True/False
+:Default:	False
+
+If this setting is true, the engine will use casting animations for magic items, including scrolls.
+Otherwise, there will be no casting animations, just as in original engine
+
+This setting can only be configured by editing the settings configuration file.
+
 show effect duration
 --------------------
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -261,6 +261,9 @@ weapon sheathing = false
 # Allow non-standard ammunition solely to bypass normal weapon resistance or weakness
 only appropriate ammunition bypasses resistance = false
 
+# Use casting animations for magic items, just as for spells
+use magic item animations = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Implements [feature #4962](https://gitlab.com/OpenMW/openmw/issues/4962).

Just refactors our spellcasting code to support both spells and magic items.
Option is disabled by default to replicate vanilla behaviour.