### PR TITLE
[Testing needed] Do not use the CPU affinity of OSG viewer

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -674,6 +674,11 @@ void OMW::Engine::go()
     mViewer = new osgViewer::Viewer;
     mViewer->setReleaseContextAtEndOfFrameHint(false);
 
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,5)
+    // Do not try to outsmart the OS thread scheduler (see bug #4785).
+    mViewer->setUseConfigureAffinity(false);
+#endif
+
     mScreenCaptureOperation = new WriteScreenshotToFileOperation(mCfgMgr.getUserDataPath().string(),
         Settings::Manager::getString("screenshot format", "General"));
 


### PR DESCRIPTION
Fixes [bug #4785](https://gitlab.com/OpenMW/openmw/issues/4785).

Using custom affinity may lead to stuttering since several threads can be assigned to the same CPU core. OSG-on-steroids workarounds this bug, but it still present in the upstream OSG.

For example, with two navigator threads I get 25 FPS with master+OSG-3.6.3 and 90-100 FPS with PR+OSG-3.6.3 or master+OSG-on-steroids.

I tested it on Linux, but it still should be tested on Windows and MacOS X.

Note: the `setUseConfigureAffinity` was added in the OSG 3.5.5, so this approach will not work with older stock OSG versions.