### PR TITLE
Increase music crossfade time to 1 second

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -397,7 +397,7 @@ namespace MWSound
 
         mNextMusic = filename;
 
-        mMusic->setFadeout(0.5f);
+        mMusic->setFadeout(1.f);
     }
 
     void SoundManager::startRandomTitle()


### PR DESCRIPTION
Apparently the original crossfade time is that. This makes music transitions even less abrupt.