### PR TITLE
Content selector: don't add file namesakes (bug #2395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 
     Bug #1515: Opening console masks dialogue, inventory menu
+    Bug #2395: Duplicated plugins in the launcher when multiple data directories provide the same plugin
     Bug #2969: Scripted items can stack
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3006: 'else if' operator breaks script compilation

--- a/apps/launcher/datafilespage.cpp
+++ b/apps/launcher/datafilespage.cpp
@@ -109,15 +109,14 @@ void Launcher::DataFilesPage::populateFileViews(const QString& contentModelName)
 {
     QStringList paths = mGameSettings.getDataDirs();
 
-    foreach(const QString &path, paths)
-        mSelector->addFiles(path);
-
     mDataLocal = mGameSettings.getDataLocal();
 
     if (!mDataLocal.isEmpty())
-        mSelector->addFiles(mDataLocal);
+        paths.insert(0, mDataLocal);
 
-    paths.insert(0, mDataLocal);
+    foreach(const QString &path, paths)
+        mSelector->addFiles(path);
+
     PathIterator pathIterator(paths);
 
     mSelector->setProfileContent(filesInProfile(contentModelName, pathIterator));

--- a/apps/opencs/editor.cpp
+++ b/apps/opencs/editor.cpp
@@ -28,8 +28,6 @@ CS::Editor::Editor (int argc, char **argv)
 
     mViewManager = new CSVDoc::ViewManager(mDocumentManager);
 
-    setupDataFiles (config.first);
-
     NifOsg::Loader::setShowMarkers(true);
 
     mDocumentManager.setFileData(mFsStrict, config.first, config.second);
@@ -77,15 +75,6 @@ CS::Editor::~Editor ()
     if(mServer && boost::filesystem::exists(mPid))
         static_cast<void> ( // silence coverity warning
         remove(mPid.string().c_str())); // ignore any error
-}
-
-void CS::Editor::setupDataFiles (const Files::PathContainer& dataDirs)
-{
-    for (Files::PathContainer::const_iterator iter = dataDirs.begin(); iter != dataDirs.end(); ++iter)
-    {
-        QString path = QString::fromUtf8 (iter->string().c_str());
-        mFileDialog.addFiles(path);
-    }
 }
 
 std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfig(bool quiet)
@@ -160,7 +149,7 @@ std::pair<Files::PathContainer, std::vector<std::string> > CS::Editor::readConfi
     dataDirs.insert (dataDirs.end(), dataLocal.begin(), dataLocal.end());
 
     //iterate the data directories and add them to the file dialog for loading
-    for (Files::PathContainer::const_iterator iter = dataDirs.begin(); iter != dataDirs.end(); ++iter)
+    for (Files::PathContainer::const_reverse_iterator iter = dataDirs.rbegin(); iter != dataDirs.rend(); ++iter)
     {
         QString path = QString::fromUtf8 (iter->string().c_str());
         mFileDialog.addFiles(path);
@@ -199,8 +188,7 @@ void CS::Editor::createAddon()
     mStartup.hide();
 
     mFileDialog.clearFiles();
-    std::pair<Files::PathContainer, std::vector<std::string> > config = readConfig(/*quiet*/true);
-    setupDataFiles (config.first);
+    readConfig(/*quiet*/true);
 
     mFileDialog.showDialog (CSVDoc::ContentAction_New);
 }
@@ -224,8 +212,7 @@ void CS::Editor::loadDocument()
     mStartup.hide();
 
     mFileDialog.clearFiles();
-    std::pair<Files::PathContainer, std::vector<std::string> > config = readConfig(/*quiet*/true);
-    setupDataFiles (config.first);
+    readConfig(/*quiet*/true);
 
     mFileDialog.showDialog (CSVDoc::ContentAction_Edit);
 }

--- a/apps/opencs/editor.hpp
+++ b/apps/opencs/editor.hpp
@@ -55,8 +55,6 @@ namespace CS
             CSVTools::Merge mMerge;
             CSVDoc::ViewManager* mViewManager;
 
-            void setupDataFiles (const Files::PathContainer& dataDirs);
-
             std::pair<Files::PathContainer, std::vector<std::string> > readConfig(bool quiet=false);
             ///< \return data paths
 

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -408,12 +408,6 @@ bool ContentSelectorModel::ContentModel::dropMimeData(const QMimeData *data, Qt:
 
 void ContentSelectorModel::ContentModel::addFile(EsmFile *file)
 {
-    for (int row = 0; row < mFiles.size(); row++)
-    {
-        if (!mFiles.at(row)->fileName().compare(file->fileName(), Qt::CaseInsensitive))
-            return;
-    }
-
     beginInsertRows(QModelIndex(), mFiles.count(), mFiles.count());
         mFiles.append(file);
     endInsertRows();
@@ -434,7 +428,7 @@ void ContentSelectorModel::ContentModel::addFiles(const QString &path)
     {
         QFileInfo info(dir.absoluteFilePath(path2));
 
-        if (item(info.absoluteFilePath()) != 0)
+        if (item(info.fileName()))
             continue;
 
         try {

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -408,6 +408,17 @@ bool ContentSelectorModel::ContentModel::dropMimeData(const QMimeData *data, Qt:
 
 void ContentSelectorModel::ContentModel::addFile(EsmFile *file)
 {
+    for (int row = 0; row < mFiles.size(); row++)
+    {
+        if (mFiles.at(row)->fileName() == file->fileName())
+        {
+            beginRemoveRows(QModelIndex(), row, row);
+                mFiles.removeAt(row);
+            endRemoveRows();
+            emit dataChanged(index(row, 0), index(mFiles.size(), 0));
+            break;
+        }
+    }
     beginInsertRows(QModelIndex(), mFiles.count(), mFiles.count());
         mFiles.append(file);
     endInsertRows();

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -411,14 +411,9 @@ void ContentSelectorModel::ContentModel::addFile(EsmFile *file)
     for (int row = 0; row < mFiles.size(); row++)
     {
         if (!mFiles.at(row)->fileName().compare(file->fileName(), Qt::CaseInsensitive))
-        {
-            beginRemoveRows(QModelIndex(), row, row);
-                delete mFiles.takeAt(row);
-            endRemoveRows();
-            emit dataChanged(index(row, 0), index(mFiles.size(), 0));
-            break;
-        }
+            return;
     }
+
     beginInsertRows(QModelIndex(), mFiles.count(), mFiles.count());
         mFiles.append(file);
     endInsertRows();

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -410,7 +410,7 @@ void ContentSelectorModel::ContentModel::addFile(EsmFile *file)
 {
     for (int row = 0; row < mFiles.size(); row++)
     {
-        if (mFiles.at(row)->fileName() == file->fileName())
+        if (!mFiles.at(row)->fileName().compare(file->fileName(), Qt::CaseInsensitive))
         {
             beginRemoveRows(QModelIndex(), row, row);
                 mFiles.removeAt(row);

--- a/components/contentselector/model/contentmodel.cpp
+++ b/components/contentselector/model/contentmodel.cpp
@@ -413,7 +413,7 @@ void ContentSelectorModel::ContentModel::addFile(EsmFile *file)
         if (!mFiles.at(row)->fileName().compare(file->fileName(), Qt::CaseInsensitive))
         {
             beginRemoveRows(QModelIndex(), row, row);
-                mFiles.removeAt(row);
+                delete mFiles.takeAt(row);
             endRemoveRows();
             emit dataChanged(index(row, 0), index(mFiles.size(), 0));
             break;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/2395).

Normally we only avoid adding files with the exact same file path into the content file list. To fix the issue, we need to avoid adding files with the same file name into the list. There were more issues, though:

1. The editor doesn't work the same as the launcher in regards to adding files into content selector dialog. It loads files in a direct order while the launcher loads them in a reverse order. So any duplicate dropping would be inconsistent between the two behaviors. I decided to make launcher behavior the main one, since that's the most commonly used behavior.
2. Unlike the test suite and the engine the launcher loaded the local data folder files *after* it loaded the rest of the files (which are in LIFO order) which caused... oddities. Now it has the highest priority and its files are loaded before any other folder to allow the fix to work properly here too.
3. The editor tried to load data folders twice in every instance openmw.cfg was reloaded. There are safeguards in content selector to prevent this from causing issues but it is a waste of CPU cycles.