### PR TITLE
Launcher: Avoid Qt "opening user openmw.cfg twice" warning

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -329,6 +329,7 @@ bool Launcher::MainDialog::setupGameSettings()
         stream.setCodec(QTextCodec::codecForName("UTF-8"));
 
         mGameSettings.readUserFile(stream);
+        file.close();
     }
 
     // Now the rest - priority: user > local > global
@@ -353,8 +354,8 @@ bool Launcher::MainDialog::setupGameSettings()
             stream.setCodec(QTextCodec::codecForName("UTF-8"));
 
             mGameSettings.readFile(stream);
+            file.close();
         }
-        file.close();
     }
 
     return true;


### PR DESCRIPTION
It's really annoying and shows up every time you launch the launcher through the terminal. Apparently we were missing a file close call.

Also moved the second close call to avoid redundantly "closing" a file that doesn't actually exist.