### PR TITLE
Water shader cleanup

### DIFF
--- a/files/shaders/water_vertex.glsl
+++ b/files/shaders/water_vertex.glsl
@@ -16,7 +16,7 @@ void main(void)
                          0.5, 0.5, 0.5, 1.0);
 
     vec4 texcoordProj = ((scalemat) * ( gl_Position));
-    screenCoordsPassthrough = vec3(texcoordProj.x, texcoordProj.y, texcoordProj.w);
+    screenCoordsPassthrough = texcoordProj.xyw;
 
     position = gl_Vertex;
 


### PR DESCRIPTION
1. Removed some unused stuff.
2. Moved light scattering calculations to refraction path since they're unused for reflection-only path, though it probably doesn't make much of a difference.
3. Fog is now applied after rain ripples completely to prevent weirdness when the fog covers them.
4. Condensed the shader in general.