### PR TITLE
[WIP] Open door when it is on the way to a next path point (bug #5073)

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -306,8 +306,6 @@ namespace MWBase
 
             virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) = 0;
 
-            virtual MWWorld::Ptr castRay(const osg::Vec3f& from, const osg::Vec3f& to, int mask) const = 0;
-
             virtual void setActorCollisionMode(const MWWorld::Ptr& ptr, bool internal, bool external) = 0;
             virtual bool isActorCollisionEnabled(const MWWorld::Ptr& ptr) = 0;
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -306,6 +306,8 @@ namespace MWBase
 
             virtual bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) = 0;
 
+            virtual MWWorld::Ptr castRay(const osg::Vec3f& from, const osg::Vec3f& to, int mask) const = 0;
+
             virtual void setActorCollisionMode(const MWWorld::Ptr& ptr, bool internal, bool external) = 0;
             virtual bool isActorCollisionEnabled(const MWWorld::Ptr& ptr) = 0;
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -614,6 +614,8 @@ namespace MWBase
 
             /// Return physical half extents of the given actor to be used in pathfinding
             virtual osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const = 0;
+
+            virtual bool hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const = 0;
     };
 }
 

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -13,6 +13,8 @@
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 
+#include "../mwphysics/collisiontype.hpp"
+
 #include "pathgrid.hpp"
 #include "creaturestats.hpp"
 #include "movement.hpp"
@@ -240,6 +242,9 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
 
     if (!door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == MWWorld::DoorState::Idle)
     {
+        if (!isDoorOnTheWay(actor, door))
+            return;
+
         if ((door.getCellRef().getTrap().empty() && door.getCellRef().getLockLevel() <= 0 ))
         {
             world->activate(door, actor);
@@ -407,4 +412,14 @@ DetourNavigator::Flags MWMechanics::AiPackage::getNavigatorFlags(const MWWorld::
         result |= DetourNavigator::Flag_openDoor;
 
     return result;
+}
+
+bool MWMechanics::AiPackage::isDoorOnTheWay(const MWWorld::Ptr& actor, const MWWorld::Ptr& door) const
+{
+    const auto world = MWBase::Environment::get().getWorld();
+    const auto halfExtents = world->getHalfExtents(actor);
+    const auto position = actor.getRefData().getPosition().asVec3() + osg::Vec3f(0, 0, halfExtents.z());
+    const auto destination = mPathFinder.getPath().front() + osg::Vec3f(0, 0, halfExtents.z());
+
+    return world->hasCollisionWithDoor(door, position, destination);
 }

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -224,6 +224,10 @@ void MWMechanics::AiPackage::evadeObstacles(const MWWorld::Ptr& actor)
 
 void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
 {
+    // note: AiWander currently does not open doors
+    if (getTypeId() == TypeIdWander)
+        return;
+
     MWBase::World* world = MWBase::Environment::get().getWorld();
     static float distance = world->getMaxActivationDistance();
 
@@ -231,8 +235,7 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
     if (door == MWWorld::Ptr())
         return;
 
-    // note: AiWander currently does not open doors
-    if (getTypeId() != TypeIdWander && !door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == MWWorld::DoorState::Idle)
+    if (!door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == MWWorld::DoorState::Idle)
     {
         if ((door.getCellRef().getTrap().empty() && door.getCellRef().getLockLevel() <= 0 ))
         {

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -228,6 +228,9 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
     if (getTypeId() == TypeIdWander)
         return;
 
+    if (mPathFinder.getPathSize() == 0)
+        return;
+
     MWBase::World* world = MWBase::Environment::get().getWorld();
     static float distance = world->getMaxActivationDistance();
 

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -13,6 +13,8 @@
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 
+#include "../mwphysics/collisiontype.hpp"
+
 #include "pathgrid.hpp"
 #include "creaturestats.hpp"
 #include "movement.hpp"
@@ -234,6 +236,9 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
     // note: AiWander currently does not open doors
     if (getTypeId() != TypeIdWander && !door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == 0)
     {
+        if (!isDoorOnTheWay(actor, door))
+            return;
+
         if ((door.getCellRef().getTrap().empty() && door.getCellRef().getLockLevel() <= 0 ))
         {
             world->activate(door, actor);
@@ -401,4 +406,17 @@ DetourNavigator::Flags MWMechanics::AiPackage::getNavigatorFlags(const MWWorld::
         result |= DetourNavigator::Flag_openDoor;
 
     return result;
+}
+
+bool MWMechanics::AiPackage::isDoorOnTheWay(const MWWorld::Ptr& actor, const MWWorld::Ptr& door) const
+{
+    if (mPathFinder.getPathSize() == 0)
+        return false;
+
+    const auto world = MWBase::Environment::get().getWorld();
+    const auto halfExtents = world->getHalfExtents(actor);
+    const auto position = actor.getRefData().getPosition().asVec3() + osg::Vec3f(0, 0, halfExtents.z());
+    const auto destination = mPathFinder.getPath().front() + osg::Vec3f(0, 0, halfExtents.z());
+
+    return world->castRay(position, destination, MWPhysics::CollisionType_Door) == door;
 }

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -13,8 +13,6 @@
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 
-#include "../mwphysics/collisiontype.hpp"
-
 #include "pathgrid.hpp"
 #include "creaturestats.hpp"
 #include "movement.hpp"
@@ -236,9 +234,6 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
     // note: AiWander currently does not open doors
     if (getTypeId() != TypeIdWander && !door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == 0)
     {
-        if (!isDoorOnTheWay(actor, door))
-            return;
-
         if ((door.getCellRef().getTrap().empty() && door.getCellRef().getLockLevel() <= 0 ))
         {
             world->activate(door, actor);
@@ -406,17 +401,4 @@ DetourNavigator::Flags MWMechanics::AiPackage::getNavigatorFlags(const MWWorld::
         result |= DetourNavigator::Flag_openDoor;
 
     return result;
-}
-
-bool MWMechanics::AiPackage::isDoorOnTheWay(const MWWorld::Ptr& actor, const MWWorld::Ptr& door) const
-{
-    if (mPathFinder.getPathSize() == 0)
-        return false;
-
-    const auto world = MWBase::Environment::get().getWorld();
-    const auto halfExtents = world->getHalfExtents(actor);
-    const auto position = actor.getRefData().getPosition().asVec3() + osg::Vec3f(0, 0, halfExtents.z());
-    const auto destination = mPathFinder.getPath().front() + osg::Vec3f(0, 0, halfExtents.z());
-
-    return world->castRay(position, destination, MWPhysics::CollisionType_Door) == door;
 }

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -147,6 +147,8 @@ namespace MWMechanics
 
         private:
             bool isNearInactiveCell(osg::Vec3f position);
+
+            bool isDoorOnTheWay(const MWWorld::Ptr& actor, const MWWorld::Ptr& door) const;
     };
 }
 

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -147,8 +147,6 @@ namespace MWMechanics
 
         private:
             bool isNearInactiveCell(osg::Vec3f position);
-
-            bool isDoorOnTheWay(const MWWorld::Ptr& actor, const MWWorld::Ptr& door) const;
     };
 }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1610,13 +1610,8 @@ namespace MWWorld
         osg::Vec3f a(x1,y1,z1);
         osg::Vec3f b(x2,y2,z2);
 
-        return !castRay(a, b, mask).isEmpty();
-    }
-
-    MWWorld::Ptr World::castRay(const osg::Vec3f& from, const osg::Vec3f& to, int mask) const
-    {
-        const auto result = mPhysics->castRay(from, to, MWWorld::Ptr(), std::vector<MWWorld::Ptr>(), mask);
-        return result.mHit ? result.mHitObject : MWWorld::Ptr();
+        MWPhysics::PhysicsSystem::RayResult result = mPhysics->castRay(a, b, MWWorld::Ptr(), std::vector<MWWorld::Ptr>(), mask);
+        return result.mHit;
     }
 
     void World::processDoors(float duration)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1610,8 +1610,13 @@ namespace MWWorld
         osg::Vec3f a(x1,y1,z1);
         osg::Vec3f b(x2,y2,z2);
 
-        MWPhysics::PhysicsSystem::RayResult result = mPhysics->castRay(a, b, MWWorld::Ptr(), std::vector<MWWorld::Ptr>(), mask);
-        return result.mHit;
+        return !castRay(a, b, mask).isEmpty();
+    }
+
+    MWWorld::Ptr World::castRay(const osg::Vec3f& from, const osg::Vec3f& to, int mask) const
+    {
+        const auto result = mPhysics->castRay(from, to, MWWorld::Ptr(), std::vector<MWWorld::Ptr>(), mask);
+        return result.mHit ? result.mHitObject : MWWorld::Ptr();
     }
 
     void World::processDoors(float duration)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -15,6 +15,7 @@
 #include <components/misc/constants.hpp>
 #include <components/misc/resourcehelpers.hpp>
 #include <components/misc/rng.hpp>
+#include <components/misc/convert.hpp>
 
 #include <components/files/collections.hpp>
 
@@ -3829,4 +3830,23 @@ namespace MWWorld
             return getHalfExtents(actor);
     }
 
+    bool World::hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const
+    {
+        const auto object = mPhysics->getObject(door);
+
+        if (!object)
+            return false;
+
+        btVector3 aabbMin;
+        btVector3 aabbMax;
+        object->getShapeInstance()->getCollisionShape()->getAabb(btTransform::getIdentity(), aabbMin, aabbMax);
+
+        const auto toLocal = object->getCollisionObject()->getWorldTransform().inverse();
+        const auto localFrom = toLocal(Misc::Convert::toBullet(position));
+        const auto localTo = toLocal(Misc::Convert::toBullet(destination));
+
+        btScalar hitDistance = 1;
+        btVector3 hitNormal;
+        return btRayAabb(localFrom, localTo, aabbMin, aabbMax, hitDistance, hitNormal);
+    }
 }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -719,6 +719,8 @@ namespace MWWorld
 
             /// Return physical half extents of the given actor to be used in pathfinding
             osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const override;
+
+            bool hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const override;
     };
 }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -420,8 +420,6 @@ namespace MWWorld
 
             bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
 
-            MWWorld::Ptr castRay (const osg::Vec3f& from, const osg::Vec3f& to, int mask) const override;
-
             void setActorCollisionMode(const Ptr& ptr, bool internal, bool external) override;
             bool isActorCollisionEnabled(const Ptr& ptr) override;
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -420,6 +420,8 @@ namespace MWWorld
 
             bool castRay (float x1, float y1, float z1, float x2, float y2, float z2) override;
 
+            MWWorld::Ptr castRay (const osg::Vec3f& from, const osg::Vec3f& to, int mask) const override;
+
             void setActorCollisionMode(const Ptr& ptr, bool internal, bool external) override;
             bool isActorCollisionEnabled(const Ptr& ptr) override;
 


### PR DESCRIPTION
This fixes the case described in the [bug](https://gitlab.com/OpenMW/openmw/issues/5073) (`Ildogesto` in `Galom Daeus, Entry`), but may introduce some other issues. However when I start a fight `Ildogesto` is able to open that door (`door_dwrv_inner00`).