### PR TITLE
[WIP, do not merge] Issue 5097: Handle ints/floats passed as strings

### DIFF
--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <stack>
 #include <iterator>
+#include <regex>
+#include <string>
 
 #include <components/misc/stringops.hpp>
 
@@ -322,6 +324,22 @@ namespace Compiler
             if (mExplicit.empty() && getContext().isId (name2))
             {
                 mExplicit = name2;
+                return true;
+            }
+
+            // In case someone tried passing an int in quotes
+            if (regex_match(name, std::regex("[+-]?[0-9]+")))
+            {
+                pushIntegerLiteral (stof(name));
+                mTokenLoc = loc;
+                return true;
+            }
+
+            // In case someone tried passing a float in quotes
+            if (regex_match(name, std::regex("[+-]?[0-9]+.[0-9]+")))
+            {
+                pushFloatLiteral (stof(name));
+                mTokenLoc = loc;
                 return true;
             }
         }


### PR DESCRIPTION
https://gitlab.com/OpenMW/openmw/issues/5097

If a script passes an int or float in quotes, exprparser can now handle that in parseName by checking if the string can be converted to an int or float. Unlike my previous attempt, this one does not break functions that expect strings (eg. messagebox "1.0" still works).

One thing to note is that the CS will still give "unexpected name" warnings when numbers are passed this way even though they're now "valid."

Tested by running scripts and console functions with quotes around their number arguments.