### PR TITLE
Make sure getSpellSuccessChance() checks mana when necessary (bug #5112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
     Bug #5104: Black Dart's enchantment doesn't trigger at low Enchant levels
     Bug #5105: NPCs start combat with werewolves from any distance
     Bug #5110: ModRegion with a redundant numerical argument breaks script execution
+    Bug #5112: Insufficient magicka for current spell not reflected on HUD icon
     Bug #5123: Script won't run on respawn
     Bug #5124: Arrow remains attached to actor if pulling animation was cancelled
     Feature #1774: Handle AvoidNode

--- a/apps/openmw/mwgui/spellmodel.cpp
+++ b/apps/openmw/mwgui/spellmodel.cpp
@@ -71,7 +71,7 @@ namespace MWGui
             {
                 newSpell.mType = Spell::Type_Spell;
                 std::string cost = std::to_string(spell->mData.mCost);
-                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor, nullptr, true, true)));
+                std::string chance = std::to_string(int(MWMechanics::getSpellSuccessChance(spell, mActor)));
                 newSpell.mCostColumn = cost + "/" + chance;
             }
             else

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -241,7 +241,7 @@ namespace MWMechanics
         float castChance = 100.f;
         if (spell != nullptr && !caster.isEmpty() && caster.getClass().isActor())
         {
-            castChance = getSpellSuccessChance(spell, caster, nullptr, false); // Uncapped casting chance
+            castChance = getSpellSuccessChance(spell, caster, nullptr, false, false); // Uncapped casting chance
         }
         if (castChance > 0)
             x *= 50 / castChance;
@@ -939,7 +939,7 @@ namespace MWMechanics
                 bool fail = false;
 
                 // Check success
-                float successChance = getSpellSuccessChance(spell, mCaster);
+                float successChance = getSpellSuccessChance(spell, mCaster, nullptr, true, false);
                 if (Misc::Rng::roll0to99() >= successChance)
                 {
                     if (mCaster == getPlayer())

--- a/apps/openmw/mwmechanics/spellcasting.hpp
+++ b/apps/openmw/mwmechanics/spellcasting.hpp
@@ -39,8 +39,8 @@ namespace MWMechanics
      * @note actor can be an NPC or a creature
      * @return success chance from 0 to 100 (in percent), if cap=false then chance above 100 may be returned.
      */
-    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool = nullptr, bool cap=true, bool checkMagicka=false);
-    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool = nullptr, bool cap=true, bool checkMagicka=false);
+    float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool = nullptr, bool cap=true, bool checkMagicka=true);
+    float getSpellSuccessChance (const std::string& spellId, const MWWorld::Ptr& actor, int* effectiveSchool = nullptr, bool cap=true, bool checkMagicka=true);
 
     int getSpellSchool(const std::string& spellId, const MWWorld::Ptr& actor);
     int getSpellSchool(const ESM::Spell* spell, const MWWorld::Ptr& actor);

--- a/apps/openmw/mwmechanics/spellpriority.cpp
+++ b/apps/openmw/mwmechanics/spellpriority.cpp
@@ -122,9 +122,6 @@ namespace MWMechanics
                 return 0.f;
         }
 
-        if (spell->mData.mCost > stats.getMagicka().getCurrent())
-            return 0.f;
-
         // Spells don't stack, so early out if the spell is still active on the target
         int types = getRangeTypes(spell->mEffects);
         if ((types & Self) && stats.getActiveSpells().isSpellActive(spell->mId))


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5112)

Make sure all getSpellSuccessChance calls work correctly -- return 0 to setSelectedSpell calls so that HUD shows an empty bar and inform AI that they have 0 chance to cast the spell so that AI doesn't accidentally decide not to flee for some reason. One unnecessary check in spell rating was removed and vanillaRateSpell behavior became more sensible.

Works fine in my testing.