### PR TITLE
Fix jumping mechanics framerate dependency (bug #4991)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
     Bug #4984: "Friendly hits" feature should be used only for player's followers
     Bug #4989: Object dimension-dependent VFX scaling behavior is inconsistent
     Bug #4990: Dead bodies prevent you from hitting
+    Bug #4991: Jumping occasionally takes too much fatigue
     Bug #4999: Drop instruction behaves differently from vanilla
     Bug #5001: Possible data race in the Animation::setAlpha()
     Bug #5004: Werewolves shield their eyes during storm

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2099,28 +2099,6 @@ void CharacterController::update(float duration, bool animationOnly)
                     lat.normalize();
                     vec = osg::Vec3f(lat.x(), lat.y(), 1.0f) * z * 0.707f;
                 }
-
-                // advance acrobatics
-                // also set jumping flag to allow GetPCJumping works
-                if (isPlayer)
-                {
-                    cls.skillUsageSucceeded(mPtr, ESM::Skill::Acrobatics, 0);
-                    MWBase::Environment::get().getWorld()->getPlayer().setJumping(true);
-                }
-
-                // decrease fatigue
-                const float fatigueJumpBase = gmst.find("fFatigueJumpBase")->mValue.getFloat();
-                const float fatigueJumpMult = gmst.find("fFatigueJumpMult")->mValue.getFloat();
-                float normalizedEncumbrance = mPtr.getClass().getNormalizedEncumbrance(mPtr);
-                if (normalizedEncumbrance > 1)
-                    normalizedEncumbrance = 1;
-                const float fatigueDecrease = fatigueJumpBase + normalizedEncumbrance * fatigueJumpMult;
-
-                if (!godmode)
-                {
-                    fatigue.setCurrent(fatigue.getCurrent() - fatigueDecrease);
-                    cls.getCreatureStats(mPtr).setFatigue(fatigue);
-                }
             }
         }
         else if(mJumpState == JumpState_InAir && !inwater && !flying && solid)
@@ -2333,7 +2311,9 @@ void CharacterController::update(float duration, bool animationOnly)
 
         movement = vec;
         cls.getMovementSettings(mPtr).mPosition[0] = cls.getMovementSettings(mPtr).mPosition[1] = 0;
-        // Can't reset jump state (mPosition[2]) here; we don't know for sure whether the PhysicSystem will actually handle it in this frame
+        if (movement.z() == 0.f)
+            cls.getMovementSettings(mPtr).mPosition[2] = 0;
+        // Can't reset jump state (mPosition[2]) here in full; we don't know for sure whether the PhysicSystem will actually handle it in this frame
         // due to the fixed minimum timestep used for the physics update. It will be reset in PhysicSystem::move once the jump is handled.
 
         if (!mSkipAnim)

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -34,6 +34,7 @@
 
 #include "../mwworld/esmstore.hpp"
 #include "../mwworld/cellstore.hpp"
+#include "../mwworld/player.hpp"
 
 #include "../mwrender/bulletdebugdraw.hpp"
 
@@ -326,7 +327,30 @@ namespace MWPhysics
             if (movement.z() > 0 && ptr.getClass().getCreatureStats(ptr).isDead() && position.z() < swimlevel)
                 velocity = osg::Vec3f(0,0,1) * 25;
 
-            ptr.getClass().getMovementSettings(ptr).mPosition[2] = 0;
+            if (ptr.getClass().getMovementSettings(ptr).mPosition[2])
+            {
+                const bool isPlayer = (ptr == MWMechanics::getPlayer());
+                // Advance acrobatics and set flag for GetPCJumping
+                if (isPlayer)
+                {
+                    ptr.getClass().skillUsageSucceeded(ptr, ESM::Skill::Acrobatics, 0);
+                    MWBase::Environment::get().getWorld()->getPlayer().setJumping(true);
+                }
+
+                // Decrease fatigue
+                if (!isPlayer || !MWBase::Environment::get().getWorld()->getGodModeState())
+                {
+                    const MWWorld::Store<ESM::GameSetting> &gmst = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>();
+                    const float fFatigueJumpBase = gmst.find("fFatigueJumpBase")->mValue.getFloat();
+                    const float fFatigueJumpMult = gmst.find("fFatigueJumpMult")->mValue.getFloat();
+                    const float normalizedEncumbrance = std::min(1.f, ptr.getClass().getNormalizedEncumbrance(ptr));
+                    const float fatigueDecrease = fFatigueJumpBase + normalizedEncumbrance * fFatigueJumpMult;
+                    MWMechanics::DynamicStat<float> fatigue = ptr.getClass().getCreatureStats(ptr).getFatigue();
+                    fatigue.setCurrent(fatigue.getCurrent() - fatigueDecrease);
+                    ptr.getClass().getCreatureStats(ptr).setFatigue(fatigue);
+                }
+                ptr.getClass().getMovementSettings(ptr).mPosition[2] = 0;
+            }
 
             // Now that we have the effective movement vector, apply wind forces to it
             if (MWBase::Environment::get().getWorld()->isInStorm())


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4991).

The way jump attempts work is, we cache the jumping state, feed physics system vertical movement every frame and see if it's going to be successful. If not (if the current framerate is above 60 or whatever the physics framerate is), we try it again in every character controller update. However, when we feed vertical movement to the physics system, we reduce fatigue and progress player's acrobatics skill each time. If we do in fact reset the jumping state, this is "fixed", but the player is unable to jump if the jumping movement is not going to be handled in this frame, so that's not a proper solution.

I work around this here by moving the fatigue decreasing and acrobatics progressing to the physics update, to the moment when the jumping state is in fact handled by the physics system and reset, so these operations are guaranteed to be only done once when a jump happens. Jumping state is now reset in the character controller if the vertical movement was cancelled by a certain conditions (sneaking, flying, knockdown state etc.) so these operations are not performed every time the player or an NPC attempts to jump. It's not a very satisfying solution due to how a part of the mechanics had to be moved to physics, but we already do that from time to time and it's better to have some working solution than a solution that isn't there at all. And there aren't any new dependencies other than the player class one necessary to set the jumping flag for GetPCJumping.

I hope I'm not going to hate myself for this.