### PR TITLE
Allow scripted faction leaving using PCLowerRank (feature #5036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
     Feature #5010: Native graphics herbalism support
     Feature #5031: Make GetWeaponType function return different values for tools
     Feature #5033: Magic armor mitigation for creatures
+    Feature #5036: Allow scripted faction leaving
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4721: Add NMake support to the Windows prebuild script

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -85,7 +85,9 @@ void MWMechanics::NpcStats::lowerRank(const std::string &faction)
     std::map<std::string, int>::iterator it = mFactionRank.find(lower);
     if (it != mFactionRank.end())
     {
-        it->second = std::max(0, it->second-1);
+        it->second = it->second-1;
+        if (it->second < 0)
+            mFactionRank.erase(it);
     }
 }
 

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -87,7 +87,10 @@ void MWMechanics::NpcStats::lowerRank(const std::string &faction)
     {
         it->second = it->second-1;
         if (it->second < 0)
+        {
             mFactionRank.erase(it);
+            mExpelled.erase(lower);
+        }
     }
 }
 


### PR DESCRIPTION
[See feature request for details.](https://gitlab.com/OpenMW/openmw/issues/5036)

NpcStats::lowerRank has been adjusted to erase the faction entry from the player faction ranks map if the new rank value is below 0 to imitate the MCP addition.