### PR TITLE
Enhance optimizer to reduce number of drawables

### DIFF
--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -87,13 +87,18 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
         RemoveEmptyNodesVisitor renv(this);
         node->accept(renv);
         renv.removeEmptyNodes();
-
-        RemoveRedundantNodesVisitor rrnv(this);
-        node->accept(rrnv);
-        rrnv.removeRedundantNodes();
-
-        MergeGroupsVisitor mgrp(this);
-        node->accept(mgrp);
+        
+        bool repass = true;
+        while(repass)
+        {   
+            RemoveRedundantNodesVisitor rrnv(this);
+            node->accept(rrnv);
+            repass = !rrnv._redundantNodeList.empty();
+            rrnv.removeRedundantNodes();    
+    
+            MergeGroupsVisitor mgrp(this);
+            node->accept(mgrp);
+        }
     }
 
     if (options & MERGE_GEOMETRY)


### PR DESCRIPTION
add an loop until convergence to redundant free node graph.
It reduces drastically number of drawables and so on FPS