### PR TITLE
Correct cast style behavior when there's no item picked (bug #5075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
     Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden
     Bug #5069: Blocking creatures' attacks doesn't degrade shields
+    Bug #5075: Enchanting cast style can be changed if there's no object
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -102,10 +102,7 @@ namespace MWMechanics
     void Enchanting::nextCastStyle()
     {
         if (itemEmpty())
-        {
-            mCastStyle = ESM::Enchantment::WhenUsed;
             return;
-        }
 
         const bool powerfulSoul = getGemCharge() >= \
                 MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find ("iSoulAmountForConstantEffect")->mValue.getInteger();
@@ -267,6 +264,8 @@ namespace MWMechanics
     void Enchanting::setEnchanter(const MWWorld::Ptr& enchanter)
     {
         mEnchanter = enchanter;
+        // Reset cast style
+        mCastStyle = ESM::Enchantment::CastOnce;
     }
 
     int Enchanting::getEnchantChance() const


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5075)

There were two issues:
1. nextCastStyle would set the casting style to When Used for no reason every time it was used (main situation: cast style button is clicked), while in Morrowind the button simply does nothing if there's no item picked or if there's no item picked anymore.
2. Cast style wasn't reset if the enchanting window was closed.

For the first issue I made nextCastStyle do nothing if there's no item picked. For the second I decided to reset casting style in setEnchanter. It seems to be fine to do it there for now.