### PR TITLE
Refactor Settings::Manager::apply()

### DIFF
--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -451,12 +451,13 @@ namespace MWGui
 
     void SettingsWindow::apply()
     {
-        const Settings::CategorySettingVector changed = Settings::Manager::apply();
+        const Settings::CategorySettingVector changed = Settings::Manager::getPendingChanges();
         MWBase::Environment::get().getWorld()->processChangedSettings(changed);
         MWBase::Environment::get().getSoundManager()->processChangedSettings(changed);
         MWBase::Environment::get().getWindowManager()->processChangedSettings(changed);
         MWBase::Environment::get().getInputManager()->processChangedSettings(changed);
         MWBase::Environment::get().getMechanicsManager()->processChangedSettings(changed);
+        Settings::Manager::resetPendingChanges();
     }
 
     void SettingsWindow::onKeyboardSwitchClicked(MyGUI::Widget* _sender)

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1130,8 +1130,8 @@ namespace MWInput
         // There is no need to track these changes.
         Settings::Manager::setInt("resolution x", "Video", x);
         Settings::Manager::setInt("resolution y", "Video", y);
-        Settings::Manager::apply("resolution x", "Video");
-        Settings::Manager::apply("resolution y", "Video");
+        Settings::Manager::resetPendingChange("resolution x", "Video");
+        Settings::Manager::resetPendingChange("resolution y", "Video");
 
         MWBase::Environment::get().getWindowManager()->windowResized(x, y);
 

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -414,17 +414,20 @@ void Manager::setBool(const std::string &setting, const std::string &category, c
     setString(setting, category, value ? "true" : "false");
 }
 
-void Manager::apply(const std::string &setting, const std::string &category)
+void Manager::resetPendingChange(const std::string &setting, const std::string &category)
 {
     CategorySettingValueMap::key_type key = std::make_pair(category, setting);
     mChangedSettings.erase(key);
 }
 
-const CategorySettingVector Manager::apply()
+const CategorySettingVector Manager::getPendingChanges()
 {
-    CategorySettingVector vec = mChangedSettings;
+    return mChangedSettings;
+}
+
+void Manager::resetPendingChanges()
+{
     mChangedSettings.clear();
-    return vec;
 }
 
 }

--- a/components/settings/settings.hpp
+++ b/components/settings/settings.hpp
@@ -35,9 +35,11 @@ namespace Settings
         void saveUser (const std::string& file);
         ///< save user settings to file
 
-        static void apply(const std::string &setting, const std::string &category);
+        static void resetPendingChange(const std::string &setting, const std::string &category);
 
-        static const CategorySettingVector apply();
+        static void resetPendingChanges();
+
+        static const CategorySettingVector getPendingChanges();
         ///< returns the list of changed settings and then clears it
 
         static int getInt (const std::string& setting, const std::string& category);


### PR DESCRIPTION
@Capostrophic had complains about the `Settings::Manager::apply()` function since it does not apply anything.

The main idea here is to split apply() to two functions - getPendingChanges() and resetPendingChanges(). 

Note: I call the resetPendingChanges() in the end of SettingsWindow::apply() instead of beginning to make sure we do not have rogue changes, which will be applied when player changes other settings and he does not expect such changes.