### PR TITLE
Escape number signs in cell/region names (bug #5047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
     Bug #5025: Data race in the ICO::setMaximumNumOfObjectsToCompilePerFrame()
     Bug #5028: Offered price caps are not trading-specific
     Bug #5038: Enchanting success chance calculations are blatantly wrong
+    Bug #5047: # in cell names sets color
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -345,7 +345,7 @@ namespace MWClass
                     store.get<ESM::Region>().find(cell->mRegion);
 
                 //name as is, not a token
-                return region->mName;
+                return MyGUI::TextIterator::toTagsString(region->mName);
             }
         }
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1184,6 +1184,7 @@ namespace MWGui
         else if (tag.compare(0, tokenLength, tokenToFind) == 0)
         {
             _result = mTranslationDataStorage.translateCellName(tag.substr(tokenLength));
+            _result = MyGUI::TextIterator::toTagsString(_result);
         }
         else if (Gui::replaceTag(tag, _result))
         {


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5047).

I modified onRetrieveTag to escape number signs in localized cell names so that MyGUI doesn't try to parse them as color codes.

Door tooltips use region names as is and don't try to localize them, so that had to be adjusted separately.