### PR TITLE
Optimize custom bones search visitor

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -247,7 +247,10 @@ namespace
         void apply(osg::Node& node)
         {
             if (SceneUtil::hasUserDescription(&node, "CustomBone"))
+            {
                 mFoundBones.emplace_back(&node, node.getParent(0));
+                return;
+            }
 
             traverse(node);
         }


### PR DESCRIPTION
Since we copy custom bones with their descendants, there is no point to traverse bone's child nodes.