### PR TITLE
AI: use a consistent check if a target is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
     Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Bug #4918: Abilities don't play looping VFX when they're initially applied
+    Bug #4920: Combat AI uses incorrect invisibility check
     Bug #4922: Werewolves can not attack if the transformation happens during attack
     Bug #4927: Spell effect having both a skill and an attribute assigned is a fatal error
     Bug #4932: Invalid records matching when loading save with edited plugin

--- a/apps/openmw/mwmechanics/aicombataction.cpp
+++ b/apps/openmw/mwmechanics/aicombataction.cpp
@@ -403,12 +403,9 @@ namespace MWMechanics
         ESM::Position actorPos = actor.getRefData().getPosition();
         ESM::Position enemyPos = enemy.getRefData().getPosition();
 
-        const CreatureStats& enemyStats = enemy.getClass().getCreatureStats(enemy);
-        if (enemyStats.getMagicEffects().get(ESM::MagicEffect::Invisibility).getMagnitude() > 0
-                || enemyStats.getMagicEffects().get(ESM::MagicEffect::Chameleon).getMagnitude() > 0)
+        if (isTargetMagicallyHidden(enemy) && !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(enemy, actor))
         {
-            if (!MWBase::Environment::get().getMechanicsManager()->awarenessCheck(enemy, actor))
-                return false;
+            return false;
         }
 
         if (actor.getClass().isPureWaterCreature(actor))

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -335,13 +335,6 @@ bool MWMechanics::AiPackage::doesPathNeedRecalc(const osg::Vec3f& newDest, const
         || mPathFinder.getPathCell() != currentCell;
 }
 
-bool MWMechanics::AiPackage::isTargetMagicallyHidden(const MWWorld::Ptr& target)
-{
-    const MagicEffects& magicEffects(target.getClass().getCreatureStats(target).getMagicEffects());
-    return (magicEffects.get(ESM::MagicEffect::Invisibility).getMagnitude() > 0)
-        || (magicEffects.get(ESM::MagicEffect::Chameleon).getMagnitude() > 75);
-}
-
 bool MWMechanics::AiPackage::isNearInactiveCell(osg::Vec3f position)
 {
     const ESM::Cell* playerCell(getPlayer().getCell()->getCell());

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -102,8 +102,6 @@ namespace MWMechanics
             /// Reset pathfinding state
             void reset();
 
-            bool isTargetMagicallyHidden(const MWWorld::Ptr& target);
-
             /// Return if actor's rotation speed is sufficient to rotate to the destination pathpoint on the run. Otherwise actor should rotate while standing.
             static bool isReachableRotatingOnTheRun(const MWWorld::Ptr& actor, const osg::Vec3f& dest);
 

--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -10,6 +10,7 @@
 
 #include "movement.hpp"
 #include "creaturestats.hpp"
+#include "combat.hpp"
 
 namespace MWMechanics
 {

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -485,4 +485,11 @@ namespace MWMechanics
 
         return (iFightDistanceBase - fFightDistanceMultiplier * d);
     }
+
+    bool isTargetMagicallyHidden(const MWWorld::Ptr& target)
+    {
+        const MagicEffects& magicEffects = target.getClass().getCreatureStats(target).getMagicEffects();
+        return (magicEffects.get(ESM::MagicEffect::Invisibility).getMagnitude() > 0)
+            || (magicEffects.get(ESM::MagicEffect::Chameleon).getMagnitude() > 75);
+    }
 }

--- a/apps/openmw/mwmechanics/combat.hpp
+++ b/apps/openmw/mwmechanics/combat.hpp
@@ -53,6 +53,8 @@ void getHandToHandDamage (const MWWorld::Ptr& attacker, const MWWorld::Ptr& vict
 void applyFatigueLoss(const MWWorld::Ptr& attacker, const MWWorld::Ptr& weapon, float attackStrength);
 
 float getFightDistanceBias(const MWWorld::Ptr& actor1, const MWWorld::Ptr& actor2);
+
+bool isTargetMagicallyHidden(const MWWorld::Ptr& target);
 }
 
 #endif


### PR DESCRIPTION
Fixes [bug #4920](https://gitlab.com/OpenMW/openmw/issues/4920).

Yhe main idea - canFight() should consider actors with Chameleon > 75 as invisible, not with Chameleon > 0.
We already use the same check for AiPursue, so I decided to re-use the isTargetMagicallyHidden() function.