### PR TITLE
Make pinnable windows hiding persistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
     Feature #4958: Support eight blood types
     Feature #4962: Add casting animations for magic items
     Feature #4968: Scalable UI widget skins
+    Feature #4994: Persistent pinnable windows hiding
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4721: Add NMake support to the Windows prebuild script

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1480,6 +1480,32 @@ namespace MWGui
         if (getMode() != GM_Inventory)
             return;
 
+        std::string settingName;
+        switch (wnd)
+        {
+            case GW_Inventory:
+                settingName = "inventory";
+                break;
+            case GW_Map:
+                settingName = "map";
+                break;
+            case GW_Magic:
+                settingName = "spells";
+                break;
+            case GW_Stats:
+                settingName = "stats";
+                break;
+            default:
+                break;
+        }
+
+        if (!settingName.empty())
+        {
+            settingName += " hidden";
+            bool hidden = Settings::Manager::getBool(settingName, "Windows");
+            Settings::Manager::setBool(settingName, "Windows", !hidden);
+        }
+
         mShown = (GuiWindow)(mShown ^ wnd);
         updateVisible();
     }
@@ -1929,12 +1955,20 @@ namespace MWGui
     void WindowManager::updatePinnedWindows()
     {
         mInventoryWindow->setPinned(Settings::Manager::getBool("inventory pin", "Windows"));
+        if (Settings::Manager::getBool("inventory hidden", "Windows"))
+            mShown = (GuiWindow)(mShown ^ GW_Inventory);
 
         mMap->setPinned(Settings::Manager::getBool("map pin", "Windows"));
+        if (Settings::Manager::getBool("map hidden", "Windows"))
+            mShown = (GuiWindow)(mShown ^ GW_Map);
 
         mSpellWindow->setPinned(Settings::Manager::getBool("spells pin", "Windows"));
+        if (Settings::Manager::getBool("spells hidden", "Windows"))
+            mShown = (GuiWindow)(mShown ^ GW_Magic);
 
         mStatsWindow->setPinned(Settings::Manager::getBool("stats pin", "Windows"));
+        if (Settings::Manager::getBool("stats hidden", "Windows"))
+            mShown = (GuiWindow)(mShown ^ GW_Stats);
     }
 
     void WindowManager::pinWindow(GuiWindow window)

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -484,24 +484,32 @@ stats x = 0.015
 stats y = 0.015
 stats w = 0.4275
 stats h = 0.45
-# Stats window pin status
 stats pin = false
+stats hidden = false
 
 # Spells window displaying powers, spells, and magical items.
 spells x = 0.63
 spells y = 0.39
 spells w = 0.36
 spells h = 0.51
-# Spells window pin status
 spells pin = false
+spells hidden = false
 
 # Local and world map window.
 map x = 0.63
 map y = 0.015
 map w = 0.36
 map h = 0.37
-# Map window pin status
 map pin = false
+map hidden = false
+
+# Player inventory window when explicitly opened.
+inventory x = 0.015
+inventory y = 0.54
+inventory w = 0.45
+inventory h = 0.38
+inventory pin = false
+inventory hidden = false
 
 # Dialog window for talking with NPCs.
 dialogue x = 0.15
@@ -520,14 +528,6 @@ console x = 0.015
 console y = 0.015
 console w = 1.0
 console h = 0.5
-
-# Player inventory window when explicitly opened.
-inventory x = 0.015
-inventory y = 0.54
-inventory w = 0.45
-inventory h = 0.38
-# Inventory window pin status
-inventory pin = false
 
 # Player inventory window when searching a container.
 inventory container x = 0.015


### PR DESCRIPTION
Implements [feature #4994](https://gitlab.com/OpenMW/openmw/issues/4994).

Just use the same approach as for "Pinned" status - store it in the settings.cfg and restore during UI initialization.