### PR TITLE
Vanilla-friendly ranged crits (bug #5067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
     Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
     Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden
+    Bug #5067: Ranged attacks on unaware opponents ("critical hits") differ from the vanilla engine
     Bug #5069: Blocking creatures' attacks doesn't degrade shields
     Bug #5074: Paralyzed actors greet the player
     Bug #5075: Enchanting cast style can be changed if there's no object

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -229,23 +229,18 @@ namespace MWMechanics
             applyWerewolfDamageMult(victim, projectile, damage);
 
             if (attacker == getPlayer())
-            {
                 attacker.getClass().skillUsageSucceeded(attacker, weaponSkill, 0);
-                const MWMechanics::AiSequence& sequence = victim.getClass().getCreatureStats(victim).getAiSequence();
 
-                bool unaware = !sequence.isInCombat()
-                    && !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(attacker, victim);
-
-                if (unaware)
-                {
-                    damage *= gmst.find("fCombatCriticalStrikeMult")->mValue.getFloat();
-                    MWBase::Environment::get().getWindowManager()->messageBox("#{sTargetCriticalStrike}");
-                    MWBase::Environment::get().getSoundManager()->playSound3D(victim, "critical damage", 1.0f, 1.0f);
-                }
-            }
-
-            if (victim.getClass().getCreatureStats(victim).getKnockedDown())
+            const MWMechanics::AiSequence& sequence = victim.getClass().getCreatureStats(victim).getAiSequence();
+            bool unaware = attacker == getPlayer() && !sequence.isInCombat()
+                && !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(attacker, victim);
+            bool knockedDown = victim.getClass().getCreatureStats(victim).getKnockedDown();
+            if (knockedDown || unaware)
+            {
                 damage *= gmst.find("fCombatKODamageMult")->mValue.getFloat();
+                if (!knockedDown)
+                    MWBase::Environment::get().getSoundManager()->playSound3D(victim, "critical damage", 1.0f, 1.0f);
+            }
         }
 
         reduceWeaponCondition(damage, validVictim, weapon, attacker);


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5067)

Since Atahualpa seems to be busy, I'm doing this myself.

The idea: if the opponent is not knocked down and is not in combat, make an awareness check for player attacks and apply knockout damage mult and play critical hit sound upon success. Critical hit message isn't shown.