### PR TITLE
Improve reset of idle animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
     Bug #4828: Potion looping effects VFX are not shown for NPCs
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
     Bug #4841: Russian localization ignores implicit keywords
+    Bug #4847: Idle animation reset oddities
     Bug #4851: No shadows since switch to OSG
     Bug #4860: Actors outside of processing range visible for one frame after spawning
     Bug #4867: Arbitrary text after local variable declarations breaks script compilation

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -350,11 +350,6 @@ void CharacterController::refreshJumpAnims(const WeaponInfo* weap, JumpingState 
     if (!force && jump == mJumpState && idle == CharState_None)
         return;
 
-    if (jump == JumpState_InAir)
-    {
-        idle = CharState_None;
-    }
-
     std::string jumpAnimName;
     MWRender::Animation::BlendMask jumpmask = MWRender::Animation::BlendMask_All;
     if (jump != JumpState_None)
@@ -1686,7 +1681,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             idle != CharState_IdleSneak && idle != CharState_IdleSwim &&
             mIdleState != CharState_IdleSneak && mIdleState != CharState_IdleSwim)
         {
-            idle = CharState_None;
+            mAnimation->disable(mCurrentIdle);
         }
 
         animPlaying = mAnimation->getInfo(mCurrentWeapon, &complete);
@@ -2138,6 +2133,9 @@ void CharacterController::update(float duration, bool animationOnly)
             forcestateupdate = true;
             jumpstate = JumpState_Landing;
             vec.z() = 0.0f;
+
+            // We should reset idle animation during landing
+            mAnimation->disable(mCurrentIdle);
 
             float height = cls.getCreatureStats(mPtr).land(isPlayer);
             float healthLost = getFallDamage(mPtr, height);


### PR DESCRIPTION
Fixes [bug #4847](https://gitlab.com/OpenMW/openmw/issues/4847).

1. Since the only purpose this code is to reset a weapon idle idle animation during attack, we can just disable current idle here, so OpenMW will just restart idle animation from beginning in the same frame if needed.

2. Morrowind seems to reset an idle animation during jump only once, during landing. Replicate this behaviour.