### PR TITLE
Use navmesh for AiWander

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -301,7 +301,7 @@ bool MWMechanics::AiPackage::checkWayIsClearForActor(const osg::Vec3f& startPoin
         return true;
 
     const float actorSpeed = actor.getClass().getSpeed(actor);
-    const float maxAvoidDist = AI_REACTION_TIME * actorSpeed + actorSpeed / MAX_VEL_ANGULAR_RADIANS * 2; // *2 - for reliability
+    const float maxAvoidDist = AI_REACTION_TIME * actorSpeed + actorSpeed / getAngularVelocity(actorSpeed) * 2; // *2 - for reliability
     const float distToTarget = osg::Vec2f(endPoint.x(), endPoint.y()).length();
 
     const float offsetXY = distToTarget > maxAvoidDist*1.5? maxAvoidDist : maxAvoidDist/2;
@@ -363,7 +363,7 @@ bool MWMechanics::AiPackage::isReachableRotatingOnTheRun(const MWWorld::Ptr& act
     // get actor's shortest radius for moving in circle
     float speed = actor.getClass().getSpeed(actor);
     speed += speed * 0.1f; // 10% real speed inaccuracy
-    float radius = speed / MAX_VEL_ANGULAR_RADIANS;
+    float radius = speed / getAngularVelocity(speed);
 
     // get radius direction to the center
     const float* rot = actor.getRefData().getPosition().rot;

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -448,7 +448,7 @@ namespace MWMechanics
         else
         {
             // have not yet reached the destination
-            evadeObstacles(actor, storage);
+            evadeObstacles(actor, duration, storage);
         }
     }
 
@@ -479,8 +479,17 @@ namespace MWMechanics
         storage.setState(AiWanderStorage::Wander_IdleNow);
     }
 
-    void AiWander::evadeObstacles(const MWWorld::Ptr& actor, AiWanderStorage& storage)
+    void AiWander::evadeObstacles(const MWWorld::Ptr& actor, float duration, AiWanderStorage& storage)
     {
+        if (mUsePathgrid)
+        {
+            const auto halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(actor);
+            const float actorTolerance = 2 * actor.getClass().getSpeed(actor) * duration
+                    + 1.2 * std::max(halfExtents.x(), halfExtents.y());
+            const float pointTolerance = std::max(MIN_TOLERANCE, actorTolerance);
+            mPathFinder.buildPathByNavMeshToNextPoint(actor, halfExtents, getNavigatorFlags(actor), pointTolerance);
+        }
+
         if (mObstacleCheck.isEvading())
         {
             // first check if we're walking into a door

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -137,7 +137,7 @@ namespace MWMechanics
             short unsigned getRandomIdle();
             void setPathToAnAllowedNode(const MWWorld::Ptr& actor, AiWanderStorage& storage, const ESM::Position& actorPos);
             void playGreetingIfPlayerGetsTooClose(const MWWorld::Ptr& actor, AiWanderStorage& storage);
-            void evadeObstacles(const MWWorld::Ptr& actor, AiWanderStorage& storage);
+            void evadeObstacles(const MWWorld::Ptr& actor, float duration, AiWanderStorage& storage);
             void turnActorToFacePlayer(const osg::Vec3f& actorPosition, const osg::Vec3f& playerPosition, AiWanderStorage& storage);
             void doPerFrameActionsForState(const MWWorld::Ptr& actor, float duration, AiWanderStorage& storage);
             void onIdleStatePerFrameActions(const MWWorld::Ptr& actor, float duration, AiWanderStorage& storage);

--- a/apps/openmw/mwmechanics/pathfinding.hpp
+++ b/apps/openmw/mwmechanics/pathfinding.hpp
@@ -84,6 +84,9 @@ namespace MWMechanics
                 const MWWorld::CellStore* cell, const PathgridGraph& pathgridGraph, const osg::Vec3f& halfExtents,
                 const DetourNavigator::Flags flags);
 
+            void buildPathByNavMeshToNextPoint(const MWWorld::ConstPtr& actor, const osg::Vec3f& halfExtents,
+                const DetourNavigator::Flags flags, const float pointTolerance);
+
             /// Remove front point if exist and within tolerance
             void update(const osg::Vec3f& position, const float pointTolerance, const float destinationTolerance);
 

--- a/apps/openmw/mwmechanics/steering.cpp
+++ b/apps/openmw/mwmechanics/steering.cpp
@@ -32,7 +32,7 @@ bool smoothTurn(const MWWorld::Ptr& actor, float targetAngleRadians, int axis, f
     if (absDiff < epsilonRadians)
         return true;
 
-    float limit = MAX_VEL_ANGULAR_RADIANS * MWBase::Environment::get().getFrameDuration();
+    float limit = getAngularVelocity(actor.getClass().getSpeed(actor)) * MWBase::Environment::get().getFrameDuration();
     if (absDiff > limit)
         diff = osg::sign(diff) * limit;
 

--- a/apps/openmw/mwmechanics/steering.hpp
+++ b/apps/openmw/mwmechanics/steering.hpp
@@ -3,6 +3,8 @@
 
 #include <osg/Math>
 
+#include <algorithm>
+
 namespace MWWorld
 {
 class Ptr;
@@ -12,7 +14,12 @@ namespace MWMechanics
 {
 
 // Max rotating speed, radian/sec
-const float MAX_VEL_ANGULAR_RADIANS(10);
+inline float getAngularVelocity(const float actorSpeed)
+{
+    const float baseAngluarVelocity = 10;
+    const float baseSpeed = 200;
+    return baseAngluarVelocity * std::max(actorSpeed / baseSpeed, 1.0f);
+}
 
 /// configure rotation settings for an actor to reach this target angle (eventually)
 /// @return have we reached the target angle?


### PR DESCRIPTION
If actor is wandering by pathgrid, AiWander build path from actor to first pathgrid node in path and prepend it to actor path. Also to avoid problem with circling around next path point when it is too far to be dropped by tolerance check and actor is moving too fast to be able to turn in correct direction because of limit, angular velocity limit depends on actor speed. There shouldn't be noticable change for standard moving speeds, but actors who move very fast will rotate instantly.
