### PR TITLE
Do not track resolution settings changes in the InputManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
     Bug #4877: Startup script executes only on a new game start
     Bug #4888: Global variable stray explicit reference calls break script compilation
     Bug #4896: Title screen music doesn't loop
+    Bug #4902: Using scrollbars in settings causes resolution to change
     Bug #4911: Editor: QOpenGLContext::swapBuffers() warning with Qt5
     Bug #4916: Specular power (shininess) material parameter is ignored when shaders are used.
     Bug #4918: Abilities don't play looping VFX when they're initially applied

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -584,6 +584,7 @@ namespace MWGui
 
     void SettingsWindow::onOpen()
     {
+        highlightCurrentResolution();
         updateControlsBox();
         resetScrollbars();
         MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mOkButton);

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -826,9 +826,6 @@ namespace MWInput
                                         Settings::Manager::getInt("resolution y", "Video"),
                                         Settings::Manager::getBool("fullscreen", "Video"),
                                         Settings::Manager::getBool("window border", "Video"));
-
-            // We should reload TrueType fonts to fit new resolution
-            MWBase::Environment::get().getWindowManager()->loadUserFonts();
         }
     }
 
@@ -1129,10 +1126,17 @@ namespace MWInput
 
     void InputManager::windowResized(int x, int y)
     {
+        // Note: this is a side effect of resolution change or window resize.
+        // There is no need to track these changes.
         Settings::Manager::setInt("resolution x", "Video", x);
         Settings::Manager::setInt("resolution y", "Video", y);
+        Settings::Manager::apply("resolution x", "Video");
+        Settings::Manager::apply("resolution y", "Video");
 
         MWBase::Environment::get().getWindowManager()->windowResized(x, y);
+
+        // We should reload TrueType fonts to fit new resolution
+        MWBase::Environment::get().getWindowManager()->loadUserFonts();
     }
 
     void InputManager::windowClosed()

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -414,6 +414,12 @@ void Manager::setBool(const std::string &setting, const std::string &category, c
     setString(setting, category, value ? "true" : "false");
 }
 
+void Manager::apply(const std::string &setting, const std::string &category)
+{
+    CategorySettingValueMap::key_type key = std::make_pair(category, setting);
+    mChangedSettings.erase(key);
+}
+
 const CategorySettingVector Manager::apply()
 {
     CategorySettingVector vec = mChangedSettings;

--- a/components/settings/settings.hpp
+++ b/components/settings/settings.hpp
@@ -35,6 +35,8 @@ namespace Settings
         void saveUser (const std::string& file);
         ///< save user settings to file
 
+        static void apply(const std::string &setting, const std::string &category);
+
         static const CategorySettingVector apply();
         ///< returns the list of changed settings and then clears it
 


### PR DESCRIPTION
Fixes [bug #4902](https://gitlab.com/OpenMW/openmw/issues/4902).

The InputManager::windowResized() is actually a side effect of resolution change, so we get unhandled "resolution x" and "resolution y" settings changes in the Settings::Manager::mChangedSettings. If a user changes an another setting after resolution change, OpenMW changes resolution again after Settings::Manager::apply() and generates an another set of "windowResized" events and so on.

So the main idea - just change setting here, without adding it to the mChangedSettings set.
In this case there will be no additional setting changes for the Settings::Manager::apply(), which may accidentally change resolution.

