### PR TITLE
Signedness fixes

### DIFF
--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -169,8 +169,8 @@ void ESMStore::validate()
             if (!fact)
             {
                 Log(Debug::Verbose) << "NPC '" << npc.mId << "' (" << npc.mName << ") has nonexistent faction '" << npc.mFaction << "', ignoring it.";
-                npc.mFaction = "";
-                npc.mNpdt.mRank = -1;
+                npc.mFaction.clear();
+                npc.mNpdt.mRank = 0;
                 changed = true;
             }
         }

--- a/components/esm/loadclot.hpp
+++ b/components/esm/loadclot.hpp
@@ -40,7 +40,7 @@ struct Clothing
         int mType;
         float mWeight;
         unsigned short mValue;
-        short mEnchant;
+        unsigned short mEnchant;
     };
     CTDTstruct mData;
 

--- a/components/esm/loadweap.hpp
+++ b/components/esm/loadweap.hpp
@@ -59,7 +59,7 @@ struct Weapon
         short mType;
         unsigned short mHealth;
         float mSpeed, mReach;
-        short mEnchant; // Enchantment points. The real value is mEnchant/10.f
+        unsigned short mEnchant; // Enchantment points. The real value is mEnchant/10.f
         unsigned char mChop[2], mSlash[2], mThrust[2]; // Min and max
         int mFlags;
     }; // 32 bytes


### PR DESCRIPTION
Some very minor fixes to some situations where signedness plays a role that shouldn't require changelog entries.
Enchantment points capacity of clothing and weapons is now unsigned short so it doesn't overflow into negatives once it's higher than 32767. Based on recent MWSE struct updates from Hrnchamd.

mRank field of NPCs became unsigned, however in NPC record validator it was assumed the default value of that field is -1 for NPCs that aren't in a faction (it's not), so after the signedness changes it assigned the rank of NPCs with nonexistent faction to 255 which doesn't really make sense and can trigger compilation warnings under certain conditions. Now it's just zero.