### PR TITLE
Disallow actors to start combat with themselves (bug #3550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     Bug #3006: 'else if' operator breaks script compilation
     Bug #3109: SetPos/Position handles actors differently
     Bug #3282: Unintended behaviour when assigning F3 and Windows keys
+    Bug #3550: Companion from mod attacks the air after combat has ended
     Bug #3623: Display scaling breaks mouse recognition
     Bug #3725: Using script function in a non-conditional expression breaks script compilation
     Bug #3733: Normal maps are inverted on mirrored UVs

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -116,6 +116,9 @@ namespace MWMechanics
                 || target.getClass().getCreatureStats(target).isDead())
             return true;
 
+        if (actor == target) // This should never happen.
+            return true;
+
         if (!storage.isFleeing())
         {
             if (storage.mCurrentAction.get()) // need to wait to init action with its attack range

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1647,18 +1647,28 @@ namespace MWMechanics
 
     void MechanicsManager::startCombat(const MWWorld::Ptr &ptr, const MWWorld::Ptr &target)
     {
-        MWMechanics::AiSequence& aiSequence = ptr.getClass().getCreatureStats(ptr).getAiSequence();
+        CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
 
-        if (aiSequence.isInCombat(target))
+        // Don't add duplicate packages nor add packages to dead actors.
+        if (stats.isDead() || stats.getAiSequence().isInCombat(target))
             return;
 
-        aiSequence.stack(MWMechanics::AiCombat(target), ptr);
+        // The target is somehow the same as the actor. Early-out.
+        if (ptr == target)
+        {
+            // We don't care about dialogue filters since the target is invalid.
+            // We still want to play the combat taunt.
+            MWBase::Environment::get().getDialogueManager()->say(ptr, "attack");
+            return;
+        }
+
+        stats.getAiSequence().stack(MWMechanics::AiCombat(target), ptr);
         if (target == getPlayer())
         {
             // if guard starts combat with player, guards pursuing player should do the same
             if (ptr.getClass().isClass(ptr, "Guard"))
             {
-                ptr.getClass().getCreatureStats(ptr).setHitAttemptActorId(target.getClass().getCreatureStats(target).getActorId()); // Stops guard from ending combat if player is unreachable
+                stats.setHitAttemptActorId(target.getClass().getCreatureStats(target).getActorId()); // Stops guard from ending combat if player is unreachable
                 for (Actors::PtrActorMap::const_iterator iter = mActors.begin(); iter != mActors.end(); ++iter)
                 {
                     if (iter->first.getClass().isClass(iter->first, "Guard"))
@@ -1676,8 +1686,7 @@ namespace MWMechanics
         }
 
         // Must be done after the target is set up, so that CreatureTargetted dialogue filter works properly
-        if (ptr.getClass().isNpc() && !ptr.getClass().getCreatureStats(ptr).isDead())
-            MWBase::Environment::get().getDialogueManager()->say(ptr, "attack");
+        MWBase::Environment::get().getDialogueManager()->say(ptr, "attack");
     }
 
     void MechanicsManager::getObjectsInRange(const osg::Vec3f &position, float radius, std::vector<MWWorld::Ptr> &objects)


### PR DESCRIPTION
Should fix [this](https://gitlab.com/OpenMW/openmw/issues/3550).

`actorID->startcombat actorID` is valid syntax, and the actor will not do anything but say the combat taunt if it's used.
Apparently companion mods sometimes exploit this fact to play combat taunts at arbitrary moments, and while it's a relatively safe thing to do in Morrowind, in OpenMW there aren't any checks for whether the target isn't the same as the attacking actor so the actor starts combat with themselves. Hilarity ensues.

I fixed that, and also made some other minor changes: creatures will also play combat taunts upon starting combat and not just during it (continuation of #2107), and dead actors won't try to start combat because that's redundant (the package will be immediately stopped).

AiCombat execution also stops if the target of the package is somehow the same as the actor executing the package. It could be necessary in the situation when the loaded save has an NPC that has suicidal tendencies.