### PR TITLE
Avoid using null pointer for player's cell in moveObjectImp

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1306,7 +1306,7 @@ namespace MWWorld
 
         CellStore* cell = ptr.getCell();
         CellStore* newCell = getExterior(cellX, cellY);
-        bool isCellActive = getPlayerPtr().getCell()->isExterior() && mWorldScene->isCellActive(*newCell);
+        bool isCellActive = getPlayerPtr().isInCell() && getPlayerPtr().getCell()->isExterior() && mWorldScene->isCellActive(*newCell);
 
         if (cell->isExterior() || (moveToActive && isCellActive && ptr.getClass().isActor()))
             cell = newCell;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5015)
Make sure isExterior is not called on a null player CellStore pointer, which should fix potential crashes.