### PR TITLE
[Feedback needed] Keep AI packages order when using repeating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
     Bug #4945: Poor random magic magnitude distribution
     Bug #4947: Player character doesn't use lip animation
     Bug #4948: Footstep sounds while levitating on ground level
+    Bug #4955: AI package repeating alters packages order
     Bug #4963: Enchant skill progress is incorrect
     Bug #4964: Multiple effect spell projectile sounds play louder than vanilla
     Bug #4965: Global light attenuation settings setup is lacking


### PR DESCRIPTION
Fixes [bug #4955](https://gitlab.com/OpenMW/openmw/issues/4955).

The issue was introduced in PR #947.

Brallion has two AI packages - an AiWander one with Duration = 5 and AiFollow one.
AiWander is first, so it takes a higher priority. After 5 hours in Sadrith Mora we remove AiWander package and place a new AiWander package to the back of AI sequence. As a result, now AiFollow takes a higher priority because it is earlier in the sequence.

There is no such issue in Morrowind - it is either does not alter packages order or does not handle Duration field at all (more likely a first option). So a suggested fix - replace an old package by a new package without altering packages order.

@Allofich, can you tell if the placing a new package exactly at the back of AI sequence is required, or you just did not consider packages order at all?