### PR TITLE
Extended.rst: Fix inexistent animation key: `open` -> `start`

### DIFF
--- a/docs/source/reference/modding/extended.rst
+++ b/docs/source/reference/modding/extended.rst
@@ -53,7 +53,7 @@ It is also possible to attach opening/closing sounds to container's animations:
 
 ::
 
-    1.0: ContainerClose: open
+    1.0: ContainerClose: start
     1.01: Sound: AC_dw_drawer_close
     2.0: ContainerClose: stop
 


### PR DESCRIPTION
From my understanding, there is no `open` key. Please correct me if I'm wrong.