### PR TITLE
Optimize the Distant Terrain memory consumption

### DIFF
--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -30,7 +30,6 @@ ChunkManager::ChunkManager(Storage *storage, Resource::SceneManager *sceneMgr, T
     , mCompositeMapSize(512)
     , mCompositeMapLevel(1.f)
     , mMaxCompGeometrySize(1.f)
-    , mCullingActive(true)
 {
 
 }
@@ -208,7 +207,8 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
 
         mCompositeMapRenderer->addCompositeMap(compositeMap.get(), false);
 
-        transform->getOrCreateUserDataContainer()->setUserData(compositeMap);
+        geometry->setCompositeMap(compositeMap);
+        geometry->setCompositeMapRenderer(mCompositeMapRenderer);
 
         TextureLayer layer;
         layer.mDiffuseMap = compositeMap->mTexture;
@@ -222,14 +222,7 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
     }
 
     transform->addChild(geometry);
-
-    if (!mCullingActive)
-    {
-        transform->setCullingActive(false);
-        geometry->setCullingActive(false);
-    }
-    else
-        transform->getBound();
+    transform->getBound();
 
     if (mSceneManager->getIncrementalCompileOperation())
     {

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -120,7 +120,7 @@ void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallba
     bool stopTraversal = (lodCallback->isSufficientDetail(this, dist)) || !getNumChildren();
 
     if (stopTraversal)
-        vd->add(this, true);
+        vd->add(this);
     else
     {
         for (unsigned int i=0; i<getNumChildren(); ++i)
@@ -142,7 +142,7 @@ void QuadTreeNode::traverseTo(ViewData* vd, float size, const osg::Vec2f& center
     bool stopTraversal = (getSize() == size);
 
     if (stopTraversal)
-        vd->add(this, true);
+        vd->add(this);
     else
     {
         for (unsigned int i=0; i<getNumChildren(); ++i)
@@ -159,7 +159,7 @@ void QuadTreeNode::intersect(ViewData* vd, TerrainLineIntersector* intersector)
         return;
 
     if (getNumChildren() == 0)
-        vd->add(this, true);
+        vd->add(this);
     else
     {
         for (unsigned int i=0; i<getNumChildren(); ++i)

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -154,18 +154,21 @@ void QuadTreeNode::traverseTo(ViewData* vd, float size, const osg::Vec2f& center
     }
 }
 
-void QuadTreeNode::traverse(osg::NodeVisitor &nv)
+void QuadTreeNode::intersect(ViewData* vd, TerrainLineIntersector* intersector)
 {
     if (!hasValidBounds())
         return;
 
-    bool needsUpdate = true;
-    ViewData* vd = getView(nv, needsUpdate);
+    if (!intersector->intersectAndClip(getBoundingBox()))
+        return;
 
-    if ((mLodCallback && mLodCallback->isSufficientDetail(this, distance(vd->getViewPoint()))) || !getNumChildren())
+    if (getNumChildren() == 0)
         vd->add(this, true);
     else
-        osg::Group::traverse(nv);
+    {
+        for (unsigned int i=0; i<getNumChildren(); ++i)
+            getChild(i)->intersect(vd, intersector);
+    }
 }
 
 void QuadTreeNode::setLodCallback(LodCallback *lodCallback)

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -61,7 +61,6 @@ QuadTreeNode::QuadTreeNode(QuadTreeNode* parent, ChildDirection direction, float
     , mValidBounds(false)
     , mSize(size)
     , mCenter(center)
-    , mViewDataMap(nullptr)
 {
     for (unsigned int i=0; i<4; ++i)
         mNeighbours[i] = 0;
@@ -179,34 +178,6 @@ void QuadTreeNode::setLodCallback(LodCallback *lodCallback)
 LodCallback *QuadTreeNode::getLodCallback()
 {
     return mLodCallback;
-}
-
-void QuadTreeNode::setViewDataMap(ViewDataMap *map)
-{
-    mViewDataMap = map;
-}
-
-ViewDataMap *QuadTreeNode::getViewDataMap()
-{
-    return mViewDataMap;
-}
-
-ViewData* QuadTreeNode::getView(osg::NodeVisitor &nv, bool& needsUpdate)
-{
-    ViewData* vd = NULL;
-    if (nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
-    {
-        osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(&nv);
-        vd = mViewDataMap->getViewData(cv->getCurrentCamera(), nv.getViewPoint(), needsUpdate);
-    }
-    else // INTERSECTION_VISITOR
-    {
-        osg::Vec3f viewPoint = nv.getViewPoint();
-        static osg::ref_ptr<osg::Object> dummyObj = new osg::DummyObject;
-        vd = mViewDataMap->getViewData(dummyObj.get(), viewPoint, needsUpdate);
-        needsUpdate = true;
-    }
-    return vd;
 }
 
 void QuadTreeNode::setBoundingBox(const osg::BoundingBox &boundingBox)

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -108,7 +108,7 @@ void QuadTreeNode::initNeighbours()
         getChild(i)->initNeighbours();
 }
 
-void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, float maxDist)
+void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist)
 {
     if (!hasValidBounds())
         return;
@@ -117,14 +117,14 @@ void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, float max
     if (dist > maxDist)
         return;
 
-    bool stopTraversal = (mLodCallback->isSufficientDetail(this, dist)) || !getNumChildren();
+    bool stopTraversal = (lodCallback->isSufficientDetail(this, dist)) || !getNumChildren();
 
     if (stopTraversal)
         vd->add(this, true);
     else
     {
         for (unsigned int i=0; i<getNumChildren(); ++i)
-            getChild(i)->traverse(vd, viewPoint, maxDist);
+            getChild(i)->traverse(vd, viewPoint, lodCallback, maxDist);
     }
 }
 
@@ -165,16 +165,6 @@ void QuadTreeNode::intersect(ViewData* vd, TerrainLineIntersector* intersector)
         for (unsigned int i=0; i<getNumChildren(); ++i)
             getChild(i)->intersect(vd, intersector);
     }
-}
-
-void QuadTreeNode::setLodCallback(LodCallback *lodCallback)
-{
-    mLodCallback = lodCallback;
-}
-
-LodCallback *QuadTreeNode::getLodCallback()
-{
-    return mLodCallback;
 }
 
 void QuadTreeNode::setBoundingBox(const osg::BoundingBox &boundingBox)

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -108,13 +108,10 @@ void QuadTreeNode::initNeighbours()
         getChild(i)->initNeighbours();
 }
 
-void QuadTreeNode::traverse(ViewData* vd, osg::NodeVisitor* nv, const osg::Vec3f& viewPoint, bool visible, float maxDist)
+void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, float maxDist)
 {
     if (!hasValidBounds())
         return;
-
-    if (nv && nv->getVisitorType() == osg::NodeVisitor::CULL_VISITOR)
-        visible = visible && !static_cast<osgUtil::CullVisitor*>(nv)->isCulled(mBoundingBox);
 
     float dist = distance(viewPoint);
     if (dist > maxDist)
@@ -123,11 +120,11 @@ void QuadTreeNode::traverse(ViewData* vd, osg::NodeVisitor* nv, const osg::Vec3f
     bool stopTraversal = (mLodCallback->isSufficientDetail(this, dist)) || !getNumChildren();
 
     if (stopTraversal)
-        vd->add(this, visible);
+        vd->add(this, true);
     else
     {
         for (unsigned int i=0; i<getNumChildren(); ++i)
-            getChild(i)->traverse(vd, nv, viewPoint, visible, maxDist);
+            getChild(i)->traverse(vd, viewPoint, maxDist);
     }
 }
 

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -92,8 +92,8 @@ namespace Terrain
         const osg::Vec2f& getCenter() const;
 
         /// Optimized version of traverse() that doesn't incur the overhead of NodeVisitor double-dispatch or fetching the various variables.
-        /// Note this doesn't do any culling for non-cull visitors (e.g. intersections) so it shouldn't be used for those.
-        void traverse(ViewData* vd, osg::NodeVisitor* nv, const osg::Vec3f& viewPoint, bool visible, float maxDist);
+        /// Note this doesn't do any culling.
+        void traverse(ViewData* vd, const osg::Vec3f& viewPoint, float maxDist);
 
         /// Traverse to a specific node and add only that node.
         void traverseTo(ViewData* vd, float size, const osg::Vec2f& center);

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -72,7 +72,15 @@ namespace Terrain
         /// center in cell coordinates
         const osg::Vec2f& getCenter() const;
 
+        /// Traverse the child tree and populate the ViewData
         virtual void traverse(osg::NodeVisitor& nv);
+
+        /// Optimized version of traverse() that doesn't incur the overhead of NodeVisitor double-dispatch or fetching the various variables.
+        /// Note this doesn't do any culling for non-cull visitors (e.g. intersections) so it shouldn't be used for those.
+        void traverse(ViewData* vd, osg::NodeVisitor* nv, const osg::Vec3f& viewPoint, bool visible, float maxDist);
+
+        /// Traverse to a specific node and add only that node.
+        void traverseTo(ViewData* vd, float size, const osg::Vec2f& center);
 
         /// Set the Lod callback to use for determining when to stop traversing further down the quad tree.
         void setLodCallback(LodCallback* lodCallback);

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -106,14 +106,6 @@ namespace Terrain
 
         LodCallback* getLodCallback();
 
-        /// Set the view data map that the finally used nodes for a given camera/intersection are pushed onto.
-        void setViewDataMap(ViewDataMap* map);
-
-        ViewDataMap* getViewDataMap();
-
-        /// Create or retrieve a view for the given traversal.
-        ViewData* getView(osg::NodeVisitor& nv, bool& needsUpdate);
-
     private:
         QuadTreeNode* mParent;
 
@@ -127,8 +119,6 @@ namespace Terrain
         osg::Vec2f mCenter;
 
         osg::ref_ptr<LodCallback> mLodCallback;
-
-        ViewDataMap* mViewDataMap;
     };
 
 }

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -91,20 +91,14 @@ namespace Terrain
         /// center in cell coordinates
         const osg::Vec2f& getCenter() const;
 
-        /// Optimized version of traverse() that doesn't incur the overhead of NodeVisitor double-dispatch or fetching the various variables.
-        /// Note this doesn't do any culling.
-        void traverse(ViewData* vd, const osg::Vec3f& viewPoint, float maxDist);
+        /// Traverse nodes according to LOD selection.
+        void traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist);
 
         /// Traverse to a specific node and add only that node.
         void traverseTo(ViewData* vd, float size, const osg::Vec2f& center);
 
         /// Adds all leaf nodes which intersect the line from start to end
         void intersect(ViewData* vd, TerrainLineIntersector* intersector);
-
-        /// Set the Lod callback to use for determining when to stop traversing further down the quad tree.
-        void setLodCallback(LodCallback* lodCallback);
-
-        LodCallback* getLodCallback();
 
     private:
         QuadTreeNode* mParent;
@@ -117,8 +111,6 @@ namespace Terrain
         bool mValidBounds;
         float mSize;
         osg::Vec2f mCenter;
-
-        osg::ref_ptr<LodCallback> mLodCallback;
     };
 
 }

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -97,9 +97,8 @@ private:
 class QuadTreeBuilder
 {
 public:
-    QuadTreeBuilder(Terrain::Storage* storage, float lodFactor, float minSize)
+    QuadTreeBuilder(Terrain::Storage* storage, float minSize)
         : mStorage(storage)
-        , mLodFactor(lodFactor)
         , mMinX(0.f), mMaxX(0.f), mMinY(0.f), mMaxY(0.f)
         , mMinSize(minSize)
     {
@@ -119,7 +118,6 @@ public:
         float centerY = (mMinY+mMaxY)/2.f + (size-origSizeY)/2.f;
 
         mRootNode = new RootNode(size, osg::Vec2f(centerX, centerY));
-        mRootNode->setLodCallback(new DefaultLodCallback(mLodFactor, mMinSize));
         addChildren(mRootNode);
 
         mRootNode->initNeighbours();
@@ -168,7 +166,6 @@ public:
         }
 
         osg::ref_ptr<QuadTreeNode> node = new QuadTreeNode(parent, direction, size, center);
-        node->setLodCallback(parent->getLodCallback());
 
         if (center.x() - halfSize > mMaxX
                 || center.x() + halfSize < mMinX
@@ -218,6 +215,7 @@ private:
     float mMinSize;
 
     osg::ref_ptr<RootNode> mRootNode;
+    osg::ref_ptr<LodCallback> mLodCallback;
 };
 
 QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resource::ResourceSystem *resourceSystem, Storage *storage, int nodeMask, int preCompileMask, int borderMask, int compMapResolution, float compMapLevel, float lodFactor, int vertexLodMod, float maxCompGeometrySize)
@@ -359,7 +357,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
                 mRootNode->traverseTo(vd, 1, osg::Vec2f(x+0.5,y+0.5));
             }
             else
-                mRootNode->traverse(vd, cv->getViewPoint(), mViewDistance);
+                mRootNode->traverse(vd, cv->getViewPoint(), mLodCallback, mViewDistance);
         }
         else
         {
@@ -424,7 +422,8 @@ void QuadTreeWorld::ensureQuadTreeBuilt()
         return;
 
     const float minSize = 1/8.f;
-    QuadTreeBuilder builder(mStorage, mLodFactor, minSize);
+    mLodCallback = new DefaultLodCallback(mLodFactor, minSize);
+    QuadTreeBuilder builder(mStorage, minSize);
     builder.build();
 
     mRootNode = builder.getRootNode();
@@ -470,7 +469,7 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, std::atomic
 
     ViewData* vd = static_cast<ViewData*>(view);
     vd->setViewPoint(viewPoint);
-    mRootNode->traverse(vd, viewPoint, mViewDistance);
+    mRootNode->traverse(vd, viewPoint, mLodCallback, mViewDistance);
 
     for (unsigned int i=0; i<vd->getNumEntries() && !abort; ++i)
     {

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -15,6 +15,7 @@ namespace Terrain
 {
     class RootNode;
     class ViewDataMap;
+    class LodCallback;
 
     /// @brief Terrain implementation that loads cells into a Quad Tree, with geometry LOD and texture LOD.
     class QuadTreeWorld : public TerrainGrid // note: derived from TerrainGrid is only to render default cells (see loadCell)
@@ -48,6 +49,7 @@ namespace Terrain
         osg::ref_ptr<RootNode> mRootNode;
 
         osg::ref_ptr<ViewDataMap> mViewDataMap;
+        osg::ref_ptr<LodCallback> mLodCallback;
 
         OpenThreads::Mutex mQuadTreeMutex;
         bool mQuadTreeBuilt;

--- a/components/terrain/terraindrawable.cpp
+++ b/components/terrain/terraindrawable.cpp
@@ -4,12 +4,10 @@
 
 #include <components/sceneutil/lightmanager.hpp>
 
+#include "compositemaprenderer.hpp"
+
 namespace Terrain
 {
-
-TerrainDrawable::TerrainDrawable()
-{
-}
 
 TerrainDrawable::TerrainDrawable(const TerrainDrawable &copy, const osg::CopyOp &copyop)
     : osg::Geometry(copy, copyop)
@@ -61,6 +59,12 @@ void TerrainDrawable::cull(osgUtil::CullVisitor *cv)
     {
         cv->addDrawableAndDepth(this, &matrix, depth);
         return;
+    }
+
+    if (mCompositeMap)
+    {
+        mCompositeMapRenderer->setImmediate(mCompositeMap);
+        mCompositeMap = nullptr;
     }
 
     bool pushedLight = mLightListCallback && mLightListCallback->pushLightState(this, cv);

--- a/components/terrain/terraindrawable.hpp
+++ b/components/terrain/terraindrawable.hpp
@@ -16,6 +16,9 @@ namespace SceneUtil
 namespace Terrain
 {
 
+    class CompositeMap;
+    class CompositeMapRenderer;
+
     /**
      * Subclass of Geometry that supports built in multi-pass rendering and built in LightListCallback.
      */
@@ -28,7 +31,8 @@ namespace Terrain
         virtual const char* className() const { return "TerrainDrawable"; }
         virtual const char* libraryName() const { return "Terrain"; }
 
-        TerrainDrawable();
+        TerrainDrawable() = default;
+        ~TerrainDrawable() = default;
         TerrainDrawable(const TerrainDrawable& copy, const osg::CopyOp& copyop);
 
         virtual void accept(osg::NodeVisitor &nv);
@@ -41,10 +45,15 @@ namespace Terrain
 
         virtual void compileGLObjects(osg::RenderInfo& renderInfo) const;
 
+        void setCompositeMap(CompositeMap* map) { mCompositeMap = map; }
+        void setCompositeMapRenderer(CompositeMapRenderer* renderer) { mCompositeMapRenderer = renderer; }
+
     private:
         PassVector mPasses;
 
         osg::ref_ptr<SceneUtil::LightListCallback> mLightListCallback;
+        osg::ref_ptr<CompositeMap> mCompositeMap;
+        osg::ref_ptr<CompositeMapRenderer> mCompositeMapRenderer;
     };
 
 }

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -61,11 +61,6 @@ osg::ref_ptr<osg::Node> TerrainGrid::buildTerrain (osg::Group* parent, float chu
             return nullptr;
         if (parent)
             parent->addChild(node);
-
-        osg::UserDataContainer* udc = node->getUserDataContainer();
-        if (udc && udc->getUserData())
-            mCompositeMapRenderer->setImmediate(static_cast<CompositeMap*>(udc->getUserData()));
-
         return node;
     }
 }

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -26,7 +26,7 @@ void ViewData::copyFrom(const ViewData& other)
     mViewPoint = other.mViewPoint;
 }
 
-void ViewData::add(QuadTreeNode *node, bool visible)
+void ViewData::add(QuadTreeNode *node)
 {
     unsigned int index = mNumEntries++;
 
@@ -34,7 +34,7 @@ void ViewData::add(QuadTreeNode *node, bool visible)
         mEntries.resize(index+1);
 
     Entry& entry = mEntries[index];
-    if (entry.set(node, visible))
+    if (entry.set(node))
         mChanged = true;
 }
 
@@ -73,7 +73,7 @@ void ViewData::reset()
 {
     // clear any unused entries
     for (unsigned int i=mNumEntries; i<mEntries.size(); ++i)
-        mEntries[i].set(nullptr, false);
+        mEntries[i].set(nullptr);
 
     // reset index for next frame
     mNumEntries = 0;
@@ -83,7 +83,7 @@ void ViewData::reset()
 void ViewData::clear()
 {
     for (unsigned int i=0; i<mEntries.size(); ++i)
-        mEntries[i].set(nullptr, false);
+        mEntries[i].set(nullptr);
     mNumEntries = 0;
     mLastUsageTimeStamp = 0;
     mChanged = false;
@@ -100,15 +100,13 @@ bool ViewData::contains(QuadTreeNode *node)
 
 ViewData::Entry::Entry()
     : mNode(nullptr)
-    , mVisible(true)
     , mLodFlags(0)
 {
 
 }
 
-bool ViewData::Entry::set(QuadTreeNode *node, bool visible)
+bool ViewData::Entry::set(QuadTreeNode *node)
 {
-    mVisible = visible;
     if (node == mNode)
         return false;
     else

--- a/components/terrain/viewdata.hpp
+++ b/components/terrain/viewdata.hpp
@@ -19,7 +19,7 @@ namespace Terrain
         ViewData();
         ~ViewData();
 
-        void add(QuadTreeNode* node, bool visible);
+        void add(QuadTreeNode* node);
 
         void reset();
 
@@ -33,10 +33,9 @@ namespace Terrain
         {
             Entry();
 
-            bool set(QuadTreeNode* node, bool visible);
+            bool set(QuadTreeNode* node);
 
             QuadTreeNode* mNode;
-            bool mVisible;
 
             unsigned int mLodFlags;
             osg::ref_ptr<osg::Node> mRenderingNode;


### PR DESCRIPTION
Adds a rest of changes in the from bzzt's branch (excepts of related to textures).
For me it slightly decreases memory usage by the Distant Terrain (usually about 50-150 MB depending on vieving distance and landmass size).

An interesting thing - on some setups Distant Terrain with vanilla viewing system gives more FPS than the common terrain system, but it costs additional memory:
in the master branch - 100MB with vanilla landscape, 200MB with TR, 350MB with TR+PC
with this PR - 50MB with vanilla landscape, 150MB with TR, 300MB with TR+PC

**Please, measure memory consumption and FPS with this PR and with latest nightlies in these situations:**
1. Vanilla viewing distance, the Distant Terrain is enabled
2. Vanilla viewing distance, the Distant Terrain is disabled
3. Increased viewing distance (40960, for example), the Distant Terrain is enabled

Depending on results, we should decide:
1. If it is even worth to spend time to improve code from these commits or we can just ignore it.
2. If the Distant Terrain really should be disabled by default. There is a non-zero chance that for most of setups it will be really faster.

