### PR TITLE
Make sure "Tri Shadow"-named shapes aren't visible (bug #5063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
     Bug #5050: Invalid spell effects are not handled gracefully
     Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
+    Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden
     Bug #5069: Blocking creatures' attacks doesn't degrade shields
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -585,8 +585,11 @@ namespace NifOsg
             {
                 const Nif::NiTriShape* triShape = static_cast<const Nif::NiTriShape*>(nifNode);
                 const std::string nodeName = Misc::StringUtils::lowerCase(triShape->name);
-                static const std::string pattern = "tri editormarker";
-                if (!hasMarkers || nodeName.compare(0, pattern.size(), pattern) != 0)
+                static const std::string markerName = "tri editormarker";
+                static const std::string shadowName = "shadow";
+                static const std::string shadowName2 = "tri shadow";
+                const bool isMarker = hasMarkers && !nodeName.compare(0, markerName.size(), markerName);
+                if (!isMarker && nodeName.compare(0, shadowName.size(), shadowName) && nodeName.compare(0, shadowName2.size(), shadowName2))
                 {
                     if (triShape->skin.empty())
                         handleTriShape(triShape, node, composite, boundTextures, animflags);


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5063)

This makes the engine and the editor behave mostly behave like TESCS in that shapes that are using this reserved name pattern and "Shadow" pattern in the beginning of the name are not handled even if they're not a part of an actor. I'm not sure this can be adjusted to behave 100% like Morrowind.exe without some awful hacks thrown into the way of how the NIF loader works.