### PR TITLE
Implement NiPalette support (feature #4882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch
     Feature #4859: Make water reflections more configurable
+    Feature #4882: Support for NiPalette node
     Feature #4887: Add openmw command option to set initial random seed
     Feature #4890: Make Distant Terrain configurable
     Feature #4958: Support eight blood types

--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -163,22 +163,23 @@ void NiPixelData::read(NIFStream *nif)
 {
     fmt = (Format)nif->getUInt();
 
-    rmask = nif->getInt(); // usually 0xff
-    gmask = nif->getInt(); // usually 0xff00
-    bmask = nif->getInt(); // usually 0xff0000
-    amask = nif->getInt(); // usually 0xff000000 or zero
+    rmask = nif->getUInt(); // usually 0xff
+    gmask = nif->getUInt(); // usually 0xff00
+    bmask = nif->getUInt(); // usually 0xff0000
+    amask = nif->getUInt(); // usually 0xff000000 or zero
 
-    bpp = nif->getInt();
+    bpp = nif->getUInt();
 
-    // Unknown
-    nif->skip(12);
+    // 8 bytes of "Old Fast Compare". Whatever that means.
+    nif->skip(8);
+    palette.read(nif);
 
-    numberOfMipmaps = nif->getInt();
+    numberOfMipmaps = nif->getUInt();
 
     // Bytes per pixel, should be bpp * 8
-    /* int bytes = */ nif->getInt();
+    /* int bytes = */ nif->getUInt();
 
-    for(int i=0; i<numberOfMipmaps; i++)
+    for(unsigned int i=0; i<numberOfMipmaps; i++)
     {
         // Image size and offset in the following data field
         Mipmap m;
@@ -189,10 +190,15 @@ void NiPixelData::read(NIFStream *nif)
     }
 
     // Read the data
-    unsigned int dataSize = nif->getInt();
+    unsigned int dataSize = nif->getUInt();
     data.reserve(dataSize);
     for (unsigned i=0; i<dataSize; ++i)
         data.push_back((unsigned char)nif->getChar());
+}
+
+void NiPixelData::post(NIFFile *nif)
+{
+    palette.post(nif);
 }
 
 void NiColorData::read(NIFStream *nif)
@@ -276,6 +282,16 @@ void NiKeyframeData::read(NIFStream *nif)
     mTranslations->read(nif);
     mScales = std::make_shared<FloatKeyMap>();
     mScales->read(nif);
+}
+
+void NiPalette::read(NIFStream *nif)
+{
+    unsigned int alphaMask = !nif->getChar() ? 0xFF000000 : 0;
+    // Fill the entire palette with black even if there isn't enough entries.
+    colors.resize(256);
+    unsigned int numEntries = nif->getUInt();
+    for (unsigned int i = 0; i < numEntries; i++)
+        colors[i] = nif->getUInt() | alphaMask;
 }
 
 } // Namespace

--- a/components/nif/data.hpp
+++ b/components/nif/data.hpp
@@ -116,6 +116,7 @@ public:
         NIPXFMT_RGB8,
         NIPXFMT_RGBA8,
         NIPXFMT_PAL8,
+        NIPXFMT_PALA8,
         NIPXFMT_DXT1,
         NIPXFMT_DXT3,
         NIPXFMT_DXT5,
@@ -123,8 +124,10 @@ public:
     };
     Format fmt;
 
-    unsigned int rmask, gmask, bmask, amask;
-    int bpp, numberOfMipmaps;
+    unsigned int rmask, gmask, bmask, amask, bpp;
+
+    NiPalettePtr palette;
+    unsigned int numberOfMipmaps;
 
     struct Mipmap
     {
@@ -136,6 +139,7 @@ public:
     std::vector<unsigned char> data;
 
     void read(NIFStream *nif);
+    void post(NIFFile *nif);
 };
 
 class NiColorData : public Record
@@ -215,6 +219,15 @@ struct NiKeyframeData : public Record
 
     Vector3KeyMapPtr mTranslations;
     FloatKeyMapPtr mScales;
+
+    void read(NIFStream *nif);
+};
+
+class NiPalette : public Record
+{
+public:
+    // 32-bit RGBA colors that correspond to 8-bit indices
+    std::vector<unsigned int> colors;
 
     void read(NIFStream *nif);
 };

--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -112,6 +112,7 @@ static std::map<std::string,RecordFactoryEntry> makeFactory()
     newFactory.insert(makeEntry("NiSourceTexture",            &construct <NiSourceTexture>             , RC_NiSourceTexture               ));
     newFactory.insert(makeEntry("NiSkinInstance",             &construct <NiSkinInstance>              , RC_NiSkinInstance                ));
     newFactory.insert(makeEntry("NiLookAtController",         &construct <NiLookAtController>          , RC_NiLookAtController            ));
+    newFactory.insert(makeEntry("NiPalette",                  &construct <NiPalette>                   , RC_NiPalette                     ));
     return newFactory;
 }
 

--- a/components/nif/record.hpp
+++ b/components/nif/record.hpp
@@ -97,7 +97,8 @@ enum RecordType
   RC_NiSkinInstance,
   RC_RootCollisionNode,
   RC_NiSphericalCollider,
-  RC_NiLookAtController
+  RC_NiLookAtController,
+  RC_NiPalette
 };
 
 /// Base class for all records

--- a/components/nif/recordptr.hpp
+++ b/components/nif/recordptr.hpp
@@ -140,6 +140,7 @@ class NiSkinInstance;
 class NiSourceTexture;
 class NiRotatingParticlesData;
 class NiAutoNormalParticlesData;
+class NiPalette;
 
 typedef RecordPtrT<Node> NodePtr;
 typedef RecordPtrT<Extra> ExtraPtr;
@@ -160,6 +161,7 @@ typedef RecordPtrT<NiSkinInstance> NiSkinInstancePtr;
 typedef RecordPtrT<NiSourceTexture> NiSourceTexturePtr;
 typedef RecordPtrT<NiRotatingParticlesData> NiRotatingParticlesDataPtr;
 typedef RecordPtrT<NiAutoNormalParticlesData> NiAutoNormalParticlesDataPtr;
+typedef RecordPtrT<NiPalette> NiPalettePtr;
 
 typedef RecordListT<Node> NodeList;
 typedef RecordListT<Property> PropertyList;


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/issues/4882).

Implements NiPalette reading and handling.
![screenshot032](https://user-images.githubusercontent.com/21265616/62987083-e1652080-be46-11e9-9f0e-693afb0365bf.png)

The NiPalette data is loaded into a vector of unsigned integer color entries. Technically there's no entry limit but there can only be up to 256 usable colors due to the format restraints. When a palettized image is loaded, it's reconstructed into a RGB/RGBA image using the palette and the original color index data contained. When the palette has hasAlpha flag turned off, its colors are considered opaque and their alpha value is discarded. When there are less entries than 256, the rest of the palette is filled with 0 (black color).

Two more internal texture pixel formats are now handled, PAL8 and PALA8, with the relevant enum corrected. One has alpha and one doesn't (guess which is which).

I made a couple of fixes along the way:
1. The last three mipmap levels in mipmap data of internal textures were discarded for some reason, which caused issues when there were *just* three mipmap levels. There doesn't seem to be any adverse effect to loading the entire mipmap level data.
2. For consistency all unsigned integers in NiPixelData are now handled as, well, unsigned integers.