### PR TITLE
Only collect every unique magic bolt sound once (bug #4964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
     Bug #4947: Player character doesn't use lip animation
     Bug #4948: Footstep sounds while levitating on ground level
     Bug #4963: Enchant skill progress is incorrect
+    Bug #4964: Multiple effect spell projectile sounds play louder than vanilla
     Bug #4965: Global light attenuation settings setup is lacking
     Bug #4969: "Miss" sound plays for any actor
     Bug #4972: Player is able to use quickkeys while disableplayerfighting is active

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -44,7 +44,7 @@
 
 namespace
 {
-    ESM::EffectList getMagicBoltData(std::vector<std::string>& projectileIDs, std::vector<std::string>& sounds, float& speed, std::string& texture, std::string& sourceName, const std::string& id)
+    ESM::EffectList getMagicBoltData(std::vector<std::string>& projectileIDs, std::set<std::string>& sounds, float& speed, std::string& texture, std::string& sourceName, const std::string& id)
     {
         const MWWorld::ESMStore& esmStore = MWBase::Environment::get().getWorld()->getStore();
         const ESM::EffectList* effects;
@@ -88,9 +88,9 @@ namespace
                 "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
             };
             if (!magicEffect->mBoltSound.empty())
-                sounds.push_back(magicEffect->mBoltSound);
+                sounds.emplace(magicEffect->mBoltSound);
             else
-                sounds.push_back(schools[magicEffect->mData.mSchool] + " bolt");
+                sounds.emplace(schools[magicEffect->mData.mSchool] + " bolt");
             projectileEffects.mList.push_back(*iter);
         }
         
@@ -297,9 +297,9 @@ namespace MWWorld
         createModel(state, ptr.getClass().getModel(ptr), pos, orient, true, true, lightDiffuseColor, texture);
 
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-        for (size_t it = 0; it != state.mSoundIds.size(); it++)
+        for (const std::string &soundid : state.mSoundIds)
         {
-            MWBase::Sound *sound = sndMgr->playSound3D(pos, state.mSoundIds.at(it), 1.0f, 1.0f,
+            MWBase::Sound *sound = sndMgr->playSound3D(pos, soundid, 1.0f, 1.0f,
                                                        MWSound::Type::Sfx, MWSound::PlayMode::Loop);
             if (sound)
                 state.mSounds.push_back(sound);
@@ -656,9 +656,9 @@ namespace MWWorld
             createModel(state, model, osg::Vec3f(esm.mPosition), osg::Quat(esm.mOrientation), true, true, lightDiffuseColor, texture);
 
             MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-            for (size_t soundIter = 0; soundIter != state.mSoundIds.size(); soundIter++)
+            for (const std::string &soundid : state.mSoundIds)
             {
-                MWBase::Sound *sound = sndMgr->playSound3D(esm.mPosition, state.mSoundIds.at(soundIter), 1.0f, 1.0f,
+                MWBase::Sound *sound = sndMgr->playSound3D(esm.mPosition, soundid, 1.0f, 1.0f,
                                                            MWSound::Type::Sfx, MWSound::PlayMode::Loop);
                 if (sound)
                     state.mSounds.push_back(sound);

--- a/apps/openmw/mwworld/projectilemanager.hpp
+++ b/apps/openmw/mwworld/projectilemanager.hpp
@@ -102,7 +102,7 @@ namespace MWWorld
             float mSpeed;
 
             std::vector<MWBase::Sound*> mSounds;
-            std::vector<std::string> mSoundIds;
+            std::set<std::string> mSoundIds;
         };
 
         struct ProjectileState : public State


### PR DESCRIPTION
[Bug 4964](https://gitlab.com/OpenMW/openmw/issues/4964).

Use a set instead of a vector for magic projectile sounds in getMagicBoltData to make sure there aren't any duplicate sound IDs, so no multiple identical sounds play at the exact same position, previously making an impression of a louder single sound, and e.g. fixing Wrath of Dagoth spell projectile audio volume, which has 7 magic effects with the exact same bolt sound. Now the volume is the same as in vanilla.