### PR TITLE
Rename getWeaponPart() function

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -64,7 +64,7 @@ ActorAnimation::~ActorAnimation()
     mScabbard.reset();
 }
 
-PartHolderPtr ActorAnimation::getWeaponPart(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor)
+PartHolderPtr ActorAnimation::attachMesh(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor)
 {
     osg::Group* parent = getBoneByName(bonename);
     if (!parent)
@@ -160,7 +160,7 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
         if (showHolsteredWeapons)
         {
             osg::Vec4f glowColor = weapon->getClass().getEnchantmentColor(*weapon);
-            mScabbard = getWeaponPart(mesh, boneName, isEnchanted, &glowColor);
+            mScabbard = attachMesh(mesh, boneName, isEnchanted, &glowColor);
             if (mScabbard)
                 resetControllers(mScabbard->getNode());
         }
@@ -168,7 +168,7 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
         return;
     }
 
-    mScabbard = getWeaponPart(scabbardName, boneName);
+    mScabbard = attachMesh(scabbardName, boneName);
 
     osg::Group* weaponNode = getBoneByName("Bip01 Weapon");
     if (!weaponNode)

--- a/apps/openmw/mwrender/actoranimation.hpp
+++ b/apps/openmw/mwrender/actoranimation.hpp
@@ -44,11 +44,11 @@ class ActorAnimation : public Animation, public MWWorld::ContainerStoreListener
         virtual void updateHolsteredWeapon(bool showHolsteredWeapons);
         virtual void updateQuiver();
         virtual std::string getHolsteredWeaponBoneName(const MWWorld::ConstPtr& weapon);
-        virtual PartHolderPtr getWeaponPart(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor);
-        virtual PartHolderPtr getWeaponPart(const std::string& model, const std::string& bonename)
+        virtual PartHolderPtr attachMesh(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor);
+        virtual PartHolderPtr attachMesh(const std::string& model, const std::string& bonename)
         {
             osg::Vec4f stubColor = osg::Vec4f(0,0,0,0);
-            return getWeaponPart(model, bonename, false, &stubColor);
+            return attachMesh(model, bonename, false, &stubColor);
         };
 
         PartHolderPtr mScabbard;


### PR DESCRIPTION
Give it a more generic name to re-use it future (for example, for shields holstering).