### PR TITLE
Don't "jump" with 0 vertical velocity in all cases (bug #5106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
     Bug #5093: Hand to hand sound plays on knocked out enemies
     Bug #5099: Non-swimming enemies will enter water if player is water walking
     Bug #5105: NPCs start combat with werewolves from any distance
+    Bug #5106: Still can jump even when encumbered
     Bug #5110: ModRegion with a redundant numerical argument breaks script execution
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2065,7 +2065,8 @@ void CharacterController::update(float duration, bool animationOnly)
             cls.getCreatureStats(mPtr).setFatigue(fatigue);
         }
 
-        if(sneak || inwater || flying || incapacitated || !solid)
+        float z = cls.getJump(mPtr);
+        if(sneak || inwater || flying || incapacitated || !solid || z <= 0)
             vec.z() = 0.0f;
 
         bool inJump = true;
@@ -2088,7 +2089,6 @@ void CharacterController::update(float duration, bool animationOnly)
         else if(vec.z() > 0.0f && mJumpState != JumpState_InAir)
         {
             // Started a jump.
-            float z = cls.getJump(mPtr);
             if (z > 0)
             {
                 if(vec.x() == 0 && vec.y() == 0)


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5106)

When getJump returns 0, instead of trying to jump and skipping the whole "not jump" situations, the player won't jump at all.

This can be optimized, but I'll refactor the whole thing later.
z > 0 check wasn't touched to avoid merge conflicts with my other jumping PR.