### PR TITLE
Fix an exception during reload when container windows is active

### DIFF
--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -161,7 +161,8 @@ namespace MWGui
         if (mModel)
             mModel->onClose();
 
-        MWBase::Environment::get().getMechanicsManager()->onClose(mPtr);
+        if (!mPtr.isEmpty())
+            MWBase::Environment::get().getMechanicsManager()->onClose(mPtr);
     }
 
     void ContainerWindow::onCloseButtonClicked(MyGUI::Widget* _sender)


### PR DESCRIPTION
It is a regression in the animated containers feature.