### PR TITLE
Improve swish sounds handling (bug #5057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
     Bug #5047: # in cell names sets color
     Bug #5050: Invalid spell effects are not handled gracefully
     Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
+    Bug #5057: Weapon swing sound plays at same pitch whether it hits or misses
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
     Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden
     Bug #5069: Blocking creatures' attacks doesn't degrade shields

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -377,7 +377,7 @@ namespace MWClass
         {
             // Missed
             if (!attacker.isEmpty() && attacker == MWMechanics::getPlayer())
-                MWBase::Environment::get().getSoundManager()->playSound3D(ptr, "miss", 1.0f, 1.0f);
+                MWBase::Environment::get().getSoundManager()->playSound3D(ptr, "miss", 0.98f, 0.75f);
             return;
         }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -711,7 +711,7 @@ namespace MWClass
         {
             // Missed
             if (!attacker.isEmpty() && attacker == MWMechanics::getPlayer())
-                sndMgr->playSound3D(ptr, "miss", 1.0f, 1.0f);
+                sndMgr->playSound3D(ptr, "miss", 0.98f, 0.75f);
             return;
         }
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1227,8 +1227,9 @@ bool CharacterController::updateCreatureState()
 
                 mAttackStrength = std::min(1.f, 0.1f + Misc::Rng::rollClosedProbability());
 
+                // Note: for non-bipedal creatures attack strength seems to be 0 during pitch calculation
                 if (weapType == WeapType_HandToHand)
-                    playSwishSound(0.0f);
+                    playSwishSound("Weapon Swish", 0.f);
             }
         }
 
@@ -1698,18 +1699,16 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
 
             if(mWeaponType != WeapType_Crossbow && mWeaponType != WeapType_BowAndArrow)
             {
-                MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
-
                 if(isWerewolf)
                 {
                     const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
                     const ESM::Sound *sound = store.get<ESM::Sound>().searchRandom("WolfSwing");
                     if(sound)
-                        sndMgr->playSound3D(mPtr, sound->mId, 1.0f, 1.0f);
+                        playSwishSound(sound->mId, attackStrength);
                 }
                 else
                 {
-                    playSwishSound(attackStrength);
+                    playSwishSound("Weapon Swish", attackStrength);
                 }
             }
             mAttackStrength = attackStrength;
@@ -1802,7 +1801,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                     mUpperBodyState = UpperCharState_MinAttackToMaxAttack;
                     break;
                 }
-                playSwishSound(0.0f);
+                playSwishSound("Weapon Swish", 0.0f);
             }
             // Fall-through
             case UpperCharState_MaxAttackToMinHit:
@@ -2839,17 +2838,12 @@ void CharacterController::setHeadTrackTarget(const MWWorld::ConstPtr &target)
     mHeadTrackTarget = target;
 }
 
-void CharacterController::playSwishSound(float attackStrength)
+void CharacterController::playSwishSound(const std::string& sound, float attackStrength)
 {
-    MWBase::SoundManager *sndMgr = MWBase::Environment::get().getSoundManager();
+    float volume = 0.98 + attackStrength * 0.02f;
+    float pitch = 0.75 + attackStrength * 0.4f;
 
-    std::string sound = "Weapon Swish";
-    if(attackStrength < 0.5f)
-        sndMgr->playSound3D(mPtr, sound, 1.0f, 0.8f); //Weak attack
-    else if(attackStrength < 1.0f)
-        sndMgr->playSound3D(mPtr, sound, 1.0f, 1.0f); //Medium attack
-    else
-        sndMgr->playSound3D(mPtr, sound, 1.0f, 1.2f); //Strong attack
+    MWBase::Environment::get().getSoundManager()->playSound3D(mPtr, sound, volume, pitch);
 }
 
 void CharacterController::updateHeadTracking(float duration)

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -310,7 +310,7 @@ public:
     /// Make this character turn its head towards \a target. To turn off head tracking, pass an empty Ptr.
     void setHeadTrackTarget(const MWWorld::ConstPtr& target);
 
-    void playSwishSound(float attackStrength);
+    void playSwishSound(const std::string& sound, float attackStrength);
 };
 
     MWWorld::ContainerStoreIterator getActiveWeapon(CreatureStats &stats, MWWorld::InventoryStore &inv, WeaponType *weaptype);


### PR DESCRIPTION
A used formula:
```
volume = 0.98 + attackStrength * 0.02;
pitch = 0.75 + attackStrength * 0.4;
```

It is used for common attacks, werewolves and "miss" sounds.
Notes:
1. For non-bipedal creatures pitch is constant. I can not tell which value exactly is used in Morrowind, so use 0 for now, as we do in out upstream code.
2. I can not tell if "hit" sounds should use pitch which depends on attack strength or not, so I did not touch them.