### PR TITLE
Only play miss sound for player attacks (bug #4969)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
     Bug #4947: Player character doesn't use lip animation
     Bug #4948: Footstep sounds while levitating on ground level
     Bug #4963: Enchant skill progress is incorrect
+    Bug #4969: "Miss" sound plays for any actor
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -376,7 +376,8 @@ namespace MWClass
         if (!successful)
         {
             // Missed
-            MWBase::Environment::get().getSoundManager()->playSound3D(ptr, "miss", 1.0f, 1.0f);
+            if (!attacker.isEmpty() && attacker == MWMechanics::getPlayer())
+                MWBase::Environment::get().getSoundManager()->playSound3D(ptr, "miss", 1.0f, 1.0f);
             return;
         }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -710,7 +710,8 @@ namespace MWClass
         if (!successful)
         {
             // Missed
-            sndMgr->playSound3D(ptr, "miss", 1.0f, 1.0f);
+            if (!attacker.isEmpty() && attacker == MWMechanics::getPlayer())
+                sndMgr->playSound3D(ptr, "miss", 1.0f, 1.0f);
             return;
         }
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4969).

What the reporter said was accurate in my testing of Morrowind. So I put the playSound3D call in actor onHit methods behind a player-is-attacker check.