### PR TITLE
Revert questionable input manager decisions

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -197,6 +197,11 @@ namespace MWInput
 
     void InputManager::handleGuiArrowKey(int action)
     {
+        // This is currently keyboard-specific code
+        // TODO: see if GUI controls can be refactored into a single function
+        if (mJoystickLastUsed)
+            return;
+
         if (SDL_IsTextInputActive())
             return;
 
@@ -224,13 +229,10 @@ namespace MWInput
         MWBase::Environment::get().getWindowManager()->injectKeyPress(key, 0, false);
     }
 
-    bool InputManager::gamepadToGuiControl(const SDL_ControllerButtonEvent &arg, bool release=false)
+    bool InputManager::gamepadToGuiControl(const SDL_ControllerButtonEvent &arg)
     {
         // Presumption of GUI mode will be removed in the future.
         // MyGUI KeyCodes *may* change.
-        // Currently button releases are ignored.
-        if (release)
-            return false;
 
         MyGUI::KeyCode key = MyGUI::KeyCode::None;
         switch (arg.button)
@@ -381,9 +383,6 @@ namespace MWInput
             case A_GameMenu:
                 toggleMainMenu ();
                 break;
-            case A_OptionsMenu:
-                toggleOptionsMenu();
-                break;
             case A_Screenshot:
                 screenshot();
                 break;
@@ -401,8 +400,7 @@ namespace MWInput
             case A_MoveRight:
             case A_MoveForward:
             case A_MoveBackward:
-                // Temporary shut-down of this function until deemed necessary.
-                //handleGuiArrowKey(action);
+                handleGuiArrowKey(action);
                 break;
             case A_Journal:
                 toggleJournal ();
@@ -1000,9 +998,9 @@ namespace MWInput
         mJoystickLastUsed = true;
         if (MWBase::Environment::get().getWindowManager()->isGuiMode())
         {
-            if (gamepadToGuiControl(arg, false))
+            if (gamepadToGuiControl(arg))
                 return;
-            else if (mGamepadGuiCursorEnabled)
+            if (mGamepadGuiCursorEnabled)
             {
                 // Temporary mouse binding until keyboard controls are available:
                 if (arg.button == SDL_CONTROLLER_BUTTON_A) // We'll pretend that A is left click.
@@ -1043,9 +1041,7 @@ namespace MWInput
         mJoystickLastUsed = true;
         if (MWBase::Environment::get().getWindowManager()->isGuiMode())
         {
-            if (gamepadToGuiControl(arg, true))
-                return;
-            else if (mGamepadGuiCursorEnabled)
+            if (mGamepadGuiCursorEnabled)
             {
                 // Temporary mouse binding until keyboard controls are available:
                 if (arg.button == SDL_CONTROLLER_BUTTON_A) // We'll pretend that A is left click.
@@ -1144,37 +1140,19 @@ namespace MWInput
         }
 
         if (MWBase::Environment::get().getWindowManager()->isConsoleMode())
-            return;
-
-        bool inGame = MWBase::Environment::get().getStateManager()->getState() != MWBase::StateManager::State_NoGame;
-        MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
-
-        if ((inGame && mode == MWGui::GM_MainMenu) || mode == MWGui::GM_Settings)
-            MWBase::Environment::get().getWindowManager()->popGuiMode();
-
-        if (inGame && mode != MWGui::GM_MainMenu)
-            MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_MainMenu);
-    }
-
-    void InputManager::toggleOptionsMenu()
-    {
-        if (MyGUI::InputManager::getInstance().isModalAny())
         {
-            MWBase::Environment::get().getWindowManager()->exitCurrentModal();
+            MWBase::Environment::get().getWindowManager()->toggleConsole();
             return;
         }
 
-        if (MWBase::Environment::get().getWindowManager()->isConsoleMode())
-            return;
-
-        MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
-        bool inGame = MWBase::Environment::get().getStateManager()->getState() != MWBase::StateManager::State_NoGame;
-
-        if ((inGame && mode == MWGui::GM_MainMenu) || mode == MWGui::GM_Settings)
-            MWBase::Environment::get().getWindowManager()->popGuiMode();
-
-        if (inGame && mode != MWGui::GM_Settings)
-            MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Settings);
+        if (!MWBase::Environment::get().getWindowManager()->isGuiMode()) //No open GUIs, open up the MainMenu
+        {
+            MWBase::Environment::get().getWindowManager()->pushGuiMode (MWGui::GM_MainMenu);
+        }
+        else //Close current GUI
+        {
+            MWBase::Environment::get().getWindowManager()->exitCurrentGuiMode();
+        }
     }
 
     void InputManager::quickLoad() {
@@ -1529,7 +1507,6 @@ namespace MWInput
         defaultButtonBindings[A_TogglePOV] = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
         defaultButtonBindings[A_Inventory] = SDL_CONTROLLER_BUTTON_B;
         defaultButtonBindings[A_GameMenu] = SDL_CONTROLLER_BUTTON_START;
-        defaultButtonBindings[A_OptionsMenu] = SDL_CONTROLLER_BUTTON_BACK;
         defaultButtonBindings[A_QuickSave] = SDL_CONTROLLER_BUTTON_GUIDE;
         defaultButtonBindings[A_MoveForward] = SDL_CONTROLLER_BUTTON_DPAD_UP;
         defaultButtonBindings[A_MoveLeft] = SDL_CONTROLLER_BUTTON_DPAD_LEFT;
@@ -1610,7 +1587,6 @@ namespace MWInput
         descriptions[A_Journal] = "sJournal";
         descriptions[A_Rest] = "sRestKey";
         descriptions[A_Inventory] = "sInventory";
-        descriptions[A_OptionsMenu] = "sPreferences";
         descriptions[A_TogglePOV] = "sTogglePOVCmd";
         descriptions[A_QuickKeysMenu] = "sQuickMenu";
         descriptions[A_QuickKey1] = "sQuick1Cmd";
@@ -1748,7 +1724,6 @@ namespace MWInput
         ret.push_back(A_Inventory);
         ret.push_back(A_Journal);
         ret.push_back(A_Rest);
-        ret.push_back(A_OptionsMenu);
         ret.push_back(A_Console);
         ret.push_back(A_QuickSave);
         ret.push_back(A_QuickLoad);
@@ -1781,7 +1756,6 @@ namespace MWInput
         ret.push_back(A_Inventory);
         ret.push_back(A_Journal);
         ret.push_back(A_Rest);
-        ret.push_back(A_OptionsMenu);
         ret.push_back(A_QuickSave);
         ret.push_back(A_QuickLoad);
         ret.push_back(A_Screenshot);

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -225,7 +225,7 @@ namespace MWInput
         void setPlayerControlsEnabled(bool enabled);
         void handleGuiArrowKey(int action);
         // Return true if GUI consumes input.
-        bool gamepadToGuiControl(const SDL_ControllerButtonEvent &arg, bool release);
+        bool gamepadToGuiControl(const SDL_ControllerButtonEvent &arg);
         bool gamepadToGuiControl(const SDL_ControllerAxisEvent &arg);
 
         void updateCursorMode();
@@ -234,7 +234,6 @@ namespace MWInput
 
     private:
         void toggleMainMenu();
-        void toggleOptionsMenu();
         void toggleSpell();
         void toggleWeapon();
         void toggleInventory();
@@ -326,8 +325,6 @@ namespace MWInput
             A_LookLeftRight,
             A_MoveForwardBackward,
             A_MoveLeftRight,
-
-            A_OptionsMenu,
 
             A_Last            // Marker for the last item
         };


### PR DESCRIPTION
These are some things people have been complaining about and some things I personally dislike about input changes introduced during gamepad behavior improvements. They weren't given much of a thought before implementation.

* Remove frankly unuseful Options Menu shortcut (I'm not sure if people are even aware of its existence).
* Revert to more pleasant 0.45.0 Escape behavior -- currently it purely toggles the main menu, like vanilla, but people complained about it not working as it did previously -- and it closed the current GUI mode. Any subsequent improvements must first be discussed as feature requests.
* Re-enable keyboard GUI arrow conversion feature -- while gamepads got DPAD arrows working for that, keyboards only got arrows for that again, but people liked that WASD or whatever set up as movement controls worked like GUI arrows. I don't have a gamepad so I can't test any possible improvements of gamepad behavior.
* Remove gamepad button release handling -- currently just dead code untouched for months triggering my non-existent OCD.

May need a review from gamepad people, because from as far as I can tell B button works kind of similarly to Escape now, and I'm unsure if test that should block DPAD from triggering button release twice works as intended. Also, maybe someone liked options menu being available directly on gamepads and I must put that back immediately.