### PR TITLE
Make sure the player cannot use quickkeys while disableplayerfighting or disableplayermagic is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
     Bug #4963: Enchant skill progress is incorrect
     Bug #4965: Global light attenuation settings setup is lacking
     Bug #4969: "Miss" sound plays for any actor
+    Bug #4972: Player is able to use quickkeys while disableplayerfighting is active
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1333,7 +1333,7 @@ namespace MWInput
 
     void InputManager::quickKey (int index)
     {
-        if (!mControlSwitch["playercontrols"])
+        if (!mControlSwitch["playercontrols"] || !mControlSwitch["playerfighting"] || !mControlSwitch["playermagic"])
             return;
         if (!checkAllowedToUseItems())
             return;


### PR DESCRIPTION
[Bug #4972](https://gitlab.com/OpenMW/openmw/issues/4972)