### PR TITLE
Change the default reverb preset to improve underwater FX transition

### DIFF
--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -798,7 +798,7 @@ bool OpenAL_Output::init(const std::string &devname, const std::string &hrtfname
                 if(alGetError() == AL_NO_ERROR)
                     Log(Debug::Info) << "Standard Reverb supported";
             }
-            EFXEAXREVERBPROPERTIES props = EFX_REVERB_PRESET_GENERIC;
+            EFXEAXREVERBPROPERTIES props = EFX_REVERB_PRESET_LIVINGROOM;
             props.flGain = 0.0f;
             LoadEffect(mDefaultEffect, props);
         }


### PR DESCRIPTION
Living room preset seems good enough to make the transition to underwater reverb preset less jarring and bring peace to CMAugust's soul.

Not bothering to add a changelog entry since most users don't pay attention to this and there's technically no issue with FX transitions (OpenAL-Soft does everything just right).