### PR TITLE
[Regression] Avoid confusing inventory doll with player in non-uniform scaling

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1180,7 +1180,7 @@ namespace MWClass
                 MWBase::Environment::get().getWorld()->getStore().get<ESM::Race>().find(ref->mBase->mRace);
 
         // Race weight should not affect 1st-person meshes, otherwise it will change hand proportions and can break aiming.
-        if (ptr == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson())
+        if (ptr == MWMechanics::getPlayer() && ptr.isInCell() && MWBase::Environment::get().getWorld()->isFirstPerson())
         {
             if (ref->mBase->isMale())
                 scale *= race->mData.mHeight.mMale;


### PR DESCRIPTION
[Resolves #5111](https://gitlab.com/OpenMW/openmw/issues/5111).

Something of a hack. We can assume that the player character is always in a cell when the player character needs to be scaled in first-person-correct way, however inventory doll while being a clone of the player is never "in a cell", so it will always be scaled properly.