### PR TITLE
Allow using functions in non-conditional expressions (bug #3725)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     Bug #3109: SetPos/Position handles actors differently
     Bug #3282: Unintended behaviour when assigning F3 and Windows keys
     Bug #3623: Display scaling breaks mouse recognition
+    Bug #3725: Using script function in a non-conditional expression breaks script compilation
     Bug #3733: Normal maps are inverted on mirrored UVs
     Bug #3765: DisableTeleporting makes Mark/Recall/Intervention effects undetectable
     Bug #3778: [Mod] Improved Thrown Weapon Projectiles - weapons have wrong transformation during throw animation


### PR DESCRIPTION
[Bug 3725](https://gitlab.com/OpenMW/openmw/issues/3725)

The idea: out of the console, when naked expressions are not allowed, code is still generated for functions so that their possible side effects - such as OnActivate disabling normal activation - can be handled without using the return value. This is similar to how instructions are handled. GetDisabled and GetDistance keywords that are not proper functions are safely ignored with logging a parser warning.

Obviously many of the functions are going to be no-op in non-conditional expressions but it's better than breaking the whole script and possibly mod.