### PR TITLE
Handle death event manually if needed before disposing a corpse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
     Feature #5122: Use magic glow for enchanted arrows
     Feature #5131: Custom skeleton bones
     Feature #5132: Unique animations for different weapon types
+    Feature #5146: Safe Dispose corpse
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4789: Optimize cell transitions

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -237,6 +237,8 @@ namespace MWBase
 
             virtual float getActorsProcessingRange() const = 0;
 
+            virtual void notifyDied(const MWWorld::Ptr& actor) = 0;
+
             virtual bool onOpen(const MWWorld::Ptr& ptr) = 0;
             virtual void onClose(const MWWorld::Ptr& ptr) = 0;
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1630,6 +1630,13 @@ namespace MWMechanics
         updateCombatMusic();
     }
 
+    void Actors::notifyDied(const MWWorld::Ptr &actor)
+    {
+        actor.getClass().getCreatureStats(actor).notifyDied();
+
+        ++mDeathCount[Misc::StringUtils::lowerCase(actor.getCellRef().getRefId())];
+    }
+
     void Actors::killDeadActors()
     {
         for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
@@ -1673,9 +1680,7 @@ namespace MWMechanics
             }
             else if (killResult == CharacterController::Result_DeathAnimJustFinished)
             {
-                iter->first.getClass().getCreatureStats(iter->first).notifyDied();
-
-                ++mDeathCount[Misc::StringUtils::lowerCase(iter->first.getCellRef().getRefId())];
+                notifyDied(iter->first);
 
                 // Reset magic effects and recalculate derived effects
                 // One case where we need this is to make sure bound items are removed upon death

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -71,6 +71,8 @@ namespace MWMechanics
             PtrActorMap::const_iterator begin() { return mActors.begin(); }
             PtrActorMap::const_iterator end() { return mActors.end(); }
 
+            void notifyDied(const MWWorld::Ptr &actor);
+
             /// Check if the target actor was detected by an observer
             /// If the observer is a non-NPC, check all actors in AI processing distance as observers
             bool isActorDetected(const MWWorld::Ptr& actor, const MWWorld::Ptr& observer);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -455,6 +455,11 @@ namespace MWMechanics
         }
     }
 
+    void MechanicsManager::notifyDied(const MWWorld::Ptr& actor)
+    {
+        mActors.notifyDied(actor);
+    }
+
     float MechanicsManager::getActorsProcessingRange() const
     {
         return mActors.getProcessingRange();

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -211,6 +211,8 @@ namespace MWMechanics
 
             virtual float getActorsProcessingRange() const override;
 
+            virtual void notifyDied(const MWWorld::Ptr& actor) override;
+
             /// Check if the target actor was detected by an observer
             /// If the observer is a non-NPC, check all actors in AI processing distance as observers
             virtual bool isActorDetected(const MWWorld::Ptr& actor, const MWWorld::Ptr& observer) override;

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -72,13 +72,10 @@ can loot during death animation
 :Default:	True
 
 If this setting is true, the player is allowed to loot actors (e.g. summoned creatures) during death animation, 
-if they are not in combat. However disposing corpses during death animation is not recommended - 
-death counter may not be incremented, and this behaviour can break quests.
-This is how Morrowind behaves.
+if they are not in combat. In this case we have to increment death counter and run disposed actor's script instantly.
 
 If this setting is false, player has to wait until end of death animation in all cases.
-This case is more safe, but makes using of summoned creatures exploit 
-(looting summoned Dremoras and Golden Saints for expensive weapons) a lot harder.
+Makes using of summoned creatures exploit (looting summoned Dremoras and Golden Saints for expensive weapons) a lot harder.
 Conflicts with mannequin mods, which use SkipAnim to prevent end of death animation.
 
 This setting can be toggled in Advanced tab of the launcher.

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -19,7 +19,7 @@
           <item>
            <widget class="QCheckBox" name="canLootDuringDeathAnimationCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the player is allowed to loot actors (e.g. summoned creatures) during death animation, if they are not in combat. However disposing corpses during death animation is not recommended - death counter may not be incremented, and this behaviour can break quests. This is how original Morrowind behaves.&lt;/p&gt;&lt;p&gt;If this setting is false, player has to wait until end of death animation in all cases. This case is more safe, but makes using of summoned creatures exploit (looting summoned Dremoras and Golden Saints for expensive weapons) a lot harder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this setting is true, the player is allowed to loot actors (e.g. summoned creatures) during death animation, if they are not in combat. In this case we have to increment death counter and run disposed actor's script instantly.&lt;/p&gt;&lt;p&gt;If this setting is false, player has to wait until end of death animation in all cases. Makes using of summoned creatures exploit (looting summoned Dremoras and Golden Saints for expensive weapons) a lot harder. Conflicts with mannequin mods, which use SkipAnim to prevent end of death animation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Can loot during death animation</string>


### PR DESCRIPTION
Implements [feature #5146](https://gitlab.com/OpenMW/openmw/issues/5146).

Just increment death counter and run script instantly if death animation was not finished yet, as in MCP.

Notes:
1. We will need to update the [MCP](https://wiki.openmw.org/index.php?title=MCP) page as well.
2. Probably the `can loot during death animation` setting is not needed at all and can be wiped out now.
3. In case if we still want to keep an original buggy behaviour, we can extend the `can loot during death animation` instead.