### PR TITLE
Add a button to delete spells from spellwindow

### DIFF
--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -153,8 +153,10 @@ namespace MWGui
         ModelIndex selected = -1;
         for (SpellModel::ModelIndex i = 0; i<int(getItemCount()); ++i)
         {
-            if (getItem(i).mSelected)
+            if (getItem(i).mSelected) {
                 selected = i;
+                break;
+            }
         }
         return selected;
     }

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -148,6 +148,17 @@ namespace MWGui
         return mSpells.size();
     }
 
+    SpellModel::ModelIndex SpellModel::getSelectedIndex() const
+    {
+        ModelIndex selected = -1;
+        for (SpellModel::ModelIndex i = 0; i<int(getItemCount()); ++i)
+        {
+            if (getItem(i).mSelected)
+                selected = i;
+        }
+        return selected;
+    }
+
     Spell SpellModel::getItem(ModelIndex index) const
     {
         if (index < 0 || index >= int(mSpells.size()))

--- a/apps/openmw/mwgui/spellmodel.hpp
+++ b/apps/openmw/mwgui/spellmodel.hpp
@@ -48,6 +48,8 @@ namespace MWGui
         ///< throws for invalid index
 
         size_t getItemCount() const;
+        ModelIndex getSelectedIndex() const;
+        ///< returns -1 if nothing is selected
 
     private:
         MWWorld::Ptr mActor;

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -50,11 +50,11 @@ namespace MWGui
         mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &SpellWindow::onFilterChanged);
         mDeleteButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SpellWindow::onDeleteClicked);
 
+        setCoord(498, 300, 302, 300);
+
         MyGUI::Window* t = mMainWidget->castType<MyGUI::Window>();
         t->eventWindowChangeCoord += MyGUI::newDelegate(this, &SpellWindow::onWindowResize);
         onWindowResize(t);
-
-        setCoord(498, 300, 302, 300);
     }
 
     SpellWindow::~SpellWindow()

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -34,27 +34,28 @@ namespace MWGui
         : WindowPinnableBase("openmw_spell_window.layout")
         , NoDrop(drag, mMainWidget)
         , mSpellView(nullptr)
-        , mDeleteButton(nullptr)
         , mUpdateTimer(0.0f)
     {
         mSpellIcons = new SpellIcons();
 
+        MyGUI::Widget* deleteButton;
+        getWidget(deleteButton, "DeleteSpellButton");
+
         getWidget(mSpellView, "SpellView");
         getWidget(mEffectBox, "EffectsBox");
         getWidget(mFilterEdit, "FilterEdit");
-        getWidget(mDeleteButton, "DeleteSpellButton");
 
         mFilterEdit->setUserString("IgnoreTabKey", "y");
 
         mSpellView->eventSpellClicked += MyGUI::newDelegate(this, &SpellWindow::onModelIndexSelected);
         mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &SpellWindow::onFilterChanged);
-        mDeleteButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SpellWindow::onDeleteClicked);
+        deleteButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SpellWindow::onDeleteClicked);
 
         setCoord(498, 300, 302, 300);
 
-        MyGUI::Window* t = mMainWidget->castType<MyGUI::Window>();
-        t->eventWindowChangeCoord += MyGUI::newDelegate(this, &SpellWindow::onWindowResize);
-        onWindowResize(t);
+        // Adjust the spell filtering widget size because of MyGUI limitations.
+        int filterWidth = mSpellView->getSize().width - deleteButton->getSize().width - 3;
+        mFilterEdit->setSize(filterWidth, mFilterEdit->getSize().height);
     }
 
     SpellWindow::~SpellWindow()
@@ -257,11 +258,5 @@ namespace MWGui
             onEnchantedItemSelected(spell.mItem, spell.mActive);
         else
             onSpellSelected(spell.mId);
-    }
-
-    void SpellWindow::onWindowResize(MyGUI::Window* window) {
-        MyGUI::IntSize sz = mFilterEdit->getSize();
-        sz.width = window->getSize().width - mDeleteButton->getSize().width - 40;
-        mFilterEdit->setSize(sz);
     }
 }

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -3,6 +3,7 @@
 #include <MyGUI_Button.h>
 #include <MyGUI_EditBox.h>
 #include <MyGUI_InputManager.h>
+#include <MyGUI_Window.h>
 
 #include <components/misc/stringops.hpp>
 #include <components/settings/settings.hpp>
@@ -33,22 +34,25 @@ namespace MWGui
         : WindowPinnableBase("openmw_spell_window.layout")
         , NoDrop(drag, mMainWidget)
         , mSpellView(nullptr)
+        , mDeleteButton(nullptr)
         , mUpdateTimer(0.0f)
     {
         mSpellIcons = new SpellIcons();
 
-        MyGUI::Button *deleteSpellBtn = nullptr;
-
         getWidget(mSpellView, "SpellView");
         getWidget(mEffectBox, "EffectsBox");
         getWidget(mFilterEdit, "FilterEdit");
-        getWidget(deleteSpellBtn, "DeleteSpellButton");
+        getWidget(mDeleteButton, "DeleteSpellButton");
 
         mFilterEdit->setUserString("IgnoreTabKey", "y");
 
         mSpellView->eventSpellClicked += MyGUI::newDelegate(this, &SpellWindow::onModelIndexSelected);
         mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &SpellWindow::onFilterChanged);
-        deleteSpellBtn->eventMouseButtonClick += MyGUI::newDelegate(this, &SpellWindow::onDeleteClicked);
+        mDeleteButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SpellWindow::onDeleteClicked);
+
+        MyGUI::Window* t = mMainWidget->castType<MyGUI::Window>();
+        t->eventWindowChangeCoord += MyGUI::newDelegate(this, &SpellWindow::onWindowResize);
+        onWindowResize(t);
 
         setCoord(498, 300, 302, 300);
     }
@@ -253,5 +257,11 @@ namespace MWGui
             onEnchantedItemSelected(spell.mItem, spell.mActive);
         else
             onSpellSelected(spell.mId);
+    }
+
+    void SpellWindow::onWindowResize(MyGUI::Window* window) {
+        MyGUI::IntSize sz = mFilterEdit->getSize();
+        sz.width = window->getSize().width - mDeleteButton->getSize().width - 40;
+        mFilterEdit->setSize(sz);
     }
 }

--- a/apps/openmw/mwgui/spellwindow.hpp
+++ b/apps/openmw/mwgui/spellwindow.hpp
@@ -33,6 +33,7 @@ namespace MWGui
         void onSpellSelected(const std::string& spellId);
         void onModelIndexSelected(SpellModel::ModelIndex index);
         void onFilterChanged(MyGUI::EditBox *sender);
+        void onDeleteClicked(MyGUI::Widget *widget);
         void onDeleteSpellAccept();
         void askDeleteSpell(const std::string& spellId);
 

--- a/apps/openmw/mwgui/spellwindow.hpp
+++ b/apps/openmw/mwgui/spellwindow.hpp
@@ -36,6 +36,7 @@ namespace MWGui
         void onDeleteClicked(MyGUI::Widget *widget);
         void onDeleteSpellAccept();
         void askDeleteSpell(const std::string& spellId);
+        void onWindowResize(MyGUI::Window* window);
 
         virtual void onPinToggled();
         virtual void onTitleDoubleClicked();
@@ -44,6 +45,7 @@ namespace MWGui
         SpellView* mSpellView;
         SpellIcons* mSpellIcons;
         MyGUI::EditBox* mFilterEdit;
+        MyGUI::Button* mDeleteButton;
 
     private:
         float mUpdateTimer;

--- a/apps/openmw/mwgui/spellwindow.hpp
+++ b/apps/openmw/mwgui/spellwindow.hpp
@@ -36,7 +36,6 @@ namespace MWGui
         void onDeleteClicked(MyGUI::Widget *widget);
         void onDeleteSpellAccept();
         void askDeleteSpell(const std::string& spellId);
-        void onWindowResize(MyGUI::Window* window);
 
         virtual void onPinToggled();
         virtual void onTitleDoubleClicked();
@@ -45,7 +44,6 @@ namespace MWGui
         SpellView* mSpellView;
         SpellIcons* mSpellIcons;
         MyGUI::EditBox* mFilterEdit;
-        MyGUI::Button* mDeleteButton;
 
     private:
         float mUpdateTimer;

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -16,7 +16,7 @@
         <Widget type="Widget" position="8 535 268 23" align="Left Bottom HStretch">
             <!-- Spell deletion button -->
             <Widget type="Button" skin="MW_Button" align="Right Bottom" position="150 0 118 24" name="DeleteSpellButton">
-                <Property key="Caption" value="Delete Spell"/>
+                <Property key="Caption" value="#{sDeleteSpell}"/>
                 <Property key="NeedKey" value="false"/>
             </Widget>
 

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -13,17 +13,17 @@
         <Widget type="SpellView" skin="MW_SpellView" position="8 38 268 490" align="Left Top Stretch" name="SpellView">
         </Widget>
 
-        <Widget type="Widget" position="8 535 268 23" align="Left Bottom HStretch">
+        <Widget type="HBox" position="8 535 268 23" align="Right Bottom HStretch">
+            <Widget type="Spacer"/>
             <!-- Spell deletion button -->
-            <Widget type="AutoSizedButton" skin="MW_Button" align="Right Bottom" position="268 0 0 24" name="DeleteSpellButton">
-                <Property key="ExpandDirection" value="Left"/>
+            <Widget type="AutoSizedButton" skin="MW_Button" align="Right Bottom" position="8 535 0 23" name="DeleteSpellButton">
                 <Property key="Caption" value="#{sDelete}"/>
                 <Property key="NeedKey" value="false"/>
             </Widget>
+        </Widget>
 
-            <!-- Search box-->
-            <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 100 23" align="Left Bottom HStretch" name="FilterEdit">
-            </Widget>
+        <!-- Search box-->
+        <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="8 535 268 23" align="Left Bottom HStretch" name="FilterEdit">
         </Widget>
 
     </Widget>

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -15,8 +15,9 @@
 
         <Widget type="Widget" position="8 535 268 23" align="Left Bottom HStretch">
             <!-- Spell deletion button -->
-            <Widget type="Button" skin="MW_Button" align="Right Bottom" position="108 0 160 24" name="DeleteSpellButton">
-                <Property key="Caption" value="#{sDeleteSpell}"/>
+            <Widget type="AutoSizedButton" skin="MW_Button" align="Right Bottom" position="268 0 0 24" name="DeleteSpellButton">
+                <Property key="ExpandDirection" value="Left"/>
+                <Property key="Caption" value="#{sDelete}"/>
                 <Property key="NeedKey" value="false"/>
             </Widget>
 

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -15,13 +15,13 @@
 
         <Widget type="Widget" position="8 535 268 23" align="Left Bottom HStretch">
             <!-- Spell deletion button -->
-            <Widget type="Button" skin="MW_Button" align="Right Bottom" position="150 0 118 24" name="DeleteSpellButton">
+            <Widget type="Button" skin="MW_Button" align="Right Bottom" position="108 0 160 24" name="DeleteSpellButton">
                 <Property key="Caption" value="#{sDeleteSpell}"/>
                 <Property key="NeedKey" value="false"/>
             </Widget>
 
             <!-- Search box-->
-            <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 142 23" align="Left Bottom HStretch" name="FilterEdit">
+            <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 100 23" align="Left Bottom HStretch" name="FilterEdit">
             </Widget>
         </Widget>
 

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -13,8 +13,16 @@
         <Widget type="SpellView" skin="MW_SpellView" position="8 38 268 490" align="Left Top Stretch" name="SpellView">
         </Widget>
 
-        <!-- Search box-->
-        <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="8 535 268 23" align="Left Bottom HStretch" name="FilterEdit">
+        <Widget type="Widget" position="8 535 268 23" align="Left Bottom HStretch">
+            <!-- Spell deletion button -->
+            <Widget type="Button" skin="MW_Button" align="Right Bottom" position="150 0 118 24" name="DeleteSpellButton">
+                <Property key="Caption" value="Delete Spell"/>
+                <Property key="NeedKey" value="false"/>
+            </Widget>
+
+            <!-- Search box-->
+            <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 142 23" align="Left Bottom HStretch" name="FilterEdit">
+            </Widget>
         </Widget>
 
     </Widget>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1065521/56700112-84dacb80-66c6-11e9-856c-2cd1c2686bbe.png)

I've added a button in bottom right to delete currently active spell. The behavior's the same as shift-clicking a spell, so it would pop up a warning dialog, etc. This is mostly useful on Android where there's no shift key to press, but also on PC for people who don't know they can press shift to delete spells.