### PR TITLE
Analogue movement fixes

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -703,7 +703,7 @@ namespace MWInput
                     mOverencumberedMessageDelay = 0.f;
                 }
 
-                if (mAlwaysRunActive || isRunning)
+                if ((mAlwaysRunActive && !mJoystickLastUsed) || isRunning)
                     mPlayer->setRunState(!actionIsActive(A_Run));
                 else
                     mPlayer->setRunState(actionIsActive(A_Run));

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1979,24 +1979,24 @@ void CharacterController::update(float duration, bool animationOnly)
         osg::Vec3f rot = cls.getRotationVector(mPtr);
 
         speed = cls.getSpeed(mPtr);
+        float analogueMult = 1.f;
         if(isPlayer)
         {
-            // Joystick anologue movement.
+            // Joystick analogue movement.
             float xAxis = std::abs(cls.getMovementSettings(mPtr).mPosition[0]);
             float yAxis = std::abs(cls.getMovementSettings(mPtr).mPosition[1]);
-            float analogueMovement = ((xAxis > yAxis) ? xAxis : yAxis);
+            analogueMult = ((xAxis > yAxis) ? xAxis : yAxis);
 
             // If Strafing, our max speed is slower so multiply by X axis instead.
             if(std::abs(vec.x()/2.0f) > std::abs(vec.y()))
-                analogueMovement = xAxis;
+                analogueMult = xAxis;
 
             // Due to the half way split between walking/running, we multiply speed by 2 while walking, unless a keyboard was used.
-            if(!isrunning && !sneak && !flying && analogueMovement <= 0.5f)
-                speed *= 2;
-
-            speed *= (analogueMovement);
+            if(!isrunning && !sneak && !flying && analogueMult <= 0.5f)
+                analogueMult *= 2.f;
         }
 
+        speed *= analogueMult;
         vec.x() *= speed;
         vec.y() *= speed;
 
@@ -2063,6 +2063,7 @@ void CharacterController::update(float duration, bool animationOnly)
             }
         }
         fatigueLoss *= duration;
+        fatigueLoss *= analogueMult;
         DynamicStat<float> fatigue = cls.getCreatureStats(mPtr).getFatigue();
 
         if (!godmode)


### PR DESCRIPTION
There were issues gamepad users complained about:
1. Always run setting interfered with analogue movement function. You would have (slow) running animation while moving at roughly walking speed. Apparently Xbox version doesn't have the equivalent of always run so I disabled always run completely on gamepads in favor of analogue movement.
2. Analogue movement didn't affect fatigue loss, so (especially noticeable when combined with the first issue) your fatigue would be consumed as if you were running at full speed even if you didn't really run. So I made analogue movement speed multiplier apply to the running/swimming/sneaking fatigue loss.

The fixes do not need changelog entries.

Edit: independent testing shows that this works as intended.