### PR TITLE
Make console to do not hide other GUI windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.46.0
 ------
 
+    Bug #1515: Opening console masks dialogue, inventory menu
     Bug #2969: Scripted items can stack
     Bug #2987: Editor: some chance and AI data fields can overflow
     Bug #3006: 'else if' operator breaks script compilation

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -333,6 +333,7 @@ namespace MWBase
             virtual void activateHitOverlay(bool interrupt=true) = 0;
             virtual void setWerewolfOverlay(bool set) = 0;
 
+            virtual void toggleConsole() = 0;
             virtual void toggleDebugWindow() = 0;
 
             /// Cycle to next or previous spell

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -2,6 +2,7 @@
 
 #include <MyGUI_EditBox.h>
 #include <MyGUI_InputManager.h>
+#include <MyGUI_LayerManager.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -151,8 +152,9 @@ namespace MWGui
     void Console::onOpen()
     {
         // Give keyboard focus to the combo box whenever the console is
-        // turned on
+        // turned on and place it over other widgets
         MyGUI::InputManager::getInstance().setKeyFocusWidget(mCommandLine);
+        MyGUI::LayerManager::getInstance().upLayerItem(mMainWidget);
     }
 
     void Console::print(const std::string &msg, const std::string& color)

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -234,6 +234,7 @@ namespace MWGui
         if (!MWBase::Environment::get().getWindowManager ()->isGuiMode ())
             return;
 
+        MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
         if (mDragAndDrop->mIsOnDragAndDrop)
         {
             // drop item into the gameworld
@@ -248,24 +249,24 @@ namespace MWGui
             WorldItemModel drop (mouseX, mouseY);
             mDragAndDrop->drop(&drop, nullptr);
 
-            MWBase::Environment::get().getWindowManager()->changePointer("arrow");
+            winMgr->changePointer("arrow");
         }
         else
         {
-            GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
+            GuiMode mode = winMgr->getMode();
 
-            if ( (mode != GM_Console) && (mode != GM_Container) && (mode != GM_Inventory) )
+            if (!winMgr->isConsoleMode() && (mode != GM_Container) && (mode != GM_Inventory))
                 return;
 
             MWWorld::Ptr object = MWBase::Environment::get().getWorld()->getFacedObject();
 
-            if (mode == GM_Console)
-                MWBase::Environment::get().getWindowManager()->setConsoleSelectedObject(object);
+            if (winMgr->isConsoleMode())
+                winMgr->setConsoleSelectedObject(object);
             else //if ((mode == GM_Container) || (mode == GM_Inventory))
             {
                 // pick up object
                 if (!object.isEmpty())
-                    MWBase::Environment::get().getWindowManager()->getInventoryWindow()->pickUpObject(object);
+                    winMgr->getInventoryWindow()->pickUpObject(object);
             }
         }
     }

--- a/apps/openmw/mwgui/mode.hpp
+++ b/apps/openmw/mwgui/mode.hpp
@@ -12,7 +12,6 @@ namespace MWGui
       GM_Companion,
       GM_MainMenu,      // Main menu mode
 
-      GM_Console,       // Console mode
       GM_Journal,       // Journal mode
 
       GM_Scroll,        // Read scroll

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -94,17 +94,19 @@ namespace MWGui
             return;
         }
 
-        bool guiMode = MWBase::Environment::get().getWindowManager()->isGuiMode();
+        MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
+        bool guiMode = winMgr->isGuiMode();
 
         if (guiMode)
         {
-            if (!MWBase::Environment::get().getWindowManager()->getCursorVisible())
+            if (!winMgr->getCursorVisible())
                 return;
             const MyGUI::IntPoint& mousePos = MyGUI::InputManager::getInstance().getMousePosition();
 
-            if (MWBase::Environment::get().getWindowManager()->getWorldMouseOver() && ((MWBase::Environment::get().getWindowManager()->getMode() == GM_Console)
-                || (MWBase::Environment::get().getWindowManager()->getMode() == GM_Container)
-                || (MWBase::Environment::get().getWindowManager()->getMode() == GM_Inventory)))
+            if (winMgr->getWorldMouseOver() &&
+                (winMgr->isConsoleMode() ||
+                (winMgr->getMode() == GM_Container) ||
+                (winMgr->getMode() == GM_Inventory)))
             {
                 if (mFocusObject.isEmpty ())
                     return;
@@ -112,7 +114,7 @@ namespace MWGui
                 const MWWorld::Class& objectclass = mFocusObject.getClass();
 
                 MyGUI::IntSize tooltipSize;
-                if ((!objectclass.hasToolTip(mFocusObject))&&(MWBase::Environment::get().getWindowManager()->getMode() == GM_Console))
+                if (!objectclass.hasToolTip(mFocusObject) && winMgr->isConsoleMode())
                 {
                     setCoord(0, 0, 300, 300);
                     mDynamicToolTipBox->setVisible(true);
@@ -212,7 +214,7 @@ namespace MWGui
                 {
                     MyGUI::IntCoord avatarPos = focus->getAbsoluteCoord();
                     MyGUI::IntPoint relMousePos = MyGUI::InputManager::getInstance ().getMousePosition () - MyGUI::IntPoint(avatarPos.left, avatarPos.top);
-                    MWWorld::Ptr item = MWBase::Environment::get().getWindowManager()->getInventoryWindow ()->getAvatarSelectedItem (relMousePos.left, relMousePos.top);
+                    MWWorld::Ptr item = winMgr->getInventoryWindow ()->getAvatarSelectedItem (relMousePos.left, relMousePos.top);
 
                     mFocusObject = item;
                     if (!mFocusObject.isEmpty ())

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -361,6 +361,7 @@ namespace MWGui
     virtual void activateHitOverlay(bool interrupt);
     virtual void setWerewolfOverlay(bool set);
 
+    virtual void toggleConsole();
     virtual void toggleDebugWindow();
 
     /// Cycle to next or previous spell

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -495,7 +495,7 @@ namespace MWInput
     void InputManager::updateCursorMode()
     {
         bool grab = !MWBase::Environment::get().getWindowManager()->containsMode(MWGui::GM_MainMenu)
-             && MWBase::Environment::get().getWindowManager()->getMode() != MWGui::GM_Console;
+             && !MWBase::Environment::get().getWindowManager()->isConsoleMode();
 
         bool was_relative = mInputManager->getMouseRelative();
         bool is_relative = !MWBase::Environment::get().getWindowManager()->isGuiMode();
@@ -864,7 +864,7 @@ namespace MWInput
         OIS::KeyCode kc = mInputManager->sdl2OISKeyCode(arg.keysym.sym);
         if (mInputBinder->getKeyBinding(mInputBinder->getControl(A_Console), ICS::Control::INCREASE)
                 == arg.keysym.scancode
-                && MWBase::Environment::get().getWindowManager()->getMode() == MWGui::GM_Console)
+                && MWBase::Environment::get().getWindowManager()->isConsoleMode())
             SDL_StopTextInput();
 
         bool consumed = false;
@@ -1152,6 +1152,9 @@ namespace MWInput
             return;
         }
 
+        if (MWBase::Environment::get().getWindowManager()->isConsoleMode())
+            return;
+
         bool inGame = MWBase::Environment::get().getStateManager()->getState() != MWBase::StateManager::State_NoGame;
         MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
 
@@ -1169,6 +1172,9 @@ namespace MWInput
             MWBase::Environment::get().getWindowManager()->exitCurrentModal();
             return;
         }
+
+        if (MWBase::Environment::get().getWindowManager()->isConsoleMode())
+            return;
 
         MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
         bool inGame = MWBase::Environment::get().getStateManager()->getState() != MWBase::StateManager::State_NoGame;
@@ -1284,6 +1290,9 @@ namespace MWInput
         if (MyGUI::InputManager::getInstance ().isModalAny())
             return;
 
+        if (MWBase::Environment::get().getWindowManager()->isConsoleMode())
+            return;
+
         // Toggle between game mode and inventory mode
         if(!MWBase::Environment::get().getWindowManager()->isGuiMode())
             MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Inventory);
@@ -1302,17 +1311,7 @@ namespace MWInput
         if (MyGUI::InputManager::getInstance ().isModalAny())
             return;
 
-        // Switch to console mode no matter what mode we are currently
-        // in, except of course if we are already in console mode
-        if (MWBase::Environment::get().getWindowManager()->isGuiMode())
-        {
-            if (MWBase::Environment::get().getWindowManager()->getMode() == MWGui::GM_Console)
-                MWBase::Environment::get().getWindowManager()->popGuiMode();
-            else
-                MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Console);
-        }
-        else
-            MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Console);
+        MWBase::Environment::get().getWindowManager()->toggleConsole();
     }
 
     void InputManager::toggleJournal()

--- a/files/mygui/openmw_console.layout
+++ b/files/mygui/openmw_console.layout
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <MyGUI type="Layout">
-  <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Console" name="_Main">
+  <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Windows" name="_Main">
     <Property key="Caption" value="#{sConsoleTitle}"/>
     <Property key="MinSize" value="40 40"/>
     <Property key="Visible" value="false"/>

--- a/files/mygui/openmw_layers.xml
+++ b/files/mygui/openmw_layers.xml
@@ -10,7 +10,6 @@
     <Layer name="JournalBooks" type="ScalingLayer" pick="true">
         <Property key="Size" value="600 520"/>
     </Layer>
-    <Layer name="Console" overlapped="false" pick="true"/>
     <Layer name="Debug" overlapped="true" pick="true"/>
     <Layer name="Notification" overlapped="false" pick="false"/>
     <Layer name="Popup" overlapped="true" pick="true"/>


### PR DESCRIPTION
Fixes [bug #1515](https://gitlab.com/OpenMW/openmw/issues/1515).

The main idea is to handle console window separately, not as a part of GUI modes stack.
The console window becomes nearly unusable with transparent UI, but Morrowind has the same issue. 
This PR should be enough to close this ticket, despite there are some minor derivations from Morrowind:
1. I still hide pinned windows when opening console, otherwise it will be unusable with a semi-transparent UI as well.
2. I restore focus to the console when closing a background window.
3. I do not allow to exit a main menu or inventory directly while the console window is visible - it leads to weird effects with both OpenMW and Morrowind.