### PR TITLE
Use dice rolls instead of chance for spell magnitude (bug #4945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
     Bug #4927: Spell effect having both a skill and an attribute assigned is a fatal error
     Bug #4938: Strings from subrecords with actually empty headers can't be empty
     Bug #4942: Hand-to-Hand attack type is chosen randomly when "always use best attack" is turned off
+    Bug #4945: Poor random magic magnitude distribution
     Bug #4947: Player character doesn't use lip animation
     Bug #4948: Footstep sounds while levitating on ground level
     Bug #4963: Enchant skill progress is incorrect

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -534,8 +534,7 @@ namespace MWMechanics
 
             if (magnitudeMult > 0 && !absorbed)
             {
-                float random = Misc::Rng::rollClosedProbability();
-                float magnitude = effectIt->mMagnMin + (effectIt->mMagnMax - effectIt->mMagnMin) * random;
+                float magnitude = effectIt->mMagnMin + Misc::Rng::rollDice(effectIt->mMagnMax - effectIt->mMagnMin + 1);
                 magnitude *= magnitudeMult;
 
                 if (!target.getClass().isActor())

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -94,7 +94,10 @@ namespace MWMechanics
                 for (unsigned int i=0; i<spell->mEffects.mList.size();++i)
                 {
                     if (spell->mEffects.mList[i].mMagnMin != spell->mEffects.mList[i].mMagnMax)
-                        random[i] = Misc::Rng::rollClosedProbability();
+                    {
+                        int delta = spell->mEffects.mList[i].mMagnMax - spell->mEffects.mList[i].mMagnMin;
+                        random[i] = Misc::Rng::rollDice(delta + 1) / static_cast<float>(delta);
+                    }
                 }
             }
 

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -637,15 +637,15 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
             bool existed = (mPermanentMagicEffectMagnitudes.find((**iter).getCellRef().getRefId()) != mPermanentMagicEffectMagnitudes.end());
             if (!existed)
             {
-                // Roll some dice, one for each effect
                 params.resize(enchantment.mEffects.mList.size());
-                for (unsigned int i=0; i<params.size();++i)
-                    params[i].mRandom = Misc::Rng::rollClosedProbability();
 
-                // Try resisting each effect
                 int i=0;
                 for (const ESM::ENAMstruct& effect : enchantment.mEffects.mList)
                 {
+                    int delta = effect.mMagnMax - effect.mMagnMin;
+                    // Roll some dice, one for each effect
+                    params[i].mRandom = Misc::Rng::rollDice(delta + 1) / static_cast<float>(delta);
+                    // Try resisting each effect
                     params[i].mMultiplier = MWMechanics::getEffectMultiplier(effect.mEffectID, actor, actor);
                     ++i;
                 }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4945).

Hopefully improves magic effect random magnitude distribution, now it's humanly possible to get the max magnitude of a spell/constant ability/enchantment applied to the character. This assumes that spell magnitudes are valid (i.e. max magnitude is higher than min magnitude). This doesn't do anything about the fact that spell magnitudes are not as pseudo-random as in Morrowind (i.e. can become mean average after continuous recalculations).

In spells and enchantments, I had to do something hacky to avoid modifying the saved spell parameters format.