### PR TITLE
Don't toggle sneaking when controls are disabled

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1395,6 +1395,7 @@ namespace MWInput
     void InputManager::toggleSneaking()
     {
         if (MWBase::Environment::get().getWindowManager()->isGuiMode()) return;
+        if (!mControlSwitch["playercontrols"]) return;
         mSneaking = !mSneaking;
         mPlayer->setSneak(mSneaking);
     }


### PR DESCRIPTION
When "toggle sneak" is enabled, it bypasses the player controls switch the default sneaking behavior acknowledges. I made it no-op in case it's off.