### PR TITLE
[Regression] Editor: Avoid locale-related settings parsing issues

### DIFF
--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <algorithm>
+#include <sstream>
 
 #include "intsetting.hpp"
 #include "doublesetting.hpp"
@@ -415,7 +416,9 @@ CSMPrefs::DoubleSetting& CSMPrefs::State::declareDouble (const std::string& key,
     if (mCurrentCategory==mCategories.end())
         throw std::logic_error ("no category for setting");
 
-    setDefault(key, std::to_string(default_));
+    std::ostringstream stream;
+    stream << default_;
+    setDefault(key, stream.str());
 
     default_ = mSettings.getFloat (key, mCurrentCategory->second.getKey());
 


### PR DESCRIPTION
Most string stream usage has been replaced with locale-sensitive to_string. While the engine is virtually free from locale-related issues, since it's guaranteed to be C locale, editor isn't, and on my Russian locale system it started to cause parsing errors once I made settings manager locale-insensitive again. There is more to_string usage in the editor and components it uses, but this is the only instance that's prone to cause issues, since converting integers to strings should be safe.