### PR TITLE
Launcher: Clone content list button (feature #4784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
     Feature #4673: Weapon sheathing
     Feature #4675: Support for NiRollController
     Feature #4730: Native animated containers support
+    Feature #4784: Launcher: Duplicate Content Lists
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch
     Feature #4859: Make water reflections more configurable

--- a/apps/launcher/datafilespage.hpp
+++ b/apps/launcher/datafilespage.hpp
@@ -62,9 +62,11 @@ namespace Launcher
         void slotProfileDeleted(const QString &item);
         void slotAddonDataChanged ();
 
-        void updateOkButton(const QString &text);
+        void updateNewProfileOkButton(const QString &text);
+        void updateCloneProfileOkButton(const QString &text);
 
         void on_newProfileAction_triggered();
+        void on_cloneProfileAction_triggered();
         void on_deleteProfileAction_triggered();
 
     public:
@@ -73,7 +75,8 @@ namespace Launcher
 
     private:
 
-        TextInputDialog *mProfileDialog;
+        TextInputDialog *mNewProfileDialog;
+        TextInputDialog *mCloneProfileDialog;
 
         Files::ConfigurationManager &mCfgMgr;
 

--- a/files/ui/datafilespage.ui
+++ b/files/ui/datafilespage.ui
@@ -2,20 +2,6 @@
 <ui version="4.0">
  <class>DataFilesPage</class>
  <widget class="QWidget" name="DataFilesPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>518</width>
-    <height>108</height>
-   </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
   <property name="contextMenuPolicy">
    <enum>Qt::DefaultContextMenu</enum>
   </property>
@@ -80,15 +66,25 @@
        </widget>
       </item>
       <item>
+       <widget class="QToolButton" name="cloneProfileButton">
+        <property name="toolTip">
+         <string>Clone Content List</string>
+        </property>
+        <property name="text">
+         <string>Clone Content List</string>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QToolButton" name="deleteProfileButton">
         <property name="toolTip">
          <string>Delete Content List</string>
         </property>
         <property name="text">
          <string>Delete Content List</string>
-        </property>
-        <property name="shortcut">
-         <string>Ctrl+D</string>
         </property>
         <property name="autoRaise">
          <bool>true</bool>
@@ -115,6 +111,22 @@
     <string>Ctrl+N</string>
    </property>
   </action>
+  <action name="cloneProfileAction">
+   <property name="icon">
+    <iconset theme="edit-copy">
+     <normaloff/>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>Clone Content List</string>
+   </property>
+   <property name="toolTip">
+    <string>Clone Content List</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+G</string>
+   </property>
+  </action>
   <action name="deleteProfileAction">
    <property name="enabled">
     <bool>false</bool>
@@ -129,6 +141,9 @@
    </property>
    <property name="toolTip">
     <string>Delete Content List</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
    </property>
   </action>
   <action name="checkAction">


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/issues/4784).

Adds a button into the launcher which which allows the user to clone the existing content list under a new name — the name dialog has the same rules as for new content list dialog, i.e. the name is not empty and the content list with the same name doesn't already exist. The created list will have the current file selection as its contents. It will also become the current content list. The action has Ctrl-G keyboard shortcut.