### PR TITLE
Improve info message about missing GDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     Bug #3778: [Mod] Improved Thrown Weapon Projectiles - weapons have wrong transformation during throw animation
     Bug #3812: Wrong multiline tooltips width when word-wrapping is enabled
     Bug #4329: Removed birthsign abilities are restored after reloading the save
+    Bug #4341: Error message about missing GDB is too vague
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons
     Bug #4411: Reloading a saved game while falling prevents damage in some cases

--- a/components/crashcatcher/crashcatcher.cpp
+++ b/components/crashcatcher/crashcatcher.cpp
@@ -176,7 +176,8 @@ static void gdb_info(pid_t pid)
         int ret = system(cmd_buf);
 
         if (ret != 0)
-            printf("\nFailed to create a crash report. Please install 'gdb' and crash again!\n");
+            printf("\nFailed to create a crash report. Please make sure that 'gdb' is installed and present in PATH then crash again."
+                   "\nCurrent PATH: %s\n", getenv("PATH"));
         fflush(stdout);
 
         /* Clean up */


### PR DESCRIPTION
Attempt to fix [bug #4341](https://gitlab.com/OpenMW/openmw/issues/4341#).

Currently OpenMW claims GDB to be not istalled when fails to find it. It does not handle case when GDB is installed, but located in directory which is not listed in PATH environmental variable.

An old message:
```
Failed to create a crash report. Please install 'gdb' and crash again!
```

A new message:
```
Failed to create a crash report - 'gdb' is not found.
Make sure that it is installed and located in directory, listed in your PATH environmental variable.
The current PATH variable value: /sbin:/usr/sbin:/usr/lib/llvm/6/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/opt/bin
```

Additionally if GDB location is known on MacOS, we can add its location to PATH. @nikolaykasyanov, what do you think?
