### PR TITLE
Hardcode the correct first person sneaking anim speed (bug #4787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     Bug #4768: Fallback numerical value recovery chokes on invalid arguments
     Bug #4775: Slowfall effect resets player jumping flag
     Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
+    Bug #4787: Sneaking makes 1st person walking/bobbing animation super-slow
     Bug #4797: Player sneaking and running stances are not accounted for when in air
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
     Bug #4803: Stray special characters before begin statement break script compilation

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -549,8 +549,9 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
         mCurrentMovement = movementAnimName;
         if(!mCurrentMovement.empty())
         {
-            bool isrunning = mPtr.getClass().getCreatureStats(mPtr).getStance(MWMechanics::CreatureStats::Stance_Run)
-                    && !MWBase::Environment::get().getWorld()->isFlying(mPtr);
+            bool isflying = MWBase::Environment::get().getWorld()->isFlying(mPtr);
+            bool isrunning = mPtr.getClass().getCreatureStats(mPtr).getStance(MWMechanics::CreatureStats::Stance_Run) && !isflying;
+            bool issneaking = mPtr.getClass().getCreatureStats(mPtr).getStance(MWMechanics::CreatureStats::Stance_Sneak) && !isflying;
 
             // For non-flying creatures, MW uses the Walk animation to calculate the animation velocity
             // even if we are running. This must be replicated, otherwise the observed speed would differ drastically.
@@ -584,7 +585,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
                     // The first person anims don't have any velocity to calculate a speed multiplier from.
                     // We use the third person velocities instead.
                     // FIXME: should be pulled from the actual animation, but it is not presently loaded.
-                    mMovementAnimSpeed = (isrunning ? 222.857f : 154.064f);
+                    mMovementAnimSpeed = (issneaking ? 33.5452f : (isrunning ? 222.857f : 154.064f));
                     mMovementAnimationControlled = false;
                 }
             }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4787)

This is kind of a stopgap solution before Hrnchamd (kudos to him) dives into the mess of the original code and can present more accurate information about how stuff works in Morrowind.exe but it works.

The hardcoded first person animation velocities are only determined for running and walking animations, but not the sneaking animation. So sneaking animation uses much higher anim speed than intended and appears to be very very slow. This fills in the missing link for the time being. I deducted the correct value by putting some debug and determining what was the value for third person animation. :smile: