### PR TITLE
Make Player->Cast select the spell instead (bug #5056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
     Bug #5038: Enchanting success chance calculations are blatantly wrong
     Bug #5047: # in cell names sets color
     Bug #5050: Invalid spell effects are not handled gracefully
+    Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5056).

Now instead of casting the spell without any animation (and potentially into an arbitrary direction) such a call will instead make the spell be chosen as if it were in the spell window but won't be added as an actual spell into the player's spellbook.

I corrected broken check for the spell being non-existent (which would cause an exception in a script that tries to cast such a spell) and slightly improved the warnings.