### PR TITLE
Armor mitigation tweaks (feature #5033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
     Feature #5000: Compressed BSA format support
     Feature #5010: Native graphics herbalism support
     Feature #5031: Make GetWeaponType function return different values for tools
+    Feature #5033: Magic armor mitigation for creatures
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4721: Add NMake support to the Windows prebuild script

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -401,10 +401,10 @@ namespace MWClass
                     stats.setHitRecovery(true); // Is this supposed to always occur?
             }
 
-            damage = std::max(1.f, damage);
-
             if(ishealth)
             {
+                damage *= damage / (damage + getArmorRating(ptr));
+                damage = std::max(1.f, damage);
                 if (!attacker.isEmpty())
                 {
                     damage = scaleDamage(damage, attacker, ptr);
@@ -597,7 +597,7 @@ namespace MWClass
 
     float Creature::getArmorRating (const MWWorld::Ptr& ptr) const
     {
-        // Note this is currently unused. Creatures do not use armor mitigation.
+        // Equipment armor rating is deliberately ignored.
         return getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::Shield).getMagnitude();
     }
 

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -108,12 +108,6 @@ namespace MWMechanics
             }
         }
 
-        if (enemy.getClass().isNpc())
-        {
-            static const float fCombatArmorMinMult = gmst.find("fCombatArmorMinMult")->mValue.getFloat();
-            rating *= std::max(fCombatArmorMinMult, rating / (rating + enemy.getClass().getArmorRating(enemy)));
-        }
-
         int value = 50.f;
         if (actor.getClass().isNpc())
         {

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -571,8 +571,8 @@ void MWWorld::InventoryStore::autoEquip (const MWWorld::Ptr& actor)
 
     // Autoequip clothing, armor and weapons.
     // Equipping lights is handled in Actors::updateEquippedLight based on environment light.
-    // Note: creatures do not use the armor mitigation and can equip only shields
-    // Use a custom logic for them - select shield based on its health instead of armor rating (since it useless for creatures)
+    // Note: creatures ignore equipment armor rating and only equip shields
+    // Use custom logic for them - select shield based on its health instead of armor rating
     autoEquipWeapon(actor, slots_);
     autoEquipArmor(actor, slots_);
 


### PR DESCRIPTION
1. Don't account for armor rating in weapon priority. It's ultimately not very effective, since enemy armor rating is not actually related to the weapon used and most of the time this would simply reduce physical damage rating by a fixed multiplier, but it has a sometimes noticeable overhead every time an AI attack is done. So it was removed for optimization. For the end user there should be no observable difference.

2. Magic armor mitigation for creatures based on Shield effect magnitude (see [feature request](https://gitlab.com/OpenMW/openmw/issues/5033) for details). I checked up with Hrnchamd on the logic of the (rather miniscule) changes, which was already mostly "implemented".