### PR TITLE
Revert "Do not use a separate GlowUpdater for every arrow in quiver"

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -274,12 +274,9 @@ void ActorAnimation::updateQuiver()
     {
         osg::ref_ptr<osg::Group> arrowNode = ammoNode->getChild(i)->asGroup();
         osg::ref_ptr<osg::Node> arrow = mResourceSystem->getSceneManager()->getInstance(model, arrowNode);
+        if (!ammo->getClass().getEnchantment(*ammo).empty())
+            mGlowUpdater = SceneUtil::addEnchantedGlow(arrow, mResourceSystem, glowColor);
     }
-
-    // Assign GlowUpdater for ammo sheathing bone itself to do not attach it to every arrow
-    ammoNode->setUpdateCallback(nullptr);
-    if (ammoCount > 0 && !ammo->getClass().getEnchantment(*ammo).empty())
-        SceneUtil::addEnchantedGlow(ammoNode, mResourceSystem, glowColor);
 }
 
 void ActorAnimation::itemAdded(const MWWorld::ConstPtr& item, int /*count*/)


### PR DESCRIPTION
It sometimes leads to
```
Warning: detected OpenGL error 'invalid operation' at after RenderBin::draw(..)
```

errors, so I have to revert it.