### PR TITLE
Human-readable light source duration (feature #5091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
     Feature #5036: Allow scripted faction leaving
     Feature #5046: Gamepad thumbstick cursor speed
     Feature #5051: Provide a separate textures for scrollbars
+    Feature #5091: Human-readable light source duration
     Feature #5094: Unix like console hotkeys
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -156,13 +156,9 @@ namespace MWClass
 
         std::string text;
 
-        if (Settings::Manager::getBool("show effect duration","Game"))
-        {
-            // -1 is infinite light source, so duration makes no sense here. Other negative values are treated as 0.
-            float remainingTime = ptr.getClass().getRemainingUsageTime(ptr);
-            if (remainingTime != -1.0f)
-                text += "\n#{sDuration}: " + MWGui::ToolTips::toString(std::max(0.f, remainingTime));
-        }
+        // Don't show duration for infinite light sources.
+        if (Settings::Manager::getBool("show effect duration","Game") && ptr.getClass().getRemainingUsageTime(ptr) != -1)
+            text += MWGui::ToolTips::getDurationString(ptr.getClass().getRemainingUsageTime(ptr), "\n#{sDuration}");
 
         text += MWGui::ToolTips::getWeightString(ref->mBase->mData.mWeight, "#{sWeight}");
         text += MWGui::ToolTips::getValueString(ref->mBase->mData.mValue, "#{sValue}");

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -137,27 +137,8 @@ namespace MWGui
                             MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "") );
                     }
                 }
-                if (effectInfo.mRemainingTime > -1 &&
-                        Settings::Manager::getBool("show effect duration","Game")) {
-                    sourcesDescription += " #{sDuration}: ";
-                    float duration = effectInfo.mRemainingTime;
-                    if (duration > 3600)
-                    {
-                        int hour = duration / 3600;
-                        duration -= hour*3600;
-                        sourcesDescription += MWGui::ToolTips::toString(hour) + "h";
-                    }
-                    if (duration > 60)
-                    {
-                        int minute = duration / 60;
-                        duration -= minute*60;
-                        sourcesDescription += MWGui::ToolTips::toString(minute) + "m";
-                    }
-                    if (duration > 0.1)
-                    {
-                        sourcesDescription += MWGui::ToolTips::toString(duration) + "s";
-                    }
-                }
+                if (effectInfo.mRemainingTime > -1 && Settings::Manager::getBool("show effect duration","Game"))
+                    sourcesDescription += MWGui::ToolTips::getDurationString(effectInfo.mRemainingTime, " #{sDuration}");
 
                 addNewLine = true;
             }

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -678,48 +678,45 @@ namespace MWGui
             return ret;
         }
 
-        constexpr float secondsPerMinute = 60.f; // 60 seconds
-        constexpr float secondsPerHour = secondsPerMinute * 60.f; // 60 minutes
-        constexpr float secondsPerDay = secondsPerHour * 24.f; // 24 hours
-        constexpr float secondsPerMonth = secondsPerDay * 30.f; // 30 days
-        constexpr float secondsPerYear = secondsPerDay * 365.f;
+        constexpr int secondsPerMinute = 60; // 60 seconds
+        constexpr int secondsPerHour = secondsPerMinute * 60; // 60 minutes
+        constexpr int secondsPerDay = secondsPerHour * 24; // 24 hours
+        constexpr int secondsPerMonth = secondsPerDay * 30; // 30 days
+        constexpr int secondsPerYear = secondsPerDay * 365;
+        int fullDuration = static_cast<int>(duration);
         int units = 0;
-        if (duration >= secondsPerYear)
+        int years = fullDuration / secondsPerYear;
+        int months = fullDuration % secondsPerYear / secondsPerMonth;
+        int days = fullDuration % secondsPerYear % secondsPerMonth / secondsPerDay; // Because a year is not exactly 12 "months"
+        int hours = fullDuration % secondsPerDay / secondsPerHour;
+        int minutes = fullDuration % secondsPerHour / secondsPerMinute;
+        int seconds = fullDuration % secondsPerMinute;
+        if (years)
         {
             units++;
-            int years = duration / secondsPerYear;
-            duration -= years * secondsPerYear;
             ret += toString(years) + " y ";
         }
-        if (duration >= secondsPerMonth)
+        if (months)
         {
             units++;
-            int months = duration / secondsPerMonth;
-            duration -= months * secondsPerMonth;
             ret += toString(months) + " mo ";
         }
-        if (units < 2 && duration >= secondsPerDay)
+        if (units < 2 && days)
         {
             units++;
-            int days = duration / secondsPerDay;
-            duration -= days * secondsPerDay;
             ret += toString(days) + " d ";
         }
-        if (units < 2 && duration >= secondsPerHour)
+        if (units < 2 && hours)
         {
             units++;
-            int hours = duration / secondsPerHour;
-            duration -= hours * secondsPerHour;
             ret += toString(hours) + " h ";
         }
-        if (units < 2 && duration >= secondsPerMinute)
-        {
-            int minutes = duration / secondsPerMinute;
-            duration -= minutes * secondsPerMinute;
+        if (units >= 2)
+            return ret;
+        if (minutes)
             ret += toString(minutes) + " min ";
-        }
-        if (units < 2 && duration >= 1.f)
-            ret += toString(int(duration)) + " s ";
+        if (seconds)
+            ret += toString(seconds) + " s ";
 
         return ret;
     }

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -667,6 +667,63 @@ namespace MWGui
         return ret;
     }
 
+    std::string ToolTips::getDurationString(float duration, const std::string& prefix)
+    {
+        std::string ret;
+        ret = prefix + ": ";
+
+        if (duration < 1.f)
+        {
+            ret += "0 s";
+            return ret;
+        }
+
+        constexpr float secondsPerMinute = 60.f; // 60 seconds
+        constexpr float secondsPerHour = secondsPerMinute * 60.f; // 60 minutes
+        constexpr float secondsPerDay = secondsPerHour * 24.f; // 24 hours
+        constexpr float secondsPerMonth = secondsPerDay * 30.f; // 30 days
+        constexpr float secondsPerYear = secondsPerDay * 365.f;
+        int units = 0;
+        if (duration >= secondsPerYear)
+        {
+            units++;
+            int years = duration / secondsPerYear;
+            duration -= years * secondsPerYear;
+            ret += toString(years) + " y ";
+        }
+        if (duration >= secondsPerMonth)
+        {
+            units++;
+            int months = duration / secondsPerMonth;
+            duration -= months * secondsPerMonth;
+            ret += toString(months) + " mo ";
+        }
+        if (units < 2 && duration >= secondsPerDay)
+        {
+            units++;
+            int days = duration / secondsPerDay;
+            duration -= days * secondsPerDay;
+            ret += toString(days) + " d ";
+        }
+        if (units < 2 && duration >= secondsPerHour)
+        {
+            units++;
+            int hours = duration / secondsPerHour;
+            duration -= hours * secondsPerHour;
+            ret += toString(hours) + " h ";
+        }
+        if (units < 2 && duration >= secondsPerMinute)
+        {
+            int minutes = duration / secondsPerMinute;
+            duration -= minutes * secondsPerMinute;
+            ret += toString(minutes) + " min ";
+        }
+        if (units < 2 && duration >= 1.f)
+            ret += toString(int(duration)) + " s ";
+
+        return ret;
+    }
+
     bool ToolTips::toggleFullHelp()
     {
         mFullHelp = !mFullHelp;

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -84,6 +84,9 @@ namespace MWGui
         static std::string getCellRefString(const MWWorld::CellRef& cellref);
         ///< Returns a string containing debug tooltip information about the given cellref.
 
+        static std::string getDurationString (float duration, const std::string& prefix);
+        ///< Returns duration as two largest time units, rounded down. Note: not localized; no line break.
+
         // these do not create an actual tooltip, but they fill in the data that is required so the tooltip
         // system knows what to show in case this widget is hovered
         static void createSkillToolTip(MyGUI::Widget* widget, int skillId);


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/issues/5091)

When show effect duration is on, the remaining duration of light sources is now displayed like this - including years, months and days. It was previous displayed like this for effects too, but now the way is shared between light sources and magic effects.
Duration is presented in almost always two largest units (non-localized), rounded down, with minutes and seconds appearing together.
![screenshot002](https://user-images.githubusercontent.com/21265616/62212908-70cff580-b3aa-11e9-9b8c-8d0a9be45e91.png)
![screenshot000](https://user-images.githubusercontent.com/21265616/62212909-71688c00-b3aa-11e9-8dd6-d74e43135567.png)

Not tested extensively.