### PR TITLE
Fix frozen rain when water refractions are disabled

### DIFF
--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -266,16 +266,16 @@ public:
 
     META_Node(MWRender, CameraRelativeTransform)
 
-    const osg::Vec3f& getLastEyePoint() const
+    const osg::Vec3f& getLastViewPoint() const
     {
-        return mEyePoint;
+        return mViewPoint;
     }
 
     virtual bool computeLocalToWorldMatrix(osg::Matrix& matrix, osg::NodeVisitor* nv) const
     {
         if (nv->getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
         {
-            mEyePoint = static_cast<osgUtil::CullVisitor*>(nv)->getEyePoint();
+            mViewPoint = static_cast<osgUtil::CullVisitor*>(nv)->getViewPoint();
         }
 
         if (_referenceFrame==RELATIVE_RF)
@@ -337,8 +337,8 @@ public:
         }
     };
 private:
-    // eyePoint for the current frame
-    mutable osg::Vec3f mEyePoint;
+    // viewPoint for the current frame
+    mutable osg::Vec3f mViewPoint;
 };
 
 class ModVertexAlphaVisitor : public osg::NodeVisitor
@@ -391,7 +391,7 @@ private:
 /// @brief Hides the node subgraph if the eye point is below water.
 /// @note Must be added as cull callback.
 /// @note Meant to be used on a node that is child of a CameraRelativeTransform.
-/// The current eye point must be retrieved by the CameraRelativeTransform since we can't get it anymore once we are in camera-relative space.
+/// The current view point must be retrieved by the CameraRelativeTransform since we can't get it anymore once we are in camera-relative space.
 class UnderwaterSwitchCallback : public osg::NodeCallback
 {
 public:
@@ -404,8 +404,8 @@ public:
 
     bool isUnderwater()
     {
-        osg::Vec3f eyePoint = mCameraRelativeTransform->getLastEyePoint();
-        return mEnabled && eyePoint.z() < mWaterLevel;
+        osg::Vec3f viewPoint = mCameraRelativeTransform->getLastViewPoint();
+        return mEnabled && viewPoint.z() < mWaterLevel;
     }
 
     virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)


### PR DESCRIPTION
Due to another set of changes from bzzt recently introduced underwater switch callback can use the viewpoint inheritted from the main camera instead of the eye point reflection camera has so that the rain doesn't get frozen for no reason, fixing [this](https://gitlab.com/OpenMW/openmw/issues/4897) regression.