### PR TITLE
Apply instant effects of permanent spells in AddSpell immediately (bug #5055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
     Bug #5038: Enchanting success chance calculations are blatantly wrong
     Bug #5047: # in cell names sets color
     Bug #5050: Invalid spell effects are not handled gracefully
+    Bug #5055: Mark, Recall, Intervention magic effect abilities have no effect when added and removed in the same frame
     Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
     Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -25,6 +25,7 @@
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/npcstats.hpp"
 #include "../mwmechanics/actorutil.hpp"
+#include "../mwmechanics/spellcasting.hpp"
 
 #include "ref.hpp"
 
@@ -464,6 +465,16 @@ namespace MWScript
                     {
                         // Apply looping particles immediately for constant effects
                         MWBase::Environment::get().getWorld()->applyLoopingParticles(ptr);
+
+                        // The spell may have an instant effect which must be handled immediately.
+                        for (const auto& effect : creatureStats.getSpells().getMagicEffects())
+                        {
+                            if (effect.second.getMagnitude() <= 0)
+                               continue;
+                            MWMechanics::CastSpell cast(ptr, ptr);
+                            if (cast.applyInstantEffect(ptr, ptr, effect.first, effect.second.getMagnitude()))
+                                creatureStats.getSpells().purgeEffect(effect.first.mId);
+                        }
                     }
                 }
         };


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5055).

Should resolve the issue (at least it seems to work). The idea is to check the permanent magic effects after a non-castable spell was added and apply then purge any instant effects that could have appeared due to the spell instead of waiting for the mechanics update to (not) apply the removed effect.