### PR TITLE
Fix spell deletion for characters without a birthsign

### DIFF
--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -152,13 +152,17 @@ namespace MWGui
 
         MWWorld::Ptr player = MWMechanics::getPlayer();
         std::string raceId = player.get<ESM::NPC>()->mBase->mRace;
-        const std::string& signId =
-            MWBase::Environment::get().getWorld()->getPlayer().getBirthSign();
         const ESM::Race* race = MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(raceId);
-        const ESM::BirthSign* birthsign = MWBase::Environment::get().getWorld()->getStore().get<ESM::BirthSign>().find(signId);
+        // can't delete racial spells, birthsign spells or powers
+        bool isInherent = race->mPowers.exists(spell->mId) || spell->mData.mType == ESM::Spell::ST_Power;
+        const std::string& signId = MWBase::Environment::get().getWorld()->getPlayer().getBirthSign();
+        if (!isInherent && !signId.empty())
+        {
+            const ESM::BirthSign* sign = MWBase::Environment::get().getWorld()->getStore().get<ESM::BirthSign>().find(signId);
+            isInherent = sign->mPowers.exists(spell->mId);
+        }
 
-        // can't delete racial spells, birthsign spells or powers 
-        if (race->mPowers.exists(spell->mId) || birthsign->mPowers.exists(spell->mId) || spell->mData.mType == ESM::Spell::ST_Power)
+        if (isInherent)
         {
             MWBase::Environment::get().getWindowManager()->messageBox("#{sDeleteSpellError}");
         }


### PR DESCRIPTION
If the character doesn't have a birthsign, find method for the birthsign throws an exception (it obviously can't find a record with empty ID) and no spell can be deleted. Doesn't happen in normal gameplay, though.
In other cases the existence of a birthsign record can be guaranteed.
So inherent spell checks were adjusted to support empty birthsign ID.