### PR TITLE
Apply looping particles when adding spell to existing actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     Bug #4896: Title screen music doesn't loop
     Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
+    Bug #4918: Abilities don't play looping VFX when they're initially applied
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4927: Spell effect having both a skill and an attribute assigned is a fatal error
     Bug #4932: Invalid records matching when loading save with edited plugin

--- a/apps/openmw/mwmechanics/disease.hpp
+++ b/apps/openmw/mwmechanics/disease.hpp
@@ -57,6 +57,7 @@ namespace MWMechanics
             {
                 // Contracted disease!
                 actor.getClass().getCreatureStats(actor).getSpells().add(it->first);
+                MWBase::Environment::get().getWorld()->applyLoopingParticles(actor);
 
                 std::string msg = "sMagicContractDisease";
                 msg = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find(msg)->mValue.getString();

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -455,10 +455,16 @@ namespace MWScript
                     std::string id = runtime.getStringLiteral (runtime[0].mInteger);
                     runtime.pop();
 
-                    // make sure a spell with this ID actually exists.
-                    MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find (id);
+                    const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find (id);
 
-                    ptr.getClass().getCreatureStats (ptr).getSpells().add (id);
+                    MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
+                    creatureStats.getSpells().add(id);
+                    ESM::Spell::SpellType type = static_cast<ESM::Spell::SpellType>(spell->mData.mType);
+                    if (type != ESM::Spell::ST_Spell && type != ESM::Spell::ST_Power)
+                    {
+                        // Apply looping particles immediately for constant effects
+                        MWBase::Environment::get().getWorld()->applyLoopingParticles(ptr);
+                    }
                 }
         };
 


### PR DESCRIPTION
Fixes [bug #4918](https://gitlab.com/OpenMW/openmw/issues/4918).

The main idea - when we add spells with constant effects to existing actor, we should apply looping particles (but should not play sounds). The `creatureStats.getSpells().add(id)` can not do it itself (it just manages the list of known spells), so we will have to do it outside this function. 

This PR handles scripts and diseases. Other usages of "add" should not cause issues since we rebuild target actor anyway (e.g. when we spawn actor or select an another race or birthsign).

Note: there is a little inconsistence with Morrowind here - when using "addSpell", OpenMW adds particles immediately, but when using the "removeSpell", it removes effects during next actor update.
Morrowind does opposite - adds particles during next update, but removes them immediately. 
But I think it does not really matter.