### PR TITLE
[ Is it usefull? ] Hierarchize transforms & Flattenstatic first transform based on isMobile flag

### DIFF
--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -140,7 +140,8 @@ void CSVRender::Object::update()
     if (light)
     {
         bool isExterior = false; // FIXME
-        SceneUtil::addLight(mBaseNode, light, Mask_ParticleSystem, Mask_Lighting, isExterior);
+        ESM::Cell dummy;
+        SceneUtil::addLight(mBaseNode, &dummy, light, Mask_ParticleSystem, Mask_Lighting, isExterior);
     }
 }
 

--- a/apps/openmw/mwclass/activator.cpp
+++ b/apps/openmw/mwclass/activator.cpp
@@ -33,8 +33,7 @@ namespace MWClass
     {
         if (!model.empty())
         {
-            renderingInterface.getObjects().insertModel(ptr, model, true);
-            ptr.getRefData().getBaseNode()->setNodeMask(MWRender::Mask_Static);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Static, true);
         }
     }
 

--- a/apps/openmw/mwclass/apparatus.cpp
+++ b/apps/openmw/mwclass/apparatus.cpp
@@ -11,6 +11,7 @@
 #include "../mwphysics/physicssystem.hpp"
 #include "../mwworld/nullaction.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -22,7 +23,7 @@ namespace MWClass
     void Apparatus::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -17,6 +17,7 @@
 #include "../mwworld/nullaction.hpp"
 #include "../mwworld/containerstore.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 #include "../mwmechanics/actorutil.hpp"
@@ -29,7 +30,7 @@ namespace MWClass
     void Armor::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/bodypart.cpp
+++ b/apps/openmw/mwclass/bodypart.cpp
@@ -1,5 +1,6 @@
 #include "bodypart.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/renderinginterface.hpp"
 #include "../mwrender/objects.hpp"
 
@@ -18,7 +19,7 @@ namespace MWClass
     void BodyPart::insertObjectRendering(const MWWorld::Ptr &ptr, const std::string &model, MWRender::RenderingInterface &renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/book.cpp
+++ b/apps/openmw/mwclass/book.cpp
@@ -14,6 +14,7 @@
 #include "../mwworld/esmstore.hpp"
 #include "../mwphysics/physicssystem.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -27,7 +28,7 @@ namespace MWClass
     void Book::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -16,6 +16,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -25,7 +26,7 @@ namespace MWClass
     void Clothing::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -23,6 +23,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/animation.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
@@ -112,7 +113,7 @@ namespace MWClass
     void Container::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model, true);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object, true);
         }
     }
 

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -57,8 +57,7 @@ namespace MWClass
     {
         if (!model.empty())
         {
-            renderingInterface.getObjects().insertModel(ptr, model, true);
-            ptr.getRefData().getBaseNode()->setNodeMask(MWRender::Mask_Static);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Static, true);
         }
     }
 

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -15,6 +15,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -24,7 +25,7 @@ namespace MWClass
     void Ingredient::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -18,6 +18,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -30,7 +31,7 @@ namespace MWClass
             ptr.get<ESM::Light>();
 
         // Insert even if model is empty, so that the light is added
-        renderingInterface.getObjects().insertModel(ptr, model, true, !(ref->mBase->mData.mFlags & ESM::Light::OffDefault));
+        renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object, true, !(ref->mBase->mData.mFlags & ESM::Light::OffDefault));
     }
 
     void Light::insertObject(const MWWorld::Ptr& ptr, const std::string& model, MWPhysics::PhysicsSystem& physics) const

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -15,6 +15,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -24,7 +25,7 @@ namespace MWClass
     void Lockpick::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -16,6 +16,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -33,7 +34,7 @@ namespace MWClass
     void Miscellaneous::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/potion.cpp
+++ b/apps/openmw/mwclass/potion.cpp
@@ -15,6 +15,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -26,7 +27,7 @@ namespace MWClass
     void Potion::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -15,6 +15,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -24,7 +25,7 @@ namespace MWClass
     void Probe::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/repair.cpp
+++ b/apps/openmw/mwclass/repair.cpp
@@ -12,6 +12,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -21,7 +22,7 @@ namespace MWClass
     void Repair::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwclass/static.cpp
+++ b/apps/openmw/mwclass/static.cpp
@@ -18,8 +18,7 @@ namespace MWClass
     {
         if (!model.empty())
         {
-            renderingInterface.getObjects().insertModel(ptr, model);
-            ptr.getRefData().getBaseNode()->setNodeMask(MWRender::Mask_Static);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Static);
         }
     }
 

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -19,6 +19,7 @@
 
 #include "../mwgui/tooltips.hpp"
 
+#include "../mwrender/vismask.hpp"
 #include "../mwrender/objects.hpp"
 #include "../mwrender/renderinginterface.hpp"
 
@@ -28,7 +29,7 @@ namespace MWClass
     void Weapon::insertObjectRendering (const MWWorld::Ptr& ptr, const std::string& model, MWRender::RenderingInterface& renderingInterface) const
     {
         if (!model.empty()) {
-            renderingInterface.getObjects().insertModel(ptr, model);
+            renderingInterface.getObjects().insertModel(ptr, model, MWRender::Mask_Object);
         }
     }
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -354,7 +354,7 @@ namespace MWMechanics
             return;
 
         // stop tracking when target is behind the actor
-        osg::Vec3f actorDirection = actor.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0);
+        osg::Vec3f actorDirection = static_cast<SceneUtil::PositionAttitudeTransform*>(actor.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0);
         osg::Vec3f targetDirection(actor2Pos - actor1Pos);
         actorDirection.z() = 0;
         targetDirection.z() = 0;

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -479,7 +479,7 @@ namespace MWMechanics
             osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(actor);
             osg::Vec3f pos = actor.getRefData().getPosition().asVec3();
             osg::Vec3f source = pos + osg::Vec3f(0, 0, 0.75f * halfExtents.z());
-            osg::Vec3f fallbackDirection = actor.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,-1,0);
+            osg::Vec3f fallbackDirection = static_cast<SceneUtil::PositionAttitudeTransform*>(actor.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,-1,0);
             osg::Vec3f destination = source + fallbackDirection * (halfExtents.y() + 16);
 
             bool isObstacleDetected = MWBase::Environment::get().getWorld()->castRay(source.x(), source.y(), source.z(), destination.x(), destination.y(), destination.z(), mask);

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -479,6 +479,8 @@ namespace MWMechanics
             osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(actor);
             osg::Vec3f pos = actor.getRefData().getPosition().asVec3();
             osg::Vec3f source = pos + osg::Vec3f(0, 0, 0.75f * halfExtents.z());
+
+            assert(!actor.getRefData().isBaseNodeFlatten());
             osg::Vec3f fallbackDirection = static_cast<SceneUtil::PositionAttitudeTransform*>(actor.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,-1,0);
             osg::Vec3f destination = source + fallbackDirection * (halfExtents.y() + 16);
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1127,6 +1127,7 @@ void CharacterController::updateIdleStormState(bool inwater)
 
     if (MWBase::Environment::get().getWorld()->isInStorm())
     {
+        assert(!mPtr.getRefData().isBaseNodeFlatten());
         osg::Vec3f stormDirection = MWBase::Environment::get().getWorld()->getStormDirection();
         osg::Vec3f characterDirection = static_cast<SceneUtil::PositionAttitudeTransform*>(mPtr.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0);
         stormDirection.normalize();

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1128,7 +1128,7 @@ void CharacterController::updateIdleStormState(bool inwater)
     if (MWBase::Environment::get().getWorld()->isInStorm())
     {
         osg::Vec3f stormDirection = MWBase::Environment::get().getWorld()->getStormDirection();
-        osg::Vec3f characterDirection = mPtr.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0);
+        osg::Vec3f characterDirection = static_cast<SceneUtil::PositionAttitudeTransform*>(mPtr.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0);
         stormDirection.normalize();
         characterDirection.normalize();
         if (stormDirection * characterDirection < -0.5f)
@@ -2891,7 +2891,7 @@ void CharacterController::updateHeadTracking(float duration)
 
         if (!mPtr.getRefData().getBaseNode())
             return;
-        const osg::Vec3f actorDirection = mPtr.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0);
+        const osg::Vec3f actorDirection = static_cast<SceneUtil::PositionAttitudeTransform*>(mPtr.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0);
 
         zAngleRadians = std::atan2(direction.x(), direction.y()) - std::atan2(actorDirection.x(), actorDirection.y());
         xAngleRadians = -std::asin(direction.z());

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -78,7 +78,7 @@ namespace MWMechanics
         float angleDegrees = osg::RadiansToDegrees(
                     signedAngleRadians (
                     (attacker.getRefData().getPosition().asVec3() - blocker.getRefData().getPosition().asVec3()),
-                    blocker.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0),
+                    static_cast<SceneUtil::PositionAttitudeTransform*>(blocker.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0),
                     osg::Vec3f(0,0,1)));
 
         const MWWorld::Store<ESM::GameSetting>& gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -75,6 +75,7 @@ namespace MWMechanics
         if (!blocker.getRefData().getBaseNode())
             return false; // shouldn't happen
 
+        assert(!blocker.getRefData().isBaseNodeFlatten());
         float angleDegrees = osg::RadiansToDegrees(
                     signedAngleRadians (
                     (attacker.getRefData().getPosition().asVec3() - blocker.getRefData().getPosition().asVec3()),

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1631,7 +1631,7 @@ namespace MWMechanics
         osg::Vec3f vec = pos1 - pos2;
         if (observer.getRefData().getBaseNode())
         {
-            osg::Vec3f observerDir = (observer.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0));
+            osg::Vec3f observerDir = (static_cast<SceneUtil::PositionAttitudeTransform*>(observer.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0));
 
             float angleRadians = std::acos(observerDir * vec / (observerDir.length() * vec.length()));
             if (angleRadians > osg::DegreesToRadians(90.f))

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1631,6 +1631,7 @@ namespace MWMechanics
         osg::Vec3f vec = pos1 - pos2;
         if (observer.getRefData().getBaseNode())
         {
+            assert(!observer.getRefData().isBaseNodeFlatten());
             osg::Vec3f observerDir = (static_cast<SceneUtil::PositionAttitudeTransform*>(observer.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0));
 
             float angleRadians = std::acos(observerDir * vec / (observerDir.length() * vec.length()));

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -43,6 +43,7 @@ namespace MWMechanics
         osg::Vec3f pos(actor.getRefData().getPosition().asVec3());
         pos.z() = 0;
 
+        assert(!actor.getRefData().isBaseNodeFlatten());
         osg::Vec3f actorDir = (static_cast<SceneUtil::PositionAttitudeTransform*>(actor.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0));
 
         for (; it != refList.end(); ++it)

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -43,7 +43,7 @@ namespace MWMechanics
         osg::Vec3f pos(actor.getRefData().getPosition().asVec3());
         pos.z() = 0;
 
-        osg::Vec3f actorDir = (actor.getRefData().getBaseNode()->getAttitude() * osg::Vec3f(0,1,0));
+        osg::Vec3f actorDir = (static_cast<SceneUtil::PositionAttitudeTransform*>(actor.getRefData().getBaseNode())->getAttitude() * osg::Vec3f(0,1,0));
 
         for (; it != refList.end(); ++it)
         {

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -167,6 +167,7 @@ osg::Vec3f Actor::getPreviousPosition() const
 
 void Actor::updateRotation ()
 {
+    assert(!mPtr.getRefData().isBaseNodeFlatten());
     btTransform tr = mCollisionObject->getWorldTransform();
     mRotation = static_cast<SceneUtil::PositionAttitudeTransform*>(mPtr.getRefData().getBaseNode())->getAttitude();
     tr.setRotation(Misc::Convert::toBullet(mRotation));

--- a/apps/openmw/mwphysics/actor.cpp
+++ b/apps/openmw/mwphysics/actor.cpp
@@ -168,7 +168,7 @@ osg::Vec3f Actor::getPreviousPosition() const
 void Actor::updateRotation ()
 {
     btTransform tr = mCollisionObject->getWorldTransform();
-    mRotation = mPtr.getRefData().getBaseNode()->getAttitude();
+    mRotation = static_cast<SceneUtil::PositionAttitudeTransform*>(mPtr.getRefData().getBaseNode())->getAttitude();
     tr.setRotation(Misc::Convert::toBullet(mRotation));
     mCollisionObject->setWorldTransform(tr);
 

--- a/apps/openmw/mwphysics/object.cpp
+++ b/apps/openmw/mwphysics/object.cpp
@@ -29,7 +29,7 @@ namespace MWPhysics
 
         setScale(ptr.getCellRef().getScale());
         /*if(ptr.getClass().isMobile(ptr))
-
+actorDirection
         setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude()));
         else
             setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())->getAttitude()));

--- a/apps/openmw/mwphysics/object.cpp
+++ b/apps/openmw/mwphysics/object.cpp
@@ -28,19 +28,20 @@ namespace MWPhysics
         mCollisionObject->setUserPointer(static_cast<PtrHolder*>(this));
 
         setScale(ptr.getCellRef().getScale());
-        /*if(ptr.getClass().isMobile(ptr))
-actorDirection
-        setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude()));
-        else
-            setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())->getAttitude()));
-*/
+        SceneUtil::PositionAttitudeTransform* trans;
+        if(ptr.getRefData().isBaseNodeFlatten())
+            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+
+        setRotation(Misc::Convert::toBullet(trans->getAttitude()));
+   /*
         ESM::Position position = ptr.getRefData().getPosition();
         const float xr = position.rot[0];
         const float yr = position.rot[1];
         const float zr = position.rot[2];
 
        setRotation(Misc::Convert::toBullet( osg::Quat(zr, osg::Vec3(0, 0, -1))        * osg::Quat(yr, osg::Vec3(0, -1, 0))        * osg::Quat(xr, osg::Vec3(-1, 0, 0))));
-
+*/
 
         const float* pos = ptr.getRefData().getPosition().pos;
         setOrigin(btVector3(pos[0], pos[1], pos[2]));

--- a/apps/openmw/mwphysics/object.cpp
+++ b/apps/openmw/mwphysics/object.cpp
@@ -28,20 +28,13 @@ namespace MWPhysics
         mCollisionObject->setUserPointer(static_cast<PtrHolder*>(this));
 
         setScale(ptr.getCellRef().getScale());
+
         SceneUtil::PositionAttitudeTransform* trans;
         if(ptr.getRefData().isBaseNodeFlatten())
-            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
-        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+            trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+        else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
         setRotation(Misc::Convert::toBullet(trans->getAttitude()));
-   /*
-        ESM::Position position = ptr.getRefData().getPosition();
-        const float xr = position.rot[0];
-        const float yr = position.rot[1];
-        const float zr = position.rot[2];
-
-       setRotation(Misc::Convert::toBullet( osg::Quat(zr, osg::Vec3(0, 0, -1))        * osg::Quat(yr, osg::Vec3(0, -1, 0))        * osg::Quat(xr, osg::Vec3(-1, 0, 0))));
-*/
 
         const float* pos = ptr.getRefData().getPosition().pos;
         setOrigin(btVector3(pos[0], pos[1], pos[2]));

--- a/apps/openmw/mwphysics/object.cpp
+++ b/apps/openmw/mwphysics/object.cpp
@@ -29,10 +29,9 @@ namespace MWPhysics
 
         setScale(ptr.getCellRef().getScale());
 
-        SceneUtil::PositionAttitudeTransform* trans;
-        if(ptr.getRefData().isBaseNodeFlatten())
-            trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
-        else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+        SceneUtil::PositionAttitudeTransform* trans = ptr.getRefData().isBaseNodeFlatten() ?
+            static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())
+            : static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
         setRotation(Misc::Convert::toBullet(trans->getAttitude()));
 

--- a/apps/openmw/mwphysics/object.cpp
+++ b/apps/openmw/mwphysics/object.cpp
@@ -12,6 +12,8 @@
 
 #include <LinearMath/btTransform.h>
 
+#include "apps/openmw/mwworld/class.hpp"
+
 namespace MWPhysics
 {
     Object::Object(const MWWorld::Ptr& ptr, osg::ref_ptr<Resource::BulletShapeInstance> shapeInstance)
@@ -26,7 +28,20 @@ namespace MWPhysics
         mCollisionObject->setUserPointer(static_cast<PtrHolder*>(this));
 
         setScale(ptr.getCellRef().getScale());
-        setRotation(Misc::Convert::toBullet(ptr.getRefData().getBaseNode()->getAttitude()));
+        /*if(ptr.getClass().isMobile(ptr))
+
+        setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude()));
+        else
+            setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())->getAttitude()));
+*/
+        ESM::Position position = ptr.getRefData().getPosition();
+        const float xr = position.rot[0];
+        const float yr = position.rot[1];
+        const float zr = position.rot[2];
+
+       setRotation(Misc::Convert::toBullet( osg::Quat(zr, osg::Vec3(0, 0, -1))        * osg::Quat(yr, osg::Vec3(0, -1, 0))        * osg::Quat(xr, osg::Vec3(-1, 0, 0))));
+
+
         const float* pos = ptr.getRefData().getPosition().pos;
         setOrigin(btVector3(pos[0], pos[1], pos[2]));
     }

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1136,10 +1136,9 @@ namespace MWPhysics
 
     void PhysicsSystem::updateRotation(const MWWorld::Ptr &ptr)
     {
-        SceneUtil::PositionAttitudeTransform* trans;
-        if(ptr.getRefData().isBaseNodeFlatten())
-            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
-        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+        SceneUtil::PositionAttitudeTransform* trans = ptr.getRefData().isBaseNodeFlatten() ?
+            static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())
+            : static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
         ObjectMap::iterator found = mObjects.find(ptr);
         if (found != mObjects.end())

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1136,10 +1136,15 @@ namespace MWPhysics
 
     void PhysicsSystem::updateRotation(const MWWorld::Ptr &ptr)
     {
+        SceneUtil::PositionAttitudeTransform* trans;
+        if(ptr.getRefData().isBaseNodeFlatten())
+            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+
         ObjectMap::iterator found = mObjects.find(ptr);
         if (found != mObjects.end())
         {
-            found->second->setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude()));
+            found->second->setRotation(Misc::Convert::toBullet(trans->getAttitude()));
             mCollisionWorld->updateSingleAabb(found->second->getCollisionObject());
             return;
         }

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1139,7 +1139,7 @@ namespace MWPhysics
         ObjectMap::iterator found = mObjects.find(ptr);
         if (found != mObjects.end())
         {
-            found->second->setRotation(Misc::Convert::toBullet(ptr.getRefData().getBaseNode()->getAttitude()));
+            found->second->setRotation(Misc::Convert::toBullet(static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude()));
             mCollisionWorld->updateSingleAabb(found->second->getCollisionObject());
             return;
         }

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1686,8 +1686,7 @@ namespace MWRender
     void Animation::addExtraLight(osg::ref_ptr<osg::Group> parent, const ESM::Light *esmLight)
     {
         bool exterior = mPtr.isInCell() && mPtr.getCell()->getCell()->isExterior();
-
-        SceneUtil::addLight(parent, esmLight, Mask_ParticleSystem, Mask_Lighting, exterior);
+        SceneUtil::addLight(parent, mPtr.getCell()->getCell(), esmLight, Mask_ParticleSystem, Mask_Lighting, exterior);
     }
 
     void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, const std::string& texture)

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -373,7 +373,8 @@ namespace MWRender
         else
         {
             mAnimation->setViewMode(NpcAnimation::VM_Normal);
-            SceneUtil::PositionAttitudeTransform* transform = mTrackingPtr.getRefData().getBaseNode();
+            //assert(mTrackingPtr.getRefData().getBaseNode()!=MWRender::Mask_Static);
+            SceneUtil::PositionAttitudeTransform* transform = static_cast<SceneUtil::PositionAttitudeTransform*>(mTrackingPtr.getRefData().getBaseNode());
             mTrackingNode = transform;
             if (transform)
                 mHeightScale = transform->getScale().z();

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -373,7 +373,7 @@ namespace MWRender
         else
         {
             mAnimation->setViewMode(NpcAnimation::VM_Normal);
-            //assert(mTrackingPtr.getRefData().getBaseNode()!=MWRender::Mask_Static);
+            assert(!mTrackingPtr.getRefData().isBaseNodeFlatten());
             SceneUtil::PositionAttitudeTransform* transform = static_cast<SceneUtil::PositionAttitudeTransform*>(mTrackingPtr.getRefData().getBaseNode());
             mTrackingNode = transform;
             if (transform)

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -169,7 +169,7 @@ void Objects::insertNPC(const MWWorld::Ptr &ptr)
 
 bool Objects::removeObject (const MWWorld::Ptr& ptr)
 {
-    SceneUtil::PositionAttitudeTransform *basenode = (SceneUtil::PositionAttitudeTransform *) ptr.getRefData().getBaseNode();
+    osg::Group *basenode =  ptr.getRefData().getBaseNode();
     if(!basenode)
         return true;
 
@@ -254,11 +254,9 @@ void Objects::updatePtr(const MWWorld::Ptr &old, const MWWorld::Ptr &cur)
         objectNode->getParent(0)->removeChild(objectNode);
         oldorig = SceneUtil::getCellOrigin(old.getCell()->getCell());
     }
-
-    SceneUtil::PositionAttitudeTransform* trans;
-    if(cur.getRefData().isBaseNodeFlatten())
-        trans = static_cast<SceneUtil::PositionAttitudeTransform*>(cur.getRefData().getBaseNode()->getChild(0)->getUserData());
-    else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(cur.getRefData().getBaseNode());
+    SceneUtil::PositionAttitudeTransform* trans = cur.getRefData().isBaseNodeFlatten() ?
+        static_cast<SceneUtil::PositionAttitudeTransform*>(cur.getRefData().getBaseNode()->getChild(0)->getUserData())
+        : static_cast<SceneUtil::PositionAttitudeTransform*>(cur.getRefData().getBaseNode());
 
     const float *f = cur.getRefData().getPosition().pos;
     trans->setPosition( osg::Vec3(f[0],f[1],f[2])-SceneUtil::getCellOrigin(cur.getCell()->getCell()));

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -101,21 +101,23 @@ public:
     osg::Matrix _m;
     TransVisitor(osg::Matrix&m )
         : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN),_m(m)
-    { }
+    {
+        //OSG_WARN<<"traversing not matrix Transform"<<std::endl;
+    }
     virtual void apply(osg::Transform &dr)
     {
         //OSG_WARN<<"traversing not matrix Transform"<<std::endl;
-        osg::Matrix m = dr.getWorldMatrices().front();
-        _m.postMult(m);
+      //  osg::Matrix m = dr.getWorldMatrices().front();
+      //  _m.postMult(m);
         traverse(dr);
-        _m.postMult(osg::Matrix::inverse(m));
+     //   _m.postMult(osg::Matrix::inverse(m));
     }
     virtual void apply(osg::MatrixTransform &dr)
     {
         //OSG_WARN<<"traversing  matrix Transform"<<std::endl;
-        _m.postMult(dr.getMatrix());
+       // _m.postMult(dr.getMatrix());
         traverse(dr);
-        _m.postMult(osg::Matrix::inverse(dr.getMatrix()));
+      //  _m.postMult(osg::Matrix::inverse(dr.getMatrix()));
     }
 
     virtual void apply(osg::Drawable &dr)
@@ -133,8 +135,9 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh, unsi
     osg::ref_ptr<SceneUtil::PositionAttitudeTransform> transbasenode = (SceneUtil::PositionAttitudeTransform *) ptr.getRefData().getBaseNode();
     osg::Group * basenode = transbasenode;
     osg::ref_ptr<ObjectAnimation> anim;
-    if(mask==Mask_Static&&!ptr.getClass().isMobile(ptr)&&!ptr.getClass().isActivator()&&!ptr.getClass().isDoor())
+    if(Settings::Manager::getBool("juval","General")&&!ptr.getClass().isMobile(ptr)&&!ptr.getClass().isActivator()&&!ptr.getClass().isDoor())
     {
+        ptr.getRefData().setBaseNodeFlatten(true);
         osg::ref_ptr<osg::Group> sub = new osg::Group;
         sub->getOrCreateUserDataContainer()->addUserObject(new PtrHolder(ptr));
 
@@ -151,19 +154,27 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh, unsi
         const float zr = objpos.rot[2];
 
         transbasenode->setAttitude( osg::Quat(zr, osg::Vec3(0, 0, -1))        * osg::Quat(yr, osg::Vec3(0, -1, 0))        * osg::Quat(xr, osg::Vec3(-1, 0, 0)));
-
-        osg::Matrix m=osg::Matrix::scale(transbasenode->getScale())*osg::Matrix::rotate(transbasenode->getAttitude())*osg::Matrix::translate(transbasenode->getPosition());
+        sub->getChild(0)->setUserData(transbasenode);
+        transbasenode->addChild(sub->getChild(0));
+        ptr.getRefData().flattenTransform();
+       /* osg::Matrix m=osg::Matrix::scale(transbasenode->getScale())*osg::Matrix::rotate(transbasenode->getAttitude())*osg::Matrix::translate(transbasenode->getPosition());
 
         TransVisitor tv( m);
         osg::ref_ptr<osg::Group> cloneoptim=(osg::Group*)sub->getChild(0)->clone(osg::CopyOp::DEEP_COPY_DRAWABLES|
                                                                         osg::CopyOp::DEEP_COPY_ARRAYS|
                                                                         //osg::CopyOp::DEEP_COPY_USERDATA|
                                                                         osg::CopyOp::DEEP_COPY_NODES);
-        sub->removeChild(0,sub->getNumChildren());
-
         cloneoptim->accept(tv);
+        SceneUtil::Optimizer opt;
+        //opt.optimize(cloneoptim,SceneUtil::Optimizer::FLATTEN_STATIC_TRANSFORMS);
+        ///keep untransformed original meshes
+        transbasenode->addChild(sub->getChild(0));
+        sub->removeChild(0,sub->getNumChildren());
+        cloneoptim->setUserData(transbasenode);*/
 
-        sub->addChild(cloneoptim);
+
+
+        //sub->addChild(cloneoptim);
 
         basenode = sub;
         basenode->setDataVariance(osg::Object::STATIC);

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -70,9 +70,9 @@ class Objects{
     osg::ref_ptr<SceneUtil::UnrefQueue> mUnrefQueue;
 
     osg::Group* insertBegin(const MWWorld::Ptr& ptr);
+public:
     osg::Group * getOrCreateCell(const MWWorld::Ptr& ptr);
 
-public:
     Objects(Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Group> rootNode, SceneUtil::UnrefQueue* unrefQueue);
     ~Objects();
 

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -68,7 +68,8 @@ class Objects{
 
     osg::ref_ptr<SceneUtil::UnrefQueue> mUnrefQueue;
 
-    void insertBegin(const MWWorld::Ptr& ptr);
+    osg::Group* insertBegin(const MWWorld::Ptr& ptr);
+    osg::Group * getOrCreateCell(const MWWorld::Ptr& ptr);
 
 public:
     Objects(Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Group> rootNode, SceneUtil::UnrefQueue* unrefQueue);
@@ -76,7 +77,7 @@ public:
 
     /// @param animated Attempt to load separate keyframes from a .kf file matching the model file?
     /// @param allowLight If false, no lights will be created, and particles systems will be removed.
-    void insertModel(const MWWorld::Ptr& ptr, const std::string &model, bool animated=false, bool allowLight=true);
+    void insertModel(const MWWorld::Ptr& ptr, const std::string &model, unsigned int mask, bool animated=false, bool allowLight=true);
 
     void insertNPC(const MWWorld::Ptr& ptr);
     void insertCreature (const MWWorld::Ptr& ptr, const std::string& model, bool weaponsShields);

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -6,6 +6,7 @@
 
 #include <osg/ref_ptr>
 #include <osg/Object>
+#include <osg/Vec3>
 
 #include "../mwworld/ptr.hpp"
 

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -34,7 +34,6 @@
 #include <components/sceneutil/util.hpp>
 #include <components/sceneutil/lightmanager.hpp>
 #include <components/sceneutil/statesetupdater.hpp>
-#include <components/sceneutil/positionattitudetransform.hpp>
 #include <components/sceneutil/workqueue.hpp>
 #include <components/sceneutil/unrefqueue.hpp>
 #include <components/sceneutil/writescene.hpp>
@@ -691,13 +690,12 @@ namespace MWRender
             mCamera->rotateCamera(-ptr.getRefData().getPosition().rot[0], -ptr.getRefData().getPosition().rot[2], false);
         }
         if(!ptr.getRefData().isBaseNodeFlatten())
-        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setAttitude(rot);
-        else {
+            static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setAttitude(rot);
+        else
+        {
             //need reflatten
-
             static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())->setAttitude(rot);
-             ptr.getRefData().flattenTransform();
-
+            ptr.getRefData().flattenTransform();
         }
     }
 

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -690,35 +690,57 @@ namespace MWRender
         {
             mCamera->rotateCamera(-ptr.getRefData().getPosition().rot[0], -ptr.getRefData().getPosition().rot[2], false);
         }
-        //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
         if(!ptr.getRefData().isBaseNodeFlatten())
         static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setAttitude(rot);
         else {
             //need reflatten
 
             static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())->setAttitude(rot);
-             //ptr.getRefData().flattenTransform();
+             ptr.getRefData().flattenTransform();
 
         }
     }
 
     void RenderingManager::moveObject(const MWWorld::Ptr &ptr, const osg::Vec3f &pos)
-    {   //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
+    {
+
+        SceneUtil::getCellOrigin(ptr.getCell()->getCell());
 
         osg::Vec3 cellorigin(0,0,0);
-        SceneUtil::PositionAttitudeTransform* ptrans, *trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
-        if(trans->getNumParents()>0)
+        SceneUtil::PositionAttitudeTransform* trans;
+        if(ptr.getRefData().isBaseNodeFlatten())
+            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+
+;
+        SceneUtil::PositionAttitudeTransform* ptrans;
+        if(ptr.getRefData().getBaseNode()->getNumParents()>0)
         {
-            ptrans=dynamic_cast<SceneUtil::PositionAttitudeTransform*>(trans->getParent(0));
-            if(ptrans)cellorigin=ptrans->getPosition();
+            ptrans=dynamic_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getParent(0));
+            if(ptrans)
+                cellorigin=SceneUtil::getCellOrigin(ptr.getCell()->getCell());
+            else
+            {
+                if(!ptr.getClass().isNpc())
+                    OSG_WARN<<"fuck"<<std::endl;
+            }
+            //if(ptrans)cellorigin=ptrans->getPosition();
         }
+        //OSG_WARN<<"moveobject"<<ptr.getRefData().std::endl;
         trans->setPosition(pos-cellorigin);
+        if(ptr.getRefData().isBaseNodeFlatten())
+            ptr.getRefData().flattenTransform();
     }
 
     void RenderingManager::scaleObject(const MWWorld::Ptr &ptr, const osg::Vec3f &scale)
-    {   //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
-        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setScale(scale);
-
+    {
+        SceneUtil::PositionAttitudeTransform* trans;
+        if(ptr.getRefData().isBaseNodeFlatten())
+            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+        trans->setScale(scale);
+        if(ptr.getRefData().isBaseNodeFlatten())
+            ptr.getRefData().flattenTransform();
         if (ptr == mCamera->getTrackingPtr()) // update height of camera
             mCamera->processViewChange();
     }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -690,18 +690,18 @@ namespace MWRender
         {
             mCamera->rotateCamera(-ptr.getRefData().getPosition().rot[0], -ptr.getRefData().getPosition().rot[2], false);
         }
-
-        ptr.getRefData().getBaseNode()->setAttitude(rot);
+        //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
+        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setAttitude(rot);
     }
 
     void RenderingManager::moveObject(const MWWorld::Ptr &ptr, const osg::Vec3f &pos)
-    {
-        ptr.getRefData().getBaseNode()->setPosition(pos);
+    {   //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
+        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setPosition(pos);
     }
 
     void RenderingManager::scaleObject(const MWWorld::Ptr &ptr, const osg::Vec3f &scale)
-    {
-        ptr.getRefData().getBaseNode()->setScale(scale);
+    {   //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
+        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setScale(scale);
 
         if (ptr == mCamera->getTrackingPtr()) // update height of camera
             mCamera->processViewChange();

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -696,7 +696,15 @@ namespace MWRender
 
     void RenderingManager::moveObject(const MWWorld::Ptr &ptr, const osg::Vec3f &pos)
     {   //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
-        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setPosition(pos);
+
+        osg::Vec3 cellorigin(0,0,0);
+        SceneUtil::PositionAttitudeTransform* ptrans, *trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+        if(trans->getNumParents()>0)
+        {
+            ptrans=dynamic_cast<SceneUtil::PositionAttitudeTransform*>(trans->getParent(0));
+            if(ptrans)cellorigin=ptrans->getPosition();
+        }
+        trans->setPosition(pos-cellorigin);
     }
 
     void RenderingManager::scaleObject(const MWWorld::Ptr &ptr, const osg::Vec3f &scale)

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -701,33 +701,23 @@ namespace MWRender
 
     void RenderingManager::moveObject(const MWWorld::Ptr &ptr, const osg::Vec3f &pos)
     {
-
-        SceneUtil::getCellOrigin(ptr.getCell()->getCell());
-
+        MWWorld::RefData& refdata = ptr.getRefData();
+        osg::Group * basenode = refdata.getBaseNode();
+        bool isFlatten = refdata.isBaseNodeFlatten();
         osg::Vec3 cellorigin(0,0,0);
-        SceneUtil::PositionAttitudeTransform* trans;
-        if(ptr.getRefData().isBaseNodeFlatten())
-            trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
-        else trans=static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
-;
-        SceneUtil::PositionAttitudeTransform* ptrans;
-        if(ptr.getRefData().getBaseNode()->getNumParents()>0)
-        {
-            ptrans=dynamic_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getParent(0));
-            if(ptrans)
-                cellorigin=SceneUtil::getCellOrigin(ptr.getCell()->getCell());
-            else
-            {
-                if(!ptr.getClass().isNpc())
-                    OSG_WARN<<"fuck"<<std::endl;
-            }
-            //if(ptrans)cellorigin=ptrans->getPosition();
-        }
-        //OSG_WARN<<"moveobject"<<ptr.getRefData().std::endl;
+        SceneUtil::PositionAttitudeTransform* trans = isFlatten ?
+            static_cast<SceneUtil::PositionAttitudeTransform*>(basenode->getChild(0)->getUserData())
+            : static_cast<SceneUtil::PositionAttitudeTransform*>(basenode);
+
+        if(basenode->getParent(0) != mSceneRoot)
+            cellorigin = SceneUtil::getCellOrigin(ptr.getCell()->getCell());
+        // else  OSG_WARN<<"Player don't have parent cell "<<std::endl;
+
         trans->setPosition(pos-cellorigin);
-        if(ptr.getRefData().isBaseNodeFlatten())
-            ptr.getRefData().flattenTransform();
+
+        if(isFlatten)
+            refdata.flattenTransform();
     }
 
     void RenderingManager::scaleObject(const MWWorld::Ptr &ptr, const osg::Vec3f &scale)

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -691,7 +691,15 @@ namespace MWRender
             mCamera->rotateCamera(-ptr.getRefData().getPosition().rot[0], -ptr.getRefData().getPosition().rot[2], false);
         }
         //assert(ptr.getRefData().getBaseNode()->getNodeMask()!=MWRender::Mask_Static && ptr.getClass()->isMobile(ptr));
+        if(!ptr.getRefData().isBaseNodeFlatten())
         static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->setAttitude(rot);
+        else {
+            //need reflatten
+
+            static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())->setAttitude(rot);
+             //ptr.getRefData().flattenTransform();
+
+        }
     }
 
     void RenderingManager::moveObject(const MWWorld::Ptr &ptr, const osg::Vec3f &pos)

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -6,6 +6,7 @@
 #include <osg/Camera>
 
 #include <components/settings/settings.hpp>
+#include <components/sceneutil/positionattitudetransform.hpp>
 
 #include "objects.hpp"
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -596,10 +596,9 @@ namespace MWScript
                     else
                         return;
 
-                    SceneUtil::PositionAttitudeTransform* trans;
-                    if(ptr.getRefData().isBaseNodeFlatten())
-                        trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
-                    else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+                    SceneUtil::PositionAttitudeTransform* trans = ptr.getRefData().isBaseNodeFlatten() ?
+                        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())
+                        : static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
                     osg::Quat attitude =  trans->getAttitude();
                     MWBase::Environment::get().getWorld()->rotateWorldObject(ptr, attitude * rot);
@@ -663,10 +662,10 @@ namespace MWScript
                     }
                     else
                         return;
-                    SceneUtil::PositionAttitudeTransform* trans;
-                    if(ptr.getRefData().isBaseNodeFlatten())
-                        trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
-                    else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+
+                    SceneUtil::PositionAttitudeTransform* trans = ptr.getRefData().isBaseNodeFlatten() ?
+                        static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData())
+                        : static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
                     // is it correct that disabled objects can't be Move-d?
                     if (!trans)

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -596,7 +596,12 @@ namespace MWScript
                     else
                         return;
 
-                    osg::Quat attitude =   static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude();
+                    SceneUtil::PositionAttitudeTransform* trans;
+                    if(ptr.getRefData().isBaseNodeFlatten())
+                        trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+                    else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
+
+                    osg::Quat attitude =  trans->getAttitude();
                     MWBase::Environment::get().getWorld()->rotateWorldObject(ptr, attitude * rot);
                 }
         };
@@ -658,12 +663,16 @@ namespace MWScript
                     }
                     else
                         return;
+                    SceneUtil::PositionAttitudeTransform* trans;
+                    if(ptr.getRefData().isBaseNodeFlatten())
+                        trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode()->getChild(0)->getUserData());
+                    else trans = static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode());
 
                     // is it correct that disabled objects can't be Move-d?
-                    if (!ptr.getRefData().getBaseNode())
+                    if (!trans)
                         return;
 
-                    osg::Vec3f diff =   static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude() * posChange;
+                    osg::Vec3f diff = trans->getAttitude() * posChange;
                     osg::Vec3f worldPos(ptr.getRefData().getPosition().asVec3());
                     worldPos += diff;
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -596,7 +596,7 @@ namespace MWScript
                     else
                         return;
 
-                    osg::Quat attitude = ptr.getRefData().getBaseNode()->getAttitude();
+                    osg::Quat attitude =   static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude();
                     MWBase::Environment::get().getWorld()->rotateWorldObject(ptr, attitude * rot);
                 }
         };
@@ -663,7 +663,7 @@ namespace MWScript
                     if (!ptr.getRefData().getBaseNode())
                         return;
 
-                    osg::Vec3f diff = ptr.getRefData().getBaseNode()->getAttitude() * posChange;
+                    osg::Vec3f diff =   static_cast<SceneUtil::PositionAttitudeTransform*>(ptr.getRefData().getBaseNode())->getAttitude() * posChange;
                     osg::Vec3f worldPos(ptr.getRefData().getPosition().asVec3());
                     worldPos += diff;
 

--- a/apps/openmw/mwworld/refdata.cpp
+++ b/apps/openmw/mwworld/refdata.cpp
@@ -131,17 +131,17 @@ namespace MWWorld
         {}
     }
 
-    void RefData::setBaseNode(SceneUtil::PositionAttitudeTransform *base)
+    void RefData::setBaseNode(osg::Group *base)
     {
         mBaseNode = base;
     }
 
-    SceneUtil::PositionAttitudeTransform* RefData::getBaseNode()
+    osg::Group* RefData::getBaseNode()
     {
         return mBaseNode;
     }
 
-    const SceneUtil::PositionAttitudeTransform* RefData::getBaseNode() const
+    const osg::Group* RefData::getBaseNode() const
     {
         return mBaseNode;
     }

--- a/apps/openmw/mwworld/refdata.cpp
+++ b/apps/openmw/mwworld/refdata.cpp
@@ -178,8 +178,8 @@ namespace MWWorld
         TransVisitor tv( m);
         osg::ref_ptr<osg::Group> cloneoptim=(osg::Group*)transbasenode->getChild(0)->clone(osg::CopyOp::DEEP_COPY_DRAWABLES|
                                                                                            osg::CopyOp::DEEP_COPY_ARRAYS|
-                                                                          //                 osg::CopyOp::DEEP_COPY_CALLBACKS|
-                                                                        //osg::CopyOp::DEEP_COPY_ALL|
+                                                                                          // osg::CopyOp::DEEP_COPY_CALLBACKS|
+                                                                         //osg::CopyOp::DEEP_COPY_ALL|
                                                                         osg::CopyOp::DEEP_COPY_NODES);
         cloneoptim->accept(tv);
 

--- a/apps/openmw/mwworld/refdata.hpp
+++ b/apps/openmw/mwworld/refdata.hpp
@@ -148,6 +148,7 @@ namespace MWWorld
             const ESM::AnimationState& getAnimationState() const;
             ESM::AnimationState& getAnimationState();
     };
+
 }
 
 #endif

--- a/apps/openmw/mwworld/refdata.hpp
+++ b/apps/openmw/mwworld/refdata.hpp
@@ -54,6 +54,8 @@ namespace MWWorld
 
             unsigned int mFlags;
 
+            bool mFlatten;
+
         public:
 
             RefData();
@@ -85,6 +87,14 @@ namespace MWWorld
 
             /// Set base node (can be a null pointer).
             void setBaseNode (osg::Group* base);
+
+            /// Do we flatten basenode transform
+            ///  (if so we store unflatten in basenode->getChild(0)->getUserData())
+            inline void setBaseNodeFlatten (bool b) { mFlatten = b; }
+
+            inline bool isBaseNodeFlatten() const { return mFlatten; }
+
+            void flattenTransform();
 
             int getCount() const;
 

--- a/apps/openmw/mwworld/refdata.hpp
+++ b/apps/openmw/mwworld/refdata.hpp
@@ -8,9 +8,9 @@
 
 #include <string>
 
-namespace SceneUtil
+namespace osg
 {
-    class PositionAttitudeTransform;
+    class Group;
 }
 
 namespace ESM
@@ -27,7 +27,7 @@ namespace MWWorld
 
     class RefData
     {
-            SceneUtil::PositionAttitudeTransform* mBaseNode;
+            osg::Group* mBaseNode;
 
             MWScript::Locals mLocals;
 
@@ -78,13 +78,13 @@ namespace MWWorld
             RefData& operator= (const RefData& refData);
 
             /// Return base node (can be a null pointer).
-            SceneUtil::PositionAttitudeTransform* getBaseNode();
+            osg::Group* getBaseNode();
 
             /// Return base node (can be a null pointer).
-            const SceneUtil::PositionAttitudeTransform* getBaseNode() const;
+            const osg::Group* getBaseNode() const;
 
             /// Set base node (can be a null pointer).
-            void setBaseNode (SceneUtil::PositionAttitudeTransform* base);
+            void setBaseNode (osg::Group* base);
 
             int getCount() const;
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -71,7 +71,7 @@ namespace
     {
         if (!ptr.getRefData().getBaseNode())
             return;
-        if(//ptr.getRefData().getBaseNode()->getNodeMask()==Mask_Static&&
+        if(ptr.getRefData().getBaseNode()->getNodeMask()== (1<<11)&&//Mask_Static&&
                 !ptr.getClass().isMobile(ptr)
                 &&!ptr.getClass().isActivator()
                 )

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -71,7 +71,14 @@ namespace
     {
         if (!ptr.getRefData().getBaseNode())
             return;
-
+        if(//ptr.getRefData().getBaseNode()->getNodeMask()==Mask_Static&&
+                !ptr.getClass().isMobile(ptr)
+                &&!ptr.getClass().isActivator()
+                )
+        {
+            OSG_WARN<<"updating immobile trans"<<std::endl;
+            return;
+        }
         rendering.rotateObject(ptr,
             ptr.getClass().isActor()
             ? makeActorOsgQuat(ptr.getRefData().getPosition())
@@ -100,7 +107,7 @@ namespace
             model = ""; // marker objects that have a hardcoded function in the game logic, should be hidden from the player
 
         ptr.getClass().insertObjectRendering(ptr, model, rendering);
-        setNodeRotation(ptr, rendering, false);
+        if(ptr.getClass().isMobile(ptr))setNodeRotation(ptr, rendering, false);
 
         ptr.getClass().insertObject (ptr, model, physics);
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -73,7 +73,7 @@ namespace
             return;
         if(ptr.getRefData().getBaseNode()->getNodeMask()== (1<<11)&&//Mask_Static&&
                 !ptr.getClass().isMobile(ptr)
-                &&!ptr.getClass().isActivator()
+                &&!ptr.getClass().isActivator() &&!ptr.getClass().isDoor()
                 )
         {
             OSG_WARN<<"updating immobile trans"<<std::endl;
@@ -107,7 +107,8 @@ namespace
             model = ""; // marker objects that have a hardcoded function in the game logic, should be hidden from the player
 
         ptr.getClass().insertObjectRendering(ptr, model, rendering);
-        if(ptr.getClass().isMobile(ptr))setNodeRotation(ptr, rendering, false);
+
+        if(ptr.getClass().isMobile(ptr)||ptr.getClass().isActivator() ||ptr.getClass().isDoor())setNodeRotation(ptr, rendering, false);
 
         ptr.getClass().insertObject (ptr, model, physics);
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -71,14 +71,7 @@ namespace
     {
         if (!ptr.getRefData().getBaseNode())
             return;
-      /*  if(ptr.getRefData().getBaseNode()->getNodeMask()== (1<<11)&&//Mask_Static&&
-                !ptr.getClass().isMobile(ptr)
-                &&!ptr.getClass().isActivator() &&!ptr.getClass().isDoor()
-                )
-        {
-            OSG_WARN<<"updating immobile trans"<<std::endl;
-            return;
-        }*/
+
         rendering.rotateObject(ptr,
             ptr.getClass().isActor()
             ? makeActorOsgQuat(ptr.getRefData().getPosition())
@@ -107,7 +100,6 @@ namespace
             model = ""; // marker objects that have a hardcoded function in the game logic, should be hidden from the player
 
         ptr.getClass().insertObjectRendering(ptr, model, rendering);
-
         setNodeRotation(ptr, rendering, false);
 
         ptr.getClass().insertObject (ptr, model, physics);

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -71,14 +71,14 @@ namespace
     {
         if (!ptr.getRefData().getBaseNode())
             return;
-        if(ptr.getRefData().getBaseNode()->getNodeMask()== (1<<11)&&//Mask_Static&&
+      /*  if(ptr.getRefData().getBaseNode()->getNodeMask()== (1<<11)&&//Mask_Static&&
                 !ptr.getClass().isMobile(ptr)
                 &&!ptr.getClass().isActivator() &&!ptr.getClass().isDoor()
                 )
         {
             OSG_WARN<<"updating immobile trans"<<std::endl;
             return;
-        }
+        }*/
         rendering.rotateObject(ptr,
             ptr.getClass().isActor()
             ? makeActorOsgQuat(ptr.getRefData().getPosition())
@@ -108,7 +108,7 @@ namespace
 
         ptr.getClass().insertObjectRendering(ptr, model, rendering);
 
-        if(ptr.getClass().isMobile(ptr)||ptr.getClass().isActivator() ||ptr.getClass().isDoor())setNodeRotation(ptr, rendering, false);
+        setNodeRotation(ptr, rendering, false);
 
         ptr.getClass().insertObject (ptr, model, physics);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -21,6 +21,7 @@
 #include <components/resource/bulletshape.hpp>
 #include <components/resource/resourcesystem.hpp>
 
+#include <components/sceneutil/util.hpp>
 #include <components/sceneutil/positionattitudetransform.hpp>
 
 #include <components/detournavigator/debug.hpp>
@@ -2215,9 +2216,10 @@ namespace MWWorld
             computeBounds.setTraversalMask(~MWRender::Mask_ParticleSystem);
             dropped.getRefData().getBaseNode()->accept(computeBounds);
             osg::BoundingBox bounds = computeBounds.getBoundingBox();
+            osg::Vec3 cellorigin = SceneUtil::getCellOrigin(cell->getCell());
             if (bounds.valid())
             {
-                bounds.set(bounds._min - pos.asVec3(), bounds._max - pos.asVec3());
+                bounds.set(bounds._min + cellorigin - pos.asVec3(), bounds._max + cellorigin - pos.asVec3());
 
                 osg::Vec3f adjust (
                             (bounds.xMin() + bounds.xMax()) / 2,

--- a/components/sceneutil/lightutil.cpp
+++ b/components/sceneutil/lightutil.cpp
@@ -13,6 +13,7 @@
 #include "visitor.hpp"
 #include "positionattitudetransform.hpp"
 #include "apps/openmw/mwrender/objects.hpp"
+
 namespace SceneUtil
 {
 
@@ -52,14 +53,9 @@ namespace SceneUtil
         light->setQuadraticAttenuation(quadraticAttenuation);
     }
 
-    void addLight (osg::Group* node, const ESM::Cell* curcell,const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior)
+    void addLight (osg::Group* node, const ESM::Cell* curcell, const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior)
     {
 
-        OSG_WARN<<node->getParent(0)->className()<<std::endl;//curcell->mPo
-        SceneUtil::PositionAttitudeTransform* cell=static_cast<SceneUtil::PositionAttitudeTransform*>(node->getParent(0));
-
-//MWRender::PtrHolder* ptr=(MWRender::PtrHolder*) cellitem->getUserDataContainer()->getUserObject(0);
-//ptr->mPtr.getCell().
         SceneUtil::FindByNameVisitor visitor("AttachLight");
         node->accept(visitor);
 
@@ -67,9 +63,6 @@ namespace SceneUtil
         if (visitor.mFoundNode)
         {
             attachTo = visitor.mFoundNode;
-            OSG_WARN<<"mFoundNode "<<visitor.mFoundNode->className()<<std::endl;
-            OSG_WARN<<"mFoundNodepar "<<visitor.mFoundNode->getParent(0)->className()<<std::endl;
-           // cell=static_cast<SceneUtil::PositionAttitudeTransform*>(visitor.mFoundNode->getParent(0));
         }
         else
         {

--- a/components/sceneutil/lightutil.cpp
+++ b/components/sceneutil/lightutil.cpp
@@ -12,7 +12,7 @@
 #include "util.hpp"
 #include "visitor.hpp"
 #include "positionattitudetransform.hpp"
-
+#include "apps/openmw/mwrender/objects.hpp"
 namespace SceneUtil
 {
 
@@ -52,8 +52,14 @@ namespace SceneUtil
         light->setQuadraticAttenuation(quadraticAttenuation);
     }
 
-    void addLight (osg::Group* node, const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior)
+    void addLight (osg::Group* node, const ESM::Cell* curcell,const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior)
     {
+
+        OSG_WARN<<node->getParent(0)->className()<<std::endl;//curcell->mPo
+        SceneUtil::PositionAttitudeTransform* cell=static_cast<SceneUtil::PositionAttitudeTransform*>(node->getParent(0));
+
+//MWRender::PtrHolder* ptr=(MWRender::PtrHolder*) cellitem->getUserDataContainer()->getUserObject(0);
+//ptr->mPtr.getCell().
         SceneUtil::FindByNameVisitor visitor("AttachLight");
         node->accept(visitor);
 
@@ -61,6 +67,9 @@ namespace SceneUtil
         if (visitor.mFoundNode)
         {
             attachTo = visitor.mFoundNode;
+            OSG_WARN<<"mFoundNode "<<visitor.mFoundNode->className()<<std::endl;
+            OSG_WARN<<"mFoundNodepar "<<visitor.mFoundNode->getParent(0)->className()<<std::endl;
+           // cell=static_cast<SceneUtil::PositionAttitudeTransform*>(visitor.mFoundNode->getParent(0));
         }
         else
         {
@@ -72,7 +81,7 @@ namespace SceneUtil
 
             // PositionAttitudeTransform seems to be slightly faster than MatrixTransform
             osg::ref_ptr<SceneUtil::PositionAttitudeTransform> trans(new SceneUtil::PositionAttitudeTransform);
-            trans->setPosition(computeBound.getBoundingBox().center());
+            trans->setPosition(computeBound.getBoundingBox().center() - SceneUtil::getCellOrigin(curcell));
 
             node->addChild(trans);
 

--- a/components/sceneutil/lightutil.hpp
+++ b/components/sceneutil/lightutil.hpp
@@ -13,6 +13,7 @@ namespace osg
 namespace ESM
 {
     struct Light;
+    struct Cell;
 }
 
 namespace SceneUtil
@@ -32,7 +33,7 @@ namespace SceneUtil
     /// @param partsysMask Node mask to ignore when computing the sub graph's bounding box.
     /// @param lightMask Mask to assign to the newly created LightSource.
     /// @param isExterior Is the light outside? May be used for deciding which attenuation settings to use.
-    void addLight (osg::Group* node, const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior);
+    void addLight (osg::Group* node, const ESM::Cell* curcell, const ESM::Light* esmLight, unsigned int partsysMask, unsigned int lightMask, bool isExterior);
 
     /// @brief Convert an ESM::Light to a SceneUtil::LightSource, and return it.
     /// @param esmLight The light definition coming from the game files containing radius, color, flicker, etc.

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -2,8 +2,18 @@
 
 #include <osg/Node>
 
+
+#include <components/esm/loadcell.hpp>
+#include <components/esm/loadland.hpp>
 namespace SceneUtil
 {
+const float cellSize = static_cast<float>(ESM::Land::REAL_SIZE);
+
+osg::Vec3 getCellOrigin(const ESM::Cell *c){
+    const ESM::CellId::CellIndex &cellid =c->getCellId().mIndex;
+    return osg::Vec3( (static_cast<float>(cellid.mX)+0.5f) * cellSize,
+                         (static_cast<float>(cellid.mY)+0.5f) * cellSize, 0);
+}
 
 void transformBoundingSphere (const osg::Matrixf& matrix, osg::BoundingSphere& bsphere)
 {

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -4,6 +4,9 @@
 #include <osg/Matrix>
 #include <osg/BoundingSphere>
 #include <osg/Vec4f>
+#include <osg/Vec3f>
+
+#include <components/esm/loadcell.hpp>
 
 namespace SceneUtil
 {
@@ -20,6 +23,8 @@ namespace SceneUtil
     float makeOsgColorComponent (unsigned int value, unsigned int shift);
 
     bool hasUserDescription(const osg::Node* node, const std::string pattern);
+
+    osg::Vec3f getCellOrigin(const ESM::Cell *);
 }
 
 #endif

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -281,6 +281,9 @@ texture min filter = linear
 # Texture mipmap type.  (none, nearest, or linear).
 texture mipmap = nearest
 
+# flatten first static for non moving objects
+flattenstatics = false
+
 [Shaders]
 
 # Force rendering with shaders. By default, only bump-mapped objects will use shaders.


### PR DESCRIPTION
2 pr in one as i ran into numeric problem flattening transforms:
- push hierarchic transforms at cell levels (require deep testing, perhaps i missed special transform ajustement)
- add flatten statics objects feature

The latter can be subject of other pr, further it's not as pertinent as i thought on first glance, if you want i remove it:
 performance was due to flatten of animated!! (see screenshot)
perhaps there's improvement on lowerend gpus....don't know

flatten test is:

```
!animated (i forgot this one, it explains mesured perf )
&&!ptr.getClass().isMobile(ptr) 
&& !ptr.getClass().isActivator() 
&& !ptr.getClass().isDoor()
```

![fok](https://user-images.githubusercontent.com/4062709/59463574-96b73000-8e26-11e9-9c04-0f1263a794a1.jpg)