### PR TITLE
Logarithmic depth buffer

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -583,7 +583,7 @@ namespace MWPhysics
 
         if (mDebugDrawEnabled && !mDebugDrawer.get())
         {
-            mDebugDrawer.reset(new MWRender::DebugDrawer(mParentNode, mCollisionWorld));
+            mDebugDrawer.reset(new MWRender::DebugDrawer(mParentNode, mCollisionWorld, mResourceSystem));
             mCollisionWorld->setDebugDrawer(mDebugDrawer.get());
             mDebugDrawer->setDebugMode(mDebugDrawEnabled);
         }

--- a/apps/openmw/mwrender/bulletdebugdraw.hpp
+++ b/apps/openmw/mwrender/bulletdebugdraw.hpp
@@ -7,6 +7,8 @@
 
 #include <LinearMath/btIDebugDraw.h>
 
+#include <components/resource/resourcesystem.hpp>
+
 class btCollisionWorld;
 
 namespace osg
@@ -32,9 +34,11 @@ protected:
     void createGeometry();
     void destroyGeometry();
 
+    Resource::ResourceSystem* mResourceSystem;
+
 public:
 
-    DebugDrawer(osg::ref_ptr<osg::Group> parentNode, btCollisionWorld *world);
+    DebugDrawer(osg::ref_ptr<osg::Group> parentNode, btCollisionWorld *world, Resource::ResourceSystem* resourceSystem);
     ~DebugDrawer();
 
     void step();

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -171,7 +171,7 @@ osg::ref_ptr<osg::Camera> LocalMap::createOrthographicCamera(float x, float y, f
 
     camera->setProjectionMatrixAsOrtho(-width/2, width/2, -height/2, height/2, 5, (zmax-zmin) + 10);
     camera->setComputeNearFarMode(osg::Camera::DO_NOT_COMPUTE_NEAR_FAR);
-    camera->setViewMatrixAsLookAt(osg::Vec3d(x, y, zmax + 5), osg::Vec3d(x, y, zmin), upVector);
+    camera->setViewMatrixAsLookAt(osg::Vec3d(x, y, zmax + 1000), osg::Vec3d(x, y, zmin), upVector);
     camera->setReferenceFrame(osg::Camera::ABSOLUTE_RF);
     camera->setRenderTargetImplementation(osg::Camera::FRAME_BUFFER_OBJECT, osg::Camera::PIXEL_BUFFER_RTT);
     camera->setClearColor(osg::Vec4(0.f, 0.f, 0.f, 1.f));

--- a/files/shaders/CMakeLists.txt
+++ b/files/shaders/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SDIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(DDIRRELATIVE resources/shaders)
 
 set(SHADER_FILES
+    tcb_vertex.glsl
+    tcb_fragment.glsl
     water_vertex.glsl
     water_fragment.glsl
     water_nm.png

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -61,6 +61,8 @@ varying vec3 passNormal;
 
 void main()
 {
+    gl_FragDepth = (log(gl_TexCoord[6].z + 1.0) / log(1000000000.0 + 1.0));
+
 #if @diffuseMap
     vec2 adjustedDiffuseUV = diffuseMapUV;
 #endif

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -53,6 +53,7 @@ varying vec3 passNormal;
 void main(void)
 {
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+    gl_TexCoord[6] = gl_Position;
     depth = gl_Position.z;
 
     vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);

--- a/files/shaders/tcb_fragment.glsl
+++ b/files/shaders/tcb_fragment.glsl
@@ -1,0 +1,6 @@
+#version 120
+
+void main()
+{
+    gl_FragDepth = (log(gl_TexCoord[6].z + 1.0) / log(1000000000.0 + 1.0));
+}

--- a/files/shaders/tcb_vertex.glsl
+++ b/files/shaders/tcb_vertex.glsl
@@ -1,0 +1,7 @@
+#version 120
+
+void main(void)
+{
+    gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+    gl_TexCoord[6] = gl_Position;
+}

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -31,6 +31,8 @@ varying vec3 passNormal;
 
 void main()
 {
+    gl_FragDepth = (log(gl_TexCoord[6].z + 1.0) / log(1000000000.0 + 1.0));
+
     vec2 adjustedUV = (gl_TextureMatrix[0] * vec4(uv, 0.0, 1.0)).xy;
 
 #if @normalMap

--- a/files/shaders/terrain_vertex.glsl
+++ b/files/shaders/terrain_vertex.glsl
@@ -21,6 +21,7 @@ varying vec3 passNormal;
 void main(void)
 {
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+    gl_TexCoord[6] = gl_Position;
     depth = gl_Position.z;
 
     vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);

--- a/files/shaders/water_fragment.glsl
+++ b/files/shaders/water_fragment.glsl
@@ -242,7 +242,7 @@ void main(void)
 #if REFRACTION
     float depthSample = linearizeDepth(texture2D(refractionDepthMap,screenCoords).x);
     float depthSampleDistorted = linearizeDepth(texture2D(refractionDepthMap,screenCoords-(normal.xy*REFR_BUMP)).x);
-    float surfaceDepth = linearizeDepth(gl_FragCoord.z);
+    float surfaceDepth = linearizeDepth(gl_FragDepth);
     float realWaterDepth = depthSample - surfaceDepth;  // undistorted water depth in view direction, independent of frustum
     float shore = clamp(realWaterDepth / BUMP_SUPPRESS_DEPTH,0,1);
 #else

--- a/files/shaders/water_fragment.glsl
+++ b/files/shaders/water_fragment.glsl
@@ -153,13 +153,14 @@ float frustumDepth;
 
 float linearizeDepth(float depth)
   {
-    float z_n = 2.0 * depth - 1.0;
-    depth = 2.0 * near * far / (far + near - z_n * frustumDepth);
+    depth = exp(depth*log(1000000000.0+1.0)) - 1;
     return depth;
   }
 
 void main(void)
 {
+    gl_FragDepth = (log(gl_TexCoord[6].z + 1.0) / log(1000000000.0 + 1.0));
+
     frustumDepth = abs(far - near);
     vec3 worldPos = position.xyz + nodePosition.xyz;
     vec2 UV = worldPos.xy / (8192.0*5.0) * 3.0;

--- a/files/shaders/water_vertex.glsl
+++ b/files/shaders/water_vertex.glsl
@@ -9,6 +9,7 @@ varying float  depthPassthrough;
 void main(void)
 {
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+    gl_TexCoord[6] = gl_Position;
 
     mat4 scalemat = mat4(0.5, 0.0, 0.0, 0.0,
                          0.0, -0.5, 0.0, 0.0,


### PR DESCRIPTION
Here are results of my experiments with these articles:

https://outerra.blogspot.com/2009/08/logarithmic-z-buffer.html
https://outerra.blogspot.com/2012/11/maximizing-depth-buffer-range-and.html
https://www.gamedev.net/blogs/entry/2006307-tip-of-the-day-logarithmic-zbuffer-artifacts-fix
https://stackoverflow.com/questions/18182139/logarithmic-depth-buffer-linearization

**Since it implemented via shaders, I suppose it will have no effect in the fixed pipeline mode.
Also you do not need to alter the "near clip" setting value.**

In my testing it worked quite good:

![Screenshot_20190618_212105](https://user-images.githubusercontent.com/26434804/59705348-43baef80-920f-11e9-8126-64413b322bce.png)

And here is what we have now in master branch:
![Screenshot_20190618_212127](https://user-images.githubusercontent.com/26434804/59705369-4c132a80-920f-11e9-88d6-e343885cce5a.png)

Unfortunately, there are issues. What I found so far:
~~1. Minimap does not render some objects (the bug is visible on the first screenshot).~~
2. There is a white outline when looking horizontally, presumably because of water shader.
3. There is a quite large performance drop (under GPU section). Maybe there are ways to optimize calculations...
4. TCB does not work well - lines are black for some reason instead of white.

I can not fix these issues by myself (since I am not familiar with GLSL at all).
Casting @AnyOldName3, @kcat and @Capostrophic here. Can we improve this approach, or it is not suitable for us?
