### PR TITLE
Container search tweaks

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -176,7 +176,7 @@ namespace MWBase
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            virtual MWWorld::Ptr searchPtr (const std::string& name, bool activeOnly) = 0;
+            virtual MWWorld::Ptr searchPtr (const std::string& name, bool activeOnly, bool searchInContainers = true) = 0;
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -994,7 +994,7 @@ namespace MWMechanics
         }
 
         if (!cellref.getOwner().empty())
-            victim = MWBase::Environment::get().getWorld()->searchPtr(cellref.getOwner(), true);
+            victim = MWBase::Environment::get().getWorld()->searchPtr(cellref.getOwner(), true, false);
 
         return (!isOwned && !isFactionOwned);
     }

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -37,6 +37,9 @@ namespace
         {
             MWWorld::Ptr container (&*iter, 0);
 
+            if (container.getRefData().getCustomData() == nullptr)
+                continue;
+
             MWWorld::Ptr ptr =
                 container.getClass().getContainerStore (container).search (id);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -679,7 +679,7 @@ namespace MWWorld
         mLocalScripts.remove (ref);
     }
 
-    Ptr World::searchPtr (const std::string& name, bool activeOnly)
+    Ptr World::searchPtr (const std::string& name, bool activeOnly, bool searchInContainers)
     {
         Ptr ret;
         // the player is always in an active cell.
@@ -706,11 +706,14 @@ namespace MWWorld
                 return ret;
         }
 
-        for (CellStore* cellstore : mWorldScene->getActiveCells())
+        if (searchInContainers)
         {
-            Ptr ptr = cellstore->searchInContainer(lowerCaseName);
-            if (!ptr.isEmpty())
-                return ptr;
+            for (CellStore* cellstore : mWorldScene->getActiveCells())
+            {
+                Ptr ptr = cellstore->searchInContainer(lowerCaseName);
+                if (!ptr.isEmpty())
+                    return ptr;
+            }
         }
 
         Ptr ptr = mPlayer->getPlayer().getClass()

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -285,7 +285,7 @@ namespace MWWorld
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            Ptr searchPtr (const std::string& name, bool activeOnly) override;
+            Ptr searchPtr (const std::string& name, bool activeOnly, bool searchInContainers = true) override;
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 


### PR DESCRIPTION
Should fix the [regression #5020](https://gitlab.com/OpenMW/openmw/issues/5020).

Summary of changes:
1. Do not try to find a container's owner inside other containers.
2. When we search for reference via string ID, ignore containers without resolved content instead of generating it.