### PR TITLE
Reset path after AiTravel is fast forwarded (bug #5037)

### DIFF
--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -88,6 +88,7 @@ namespace MWMechanics
         // that is the user's responsibility
         MWBase::Environment::get().getWorld()->moveObject(actor, mX, mY, mZ);
         actor.getClass().adjustPosition(actor, false);
+        reset();
     }
 
     void AiTravel::writeState(ESM::AiSequence::AiSequence &sequence) const


### PR DESCRIPTION
Otherwise actor will keep going to the first path point that may be unreachable.