### PR TITLE
Make sure fade operations properly end (bug #4639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4540: Rain delay when exiting water
+    Bug #4639: Black screen after completing first mages guild mission + training
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4703: Editor: it's possible to preview levelled list records
     Bug #4705: Editor: unable to open exterior cell views from Instances table

--- a/apps/openmw/mwgui/screenfader.cpp
+++ b/apps/openmw/mwgui/screenfader.cpp
@@ -38,8 +38,16 @@ namespace MWGui
         if (!mRunning)
             return;
 
-        if (mRemainingTime <= 0 || mStartAlpha == mTargetAlpha)
+        if (mStartAlpha == mTargetAlpha)
         {
+            finish();
+            return;
+        }
+
+        if (mRemainingTime <= 0)
+        {
+            // Make sure the target alpha is applied
+            mFader->notifyAlphaChanged(mTargetAlpha);
             finish();
             return;
         }
@@ -162,7 +170,7 @@ namespace MWGui
         if (time < 0.f)
             return;
 
-        if (time == 0.f)
+        if (time == 0.f && delay == 0.f)
         {
             mCurrentAlpha = targetAlpha;
             applyAlpha();


### PR DESCRIPTION
Due to various reasons fader may not properly update the alpha, and when it happens to be too late to update it (for example, if the game was minimized and the GUI updates were paused for the time of the fade operation) fade operation will not finish properly and the alpha will remain whatever it was in the frame before the fade operation was finished.

I added a safe guard for the case it happens so if there's no time to finish the fade operation the final target alpha is set anyway just in case it's not equal to the current alpha (if the alpha is the same there won't be any difference from the current behavior because notifyAlphaChanged early-outs).

Also I fixed a erroneous check in fade operation queueing: non-zero delay was ignored if the fade operation was planned to be immediate.

The easiest way to trigger the [original issue](https://gitlab.com/OpenMW/openmw/issues/4639) in my experience is to minimize the game while the training fade in hasn't been finished and wait for some seconds before going back in. These changes fix the resulting black screen.