### PR TITLE
Update background texture if a new one is empty (regression #4986)

### DIFF
--- a/apps/openmw/mwgui/itemwidget.cpp
+++ b/apps/openmw/mwgui/itemwidget.cpp
@@ -148,9 +148,9 @@ namespace MWGui
         if (backgroundTex != "")
             backgroundTex += ".dds";
 
+        float scale = 1.f;
         if (!backgroundTex.empty())
         {
-            float scale = 1.f;
             auto found = mScales.find(backgroundTex);
             if (found == mScales.end())
             {
@@ -165,12 +165,12 @@ namespace MWGui
             }
             else
                 scale = found->second;
-
-            if (state == Barter && !isMagic)
-                setFrame(backgroundTex, MyGUI::IntCoord(2*scale,2*scale,44*scale,44*scale));
-            else
-                setFrame(backgroundTex, MyGUI::IntCoord(0,0,44*scale,44*scale));
         }
+
+        if (state == Barter && !isMagic)
+            setFrame(backgroundTex, MyGUI::IntCoord(2*scale,2*scale,44*scale,44*scale));
+        else
+            setFrame(backgroundTex, MyGUI::IntCoord(0,0,44*scale,44*scale));
 
         setIcon(ptr);
     }


### PR DESCRIPTION
Fixes a regression in my recent PR with scalable textures (#2302).

We should update backround texture even in case when the `backgroundTex` is empty, what we did before.
