### PR TITLE
Use 2D distance for fight rating of vertically moving actors (bug #4961)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
     Bug #4945: Poor random magic magnitude distribution
     Bug #4947: Player character doesn't use lip animation
     Bug #4948: Footstep sounds while levitating on ground level
+    Bug #4961: Flying creature combat engagement takes z-axis into account
     Bug #4963: Enchant skill progress is incorrect
     Bug #4964: Multiple effect spell projectile sounds play louder than vanilla
     Bug #4965: Global light attenuation settings setup is lacking

--- a/apps/openmw/mwmechanics/actorutil.cpp
+++ b/apps/openmw/mwmechanics/actorutil.cpp
@@ -3,6 +3,7 @@
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 
+#include "../mwworld/class.hpp"
 #include "../mwworld/player.hpp"
 
 namespace MWMechanics
@@ -15,5 +16,11 @@ namespace MWMechanics
     bool isPlayerInCombat()
     {
         return MWBase::Environment::get().getWorld()->getPlayer().isInCombat();
+    }
+
+    bool canActorMoveByZAxis(const MWWorld::Ptr& actor)
+    {
+        MWBase::World* world = MWBase::Environment::get().getWorld();
+        return (actor.getClass().canSwim(actor) && world->isSwimming(actor)) || world->isFlying(actor);
     }
 }

--- a/apps/openmw/mwmechanics/actorutil.hpp
+++ b/apps/openmw/mwmechanics/actorutil.hpp
@@ -10,6 +10,7 @@ namespace MWMechanics
 {
     MWWorld::Ptr getPlayer();
     bool isPlayerInCombat();
+    bool canActorMoveByZAxis(const MWWorld::Ptr& actor);
 }
 
 #endif

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -402,9 +402,3 @@ DetourNavigator::Flags MWMechanics::AiPackage::getNavigatorFlags(const MWWorld::
 
     return result;
 }
-
-bool MWMechanics::AiPackage::canActorMoveByZAxis(const MWWorld::Ptr& actor) const
-{
-    MWBase::World* world = MWBase::Environment::get().getWorld();
-    return (actor.getClass().canSwim(actor) && world->isSwimming(actor)) || world->isFlying(actor) || !world->isActorCollisionEnabled(actor);
-}

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -130,8 +130,6 @@ namespace MWMechanics
 
             DetourNavigator::Flags getNavigatorFlags(const MWWorld::Ptr& actor) const;
 
-            bool canActorMoveByZAxis(const MWWorld::Ptr& actor) const;
-
             // TODO: all this does not belong here, move into temporary storage
             PathFinder mPathFinder;
             ObstacleCheck mObstacleCheck;

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -215,11 +215,7 @@ namespace MWMechanics
             getAllowedNodes(actor, currentCell->getCell(), storage);
         }
 
-        bool actorCanMoveByZ = (actor.getClass().canSwim(actor) && MWBase::Environment::get().getWorld()->isSwimming(actor))
-            || MWBase::Environment::get().getWorld()->isFlying(actor)
-            || !MWBase::Environment::get().getWorld()->isActorCollisionEnabled(actor);
-
-        if(actorCanMoveByZ && mDistance > 0) {
+        if (canActorMoveByZAxis(actor) && mDistance > 0) {
             // Typically want to idle for a short time before the next wander
             if (Misc::Rng::rollDice(100) >= 92 && storage.mState != AiWanderStorage::Wander_Walking) {
                 wanderNearStart(actor, storage, mDistance);

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -475,6 +475,11 @@ namespace MWMechanics
     {
         osg::Vec3f pos1 (actor1.getRefData().getPosition().asVec3());
         osg::Vec3f pos2 (actor2.getRefData().getPosition().asVec3());
+        if (canActorMoveByZAxis(actor2))
+        {
+            pos1.z() = 0.f;
+            pos2.z() = 0.f;
+        }
 
         float d = (pos1 - pos2).length();
 


### PR DESCRIPTION
For actors that can move vertically (normally flying or swimming creatures), fight distance bias are based on 2D positions of the actors that are about to fight discarding the Z component. Should resolve [the relevant bug report](https://gitlab.com/OpenMW/openmw/issues/4961).

actor2 is checked because that's the actor about to engage in combat.