### PR TITLE
Fix combat sound inconsistencies (bugs #5092, #5093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@
     Bug #5074: Paralyzed actors greet the player
     Bug #5075: Enchanting cast style can be changed if there's no object
     Bug #5082: Scrolling with controller in GUI mode is broken
+    Bug #5092: NPCs with enchanted weapons play sound when out of charges
+    Bug #5093: Hand to hand sound plays on knocked out enemies
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -441,7 +441,7 @@ namespace MWMechanics
             if(sound)
                 sndMgr->playSound3D(victim, sound->mId, 1.0f, 1.0f);
         }
-        else
+        else if (!healthdmg)
             sndMgr->playSound3D(victim, "Hand To Hand Hit", 1.0f, 1.0f);
     }
 

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -838,21 +838,24 @@ namespace MWMechanics
             if (item.getCellRef().getEnchantmentCharge() < castCost)
             {
                 if (mCaster == getPlayer())
+                {
                     MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicInsufficientCharge}");
 
-                // Failure sound
-                int school = 0;
-                if (!enchantment->mEffects.mList.empty())
-                {
-                    short effectId = enchantment->mEffects.mList.front().mEffectID;
-                    const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectId);
-                    school = magicEffect->mData.mSchool;
+                    // Failure sound
+                    int school = 0;
+                    if (!enchantment->mEffects.mList.empty())
+                    {
+                        short effectId = enchantment->mEffects.mList.front().mEffectID;
+                        const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectId);
+                        school = magicEffect->mData.mSchool;
+                    }
+
+                    static const std::string schools[] = {
+                        "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
+                    };
+                    MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+                    sndMgr->playSound3D(mCaster, "Spell Failure " + schools[school], 1.0f, 1.0f);
                 }
-                static const std::string schools[] = {
-                    "alteration", "conjuration", "destruction", "illusion", "mysticism", "restoration"
-                };
-                MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-                sndMgr->playSound3D(mCaster, "Spell Failure " + schools[school], 1.0f, 1.0f);
                 return false;
             }
             // Reduce charge


### PR DESCRIPTION
Since nobody seems to be comfortable just copy-pasting commits from my branch while I'm away, I'll give it a go myself as the issues and the changes necessary to solve them ([5092](https://gitlab.com/OpenMW/openmw/issues/5092), [5093](https://gitlab.com/OpenMW/openmw/issues/5093)) are comparatively minor.

1. Right now hand to hand sounds are played when hand to hand damage is recovered. Not a very good idea, but it works. Anyway, Hand to Hand Hit sound will only play if fatigue damage is inflicted due to the added check, like described in the report.
2. Spell failure sound playback was moved behind a "caster is player" check. This sound is played when the used item charge isn't enough to cast the enchantment.