### PR TITLE
Increase required MyGUI version to 3.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ if (DEFINED ENV{TRAVIS_BRANCH} OR DEFINED ENV{APPVEYOR})
 endif()
 
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
-find_package(MyGUI 3.2.1 REQUIRED)
+find_package(MyGUI 3.2.2 REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(Bullet ${REQUIRED_BULLET_VERSION} REQUIRED COMPONENTS BulletCollision LinearMath)

--- a/apps/openmw/mwgui/formatting.cpp
+++ b/apps/openmw/mwgui/formatting.cpp
@@ -254,16 +254,6 @@ namespace MWGui
                     if (plainText.size() && brAtEnd)
                         plainText.erase(plainText.end()-1);
 
-#if (MYGUI_VERSION < MYGUI_DEFINE_VERSION(3, 2, 2))
-                    // splitting won't be fully functional until 3.2.2 (see TextElement::pageSplit())
-                    // hack: prevent newlines at the end of the book possibly creating unnecessary pages
-                    if (event == BookTextParser::Event_EOF)
-                    {
-                        while (plainText.size() && plainText[plainText.size()-1] == '\n')
-                            plainText.erase(plainText.end()-1);
-                    }
-#endif
-
                     if (!plainText.empty() || brBeforeLastTag || isPrevImg)
                     {
                         TextElement elem(paper, pag, mBlockStyle,
@@ -443,8 +433,6 @@ namespace MWGui
             int ret = mPaginator.getCurrentTop() + lastLine * lineHeight;
 
             // first empty lines that would go to the next page should be ignored
-            // unfortunately, getLineInfo method won't be available until 3.2.2
-#if (MYGUI_VERSION >= MYGUI_DEFINE_VERSION(3, 2, 2))
             mPaginator.setIgnoreLeadingEmptyLines(true);
 
             const MyGUI::VectorLineInfo & lines = mEditBox->getSubWidgetText()->castType<MyGUI::EditText>()->getLineInfo();
@@ -458,7 +446,6 @@ namespace MWGui
                     break;
                 }
             }
-#endif
             return ret;
         }
 

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -535,9 +535,7 @@ namespace MWGui
           , mRepeatStepTime(0.1f)
           , mIsIncreasing(true)
         {
-#if MYGUI_VERSION >= MYGUI_DEFINE_VERSION(3,2,2)
             ScrollBar::setRepeatEnabled(false);
-#endif
         }
 
         MWScrollBar::~MWScrollBar()

--- a/components/widgets/box.cpp
+++ b/components/widgets/box.cpp
@@ -1,8 +1,6 @@
 #include "box.hpp"
 
-#if (MYGUI_VERSION >= MYGUI_DEFINE_VERSION(3, 2, 2))
 #include <MyGUI_EditText.h>
-#endif
 
 namespace Gui
 {
@@ -59,10 +57,8 @@ namespace Gui
     int AutoSizedEditBox::getWidth()
     {
         // If the widget has the one short text line, we can shrink widget to avoid a lot of empty space.
-        // Unfortunately, getLineInfo method is available since MyGUI 3.2.2, so with older MyGUI versions tooltips will just have the fixed width.
         int textWidth = mMaxWidth;
 
-#if (MYGUI_VERSION >= MYGUI_DEFINE_VERSION(3, 2, 2))
         if (mShrink)
         {
             // MyGUI needs to know the widget size for wordwrapping, but we will know the widget size only after wordwrapping.
@@ -81,7 +77,6 @@ namespace Gui
                 mWasResized = true;
             }
         }
-#endif
 
         return textWidth;
     }


### PR DESCRIPTION
Since 3.2.2 was released 4 years ago, there is no point to have pre-processing directives just for 3.2.1, which was released almost 5 years ago.