### PR TITLE
Make SayDone return 1 on the frame speech is started (bug #4879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
     Bug #4867: Arbitrary text after local variable declarations breaks script compilation
     Bug #4876: AI ratings handling inconsistencies
     Bug #4877: Startup script executes only on a new game start
+    Bug #4879: SayDone returns 0 on the frame Say is called
     Bug #4888: Global variable stray explicit reference calls break script compilation
     Bug #4896: Title screen music doesn't loop
     Bug #4902: Using scrollbars in settings causes resolution to change

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -994,6 +994,15 @@ namespace MWSound
 
     void SoundManager::updateSounds(float duration)
     {
+        // We update active say sounds map for specific actors here
+        // because for vanilla compatibility we can't do it immediately.
+        SaySoundMap::iterator queuesayiter = mSaySoundsQueue.begin();
+        while (queuesayiter != mSaySoundsQueue.end())
+        {
+            mActiveSaySounds[queuesayiter->first] = queuesayiter->second;
+            mSaySoundsQueue.erase(queuesayiter++);
+        }
+
         static float timePassed = 0.0;
 
         timePassed += duration;
@@ -1076,14 +1085,7 @@ namespace MWSound
                 ++snditer;
         }
 
-        SaySoundMap::iterator sayiter = mSaySoundsQueue.begin();
-        while (sayiter != mSaySoundsQueue.end())
-        {
-            mActiveSaySounds[sayiter->first] = sayiter->second;
-            mSaySoundsQueue.erase(sayiter++);
-        }
-
-        sayiter = mActiveSaySounds.begin();
+        SaySoundMap::iterator sayiter = mActiveSaySounds.begin();
         while (sayiter != mActiveSaySounds.end())
         {
             MWWorld::ConstPtr ptr = sayiter->first;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -769,7 +769,10 @@ namespace MWSound
             for(SoundBufferRefPair &snd : snditer->second)
                 mOutput->finishSound(snd.first);
         }
-        SaySoundMap::iterator sayiter = mActiveSaySounds.find(ptr);
+        SaySoundMap::iterator sayiter = mSaySoundsQueue.find(ptr);
+        if(sayiter != mSaySoundsQueue.end())
+            mOutput->finishStream(sayiter->second);
+        sayiter = mActiveSaySounds.find(ptr);
         if(sayiter != mActiveSaySounds.end())
             mOutput->finishStream(sayiter->second);
     }
@@ -783,6 +786,12 @@ namespace MWSound
                 for(SoundBufferRefPair &sndbuf : snd.second)
                     mOutput->finishSound(sndbuf.first);
             }
+        }
+
+        for(SaySoundMap::value_type &snd : mSaySoundsQueue)
+        {
+            if(!snd.first.isEmpty() && snd.first != MWMechanics::getPlayer() && snd.first.getCell() == cell)
+                mOutput->finishStream(snd.second);
         }
 
         for(SaySoundMap::value_type &snd : mActiveSaySounds)
@@ -1086,7 +1095,7 @@ namespace MWSound
         }
 
         SaySoundMap::iterator sayiter = mActiveSaySounds.begin();
-        while (sayiter != mActiveSaySounds.end())
+        while(sayiter != mActiveSaySounds.end())
         {
             MWWorld::ConstPtr ptr = sayiter->first;
             Stream *sound = sayiter->second;

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -93,6 +93,7 @@ namespace MWSound
         SoundMap mActiveSounds;
 
         typedef std::map<MWWorld::ConstPtr,Stream*> SaySoundMap;
+        SaySoundMap mSaySoundsQueue;
         SaySoundMap mActiveSaySounds;
 
         typedef std::vector<Stream*> TrackList;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4879).

Hrnchamd stated that SayDone uses the playback marker used for looking up the sound loudness for lip sync to determine whether the sound is being played, and that marker only fires off during the sound system update (which is later than when the scripts are updated) so it will start to return 0 with the following frame — however it will start to return 1 once the sound buffer end is reached no matter what.

I've added a say sound queue map that is copied into the active say sounds map during the sound system update to simulate this behavior.