### PR TITLE
Don't clear the depth buffer to render the first person model

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -370,18 +370,18 @@ private:
 
 void NpcAnimation::setRenderBin()
 {
-    osg::StateSet* stoteset = mObjectRoot->getOrCreateStateSet();
+    osg::StateSet* stateset = mObjectRoot->getOrCreateStateSet();
     osg::ref_ptr<osg::PolygonOffset> polyoffset = new osg::PolygonOffset;
     polyoffset->setFactor(1.0f);
     if (mViewMode == VM_FirstPerson)
     {
         polyoffset->setUnits(-1000000.0f);
-        stoteset->setAttributeAndModes(polyoffset, osg::StateAttribute::OVERRIDE | osg::StateAttribute::ON);
-        stoteset->setRenderBinDetails(RenderBin_FirstPerson, "DepthClear", osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
+        stateset->setAttributeAndModes(polyoffset, osg::StateAttribute::OVERRIDE | osg::StateAttribute::ON);
+        stateset->setRenderBinDetails(RenderBin_FirstPerson, "DepthClear", osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
     }
     else
         polyoffset->setUnits(0.0f);
-        stoteset->setAttributeAndModes(polyoffset, osg::StateAttribute::OVERRIDE | osg::StateAttribute::ON);
+        stateset->setAttributeAndModes(polyoffset, osg::StateAttribute::OVERRIDE | osg::StateAttribute::ON);
         Animation::setRenderBin();
 }
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -375,7 +375,7 @@ void NpcAnimation::setRenderBin()
     polyoffset->setFactor(1.0f);
     if (mViewMode == VM_FirstPerson)
     {
-        polyoffset->setUnits(-1000000.0f);
+        polyoffset->setUnits(-5000000.0f);
         stateset->setAttributeAndModes(polyoffset, osg::StateAttribute::OVERRIDE | osg::StateAttribute::ON);
         stateset->setRenderBinDetails(RenderBin_FirstPerson, "DepthClear", osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
     }


### PR DESCRIPTION
I am not a programmer, I don't know C++ or OpenSceneGraph, and I have no idea what I'm doing, other than hopefully invoking some variation of Cunningham's Law. Sorry if this is a horrible waste of your time.

I wanted to use [reshade](https://reshade.me/) with OpenMW to inject ambient occlusion (until such a time as post-processing shaders are supported natively). However, that shader requires depth buffer access, which is [deliberately cleared in first-person mode in OpenMW so the hands/weapon models don't clip with the world](https://forum.openmw.org/viewtopic.php?t=3230).

Scrawl mentioned glPolygonOffset in the thread I linked, so I googled that and came up with this alternative (horrible and hacky) way of stopping the first person model from clipping, while also leaving all the depth information that reshade needs accessible. I had to set and unset the polygon offset depending on whether you're in first person mode because otherwise the third person player character would be rendered at an incorrect depth.

Ideally the GUI would also be output to the depth buffer as infinitely close so that Reshade's depth of field filters don't blur it, but I haven't been able to work out a way to do that with my layman's skills.