### PR TITLE
Update weapon state when we cancel attack animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
     Bug #5105: NPCs start combat with werewolves from any distance
     Bug #5110: ModRegion with a redundant numerical argument breaks script execution
     Bug #5123: Script won't run on respawn
+    Bug #5124: Arrow remains attached to actor if pulling animation was cancelled
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -315,6 +315,8 @@ void CharacterController::refreshHitRecoilAnims(CharacterState& idle)
             {
                 mAnimation->disable(mCurrentWeapon);
                 mUpperBodyState = UpperCharState_WeapEquiped;
+                if (mWeaponType > WeapType_HandToHand && mWeaponType < WeapType_Spell)
+                    mAnimation->showWeapons(true);
             }
             else if (mUpperBodyState > UpperCharState_Nothing && mUpperBodyState < UpperCharState_WeapEquiped)
             {
@@ -1321,6 +1323,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         mUpperBodyState = UpperCharState_WeapEquiped;
         mAttackingOrSpell = false;
         mAnimation->disable(mCurrentWeapon);
+        mAnimation->showWeapons(true);
         if (mPtr == getPlayer())
             MWBase::Environment::get().getWorld()->getPlayer().setAttackingOrSpell(false);
     }
@@ -1726,7 +1729,11 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         else if (isKnockedDown())
         {
             if (mUpperBodyState > UpperCharState_WeapEquiped)
+            {
                 mUpperBodyState = UpperCharState_WeapEquiped;
+                if (mWeaponType > WeapType_HandToHand && mWeaponType < WeapType_Spell)
+                    mAnimation->showWeapons(true);
+            }
             mAnimation->disable(mCurrentWeapon);
         }
     }


### PR DESCRIPTION
Fixes [bug #5124](https://gitlab.com/OpenMW/openmw/issues/5124).

Just update weapon state (including quiver and attached arrow) when we cancel weapon attack animation.