### PR TITLE
Use the logging system for compiler errors

### DIFF
--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -50,8 +50,7 @@ namespace MWDialogue
     DialogueManager::DialogueManager (const Compiler::Extensions& extensions, Translation::Storage& translationDataStorage) :
       mTranslationDataStorage(translationDataStorage)
       , mCompilerContext (MWScript::CompilerContext::Type_Dialogue)
-      , mErrorStream(std::cout.rdbuf())
-      , mErrorHandler(mErrorStream)
+      , mErrorHandler()
       , mTalkedTo(false)
       , mTemporaryDispositionChange(0.f)
       , mPermanentDispositionChange(0.f)
@@ -204,8 +203,7 @@ namespace MWDialogue
 
         if (!success)
         {
-            Log(Debug::Warning)
-                << "Warning: compiling failed (dialogue script)\n" << cmd << "\n\n";
+            Log(Debug::Error) << "Error: compiling failed (dialogue script): \n" << cmd << "\n";
         }
 
         return success;

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.hpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.hpp
@@ -33,7 +33,6 @@ namespace MWDialogue
 
             Translation::Storage& mTranslationDataStorage;
             MWScript::CompilerContext mCompilerContext;
-            std::ostream mErrorStream;
             Compiler::StreamErrorHandler mErrorHandler;
 
             MWWorld::Ptr mActor;

--- a/apps/openmw/mwdialogue/scripttest.cpp
+++ b/apps/openmw/mwdialogue/scripttest.cpp
@@ -28,8 +28,7 @@ void test(const MWWorld::Ptr& actor, int &compiled, int &total, const Compiler::
 
     MWScript::CompilerContext compilerContext(MWScript::CompilerContext::Type_Dialogue);
     compilerContext.setExtensions(extensions);
-    std::ostream errorStream(std::cout.rdbuf());
-    Compiler::StreamErrorHandler errorHandler(errorStream);
+    Compiler::StreamErrorHandler errorHandler;
     errorHandler.setWarningsMode (warningsMode);
 
     const MWWorld::Store<ESM::Dialogue>& dialogues = MWBase::Environment::get().getWorld()->getStore().get<ESM::Dialogue>();
@@ -84,8 +83,7 @@ void test(const MWWorld::Ptr& actor, int &compiled, int &total, const Compiler::
 
                 if (!success)
                 {
-                    Log(Debug::Warning)
-                        << "compiling failed (dialogue script)\n" << info->mResultScript << "\n\n";
+                    Log(Debug::Error) << "Error: compiling failed (dialogue script): \n" << info->mResultScript << "\n";
                 }
             }
         }

--- a/apps/openmw/mwscript/scriptmanagerimp.cpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.cpp
@@ -25,7 +25,7 @@ namespace MWScript
     ScriptManager::ScriptManager (const MWWorld::ESMStore& store,
         Compiler::Context& compilerContext, int warningsMode,
         const std::vector<std::string>& scriptBlacklist)
-    : mErrorHandler (std::cerr), mStore (store),
+    : mErrorHandler(), mStore (store),
       mCompilerContext (compilerContext), mParser (mErrorHandler, mCompilerContext),
       mOpcodesInstalled (false), mGlobalScripts (store)
     {
@@ -72,8 +72,7 @@ namespace MWScript
 
             if (!Success)
             {
-                Log(Debug::Warning)
-                    << "Warning: compiling failed: " << name;
+                Log(Debug::Error) << "Error: script compiling failed: " << name;
             }
 
             if (Success)

--- a/components/compiler/streamerrorhandler.cpp
+++ b/components/compiler/streamerrorhandler.cpp
@@ -1,5 +1,9 @@
 #include "streamerrorhandler.hpp"
 
+#include <sstream>
+
+#include <components/debug/debuglog.hpp>
+
 #include "tokenloc.hpp"
 
 namespace Compiler
@@ -9,32 +13,47 @@ namespace Compiler
     void StreamErrorHandler::report (const std::string& message, const TokenLoc& loc,
         Type type)
     {
+        Debug::Level logLevel = Debug::Info; // Usually script warnings are not too important
+        if (type == ErrorMessage)
+            logLevel = Debug::Error;
+
+        std::stringstream text;
+
         if (type==ErrorMessage)
-            mStream << "error ";
+            text << "Error: ";
         else
-            mStream << "warning ";
+            text << "Warning: ";
 
         if (!mContext.empty())
-            mStream << mContext << " ";
+            text << mContext << " ";
 
-        mStream
-            << "line " << loc.mLine+1 << ", column " << loc.mColumn+1
-            << " (" << loc.mLiteral << ")" << std::endl
-            << "    " << message << std::endl;
+        text << "line " << loc.mLine+1 << ", column " << loc.mColumn+1
+             << " (" << loc.mLiteral << "): " << message;
+
+        Log(logLevel) << text.str();
     }
 
     // Report a file related error
 
     void StreamErrorHandler::report (const std::string& message, Type type)
     {
+        Debug::Level logLevel = Debug::Info;
         if (type==ErrorMessage)
-            mStream << "error ";
-        else
-            mStream << "warning ";
+            logLevel = Debug::Error;
 
-        mStream
-            << "file:" << std::endl
-            << "    " << message << std::endl;
+        std::stringstream text;
+
+        if (type==ErrorMessage)
+            text << "Error: ";
+        else
+            text << "Warning: ";
+
+        if (!mContext.empty())
+            text << mContext << " ";
+
+        text << "file: " << message << std::endl;
+
+        Log(logLevel) << text.str();
     }
 
     void StreamErrorHandler::setContext(const std::string &context)
@@ -42,5 +61,5 @@ namespace Compiler
         mContext = context;
     }
 
-    StreamErrorHandler::StreamErrorHandler (std::ostream& ErrorStream) : mStream (ErrorStream) {}
+    StreamErrorHandler::StreamErrorHandler()  {}
 }

--- a/components/compiler/streamerrorhandler.hpp
+++ b/components/compiler/streamerrorhandler.hpp
@@ -7,12 +7,10 @@
 
 namespace Compiler
 {
-    /// \brief Error handler implementation: Write errors into stream
+    /// \brief Error handler implementation: Write errors into logging stream
 
     class StreamErrorHandler : public ErrorHandler
     {
-            std::ostream& mStream;
-
             std::string mContext;
 
         // not implemented
@@ -32,7 +30,7 @@ namespace Compiler
 
         // constructors
 
-            StreamErrorHandler (std::ostream& ErrorStream);
+            StreamErrorHandler ();
             ///< constructor
     };
 }


### PR DESCRIPTION
Currently error handlers for scripting system use cout/cerr directly instead of logging system.
As a result, there is no filtering and color selection for them.

With this PR, script errors use the Error level, and script warnings - Info level (since they are usually harmless and do not require actions from user).

Note: I can rename the StreamErrorHandler to the LogErrorHandler, if needed.