### PR TITLE
Make framerate limit configurable in the launcher

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -128,10 +128,6 @@ bool Launcher::GraphicsPage::loadSettings()
         framerateLimitCheckBox->setCheckState(Qt::Checked);
         framerateLimitSpinBox->setValue(fpsLimit);
     }
-    else
-    {
-        framerateLimitSpinBox->setEnabled(false);
-    }
 
     return true;
 }

--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -44,6 +44,7 @@ Launcher::GraphicsPage::GraphicsPage(Files::ConfigurationManager &cfg, Settings:
     connect(fullScreenCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotFullScreenChanged(int)));
     connect(standardRadioButton, SIGNAL(toggled(bool)), this, SLOT(slotStandardToggled(bool)));
     connect(screenComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(screenChanged(int)));
+    connect(framerateLimitCheckBox, SIGNAL(toggled(bool)), this, SLOT(slotFramerateLimitToggled(bool)));
 
 }
 
@@ -121,6 +122,17 @@ bool Launcher::GraphicsPage::loadSettings()
         customHeightSpinBox->setValue(height);
     }
 
+    float fpsLimit = mEngineSettings.getFloat("framerate limit", "Video");
+    if (fpsLimit != 0)
+    {
+        framerateLimitCheckBox->setCheckState(Qt::Checked);
+        framerateLimitSpinBox->setValue(fpsLimit);
+    }
+    else
+    {
+        framerateLimitSpinBox->setEnabled(false);
+    }
+
     return true;
 }
 
@@ -166,6 +178,17 @@ void Launcher::GraphicsPage::saveSettings()
     int cScreen = screenComboBox->currentIndex();
     if (cScreen != mEngineSettings.getInt("screen", "Video"))
         mEngineSettings.setInt("screen", "Video", cScreen);
+
+    if (framerateLimitCheckBox->checkState())
+    {
+        float cFpsLimit = framerateLimitSpinBox->value();
+        if (cFpsLimit != mEngineSettings.getFloat("framerate limit", "Video"))
+            mEngineSettings.setFloat("framerate limit", "Video", cFpsLimit);
+    }
+    else if (mEngineSettings.getFloat("framerate limit", "Video") != 0)
+    {
+        mEngineSettings.setFloat("framerate limit", "Video", 0);
+    }
 }
 
 QStringList Launcher::GraphicsPage::getAvailableResolutions(int screen)
@@ -265,4 +288,9 @@ void Launcher::GraphicsPage::slotStandardToggled(bool checked)
         customWidthSpinBox->setEnabled(true);
         customHeightSpinBox->setEnabled(true);
     }
+}
+
+void Launcher::GraphicsPage::slotFramerateLimitToggled(bool checked)
+{
+    framerateLimitSpinBox->setEnabled(checked);
 }

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -31,6 +31,7 @@ namespace Launcher
     private slots:
         void slotFullScreenChanged(int state);
         void slotStandardToggled(bool checked);
+        void slotFramerateLimitToggled(bool checked);
 
     private:
         Files::ConfigurationManager &mCfgMgr;

--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -30,8 +30,8 @@ namespace Fallback
         {
             try
             {
-                // We have to rely on Boost because std::stof from C++11
-                // uses the current locale for separators which we don't want and often silently ignores parsing errors.
+                // We have to rely on Boost because std::stof from C++11 uses the current locale
+                // for separators (which is undesired) and it often silently ignores parsing errors.
                 return boost::lexical_cast<float>(fallback);
             }
             catch (boost::bad_lexical_cast&)

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -355,8 +355,8 @@ float Manager::getFloat (const std::string& setting, const std::string& category
     const std::string value = getString(setting, category);
     try
     {
-        // We have to rely on Boost because std::stof from C++11
-        // uses the current locale for separators which we don't want and often silently ignores parsing errors.
+        // We have to rely on Boost because std::stof from C++11 uses the current locale
+        // for separators (which is undesired) and it often silently ignores parsing errors.
         return boost::lexical_cast<float>(value);
     }
     catch (boost::bad_lexical_cast&)

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/filesystem/fstream.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 
 namespace Settings
 {
@@ -354,12 +355,14 @@ float Manager::getFloat (const std::string& setting, const std::string& category
     const std::string value = getString(setting, category);
     try
     {
-        return std::stof(value);
+        // We have to rely on Boost because std::stof from C++11
+        // uses the current locale for separators which we don't want and often silently ignores parsing errors.
+        return boost::lexical_cast<float>(value);
     }
-    catch(const std::exception& e)
+    catch (boost::bad_lexical_cast&)
     {
         Log(Debug::Warning) << "Cannot parse setting '" << setting << "' (invalid setting value: " << value << ").";
-        return 0;
+        return 0.f;
     }
 }
 
@@ -401,12 +404,16 @@ void Manager::setString(const std::string &setting, const std::string &category,
 
 void Manager::setInt (const std::string& setting, const std::string& category, const int value)
 {
-    setString(setting, category, std::to_string(value));
+    std::ostringstream stream;
+    stream << value;
+    setString(setting, category, stream.str());
 }
 
 void Manager::setFloat (const std::string &setting, const std::string &category, const float value)
 {
-    setString(setting, category, std::to_string(value));
+    std::ostringstream stream;
+    stream << value;
+    setString(setting, category, stream.str());
 }
 
 void Manager::setBool(const std::string &setting, const std::string &category, const bool value)

--- a/files/ui/graphicspage.ui
+++ b/files/ui/graphicspage.ui
@@ -34,7 +34,7 @@
       <item row="2" column="0">
        <widget class="QCheckBox" name="windowBorderCheckBox">
         <property name="text">
-         <string>Window border</string>
+         <string>Window Border</string>
         </property>
        </widget>
       </item>
@@ -65,7 +65,7 @@
       <item row="6" column="0">
        <widget class="QCheckBox" name="framerateLimitCheckBox">
         <property name="text">
-         <string>Framerate limit</string>
+         <string>Framerate Limit:</string>
         </property>
        </widget>
       </item>
@@ -152,6 +152,9 @@
       </item>
       <item row="6" column="1">
        <widget class="QDoubleSpinBox" name="framerateLimitSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="suffix">
          <string> FPS</string>
         </property>
@@ -162,7 +165,7 @@
          <double>1</double>
         </property>
         <property name="maximum">
-         <double>999</double>
+         <double>1000</double>
         </property>
         <property name="singleStep">
          <double>15</double>

--- a/files/ui/graphicspage.ui
+++ b/files/ui/graphicspage.ui
@@ -62,6 +62,13 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="framerateLimitCheckBox">
+        <property name="text">
+         <string>Framerate limit</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <widget class="QComboBox" name="antiAliasingComboBox">
         <item>
@@ -142,6 +149,28 @@
          <widget class="QComboBox" name="resolutionComboBox"/>
         </item>
        </layout>
+      </item>
+      <item row="6" column="1">
+       <widget class="QDoubleSpinBox" name="framerateLimitSpinBox">
+        <property name="suffix">
+         <string> FPS</string>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="minimum">
+         <double>1</double>
+        </property>
+        <property name="maximum">
+         <double>999</double>
+        </property>
+        <property name="singleStep">
+         <double>15</double>
+        </property>
+        <property name="value">
+         <double>300</double>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Because apparently if you want something to be done right, you must do it yourself, I made framerate limit configurable in the launcher, with the range being 1-1000 and the "default" value being 300. The actual default value of the setting wasn't changed, so the limit will appear to be disabled by default.
It's a QDoubleSpinBox because the setting has a floating point value type. I decided to have 1 decimal precision for the value.

Settings manager was made locale-independent again (after akortunov's changes in January), being locale-dependent was a real issue in the launcher since the changed values were using wrong separators on my Russian locale system at least so the engine couldn't recover them properly. get methods work like in the fallback manager while set methods use string streams again. This isn't necessarily bad — now they always use the correct separators and only have significant digits included without trailing zeroes and will be properly loaded in both the Qt-based apps and the engine.

Yes, this means that getFloat is going to be using boost::lexical_cast. I don't believe there's a good way around it. Lexical cast works best for the purpose and it's best to be consistent between different config managers.

If this is merged the *cough* discussions on what the default framerate limit should be can proceed.