### PR TITLE
Allow to maximize windows via Shift + Double Click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
     Feature #3610: Option to invert X axis
     Feature #3893: Implicit target for "set" function in console
     Feature #3980: In-game option to disable controller
+    Feature #3999: Shift + Double Click should maximize/restore menu size
     Feature #4001: Toggle sneak controller shortcut
     Feature #4209: Editor: Faction rank sub-table
     Feature #4360: Improve default controller bindings

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -322,6 +322,7 @@ namespace MWBase
             virtual void removeCurrentModal(MWGui::WindowModal* input) = 0;
 
             virtual void pinWindow (MWGui::GuiWindow window) = 0;
+            virtual void toggleMaximized(MWGui::Layout *layout) = 0;
 
             /// Fade the screen in, over \a time seconds
             virtual void fadeScreenIn(const float time, bool clearQueue=true, float delay=0.f) = 0;

--- a/apps/openmw/mwgui/exposedwindow.cpp
+++ b/apps/openmw/mwgui/exposedwindow.cpp
@@ -2,12 +2,12 @@
 
 namespace MWGui
 {
-    MyGUI::VectorWidgetPtr ExposedWindow::getSkinWidgetsByName (const std::string &name)
+    MyGUI::VectorWidgetPtr Window::getSkinWidgetsByName (const std::string &name)
     {
         return MyGUI::Widget::getSkinWidgetsByName (name);
     }
 
-    MyGUI::Widget* ExposedWindow::getSkinWidget(const std::string & _name, bool _throw)
+    MyGUI::Widget* Window::getSkinWidget(const std::string & _name, bool _throw)
     {
         MyGUI::VectorWidgetPtr widgets = getSkinWidgetsByName (_name);
 

--- a/apps/openmw/mwgui/exposedwindow.hpp
+++ b/apps/openmw/mwgui/exposedwindow.hpp
@@ -9,9 +9,9 @@ namespace MWGui
     /**
      * @brief subclass to provide access to some Widget internals.
      */
-    class ExposedWindow : public MyGUI::Window
+    class Window : public MyGUI::Window
     {
-        MYGUI_RTTI_DERIVED(ExposedWindow)
+        MYGUI_RTTI_DERIVED(Window)
 
     public:
         MyGUI::VectorWidgetPtr getSkinWidgetsByName (const std::string &name);

--- a/apps/openmw/mwgui/inventorywindow.hpp
+++ b/apps/openmw/mwgui/inventorywindow.hpp
@@ -65,6 +65,9 @@ namespace MWGui
             /// Cycle to previous/next weapon
             void cycle(bool next);
 
+        protected:
+            virtual void onTitleDoubleClicked();
+
         private:
             DragAndDrop* mDragAndDrop;
 
@@ -104,10 +107,14 @@ namespace MWGui
             float mScaleFactor;
             float mUpdateTimer;
 
+            void toggleMaximized();
+
             void onItemSelected(int index);
             void onItemSelectedFromSourceModel(int index);
 
             void onBackgroundSelected();
+
+            std::string getModeSetting() const;
 
             void sellItem(MyGUI::Widget* sender, int count);
             void dragItem(MyGUI::Widget* sender, int count);
@@ -116,7 +123,6 @@ namespace MWGui
             void onFilterChanged(MyGUI::Widget* _sender);
             void onAvatarClicked(MyGUI::Widget* _sender);
             void onPinToggled();
-            void onTitleDoubleClicked();
 
             void updateEncumbranceBar();
             void notifyContentChanged();

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -931,7 +931,9 @@ namespace MWGui
 
     void MapWindow::onTitleDoubleClicked()
     {
-        if (!mPinned)
+        if (MyGUI::InputManager::getInstance().isShiftPressed())
+            MWBase::Environment::get().getWindowManager()->toggleMaximized(this);
+        else if (!mPinned)
             MWBase::Environment::get().getWindowManager()->toggleVisible(GW_Map);
     }
 

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -62,7 +62,9 @@ namespace MWGui
 
     void SpellWindow::onTitleDoubleClicked()
     {
-        if (!mPinned)
+        if (MyGUI::InputManager::getInstance().isShiftPressed())
+            MWBase::Environment::get().getWindowManager()->toggleMaximized(this);
+        else if (!mPinned)
             MWBase::Environment::get().getWindowManager()->toggleVisible(GW_Magic);
     }
 

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -4,6 +4,7 @@
 #include <MyGUI_ScrollView.h>
 #include <MyGUI_ProgressBar.h>
 #include <MyGUI_ImageBox.h>
+#include <MyGUI_InputManager.h>
 #include <MyGUI_Gui.h>
 
 #include <components/settings/settings.hpp>
@@ -652,7 +653,13 @@ namespace MWGui
 
     void StatsWindow::onTitleDoubleClicked()
     {
-        if (!mPinned)
+        if (MyGUI::InputManager::getInstance().isShiftPressed())
+        {
+            MWBase::Environment::get().getWindowManager()->toggleMaximized(this);
+            MyGUI::Window* t = mMainWidget->castType<MyGUI::Window>();
+            onWindowResize(t);
+        }
+        else if (!mPinned)
             MWBase::Environment::get().getWindowManager()->toggleVisible(GW_Stats);
     }
 }

--- a/apps/openmw/mwgui/windowbase.cpp
+++ b/apps/openmw/mwgui/windowbase.cpp
@@ -1,5 +1,6 @@
 #include "windowbase.hpp"
 
+#include <MyGUI_Button.h>
 #include <MyGUI_InputManager.h>
 #include <MyGUI_RenderManager.h>
 
@@ -9,6 +10,7 @@
 #include <components/widgets/imagebutton.hpp>
 
 #include "draganddrop.hpp"
+#include "exposedwindow.hpp"
 
 using namespace MWGui;
 
@@ -16,6 +18,32 @@ WindowBase::WindowBase(const std::string& parLayout)
   : Layout(parLayout)
 {
     mMainWidget->setVisible(false);
+
+    Window* window = mMainWidget->castType<Window>(false);
+    if (!window)
+        return;
+
+    MyGUI::Button* button = nullptr;
+    MyGUI::VectorWidgetPtr widgets = window->getSkinWidgetsByName("Action");
+    for (MyGUI::Widget* widget : widgets)
+    {
+        if (widget->isUserString("SupportDoubleClick"))
+            button = widget->castType<MyGUI::Button>();
+    }
+
+    if (button)
+        button->eventMouseButtonDoubleClick += MyGUI::newDelegate(this, &WindowBase::onDoubleClick);
+}
+
+void WindowBase::onTitleDoubleClicked()
+{
+    if (MyGUI::InputManager::getInstance().isShiftPressed())
+        MWBase::Environment::get().getWindowManager()->toggleMaximized(this);
+}
+
+void WindowBase::onDoubleClick(MyGUI::Widget *_sender)
+{
+    onTitleDoubleClicked();
 }
 
 void WindowBase::setVisible(bool visible)

--- a/apps/openmw/mwgui/windowbase.hpp
+++ b/apps/openmw/mwgui/windowbase.hpp
@@ -20,7 +20,7 @@ namespace MWGui
 
     class WindowBase: public Layout
     {
-        public:
+    public:
         WindowBase(const std::string& parLayout);
 
         virtual MyGUI::Widget* getDefaultKeyFocus() { return nullptr; }
@@ -52,8 +52,13 @@ namespace MWGui
 
         /// Called when GUI viewport changes size
         virtual void onResChange(int width, int height) {}
-    };
 
+    protected:
+        virtual void onTitleDoubleClicked();
+
+    private:
+        void onDoubleClick(MyGUI::Widget* _sender);
+    };
 
     /*
      * "Modal" windows cause the rest of the interface to be inaccessible while they are visible

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -350,6 +350,7 @@ namespace MWGui
     virtual void removeCurrentModal(WindowModal* input);
 
     virtual void pinWindow (MWGui::GuiWindow window);
+    virtual void toggleMaximized(Layout *layout);
 
     /// Fade the screen in, over \a time seconds
     virtual void fadeScreenIn(const float time, bool clearQueue, float delay);

--- a/apps/openmw/mwgui/windowpinnablebase.cpp
+++ b/apps/openmw/mwgui/windowpinnablebase.cpp
@@ -1,7 +1,5 @@
 #include "windowpinnablebase.hpp"
 
-#include <MyGUI_Button.h>
-
 #include "exposedwindow.hpp"
 
 namespace MWGui
@@ -9,21 +7,10 @@ namespace MWGui
     WindowPinnableBase::WindowPinnableBase(const std::string& parLayout)
       : WindowBase(parLayout), mPinned(false)
     {
-        ExposedWindow* window = mMainWidget->castType<ExposedWindow>();
+        Window* window = mMainWidget->castType<Window>();
         mPinButton = window->getSkinWidget ("Button");
 
         mPinButton->eventMouseButtonPressed += MyGUI::newDelegate(this, &WindowPinnableBase::onPinButtonPressed);
-
-        MyGUI::Button* button = nullptr;
-        MyGUI::VectorWidgetPtr widgets = window->getSkinWidgetsByName("Action");
-        for (MyGUI::Widget* widget : widgets)
-        {
-            if (widget->isUserString("HideWindowOnDoubleClick"))
-                button = widget->castType<MyGUI::Button>();
-        }
-
-        if (button)
-            button->eventMouseButtonDoubleClick += MyGUI::newDelegate(this, &WindowPinnableBase::onDoubleClick);
     }
 
     void WindowPinnableBase::onPinButtonPressed(MyGUI::Widget* _sender, int left, int top, MyGUI::MouseButton id)
@@ -39,11 +26,6 @@ namespace MWGui
             mPinButton->changeWidgetSkin ("PinUp");
 
         onPinToggled();
-    }
-
-    void WindowPinnableBase::onDoubleClick(MyGUI::Widget *_sender)
-    {
-        onTitleDoubleClicked();
     }
 
     void WindowPinnableBase::setPinned(bool pinned)

--- a/apps/openmw/mwgui/windowpinnablebase.hpp
+++ b/apps/openmw/mwgui/windowpinnablebase.hpp
@@ -17,11 +17,9 @@ namespace MWGui
 
     private:
         void onPinButtonPressed(MyGUI::Widget* _sender, int left, int top, MyGUI::MouseButton id);
-        void onDoubleClick(MyGUI::Widget* _sender);
 
     protected:
         virtual void onPinToggled() = 0;
-        virtual void onTitleDoubleClicked() = 0;
 
         MyGUI::Widget* mPinButton;
         bool mPinned;

--- a/files/mygui/openmw_inventory_window.layout
+++ b/files/mygui/openmw_inventory_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 600 300" name="_Main">
+    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 600 300" name="_Main">
         <Property key="MinSize" value="40 40"/>
 
         <Widget type="Widget" skin="" position="0 0 224 223" align="Left Top" name="LeftPane">

--- a/files/mygui/openmw_map_window.layout
+++ b/files/mygui/openmw_map_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 300" name="_Main">
+    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 300" name="_Main">
         <Property key="MinSize" value="40 40"/>
 
         <!-- Local map -->

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 600" name="_Main">
+    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 600" name="_Main">
         <Property key="MinSize" value="40 40"/>
 
         <!-- Effect box-->

--- a/files/mygui/openmw_stats_window.layout
+++ b/files/mygui/openmw_stats_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 500 342" name="_Main">
+    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 500 342" name="_Main">
         <Property key="MinSize" value="40 40"/>
 
         <Widget type="Widget" skin="" name="LeftPane" position="0 0 220 342">

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -589,6 +589,7 @@
         <!-- This invisible button makes it possible to move the
              window by dragging the caption. -->
         <Child type="Button" offset="4 4 248 20" align="HStretch Top" name="Action">
+            <Property key="SupportDoubleClick" value="1"/>
             <Property key="Scale" value="1 1 0 0"/>
         </Child>
     </Resource>
@@ -725,6 +726,7 @@
         <!-- This invisible button makes it possible to move the
              window by dragging the caption. -->
         <Child type="Button" offset="4 4 248 20" align="HStretch Top" name="Action">
+            <Property key="SupportDoubleClick" value="1"/>
             <Property key="Scale" value="1 1 0 0"/>
         </Child>
     </Resource>
@@ -860,8 +862,8 @@
         <!-- This invisible button makes it possible to move the
              window by dragging the caption. -->
         <Child type="Button" offset="4 4 248 20" align="HStretch Top" name="Action">
+            <Property key="SupportDoubleClick" value="1"/>
             <Property key="Scale" value="1 1 0 0"/>
-            <Property key="HideWindowOnDoubleClick" value="1"/>
         </Child>
 
         <Child type="Button" skin="PinUp" offset="232 4 19 19" align="Right Top" name="Button"/>

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -484,86 +484,151 @@ stats x = 0.015
 stats y = 0.015
 stats w = 0.4275
 stats h = 0.45
+stats maximized x = 0.0
+stats maximized y = 0.0
+stats maximized w = 1.0
+stats maximized h = 1.0
 stats pin = false
 stats hidden = false
+stats maximized = false
 
 # Spells window displaying powers, spells, and magical items.
 spells x = 0.63
 spells y = 0.39
 spells w = 0.36
 spells h = 0.51
+spells maximized x = 0.0
+spells maximized y = 0.0
+spells maximized w = 1.0
+spells maximized h = 1.0
 spells pin = false
 spells hidden = false
+spells maximized = false
 
 # Local and world map window.
 map x = 0.63
 map y = 0.015
 map w = 0.36
 map h = 0.37
+map maximized x = 0.0
+map maximized y = 0.0
+map maximized w = 1.0
+map maximized h = 1.0
 map pin = false
 map hidden = false
+map maximized = false
 
 # Player inventory window when explicitly opened.
-inventory x = 0.015
+inventory x = 0.0
 inventory y = 0.54
 inventory w = 0.45
 inventory h = 0.38
+inventory maximized x = 0.0
+inventory maximized y = 0.0
+inventory maximized w = 1.0
+inventory maximized h = 1.0
 inventory pin = false
 inventory hidden = false
-
-# Dialog window for talking with NPCs.
-dialogue x = 0.15
-dialogue y = 0.5
-dialogue w = 0.7
-dialogue h = 0.45
-
-# Alchemy window for crafting potions.
-alchemy x = 0.25
-alchemy y = 0.25
-alchemy w = 0.5
-alchemy h = 0.5
-
-# Console command window for debugging commands.
-console x = 0.015
-console y = 0.015
-console w = 1.0
-console h = 0.5
+inventory maximized = false
 
 # Player inventory window when searching a container.
 inventory container x = 0.015
 inventory container y = 0.54
 inventory container w = 0.45
 inventory container h = 0.38
+inventory container maximized x = 0.0
+inventory container maximized y = 0.5
+inventory container maximized w = 1.0
+inventory container maximized h = 0.5
+inventory container maximized = false
 
 # Player inventory window when bartering with a shopkeeper.
 inventory barter x = 0.015
 inventory barter y = 0.54
 inventory barter w = 0.45
 inventory barter h = 0.38
+inventory barter maximized x = 0.0
+inventory barter maximized y = 0.5
+inventory barter maximized w = 1.0
+inventory barter maximized h = 0.5
+inventory barter maximized = false
 
 # Player inventory window when trading with a companion.
 inventory companion x = 0.015
 inventory companion y = 0.54
 inventory companion w = 0.45
 inventory companion h = 0.38
+inventory companion maximized x = 0.0
+inventory companion maximized y = 0.5
+inventory companion maximized w = 1.0
+inventory companion maximized h = 0.5
+inventory companion maximized = false
+
+# Dialog window for talking with NPCs.
+dialogue x = 0.15
+dialogue y = 0.5
+dialogue w = 0.7
+dialogue h = 0.45
+dialogue maximized x = 0.0
+dialogue maximized y = 0.0
+dialogue maximized w = 1.0
+dialogue maximized h = 1.0
+dialogue maximized = false
+
+# Alchemy window for crafting potions.
+alchemy x = 0.25
+alchemy y = 0.25
+alchemy w = 0.5
+alchemy h = 0.5
+alchemy maximized x = 0.0
+alchemy maximized y = 0.0
+alchemy maximized w = 1.0
+alchemy maximized h = 1.0
+alchemy maximized = false
+
+# Console command window for debugging commands.
+console x = 0.015
+console y = 0.015
+console w = 1.0
+console h = 0.5
+console maximized x = 0.0
+console maximized y = 0.0
+console maximized w = 1.0
+console maximized h = 1.0
+console maximized = false
 
 # Container inventory when searching a container.
 container x = 0.49
 container y = 0.54
 container w = 0.39
 container h = 0.38
+container maximized x = 0.0
+container maximized y = 0.0
+container maximized w = 1.0
+container maximized h = 0.5
+container maximized = false
 
 # NPC inventory window when bartering with a shopkeeper.
 barter x = 0.6
 barter y = 0.27
 barter w = 0.38
 barter h = 0.63
+barter maximized x = 0.0
+barter maximized y = 0.0
+barter maximized w = 1.0
+barter maximized h = 0.5
+barter maximized = false
 
 # NPC inventory window when trading with a companion.
 companion x = 0.6
 companion y = 0.27
 companion w = 0.38
 companion h = 0.63
+companion maximized x = 0.0
+companion maximized y = 0.0
+companion maximized w = 1.0
+companion maximized h = 0.5
+companion maximized = false
 
 [Navigator]
 


### PR DESCRIPTION
Implements [feature #3999](https://gitlab.com/OpenMW/openmw/issues/3999).

Most of windows use the whole screen when maximized (excepts of inventory-related ones - they occupy only the half of screen).