### PR TITLE
Prevent front() and operator[] from causing undefined behavior (bug #5118)

### DIFF
--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -112,10 +112,7 @@ struct TypesetBookImpl : TypesetBook
         if (i->empty())
             return Range (Utf8Point (nullptr), Utf8Point (nullptr));
 
-        Utf8Point begin = &i->front ();
-        Utf8Point end   = &i->front () + i->size ();
-
-        return Range (begin, end);
+        return Range (i->data(), i->data() + i->size());
     }
 
     size_t pageCount () const { return mPages.size (); }
@@ -346,8 +343,8 @@ struct TypesetBookImpl::Typesetter : BookTypesetter
         assert (end <= mCurrentContent->size ());
         assert (begin <= mCurrentContent->size ());
 
-        Utf8Point begin_ = &mCurrentContent->front () + begin;
-        Utf8Point end_   = &mCurrentContent->front () + end  ;
+        Utf8Point begin_ = mCurrentContent->data() + begin;
+        Utf8Point end_   = mCurrentContent->data() + end;
 
         writeImpl (static_cast <StyleImpl*> (style), begin_, end_);
     }

--- a/components/nif/nifstream.hpp
+++ b/components/nif/nifstream.hpp
@@ -160,9 +160,9 @@ public:
     {
         std::vector<char> str(length + 1, 0);
 
-        inp->read(&str[0], length);
+        inp->read(str.data(), length);
 
-        return &str[0];
+        return str.data();
     }
     ///Read in a string of the length specified in the file
     std::string getString()
@@ -181,34 +181,34 @@ public:
     void getUShorts(std::vector<unsigned short> &vec, size_t size)
     {
         vec.resize(size);
-        readLittleEndianDynamicBufferOfType<unsigned short,unsigned short>(inp, &vec.front(), size);
+        readLittleEndianDynamicBufferOfType<unsigned short,unsigned short>(inp, vec.data(), size);
     }
 
     void getFloats(std::vector<float> &vec, size_t size)
     {
         vec.resize(size);
-        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp, &vec.front(), size);
+        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp, vec.data(), size);
     }
 
     void getVector2s(std::vector<osg::Vec2f> &vec, size_t size)
     {
         vec.resize(size);
         /* The packed storage of each Vec2f is 2 floats exactly */
-        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp,(float*) &vec.front(), size*2);
+        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp,(float*)vec.data(), size*2);
     }
 
     void getVector3s(std::vector<osg::Vec3f> &vec, size_t size)
     {
         vec.resize(size);
         /* The packed storage of each Vec3f is 3 floats exactly */
-        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp, (float*) &vec.front(), size*3);
+        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp, (float*)vec.data(), size*3);
     }
 
     void getVector4s(std::vector<osg::Vec4f> &vec, size_t size)
     {
         vec.resize(size);
         /* The packed storage of each Vec4f is 4 floats exactly */
-        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp, (float*) &vec.front(), size*4);
+        readLittleEndianDynamicBufferOfType<float,uint32_t>(inp, (float*)vec.data(), size*4);
     }
 
     void getQuaternions(std::vector<osg::Quat> &quat, size_t size)

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1034,11 +1034,10 @@ namespace NifOsg
         {
             const Nif::NiTriShapeData* data = triShape->data.getPtr();
 
-            {
-                geometry->setVertexArray(new osg::Vec3Array(data->vertices.size(), &data->vertices[0]));
-                if (!data->normals.empty())
-                    geometry->setNormalArray(new osg::Vec3Array(data->normals.size(), &data->normals[0]), osg::Array::BIND_PER_VERTEX);
-            }
+            if (!data->vertices.empty())
+                geometry->setVertexArray(new osg::Vec3Array(data->vertices.size(), data->vertices.data()));
+            if (!data->normals.empty())
+                geometry->setNormalArray(new osg::Vec3Array(data->normals.size(), data->normals.data()), osg::Array::BIND_PER_VERTEX);
 
             int textureStage = 0;
             for (std::vector<int>::const_iterator it = boundTextures.begin(); it != boundTextures.end(); ++it,++textureStage)
@@ -1048,19 +1047,20 @@ namespace NifOsg
                 {
                     Log(Debug::Verbose) << "Out of bounds UV set " << uvSet << " on TriShape \"" << triShape->name << "\" in " << mFilename;
                     if (!data->uvlist.empty())
-                        geometry->setTexCoordArray(textureStage, new osg::Vec2Array(data->uvlist[0].size(), &data->uvlist[0][0]), osg::Array::BIND_PER_VERTEX);
+                        geometry->setTexCoordArray(textureStage, new osg::Vec2Array(data->uvlist[0].size(), data->uvlist[0].data()), osg::Array::BIND_PER_VERTEX);
                     continue;
                 }
 
-                geometry->setTexCoordArray(textureStage, new osg::Vec2Array(data->uvlist[uvSet].size(), &data->uvlist[uvSet][0]), osg::Array::BIND_PER_VERTEX);
+                geometry->setTexCoordArray(textureStage, new osg::Vec2Array(data->uvlist[uvSet].size(), data->uvlist[uvSet].data()), osg::Array::BIND_PER_VERTEX);
             }
 
             if (!data->colors.empty())
-                geometry->setColorArray(new osg::Vec4Array(data->colors.size(), &data->colors[0]), osg::Array::BIND_PER_VERTEX);
+                geometry->setColorArray(new osg::Vec4Array(data->colors.size(), data->colors.data()), osg::Array::BIND_PER_VERTEX);
 
-            geometry->addPrimitiveSet(new osg::DrawElementsUShort(osg::PrimitiveSet::TRIANGLES,
-                                                                  data->triangles.size(),
-                                                                  (unsigned short*)&data->triangles[0]));
+            if (!data->triangles.empty())
+                geometry->addPrimitiveSet(new osg::DrawElementsUShort(osg::PrimitiveSet::TRIANGLES,
+                                                                    data->triangles.size(),
+                                                                    (unsigned short*)data->triangles.data()));
 
             // osg::Material properties are handled here for two reasons:
             // - if there are no vertex colors, we need to disable colorMode.
@@ -1115,7 +1115,7 @@ namespace NifOsg
                 return morphGeom;
             // Note we are not interested in morph 0, which just contains the original vertices
             for (unsigned int i = 1; i < morphs.size(); ++i)
-                morphGeom->addMorphTarget(new osg::Vec3Array(morphs[i].mVertices.size(), &morphs[i].mVertices[0]), 0.f);
+                morphGeom->addMorphTarget(new osg::Vec3Array(morphs[i].mVertices.size(), morphs[i].mVertices.data()), 0.f);
 
             return morphGeom;
         }
@@ -1282,7 +1282,7 @@ namespace NifOsg
             }
 
             unsigned char* data = new unsigned char[pixelData->data.size()];
-            memcpy(data, &pixelData->data[0], pixelData->data.size());
+            memcpy(data, pixelData->data.data(), pixelData->data.size());
 
             image->setImage(width, height, 1, pixelformat, pixelformat, GL_UNSIGNED_BYTE, data, osg::Image::USE_NEW_DELETE);
             image->setMipmapLevels(mipmapVector);


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5118)

front() and operator[] operations are undefined on empty containers. More modern data() from C++11 isn't, at least isn't really, the resulting pointer is either null or to an empty range address, and it won't cause program termination if ran on an empty container. Also it looks nicer and more readable. So I added some safety checks and replaced most of older syntax with data() to avoid the issues the reporter experienced.

Not adding it to the changelog since there's no difference to the end user who with 99% probability uses prebuilt binaries with no such issue.