### PR TITLE
fix transparent writing depth buffer

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1627,13 +1627,15 @@ namespace NifOsg
                         blendFunc = shareAttribute(blendFunc);
                         stateset->setAttributeAndModes(blendFunc, osg::StateAttribute::ON);
                         
-                        osg::ref_ptr<osg::Depth> depth = new osg::Depth(osg::Depth::LESS, 0.0, 1.0, false);
-                        depth = shareAttribute(depth);
-                        stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
 
                         bool noSort = (alphaprop->flags>>13)&1;
                         if (!noSort)
+                        {
+                            osg::ref_ptr<osg::Depth> depth = new osg::Depth(osg::Depth::LESS, 0.0, 1.0, false);
+                            depth = shareAttribute(depth);
+                            stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
                             stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+                        }
                         else
                             stateset->setRenderBinToInherit();
                     }

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1626,7 +1626,10 @@ namespace NifOsg
                                                                                    getBlendMode((alphaprop->flags>>5)&0xf)));
                         blendFunc = shareAttribute(blendFunc);
                         stateset->setAttributeAndModes(blendFunc, osg::StateAttribute::ON);
-                        stateset->setAttributeAndModes(new osg::Depth(osg::Depth::LESS, 0.0, 1.0, false));
+                        
+                        osg::ref_ptr<osg::Depth> depth = new osg::Depth(osg::Depth::LESS, 0.0, 1.0, false);
+                        depth = shareAttribute(depth);
+                        stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
 
                         bool noSort = (alphaprop->flags>>13)&1;
                         if (!noSort)

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1626,6 +1626,7 @@ namespace NifOsg
                                                                                    getBlendMode((alphaprop->flags>>5)&0xf)));
                         blendFunc = shareAttribute(blendFunc);
                         stateset->setAttributeAndModes(blendFunc, osg::StateAttribute::ON);
+                        stateset->setAttributeAndModes(new osg::Depth(osg::Depth::LESS, 0.0, 1.0, false));
 
                         bool noSort = (alphaprop->flags>>13)&1;
                         if (!noSort)


### PR DESCRIPTION
as transparent bin depth sorts drawables, it doesn't disable depth write...this behavior is implicit in osg and so depthwrite should be disable to comply with nif semantic of "blending" (in which depth write off is not specified: my guess is original engine treat unsorted blended in a peculiar fashion -surely depth peeling-). 
Arguments:
- sorting back2front with depth test don't garantee transparents don't occlude each others (sorting is coarse grain)
- enable depthwrite interferes with Occlusion Queries Node which are based on depth test : transparents write depth so queries coming from behind return not visible (which is not.. because "transparents")
Further it mitigates bug  https://gitlab.com/OpenMW/openmw/issues/3366 too
![alphafix](https://user-images.githubusercontent.com/4062709/61089786-8b165380-a43c-11e9-8eaf-1d232ff808ca.png)
