### PR TITLE
Improve handling for actors outsise of actors processing range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
     Bug #4969: "Miss" sound plays for any actor
     Bug #4972: Player is able to use quickkeys while disableplayerfighting is active
     Bug #4979: AiTravel maximum range depends on "actors processing range" setting
+    Bug #4980: Drowning mechanics is applied for actors indifferently from distance to player
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
     Bug #4965: Global light attenuation settings setup is lacking
     Bug #4969: "Miss" sound plays for any actor
     Bug #4972: Player is able to use quickkeys while disableplayerfighting is active
+    Bug #4979: AiTravel maximum range depends on "actors processing range" setting
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1539,7 +1539,10 @@ namespace MWMechanics
 
                     if(iter->first.getClass().isNpc())
                     {
-                        updateDrowning(iter->first, duration, ctrl->isKnockedOut(), isPlayer);
+                        // We can not update drowning state for actors outside of AI distance - they can not resurface to breathe
+                        if (inProcessingRange)
+                            updateDrowning(iter->first, duration, ctrl->isKnockedOut(), isPlayer);
+
                         calculateNpcStatModifiers(iter->first, duration);
 
                         if (timerUpdateEquippedLight == 0)

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -3,7 +3,6 @@
 #include <components/esm/aisequence.hpp>
 
 #include "../mwbase/environment.hpp"
-#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
@@ -19,9 +18,8 @@ bool isWithinMaxRange(const osg::Vec3f& pos1, const osg::Vec3f& pos2)
 {
     // Maximum travel distance for vanilla compatibility.
     // Was likely meant to prevent NPCs walking into non-loaded exterior cells, but for some reason is used in interior cells as well.
-    // The specific range below is configurable, but its limit is currently 7168 units. Anything greater will break shoddily-written content (*cough* MW *cough*) in bizarre ways.
-    float aiDistance = MWBase::Environment::get().getMechanicsManager()->getActorsProcessingRange();
-    return (pos1 - pos2).length2() <= aiDistance*aiDistance;
+    // We can make this configurable at some point, but the default *must* be the below value. Anything else will break shoddily-written content (*cough* MW *cough*) in bizarre ways.
+    return (pos1 - pos2).length2() <= 7168*7168;
 }
 
 }

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -109,6 +109,8 @@ actors processing range
 This setting allows to specify a distance from player in game units, in which OpenMW updates actor's state.
 Actor state update includes AI, animations, and physics processing.
 Actors near that border start softly fade out instead of just appearing/disapperaing.
+It is not recommended to change this value from default if you use mods with
+long-range AiTravel packages (e.g. patrols, caravans and travellers).
 
 This setting can be controlled in game with the "Actors processing range slider" in the Prefs panel of the Options menu.
 


### PR DESCRIPTION
Summary of changes:
1. Do not use the actors processing range to determine a maximum range if AiTravel package ([bug #4979](https://gitlab.com/OpenMW/openmw/issues/4979)). There is a distance between actor and tanget, not between actor and player.
2. Do not update drowning state for actors outside of processing range ([bug #4980](https://gitlab.com/OpenMW/openmw/issues/4980)).