### PR TITLE
Use up-to-date magic effects for GetEffect (bug #3894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     Bug #3765: DisableTeleporting makes Mark/Recall/Intervention effects undetectable
     Bug #3778: [Mod] Improved Thrown Weapon Projectiles - weapons have wrong transformation during throw animation
     Bug #3812: Wrong multiline tooltips width when word-wrapping is enabled
+    Bug #3894: Hostile spell effects not detected/present on first frame of OnPCHitMe
     Bug #4202: Open .omwaddon files without needing toopen openmw-cs first
     Bug #4240: Ash storm origin coordinates and hand shielding animation behavior are incorrect
     Bug #4276: Resizing character window differs from vanilla

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -443,7 +443,16 @@ namespace MWScript
                     if(key < 0 || key > 32767 || *end != '\0')
                         key = ESM::MagicEffect::effectStringToId(effect);
 
-                    const MWMechanics::MagicEffects& effects = ptr.getClass().getCreatureStats(ptr).getMagicEffects();
+                    const MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+
+                    MWMechanics::MagicEffects effects = stats.getSpells().getMagicEffects();
+                    effects += stats.getActiveSpells().getMagicEffects();
+                    if (ptr.getClass().isNpc())
+                    {
+                        MWWorld::InventoryStore& store = ptr.getClass().getInventoryStore(ptr);
+                        effects += store.getMagicEffects();
+                    }
+
                     for (MWMechanics::MagicEffects::Collection::const_iterator it = effects.begin(); it != effects.end(); ++it)
                     {
                         if (it->first.mId == key && it->second.getModifier() > 0)


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/3894)

Instead of using general magic effects of the actor updated for mechanics purposes in the next frame after scripts are updated up-to-date magic effects gathered from all effect sources are now used in GetEffect in the same way.

Test case given by rot now works as intended.