### PR TITLE
Show spell cost in spell buying window (feature #5147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@
     Feature #5131: Custom skeleton bones
     Feature #5132: Unique animations for different weapon types
     Feature #5146: Safe Dispose corpse
+    Feature #5147: Show spell magicka cost in spell buying window
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4789: Optimize cell transitions

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -42,8 +42,10 @@ namespace MWGui
         const MWWorld::ESMStore &store =
             MWBase::Environment::get().getWorld()->getStore();
 
-        int price = static_cast<int>(spell.mData.mCost*store.get<ESM::GameSetting>().find("fSpellValueMult")->mValue.getFloat());
+        int cost = spell.mData.mCost;
+        int price = static_cast<int>(cost*store.get<ESM::GameSetting>().find("fSpellValueMult")->mValue.getFloat());
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr,price,true);
+        std::string costString = " (" + MyGUI::utility::toString(cost) + (abs(cost) == 1 ? " #{sPoint}) " : " #{sPoints}) ");
 
         MWWorld::Ptr player = MWMechanics::getPlayer();
         int playerGold = player.getClass().getContainerStore(player).count(MWWorld::ContainerStore::sGoldId);
@@ -65,7 +67,7 @@ namespace MWGui
         mCurrentY += lineHeight;
 
         toAdd->setUserData(price);
-        toAdd->setCaptionWithReplacing(spell.mName+"   -   "+MyGUI::utility::toString(price)+"#{sgp}");
+        toAdd->setCaptionWithReplacing(spell.mName+costString+"   -   "+MyGUI::utility::toString(price)+"#{sgp}");
         toAdd->setSize(mSpellsView->getWidth(), lineHeight);
         toAdd->eventMouseWheel += MyGUI::newDelegate(this, &SpellBuyingWindow::onMouseWheel);
         toAdd->setUserString("ToolTipType", "Spell");


### PR DESCRIPTION
[Feature 5147](https://gitlab.com/OpenMW/openmw/issues/5147).

Works like it works in Morrowind with the MCP feature enabled.

The spell magicka cost is added after the spell name in braces and has a singular or plural point suffix depending on the value.

Like this.
![screenshot021](https://user-images.githubusercontent.com/21265616/64063600-e542c200-cbfe-11e9-8d06-79cae02564ca.png)
