### PR TITLE
Disallow paralyzed actors to greet the player (bug #5074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
     Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden
     Bug #5069: Blocking creatures' attacks doesn't degrade shields
+    Bug #5074: Paralyzed actors greet the player
     Bug #5075: Enchanting cast style can be changed if there's no object
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -527,7 +527,8 @@ namespace MWMechanics
         if (greetingState == AiWanderStorage::Greet_None)
         {
             if ((playerPos - actorPos).length2() <= helloDistance*helloDistance &&
-                !player.getClass().getCreatureStats(player).isDead() && MWBase::Environment::get().getWorld()->getLOS(player, actor)
+                !player.getClass().getCreatureStats(player).isDead() && !actor.getClass().getCreatureStats(actor).isParalyzed()
+                && MWBase::Environment::get().getWorld()->getLOS(player, actor)
                 && MWBase::Environment::get().getMechanicsManager()->awarenessCheck(player, actor))
                 greetingTimer++;
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5074)
Now, this probably isn't exactly what vanilla does (Hrnchamd's research doesn't mention anything about paralyze and he himself didn't clarify it), but it simulates vanilla behavior well enough.