### PR TITLE
Make sure forcePPL and clamp are defined in the editor

### DIFF
--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -11,6 +11,7 @@
 #include <components/esm/cellref.hpp>
 
 #include <components/resource/scenemanager.hpp>
+#include <components/shader/shadermanager.hpp>
 #include <components/vfs/manager.hpp>
 #include <components/vfs/registerarchives.hpp>
 
@@ -74,6 +75,11 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
 
     mResourcesManager.setVFS(mVFS.get());
     mResourceSystem.reset(new Resource::ResourceSystem(mVFS.get()));
+
+    Shader::ShaderManager::DefineMap defines = mResourceSystem->getSceneManager()->getShaderManager().getGlobalDefines();
+    defines["forcePPL"] = "0";
+    defines["clamp"] = "1";
+    mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(defines);
 
     mResourceSystem->getSceneManager()->setShaderPath((resDir / "shaders").string());
 

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -79,6 +79,13 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     Shader::ShaderManager::DefineMap defines = mResourceSystem->getSceneManager()->getShaderManager().getGlobalDefines();
     defines["forcePPL"] = "0";
     defines["clamp"] = "1";
+    defines["shadows_enabled"] = "0";
+    defines["shadow_texture_unit_list"] = "";
+    defines["shadowMapsOverlap"] = "0";
+    defines["useShadowDebugOverlay"] = "0";
+    defines["perspectiveShadowMaps"] = "0";
+    defines["disableNormalOffsetShadows"] = "0";
+    defines["shadowNormalOffset"] = "0.0";
     mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(defines);
 
     mResourceSystem->getSceneManager()->setShaderPath((resDir / "shaders").string());

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -11,6 +11,7 @@
 #include <components/esm/cellref.hpp>
 
 #include <components/resource/scenemanager.hpp>
+#include <components/sceneutil/shadow.hpp>
 #include <components/shader/shadermanager.hpp>
 #include <components/vfs/manager.hpp>
 #include <components/vfs/registerarchives.hpp>
@@ -77,15 +78,11 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     mResourceSystem.reset(new Resource::ResourceSystem(mVFS.get()));
 
     Shader::ShaderManager::DefineMap defines = mResourceSystem->getSceneManager()->getShaderManager().getGlobalDefines();
+    Shader::ShaderManager::DefineMap shadowDefines = SceneUtil::ShadowManager::getShadowsDisabledDefines();
     defines["forcePPL"] = "0";
     defines["clamp"] = "1";
-    defines["shadows_enabled"] = "0";
-    defines["shadow_texture_unit_list"] = "";
-    defines["shadowMapsOverlap"] = "0";
-    defines["useShadowDebugOverlay"] = "0";
-    defines["perspectiveShadowMaps"] = "0";
-    defines["disableNormalOffsetShadows"] = "0";
-    defines["shadowNormalOffset"] = "0.0";
+    for (const auto& define : shadowDefines)
+        defines[define.first] = define.second;
     mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(defines);
 
     mResourceSystem->getSceneManager()->setShaderPath((resDir / "shaders").string());

--- a/components/sceneutil/shadow.hpp
+++ b/components/sceneutil/shadow.hpp
@@ -15,6 +15,8 @@ namespace SceneUtil
     public:
         static void disableShadowsForStateSet(osg::ref_ptr<osg::StateSet> stateSet);
 
+        static Shader::ShaderManager::DefineMap getShadowsDisabledDefines();
+
         ShadowManager(osg::ref_ptr<osg::Group> sceneRoot, osg::ref_ptr<osg::Group> rootNode, unsigned int outdoorShadowCastingMask, unsigned int indoorShadowCastingMask, Shader::ShaderManager &shaderManager);
 
         virtual ~ShadowManager() = default;
@@ -22,8 +24,6 @@ namespace SceneUtil
         virtual void setupShadowSettings();
 
         virtual Shader::ShaderManager::DefineMap getShadowDefines();
-
-        virtual Shader::ShaderManager::DefineMap getShadowsDisabledDefines();
 
         virtual void enableIndoorMode();
 


### PR DESCRIPTION
After somewhat recent changes to the initialization of these shader defines editor was logging "stuff undefined" errors for akortunov, which meant that the editor would fail to create shaders and fall back to fixed function pipeline. AnyOldName3 recommended to put the initialization of these defines for the editor here specifically. Now what gets used is the previous defaults.