### PR TITLE
Tweak object VFX scaling (bug #4989)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
     Bug #4979: AiTravel maximum range depends on "actors processing range" setting
     Bug #4980: Drowning mechanics is applied for actors indifferently from distance to player
     Bug #4984: "Friendly hits" feature should be used only for player's followers
+    Bug #4989: Object dimension-dependent VFX scaling behavior is inconsistent
     Bug #4990: Dead bodies prevent you from hitting
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1631,7 +1631,7 @@ namespace MWRender
         SceneUtil::addLight(parent, esmLight, Mask_ParticleSystem, Mask_Lighting, exterior);
     }
 
-    void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, const std::string& texture, float scale)
+    void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, const std::string& texture)
     {
         if (!mObjectRoot.get())
             return;
@@ -1663,7 +1663,12 @@ namespace MWRender
         }
 
         osg::ref_ptr<osg::PositionAttitudeTransform> trans = new osg::PositionAttitudeTransform;
-        trans->setScale(osg::Vec3f(scale, scale, scale));
+        if (!mPtr.getClass().isNpc())
+        {
+            osg::Vec3f bounds (MWBase::Environment::get().getWorld()->getHalfExtents(mPtr) * 2.f / Constants::UnitsPerFoot);
+            float scale = std::max({ bounds.x()/3.f, bounds.y()/3.f, bounds.z()/6.f });
+            trans->setScale(osg::Vec3f(scale, scale, scale));
+        }
         parentNode->addChild(trans);
 
         osg::ref_ptr<osg::Node> node = mResourceSystem->getSceneManager()->getInstance(model, trans);

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -365,7 +365,7 @@ public:
      * @param texture override the texture specified in the model's materials - if empty, do not override
      * @note Will not add an effect twice.
      */
-    void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", const std::string& texture = "", float scale = 1.0f);
+    void addEffect (const std::string& model, int effectId, bool loop = false, const std::string& bonename = "", const std::string& texture = "");
     void removeEffect (int effectId);
     void removeEffects ();
     void getLoopingEffects (std::vector<int>& out) const;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4989)

I'm still not quite sure about object scaling but I think it should be fine as it is.
List of changes:
1. addEffect now handles effect scaling so that any VFX can be scaled according to the bounding box and not just spellcasting VFX. Most notably it fixes Dagoth Ur shield VFX rendering.
2. VFX are no longer scaled twice according to the NPC height (Morrowind doesn't do that and they already looked fine without the additional scaling because of the scaling of the NPC root node the effects are added to).
3. The scaling is more accurate to vanilla: instead of using arbitrarily chosen divisors added, actual divisors used by vanilla are used which are based on yards - this was determined by exploring the vanilla scenegraph.
4. The scaling code was made much shorter.

Objects without animation (disabled, invisible objects) share the code for creatures/non-actors with animation.

This should make the scaling behavior make much more sense.