### PR TITLE
Fixed crash with sound disabled (bug #4600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4540: Rain delay when exiting water
+    Bug #4600: Crash when no sound output is available or --no-sound is used. 
     Bug #4639: Black screen after completing first mages guild mission + training
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4703: Editor: it's possible to preview levelled list records

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -983,7 +983,6 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
     if(evt.compare(0, 7, "sound: ") == 0)
     {
         MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-        sndMgr->stopSound3D(mPtr, evt.substr(7));
         sndMgr->playSound3D(mPtr, evt.substr(7), 1.0f, 1.0f);
         return;
     }
@@ -1024,7 +1023,6 @@ void CharacterController::handleTextKey(const std::string &groupname, const std:
             }
             else
             {
-                sndMgr->stopSound3D(mPtr, sound);
                 sndMgr->playSound3D(mPtr, sound, volume, pitch);
             }
         }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -747,6 +747,9 @@ namespace MWSound
 
     void SoundManager::stopSound(const std::string& soundId)
     {
+        if(!mOutput->isInitialized())
+            return;
+
         Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
         if (!sfx) return;
 
@@ -755,6 +758,9 @@ namespace MWSound
 
     void SoundManager::stopSound3D(const MWWorld::ConstPtr &ptr, const std::string& soundId)
     {
+        if(!mOutput->isInitialized())
+            return;
+
         Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
         if (!sfx) return;
 


### PR DESCRIPTION
[Bug #4600](https://gitlab.com/OpenMW/openmw/issues/4600)

It crashed inside openal code when either the sound is disabled with `--no-sound` or because there's no output device detected by the OS.

The reason was that `SoundManager::stopSound3D` forgot to check if `mOutput` was initialized before calling functions on it (the full callstack is in the bug report).

As it turned out, the call to stopSound3D that generated the crash wasn't even needed, so I removed it in the second commit (playSound3D already stops the sound).