### PR TITLE
Fix actors stuck in closing door (bug #5138)

### DIFF
--- a/apps/openmw/mwmechanics/aiavoiddoor.hpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.hpp
@@ -36,8 +36,14 @@ namespace MWMechanics
         private:
             float mDuration;
             MWWorld::ConstPtr mDoorPtr;
-            ESM::Position mLastPos;
-            float mAdjAngle;
+            osg::Vec3f mLastPos;
+            int mDirection;
+
+            bool isStuck(const osg::Vec3f& actorPos) const;
+
+            void adjustDirection();
+
+            float getAdjustedAngle() const;
     };
 }
 #endif

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1649,7 +1649,6 @@ namespace MWWorld
                 }
 
                 // we need to undo the rotation
-                rotateObject(door, objPos.rot[0], objPos.rot[1], oldRot);
                 reached = false;
             }
         }
@@ -1671,6 +1670,8 @@ namespace MWWorld
                 if (!closeSound.empty() && MWBase::Environment::get().getSoundManager()->getSoundPlaying(door, closeSound))
                     MWBase::Environment::get().getSoundManager()->stopSound3D(door, closeSound);
             }
+
+            rotateObject(door, objPos.rot[0], objPos.rot[1], oldRot);
         }
 
         // the rotation order we want to use


### PR DESCRIPTION
Two things are done:
1. Add more variation in changing direction for actor when it tries to avoid door using `AiAvoidDoor` package. It helps solve the issue but with some delay for actor to get out.
2. Rotate door in opposite direction when collision with actor is detected. Previously when collision with any actor is detected opening or closing door rotation was rolled back to begin of the frame. So until actor will find the right direction to move door will not rotate. If we start to rotate door in opposite direction it helps actor to find a way eventually. This may produce issues with visibly operlapping actors and doors. Probably need more detailed testing for this.