### PR TITLE
Improve face shielding behavior in general case (bug #4240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     Bug #3765: DisableTeleporting makes Mark/Recall/Intervention effects undetectable
     Bug #3778: [Mod] Improved Thrown Weapon Projectiles - weapons have wrong transformation during throw animation
     Bug #3812: Wrong multiline tooltips width when word-wrapping is enabled
+    Bug #4240: Ash storm origin coordinates and hand shielding animation behavior are incorrect
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -710,10 +710,9 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
     if (mIsStorm)
     {
         osg::Vec3f playerPos (player.getRefData().getPosition().asVec3());
-        osg::Vec3f redMountainPos (19950, 72032, 27831);
-
+        playerPos.z() = 0;
+        osg::Vec3f redMountainPos (25000, 70000, 0);
         mStormDirection = (playerPos - redMountainPos);
-        mStormDirection.z() = 0;
         mStormDirection.normalize();
         mRendering.getSkyManager()->setStormDirection(mStormDirection);
     }


### PR DESCRIPTION
While this doesn't fix wind velocity and direction calculations (meaning broken blizzard behavior is unchanged), it addresses the concerns of the reporter of [the issue](https://gitlab.com/OpenMW/openmw/issues/4240).

1. Red Mountain as ash storm/blight storm origin hardcoded position was corrected. The relevant code must be completely rewritten, but I kept the changes minimal for now.
2. Storm idle state handling was rewritten with Hrnchamd's research in mind. Instead of stopping the animation almost immediately if the current conditions don't fit the conditions of animation playback, only its looping is disabled. The animation playback itself makes a bit more sense too.