### PR TITLE
Rewrite messed up playerlooking switch handling (bug #5078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
     Bug #5069: Blocking creatures' attacks doesn't degrade shields
     Bug #5074: Paralyzed actors greet the player
     Bug #5075: Enchanting cast style can be changed if there's no object
+    Bug #5078: DisablePlayerLooking is broken
     Bug #5082: Scrolling with controller in GUI mode is broken
     Bug #5092: NPCs with enchanted weapons play sound when out of charges
     Bug #5093: Hand to hand sound plays on knocked out enemies

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -407,7 +407,6 @@ namespace MWBase
             virtual void togglePreviewMode(bool enable) = 0;
             virtual bool toggleVanityMode(bool enable) = 0;
             virtual void allowVanityMode(bool allow) = 0;
-            virtual void togglePlayerLooking(bool enable) = 0;
             virtual void changeVanityModeScale(float factor) = 0;
             virtual bool vanityRotateCamera(float * rot) = 0;
             virtual void setCameraDistance(float dist, bool adjust = false, bool override = true)=0;

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -589,7 +589,7 @@ namespace MWInput
                 rot[2] = xAxis * (dt * 100.0f) * 10.0f * mCameraSensitivity * (1.0f/256.f) * (mInvertX ? -1 : 1);
 
                 // Only actually turn player when we're not in vanity mode
-                if(!MWBase::Environment::get().getWorld()->vanityRotateCamera(rot))
+                if(!MWBase::Environment::get().getWorld()->vanityRotateCamera(rot) && mControlSwitch["playerlooking"])
                 {
                     mPlayer->yaw(rot[2]);
                     mPlayer->pitch(rot[0]);
@@ -827,9 +827,6 @@ namespace MWInput
 
     void InputManager::toggleControlSwitch (const std::string& sw, bool value)
     {
-        if (mControlSwitch[sw] == value) {
-            return;
-        }
         /// \note 7 switches at all, if-else is relevant
         if (sw == "playercontrols" && !value) {
             mPlayer->setLeftRight(0);
@@ -841,8 +838,8 @@ namespace MWInput
             mPlayer->setUpDown(0);
         } else if (sw == "vanitymode") {
             MWBase::Environment::get().getWorld()->allowVanityMode(value);
-        } else if (sw == "playerlooking") {
-            MWBase::Environment::get().getWorld()->togglePlayerLooking(value);
+        } else if (sw == "playerlooking" && !value) {
+            MWBase::Environment::get().getWorld()->rotateObject(mPlayer->getPlayer(), 0.f, 0.f, 0.f);
         }
         mControlSwitch[sw] = value;
     }
@@ -976,7 +973,7 @@ namespace MWInput
             rot[2] = -x;
 
             // Only actually turn player when we're not in vanity mode
-            if(!MWBase::Environment::get().getWorld()->vanityRotateCamera(rot))
+            if(!MWBase::Environment::get().getWorld()->vanityRotateCamera(rot) && mControlSwitch["playerlooking"])
             {
                 mPlayer->yaw(x);
                 mPlayer->pitch(y);

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -48,7 +48,6 @@ namespace MWRender
       mAnimation(nullptr),
       mFirstPersonView(true),
       mPreviewMode(false),
-      mFreeLook(true),
       mNearest(30.f),
       mFurthest(800.f),
       mIsNearest(false),
@@ -391,11 +390,6 @@ namespace MWRender
 
         osg::Vec3d offset = orient * osg::Vec3d(0, isFirstPerson() ? 0 : -mCameraDistance, 0);
         camera = focal + offset;
-    }
-
-    void Camera::togglePlayerLooking(bool enable)
-    {
-        mFreeLook = enable;
     }
 
     bool Camera::isVanityOrPreviewModeEnabled()

--- a/apps/openmw/mwrender/camera.hpp
+++ b/apps/openmw/mwrender/camera.hpp
@@ -37,7 +37,6 @@ namespace MWRender
 
         bool mFirstPersonView;
         bool mPreviewMode;
-        bool mFreeLook;
         float mNearest;
         float mFurthest;
         bool mIsNearest;
@@ -118,8 +117,6 @@ namespace MWRender
 
         /// Stores focal and camera world positions in passed arguments
         void getPosition(osg::Vec3f &focal, osg::Vec3f &camera);
-
-        void togglePlayerLooking(bool enable);
 
         bool isVanityOrPreviewModeEnabled();
 

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -1353,11 +1353,6 @@ namespace MWRender
         mCamera->allowVanityMode(allow);
     }
 
-    void RenderingManager::togglePlayerLooking(bool enable)
-    {
-        mCamera->togglePlayerLooking(enable);
-    }
-
     void RenderingManager::changeVanityModeScale(float factor)
     {
         if(mCamera->isVanityOrPreviewModeEnabled())

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -208,7 +208,6 @@ namespace MWRender
         void togglePreviewMode(bool enable);
         bool toggleVanityMode(bool enable);
         void allowVanityMode(bool allow);
-        void togglePlayerLooking(bool enable);
         void changeVanityModeScale(float factor);
 
         /// temporarily override the field of view with given value.

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2389,11 +2389,6 @@ namespace MWWorld
         mRendering->allowVanityMode(allow);
     }
 
-    void World::togglePlayerLooking(bool enable)
-    {
-        mRendering->togglePlayerLooking(enable);
-    }
-
     void World::changeVanityModeScale(float factor)
     {
         mRendering->changeVanityModeScale(factor);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -526,8 +526,6 @@ namespace MWWorld
 
             void allowVanityMode(bool allow) override;
 
-            void togglePlayerLooking(bool enable) override;
-
             void changeVanityModeScale(float factor) override;
 
             bool vanityRotateCamera(float * rot) override;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5078)

It was never implemented correctly to begin with, disregarding the fact that the rotation of the player is reset when DisablePlayerControls is used or breaking something else, then it got completely mutilated because mFreeLook became unused after Chris' camera refactoring in 2013. So DisablePlayerLooking became no-op years ago.

So I purged much of the dead code then replaced it with my own implementation of the switch which replicates what I see in Morrowind: DisablePlayerLooking resets player (and camera) rotation when it is initially applied and blocks its change by mouselook. Note that the player's angle depends on the current cell's real north like in Morrowind, and will not reset upon cell transitions until a new DisablePlayerLooking call is done.

Apparently vanilla will do whatever toggling a controls switch would have done if it was actually toggled even if the switch wasn't actually toggled, so I removed the code that prevents that too.

Preview mode doesn't seem to be affected by playerlooking switch in vanilla, I replicated it.