### PR TITLE
Use NiSwitchNode initial index field

### DIFF
--- a/components/nif/node.hpp
+++ b/components/nif/node.hpp
@@ -238,10 +238,12 @@ struct NiRotatingParticles : Node
 // A node used as the base to switch between child nodes, such as for LOD levels.
 struct NiSwitchNode : public NiNode
 {
+    unsigned int initialIndex;
+
     void read(NIFStream *nif)
     {
         NiNode::read(nif);
-        nif->getInt(); // unknown
+        initialIndex = nif->getUInt();
     }
 };
 

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -629,10 +629,8 @@ namespace NifOsg
 
             if (nifNode->recType == Nif::RC_NiSwitchNode)
             {
-                // show only first child by default
-                node->asSwitch()->setSingleChildOn(0);
-
                 const Nif::NiSwitchNode* niSwitchNode = static_cast<const Nif::NiSwitchNode*>(nifNode);
+                node->asSwitch()->setSingleChildOn(niSwitchNode->initialIndex);
                 if (niSwitchNode->name == Constants::NightDayLabel && !SceneUtil::hasUserDescription(rootNode, Constants::NightDayLabel))
                     rootNode->getOrCreateUserDataContainer()->addDescription(Constants::NightDayLabel);
                 else if (niSwitchNode->name == Constants::HerbalismLabel && !SceneUtil::hasUserDescription(rootNode, Constants::HerbalismLabel))


### PR DESCRIPTION
According to Hrnchamd the numerical value is the index of the initial switch node state expressed in an unsigned integer.