### PR TITLE
Sneaking consistency fixes (bug #5103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
     Bug #5092: NPCs with enchanted weapons play sound when out of charges
     Bug #5093: Hand to hand sound plays on knocked out enemies
     Bug #5099: Non-swimming enemies will enter water if player is water walking
+    Bug #5103: Sneaking state behavior is still inconsistent
     Bug #5104: Black Dart's enchantment doesn't trigger at low Enchant levels
     Bug #5105: NPCs start combat with werewolves from any distance
     Bug #5110: ModRegion with a redundant numerical argument breaks script execution

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -939,10 +939,9 @@ namespace MWClass
         const float normalizedEncumbrance = getNormalizedEncumbrance(ptr);
 
         bool swimming = world->isSwimming(ptr);
+        bool sneaking = MWBase::Environment::get().getMechanicsManager()->isSneaking(ptr);
+        bool running = stats.getStance(MWMechanics::CreatureStats::Stance_Run);
         bool inair = !world->isOnGround(ptr) && !swimming && !world->isFlying(ptr);
-        bool sneaking = stats.getStance(MWMechanics::CreatureStats::Stance_Sneak);
-        sneaking = sneaking && (inair || MWBase::Environment::get().getMechanicsManager()->isSneaking(ptr));
-        bool running =  stats.getStance(MWMechanics::CreatureStats::Stance_Run);
         running = running && (inair || MWBase::Environment::get().getMechanicsManager()->isRunning(ptr));
 
         float walkSpeed = gmst.fMinWalkSpeed->mValue.getFloat() + 0.01f*npcdata->mNpcStats.getAttribute(ESM::Attribute::Speed).getModified()*

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1785,14 +1785,7 @@ namespace MWMechanics
 
         MWWorld::Ptr player = getPlayer();
 
-        CreatureStats& stats = player.getClass().getCreatureStats(player);
-        MWBase::World* world = MWBase::Environment::get().getWorld();
-
-        bool sneaking = stats.getStance(MWMechanics::CreatureStats::Stance_Sneak);
-        bool inair = !world->isOnGround(player) && !world->isSwimming(player) && !world->isFlying(player);
-        sneaking = sneaking && (ctrl->isSneaking() || inair);
-
-        if (!sneaking)
+        if (!MWBase::Environment::get().getMechanicsManager()->isSneaking(player))
         {
             MWBase::Environment::get().getWindowManager()->setSneakVisibility(false);
             return;
@@ -1800,6 +1793,7 @@ namespace MWMechanics
 
         static float sneakSkillTimer = 0.f; // Times sneak skill progress from "avoid notice"
 
+        MWBase::World* world = MWBase::Environment::get().getWorld();
         const MWWorld::Store<ESM::GameSetting>& gmst = world->getStore().get<ESM::GameSetting>();
         static const float fSneakUseDist = gmst.find("fSneakUseDist")->mValue.getFloat();
         static const float fSneakUseDelay = gmst.find("fSneakUseDelay")->mValue.getFloat();

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -549,10 +549,6 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
         mCurrentMovement = movementAnimName;
         if(!mCurrentMovement.empty())
         {
-            bool isflying = MWBase::Environment::get().getWorld()->isFlying(mPtr);
-            bool isrunning = mPtr.getClass().getCreatureStats(mPtr).getStance(MWMechanics::CreatureStats::Stance_Run) && !isflying;
-            bool issneaking = mPtr.getClass().getCreatureStats(mPtr).getStance(MWMechanics::CreatureStats::Stance_Sneak) && !isflying;
-
             // For non-flying creatures, MW uses the Walk animation to calculate the animation velocity
             // even if we are running. This must be replicated, otherwise the observed speed would differ drastically.
             std::string anim = mCurrentMovement;
@@ -585,7 +581,7 @@ void CharacterController::refreshMovementAnims(const WeaponInfo* weap, Character
                     // The first person anims don't have any velocity to calculate a speed multiplier from.
                     // We use the third person velocities instead.
                     // FIXME: should be pulled from the actual animation, but it is not presently loaded.
-                    mMovementAnimSpeed = (issneaking ? 33.5452f : (isrunning ? 222.857f : 154.064f));
+                    mMovementAnimSpeed = (isSneaking() ? 33.5452f : (isRunning() ? 222.857f : 154.064f));
                     mMovementAnimationControlled = false;
                 }
             }

--- a/apps/openmw/mwscript/controlextensions.cpp
+++ b/apps/openmw/mwscript/controlextensions.cpp
@@ -186,14 +186,7 @@ namespace MWScript
                 virtual void execute (Interpreter::Runtime& runtime)
                 {
                     MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
-                    MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
-                    MWBase::World* world = MWBase::Environment::get().getWorld();
-
-                    bool stanceOn = stats.getStance(MWMechanics::CreatureStats::Stance_Sneak);
-                    bool sneaking = MWBase::Environment::get().getMechanicsManager()->isSneaking(ptr);
-                    bool inair = !world->isOnGround(ptr) && !world->isSwimming(ptr) && !world->isFlying(ptr);
-
-                    runtime.push(stanceOn && (sneaking || inair));
+                    runtime.push(MWBase::Environment::get().getMechanicsManager()->isSneaking(ptr));
                 }
         };
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5103)

Some fixes for sneaking state. Again.

1. Hopefully fixed swimming animation speed regression by using a more reliable animation state check instead of a stance check.
2. You no longer pickpocket actors when sneaking button is pressed and you are flying.
3. Common sneaking stance check code was moved to mechanics manager to reduce code duplication. First person camera sinking wasn't changed because it was affected too much by the animation state.
4. Being in air but not flying while sneaking stance is on counts as sneaking, and boot weight while falling/jumping does not affect the sneaking bonus.