### PR TITLE
More argument usage corrections

### DIFF
--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -108,8 +108,6 @@ namespace MWScript
                         MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,angle,az);
                     else if (axis == "z")
                         MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,angle);
-                    else
-                        throw std::runtime_error ("invalid rotation axis: " + axis);
                 }
         };
 
@@ -137,8 +135,6 @@ namespace MWScript
                     {
                         runtime.push(osg::RadiansToDegrees(ptr.getCellRef().getPosition().rot[2]));
                     }
-                    else
-                        throw std::runtime_error ("invalid rotation axis: " + axis);
                 }
         };
 
@@ -195,8 +191,6 @@ namespace MWScript
                     {
                         runtime.push(ptr.getRefData().getPosition().pos[2]);
                     }
-                    else
-                        throw std::runtime_error ("invalid axis: " + axis);
                 }
         };
 
@@ -248,7 +242,9 @@ namespace MWScript
                         updated = MWBase::Environment::get().getWorld()->moveObject(ptr,ax,ay,pos,true);
                     }
                     else
-                        throw std::runtime_error ("invalid axis: " + axis);
+                    {
+                        return;
+                    }
 
                     dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr,updated);
                 }
@@ -278,8 +274,6 @@ namespace MWScript
                     {
                         runtime.push(ptr.getCellRef().getPosition().pos[2]);
                     }
-                    else
-                        throw std::runtime_error ("invalid axis: " + axis);
                 }
         };
 
@@ -570,8 +564,6 @@ namespace MWScript
                         MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay+rotation,az);
                     else if (axis == "z")
                         MWBase::Environment::get().getWorld()->rotateObject(ptr,ax,ay,az+rotation);
-                    else
-                        throw std::runtime_error ("invalid rotation axis: " + axis);
                 }
         };
 
@@ -604,7 +596,7 @@ namespace MWScript
                     else if (axis == "z")
                         rot = osg::Quat(rotation, -osg::Z_AXIS);
                     else
-                        throw std::runtime_error ("invalid rotation axis: " + axis);
+                        return;
 
                     osg::Quat attitude = ptr.getRefData().getBaseNode()->getAttitude();
                     MWBase::Environment::get().getWorld()->rotateWorldObject(ptr, attitude * rot);
@@ -667,7 +659,7 @@ namespace MWScript
                         posChange=osg::Vec3f(0, 0, movement);
                     }
                     else
-                        throw std::runtime_error ("invalid movement axis: " + axis);
+                        return;
 
                     // is it correct that disabled objects can't be Move-d?
                     if (!ptr.getRefData().getBaseNode())
@@ -711,7 +703,7 @@ namespace MWScript
                     else if (axis == "z")
                         diff.z() += movement;
                     else
-                        throw std::runtime_error ("invalid movement axis: " + axis);
+                        return;
 
                     // We should move actors, standing on moving object, too.
                     // This approach can be used to create elevators.

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -33,7 +33,7 @@ namespace Compiler
         {
             extensions.registerInstruction ("aiactivate", "c/l", opcodeAIActivate,
                 opcodeAIActivateExplicit);
-            extensions.registerInstruction ("aitravel", "fff/l", opcodeAiTravel,
+            extensions.registerInstruction ("aitravel", "fff/lx", opcodeAiTravel,
                 opcodeAiTravelExplicit);
             extensions.registerInstruction ("aiescort", "cffff/l", opcodeAiEscort,
                 opcodeAiEscortExplicit);
@@ -422,7 +422,7 @@ namespace Compiler
 
             for (int i=0; i<numberOfDynamics; ++i)
             {
-                extensions.registerFunction (get + dynamics[i], 'f', "",
+                extensions.registerFunction (get + dynamics[i], 'f', "x",
                     opcodeGetDynamic+i, opcodeGetDynamicExplicit+i);
 
                 extensions.registerInstruction (set + dynamics[i], "f",
@@ -510,8 +510,8 @@ namespace Compiler
             extensions.registerFunction ("pcexpelled", 'l', "/S", opcodePcExpelled, opcodePcExpelledExplicit);
             extensions.registerInstruction ("pcexpell", "/S", opcodePcExpell, opcodePcExpellExplicit);
             extensions.registerInstruction ("pcclearexpelled", "/S", opcodePcClearExpelled, opcodePcClearExpelledExplicit);
-            extensions.registerInstruction ("raiserank", "", opcodeRaiseRank, opcodeRaiseRankExplicit);
-            extensions.registerInstruction ("lowerrank", "", opcodeLowerRank, opcodeLowerRankExplicit);
+            extensions.registerInstruction ("raiserank", "x", opcodeRaiseRank, opcodeRaiseRankExplicit);
+            extensions.registerInstruction ("lowerrank", "x", opcodeLowerRank, opcodeLowerRankExplicit);
 
             extensions.registerFunction ("ondeath", 'l', "", opcodeOnDeath, opcodeOnDeathExplicit);
             extensions.registerFunction ("onmurder", 'l', "", opcodeOnMurder, opcodeOnMurderExplicit);

--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -180,7 +180,7 @@ namespace Compiler
             extensions.registerFunction ("getjournalindex", 'l', "c", opcodeGetJournalIndex);
             extensions.registerInstruction ("addtopic", "S" , opcodeAddTopic);
             extensions.registerInstruction ("choice", "j/SlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSlSl", opcodeChoice);
-            extensions.registerInstruction("forcegreeting","",opcodeForceGreeting,
+            extensions.registerInstruction("forcegreeting","X",opcodeForceGreeting,
                 opcodeForceGreetingExplicit);
             extensions.registerInstruction("goodbye", "", opcodeGoodbye);
             extensions.registerInstruction("setreputation", "l", opcodeSetReputation,
@@ -536,10 +536,10 @@ namespace Compiler
             extensions.registerInstruction("setpos","cf",opcodeSetPos,opcodeSetPosExplicit);
             extensions.registerFunction("getpos",'f',"c",opcodeGetPos,opcodeGetPosExplicit);
             extensions.registerFunction("getstartingpos",'f',"c",opcodeGetStartingPos,opcodeGetStartingPosExplicit);
-            extensions.registerInstruction("position","ffff",opcodePosition,opcodePositionExplicit);
-            extensions.registerInstruction("positioncell","ffffc",opcodePositionCell,opcodePositionCellExplicit);
-            extensions.registerInstruction("placeitemcell","ccffff",opcodePlaceItemCell);
-            extensions.registerInstruction("placeitem","cffff",opcodePlaceItem);
+            extensions.registerInstruction("position","ffffX",opcodePosition,opcodePositionExplicit);
+            extensions.registerInstruction("positioncell","ffffcX",opcodePositionCell,opcodePositionCellExplicit);
+            extensions.registerInstruction("placeitemcell","ccffffX",opcodePlaceItemCell);
+            extensions.registerInstruction("placeitem","cffffX",opcodePlaceItem);
             extensions.registerInstruction("placeatpc","clflX",opcodePlaceAtPc);
             extensions.registerInstruction("placeatme","clflX",opcodePlaceAtMe,opcodePlaceAtMeExplicit);
             extensions.registerInstruction("modscale","f",opcodeModScale,opcodeModScaleExplicit);


### PR DESCRIPTION
More research led to additional findings about some more functions that commonly "accept" extra arguments for no benefit. OpenMW freaks out and then the mods using the no-op syntax break. Sometimes catastrophically.

1. Someone used a cell string argument for AITravel.
2. Someone used a reference ID string argument for GetHealth.
3. Someone used faction string arguments for LowerRank and RaiseRank.
4. Someone used redundant numerical arguments with unknown meaning for ForceGreeting (the guess is that they attempted to force a certain greeting group to be used by the actor).
5. Position and PlaceItem accepted a zero (number) after them and that was used in some cases. Cell variants of the functions also accept the redundant argument for consistency (I think I've seen a case where PlaceItemCell was fed a zero).

These are all now ignored (with logging a parser warning).

6. Requested by akortunov: invalid axis arguments for various transformation instructions are now handled more gracefully. Morrowind simply does nothing if these are used, while we throw an exception (which makes the script broken). Now there isn't any exception but simply nothing happens (these commands are often run per-frame, so logging their invalid execution would be pretty spammy).