### PR TITLE
Make unarmed creature attacks affect shield condition again (bug #5069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
     Bug #5050: Invalid spell effects are not handled gracefully
     Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
+    Bug #5069: Blocking creatures' attacks doesn't degrade shields
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -115,16 +115,13 @@ namespace MWMechanics
 
         if (Misc::Rng::roll0to99() < x)
         {
-            if (!(weapon.isEmpty() && !attacker.getClass().isNpc())) // Unarmed creature attacks don't affect armor condition
-            {
-                // Reduce shield durability by incoming damage
-                int shieldhealth = shield->getClass().getItemHealth(*shield);
+            // Reduce shield durability by incoming damage
+            int shieldhealth = shield->getClass().getItemHealth(*shield);
 
-                shieldhealth -= std::min(shieldhealth, int(damage));
-                shield->getCellRef().setCharge(shieldhealth);
-                if (shieldhealth == 0)
-                    inv.unequipItem(*shield, blocker);
-            }
+            shieldhealth -= std::min(shieldhealth, int(damage));
+            shield->getCellRef().setCharge(shieldhealth);
+            if (shieldhealth == 0)
+                inv.unequipItem(*shield, blocker);
             // Reduce blocker fatigue
             const float fFatigueBlockBase = gmst.find("fFatigueBlockBase")->mValue.getFloat();
             const float fFatigueBlockMult = gmst.find("fFatigueBlockMult")->mValue.getFloat();


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5069).

When I reintroduced the original quirk I made an assumption that shield condition doesn't need to be affected during block, apparently erroneous. This reverts block shield condition damage logic to what it was in 0.44.0.