### PR TITLE
Allow SwimRunForward state WalkForward fallback (bug #5126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,9 @@
     Bug #5112: Insufficient magicka for current spell not reflected on HUD icon
     Bug #5123: Script won't run on respawn
     Bug #5124: Arrow remains attached to actor if pulling animation was cancelled
+    Bug #5126: Swimming creatures without RunForward animations are motionless during combat
     Bug #5134: Doors rotation by "Lock" console command is inconsistent
+    Bug #5126: Swimming creatures without RunForward animations are motionless during combat
     Bug #5137: Textures with Clamp Mode set to Clamp instead of Wrap are too dark outside the boundaries
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -529,19 +529,7 @@ void CharacterController::refreshMovementAnims(const std::string& weapShortGroup
             if(!mAnimation->hasAnimation(movementAnimName))
             {
                 std::string::size_type swimpos = movementAnimName.find("swim");
-                if(swimpos == std::string::npos)
-                {
-                    std::string::size_type runpos = movementAnimName.find("run");
-                    if (runpos != std::string::npos)
-                    {
-                        movementAnimName.replace(runpos, runpos+3, "walk");
-                        if (!mAnimation->hasAnimation(movementAnimName))
-                            movementAnimName.clear();
-                    }
-                    else
-                        movementAnimName.clear();
-                }
-                else
+                if (swimpos != std::string::npos)
                 {
                     movementAnimName.erase(swimpos, 4);
                     if (!weapShortGroup.empty())
@@ -552,8 +540,18 @@ void CharacterController::refreshMovementAnims(const std::string& weapShortGroup
                         else
                             movementAnimName = fallbackShortWeaponGroup(movementAnimName, &movemask);
                     }
+                }
 
-                    if (!mAnimation->hasAnimation(movementAnimName))
+                if (swimpos == std::string::npos || !mAnimation->hasAnimation(movementAnimName))
+                {
+                    std::string::size_type runpos = movementAnimName.find("run");
+                    if (runpos != std::string::npos)
+                    {
+                        movementAnimName.replace(runpos, runpos+3, "walk");
+                        if (!mAnimation->hasAnimation(movementAnimName))
+                            movementAnimName.clear();
+                    }
+                    else
                         movementAnimName.clear();
                 }
             }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5126)

Shuffled the relevant code a little to enable walk animation fallback for swimming animations. Should allow swimming creatures to use their WalkForward animation if it's present and running animation is not.

Right, works on a slaughterfish with running animation artificially removed.