### PR TITLE
Actually check if setting gamma level is supported

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -524,7 +524,8 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
     else
         gameControllerdb = ""; //if it doesn't exist, pass in an empty string
 
-    MWInput::InputManager* input = new MWInput::InputManager (mWindow, mViewer, mScreenCaptureHandler, mScreenCaptureOperation, keybinderUser, keybinderUserExists, gameControllerdb, mGrab);
+    bool isGammaSupported = false;
+    MWInput::InputManager* input = new MWInput::InputManager (mWindow, mViewer, mScreenCaptureHandler, mScreenCaptureOperation, keybinderUser, keybinderUserExists, gameControllerdb, mGrab, isGammaSupported);
     mEnvironment.setInputManager (input);
 
     std::string myguiResources = (mResDir / "mygui").string();
@@ -556,7 +557,7 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
     input->setPlayer(&mEnvironment.getWorld()->getPlayer());
 
     window->setStore(mEnvironment.getWorld()->getStore());
-    window->initUI();
+    window->initUI(isGammaSupported);
 
     //Load translation data
     mTranslationDataStorage.setEncoder(mEncoder);

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -166,7 +166,7 @@ namespace MWGui
         }
     }
 
-    SettingsWindow::SettingsWindow() :
+    SettingsWindow::SettingsWindow(const bool isGammaSupported) :
         WindowBase("openmw_settings_window.layout"),
         mKeyboardMode(true)
     {
@@ -188,19 +188,20 @@ namespace MWGui
         getWidget(mWaterTextureSize, "WaterTextureSize");
         getWidget(mWaterReflectionDetail, "WaterReflectionDetail");
 
-#ifndef WIN32
-        // hide gamma controls since it currently does not work under Linux
-        MyGUI::ScrollBar *gammaSlider;
-        getWidget(gammaSlider, "GammaSlider");
-        gammaSlider->setVisible(false);
-        MyGUI::TextBox *textBox;
-        getWidget(textBox, "GammaText");
-        textBox->setVisible(false);
-        getWidget(textBox, "GammaTextDark");
-        textBox->setVisible(false);
-        getWidget(textBox, "GammaTextLight");
-        textBox->setVisible(false);
-#endif
+        if (!isGammaSupported)
+        {
+            // hide gamma controls since it does not work on a target machine
+            MyGUI::ScrollBar *gammaSlider;
+            getWidget(gammaSlider, "GammaSlider");
+            gammaSlider->setVisible(false);
+            MyGUI::TextBox *textBox;
+            getWidget(textBox, "GammaText");
+            textBox->setVisible(false);
+            getWidget(textBox, "GammaTextDark");
+            textBox->setVisible(false);
+            getWidget(textBox, "GammaTextLight");
+            textBox->setVisible(false);
+        }
 
         mMainWidget->castType<MyGUI::Window>()->eventWindowChangeCoord += MyGUI::newDelegate(this, &SettingsWindow::onWindowResize);
 

--- a/apps/openmw/mwgui/settingswindow.hpp
+++ b/apps/openmw/mwgui/settingswindow.hpp
@@ -13,7 +13,7 @@ namespace MWGui
     class SettingsWindow : public WindowBase
     {
         public:
-            SettingsWindow();
+            SettingsWindow(const bool isGammaSupported);
 
             virtual void onOpen();
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -382,7 +382,7 @@ namespace MWGui
         mFontLoader->loadTrueTypeFonts();
     }
 
-    void WindowManager::initUI()
+    void WindowManager::initUI(const bool isGammaSupported)
     {
         // Get size info from the Gui object
         int w = MyGUI::RenderManager::getInstance().getViewSize().width;
@@ -497,7 +497,7 @@ namespace MWGui
         mCountDialog = new CountDialog();
         mWindows.push_back(mCountDialog);
 
-        mSettingsWindow = new SettingsWindow();
+        mSettingsWindow = new SettingsWindow(isGammaSupported);
         mWindows.push_back(mSettingsWindow);
         mGuiModeStates[GM_Settings] = GuiModeState(mSettingsWindow);
 

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -138,7 +138,7 @@ namespace MWGui
     /// Set the ESMStore to use for retrieving of GUI-related strings.
     void setStore (const MWWorld::ESMStore& store);
 
-    void initUI();
+    void initUI(const bool isGammaSupported);
     virtual void loadUserFonts();
 
     virtual Loading::Listener* getLoadingScreen();

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -39,7 +39,7 @@ namespace MWInput
             osg::ref_ptr<osgViewer::ScreenCaptureHandler> screenCaptureHandler,
             osgViewer::ScreenCaptureHandler::CaptureOperation *screenCaptureOperation,
             const std::string& userFile, bool userFileExists,
-            const std::string& controllerBindingsFile, bool grab)
+            const std::string& controllerBindingsFile, bool grab, bool& isGammaSupported)
         : mWindow(window)
         , mWindowVisible(true)
         , mViewer(viewer)
@@ -86,8 +86,11 @@ namespace MWInput
         mInputManager->setControllerEventCallback(this);
 
         mVideoWrapper = new SDLUtil::VideoWrapper(window, viewer);
-        mVideoWrapper->setGammaContrast(Settings::Manager::getFloat("gamma", "Video"),
-                                        Settings::Manager::getFloat("contrast", "Video"));
+        isGammaSupported = mVideoWrapper->setGammaContrast(Settings::Manager::getFloat("gamma", "Video"),
+                                                                Settings::Manager::getFloat("contrast", "Video"));
+
+        if (!isGammaSupported)
+            Log(Debug::Info) << "Setting gamma is not supported. Disable in-game gamma slider.";
 
         std::string file = userFileExists ? userFile : "";
         mInputBinder = new ICS::InputControlSystem(file, true, this, nullptr, A_Last);

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -76,7 +76,7 @@ namespace MWInput
             osg::ref_ptr<osgViewer::ScreenCaptureHandler> screenCaptureHandler,
             osgViewer::ScreenCaptureHandler::CaptureOperation *screenCaptureOperation,
             const std::string& userFile, bool userFileExists,
-            const std::string& controllerBindingsFile, bool grab);
+            const std::string& controllerBindingsFile, bool grab, bool& isGammaSupported);
 
         virtual ~InputManager();
 

--- a/components/sdlutil/sdlvideowrapper.cpp
+++ b/components/sdlutil/sdlvideowrapper.cpp
@@ -41,10 +41,10 @@ namespace SDLUtil
         mViewer->startThreading();
     }
 
-    void VideoWrapper::setGammaContrast(float gamma, float contrast)
+    bool VideoWrapper::setGammaContrast(float gamma, float contrast, bool probe)
     {
-        if (gamma == mGamma && contrast == mContrast)
-            return;
+        if (gamma == mGamma && contrast == mContrast && !probe)
+            return true;
 
         mGamma = gamma;
         mContrast = contrast;
@@ -65,7 +65,13 @@ namespace SDLUtil
             red[i] = green[i] = blue[i] = static_cast<Uint16>(value);
         }
         if (SDL_SetWindowGammaRamp(mWindow, red, green, blue) < 0)
-            Log(Debug::Warning) << "Couldn't set gamma: " << SDL_GetError();
+        {
+            if (!probe)
+                Log(Debug::Warning) << "Couldn't set gamma: " << SDL_GetError();
+            return false;
+        }
+
+        return true;
     }
 
     void VideoWrapper::setVideoMode(int width, int height, bool fullscreen, bool windowBorder)

--- a/components/sdlutil/sdlvideowrapper.hpp
+++ b/components/sdlutil/sdlvideowrapper.hpp
@@ -23,7 +23,7 @@ namespace SDLUtil
 
         void setSyncToVBlank(bool sync);
 
-        void setGammaContrast(float gamma, float contrast);
+        bool setGammaContrast(float gamma, float contrast, bool probe = false);
 
         void setVideoMode(int width, int height, bool fullscreen, bool windowBorder);
 


### PR DESCRIPTION
Related to [feature #3491](https://gitlab.com/OpenMW/openmw/issues/3491).

Currently we forcibly disable gamma slider for everything excepts Windows indifferently if it is supported or not.

The main idea of this PR is to check if the setting works on a target machine, and disable gamma slider if it does not for some reason indifferently from OS.

Note: this PR obviously does not implement a post-processing shader to adjust the brightness level.
Such kind of shader more likely is a post-1.0 feature, which will not work in the fixed pipeline mode anyway. 

But with this PR 3491 becomes a not 1.0 blocker, also this issue actually is not related to either Linux or SDL.