### PR TITLE
Fix zero division in enchantment magnitude calculation

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -644,7 +644,8 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
                 {
                     int delta = effect.mMagnMax - effect.mMagnMin;
                     // Roll some dice, one for each effect
-                    params[i].mRandom = Misc::Rng::rollDice(delta + 1) / static_cast<float>(delta);
+                    if (delta)
+                        params[i].mRandom = Misc::Rng::rollDice(delta + 1) / static_cast<float>(delta);
                     // Try resisting each effect
                     params[i].mMultiplier = MWMechanics::getEffectMultiplier(effect.mEffectID, actor, actor);
                     ++i;


### PR DESCRIPTION
This zero division led to constant magnitude effects of enchanted items being not only unable to work, but also make the relevant stats of the character 0 or worse. Oops.

Now random multiplier is only calculated if the delta is not 0, like for constant abilities. It should be initialized as zero otherwise and the item will use the minimum magnitude in the result, which is what we want.