### PR TITLE
[Final tests] Editor: Terrain texture selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
     Feature #3025: Analogue gamepad movement controls
     Feature #3442: Default values for fallbacks from ini file
     Feature #3610: Option to invert X axis
+    Feature #3871: Editor: Terrain Selection
     Feature #3893: Implicit target for "set" function in console
     Feature #3980: In-game option to disable controller
     Feature #3999: Shift + Double Click should maximize/restore menu size

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -89,7 +89,7 @@ opencs_units (view/render
     scenewidget worldspacewidget pagedworldspacewidget unpagedworldspacewidget
     previewwidget editmode instancemode instanceselectionmode instancemovemode
     orbitcameramode pathgridmode selectionmode pathgridselectionmode cameracontroller
-    cellwater terraintexturemode actor
+    cellwater terraintexturemode actor terrainselection
     )
 
 opencs_units_noqt (view/render

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -91,19 +91,19 @@ std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(const osg::Vec3d& 
     return std::make_pair(x, y);
 }
 
-float CSMWorld::CellCoordinates::textureSelectionToWorldCoords(int pos)
+float CSMWorld::CellCoordinates::textureGlobalToWorldCoords(int textureGlobal)
 {
-    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / ESM::Land::LAND_TEXTURE_SIZE;
+    return ESM::Land::REAL_SIZE * static_cast<float>(textureGlobal) / ESM::Land::LAND_TEXTURE_SIZE;
 }
 
-float CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(int pos)
+float CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(int vertexGlobal)
 {
-    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1);
+    return ESM::Land::REAL_SIZE * static_cast<float>(vertexGlobal) / (ESM::Land::LAND_SIZE - 1);
 }
 
-int CSMWorld::CellCoordinates::vertexSelectionToInCellCoords(int pos)
+int CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(int vertexGlobal)
 {
-    return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1)) * (ESM::Land::LAND_SIZE - 1));
+    return static_cast<int>(vertexGlobal - std::floor(static_cast<float>(vertexGlobal) / (ESM::Land::LAND_SIZE - 1)) * (ESM::Land::LAND_SIZE - 1));
 }
 
 std::string CSMWorld::CellCoordinates::textureGlobalToCellId(const std::pair<int, int>& textureGlobal)

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -8,13 +8,6 @@
 #include <components/esm/loadland.hpp>
 #include <components/misc/constants.hpp>
 
-namespace
-{
-    const int cellSize {ESM::Land::REAL_SIZE};
-    const int landSize {ESM::Land::LAND_SIZE};
-    const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
-}
-
 CSMWorld::CellCoordinates::CellCoordinates() : mX (0), mY (0) {}
 
 CSMWorld::CellCoordinates::CellCoordinates (int x, int y) : mX (x), mY (y) {}
@@ -76,10 +69,10 @@ std::pair<int, int> CSMWorld::CellCoordinates::coordinatesToCellIndex (float x, 
     return std::make_pair (std::floor (x / Constants::CellSizeInUnits), std::floor (y / Constants::CellSizeInUnits));
 }
 
-std::pair<int, int> CSMWorld::CellCoordinates::toTextureCoords(osg::Vec3d worldPos)
+std::pair<int, int> CSMWorld::CellCoordinates::toTextureCoords(const osg::Vec3d& worldPos)
 {
-    const auto xd = static_cast<float>(worldPos.x() * landTextureSize / cellSize - 0.25f);
-    const auto yd = static_cast<float>(worldPos.y() * landTextureSize / cellSize + 0.25f);
+    const auto xd = static_cast<float>(worldPos.x() * ESM::Land::LAND_TEXTURE_SIZE / ESM::Land::REAL_SIZE - 0.25f);
+    const auto yd = static_cast<float>(worldPos.y() * ESM::Land::LAND_TEXTURE_SIZE / ESM::Land::REAL_SIZE + 0.25f);
 
     const auto x = static_cast<int>(std::floor(xd));
     const auto y = static_cast<int>(std::floor(yd));
@@ -87,10 +80,10 @@ std::pair<int, int> CSMWorld::CellCoordinates::toTextureCoords(osg::Vec3d worldP
     return std::make_pair(x, y);
 }
 
-std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(osg::Vec3d worldPos)
+std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(const osg::Vec3d& worldPos)
 {
-    const auto xd = static_cast<float>(worldPos.x() * (landSize - 1) / cellSize + 0.5f);
-    const auto yd = static_cast<float>(worldPos.y() * (landSize - 1) / cellSize + 0.5f);
+    const auto xd = static_cast<float>(worldPos.x() * (ESM::Land::LAND_SIZE - 1) / ESM::Land::REAL_SIZE + 0.5f);
+    const auto yd = static_cast<float>(worldPos.y() * (ESM::Land::LAND_SIZE - 1) / ESM::Land::REAL_SIZE + 0.5f);
 
     const auto x = static_cast<int>(std::floor(xd));
     const auto y = static_cast<int>(std::floor(yd));
@@ -100,30 +93,30 @@ std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(osg::Vec3d worldPo
 
 float CSMWorld::CellCoordinates::textureSelectionToWorldCoords(int pos)
 {
-    return cellSize * static_cast<float>(pos) / landTextureSize;
+    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / ESM::Land::LAND_TEXTURE_SIZE;
 }
 
 float CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(int pos)
 {
-    return cellSize * static_cast<float>(pos) / (landSize - 1);
+    return ESM::Land::REAL_SIZE * static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1);
 }
 
 int CSMWorld::CellCoordinates::vertexSelectionToInCellCoords(int pos)
 {
-    return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (landSize - 1)) * (landSize - 1));
+    return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (ESM::Land::LAND_SIZE - 1)) * (ESM::Land::LAND_SIZE - 1));
 }
 
-std::string CSMWorld::CellCoordinates::textureGlobalToCellId(std::pair<int, int> textureGlobal)
+std::string CSMWorld::CellCoordinates::textureGlobalToCellId(const std::pair<int, int>& textureGlobal)
 {
-    int x = std::floor(static_cast<float>(textureGlobal.first) / landTextureSize);
-    int y = std::floor(static_cast<float>(textureGlobal.second) / landTextureSize);
+    int x = std::floor(static_cast<float>(textureGlobal.first) / ESM::Land::LAND_TEXTURE_SIZE);
+    int y = std::floor(static_cast<float>(textureGlobal.second) / ESM::Land::LAND_TEXTURE_SIZE);
     return generateId(x, y);
 }
 
-std::string CSMWorld::CellCoordinates::vertexGlobalToCellId(std::pair<int, int> vertexGlobal)
+std::string CSMWorld::CellCoordinates::vertexGlobalToCellId(const std::pair<int, int>& vertexGlobal)
 {
-    int x = std::floor(static_cast<float>(vertexGlobal.first) / (landSize - 1));
-    int y = std::floor(static_cast<float>(vertexGlobal.second) / (landSize - 1));
+    int x = std::floor(static_cast<float>(vertexGlobal.first) / (ESM::Land::LAND_SIZE - 1));
+    int y = std::floor(static_cast<float>(vertexGlobal.second) / (ESM::Land::LAND_SIZE - 1));
     return generateId(x, y);
 }
 

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -113,6 +113,13 @@ int CSMWorld::CellCoordinates::vertexSelectionToInCellCoords(int pos)
     return static_cast<int>(pos - std::floor(static_cast<float>(pos) / (landSize - 1)) * (landSize - 1));
 }
 
+std::string CSMWorld::CellCoordinates::textureGlobalToCellId(std::pair<int, int> textureGlobal)
+{
+    int x = std::floor(static_cast<float>(textureGlobal.first) / landTextureSize);
+    int y = std::floor(static_cast<float>(textureGlobal.second) / landTextureSize);
+    return generateId(x, y);
+}
+
 std::string CSMWorld::CellCoordinates::vertexGlobalToCellId(std::pair<int, int> vertexGlobal)
 {
     int x = std::floor(static_cast<float>(vertexGlobal.first) / (landSize - 1));

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -49,10 +49,10 @@ namespace CSMWorld
             static std::pair<int, int> coordinatesToCellIndex (float x, float y);
 
             ///Converts worldspace coordinates to global texture selection, taking in account the texture offset.
-            static std::pair<int, int> toTextureCoords(osg::Vec3d worldPos);
+            static std::pair<int, int> toTextureCoords(const osg::Vec3d& worldPos);
 
             ///Converts worldspace coordinates to global vertex selection.
-            static std::pair<int, int> toVertexCoords(osg::Vec3d worldPos);
+            static std::pair<int, int> toVertexCoords(const osg::Vec3d& worldPos);
 
             ///Converts global texture coordinate to worldspace coordinate that is at the upper left corner of the selected texture.
             static float textureSelectionToWorldCoords(int);
@@ -63,10 +63,10 @@ namespace CSMWorld
             ///Converts local cell's heightmap coordinates from the global vertex coordinate
             static int vertexSelectionToInCellCoords(int);
 
-            static std::string textureGlobalToCellId(std::pair<int, int>);
+            static std::string textureGlobalToCellId(const std::pair<int, int>&);
 
             ///Converts global vertex coordinates to cell id
-            static std::string vertexGlobalToCellId(std::pair<int, int>);
+            static std::string vertexGlobalToCellId(const std::pair<int, int>&);
     };
 
     bool operator== (const CellCoordinates& left, const CellCoordinates& right);

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -63,6 +63,8 @@ namespace CSMWorld
             ///Converts local cell's heightmap coordinates from the global vertex coordinate
             static int vertexSelectionToInCellCoords(int);
 
+            static std::string textureGlobalToCellId(std::pair<int, int>);
+
             ///Converts global vertex coordinates to cell id
             static std::string vertexGlobalToCellId(std::pair<int, int>);
     };

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -55,18 +55,19 @@ namespace CSMWorld
             static std::pair<int, int> toVertexCoords(const osg::Vec3d& worldPos);
 
             ///Converts global texture coordinate to worldspace coordinate that is at the upper left corner of the selected texture.
-            static float textureSelectionToWorldCoords(int);
+            static float textureGlobalToWorldCoords(int textureGlobal);
 
             ///Converts global vertex coordinate to worldspace coordinate
-            static float vertexSelectionToWorldCoords(int);
+            static float vertexGlobalToWorldCoords(int vertexGlobal);
 
-            ///Converts local cell's heightmap coordinates from the global vertex coordinate
-            static int vertexSelectionToInCellCoords(int);
+            ///Converts global vertex coordinate to local cell's heightmap coordinates
+            static int vertexGlobalToInCellCoords(int vertexGlobal);
 
-            static std::string textureGlobalToCellId(const std::pair<int, int>&);
+            ///Converts global texture coordinates to cell id
+            static std::string textureGlobalToCellId(const std::pair<int, int>& textureGlobal);
 
             ///Converts global vertex coordinates to cell id
-            static std::string vertexGlobalToCellId(const std::pair<int, int>&);
+            static std::string vertexGlobalToCellId(const std::pair<int, int>& vertexGlobal);
     };
 
     bool operator== (const CellCoordinates& left, const CellCoordinates& right);

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -140,7 +140,7 @@ void CSVRender::PagedWorldspaceWidget::addEditModeSelectorButtons (
         new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain shape editing"),
         "terrain-shape");
     tool->addButton (
-        new TerrainTextureMode (this, tool),
+        new TerrainTextureMode (this, mRootNode, tool),
         "terrain-texture");
     tool->addButton (
         new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain vertex paint editing"),

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -66,12 +66,12 @@ void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, 
     {
         for(auto const& localPos: localPositions)
         {
-            auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
-            auto itertemp = std::find(mTemporarySelection.begin(), mTemporarySelection.end(), localPos);
+            auto iterTemp = std::find(mTemporarySelection.begin(), mTemporarySelection.end(), localPos);
             mDraggedOperationFlag = true;
 
-            if (itertemp == mTemporarySelection.end())
+            if (iterTemp == mTemporarySelection.end())
             {
+                auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
                 if (iter != mSelection.end())
                 {
                     mSelection.erase(iter);

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -127,7 +127,7 @@ void CSVRender::TerrainSelection::update()
     mGeometry->setVertexArray(vertices);
     osg::ref_ptr<osg::DrawArrays> drawArrays = new osg::DrawArrays(osg::PrimitiveSet::LINES);
     drawArrays->setCount(vertices->size());
-    mGeometry->addPrimitiveSet(drawArrays);
+    if (vertices->size() != 0) mGeometry->addPrimitiveSet(drawArrays);
     mSelectionNode->addChild(mGeometry);
 }
 

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -56,8 +56,10 @@ void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, in
 void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
 {
     if (std::find(mSelection.begin(), mSelection.end(), localPos) == mSelection.end())
-            mSelection.emplace_back(localPos);
-    update();
+    {
+        mSelection.emplace_back(localPos);
+        update();
+    }
 }
 
 void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool toggleInProgress)
@@ -115,7 +117,7 @@ void CSVRender::TerrainSelection::activate()
 
 void CSVRender::TerrainSelection::deactivate()
 {
-    if (mParentNode->containsNode(mSelectionNode)) mParentNode->removeChild(mSelectionNode);
+    mParentNode->removeChild(mSelectionNode);
 }
 
 void CSVRender::TerrainSelection::update()

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -110,12 +110,12 @@ void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, 
 
 void CSVRender::TerrainSelection::activate()
 {
-    mParentNode->addChild(mSelectionNode);
+    if (!mParentNode->containsNode(mSelectionNode)) mParentNode->addChild(mSelectionNode);
 }
 
 void CSVRender::TerrainSelection::deactivate()
 {
-    mParentNode->removeChild(mSelectionNode);
+    if (mParentNode->containsNode(mSelectionNode)) mParentNode->removeChild(mSelectionNode);
 }
 
 void CSVRender::TerrainSelection::update()

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -15,13 +15,6 @@
 #include "cell.hpp"
 #include "worldspacewidget.hpp"
 
-namespace
-{
-    const int cellSize {ESM::Land::REAL_SIZE};
-    const int landSize {ESM::Land::LAND_SIZE};
-    const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
-}
-
 CSVRender::TerrainSelection::TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type):
 mParentNode(parentNode), mWorldspaceWidget (worldspaceWidget), mDraggedOperationFlag(false), mSelectionType(type)
 {
@@ -180,10 +173,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
     {
         // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
         const float nudgePercentage = 0.25f;
-        const int nudgeOffset = (cellSize / landTextureSize) * nudgePercentage;
-        const int landHeightsNudge = (cellSize / landSize) / (landSize - 1); // Does this work with all land size configurations?
+        const int nudgeOffset = (ESM::Land::REAL_SIZE / ESM::Land::LAND_TEXTURE_SIZE) * nudgePercentage;
+        const int landHeightsNudge = (ESM::Land::REAL_SIZE / ESM::Land::LAND_SIZE) / (ESM::Land::LAND_SIZE - 1); // Does this work with all land size configurations?
 
-        const int textureSizeToLandSizeModifier = (landSize - 1) / landTextureSize;
+        const int textureSizeToLandSizeModifier = (ESM::Land::LAND_SIZE - 1) / ESM::Land::LAND_TEXTURE_SIZE;
 
         for (std::pair<int, int> &localPos : mSelection)
         {
@@ -203,8 +196,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
                     vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
                 }
@@ -215,8 +208,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
                     vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
                 }
@@ -227,8 +220,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
                 }
@@ -239,8 +232,8 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
                     vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
                 }
@@ -251,10 +244,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 
 int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global vertex coordinates
 {
-    int cellX = std::floor((1.0f*x / (landSize - 1)));
-    int cellY = std::floor((1.0f*y / (landSize - 1)));
-    int localX = x - cellX * (landSize - 1);
-    int localY = y - cellY * (landSize - 1);
+    int cellX = std::floor((1.0f*x / (ESM::Land::LAND_SIZE - 1)));
+    int cellY = std::floor((1.0f*y / (ESM::Land::LAND_SIZE - 1)));
+    int localX = x - cellX * (ESM::Land::LAND_SIZE - 1);
+    int localY = y - cellY * (ESM::Land::LAND_SIZE - 1);
 
     std::string cellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
 
@@ -264,5 +257,5 @@ int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global ver
     int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
     const CSMWorld::LandHeightsColumn::DataType mPointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
 
-    return mPointer[localY*landSize + localX];
+    return mPointer[localY*ESM::Land::LAND_SIZE + localX];
 }

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -43,17 +43,13 @@ std::vector<std::pair<int, int>> CSVRender::TerrainSelection::getTerrainSelectio
     return mSelection;
 }
 
-void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, int>> localPositions)
+void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, int>> &localPositions)
 {
-    mSelection.clear();
-    for(auto const& value: localPositions)
-    {
-        mSelection.emplace_back(value);
-    }
+    mSelection = localPositions;
     update();
 }
 
-void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
+void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> &localPos)
 {
     if (std::find(mSelection.begin(), mSelection.end(), localPos) == mSelection.end())
     {
@@ -62,7 +58,7 @@ void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
     }
 }
 
-void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool toggleInProgress)
+void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool toggleInProgress)
 {
     if (toggleInProgress == true)
     {
@@ -146,7 +142,7 @@ void CSVRender::TerrainSelection::drawShapeSelection(const osg::ref_ptr<osg::Vec
 {
     if (!mSelection.empty())
     {
-        for (std::pair<int, int> localPos : mSelection)
+        for (std::pair<int, int> &localPos : mSelection)
         {
             int x (localPos.first);
             int y (localPos.second);
@@ -189,7 +185,7 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 
         const int textureSizeToLandSizeModifier = (landSize - 1) / landTextureSize;
 
-        for (std::pair<int, int> localPos : mSelection)
+        for (std::pair<int, int> &localPos : mSelection)
         {
             int x (localPos.first);
             int y (localPos.second);

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -60,7 +60,7 @@ void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> &localPos)
 
 void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool toggleInProgress)
 {
-    if (toggleInProgress == true)
+    if (toggleInProgress)
     {
         for(auto const& localPos: localPositions)
         {

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -1,0 +1,271 @@
+#include "terrainselection.hpp"
+
+#include <algorithm>
+
+#include <osg/Group>
+#include <osg/Geometry>
+#include <osg/PositionAttitudeTransform>
+
+#include <components/esm/loadland.hpp>
+
+#include "../../model/world/cellcoordinates.hpp"
+#include "../../model/world/columnimp.hpp"
+#include "../../model/world/idtable.hpp"
+
+#include "cell.hpp"
+#include "worldspacewidget.hpp"
+
+namespace
+{
+    const int cellSize {ESM::Land::REAL_SIZE};
+    const int landSize {ESM::Land::LAND_SIZE};
+    const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
+}
+
+CSVRender::TerrainSelection::TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type):
+mParentNode(parentNode), mWorldspaceWidget (worldspaceWidget), mDraggedOperationFlag(false), mSelectionType(type)
+{
+    mGeometry = new osg::Geometry();
+
+    mSelectionNode = new osg::Group();
+    mSelectionNode->addChild(mGeometry);
+
+    activate();
+}
+
+CSVRender::TerrainSelection::~TerrainSelection()
+{
+    deactivate();
+}
+
+std::vector<std::pair<int, int>> CSVRender::TerrainSelection::getTerrainSelection() const
+{
+    return mSelection;
+}
+
+void CSVRender::TerrainSelection::onlySelect(const std::vector<std::pair<int, int>> localPositions)
+{
+    mSelection.clear();
+    for(auto const& value: localPositions)
+    {
+        mSelection.emplace_back(value);
+    }
+    update();
+}
+
+void CSVRender::TerrainSelection::addSelect(const std::pair<int, int> localPos)
+{
+    if (std::find(mSelection.begin(), mSelection.end(), localPos) == mSelection.end())
+            mSelection.emplace_back(localPos);
+    update();
+}
+
+void CSVRender::TerrainSelection::toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool toggleInProgress)
+{
+    if (toggleInProgress == true)
+    {
+        for(auto const& localPos: localPositions)
+        {
+            auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
+            auto itertemp = std::find(mTemporarySelection.begin(), mTemporarySelection.end(), localPos);
+            mDraggedOperationFlag = true;
+
+            if (itertemp == mTemporarySelection.end())
+            {
+                if (iter != mSelection.end())
+                {
+                    mSelection.erase(iter);
+                }
+                else
+                {
+                    mSelection.emplace_back(localPos);
+                }
+            }
+
+            mTemporarySelection.push_back(localPos);
+        }
+    }
+    else if (mDraggedOperationFlag == false)
+    {
+        for(auto const& localPos: localPositions)
+        {
+            const auto iter = std::find(mSelection.begin(), mSelection.end(), localPos);
+            if (iter != mSelection.end())
+            {
+                mSelection.erase(iter);
+            }
+            else
+            {
+                mSelection.emplace_back(localPos);
+            }
+        }
+    }
+    else
+    {
+        mDraggedOperationFlag = false;
+        mTemporarySelection.clear();
+    }
+    update();
+}
+
+void CSVRender::TerrainSelection::activate()
+{
+    mParentNode->addChild(mSelectionNode);
+}
+
+void CSVRender::TerrainSelection::deactivate()
+{
+    mParentNode->removeChild(mSelectionNode);
+}
+
+void CSVRender::TerrainSelection::update()
+{
+    mSelectionNode->removeChild(mGeometry);
+    mGeometry = new osg::Geometry();
+
+    const osg::ref_ptr<osg::Vec3Array> vertices (new osg::Vec3Array);
+
+    switch (mSelectionType)
+    {
+        case TerrainSelectionType::Texture : drawTextureSelection(vertices);
+        break;
+        case TerrainSelectionType::Shape : drawShapeSelection(vertices);
+        break;
+    }
+
+    mGeometry->setVertexArray(vertices);
+    osg::ref_ptr<osg::DrawArrays> drawArrays = new osg::DrawArrays(osg::PrimitiveSet::LINES);
+    drawArrays->setCount(vertices->size());
+    mGeometry->addPrimitiveSet(drawArrays);
+    mSelectionNode->addChild(mGeometry);
+}
+
+void CSVRender::TerrainSelection::drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices)
+{
+    if (!mSelection.empty())
+    {
+        for (std::pair<int, int> localPos : mSelection)
+        {
+            int x (localPos.first);
+            int y (localPos.second);
+
+            float xWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x));
+            float yWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y));
+
+            osg::Vec3f pointXY(xWorldCoord, yWorldCoord, calculateLandHeight(x, y) + 2);
+
+            vertices->push_back(pointXY);
+            vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y - 1), calculateLandHeight(x, y - 1) + 2));
+            vertices->push_back(pointXY);
+            vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x - 1), yWorldCoord, calculateLandHeight(x - 1, y) + 2));
+
+            const auto north = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y + 1));
+            if (north == mSelection.end())
+            {
+                vertices->push_back(pointXY);
+                vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y + 1), calculateLandHeight(x, y + 1) + 2));
+            }
+
+            const auto east = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x + 1, y));
+            if (east == mSelection.end())
+            {
+                vertices->push_back(pointXY);
+                vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x + 1), yWorldCoord, calculateLandHeight(x + 1, y) + 2));
+            }
+        }
+    }
+}
+
+void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::Vec3Array> vertices)
+{
+    if (!mSelection.empty())
+    {
+
+        // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
+        const float nudgePercentage = 0.25f;
+        const int nudgeOffset = (cellSize / landTextureSize) * nudgePercentage;
+        const int landHeightsNudge = (cellSize / landSize) / (landSize - 1); // Does this work with all land size configurations?
+
+        const int textureSizeToLandSizeModifier = (landSize - 1) / landTextureSize;
+
+        for (std::pair<int, int> localPos : mSelection)
+        {
+            int x (localPos.first);
+            int y (localPos.second);
+
+            // convert texture selection to global vertex coordinates at selection box corners
+            int x1 = x * textureSizeToLandSizeModifier + landHeightsNudge;
+            int x2 = x * textureSizeToLandSizeModifier + textureSizeToLandSizeModifier + landHeightsNudge;
+            int y1 = y * textureSizeToLandSizeModifier - landHeightsNudge;
+            int y2 = y * textureSizeToLandSizeModifier + textureSizeToLandSizeModifier - landHeightsNudge;
+
+            // Draw edges (check all sides, draw lines between vertices, +1 height to keep lines above ground)
+            // Check adjancent selections, draw lines only to edges of the selection
+            const auto north = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y + 1));
+            if (north == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
+                }
+            }
+
+            const auto south = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y - 1));
+            if (south == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
+                }
+            }
+
+            const auto east = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x + 1, y));
+            if (east == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
+                }
+            }
+
+            const auto west = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x - 1, y));
+            if (west == mSelection.end())
+            {
+                for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
+                {
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+(i-1)*(cellSize / (landSize - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y)+i*(cellSize / (landSize - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
+                }
+            }
+        }
+    }
+}
+
+int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global vertex coordinates
+{
+    int cellX = std::floor((1.0f*x / (landSize - 1)));
+    int cellY = std::floor((1.0f*y / (landSize - 1)));
+    int localX = x - cellX * (landSize - 1);
+    int localY = y - cellY * (landSize - 1);
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
+
+    CSMDoc::Document& document = mWorldspaceWidget->getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+    const CSMWorld::LandHeightsColumn::DataType mPointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+    return mPointer[localY*landSize + localX];
+}

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -182,7 +182,6 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 {
     if (!mSelection.empty())
     {
-
         // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
         const float nudgePercentage = 0.25f;
         const int nudgeOffset = (cellSize / landTextureSize) * nudgePercentage;

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -140,28 +140,28 @@ void CSVRender::TerrainSelection::drawShapeSelection(const osg::ref_ptr<osg::Vec
             int x (localPos.first);
             int y (localPos.second);
 
-            float xWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x));
-            float yWorldCoord(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y));
+            float xWorldCoord(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(x));
+            float yWorldCoord(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(y));
 
             osg::Vec3f pointXY(xWorldCoord, yWorldCoord, calculateLandHeight(x, y) + 2);
 
             vertices->push_back(pointXY);
-            vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y - 1), calculateLandHeight(x, y - 1) + 2));
+            vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(y - 1), calculateLandHeight(x, y - 1) + 2));
             vertices->push_back(pointXY);
-            vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x - 1), yWorldCoord, calculateLandHeight(x - 1, y) + 2));
+            vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(x - 1), yWorldCoord, calculateLandHeight(x - 1, y) + 2));
 
             const auto north = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x, y + 1));
             if (north == mSelection.end())
             {
                 vertices->push_back(pointXY);
-                vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(y + 1), calculateLandHeight(x, y + 1) + 2));
+                vertices->push_back(osg::Vec3f(xWorldCoord, CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(y + 1), calculateLandHeight(x, y + 1) + 2));
             }
 
             const auto east = std::find(mSelection.begin(), mSelection.end(), std::make_pair(x + 1, y));
             if (east == mSelection.end())
             {
                 vertices->push_back(pointXY);
-                vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexSelectionToWorldCoords(x + 1), yWorldCoord, calculateLandHeight(x + 1, y) + 2));
+                vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(x + 1), yWorldCoord, calculateLandHeight(x + 1, y) + 2));
             }
         }
     }
@@ -196,10 +196,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
-                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
                 }
             }
 
@@ -208,10 +208,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
-                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
                 }
             }
 
@@ -220,10 +220,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
                 }
             }
 
@@ -232,10 +232,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureSelectionToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureSelectionToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
                 }
             }
         }

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -30,7 +30,6 @@ namespace CSVRender
     /// \brief Class handling the terrain selection data and rendering
     class TerrainSelection
     {
-
         public:
 
             TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type);

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -46,10 +46,6 @@ namespace CSVRender
 
         protected:
 
-            void addToSelection(osg::Vec3d worldPos);
-            void toggleSelection(osg::Vec3d worldPos);
-            void deselect();
-
             void update();
 
             void drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices);

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -35,9 +35,9 @@ namespace CSVRender
             TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type);
             ~TerrainSelection();
 
-            void onlySelect(const std::vector<std::pair<int, int>> localPositions);
-            void addSelect(const std::pair<int, int> localPos);
-            void toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool);
+            void onlySelect(const std::vector<std::pair<int, int>> &localPositions);
+            void addSelect(const std::pair<int, int> &localPos);
+            void toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool);
 
             void activate();
             void deactivate();

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -1,0 +1,75 @@
+#ifndef CSV_RENDER_TERRAINSELECTION_H
+#define CSV_RENDER_TERRAINSELECTION_H
+
+#include <utility>
+#include <vector>
+
+#include <osg/Vec3d>
+#include <osg/ref_ptr>
+#include <osg/PositionAttitudeTransform>
+
+#include <components/esm/loadland.hpp>
+#include "../../model/world/cellcoordinates.hpp"
+
+namespace osg
+{
+    class Group;
+}
+
+namespace CSVRender
+{
+    struct WorldspaceHitResult;
+    class WorldspaceWidget;
+
+    enum class TerrainSelectionType
+    {
+        Texture,
+        Shape
+    };
+
+    /// \brief Class handling the terrain selection data and rendering
+    class TerrainSelection
+    {
+
+        public:
+
+            TerrainSelection(osg::Group* parentNode, WorldspaceWidget *worldspaceWidget, TerrainSelectionType type);
+            ~TerrainSelection();
+
+            void onlySelect(const std::vector<std::pair<int, int>> localPositions);
+            void addSelect(const std::pair<int, int> localPos);
+            void toggleSelect(const std::vector<std::pair<int, int>> localPositions, bool);
+
+            void activate();
+            void deactivate();
+
+            std::vector<std::pair<int, int>> getTerrainSelection() const;
+
+        protected:
+
+            void addToSelection(osg::Vec3d worldPos);
+            void toggleSelection(osg::Vec3d worldPos);
+            void deselect();
+
+            void update();
+
+            void drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices);
+            void drawTextureSelection(const osg::ref_ptr<osg::Vec3Array> vertices);
+
+            int calculateLandHeight(int x, int y);
+
+        private:
+
+            osg::Group* mParentNode;
+            WorldspaceWidget *mWorldspaceWidget;
+            osg::ref_ptr<osg::PositionAttitudeTransform> mBaseNode;
+            osg::ref_ptr<osg::Geometry> mGeometry;
+            osg::ref_ptr<osg::Group> mSelectionNode;
+            std::vector<std::pair<int, int>> mSelection; // Global terrain selection coordinate in either vertex or texture units
+            std::vector<std::pair<int, int>> mTemporarySelection; // Used during toggle to compare the most recent drag operation
+            bool mDraggedOperationFlag; //true during drag operation, false when click-operation
+            TerrainSelectionType mSelectionType;
+    };
+}
+
+#endif

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -37,7 +37,7 @@ namespace CSVRender
 
             void onlySelect(const std::vector<std::pair<int, int>> &localPositions);
             void addSelect(const std::pair<int, int> &localPos);
-            void toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool);
+            void toggleSelect(const std::vector<std::pair<int, int>> &localPositions, bool toggleInProgress);
 
             void activate();
             void deactivate();

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -112,7 +112,7 @@ void CSVRender::TerrainTextureMode::primaryEditPressed(const WorldspaceHitResult
     CSMWorld::IdCollection<CSMWorld::LandTexture>& landtexturesCollection = document.getData().getLandTextures();
     int index = landtexturesCollection.searchId(mBrushTexture);
 
-    if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted() &&  hit.hit && hit.tag == 0)
+    if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted() && hit.hit && hit.tag == 0)
     {
         undoStack.beginMacro ("Edit texture records");
         if(allowLandTextureEditing(mCellId)==true)
@@ -505,25 +505,24 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(std::pair<int, int> te
 
     if (mBrushShape == 1)
     {
-        for(int i = texCoords.first - r; i <= texCoords.first + r; ++i)
+        for (int i = -r; i <= r; i++)
         {
-            for(int j = texCoords.second - r; j <= texCoords.second + r; ++j)
+            for (int j = -r; j <= r; j++)
             {
-                selections.emplace_back(std::make_pair(i, j));
+                selections.emplace_back(i + texCoords.first, j + texCoords.second);
             }
         }
     }
 
     if (mBrushShape == 2)
     {
-        for(int i = texCoords.first - r; i <= texCoords.first + r; ++i)
+        for (int i = -r; i <= r; i++)
         {
-            for(int j = texCoords.second - r; j <= texCoords.second + r; ++j)
+            for (int j = -r; j <= r; j++)
             {
-                int distanceX = abs(i - texCoords.first);
-                int distanceY = abs(j - texCoords.second);
-                int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
-                if (distance < r) selections.emplace_back(std::make_pair(i, j));
+                osg::Vec2f coords(i,j);
+                if (std::round(coords.length()) < r)
+                    selections.emplace_back(i + texCoords.first, j + texCoords.second);
             }
         }
     }
@@ -534,7 +533,7 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(std::pair<int, int> te
         {
             for(auto const& value: mCustomBrushShape)
             {
-                selections.emplace_back(std::make_pair(texCoords.first + value.first, texCoords.second + value.second));
+                selections.emplace_back(texCoords.first + value.first, texCoords.second + value.second);
             }
         }
     }
@@ -585,8 +584,7 @@ void CSVRender::TerrainTextureMode::createTexture(std::string textureFileName)
             newId = CSMWorld::LandTexture::createUniqueRecordId(0, counter);
             freeIndexFound = true;
         }
-    }
-    while (freeIndexFound == false);
+    } while (freeIndexFound == false);
 
     std::size_t idlocation = textureFileName.find("Texture: ");
     textureFileName = textureFileName.substr (idlocation + 9);
@@ -711,22 +709,12 @@ void CSVRender::TerrainTextureMode::setBrushShape(int brushShape)
         selectionCenterY = selectionCenterY / selectionAmount;
 
         mCustomBrushShape.clear();
-        std::pair<int, int> differentialPos {};
-        for(auto const& value: terrainSelection)
-        {
-            differentialPos.first = value.first - selectionCenterX;
-            differentialPos.second = value.second - selectionCenterY;
-            mCustomBrushShape.push_back(differentialPos);
-        }
+        for (auto const& value: terrainSelection)
+            mCustomBrushShape.emplace_back(value.first - selectionCenterX, value.second - selectionCenterY);
     }
 }
 
 void CSVRender::TerrainTextureMode::setBrushTexture(std::string brushTexture)
 {
     mBrushTexture = brushTexture;
-}
-
-CSVRender::PagedWorldspaceWidget& CSVRender::TerrainTextureMode::getPagedWorldspaceWidget()
-{
-    return dynamic_cast<PagedWorldspaceWidget&>(getWorldspaceWidget());
 }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -496,12 +496,9 @@ bool CSVRender::TerrainTextureMode::isInCellSelection(int globalSelectionX, int 
 {
     if (CSVRender::PagedWorldspaceWidget *paged = dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
     {
-        CSMWorld::CellSelection selection = paged->getCellSelection();
-        if (selection.has (CSMWorld::CellCoordinates::fromId(
-            CSMWorld::CellCoordinates::textureGlobalToCellId(std::make_pair(globalSelectionX, globalSelectionY))).first))
-        {
-            return true;
-        }
+        std::pair<int, int> textureCoords = std::make_pair(globalSelectionX, globalSelectionY);
+        std::string cellId = CSMWorld::CellCoordinates::textureGlobalToCellId(textureCoords);
+        return paged->getCellSelection().has(CSMWorld::CellCoordinates::fromId(cellId).first);
     }
     return false;
 }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -493,6 +493,21 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 }
 
+bool CSVRender::TerrainTextureMode::isInCellSelection(const int& globalSelectionX, const int& globalSelectionY)
+{
+    if (CSVRender::PagedWorldspaceWidget *paged = dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        CSMWorld::CellSelection selection = paged->getCellSelection();
+        if (selection.has (CSMWorld::CellCoordinates::fromId(
+            CSMWorld::CellCoordinates::textureGlobalToCellId(std::make_pair(globalSelectionX, globalSelectionY))).first))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+
 void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation)
 {
     int r = mBrushSize / 2;
@@ -500,7 +515,7 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
 
     if (mBrushShape == 0)
     {
-        selections.emplace_back(texCoords);
+        if (isInCellSelection(texCoords.first, texCoords.second)) selections.emplace_back(texCoords);
     }
 
     if (mBrushShape == 1)
@@ -509,7 +524,12 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
         {
             for (int j = -r; j <= r; j++)
             {
-                selections.emplace_back(i + texCoords.first, j + texCoords.second);
+                int x = i + texCoords.first;
+                int y = j + texCoords.second;
+                if (isInCellSelection(x, y))
+                {
+                    selections.emplace_back(x, y);
+                }
             }
         }
     }
@@ -522,7 +542,14 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
             {
                 osg::Vec2f coords(i,j);
                 if (std::round(coords.length()) < r)
-                    selections.emplace_back(i + texCoords.first, j + texCoords.second);
+                {
+                    int x = i + texCoords.first;
+                    int y = j + texCoords.second;
+                    if (isInCellSelection(x, y))
+                    {
+                        selections.emplace_back(x, y);
+                    }
+                }
             }
         }
     }
@@ -533,7 +560,12 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
         {
             for(auto const& value: mCustomBrushShape)
             {
-                selections.emplace_back(texCoords.first + value.first, texCoords.second + value.second);
+                int x = texCoords.first + value.first;
+                int y = texCoords.second + value.second;
+                if (isInCellSelection(x, y))
+                {
+                    selections.emplace_back(x, y);
+                }
             }
         }
     }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -493,7 +493,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 }
 
-void CSVRender::TerrainTextureMode::selectTerrainTextures(std::pair<int, int> texCoords, unsigned char selectMode, bool dragOperation)
+void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation)
 {
     int r = mBrushSize / 2;
     std::vector<std::pair<int, int>> selections;

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -114,7 +114,7 @@ void CSVRender::TerrainTextureMode::primaryEditPressed(const WorldspaceHitResult
     if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted() && hit.hit && hit.tag == 0)
     {
         undoStack.beginMacro ("Edit texture records");
-        if(allowLandTextureEditing(mCellId)==true)
+        if(allowLandTextureEditing(mCellId))
         {
             undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, mCellId));
             editTerrainTextureGrid(hit);
@@ -162,7 +162,7 @@ bool CSVRender::TerrainTextureMode::primaryEditStartDrag (const QPoint& pos)
     {
         undoStack.beginMacro ("Edit texture records");
         mIsEditing = true;
-        if(allowLandTextureEditing(mCellId)==true)
+        if(allowLandTextureEditing(mCellId))
         {
             undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, mCellId));
             editTerrainTextureGrid(hit);
@@ -245,7 +245,7 @@ void CSVRender::TerrainTextureMode::dragCompleted(const QPoint& pos)
 
         if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted())
         {
-             if (mIsEditing == true)
+             if (mIsEditing)
              {
                  undoStack.endMacro();
                  mIsEditing = false;
@@ -299,7 +299,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
         *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
 
     mCellId = getWorldspaceWidget().getCellId (hit.worldPos);
-    if(allowLandTextureEditing(mCellId)==true) {}
+    if(allowLandTextureEditing(mCellId)) {}
 
     std::pair<CSMWorld::CellCoordinates, bool> cellCoordinates_pair = CSMWorld::CellCoordinates::fromId (mCellId);
 
@@ -321,7 +321,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 
     mCellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
-    if(allowLandTextureEditing(mCellId)==true) {}
+    if(allowLandTextureEditing(mCellId)) {}
 
     std::string iteratedCellId;
 
@@ -340,7 +340,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
         CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(mCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
         CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
 
-        if(allowLandTextureEditing(mCellId)==true)
+        if(allowLandTextureEditing(mCellId))
         {
             newTerrain[yHitInCell*landTextureSize+xHitInCell] = brushInt;
             pushEditToCommand(newTerrain, document, landTable, mCellId);
@@ -364,7 +364,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
             for(int j_cell = upperLeftCellY; j_cell <= lowerrightCellY; j_cell++)
             {
                 iteratedCellId = CSMWorld::CellCoordinates::generateId(i_cell, j_cell);
-                if(allowLandTextureEditing(iteratedCellId)==true)
+                if(allowLandTextureEditing(iteratedCellId))
                 {
                     CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(iteratedCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
                     CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
@@ -414,7 +414,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
             for(int j_cell = upperLeftCellY; j_cell <= lowerrightCellY; j_cell++)
             {
                 iteratedCellId = CSMWorld::CellCoordinates::generateId(i_cell, j_cell);
-                if(allowLandTextureEditing(iteratedCellId)==true)
+                if(allowLandTextureEditing(iteratedCellId))
                 {
                     CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(iteratedCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
                     CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
@@ -462,7 +462,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
         CSMWorld::LandTexturesColumn::DataType newTerrainPointer = landTable.data(landTable.getModelIndex(mCellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
         CSMWorld::LandTexturesColumn::DataType newTerrain(newTerrainPointer);
 
-        if(allowLandTextureEditing(mCellId)==true && !mCustomBrushShape.empty())
+        if(allowLandTextureEditing(mCellId) && !mCustomBrushShape.empty())
         {
             for(auto const& value: mCustomBrushShape)
             {
@@ -478,7 +478,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
                     int yInOtherCell = yHitInCell + value.second - cellYDifference * landTextureSize;
 
                     std::string cellId = CSMWorld::CellCoordinates::generateId(cellX+cellXDifference, cellY+cellYDifference);
-                    if (allowLandTextureEditing(cellId)==true)
+                    if (allowLandTextureEditing(cellId))
                     {
                         CSMWorld::LandTexturesColumn::DataType newTerrainPointerOtherCell = landTable.data(landTable.getModelIndex(cellId, textureColumn)).value<CSMWorld::LandTexturesColumn::DataType>();
                         CSMWorld::LandTexturesColumn::DataType newTerrainOtherCell(newTerrainPointerOtherCell);

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -235,7 +235,7 @@ void CSVRender::TerrainTextureMode::drag (const QPoint& pos, int diffX, int diff
 
 void CSVRender::TerrainTextureMode::dragCompleted(const QPoint& pos)
 {
-    if (mDragMode == InteractionType_PrimaryEdit)
+    if (mDragMode == InteractionType_PrimaryEdit && mIsEditing)
     {
         CSMDoc::Document& document = getWorldspaceWidget().getDocument();
         QUndoStack& undoStack = document.getUndoStack();
@@ -245,11 +245,8 @@ void CSVRender::TerrainTextureMode::dragCompleted(const QPoint& pos)
 
         if (index != -1 && !landtexturesCollection.getRecord(index).isDeleted())
         {
-             if (mIsEditing)
-             {
-                 undoStack.endMacro();
-                 mIsEditing = false;
-             }
+             undoStack.endMacro();
+             mIsEditing = false;
         }
     }
 }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -492,7 +492,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     }
 }
 
-bool CSVRender::TerrainTextureMode::isInCellSelection(const int& globalSelectionX, const int& globalSelectionY)
+bool CSVRender::TerrainTextureMode::isInCellSelection(int globalSelectionX, int globalSelectionY)
 {
     if (CSVRender::PagedWorldspaceWidget *paged = dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
     {
@@ -732,12 +732,12 @@ void CSVRender::TerrainTextureMode::setBrushShape(int brushShape)
 
         for(auto const& value: terrainSelection)
         {
-            selectionCenterX = selectionCenterX + value.first;
-            selectionCenterY = selectionCenterY + value.second;
+            selectionCenterX += value.first;
+            selectionCenterY += value.second;
             ++selectionAmount;
         }
-        selectionCenterX = selectionCenterX / selectionAmount;
-        selectionCenterY = selectionCenterY / selectionAmount;
+        selectionCenterX /= selectionAmount;
+        selectionCenterY /= selectionAmount;
 
         mCustomBrushShape.clear();
         for (auto const& value: terrainSelection)

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -36,7 +36,6 @@
 #include "pagedworldspacewidget.hpp"
 #include "mask.hpp"
 #include "object.hpp" // Something small needed regarding pointers from here ()
-#include "terrainselection.hpp"
 #include "worldspacewidget.hpp"
 
 CSVRender::TerrainTextureMode::TerrainTextureMode (WorldspaceWidget *worldspaceWidget, osg::Group* parentNode, QWidget *parent)

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <memory>
 
-#include <osg/Group>
-
 #include <QWidget>
 #include <QEvent>
 
@@ -22,6 +20,11 @@
 #endif
 
 #include "terrainselection.hpp"
+
+namespace osg
+{
+    class Group;
+}
 
 namespace CSVWidget
 {
@@ -82,7 +85,7 @@ namespace CSVRender
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
             /// \brief Handle brush mechanics for texture selection
-            void selectTerrainTextures (std::pair<int, int>, unsigned char, bool);
+            void selectTerrainTextures (const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation);
 
             /// \brief Push texture edits to command macro
             void pushEditToCommand (CSMWorld::LandTexturesColumn::DataType& newLandGrid, CSMDoc::Document& document,

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -85,7 +85,7 @@ namespace CSVRender
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
             /// \brief Check if global selection coordinate belongs to cell in view
-            bool isInCellSelection(const int& globalSelectionX, const int& globalSelectionY);
+            bool isInCellSelection(int globalSelectionX, int globalSelectionY);
 
             /// \brief Handle brush mechanics for texture selection
             void selectTerrainTextures (const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation);

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -110,8 +110,6 @@ namespace CSVRender
             const int landSize {ESM::Land::LAND_SIZE};
             const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
 
-            PagedWorldspaceWidget& getPagedWorldspaceWidget();
-
         signals:
             void passBrushTexture(std::string brushTexture);
 

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -4,6 +4,7 @@
 #include "editmode.hpp"
 
 #include <string>
+#include <memory>
 
 #include <QWidget>
 #include <QEvent>
@@ -18,6 +19,8 @@
 #include "../../model/world/landtexture.hpp"
 #endif
 
+#include "terrainselection.hpp"
+
 namespace CSVWidget
 {
     class SceneToolTextureBrush;
@@ -25,6 +28,7 @@ namespace CSVWidget
 
 namespace CSVRender
 {
+    class PagedWorldspaceWidget;
 
     class TerrainTextureMode : public EditMode
     {
@@ -32,8 +36,17 @@ namespace CSVRender
 
         public:
 
+            enum InteractionType
+            {
+                InteractionType_PrimaryEdit,
+                InteractionType_PrimarySelect,
+                InteractionType_SecondaryEdit,
+                InteractionType_SecondarySelect,
+                InteractionType_None
+            };
+
             /// \brief Editmode for terrain texture grid
-            TerrainTextureMode(WorldspaceWidget*, QWidget* parent = nullptr);
+            TerrainTextureMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
 
             void primaryOpenPressed (const WorldspaceHitResult& hit);
 
@@ -68,6 +81,9 @@ namespace CSVRender
             /// \brief Handle brush mechanics, maths regarding worldspace hit etc.
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
+            /// \brief Handle brush mechanics for texture selection
+            void selectTerrainTextures (std::pair<int, int>, unsigned char, bool);
+
             /// \brief Push texture edits to command macro
             void pushEditToCommand (CSMWorld::LandTexturesColumn::DataType& newLandGrid, CSMDoc::Document& document,
                 CSMWorld::IdTable& landTable, std::string cellId);
@@ -83,11 +99,18 @@ namespace CSVRender
             std::string mBrushTexture;
             int mBrushSize;
             int mBrushShape;
+            std::vector<std::pair<int, int>> mCustomBrushShape;
             CSVWidget::SceneToolTextureBrush *mTextureBrushScenetool;
+            int mDragMode;
+            osg::Group* mParentNode;
+            bool mIsEditing;
+            std::unique_ptr<TerrainSelection> mTerrainTextureSelection;
 
             const int cellSize {ESM::Land::REAL_SIZE};
             const int landSize {ESM::Land::LAND_SIZE};
             const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
+
+            PagedWorldspaceWidget& getPagedWorldspaceWidget();
 
         signals:
             void passBrushTexture(std::string brushTexture);

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <memory>
 
+#include <osg/Group>
+
 #include <QWidget>
 #include <QEvent>
 
@@ -28,8 +30,6 @@ namespace CSVWidget
 
 namespace CSVRender
 {
-    class PagedWorldspaceWidget;
-
     class TerrainTextureMode : public EditMode
     {
         Q_OBJECT

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -84,6 +84,9 @@ namespace CSVRender
             /// \brief Handle brush mechanics, maths regarding worldspace hit etc.
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);
 
+            /// \brief Check if global selection coordinate belongs to cell in view
+            bool isInCellSelection(const int& globalSelectionX, const int& globalSelectionY);
+
             /// \brief Handle brush mechanics for texture selection
             void selectTerrainTextures (const std::pair<int, int>& texCoords, unsigned char selectMode, bool dragOperation);
 


### PR DESCRIPTION
Rebased terrain texture selection. Supports also terrain vertex selection.

Based on https://github.com/OpenMW/openmw/pull/1769 which is originally based on PlutonicOverkills https://github.com/OpenMW/openmw/pull/1414 .

I was able to test this only with Qt5. It worked. Anyway, merge?