### PR TITLE
Partially revert "Get rid of redundant setKeyFocusWidget() method"

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -289,6 +289,9 @@ namespace MWBase
 
             virtual const Translation::Storage& getTranslationDataStorage() const = 0;
 
+            /// Warning: do not use MyGUI::InputManager::setKeyFocusWidget directly. Instead use this.
+            virtual void setKeyFocusWidget (MyGUI::Widget* widget) = 0;
+
             virtual void loadUserFonts() = 0;
 
             virtual Loading::Listener* getLoadingScreen() = 0;

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -5,7 +5,6 @@
 #include <MyGUI_EditBox.h>
 #include <MyGUI_ControllerManager.h>
 #include <MyGUI_ControllerRepeatClick.h>
-#include <MyGUI_InputManager.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -169,7 +168,7 @@ namespace MWGui
 
         update();
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mNameEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mNameEdit);
     }
 
     void AlchemyWindow::onIngredientSelected(MyGUI::Widget* _sender)

--- a/apps/openmw/mwgui/birth.cpp
+++ b/apps/openmw/mwgui/birth.cpp
@@ -4,7 +4,6 @@
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_Gui.h>
 #include <MyGUI_ScrollView.h>
-#include <MyGUI_InputManager.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -72,7 +71,7 @@ namespace MWGui
         WindowModal::onOpen();
         updateBirths();
         updateSpells();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mBirthList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mBirthList);
 
         // Show the current birthsign by default
         const std::string &signId =

--- a/apps/openmw/mwgui/bookwindow.cpp
+++ b/apps/openmw/mwgui/bookwindow.cpp
@@ -101,7 +101,7 @@ namespace MWGui
 
         setTakeButtonShow(showTakeButton);
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mCloseButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
     }
 
     void BookWindow::setTakeButtonShow(bool show)
@@ -161,9 +161,9 @@ namespace MWGui
         mPrevPageButton->setVisible(prevPageVisible);
 
         if (focus == mNextPageButton && !nextPageVisible && prevPageVisible)
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mPrevPageButton);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mPrevPageButton);
         else if (focus == mPrevPageButton && !prevPageVisible && nextPageVisible)
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mNextPageButton);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mNextPageButton);
 
         if (mPages.empty())
             return;

--- a/apps/openmw/mwgui/class.cpp
+++ b/apps/openmw/mwgui/class.cpp
@@ -3,7 +3,6 @@
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_ListBox.h>
 #include <MyGUI_Gui.h>
-#include <MyGUI_InputManager.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -136,7 +135,7 @@ namespace MWGui
         WindowModal::onOpen ();
         updateClasses();
         updateStats();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mClassList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mClassList);
 
         // Show the current class by default
         MWWorld::Ptr player = MWMechanics::getPlayer();
@@ -437,7 +436,7 @@ namespace MWGui
         getWidget(mEditName, "EditName");
 
         // Make sure the edit box has focus
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mEditName);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mEditName);
 
         MyGUI::Button* descriptionButton;
         getWidget(descriptionButton, "DescriptionButton");
@@ -903,7 +902,7 @@ namespace MWGui
         okButton->setCaption(MWBase::Environment::get().getWindowManager()->getGameSettingString("sInputMenu1", ""));
 
         // Make sure the edit box has focus
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mTextEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mTextEdit);
     }
 
     DescriptionDialog::~DescriptionDialog()

--- a/apps/openmw/mwgui/confirmationdialog.cpp
+++ b/apps/openmw/mwgui/confirmationdialog.cpp
@@ -2,7 +2,6 @@
 
 #include <MyGUI_Button.h>
 #include <MyGUI_EditBox.h>
-#include <MyGUI_InputManager.h>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
@@ -34,7 +33,7 @@ namespace MWGui
 
         mMessage->setSize(mMessage->getWidth(), mMessage->getTextSize().height + 24);
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mOkButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mOkButton);
 
         center();
     }

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -1,7 +1,6 @@
 #include "console.hpp"
 
 #include <MyGUI_EditBox.h>
-#include <MyGUI_InputManager.h>
 #include <MyGUI_LayerManager.h>
 
 #include <boost/filesystem.hpp>
@@ -153,7 +152,7 @@ namespace MWGui
     {
         // Give keyboard focus to the combo box whenever the console is
         // turned on and place it over other widgets
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mCommandLine);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCommandLine);
         MyGUI::LayerManager::getInstance().upLayerItem(mMainWidget);
     }
 
@@ -450,7 +449,7 @@ namespace MWGui
                 mPtr = object;
             }
             // User clicked on an object. Restore focus to the console command line.
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mCommandLine);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCommandLine);
         }
         else
         {

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -141,7 +141,7 @@ namespace MWGui
         mItemView->setModel (mSortModel);
         mItemView->resetScrollBars();
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mCloseButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
 
         setTitle(container.getClass().getName(container));
     }
@@ -175,7 +175,7 @@ namespace MWGui
         if(mDragAndDrop != nullptr && mDragAndDrop->mIsOnDragAndDrop)
             return;
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mCloseButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
 
         // transfer everything into the player's inventory
         ItemModel* playerModel = MWBase::Environment::get().getWindowManager()->getInventoryWindow()->getModel();
@@ -222,7 +222,7 @@ namespace MWGui
     {
         if(mDragAndDrop == nullptr || !mDragAndDrop->mIsOnDragAndDrop)
         {
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mCloseButton);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
 
             onTakeAllButtonClicked(mTakeButton);
 

--- a/apps/openmw/mwgui/countdialog.cpp
+++ b/apps/openmw/mwgui/countdialog.cpp
@@ -3,7 +3,6 @@
 #include <MyGUI_Button.h>
 #include <MyGUI_ScrollBar.h>
 #include <MyGUI_RenderManager.h>
-#include <MyGUI_InputManager.h>
 
 #include <components/widgets/numericeditbox.hpp>
 
@@ -48,7 +47,7 @@ namespace MWGui
                 mMainWidget->getHeight());
 
         // by default, the text edit field has the focus of the keyboard
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mItemEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mItemEdit);
 
         mSlider->setScrollPosition(maxCount-1);
 

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -5,7 +5,6 @@
 #include <MyGUI_ProgressBar.h>
 #include <MyGUI_ScrollBar.h>
 #include <MyGUI_Button.h>
-#include <MyGUI_InputManager.h>
 
 #include <components/debug/debuglog.hpp>
 #include <components/widgets/list.hpp>
@@ -381,7 +380,7 @@ namespace MWGui
         {
             onTopicActivated(topic);
             if (mGoodbyeButton->getEnabled())
-                MyGUI::InputManager::getInstance().setKeyFocusWidget(mGoodbyeButton);
+                MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mGoodbyeButton);
         }
         else if (topic == sPersuasion)
             mPersuasionDialog.setVisible(true);
@@ -444,7 +443,7 @@ namespace MWGui
             return;
         }
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mGoodbyeButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mGoodbyeButton);
 
         setTitle(mPtr.getClass().getName(mPtr));
 
@@ -623,7 +622,7 @@ namespace MWGui
         bool goodbyeWasEnabled = mGoodbyeButton->getEnabled();
         mGoodbyeButton->setEnabled(goodbyeEnabled);
         if (goodbyeEnabled && !goodbyeWasEnabled)
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mGoodbyeButton);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mGoodbyeButton);
 
         bool topicsEnabled = !MWBase::Environment::get().getDialogueManager()->isInChoice() && !mGoodbye;
         mTopicsList->setEnabled(topicsEnabled);

--- a/apps/openmw/mwgui/enchantingdialog.cpp
+++ b/apps/openmw/mwgui/enchantingdialog.cpp
@@ -5,7 +5,6 @@
 #include <MyGUI_Button.h>
 #include <MyGUI_ScrollView.h>
 #include <MyGUI_EditBox.h>
-#include <MyGUI_InputManager.h>
 
 #include <components/widgets/list.hpp>
 #include <components/settings/settings.hpp>
@@ -68,7 +67,7 @@ namespace MWGui
     void EnchantingDialog::onOpen()
     {
         center();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mName);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mName);
     }
 
     void EnchantingDialog::setSoulGem(const MWWorld::Ptr &gem)

--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -254,7 +254,7 @@ namespace
             }
             updateShowingPages();
 
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(getWidget<MyGUI::Widget>(CloseBTN));
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(getWidget<MyGUI::Widget>(CloseBTN));
         }
 
         void onClose()
@@ -377,9 +377,9 @@ namespace
             prevPageBtn->setVisible(prevPageVisible);
 
             if (focus == nextPageBtn && !nextPageVisible && prevPageVisible)
-                MyGUI::InputManager::getInstance().setKeyFocusWidget(prevPageBtn);
+                MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(prevPageBtn);
             else if (focus == prevPageBtn && !prevPageVisible && nextPageVisible)
-                MyGUI::InputManager::getInstance().setKeyFocusWidget(nextPageBtn);
+                MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nextPageBtn);
 
             setVisible (PageOneNum, relPages > 0);
             setVisible (PageTwoNum, relPages > 1);

--- a/apps/openmw/mwgui/keyboardnavigation.cpp
+++ b/apps/openmw/mwgui/keyboardnavigation.cpp
@@ -83,7 +83,7 @@ void KeyboardNavigation::restoreFocus(int mode)
     {
         MyGUI::Widget* w = found->second;
         if (w && w->getVisible() && w->getEnabled())
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(found->second);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(found->second);
     }
 }
 
@@ -130,7 +130,7 @@ void KeyboardNavigation::onFrame()
     // workaround incorrect key focus resets (fix in MyGUI TBD)
     if (!shouldAcceptKeyFocus(focus) && shouldAcceptKeyFocus(mCurrentFocus) && (!mModalWindow || isRootParent(mCurrentFocus, mModalWindow)))
     {
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mCurrentFocus);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCurrentFocus);
         focus = mCurrentFocus;
     }
 
@@ -154,12 +154,12 @@ void KeyboardNavigation::setDefaultFocus(MyGUI::Widget *window, MyGUI::Widget *d
     MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
     if (!focus || !shouldAcceptKeyFocus(focus))
     {
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(defaultFocus);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(defaultFocus);
     }
     else
     {
         if (!isRootParent(focus, window))
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(defaultFocus);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(defaultFocus);
     }
 }
 
@@ -276,7 +276,7 @@ bool KeyboardNavigation::switchFocus(int direction, bool wrap)
     else if (direction == D_Up && (vertdiff >= 0 || !isVertical))
         return false;
 
-    MyGUI::InputManager::getInstance().setKeyFocusWidget(keyFocusList[index]);
+    MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(keyFocusList[index]);
     return true;
 }
 
@@ -291,7 +291,7 @@ bool KeyboardNavigation::selectFirstWidget()
 
     if (!keyFocusList.empty())
     {
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(keyFocusList[0]);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(keyFocusList[0]);
         return true;
     }
     return false;

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -3,7 +3,6 @@
 #include <MyGUI_TextBox.h>
 #include <MyGUI_Gui.h>
 #include <MyGUI_RenderManager.h>
-#include <MyGUI_InputManager.h>
 
 #include <components/widgets/imagebutton.hpp>
 #include <components/settings/settings.hpp>
@@ -68,12 +67,12 @@ namespace MWGui
             if (isMainMenu)
             {
                 if (mButtons["loadgame"]->getVisible())
-                    MyGUI::InputManager::getInstance().setKeyFocusWidget(mButtons["loadgame"]);
+                    MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mButtons["loadgame"]);
                 else
-                    MyGUI::InputManager::getInstance().setKeyFocusWidget(mButtons["newgame"]);
+                    MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mButtons["newgame"]);
             }
             else
-                MyGUI::InputManager::getInstance().setKeyFocusWidget(mButtons["return"]);
+                MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mButtons["return"]);
         }
 
         Layout::setVisible (visible);

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -1123,7 +1123,7 @@ namespace MWGui
     {
         WindowModal::onOpen();
         center();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mTextEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mTextEdit);
     }
 
     void EditNoteDialog::onCancelButtonClicked(MyGUI::Widget *sender)

--- a/apps/openmw/mwgui/race.cpp
+++ b/apps/openmw/mwgui/race.cpp
@@ -3,7 +3,6 @@
 #include <MyGUI_ListBox.h>
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_Gui.h>
-#include <MyGUI_InputManager.h>
 
 #include <osg/Texture2D>
 
@@ -166,7 +165,7 @@ namespace MWGui
         mHeadRotate->setScrollPosition(initialPos);
         onHeadRotate(mHeadRotate, initialPos);
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mRaceList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mRaceList);
     }
 
     void RaceDialog::setRaceId(const std::string &raceId)

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -94,7 +94,7 @@ namespace MWGui
         MWBase::Environment::get().getStateManager()->deleteGame (mCurrentCharacter, mCurrentSlot);
         mSaveList->removeItemAt(mSaveList->getIndexSelected());
         onSlotSelected(mSaveList, mSaveList->getIndexSelected());
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mSaveList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mSaveList);
 
         if (mSaveList->getItemCount() == 0)
         {
@@ -114,7 +114,7 @@ namespace MWGui
 
     void SaveGameDialog::onDeleteSlotCancel()
     {
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mSaveList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mSaveList);
     }
 
     void SaveGameDialog::onSaveNameChanged(MyGUI::EditBox *sender)
@@ -138,9 +138,9 @@ namespace MWGui
 
         mSaveNameEdit->setCaption ("");
         if (mSaving)
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mSaveNameEdit);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mSaveNameEdit);
         else
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mSaveList);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mSaveList);
 
         center();
 
@@ -244,7 +244,7 @@ namespace MWGui
 
     void SaveGameDialog::onConfirmationCancel()
     {
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mSaveList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mSaveList);
     }
 
     void SaveGameDialog::accept(bool reallySure)
@@ -331,7 +331,7 @@ namespace MWGui
     void SaveGameDialog::onCharacterAccept(MyGUI::ComboBox* sender, size_t pos)
     {
         // Give key focus to save list so we can confirm the selection with Enter
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mSaveList);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mSaveList);
     }
 
     void SaveGameDialog::fillSaveList()

--- a/apps/openmw/mwgui/scrollwindow.cpp
+++ b/apps/openmw/mwgui/scrollwindow.cpp
@@ -1,7 +1,6 @@
 #include "scrollwindow.hpp"
 
 #include <MyGUI_ScrollView.h>
-#include <MyGUI_InputManager.h>
 
 #include <components/esm/loadbook.hpp>
 #include <components/widgets/imagebutton.hpp>
@@ -67,7 +66,7 @@ namespace MWGui
 
         setTakeButtonShow(showTakeButton);
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mCloseButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mCloseButton);
     }
 
     void ScrollWindow::onKeyButtonPressed(MyGUI::Widget *sender, MyGUI::KeyCode key, MyGUI::Char character)

--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -6,7 +6,6 @@
 #include <MyGUI_ScrollView.h>
 #include <MyGUI_Gui.h>
 #include <MyGUI_TabControl.h>
-#include <MyGUI_InputManager.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -616,7 +615,7 @@ namespace MWGui
         highlightCurrentResolution();
         updateControlsBox();
         resetScrollbars();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mOkButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mOkButton);
     }
 
     void SettingsWindow::onWindowResize(MyGUI::Window *_sender)

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -2,7 +2,6 @@
 
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_Gui.h>
-#include <MyGUI_InputManager.h>
 
 #include <components/esm/records.hpp>
 #include <components/widgets/list.hpp>
@@ -432,7 +431,7 @@ namespace MWGui
     void SpellCreationDialog::onOpen()
     {
         center();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mNameEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mNameEdit);
     }
 
     void SpellCreationDialog::onReferenceUnavailable ()

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -83,7 +83,7 @@ namespace MWGui
         // Reset the filter focus when opening the window
         MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
         if (focus == mFilterEdit)
-            MyGUI::InputManager::getInstance().resetKeyFocusWidget();
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nullptr);
 
         updateSpells();
     }

--- a/apps/openmw/mwgui/textinput.cpp
+++ b/apps/openmw/mwgui/textinput.cpp
@@ -5,7 +5,6 @@
 
 #include <MyGUI_EditBox.h>
 #include <MyGUI_Button.h>
-#include <MyGUI_InputManager.h>
 
 namespace MWGui
 {
@@ -24,7 +23,7 @@ namespace MWGui
         okButton->eventMouseButtonClick += MyGUI::newDelegate(this, &TextInputDialog::onOkClicked);
 
         // Make sure the edit box has focus
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mTextEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mTextEdit);
     }
 
     void TextInputDialog::setNextButtonShow(bool shown)
@@ -47,7 +46,7 @@ namespace MWGui
     {
         WindowModal::onOpen();
         // Make sure the edit box has focus
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mTextEdit);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mTextEdit);
     }
 
     // widget controls
@@ -57,7 +56,7 @@ namespace MWGui
         if (mTextEdit->getCaption() == "")
         {
             MWBase::Environment::get().getWindowManager()->messageBox ("#{sNotifyMessage37}");
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mTextEdit);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget (mTextEdit);
         }
         else
             eventDone(this);

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -136,7 +136,7 @@ namespace MWGui
 
         onFilterChanged(mFilterAll);
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mTotalBalance);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mTotalBalance);
     }
 
     void TradeWindow::onFrame(float dt)

--- a/apps/openmw/mwgui/waitdialog.cpp
+++ b/apps/openmw/mwgui/waitdialog.cpp
@@ -93,9 +93,9 @@ namespace MWGui
         }
             
         if (mUntilHealedButton->getVisible())
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mUntilHealedButton);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mUntilHealedButton);
         else
-            MyGUI::InputManager::getInstance().setKeyFocusWidget(mWaitButton);
+            MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mWaitButton);
     }
 
     bool WaitDialog::exit()
@@ -222,7 +222,7 @@ namespace MWGui
     {
         mHourText->setCaptionWithReplacing (MyGUI::utility::toString(position+1) + " #{sRestMenu2}");
         mManualHours = position+1;
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mWaitButton);
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(mWaitButton);
     }
 
     void WaitDialog::onKeyButtonPressed(MyGUI::Widget *sender, MyGUI::KeyCode key, MyGUI::Char character)

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -697,7 +697,7 @@ namespace MWGui
             setCursorVisible(!gameMode);
 
         if (gameMode)
-            MyGUI::InputManager::getInstance().resetKeyFocusWidget();
+            setKeyFocusWidget (nullptr);
 
         // Icons of forced hidden windows are displayed
         setMinimapVisibility((mAllowed & GW_Map) && (!mMap->pinned() || (mForceHidden & GW_Map)));
@@ -1675,6 +1675,13 @@ namespace MWGui
         }
     }
 
+    // Remove this wrapper once onKeyFocusChanged call is rendered unnecessary
+    void WindowManager::setKeyFocusWidget(MyGUI::Widget *widget)
+    {
+        MyGUI::InputManager::getInstance().setKeyFocusWidget(widget);
+        onKeyFocusChanged(widget);
+    }
+
     void WindowManager::onKeyFocusChanged(MyGUI::Widget *widget)
     {
         if (widget && widget->castType<MyGUI::EditBox>(false))
@@ -1868,7 +1875,7 @@ namespace MWGui
         sizeVideo(screenSize.width, screenSize.height);
 
         MyGUI::Widget* oldKeyFocus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(mVideoWidget);
+        setKeyFocusWidget(mVideoWidget);
 
         mVideoBackground->setVisible(true);
 
@@ -1906,7 +1913,7 @@ namespace MWGui
 
         MWBase::Environment::get().getSoundManager()->resumeSounds();
 
-        MyGUI::InputManager::getInstance().setKeyFocusWidget(oldKeyFocus);
+        setKeyFocusWidget(oldKeyFocus);
 
         setCursorVisible(cursorWasVisible);
 

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -147,6 +147,9 @@ namespace MWGui
     /// (and will continually update the window while doing so)
     virtual void playVideo(const std::string& name, bool allowSkipping);
 
+    /// Warning: do not use MyGUI::InputManager::setKeyFocusWidget directly. Instead use this.
+    virtual void setKeyFocusWidget (MyGUI::Widget* widget);
+
     virtual void setNewGame(bool newgame);
 
     virtual void pushGuiMode(GuiMode mode, const MWWorld::Ptr& arg);


### PR DESCRIPTION
Temporary workaround of weird player controls regressions caused by onKeyFocusChanged events no longer being fired when the focus widget didn't change so that the cause of problems with that can be determined isolated from the players. Some other stuff that wasn't necessary anymore and didn't cause issues after it was removed wasn't brought back.