### PR TITLE
Add support for QuadraticMethod/LinearMethod setup (bug #4965, continuation)

### DIFF
--- a/components/sceneutil/lightutil.cpp
+++ b/components/sceneutil/lightutil.cpp
@@ -22,29 +22,35 @@ namespace SceneUtil
         float linearAttenuation = 0.f;
         float constantAttenuation = 0.f;
 
-        const bool useConstant = Fallback::Map::getBool("LightAttenuation_UseConstant");
-        if (useConstant)
-        {
-            constantAttenuation = Fallback::Map::getFloat("LightAttenuation_ConstantValue");
-        }
+        static const bool useConstant = Fallback::Map::getBool("LightAttenuation_UseConstant");
+        static const bool useLinear = Fallback::Map::getBool("LightAttenuation_UseLinear");
+        static const bool useQuadratic = Fallback::Map::getBool("LightAttenuation_UseQuadratic");
+        static const float constantValue = Fallback::Map::getFloat("LightAttenuation_ConstantValue");
+        static const float linearValue = Fallback::Map::getFloat("LightAttenuation_LinearValue");
+        static const float quadraticValue = Fallback::Map::getFloat("LightAttenuation_QuadraticValue");
+        static const float linearRadiusMult = Fallback::Map::getFloat("LightAttenuation_LinearRadiusMult");
+        static const float quadraticRadiusMult = Fallback::Map::getFloat("LightAttenuation_QuadraticRadiusMult");
+        static const int linearMethod = Fallback::Map::getInt("LightAttenuation_LinearMethod");
+        static const int quadraticMethod = Fallback::Map::getInt("LightAttenuation_QuadraticMethod");
+        static const bool outQuadInLin = Fallback::Map::getBool("LightAttenuation_OutQuadInLin");
 
-        const bool useLinear = Fallback::Map::getBool("LightAttenuation_UseLinear");
+        if (useConstant)
+            constantAttenuation = constantValue;
+
         if (useLinear)
         {
-            const float linearValue = Fallback::Map::getFloat("LightAttenuation_LinearValue");
-            const float linearRadiusMult = Fallback::Map::getFloat("LightAttenuation_LinearRadiusMult");
+            linearAttenuation = linearMethod == 0 ? linearValue : 0.01f;
             float r = radius * linearRadiusMult;
-            if (r) linearAttenuation = linearValue / r;
+            if (r && (linearMethod == 1 || linearMethod == 2))
+                linearAttenuation = linearValue / std::pow(r, linearMethod);
         }
 
-        const bool useQuadratic = Fallback::Map::getBool("LightAttenuation_UseQuadratic");
-        const bool outQuadInLin = Fallback::Map::getBool("LightAttenuation_OutQuadInLin");
         if (useQuadratic && (!outQuadInLin || isExterior))
         {
-            const float quadraticValue = Fallback::Map::getFloat("LightAttenuation_QuadraticValue");
-            const float quadraticRadiusMult = Fallback::Map::getFloat("LightAttenuation_QuadraticRadiusMult");
+            quadraticAttenuation = quadraticMethod == 0 ? quadraticValue : 0.01f;
             float r = radius * quadraticRadiusMult;
-            if (r) quadraticAttenuation = quadraticValue / std::pow(r, 2);
+            if (r && (quadraticMethod == 1 || quadraticMethod == 2))
+                quadraticAttenuation = quadraticValue / std::pow(r, quadraticMethod);
         }
 
         light->setConstantAttenuation(constantAttenuation);


### PR DESCRIPTION
Continuation of #2315, now these settings are used like they are used in [MWSE's](https://github.com/MWSE/MWSE/blob/master/MWSE/NIPointLight.cpp#L41) accurate implementation of the original logic.

Also made all constant settings read-only to avoid reinitialization for every single light source.