### PR TITLE
Additional herbalism-related tweaks

### DIFF
--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -89,6 +89,10 @@ namespace MWClass
             ptr.get<ESM::Container>();
         if (ref->mBase->mFlags & ESM::Container::Respawn)
         {
+            // Container was not touched, there is no need to modify its content.
+            if (ptr.getRefData().getCustomData() == nullptr)
+                return;
+
             MWBase::Environment::get().getWorld()->removeContainerScripts(ptr);
             ptr.getRefData().setCustomData(nullptr);
         }

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1990,9 +1990,7 @@ namespace MWRender
             mObjectRoot->accept(visitor);
         }
 
-        if (ptr.getTypeName() == typeid(ESM::Container).name() &&
-            SceneUtil::hasUserDescription(mObjectRoot, Constants::HerbalismLabel) &&
-            ptr.getRefData().getCustomData() != nullptr)
+        if (ptr.getRefData().getCustomData() != nullptr && canBeHarvested())
         {
             const MWWorld::ContainerStore& store = ptr.getClass().getContainerStore(ptr);
             if (!store.hasVisibleItems())

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3335,9 +3335,13 @@ namespace MWWorld
                 return true;
 
             // Consider references inside containers as well (except if we are looking for a Creature, they cannot be in containers)
-            if (mType != World::Detect_Creature &&
-                    (ptr.getClass().isActor() || ptr.getClass().getTypeName() == typeid(ESM::Container).name()))
+            bool isContainer = ptr.getClass().getTypeName() == typeid(ESM::Container).name();
+            if (mType != World::Detect_Creature && (ptr.getClass().isActor() || isContainer))
             {
+                // but ignore containers without resolved content
+                if (isContainer && ptr.getRefData().getCustomData() == nullptr)
+                    return true;
+
                 MWWorld::ContainerStore& store = ptr.getClass().getContainerStore(ptr);
                 {
                     for (MWWorld::ContainerStoreIterator it = store.begin(); it != store.end(); ++it)


### PR DESCRIPTION
1. By design we ignore non-organic containers for herbalism, but I missed it in one place, when we add objects to scene.

2. There is no need to respawn container's content, if it was not touched. Otherwise we resolve its content first for removeContainerScripts() and then we remove it anyway.

3. Ignore containers without resolved content for Detect spells. Otherwise Detect Key and Detect Magic will resolve content for nearby containers to check if they have keys or enchanted items. Morrowind seems to use a similar approach, but I am not sure if it is the same.
Later we can try to implement a some kind of "temporary" container store, which we will not need to store in savegame, but it is a separate feature anyway.