### PR TITLE
Optimizer: Only merge pure osg::Groups

### DIFF
--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -1802,12 +1802,11 @@ bool Optimizer::MergeGeometryVisitor::mergePrimitive(osg::DrawElementsUInt& lhs,
 
 bool Optimizer::MergeGroupsVisitor::isOperationPermissible(osg::Group& node)
 {
-    return !node.asSwitch() &&
-           !node.asTransform() &&
-           !node.getCullCallback() &&
+    return !node.getCullCallback() &&
            !node.getEventCallback() &&
            !node.getUpdateCallback() &&
-            isOperationPermissibleForObject(&node);
+            isOperationPermissibleForObject(&node) &&
+           typeid(node)==typeid(osg::Group);
 }
 
 void Optimizer::MergeGroupsVisitor::apply(osg::LOD &lod)


### PR DESCRIPTION
Avoid merging derivative classes because they often have specialized function and behave... badly when their children are stuffed into an unrelated group by the optimizer. Fixes missing lantern glass issues with Morrowind Optimization Patch in my testing.

I'm aware of the overhead of typeid but it's preferable to doing a dynamic cast to osg::LOD and checking if it resulted in nothing because it's a typeid check has both better "universality" and lower overhead. Also something similar is already done in empty node and redundant node visitors and OSG itself.