### PR TITLE
Allow to shrink tooltip width to its actual text width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     Bug #3733: Normal maps are inverted on mirrored UVs
     Bug #3765: DisableTeleporting makes Mark/Recall/Intervention effects undetectable
     Bug #3778: [Mod] Improved Thrown Weapon Projectiles - weapons have wrong transformation during throw animation
+    Bug #3812: Wrong multiline tooltips width when word-wrapping is enabled
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons

--- a/components/widgets/box.hpp
+++ b/components/widgets/box.hpp
@@ -65,7 +65,11 @@ namespace Gui
 
     protected:
         virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        virtual int getWidth();
         std::string mFontSize;
+        bool mShrink = false;
+        bool mWasResized = false;
+        int mMaxWidth = 0;
     };
 
     class AutoSizedButton : public AutoSizedWidget, public Button

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -47,12 +47,14 @@
             <Property key="Padding" value="8"/>
             <Property key="Spacing" value="8"/>
 
-            <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 284 18" align="Left Top" name="CenteredCaption">
+            <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 0 18" align="Left Top" name="CenteredCaption">
                 <Property key="TextAlign" value="Center"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
 
             <Widget type="AutoSizedEditBox" skin="SandText" position="8 30 430 18" align="Left Top" name="CenteredCaptionText">
                 <Property key="MultiLine" value="true"/>
+                <Property key="Shrink" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
             </Widget>
@@ -80,18 +82,21 @@
             <Property key="Padding" value="8"/>
             <Property key="Spacing" value="8"/>
 
-            <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 284 18" align="Left Top" name="ClassName">
+            <Widget type="AutoSizedTextBox" skin="NormalText" position="8 8 0 18" align="Left Top HStretch" name="ClassName">
                 <Property key="TextAlign" value="Center"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
 
             <Widget type="AutoSizedEditBox" skin="SandText" position="8 30 430 18" align="Left Top" name="ClassDescription">
                 <Property key="MultiLine" value="true"/>
+                <Property key="Shrink" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
             </Widget>
 
-            <Widget type="AutoSizedEditBox" skin="SandText" position="8 52 284 18" align="Left Bottom" name="ClassSpecialisation">
+            <Widget type="AutoSizedTextBox" skin="SandText" position="8 52 0 18" align="Left Bottom" name="ClassSpecialisation">
                 <Property key="TextAlign" value="Center"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
         </Widget>
 
@@ -125,8 +130,10 @@
 
             <Widget type="AutoSizedEditBox" skin="SandText" position="44 8 392 0" align="Left Top" name="HealthDescription">
                 <Property key="MultiLine" value="true"/>
+                <Property key="Shrink" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
         </Widget>
 
@@ -137,18 +144,22 @@
             <Property key="Spacing" value="8"/>
 
             <Widget type="HBox">
+                <UserString key="HStretch" value="true"/>
                 <Property key="Spacing" value="8"/>
                 <Widget type="ImageBox" skin="ImageBox" position="8 8 32 32" align="Left Top" name="AttributeImage"/>
 
-                <Widget type="AutoSizedEditBox" skin="NormalText" position="44 8 392 32" align="Left Top" name="AttributeName">
+                <Widget type="AutoSizedTextBox" skin="NormalText" position="44 8 0 32" align="Left Top" name="AttributeName">
                     <Property key="TextAlign" value="Left VCenter"/>
+                    <UserString key="HStretch" value="true"/>
                 </Widget>
             </Widget>
 
             <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 436 248" align="Left Top" name="AttributeDescription">
                 <Property key="MultiLine" value="true"/>
+                <Property key="Shrink" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
         </Widget>
 
@@ -179,19 +190,22 @@
 
             <Widget type="AutoSizedEditBox" skin="SandText" position="8 44 430 0" align="Left Top" name="SkillDescription">
                 <Property key="MultiLine" value="true"/>
+                <Property key="Shrink" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
                 <Property key="Spacing" value="28"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
 
             <Widget type="Widget" skin="" position="0 0 0 2" align="Left Top" />
 
-            <Widget type="AutoSizedTextBox" skin="SandText" position="8 48 444 18" align="Left Bottom" name="SkillMaxed">
+            <Widget type="AutoSizedTextBox" skin="SandText" position="8 48 200 18" align="Left Bottom" name="SkillMaxed">
                 <Property key="Caption" value="#{sSkillMaxReached}"/>
                 <Property key="TextAlign" value="Center"/>
+                <UserString key="HStretch" value="true"/>
             </Widget>
             <Widget type="VBox" name="SkillProgressVBox">
-                <Widget type="AutoSizedTextBox" skin="NormalText" position="8 48 444 18" align="Left Bottom">
+                <Widget type="AutoSizedTextBox" skin="NormalText" position="8 48 200 18" align="Left Bottom">
                     <Property key="Caption" value="#{sSkillProgress}"/>
                     <Property key="TextAlign" value="Center"/>
                 </Widget>


### PR DESCRIPTION
Fixes [bug #3812](https://gitlab.com/OpenMW/openmw/issues/3812).

The main idea - add a "Shrink" attribute to the AutoSizedEditBox. If this attribute is "true", we use the default widget width for wordwrapping, and then shrink widget to the actual space, which its text uses.

This approach allow us to remove unused space from the right part of tooltips.

I modified only class, race, dynamic stats, attributes and skills tooltips yet since most of tooltips in Morrowind do not support this feature, but we can modify other ones if needed.

Note: if we merge this PR, we will need to modify [this](https://wiki.openmw.org/index.php?title=GUI_Architecture#AutoSizedEditBox) article since it says that the AutoSizedEditBox has the fixed width.