### PR TITLE
Ignore on-strike enchanted projectile charge (#5104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
     Bug #5092: NPCs with enchanted weapons play sound when out of charges
     Bug #5093: Hand to hand sound plays on knocked out enemies
     Bug #5099: Non-swimming enemies will enter water if player is water walking
+    Bug #5104: Black Dart's enchantment doesn't trigger at low Enchant levels
     Bug #5105: NPCs start combat with werewolves from any distance
     Bug #5110: ModRegion with a redundant numerical argument breaks script execution
     Feature #1774: Handle AvoidNode

--- a/apps/openmw/mwmechanics/weaponpriority.cpp
+++ b/apps/openmw/mwmechanics/weaponpriority.cpp
@@ -102,8 +102,9 @@ namespace MWMechanics
             if (enchantment->mData.mType == ESM::Enchantment::WhenStrikes)
             {
                 int castCost = getEffectiveEnchantmentCastCost(static_cast<float>(enchantment->mData.mCost), actor);
+                float charge = item.getCellRef().getEnchantmentCharge();
 
-                if (item.getCellRef().getEnchantmentCharge() == -1 || item.getCellRef().getEnchantmentCharge() >= castCost)
+                if (charge == -1 || charge >= castCost || weapon->mData.mType >= ESM::Weapon::MarksmanThrown)
                     rating += rateEffects(enchantment->mEffects, actor, enemy);
             }
         }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5104).

To simulate the vanilla behavior, on-strike enchantments of projectiles ignore the charge of their objects, so the enchantment will always be applied regardless of the enchant skill level. No messages are shown. AI is aware of this when rating a weapon.