### PR TITLE
Open door when it is on the way to a next path point (bug #5073)

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -614,6 +614,8 @@ namespace MWBase
 
             /// Return physical half extents of the given actor to be used in pathfinding
             virtual osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const = 0;
+
+            virtual bool hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const = 0;
     };
 }
 

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -13,6 +13,8 @@
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/inventorystore.hpp"
 
+#include "../mwphysics/collisiontype.hpp"
+
 #include "pathgrid.hpp"
 #include "creaturestats.hpp"
 #include "movement.hpp"
@@ -222,6 +224,19 @@ void MWMechanics::AiPackage::evadeObstacles(const MWWorld::Ptr& actor)
     }
 }
 
+namespace
+{
+    bool isDoorOnTheWay(const MWWorld::Ptr& actor, const MWWorld::Ptr& door, const osg::Vec3f& nextPathPoint)
+    {
+        const auto world = MWBase::Environment::get().getWorld();
+        const auto halfExtents = world->getHalfExtents(actor);
+        const auto position = actor.getRefData().getPosition().asVec3() + osg::Vec3f(0, 0, halfExtents.z());
+        const auto destination = nextPathPoint + osg::Vec3f(0, 0, halfExtents.z());
+
+        return world->hasCollisionWithDoor(door, position, destination);
+    }
+}
+
 void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
 {
     // note: AiWander currently does not open doors
@@ -240,6 +255,9 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
 
     if (!door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == MWWorld::DoorState::Idle)
     {
+        if (!isDoorOnTheWay(actor, door, mPathFinder.getPath().front()))
+            return;
+
         if ((door.getCellRef().getTrap().empty() && door.getCellRef().getLockLevel() <= 0 ))
         {
             world->activate(door, actor);

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -224,6 +224,10 @@ void MWMechanics::AiPackage::evadeObstacles(const MWWorld::Ptr& actor)
 
 void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
 {
+    // note: AiWander currently does not open doors
+    if (getTypeId() == TypeIdWander)
+        return;
+
     MWBase::World* world = MWBase::Environment::get().getWorld();
     static float distance = world->getMaxActivationDistance();
 
@@ -231,8 +235,7 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
     if (door == MWWorld::Ptr())
         return;
 
-    // note: AiWander currently does not open doors
-    if (getTypeId() != TypeIdWander && !door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == MWWorld::DoorState::Idle)
+    if (!door.getCellRef().getTeleport() && door.getClass().getDoorState(door) == MWWorld::DoorState::Idle)
     {
         if ((door.getCellRef().getTrap().empty() && door.getCellRef().getLockLevel() <= 0 ))
         {

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -228,6 +228,9 @@ void MWMechanics::AiPackage::openDoors(const MWWorld::Ptr& actor)
     if (getTypeId() == TypeIdWander)
         return;
 
+    if (mPathFinder.getPathSize() == 0)
+        return;
+
     MWBase::World* world = MWBase::Environment::get().getWorld();
     static float distance = world->getMaxActivationDistance();
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -15,6 +15,7 @@
 #include <components/misc/constants.hpp>
 #include <components/misc/resourcehelpers.hpp>
 #include <components/misc/rng.hpp>
+#include <components/misc/convert.hpp>
 
 #include <components/files/collections.hpp>
 
@@ -3851,4 +3852,23 @@ namespace MWWorld
             return getHalfExtents(actor);
     }
 
+    bool World::hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const
+    {
+        const auto object = mPhysics->getObject(door);
+
+        if (!object)
+            return false;
+
+        btVector3 aabbMin;
+        btVector3 aabbMax;
+        object->getShapeInstance()->getCollisionShape()->getAabb(btTransform::getIdentity(), aabbMin, aabbMax);
+
+        const auto toLocal = object->getCollisionObject()->getWorldTransform().inverse();
+        const auto localFrom = toLocal(Misc::Convert::toBullet(position));
+        const auto localTo = toLocal(Misc::Convert::toBullet(destination));
+
+        btScalar hitDistance = 1;
+        btVector3 hitNormal;
+        return btRayAabb(localFrom, localTo, aabbMin, aabbMax, hitDistance, hitNormal);
+    }
 }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -719,6 +719,8 @@ namespace MWWorld
 
             /// Return physical half extents of the given actor to be used in pathfinding
             osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const override;
+
+            bool hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const override;
     };
 }
 


### PR DESCRIPTION
Follow up for https://github.com/OpenMW/openmw/pull/2494 .

Now different approach.
1. Check does actor has a path partially helps. If actor is not going anywhere there is no point to open door.
2. Quite less expensive raycasting is used to detect collision with door - `btRayAabb`. Simply detect ray collision with door bounding box.