### PR TITLE
Shader adjustments

### DIFF
--- a/files/shaders/lighting.glsl
+++ b/files/shaders/lighting.glsl
@@ -63,7 +63,7 @@ vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, out vec3 shadow
         lightResult.xyz += gl_FrontMaterial.emission.xyz;
 
 #if @clamp
-    lightResult = clamp(lightResult, vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0));
+    lightResult = clamp(lightResult, vec4(0.0), vec4(1.0));
 #else
     lightResult = max(lightResult, 0.0);
 #endif

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -98,7 +98,7 @@ void main()
 #if @diffuseMap
     gl_FragData[0] = texture2D(diffuseMap, adjustedDiffuseUV);
 #else
-    gl_FragData[0] = vec4(1.0, 1.0, 1.0, 1.0);
+    gl_FragData[0] = vec4(1.0);
 #endif
 
 #if @detailMap
@@ -117,7 +117,13 @@ void main()
     float shadowing = unshadowedLightRatio();
 
 #if !PER_PIXEL_LIGHTING
+
+#if @clamp
+    gl_FragData[0] *= clamp(lighting + vec4(shadowDiffuseLighting * shadowing, 0), vec4(0.0), vec4(1.0));
+#else
     gl_FragData[0] *= lighting + vec4(shadowDiffuseLighting * shadowing, 0);
+#endif
+
 #else
     gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing);
 #endif

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -69,7 +69,13 @@ void main()
     float shadowing = unshadowedLightRatio();
 
 #if !PER_PIXEL_LIGHTING
+
+#if @clamp
+    gl_FragData[0] *= clamp(lighting + vec4(shadowDiffuseLighting * shadowing, 0), vec4(0.0), vec4(1.0));
+#else
     gl_FragData[0] *= lighting + vec4(shadowDiffuseLighting * shadowing, 0);
+#endif
+
 #else
     gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing);
 #endif

--- a/files/shaders/water_fragment.glsl
+++ b/files/shaders/water_fragment.glsl
@@ -170,7 +170,7 @@ void main(void)
     vec2 screenCoords = screenCoordsPassthrough.xy / screenCoordsPassthrough.z;
     screenCoords.y = (1.0-screenCoords.y);
 
-    vec2 nCoord = vec2(0.0,0.0);
+    vec2 nCoord = vec2(0.0);
 
     #define waterTimer osg_SimulationTime
 
@@ -186,7 +186,7 @@ void main(void)
     if (rainIntensity > 0.01)
       rainRipple = rainCombined(position.xy / 1000.0,waterTimer) * clamp(rainIntensity,0.0,1.0);
     else
-      rainRipple = vec4(0.0,0.0,0.0,0.0);
+      rainRipple = vec4(0.0);
 
     vec3 rippleAdd = rainRipple.xyz * rainRipple.w * 10.0;
 


### PR DESCRIPTION
Result of yesterday's discussion with AnyOldName3.

1. Clamp per-vertex directional diffuse lighting

Right now per-vertex shader lighting looks brighter (and "more realistic") than per-pixel shader lighting and fixed function pipeline because of how shadow support was implemented. Basically, sun diffuse lighting accidentally became unclamped and it led to the lighting becoming inconsistent with FFP, since the lighting contribution should only hit (1.0, 1.0, 1.0, 1.0). The lighting is now re-clamped in the relevant parts of shaders if the relevant define is "1" so per-vertex lighting looks "right" again when it's clamped. The side effect is the same as the one for per-pixel clamped lighting: overbright areas get weaker shadows.

2. Simplify vectors

As per AnyOldName3's suggestion vectors were simplified: if all components of a vector are the same number they don't need to be declared explicitly. This makes the lines such vector are used in shorter.