### PR TITLE
Use the StateSetUpdater to modify alpha for Animation objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
     Bug #4989: Object dimension-dependent VFX scaling behavior is inconsistent
     Bug #4990: Dead bodies prevent you from hitting
     Bug #4999: Drop instruction behaves differently from vanilla
+    Bug #5001: Possible data race in the Animation::setAlpha()
     Bug #5004: Werewolves shield their eyes during storm
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -35,6 +35,7 @@ namespace MWRender
 class ResetAccumRootCallback;
 class RotateController;
 class GlowUpdater;
+class TransparencyUpdater;
 
 class EffectAnimationTime : public SceneUtil::ControllerSource
 {
@@ -266,6 +267,7 @@ protected:
 
     osg::ref_ptr<SceneUtil::LightSource> mGlowLight;
     osg::ref_ptr<GlowUpdater> mGlowUpdater;
+    osg::ref_ptr<TransparencyUpdater> mTransparencyUpdater;
 
     float mAlpha;
 


### PR DESCRIPTION
Should fix [bug #5001](https://gitlab.com/OpenMW/openmw/issues/5001).

An approach, suggested by bzzt, leads to performance loss since we recreate the whole stateset every time we need to change the alpha level.

I use the StateSetUpdater instead, so performance is the same as in master branch.