### PR TITLE
Use friendly hits only for player's followers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
     Bug #4972: Player is able to use quickkeys while disableplayerfighting is active
     Bug #4979: AiTravel maximum range depends on "actors processing range" setting
     Bug #4980: Drowning mechanics is applied for actors indifferently from distance to player
+    Bug #4984: "Friendly hits" feature should be used only for player's followers
     Feature #2229: Improve pathfinding AI
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis


### PR DESCRIPTION
Fixes [bug #4984](https://gitlab.com/OpenMW/openmw/issues/4984).

Morrowind applies this feature only for player's followers, while OpenMW tries to apply it to any followers.