### PR TITLE
Fix some thread sync issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     Bug #4828: Potion looping effects VFX are not shown for NPCs
     Bug #4837: CTD when a mesh with NiLODNode root node with particles is loaded
     Bug #4841: Russian localization ignores implicit keywords
+    Bug #4844: Data race in savegame loading / GlobalMap render
     Bug #4847: Idle animation reset oddities
     Bug #4851: No shadows since switch to OSG
     Bug #4860: Actors outside of processing range visible for one frame after spawning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
     Bug #5001: Possible data race in the Animation::setAlpha()
     Bug #5004: Werewolves shield their eyes during storm
     Bug #5018: Spell tooltips don't support purely negative magnitudes
+    Bug #5025: Data race in the ICO::setMaximumNumOfObjectsToCompilePerFrame()
     Bug #5028: Offered price caps are not trading-specific
     Bug #5038: Enchanting success chance calculations are blatantly wrong
     Feature #1774: Handle AvoidNode

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -257,9 +257,9 @@ OMW::Engine::~Engine()
 
     mWorkQueue = nullptr;
 
-    mResourceSystem.reset();
-
     mViewer = nullptr;
+
+    mResourceSystem.reset();
 
     delete mEncoder;
     mEncoder = nullptr;

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -165,11 +165,6 @@ namespace MWGui
         if (mMainWidget->getVisible())
             return;
 
-        if (mViewer->getIncrementalCompileOperation())
-        {
-            mViewer->getIncrementalCompileOperation()->setMaximumNumOfObjectsToCompilePerFrame(100);
-        }
-
         // Assign dummy bounding sphere callback to avoid the bounding sphere of the entire scene being recomputed after each frame of loading
         // We are already using node masks to avoid the scene from being updated/rendered, but node masks don't work for computeBound()
         mViewer->getSceneData()->setComputeBoundingSphereCallback(new DontComputeBoundCallback);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -268,6 +268,7 @@ namespace MWRender
         {
             mViewer->setIncrementalCompileOperation(new osgUtil::IncrementalCompileOperation);
             mViewer->getIncrementalCompileOperation()->setTargetFrameRate(Settings::Manager::getFloat("target framerate", "Cells"));
+            mViewer->getIncrementalCompileOperation()->setMaximumNumOfObjectsToCompilePerFrame(100);
         }
 
         mResourceSystem->getSceneManager()->setIncrementalCompileOperation(mViewer->getIncrementalCompileOperation());

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -500,7 +500,12 @@ namespace MWWorld
     }
     void Store<ESM::Land>::setUp()
     {
+        // The land is static for given game session, there is no need to refresh it every load.
+        if (mBuilt)
+            return;
+
         std::sort(mStatic.begin(), mStatic.end(), Compare());
+        mBuilt = true;
     }
 
 

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -247,6 +247,8 @@ namespace MWWorld
 
         RecordId load(ESM::ESMReader &esm);
         void setUp();
+    private:
+        bool mBuilt = false;
     };
 
     template <>

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -353,11 +353,11 @@ namespace ESMTerrain
     std::string Storage::getTextureName(UniqueTextureId id)
     {
         // Goes under used terrain blend transitions
-        static const std::string baseTexture = "textures\\tx_black_01.dds";
+        static constexpr char baseTexture[] = "textures\\tx_black_01.dds";
         if (id.first == -1)
             return baseTexture;
 
-        static const std::string defaultTexture = "textures\\_land_default.dds";
+        static constexpr char defaultTexture[] = "textures\\_land_default.dds";
         if (id.first == 0)
             return defaultTexture; // Not sure if the default texture really is hardcoded?
 

--- a/extern/osg-ffmpeg-videoplayer/videostate.hpp
+++ b/extern/osg-ffmpeg-videoplayer/videostate.hpp
@@ -80,8 +80,8 @@ struct PacketQueue {
 
     AVPacketList *first_pkt, *last_pkt;
     std::atomic<bool> flushing;
-    int nb_packets;
-    int size;
+    std::atomic<int> nb_packets;
+    std::atomic<int> size;
 
     OpenThreads::Mutex mutex;
     OpenThreads::Condition cond;


### PR DESCRIPTION
Summary of changes:
1. Fix possible data race when some threads try to modify a static local string variable.
2. OSG viewer keeps the reference to the WorkQueue, so we actually stop background (e.g. preloading) tasks after we destroy the ResourceManager, which is not right. 
The current solution is to destroy viewer before ResourceManager, so work items will be stopped before resources destroying.
3. We sort data in the Land store every time when we load savegame, but this store is supposed to be static to do not conflict with the global map rendering task ([bug #4844](https://gitlab.com/OpenMW/openmw/issues/4844)).
Since we do not change terrain on the fly, we can just sort data only once during game start before lauch the global map rendering task.
4. Setup a per-frame compile limit for ICO only once during setup (fixes [bug #5025](https://gitlab.com/OpenMW/openmw/issues/5025)). I suppose that initially the limit was designed to be dynamic depending on framerate, but this approach was changed anyway a long time ago.
5. Make integer fields of PacketQueue atomic to avoid data races - this struct is accessed from different threads and we already use atomic for `flushing` field.