### PR TITLE
Enchanting window stays open after a failed attempt (feature #5034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
     Feature #5010: Native graphics herbalism support
     Feature #5031: Make GetWeaponType function return different values for tools
     Feature #5033: Magic armor mitigation for creatures
+    Feature #5034: Make enchanting window stay open after a failed attempt
     Feature #5036: Allow scripted faction leaving
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -366,13 +366,19 @@ namespace MWGui
         {
             MWBase::Environment::get().getWindowManager()->playSound("enchant success");
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sEnchantmentMenu12}");
+            MWBase::Environment::get().getWindowManager()->removeGuiMode (GM_Enchanting);
         }
         else
         {
             MWBase::Environment::get().getWindowManager()->playSound("enchant fail");
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage34}");
+            if (!mEnchanting.getGem().isEmpty() && !mEnchanting.getGem().getRefData().getCount())
+            {
+                setSoulGem(MWWorld::Ptr());
+                mEnchanting.nextCastStyle();
+                updateLabels();
+                updateEffectsView();
+            }
         }
-
-        MWBase::Environment::get().getWindowManager()->removeGuiMode (GM_Enchanting);
     }
 }


### PR DESCRIPTION
[See feature request for details](https://gitlab.com/OpenMW/openmw/issues/5034).

I put the GUI mode exit into "enchanting successful" code path. I had to update window some more in the "enchanting unsuccessful" code path to avoid the situation where the soul gem was still present as an item with 0 count in the window. Cast style and magic effects are reset.

Seems to work in my testing.