### PR TITLE
Some options shuffling

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -74,7 +74,6 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(preventMerchantEquippingCheckBox, "prevent merchant equipping", "Game");
     loadSettingBool(classicReflectedAbsorbSpellsCheckBox, "classic reflected absorb spells behavior", "Game");
     loadSettingBool(rebalanceSoulGemValuesCheckBox, "rebalance soul gem values", "Game");
-    loadSettingBool(chargeForEveryFollowerCheckBox, "charge for every follower travelling", "Game");
     loadSettingBool(enchantedWeaponsMagicalCheckBox, "enchanted weapons are magical", "Game");
     loadSettingBool(permanentBarterDispositionChangeCheckBox, "barter disposition change is permanent", "Game");
     int unarmedFactorsStrengthIndex = mEngineSettings.getInt("strength influences hand to hand", "Game");
@@ -135,7 +134,6 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(preventMerchantEquippingCheckBox, "prevent merchant equipping", "Game");
     saveSettingBool(rebalanceSoulGemValuesCheckBox, "rebalance soul gem values", "Game");
     saveSettingBool(classicReflectedAbsorbSpellsCheckBox, "classic reflected absorb spells behavior", "Game");
-    saveSettingBool(chargeForEveryFollowerCheckBox, "charge for every follower travelling", "Game");
     saveSettingBool(enchantedWeaponsMagicalCheckBox, "enchanted weapons are magical", "Game");
     saveSettingBool(permanentBarterDispositionChangeCheckBox, "barter disposition change is permanent", "Game");
     int unarmedFactorsStrengthIndex = unarmedFactorsStrengthComboBox->currentIndex();

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -81,6 +81,7 @@ bool Launcher::AdvancedPage::loadSettings()
         unarmedFactorsStrengthComboBox->setCurrentIndex(unarmedFactorsStrengthIndex);
     loadSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     loadSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
+    loadSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
 
     // Input Settings
     loadSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");
@@ -141,6 +142,7 @@ void Launcher::AdvancedPage::saveSettings()
         mEngineSettings.setInt("strength influences hand to hand", "Game", unarmedFactorsStrengthIndex);
     saveSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     saveSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
+    saveSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
 
     // Input Settings
     saveSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -71,11 +71,8 @@ namespace MWGui
         std::set<MWWorld::Ptr> followers;
         MWWorld::ActionTeleport::getFollowersToTeleport(player, followers);
 
-        // Apply followers cost, in vanilla one follower travels for free
-        if (Settings::Manager::getBool("charge for every follower travelling", "Game"))
-            price *= 1 + static_cast<int>(followers.size());
-        else
-            price *= std::max(1, static_cast<int>(followers.size()));
+        // Apply followers cost, unlike vanilla the first follower doesn't travel for free
+        price *= 1 + static_cast<int>(followers.size());
 
         int lineHeight = MWBase::Environment::get().getWindowManager()->getFontHeight() + 2;
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2372,7 +2372,8 @@ void CharacterController::update(float duration, bool animationOnly)
     moved.x() *= scale;
     moved.y() *= scale;
 
-    if (mPtr.getClass().isNpc() && !Settings::Manager::getBool("normalise race speed", "Game"))
+    static const bool normalizeSpeed = Settings::Manager::getBool("normalise race speed", "Game");
+    if (mPtr.getClass().isNpc() && !normalizeSpeed)
     {
         const ESM::NPC* npc = mPtr.get<ESM::NPC>()->mBase;
         const ESM::Race* race = world->getStore().get<ESM::Race>().find(npc->mRace);

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2372,7 +2372,7 @@ void CharacterController::update(float duration, bool animationOnly)
     moved.x() *= scale;
     moved.y() *= scale;
 
-    if(mPtr.getClass().isNpc())
+    if (mPtr.getClass().isNpc() && !Settings::Manager::getBool("normalise race speed", "Game"))
     {
         const ESM::NPC* npc = mPtr.get<ESM::NPC>()->mBase;
         const ESM::Race* race = world->getStore().get<ESM::Race>().find(npc->mRace);

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -238,3 +238,34 @@ An enchanted bow with chitin arrows will no longer be enough for the purpose, wh
 This was previously the default engine behavior that diverged from Morrowind design.
 
 This setting can be toggled in Advanced tab of the launcher.
+
+strength influences hand to hand
+--------------------------------
+
+:Type:		integer
+:Range:		0, 1, 2
+:Default:	0
+
+This setting controls the behavior of factoring of Strength attribute into hand-to-hand damage, which is using the formula
+Morrowind Code Patch uses for its equivalent feature: damage is multiplied by its value divided by 40.
+
+0: Strength attribute is ignored
+1: Strength attribute is factored in damage from any actor
+2: Strength attribute is factored in damage from any actor except werewolves
+
+This setting can be controlled in Advanced tab of the launcher.
+
+normalise race speed
+--------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+By default race weight is factored into horizontal movement speed like in Morrowind.
+For example, an NPC which has 1.2 race weight is faster than an NPC with the exact same stats and weight 1.0 by a factor of 120%.
+If this setting is true, race weight is ignored in the calculations which allows for a movement behavior
+equivalent to the one introduced by the equivalent Morrowind Code Patch feature.
+This makes the movement speed behavior more fair between different races.
+
+This setting can be controlled in Advanced tab of the launcher.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -225,9 +225,6 @@ classic reflected absorb spells behavior = true
 # Show duration of magic effect and lights in the spells window.
 show effect duration = false
 
-# Account for the first follower in fast travel cost calculations.
-charge for every follower travelling = false
-
 # Prevent merchants from equipping items that are sold to them.
 prevent merchant equipping = false
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -261,6 +261,9 @@ only appropriate ammunition bypasses resistance = false
 # Use casting animations for magic items, just as for spells
 use magic item animations = false
 
+# Don't use race weight in NPC movement speed calculations
+normalise race speed = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -159,6 +159,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="normaliseRaceSpeedCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Don't use race weight in NPC movement speed calculations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Normalise race speed</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -57,16 +57,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="chargeForEveryFollowerCheckBox">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Account for the first follower in fast travel cost calculations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Charge for every follower travelling</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="enchantedWeaponsMagicalCheckBox">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make enchanted weaponry without Magical flag bypass normal weapons resistance, like in Morrowind.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>


### PR DESCRIPTION
1. Always account for every follower travelling in fast travel price calculations. Normally the first follower travels for free. The respective option has been removed.

There are a few reasons for this:
* The option was never documented, although it did get an Advanced tab checkbox
* It's a "default" fix in MCP, so at least Hrnchamd deems it an issue worthy enough not to be in a purist player's game and be not intended by Bethesda (it does seem pretty nonsensical)
* It shouldn't be controversial enough to make it the hardcoded default even before the Great Dehardcoding comes
* I asked about such a change some time ago, didn't get any opinion on this.

2. Make previously used MCP-like normalized race speed behavior optional.
3. Document that option and also `strength influences hand to hand` option.