### PR TITLE
Use 3d coordinates to detect stuck (bug #5127)

### DIFF
--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -2,8 +2,6 @@
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 
-#include "../mwbase/world.hpp"
-#include "../mwbase/environment.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
 
@@ -125,17 +123,15 @@ namespace MWMechanics
      */
     void ObstacleCheck::update(const MWWorld::Ptr& actor, float duration)
     {
-        const ESM::Position pos = actor.getRefData().getPosition();
+        const MWWorld::Class& cls = actor.getClass();
+        ESM::Position pos = actor.getRefData().getPosition();
 
-        if (mDistSameSpot == -1)
-        {
-            const osg::Vec3f halfExtents = MWBase::Environment::get().getWorld()->getHalfExtents(actor);
-            mDistSameSpot = DIST_SAME_SPOT * actor.getClass().getSpeed(actor) + 1.2 * std::max(halfExtents.x(), halfExtents.y());
-        }
+        if(mDistSameSpot == -1)
+            mDistSameSpot = DIST_SAME_SPOT * cls.getSpeed(actor);
 
-        const float distSameSpot = mDistSameSpot * duration;
-        const float squaredMovedDistance = (osg::Vec2f(pos.pos[0], pos.pos[1]) - osg::Vec2f(mPrevX, mPrevY)).length2();
-        const bool samePosition = squaredMovedDistance < distSameSpot * distSameSpot;
+        float distSameSpot = mDistSameSpot * duration;
+
+        bool samePosition =  (osg::Vec2f(pos.pos[0], pos.pos[1]) - osg::Vec2f(mPrevX, mPrevY)).length2() <  distSameSpot * distSameSpot;
 
         // update position
         mPrevX = pos.pos[0];

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -76,10 +76,8 @@ namespace MWMechanics
         return MWWorld::Ptr(); // none found
     }
 
-    ObstacleCheck::ObstacleCheck():
-        mPrevX(0) // to see if the moved since last time
-      , mPrevY(0)
-      , mWalkState(State_Norm)
+    ObstacleCheck::ObstacleCheck()
+      : mWalkState(State_Norm)
       , mStuckDuration(0)
       , mEvadeDuration(0)
       , mDistSameSpot(-1) // avoid calculating it each time
@@ -123,19 +121,15 @@ namespace MWMechanics
      */
     void ObstacleCheck::update(const MWWorld::Ptr& actor, float duration)
     {
-        const MWWorld::Class& cls = actor.getClass();
-        ESM::Position pos = actor.getRefData().getPosition();
+        const osg::Vec3f pos = actor.getRefData().getPosition().asVec3();
 
-        if(mDistSameSpot == -1)
-            mDistSameSpot = DIST_SAME_SPOT * cls.getSpeed(actor);
+        if (mDistSameSpot == -1)
+            mDistSameSpot = DIST_SAME_SPOT * actor.getClass().getSpeed(actor);
 
-        float distSameSpot = mDistSameSpot * duration;
+        const float distSameSpot = mDistSameSpot * duration;
+        const bool samePosition =  (pos - mPrev).length2() <  distSameSpot * distSameSpot;
 
-        bool samePosition =  (osg::Vec2f(pos.pos[0], pos.pos[1]) - osg::Vec2f(mPrevX, mPrevY)).length2() <  distSameSpot * distSameSpot;
-
-        // update position
-        mPrevX = pos.pos[0];
-        mPrevY = pos.pos[1];
+        mPrev = pos;
 
         switch(mWalkState)
         {

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENMW_MECHANICS_OBSTACLE_H
 #define OPENMW_MECHANICS_OBSTACLE_H
 
+#include <osg/Vec3f>
+
 namespace MWWorld
 {
     class Ptr;
@@ -37,9 +39,8 @@ namespace MWMechanics
 
         private:
 
-            // for checking if we're stuck (ignoring Z axis)
-            float mPrevX;
-            float mPrevY;
+            // for checking if we're stuck
+            osg::Vec3f mPrev;
 
             // directions to try moving in when get stuck
             static const float evadeDirections[NUM_EVADE_DIRECTIONS][2];


### PR DESCRIPTION
1. Revert changes adding half extents to formula.
2. Replace (x, y) coordinates by (x, y, z). To able water and flying creatures (like Horkers) move to player going up and down.