### PR TITLE
Allow usage of more keywords as string arguments (bug #5087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
     Bug #5075: Enchanting cast style can be changed if there's no object
     Bug #5078: DisablePlayerLooking is broken
     Bug #5082: Scrolling with controller in GUI mode is broken
+    Bug #5087: Some valid script names can't be used as string arguments
     Bug #5089: Swimming/Underwater creatures only swim around ground level
     Bug #5092: NPCs with enchanted weapons play sound when out of charges
     Bug #5093: Hand to hand sound plays on knocked out enemies

--- a/components/compiler/stringparser.cpp
+++ b/components/compiler/stringparser.cpp
@@ -56,6 +56,23 @@ namespace Compiler
             }
         }
 
+        if (keyword==Scanner::K_end || keyword==Scanner::K_begin ||
+            keyword==Scanner::K_short || keyword==Scanner::K_long ||
+            keyword==Scanner::K_float || keyword==Scanner::K_if ||
+            keyword==Scanner::K_endif || keyword==Scanner::K_else ||
+            keyword==Scanner::K_elseif || keyword==Scanner::K_while ||
+            keyword==Scanner::K_endwhile || keyword==Scanner::K_return ||
+            keyword==Scanner::K_messagebox || keyword==Scanner::K_set ||
+            keyword==Scanner::K_to || keyword==Scanner::K_startscript ||
+            keyword==Scanner::K_stopscript || keyword==Scanner::K_enable ||
+            keyword==Scanner::K_disable || keyword==Scanner::K_getdisabled ||
+            keyword==Scanner::K_getdistance || keyword==Scanner::K_scriptrunning ||
+            keyword==Scanner::K_getsquareroot || keyword==Scanner::K_menumode ||
+            keyword==Scanner::K_random || keyword==Scanner::K_getsecondspassed)
+        {
+            return parseName (loc.mLiteral, loc, scanner);
+        }
+
         return Parser::parseKeyword (keyword, loc, scanner);
     }
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5087)

This the exact same set of additional keywords expression parser accept as variables (mostly keywords and instructions), introduced as supported string literals into the string parser. They are all valid script names so I figured it should be enough to resolve the issue.
Yes, this means constructions like "startscript startscript" and "stopscript stopscript" are now legal.