### PR TITLE
engine: fix window creation when SDL returns different-sized window

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -428,11 +428,11 @@ void OMW::Engine::createWindow(Settings::Manager& settings)
 
     osg::ref_ptr<osg::Camera> camera = mViewer->getCamera();
     camera->setGraphicsContext(graphicsWindow);
-    camera->setViewport(0, 0, width, height);
+    camera->setViewport(0, 0, traits->width, traits->height);
 
     mViewer->realize();
 
-    mViewer->getEventQueue()->getCurrentEventState()->setWindowRectangle(0, 0, width, height);
+    mViewer->getEventQueue()->getCurrentEventState()->setWindowRectangle(0, 0, traits->width, traits->height);
 }
 
 void OMW::Engine::setWindowIcon()


### PR DESCRIPTION
If sdl2 returns a different size from what was requested when creating a window, there would be inconsistency between size of the actual window and the opengl viewport used by osg. This resulted in graphical glitches on android.

Would appreciate if people could test it on different os/windowed/fullscreen combinations.