### PR TITLE
Make sure failed pick/trap attempts are a crime (bug #5149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
     Bug #5126: Swimming creatures without RunForward animations are motionless during combat
     Bug #5134: Doors rotation by "Lock" console command is inconsistent
     Bug #5137: Textures with Clamp Mode set to Clamp instead of Wrap are too dark outside the boundaries
+    Bug #5149: Failing lock pick attempts isn't always a crime
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -143,8 +143,8 @@ namespace MWBase
             /// @param container The container the item is in; may be empty for an item in the world
             virtual void itemTaken (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item, const MWWorld::Ptr& container,
                                     int count, bool alarm = true) = 0;
-            /// Utility to check if opening (i.e. unlocking) this object is illegal and calling commitCrime if so
-            virtual void objectOpened (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item) = 0;
+            /// Utility to check if unlocking this object is illegal and calling commitCrime if so
+            virtual void unlockAttempted (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item) = 0;
             /// Attempt sleeping in a bed. If this is illegal, call commitCrime.
             /// @return was it illegal, and someone saw you doing it?
             virtual bool sleepInBed (const MWWorld::Ptr& ptr, const MWWorld::Ptr& bed) = 0;

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1034,7 +1034,7 @@ namespace MWMechanics
             return false;
     }
 
-    void MechanicsManager::objectOpened(const MWWorld::Ptr &ptr, const MWWorld::Ptr &item)
+    void MechanicsManager::unlockAttempted(const MWWorld::Ptr &ptr, const MWWorld::Ptr &item)
     {
         MWWorld::Ptr victim;
         if (isAllowedToUse(ptr, item, victim))

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -142,8 +142,8 @@ namespace MWMechanics
             /// @param container The container the item is in; may be empty for an item in the world
             virtual void itemTaken (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item, const MWWorld::Ptr& container,
                                     int count, bool alarm = true) override;
-            /// Utility to check if opening (i.e. unlocking) this object is illegal and calling commitCrime if so
-            virtual void objectOpened (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item) override;
+            /// Utility to check if unlocking this object is illegal and calling commitCrime if so
+            virtual void unlockAttempted (const MWWorld::Ptr& ptr, const MWWorld::Ptr& item) override;
             /// Attempt sleeping in a bed. If this is illegal, call commitCrime.
             /// @return was it illegal, and someone saw you doing it? Also returns fail when enemies are nearby
             virtual bool sleepInBed (const MWWorld::Ptr& ptr, const MWWorld::Ptr& bed) override;

--- a/apps/openmw/mwmechanics/security.cpp
+++ b/apps/openmw/mwmechanics/security.cpp
@@ -59,7 +59,7 @@ namespace MWMechanics
                 resultMessage = "#{sLockFail}";
         }
 
-        MWBase::Environment::get().getMechanicsManager()->objectOpened(mActor, lock);
+        MWBase::Environment::get().getMechanicsManager()->unlockAttempted(mActor, lock);
         int uses = lockpick.getClass().getItemHealth(lockpick);
         --uses;
         lockpick.getCellRef().setCharge(uses);
@@ -101,7 +101,7 @@ namespace MWMechanics
                 resultMessage = "#{sTrapFail}";
         }
 
-        MWBase::Environment::get().getMechanicsManager()->objectOpened(mActor, trap);
+        MWBase::Environment::get().getMechanicsManager()->unlockAttempted(mActor, trap);
         int uses = probe.getClass().getItemHealth(probe);
         --uses;
         probe.getCellRef().setCharge(uses);

--- a/apps/openmw/mwmechanics/security.cpp
+++ b/apps/openmw/mwmechanics/security.cpp
@@ -48,7 +48,6 @@ namespace MWMechanics
             resultMessage = "#{sLockImpossible}";
         else
         {
-            MWBase::Environment::get().getMechanicsManager()->objectOpened(mActor, lock);
             if (Misc::Rng::roll0to99() <= x)
             {
                 lock.getClass().unlock(lock);
@@ -60,6 +59,7 @@ namespace MWMechanics
                 resultMessage = "#{sLockFail}";
         }
 
+        MWBase::Environment::get().getMechanicsManager()->objectOpened(mActor, lock);
         int uses = lockpick.getClass().getItemHealth(lockpick);
         --uses;
         lockpick.getCellRef().setCharge(uses);
@@ -89,7 +89,6 @@ namespace MWMechanics
             resultMessage = "#{sTrapImpossible}";
         else
         {
-            MWBase::Environment::get().getMechanicsManager()->objectOpened(mActor, trap);
             if (Misc::Rng::roll0to99() <= x)
             {
                 trap.getCellRef().setTrap("");
@@ -102,6 +101,7 @@ namespace MWMechanics
                 resultMessage = "#{sTrapFail}";
         }
 
+        MWBase::Environment::get().getMechanicsManager()->objectOpened(mActor, trap);
         int uses = probe.getClass().getItemHealth(probe);
         --uses;
         probe.getCellRef().setCharge(uses);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -712,9 +712,6 @@ namespace MWMechanics
                     if (target.getCellRef().getLockLevel() > 0)
                     {
                         MWBase::Environment::get().getSoundManager()->playSound3D(target, "Open Lock", 1.f, 1.f);
-                        if (!caster.isEmpty())
-                            MWBase::Environment::get().getMechanicsManager()->objectOpened(getPlayer(), target);
-                            // Use the player instead of the caster for vanilla crime compatibility
 
                         if (caster == getPlayer())
                             MWBase::Environment::get().getWindowManager()->messageBox("#{sMagicOpenSuccess}");
@@ -723,6 +720,11 @@ namespace MWMechanics
                 }
                 else
                     MWBase::Environment::get().getSoundManager()->playSound3D(target, "Open Lock Fail", 1.f, 1.f);
+
+                // Failed attempt is a crime too
+                if (!caster.isEmpty())
+                    MWBase::Environment::get().getMechanicsManager()->objectOpened(getPlayer(), target);
+                    // Use the player instead of the caster for vanilla crime compatibility
                 return true;
             }
         }

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -721,9 +721,8 @@ namespace MWMechanics
                 else
                     MWBase::Environment::get().getSoundManager()->playSound3D(target, "Open Lock Fail", 1.f, 1.f);
 
-                // Failed attempt is a crime too
                 if (!caster.isEmpty())
-                    MWBase::Environment::get().getMechanicsManager()->objectOpened(getPlayer(), target);
+                    MWBase::Environment::get().getMechanicsManager()->unlockAttempted(getPlayer(), target);
                     // Use the player instead of the caster for vanilla crime compatibility
                 return true;
             }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5149)

Move some lines to make sure the crime event is always triggered when necessary, even if the lock is too complex to be opened