### PR TITLE
[Regression] Make sure local path includes trailing slash

### DIFF
--- a/components/files/linuxpath.cpp
+++ b/components/files/linuxpath.cpp
@@ -87,7 +87,7 @@ boost::filesystem::path LinuxPath::getLocalPath() const
     {
         if (readlink(path, &binPath[0], binPath.size()) != -1)
         {
-            localPath = boost::filesystem::path(binPath).parent_path();
+            localPath = boost::filesystem::path(binPath).parent_path() / "/";
             break;
         }
     }

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -85,7 +85,7 @@ boost::filesystem::path WindowsPath::getLocalPath() const
 
     if (GetModuleFileNameW(nullptr, path, MAX_PATH + 1) > 0)
     {
-        localPath = boost::filesystem::path(bconv::utf_to_utf<char>(path)).parent_path();
+        localPath = boost::filesystem::path(bconv::utf_to_utf<char>(path)).parent_path() / "/";
     }
 
     // lookup exe path


### PR DESCRIPTION
Launcher assumes it does but parent_path doesn't have one, so it breaks some stuff.