### PR TITLE
Log orphan nodes of a pathgrid record in a single message

### DIFF
--- a/apps/opencs/model/tools/pathgridcheck.cpp
+++ b/apps/opencs/model/tools/pathgridcheck.cpp
@@ -120,18 +120,27 @@ void CSMTools::PathgridCheckStage::perform (int stage, CSMDoc::Messages& message
         }
     }
 
+    std::vector<int> orphanList;
     // check pathgrid points that are not connected to anything
     for (unsigned int i = 0; i < pointList.size(); ++i)
     {
         if (pointList[i].mConnectionNum == 0)
+            orphanList.emplace_back(i);
+    }
+
+    if (!orphanList.empty())
+    {
+        std::string message;
+        if (orphanList.size() == 1)
+            message = "Point #" + std::to_string(orphanList.front()) + " is not connected to any other point";
+        else
         {
-            std::ostringstream ss;
-            ss << "Point #" << i << " ("
-            << pathgrid.mPoints[i].mX << ", "
-            << pathgrid.mPoints[i].mY << ", "
-            << pathgrid.mPoints[i].mZ << ") is disconnected from other points";
-            messages.add (id, ss.str(), "", CSMDoc::Message::Severity_Warning);
+            message = "Points #" + std::to_string(orphanList.front());
+            for (std::vector<int>::const_iterator i = orphanList.begin()+1; i != orphanList.end(); i++)
+                message += ", #" + std::to_string(*i);
+            message += " are not connected to any other point";
         }
+        messages.add (id, message, "", CSMDoc::Message::Severity_Warning);
     }
 
     // TODO: check whether there are disconnected graphs


### PR DESCRIPTION
Slightly improves pathgrid verifier. It's by far one of the least useful verifiers but its messages take the most space in the results, so I had an idea to mitigate this by logging orphan nodes in a single pathgrid record in a single message. Some pathgrid records in Bethesda files have a lot of orphan nodes.

I reworded the message for the issue to be more obvious. The message also logged the path point coordinates, which I dropped because it too is frankly useless — the important information the message conveys is that the point is not connected to anything, the point being located in a specific place is not important.

Now you'll see this instead of having 8 separate messages being dumped on you.
![single message](https://user-images.githubusercontent.com/21265616/58518774-3df65f00-81b9-11e9-8460-6236f7f86a49.png)
