### PR TITLE
Make progress bars close to vanilla

### DIFF
--- a/files/mygui/openmw_hud_energybar.skin.xml
+++ b/files/mygui/openmw_hud_energybar.skin.xml
@@ -19,43 +19,43 @@
     </Resource>
 
     <!-- Progress bar track, various colors -->
-    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Red" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_BarTrack_Red" size="16 8" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=health}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
+            <State name="normal" offset="0 0 16 8"/>
         </BasisSkin>
     </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Green" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_BarTrack_Green" size="16 8" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=fatigue}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
+            <State name="normal" offset="0 0 16 8"/>
         </BasisSkin>
     </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Blue" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_BarTrack_Blue" size="16 8" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=magic}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
+            <State name="normal" offset="0 0 16 8"/>
         </BasisSkin>
     </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Yellow" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_BarTrack_Yellow" size="16 8" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="1 1 0"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
+            <State name="normal" offset="0 0 16 8"/>
         </BasisSkin>
     </Resource>
 
 
-    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Magic" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_BarTrack_Magic" size="16 2" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=magic_fill}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 2" align="Stretch">
+            <State name="normal" offset="0 0 16 2"/>
         </BasisSkin>
     </Resource>
 
-    <Resource type="AutoSizedResourceSkin" name="MW_BarTrack_Weapon" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_BarTrack_Weapon" size="16 2" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=weapon_fill}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 2" align="Stretch">
+            <State name="normal" offset="0 0 16 2"/>
         </BasisSkin>
     </Resource>
 

--- a/files/mygui/openmw_progress.skin.xml
+++ b/files/mygui/openmw_progress.skin.xml
@@ -2,59 +2,40 @@
 
 <MyGUI type="Resource" version="1.1">
     <!-- Progress bar track, various colors -->
-    <Resource type="AutoSizedResourceSkin" name="MW_Track_Red" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_Track_Red" size="2 14" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=health}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 16" align="Stretch">
+            <State name="normal" offset="0 0 16 16"/>
         </BasisSkin>
     </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_Track_Blue" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_Track_Blue" size="2 14" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=magic}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 16">
+            <State name="normal" offset="0 0 16 16"/>
         </BasisSkin>
     </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_Track_Green" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_Track_Green" size="2 14" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="#{fontcolour=fatigue}"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 16" align="Stretch">
+            <State name="normal" offset="0 0 16 16"/>
         </BasisSkin>
     </Resource>
-    <!-- Lighter variants (only uses top half of the gradient) -->
-    <Resource type="AutoSizedResourceSkin" name="MW_BigTrack_Progress_Red_Small" texture="textures\menu_bar_gray.dds" >
+    <Resource type="ResourceSkin" name="MW_Progress_Drowning_Full_Small" size="16 2" texture="textures\menu_bar_gray.dds" >
+        <Property key="Colour" value="0.235 0.745 0.745"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 2" align="Stretch">
+            <State name="normal" offset="0 0 16 2"/>
+        </BasisSkin>
+    </Resource>
+    <Resource type="ResourceSkin" name="MW_Progress_Drowning_Small" size="16 2" texture="textures\menu_bar_gray.dds" >
         <Property key="Colour" value="1 0 0"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 2" align="Stretch">
+            <State name="normal" offset="0 0 16 2"/>
         </BasisSkin>
     </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_BigTrack_Progress_Blue_Small" size="16 8" texture="textures\menu_bar_gray.dds" >
-        <Property key="Colour" value="0.3 0.3 1"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
-        </BasisSkin>
-    </Resource>
-    <Resource type="AutoSizedResourceSkin" name="MW_BigTrack_Progress_Green_Small" texture="textures\menu_bar_gray.dds" >
-        <Property key="Colour" value="0.298 0.784 0.780"/>
-        <BasisSkin type="MainSkin" align="Stretch">
-            <State name="normal"/>
-        </BasisSkin>
-    </Resource>
-    <Resource type="ResourceSkin" name="MW_Progress_Drowning_Full_Small" size="16 8" texture="white" >
-        <Property key="Colour" value="0.035 0.545 0.545"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
-        </BasisSkin>
-    </Resource>
-    <Resource type="ResourceSkin" name="MW_Progress_Drowning_Small" size="16 8" texture="white" >
-        <Property key="Colour" value="0.785 0 0"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
-        </BasisSkin>
-    </Resource>
-    <Resource type="ResourceSkin" name="MW_Progress_Loading_Small" size="16 8" texture="white" >
-        <Property key="Colour" value="0 0.615 0.620"/>
-        <BasisSkin type="MainSkin" offset="0 0 16 8" align="Stretch">
-            <State name="normal" offset="0 0 16 8"/>
+    <Resource type="ResourceSkin" name="MW_Progress_Loading_Small" size="16 2" texture="textures\menu_bar_gray.dds" >
+        <Property key="Colour" value="0 0.815 0.820"/>
+        <BasisSkin type="MainSkin" offset="0 0 16 2" align="Stretch">
+            <State name="normal" offset="0 0 16 2"/>
         </BasisSkin>
     </Resource>
     <Resource type="ResourceSkin" name="ProgressText" size="16 16">


### PR DESCRIPTION
According to my testing, in the Morrowind:
1. Thin progress bars (such as in the loading screen or on the drowing widget) use the menu_bar_gray.dds as well.
2. Progress bars have a weird tiling - Morrowind draws the menu_bar_gray.dds texture without any scaling and then starts to repeat only pixels near texture border. OpenMW scales texture to the whole widget size instead. As a result, large progress bars are darker in the Morrowind than in OpenMW, and tiny progress bars are lighter than in OpenMW.

So summary of changes:
1. Use the menu_bar_gray.dds for all progress bars.
2. Rollback texture scaling for scrollbars since it makes no sense anyway.
Instead I use the 16x16 part of texture for large progress bars (e.g. skill progress bar), 16x8 for small ones (e.g. dynamic stas on HUD) and 16x2 for tiny ones (e.g. loading bar).
3. Remove old unused MW_BigTrack_Progress_*_Small widgets.

In theory, it is possible to replicate a pseudo-tiling, bit it is a huge mess, and I doubt that there are mods which rely on such behaviour anyway.