### PR TITLE
Do not use the xbase_anim.kf as a fallback for werewolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
     Bug #4984: "Friendly hits" feature should be used only for player's followers
     Bug #4989: Object dimension-dependent VFX scaling behavior is inconsistent
     Bug #4990: Dead bodies prevent you from hitting
+    Bug #5004: Werewolves shield their eyes during storm
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -493,7 +493,7 @@ void NpcAnimation::updateNpcBase()
     if(!is1stPerson)
     {
         const std::string base = "meshes\\xbase_anim.nif";
-        if (smodel != base)
+        if (smodel != base && !isWerewolf)
             addAnimSource(base, smodel);
 
         if (smodel != defaultSkeleton && base != defaultSkeleton)
@@ -507,7 +507,7 @@ void NpcAnimation::updateNpcBase()
     else
     {
         const std::string base = "meshes\\xbase_anim.1st.nif";
-        if (smodel != base)
+        if (smodel != base && !isWerewolf)
             addAnimSource(base, smodel);
 
         addAnimSource(smodel, smodel);


### PR DESCRIPTION
Fixes [bug #5004](https://gitlab.com/OpenMW/openmw/issues/5004).

Existing fallback for werewolves makes no sense - animations from base file were not designed for them.