### PR TITLE
Class quiz fixes

### DIFF
--- a/apps/openmw/mwgui/charactercreation.hpp
+++ b/apps/openmw/mwgui/charactercreation.hpp
@@ -75,8 +75,9 @@ namespace MWGui
 
     //Class generation vars
     unsigned mGenerateClassStep;                 // Keeps track of current step in Generate Class dialog
+    ESM::Class::Specialization mGenerateClassResponses[3];
     unsigned mGenerateClassSpecializations[3];   // A counter for each specialization which is increased when an answer is chosen
-    std::string mGenerateClass;                  // In order: Stealth, Combat, Magic
+    std::string mGenerateClass;                  // In order: Combat, Magic, Stealth
 
     ////Dialog events
     //Name dialog


### PR DESCRIPTION
Removes the "Failed to deduce class" error, and uses original MW logic to select the class. Also randomises the order of the displayed responses like in vanilla.