### PR TITLE
Support negative effect magnitude in spell/ingredient/potion tooltips (bug #5018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
     Bug #4999: Drop instruction behaves differently from vanilla
     Bug #5001: Possible data race in the Animation::setAlpha()
     Bug #5004: Werewolves shield their eyes during storm
+    Bug #5018: Spell tooltips don't support purely negative magnitudes
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -408,7 +408,7 @@ namespace MWGui
                 spellLine += " " + MWBase::Environment::get().getWindowManager()->getGameSettingString(ESM::Attribute::sGmstAttributeIds[mEffectParams.mAttribute], "");
             }
 
-            if (mEffectParams.mMagnMin >= 0 || mEffectParams.mMagnMax >= 0) {
+            if (mEffectParams.mMagnMin || mEffectParams.mMagnMax) {
                 ESM::MagicEffect::MagnitudeDisplayType displayType = magicEffect->getMagnitudeDisplayType();
                 if ( displayType == ESM::MagicEffect::MDT_TimesInt ) {
                     std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
@@ -431,9 +431,9 @@ namespace MWGui
                     else if ( displayType == ESM::MagicEffect::MDT_Feet )
                         spellLine += " " + ft;
                     else if ( displayType == ESM::MagicEffect::MDT_Level )
-                        spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? lvl : lvls );
+                        spellLine += " " + ((mEffectParams.mMagnMin == mEffectParams.mMagnMax && std::abs(mEffectParams.mMagnMin) == 1) ? lvl : lvls );
                     else  // ESM::MagicEffect::MDT_Points
-                        spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
+                        spellLine += " " + ((mEffectParams.mMagnMin == mEffectParams.mMagnMax && std::abs(mEffectParams.mMagnMin) == 1) ? pt : pts );
                 }
             }
 


### PR DESCRIPTION
One of the weirder [reports](https://gitlab.com/OpenMW/openmw/issues/5018) lately.