### PR TITLE
[Regression] Fix disappearing cursor in the self-enchanting menu

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -779,7 +779,7 @@ namespace MWInput
         mMouseLookEnabled = !guiMode;
         if (guiMode)
             MWBase::Environment::get().getWindowManager()->showCrosshair(false);
-        MWBase::Environment::get().getWindowManager()->setCursorVisible(guiMode && (mJoystickLastUsed && !mGamepadGuiCursorEnabled));
+        MWBase::Environment::get().getWindowManager()->setCursorVisible(guiMode && (!mJoystickLastUsed || mGamepadGuiCursorEnabled));
         // if not in gui mode, the camera decides whether to show crosshair or not.
     }
 


### PR DESCRIPTION
The regression was added in the commit 37f5ab210435ff7a015fc56ae309daba0051230a

Currently `mJoystickLastUsed` is alway "false" if a player does not use a controller, so the argument of `setCursorVisible` is always "false".
As a result, there is no cursor in the self-enchanting menu.
Judging by logic, we should enable cursor in two cases:
1. When player does not use a joystick and the game is in the GUI mode.
2. When player uses a joystick, the game is in the GUI mode and the gamepad cursor is enabled.

So the resolution is to invert the second statement in the `setCursorVisible`.
It would be nice if a user with gamepad could test this change.