### PR TITLE
[Review phase] Editor: Transient land shape editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,6 @@
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch
     Feature #4840: Editor: Transient terrain change support
-    Feature #????: Editor: Land shape editing, land selection
     Feature #4859: Make water reflections more configurable
     Feature #4882: Support for NiPalette node
     Feature #4887: Add openmw command option to set initial random seed
@@ -212,6 +211,7 @@
     Feature #5132: Unique animations for different weapon types
     Feature #5146: Safe Dispose corpse
     Feature #5147: Show spell magicka cost in spell buying window
+    Feature #5170: Editor: Land shape editing, land selection
     Feature #5193: Weapon sheathing
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@
     Feature #4784: Launcher: Duplicate Content Lists
     Feature #4812: Support NiSwitchNode
     Feature #4836: Daytime node switch
+    Feature #4840: Editor: Transient terrain change support
+    Feature #????: Editor: Land shape editing, land selection
     Feature #4859: Make water reflections more configurable
     Feature #4882: Support for NiPalette node
     Feature #4887: Add openmw command option to set initial random seed

--- a/CHANGELOG_PR.md
+++ b/CHANGELOG_PR.md
@@ -40,6 +40,8 @@ New Features:
 
 New Editor Features:
 - "Faction Ranks" table for "Faction" records (#4209)
+- Changes to height editing can be cancelled without changes to data (press esc to cancel) (#4840)
+- Land heightmap/shape editing and vertex selection (#5170)
 
 Bug Fixes:
 - Scripted Items cannot be stacked anymore to avoid multiple script execution (#2969)

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -82,14 +82,14 @@ opencs_units_noqt (view/world
 
 opencs_units (view/widget
     scenetoolbar scenetool scenetoolmode pushbutton scenetooltoggle scenetoolrun modebutton
-    scenetooltoggle2 scenetooltexturebrush completerpopup coloreditor colorpickerpopup droplineedit
+    scenetooltoggle2 scenetooltexturebrush scenetoolshapebrush completerpopup coloreditor colorpickerpopup droplineedit
     )
 
 opencs_units (view/render
     scenewidget worldspacewidget pagedworldspacewidget unpagedworldspacewidget
     previewwidget editmode instancemode instanceselectionmode instancemovemode
     orbitcameramode pathgridmode selectionmode pathgridselectionmode cameracontroller
-    cellwater terraintexturemode actor terrainselection
+    cellwater terraintexturemode actor terrainselection terrainshapemode
     )
 
 opencs_units_noqt (view/render

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -248,7 +248,7 @@ void CSMPrefs::State::declare()
         addValues (landeditOutsideVisibleCell);
     declareInt ("texturebrush-maximumsize", "Maximum texture brush size", 50).
         setMin (1);
-    declareInt ("shapebrush-maximumsize", "Maximum texture brush size", 100).
+    declareInt ("shapebrush-maximumsize", "Maximum shape brush size", 100).
         setMin (1);
     declareBool ("open-list-view", "Open displays list view", false).
         setTooltip ("When opening a reference from the scene view, it will open the"

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -242,14 +242,24 @@ void CSMPrefs::State::declare()
         addValues (insertOutsideCell);
     declareEnum ("outside-visible-drop", "Handling drops outside of visible cells", showAndInsert).
         addValues (insertOutsideVisibleCell);
-    declareEnum ("outside-landedit", "Handling land edit outside of cells", createAndLandEdit).
+    declareEnum ("outside-landedit", "Handling terrain edit outside of cells", createAndLandEdit).
+        setTooltip("Behavior of terrain editing, if land editing brush reaches an area without cell record.").
         addValues (landeditOutsideCell);
-    declareEnum ("outside-visible-landedit", "Handling land edit outside of visible cells", showAndLandEdit).
+    declareEnum ("outside-visible-landedit", "Handling terrain edit outside of visible cells", showAndLandEdit).
+        setTooltip("Behavior of terrain editing, if land editing brush reaches an area that is not currently visible.").
         addValues (landeditOutsideVisibleCell);
     declareInt ("texturebrush-maximumsize", "Maximum texture brush size", 50).
         setMin (1);
-    declareInt ("shapebrush-maximumsize", "Maximum shape brush size", 100).
+    declareInt ("shapebrush-maximumsize", "Maximum height edit brush size", 100).
+        setTooltip("Setting for the slider range of brush size in terrain height editing.").
         setMin (1);
+    declareBool ("landedit-post-smoothpainting", "Smooth land after painting height", false).
+        setTooltip("Raise and lower tools will leave bumpy finish without this option");
+    declareDouble ("landedit-post-smoothstrength", "Smoothing strength (post-edit)", 0.25).
+        setTooltip("If smoothing land after painting height is used, this is the percentage of smooth applied afterwards. "
+        "Negative values may be used to roughen instead of smooth.").
+        setMin (-1).
+        setMax (1);
     declareBool ("open-list-view", "Open displays list view", false).
         setTooltip ("When opening a reference from the scene view, it will open the"
         " instance list view instead of the individual instance record view.");

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -170,7 +170,7 @@ void CSMPrefs::State::declare()
         "list go to the first/last item");
 
     declareCategory ("3D Scene Input");
-    
+
     declareDouble ("navi-wheel-factor", "Camera Zoom Sensitivity", 8).setRange(-100.0, 100.0);
     declareDouble ("s-navi-sensitivity", "Secondary Camera Movement Sensitivity", 50.0).setRange(-1000.0, 1000.0);
     declareSeparator();
@@ -178,7 +178,7 @@ void CSMPrefs::State::declare()
     declareDouble ("p-navi-free-sensitivity", "Free Camera Sensitivity", 1/650.).setPrecision(5).setRange(0.0, 1.0);
     declareBool ("p-navi-free-invert", "Invert Free Camera Mouse Input", false);
     declareDouble ("navi-free-lin-speed", "Free Camera Linear Speed", 1000.0).setRange(1.0, 10000.0);
-    declareDouble ("navi-free-rot-speed", "Free Camera Rotational Speed", 3.14 / 2).setRange(0.001, 6.28);    
+    declareDouble ("navi-free-rot-speed", "Free Camera Rotational Speed", 3.14 / 2).setRange(0.001, 6.28);
     declareDouble ("navi-free-speed-mult", "Free Camera Speed Multiplier (from Modifier)", 8).setRange(0.001, 1000.0);
     declareSeparator();
 
@@ -247,6 +247,8 @@ void CSMPrefs::State::declare()
     declareEnum ("outside-visible-landedit", "Handling land edit outside of visible cells", showAndLandEdit).
         addValues (landeditOutsideVisibleCell);
     declareInt ("texturebrush-maximumsize", "Maximum texture brush size", 50).
+        setMin (1);
+    declareInt ("shapebrush-maximumsize", "Maximum texture brush size", 100).
         setMin (1);
     declareBool ("open-list-view", "Open displays list view", false).
         setTooltip ("When opening a reference from the scene view, it will open the"

--- a/apps/opencs/model/world/columnimp.cpp
+++ b/apps/opencs/model/world/columnimp.cpp
@@ -89,10 +89,12 @@ namespace CSMWorld
 
         DataType values(Size, 0);
 
-        if (land.isDataLoaded(Land::DATA_WNAM))
+        if (land.mDataTypes & Land::DATA_WNAM)
         {
             for (int i = 0; i < Size; ++i)
+            {
                 values[i] = land.mWnam[i];
+            }
         }
 
         QVariant variant;

--- a/apps/opencs/model/world/columnimp.cpp
+++ b/apps/opencs/model/world/columnimp.cpp
@@ -92,9 +92,7 @@ namespace CSMWorld
         if (land.mDataTypes & Land::DATA_WNAM)
         {
             for (int i = 0; i < Size; ++i)
-            {
                 values[i] = land.mWnam[i];
-            }
         }
 
         QVariant variant;

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -360,11 +360,6 @@ float CSVRender::Cell::getSumOfAlteredAndTrueHeight(int cellX, int cellY, int in
     return mTerrainStorage->getSumOfAlteredAndTrueHeight(cellX, cellY, inCellX, inCellY);
 }
 
-float* CSVRender::Cell::getAlteredHeights()
-{
-    return mTerrainStorage->getAlteredHeights();
-}
-
 float* CSVRender::Cell::getAlteredHeight(int inCellX, int inCellY)
 {
     return mTerrainStorage->getAlteredHeight(inCellX, inCellY);

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -149,7 +149,6 @@ void CSVRender::Cell::updateLand()
     }
 
     // No land data
-    mLandDeleted = true;
     unloadLand();
 }
 

--- a/apps/opencs/view/render/cell.cpp
+++ b/apps/opencs/view/render/cell.cpp
@@ -134,7 +134,7 @@ void CSVRender::Cell::updateLand()
             else
             {
                 mTerrain.reset(new Terrain::TerrainGrid(mCellNode, mCellNode,
-                    mData.getResourceSystem().get(), new TerrainStorage(mData), Mask_Terrain));
+                    mData.getResourceSystem().get(), mTerrainStorage, Mask_Terrain));
             }
 
             mTerrain->loadCell(esmLand.mX, esmLand.mY);
@@ -168,6 +168,8 @@ CSVRender::Cell::Cell (CSMWorld::Data& data, osg::Group* rootNode, const std::st
   mSubModeElementMask (0), mUpdateLand(true), mLandDeleted(false)
 {
     std::pair<CSMWorld::CellCoordinates, bool> result = CSMWorld::CellCoordinates::fromId (id);
+
+    mTerrainStorage = new TerrainStorage(mData);
 
     if (result.second)
         mCoordinates = result.first;
@@ -345,6 +347,33 @@ bool CSVRender::Cell::referenceAdded (const QModelIndex& parent, int start, int 
         return false;
 
     return addObjects (start, end);
+}
+
+void CSVRender::Cell::setAlteredHeight(int inCellX, int inCellY, float height)
+{
+    mTerrainStorage->setAlteredHeight(inCellX, inCellY, height);
+    mUpdateLand = true;
+}
+
+float CSVRender::Cell::getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY)
+{
+    return mTerrainStorage->getSumOfAlteredAndTrueHeight(cellX, cellY, inCellX, inCellY);
+}
+
+float* CSVRender::Cell::getAlteredHeights()
+{
+    return mTerrainStorage->getAlteredHeights();
+}
+
+float* CSVRender::Cell::getAlteredHeight(int inCellX, int inCellY)
+{
+    return mTerrainStorage->getAlteredHeight(inCellX, inCellY);
+}
+
+void CSVRender::Cell::resetAlteredHeights()
+{
+    mTerrainStorage->resetHeights();
+    mUpdateLand = true;
 }
 
 void CSVRender::Cell::pathgridModified()

--- a/apps/opencs/view/render/cell.hpp
+++ b/apps/opencs/view/render/cell.hpp
@@ -9,6 +9,7 @@
 #include <osg/ref_ptr>
 
 #include "../../model/world/cellcoordinates.hpp"
+#include "terrainstorage.hpp"
 
 class QModelIndex;
 
@@ -58,6 +59,7 @@ namespace CSVRender
             int mSubMode;
             unsigned int mSubModeElementMask;
             bool mUpdateLand, mLandDeleted;
+            TerrainStorage *mTerrainStorage;
 
             /// Ignored if cell does not have an object with the given ID.
             ///
@@ -117,6 +119,16 @@ namespace CSVRender
             /// \return Did this call result in a modification of the visual representation of
             /// this cell?
             bool referenceAdded (const QModelIndex& parent, int start, int end);
+
+            void setAlteredHeight(int inCellX, int inCellY, float height);
+
+            float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
+
+            float* getAlteredHeights();
+
+            float* getAlteredHeight(int inCellX, int inCellY);
+
+            void resetAlteredHeights();
 
             void pathgridModified();
 

--- a/apps/opencs/view/render/cell.hpp
+++ b/apps/opencs/view/render/cell.hpp
@@ -124,8 +124,6 @@ namespace CSVRender
 
             float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
 
-            float* getAlteredHeights();
-
             float* getAlteredHeight(int inCellX, int inCellY);
 
             void resetAlteredHeights();

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -816,13 +816,8 @@ float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeight(const CSMWorld::Ce
 
 void CSVRender::PagedWorldspaceWidget::resetAllAlteredHeights()
 {
-    std::map<CSMWorld::CellCoordinates, Cell *>::iterator iter (mCells.begin());
-
-    while (iter!=mCells.end())
-    {
-        iter->second->resetAlteredHeights();
-        ++iter;
-    }
+    for (const auto& cell : mCells)
+        cell.second->resetAlteredHeights();
 }
 
 std::vector<osg::ref_ptr<CSVRender::TagBase> > CSVRender::PagedWorldspaceWidget::getSelection (

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -25,6 +25,7 @@
 #include "cameracontroller.hpp"
 #include "cellarrow.hpp"
 #include "terraintexturemode.hpp"
+#include "terrainshapemode.hpp"
 
 bool CSVRender::PagedWorldspaceWidget::adjustCells()
 {
@@ -137,11 +138,9 @@ void CSVRender::PagedWorldspaceWidget::addEditModeSelectorButtons (
 
     /// \todo replace EditMode with suitable subclasses
     tool->addButton (
-        new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain shape editing"),
-        "terrain-shape");
+        new TerrainShapeMode (this, mRootNode, tool), "terrain-shape");
     tool->addButton (
-        new TerrainTextureMode (this, mRootNode, tool),
-        "terrain-texture");
+        new TerrainTextureMode (this, mRootNode, tool), "terrain-texture");
     tool->addButton (
         new EditMode (this, QIcon (":placeholder"), Mask_Reference, "Terrain vertex paint editing"),
         "terrain-vertex");
@@ -789,6 +788,46 @@ CSVRender::Cell* CSVRender::PagedWorldspaceWidget::getCell(const osg::Vec3d& poi
         return searchResult->second;
     else
         return 0;
+}
+
+CSVRender::Cell* CSVRender::PagedWorldspaceWidget::getCell(const CSMWorld::CellCoordinates& coords) const
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::const_iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end())
+        return searchResult->second;
+    else
+        return 0;
+}
+
+void CSVRender::PagedWorldspaceWidget::setCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY, float height)
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end()) searchResult->second->setAlteredHeight(inCellX, inCellY, height);
+}
+
+float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeights(const CSMWorld::CellCoordinates& coords)
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end()) return searchResult->second->getAlteredHeights();
+    return nullptr;
+}
+
+float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY)
+{
+    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
+    if (searchResult != mCells.end()) return searchResult->second->getAlteredHeight(inCellX, inCellY);
+    return nullptr;
+}
+
+void CSVRender::PagedWorldspaceWidget::resetAllAlteredHeights()
+{
+    std::map<CSMWorld::CellCoordinates, Cell *>::iterator iter (mCells.begin());
+
+    while (iter!=mCells.end())
+    {
+        iter->second->resetAlteredHeights();
+        ++iter;
+    }
 }
 
 std::vector<osg::ref_ptr<CSVRender::TagBase> > CSVRender::PagedWorldspaceWidget::getSelection (

--- a/apps/opencs/view/render/pagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.cpp
@@ -796,26 +796,21 @@ CSVRender::Cell* CSVRender::PagedWorldspaceWidget::getCell(const CSMWorld::CellC
     if (searchResult != mCells.end())
         return searchResult->second;
     else
-        return 0;
+        return nullptr;
 }
 
 void CSVRender::PagedWorldspaceWidget::setCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY, float height)
 {
     std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
-    if (searchResult != mCells.end()) searchResult->second->setAlteredHeight(inCellX, inCellY, height);
-}
-
-float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeights(const CSMWorld::CellCoordinates& coords)
-{
-    std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
-    if (searchResult != mCells.end()) return searchResult->second->getAlteredHeights();
-    return nullptr;
+    if (searchResult != mCells.end())
+        searchResult->second->setAlteredHeight(inCellX, inCellY, height);
 }
 
 float* CSVRender::PagedWorldspaceWidget::getCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY)
 {
     std::map<CSMWorld::CellCoordinates, Cell*>::iterator searchResult = mCells.find(coords);
-    if (searchResult != mCells.end()) return searchResult->second->getAlteredHeight(inCellX, inCellY);
+    if (searchResult != mCells.end())
+        return searchResult->second->getAlteredHeight(inCellX, inCellY);
     return nullptr;
 }
 

--- a/apps/opencs/view/render/pagedworldspacewidget.hpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.hpp
@@ -128,8 +128,6 @@ namespace CSVRender
 
             void setCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY, float height);
 
-            float* getCellAlteredHeights(const CSMWorld::CellCoordinates& coords);
-
             float* getCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY);
 
             void resetAllAlteredHeights();

--- a/apps/opencs/view/render/pagedworldspacewidget.hpp
+++ b/apps/opencs/view/render/pagedworldspacewidget.hpp
@@ -124,6 +124,16 @@ namespace CSVRender
 
             virtual Cell* getCell(const osg::Vec3d& point) const;
 
+            virtual Cell* getCell(const CSMWorld::CellCoordinates& coords) const;
+
+            void setCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY, float height);
+
+            float* getCellAlteredHeights(const CSMWorld::CellCoordinates& coords);
+
+            float* getCellAlteredHeight(const CSMWorld::CellCoordinates& coords, int inCellX, int inCellY);
+
+            void resetAllAlteredHeights();
+
             virtual std::vector<osg::ref_ptr<TagBase> > getSelection (unsigned int elementMask)
                 const;
 

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -249,13 +249,11 @@ int CSVRender::TerrainSelection::calculateLandHeight(int x, int y) // global ver
     int localX = x - cellX * (ESM::Land::LAND_SIZE - 1);
     int localY = y - cellY * (ESM::Land::LAND_SIZE - 1);
 
-    std::string cellId = CSMWorld::CellCoordinates::generateId(cellX, cellY);
+    CSMWorld::CellCoordinates coords (cellX, cellY);
 
-    CSMDoc::Document& document = mWorldspaceWidget->getDocument();
-    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
-        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
-    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
-    const CSMWorld::LandHeightsColumn::DataType mPointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+    float landHeight = 0.f;
+    if (CSVRender::Cell* cell = dynamic_cast<CSVRender::Cell*>(mWorldspaceWidget->getCell(coords)))
+        landHeight = cell->getSumOfAlteredAndTrueHeight(cellX, cellY, localX, localY);
 
-    return mPointer[localY*ESM::Land::LAND_SIZE + localX];
+    return landHeight;
 }

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -45,16 +45,7 @@
 
 CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidget, osg::Group* parentNode, QWidget *parent)
 : EditMode (worldspaceWidget, QIcon {":scenetoolbar/editing-terrain-shape"}, Mask_Terrain | Mask_Reference, "Terrain land editing", parent),
-    mBrushSize(1),
-    mBrushShape(CSVWidget::BrushShape_Point),
-    mShapeBrushScenetool(nullptr),
-    mDragMode(InteractionType_None),
-    mParentNode(parentNode),
-    mIsEditing(false),
-    mTotalDiffY(0),
-    mShapeEditTool(ShapeEditTool_Drag),
-    mShapeEditToolStrength(8),
-    mTargetHeight(0)
+    mParentNode(parentNode)
 {
 }
 

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -50,7 +50,7 @@ CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidge
     mIsEditing(false),
     mTotalDiffY(0),
     mShapeEditTool(0),
-    mShapeEditToolStrength(0),
+    mShapeEditToolStrength(8),
     mTargetHeight(0)
 {
 }
@@ -656,10 +656,9 @@ void CSVRender::TerrainShapeMode::smoothHeight(const CSMWorld::CellCoordinates& 
             float averageHeight = (upHeight + downHeight + rightHeight + leftHeight +
                 upAlteredHeight + downAlteredHeight + rightAlteredHeight + leftAlteredHeight) / 4;
             if ((thisHeight + thisAlteredHeight) != averageHeight) mAlteredCells.emplace_back(cellCoords);
-            if (toolStrength > abs(thisHeight + thisAlteredHeight - averageHeight) && toolStrength > 8.0f) toolStrength =
-                abs(thisHeight + thisAlteredHeight - averageHeight); //Cut down excessive changes
-            if (thisHeight + thisAlteredHeight > averageHeight) alterHeight(cellCoords, inCellX, inCellY, -toolStrength);
-            if (thisHeight + thisAlteredHeight < averageHeight) alterHeight(cellCoords, inCellX, inCellY, +toolStrength);
+            if (toolStrength > abs(thisHeight + thisAlteredHeight - averageHeight)) toolStrength = abs(thisHeight + thisAlteredHeight - averageHeight);
+            if (thisHeight + thisAlteredHeight > averageHeight) alterHeight(cellCoords, inCellX, inCellY, - toolStrength);
+            if (thisHeight + thisAlteredHeight < averageHeight) alterHeight(cellCoords, inCellX, inCellY, + toolStrength);
         }
     }
 }
@@ -694,8 +693,8 @@ void CSVRender::TerrainShapeMode::flattenHeight(const CSMWorld::CellCoordinates&
 
     if (toolStrength > abs(thisHeight - targetHeight) && toolStrength > 8.0f) toolStrength =
         abs(thisHeight - targetHeight); //Cut down excessive changes
-    if (thisHeight + thisAlteredHeight > targetHeight) alterHeight(cellCoords, inCellX, inCellY, -toolStrength);
-    if (thisHeight + thisAlteredHeight < targetHeight) alterHeight(cellCoords, inCellX, inCellY, +toolStrength);
+    if (thisHeight + thisAlteredHeight > targetHeight) alterHeight(cellCoords, inCellX, inCellY, thisAlteredHeight - toolStrength);
+    if (thisHeight + thisAlteredHeight < targetHeight) alterHeight(cellCoords, inCellX, inCellY, thisAlteredHeight + toolStrength);
 }
 
 void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* thisHeight,

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -192,8 +192,11 @@ void CSVRender::TerrainShapeMode::drag (const QPoint& pos, int diffX, int diffY,
         WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
         std::string cellId = getWorldspaceWidget().getCellId (hit.worldPos);
         mTotalDiffY += diffY;
-        if (mIsEditing == true && mShapeEditTool == ShapeEditTool_Drag) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(mEditingPos), true);
-        if (mIsEditing == true && mShapeEditTool != ShapeEditTool_Drag) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), true);
+        if (mIsEditing)
+        {
+            if (mShapeEditTool == ShapeEditTool_Drag) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(mEditingPos), true);
+            if (mShapeEditTool != ShapeEditTool_Drag) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), true);
+        }
     }
 
     if (mDragMode == InteractionType_PrimarySelect)
@@ -213,7 +216,7 @@ void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
 {
     if (mDragMode == InteractionType_PrimaryEdit)
     {
-        if (mIsEditing == true)
+        if (mIsEditing)
         {
             mTotalDiffY = 0;
             mIsEditing = false;
@@ -539,7 +542,7 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
     std::string cellDownLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() + 1);
     std::string cellDownRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY() + 1);
 
-    if ((allowLandShapeEditing(cellId, useTool)==true) && (useTool || (isLandLoaded(cellId))))
+    if (allowLandShapeEditing(cellId, useTool) && (useTool || (isLandLoaded(cellId))))
     {
         if (CSVRender::PagedWorldspaceWidget *paged =
             dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
@@ -608,7 +611,7 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
             // Change values of edging cells
             if ((inCellX == 0) && (useTool || isLandLoaded(cellLeftId)))
             {
-                if(allowLandShapeEditing(cellLeftId, useTool)==true)
+                if(allowLandShapeEditing(cellLeftId, useTool))
                 {
                     CSMWorld::CellCoordinates edgeCellCoords = cellCoords.move(-1, 0);
                     if (useTool && std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) == mAlteredCells.end())
@@ -619,7 +622,7 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
             }
             if ((inCellY == 0) && (useTool || isLandLoaded(cellUpId)))
             {
-                if(allowLandShapeEditing(cellUpId, useTool)==true)
+                if(allowLandShapeEditing(cellUpId, useTool))
                 {
                     CSMWorld::CellCoordinates edgeCellCoords = cellCoords.move(0, -1);
                     if (useTool && std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) == mAlteredCells.end())
@@ -631,7 +634,7 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
 
             if ((inCellX == ESM::Land::LAND_SIZE - 1) && (useTool || isLandLoaded(cellRightId)))
             {
-                if(allowLandShapeEditing(cellRightId, useTool)==true)
+                if(allowLandShapeEditing(cellRightId, useTool))
                 {
                     CSMWorld::CellCoordinates edgeCellCoords = cellCoords.move(1, 0);
                     if (useTool && std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) == mAlteredCells.end())
@@ -642,7 +645,7 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
             }
             if ((inCellY == ESM::Land::LAND_SIZE - 1) && (useTool || isLandLoaded(cellDownId)))
             {
-                if(allowLandShapeEditing(cellDownId, useTool)==true)
+                if(allowLandShapeEditing(cellDownId, useTool))
                 {
                     CSMWorld::CellCoordinates edgeCellCoords = cellCoords.move(0, 1);
                     if (useTool && std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) == mAlteredCells.end())
@@ -687,7 +690,7 @@ void CSVRender::TerrainShapeMode::smoothHeight(const CSMWorld::CellCoordinates& 
         float downAlteredHeight = 0.0f;
         float upHeight = 0.0f;
 
-        if(allowLandShapeEditing(cellId)==true)
+        if(allowLandShapeEditing(cellId))
         {
             //Get key values for calculating average, handle cell edges, check for null pointers
             if (inCellX == 0)
@@ -1016,7 +1019,7 @@ bool CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordi
             }
         }
 
-        if (reverseMode == true)
+        if (reverseMode)
         {
             for(int inCellY = ESM::Land::LAND_SIZE - 1; inCellY >= 0; --inCellY)
             {

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -887,36 +887,6 @@ void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoor
     }
 }
 
-void CSVRender::TerrainShapeMode::fixEdges(const CSMWorld::CellCoordinates& cellCoords)
-{
-    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
-    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
-        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
-    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
-    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
-    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
-    std::string cellRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
-    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
-    std::string cellDownId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
-    if (allowLandShapeEditing(cellId) == true)
-    {
-        const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-        const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer = landTable.data(landTable.getModelIndex(cellLeftId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-        const CSMWorld::LandHeightsColumn::DataType landRightShapePointer = landTable.data(landTable.getModelIndex(cellRightId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-        const CSMWorld::LandHeightsColumn::DataType landUpShapePointer = landTable.data(landTable.getModelIndex(cellUpId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-        const CSMWorld::LandHeightsColumn::DataType landDownShapePointer = landTable.data(landTable.getModelIndex(cellDownId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-        CSMWorld::LandHeightsColumn::DataType landShapeNew(landShapePointer);
-        for(int i = 0; i < landSize; ++i)
-        {
-            if(document.getData().getCells().searchId (cellLeftId) != -1 && document.getData().getLand().searchId (cellLeftId) != -1 && landShapePointer[i * landSize] != landLeftShapePointer[i * landSize + landSize - 1]) landShapeNew[i * landSize] = landLeftShapePointer[i * landSize + landSize - 1];
-            if(document.getData().getCells().searchId (cellRightId) != -1 && document.getData().getLand().searchId (cellRightId) != -1 && landShapePointer[i * landSize + landSize - 1] != landRightShapePointer[i * landSize]) landShapeNew[i * landSize + landSize - 1] = landRightShapePointer[i * landSize];
-            if(document.getData().getCells().searchId (cellUpId) != -1 && document.getData().getLand().searchId (cellUpId) != -1 && landShapePointer[i] != landUpShapePointer[(landSize - 1) * landSize + i]) landShapeNew[i] = landUpShapePointer[(landSize - 1) * landSize + i];
-            if(document.getData().getCells().searchId (cellDownId) != -1 && document.getData().getLand().searchId (cellDownId) != -1 && landShapePointer[(landSize - 1) * landSize + i] != landDownShapePointer[i]) landShapeNew[(landSize - 1) * landSize + i] = landDownShapePointer[i];
-        }
-        pushEditToCommand(landShapeNew, document, landTable, cellId);
-    }
-}
-
 void CSVRender::TerrainShapeMode::compareAndLimit(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* limitedAlteredHeightXAxis, float* limitedAlteredHeightYAxis, bool* steepnessIsWithinLimits)
 {
     if (limitedAlteredHeightXAxis)
@@ -1185,7 +1155,6 @@ bool CSVRender::TerrainShapeMode::allowLandShapeEditing(std::string cellId)
         if (mode=="Create cell and land, then edit")
         {
             document.getUndoStack().push (new CSMWorld::CreateCommand (landTable, cellId));
-            fixEdges(CSMWorld::CellCoordinates::fromId (cellId).first);
         }
     }
 

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -247,8 +247,7 @@ void CSVRender::TerrainShapeMode::dragWheel (int diff, double speedFactor)
 void CSVRender::TerrainShapeMode::applyTerrainEditChanges()
 {
     std::sort(mAlteredCells.begin(), mAlteredCells.end());
-    std::set<CSMWorld::CellCoordinates> removeDuplicates(mAlteredCells.begin(), mAlteredCells.end());
-    mAlteredCells.assign(removeDuplicates.begin(), removeDuplicates.end());
+    mAlteredCells.erase(std::unique(mAlteredCells.begin(), mAlteredCells.end()), mAlteredCells.end());
 
     CSMDoc::Document& document = getWorldspaceWidget().getDocument();
     CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -352,6 +352,7 @@ void CSVRender::TerrainShapeMode::dragWheel (int diff, double speedFactor)
 void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>& vertexCoords, bool dragOperation)
 {
     int r = mBrushSize / 2;
+    if (r == 0) r = 1; // Prevent division by zero later, which might happen when mBrushSize == 1
 
     std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
     CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
@@ -409,7 +410,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                     float smoothedByDistance = 0.0f;
                     if (mShapeEditTool == 0) smoothedByDistance = mTotalDiffY - mTotalDiffY * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
                     if (mShapeEditTool == 1 || mShapeEditTool == 2) smoothedByDistance = (r + mShapeEditToolStrength) - (r + mShapeEditToolStrength) * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
-                    if (distance < r)
+                    if (distance <= r)
                     {
                         if (mShapeEditTool >= 0 && mShapeEditTool < 3) alterHeight(cellCoords, x, y, smoothedByDistance);
                         if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
@@ -978,7 +979,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
                 int distanceX = abs(i - vertexCoords.first);
                 int distanceY = abs(j - vertexCoords.second);
                 int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
-                if (distance < r) selections.emplace_back(std::make_pair(i, j));
+                if (distance <= r) selections.emplace_back(std::make_pair(i, j));
             }
         }
     }

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1,0 +1,1156 @@
+#include "terrainshapemode.hpp"
+
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <memory>
+
+#include <QWidget>
+#include <QIcon>
+#include <QEvent>
+#include <QDropEvent>
+#include <QDragEnterEvent>
+#include <QDrag>
+
+#include <osg/Group>
+
+#include <components/esm/loadland.hpp>
+
+#include "../widget/modebutton.hpp"
+#include "../widget/scenetoolbar.hpp"
+#include "../widget/scenetoolshapebrush.hpp"
+
+#include "../../model/doc/document.hpp"
+#include "../../model/prefs/state.hpp"
+#include "../../model/world/columnbase.hpp"
+#include "../../model/world/commandmacro.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/data.hpp"
+#include "../../model/world/idtable.hpp"
+#include "../../model/world/idtree.hpp"
+#include "../../model/world/land.hpp"
+#include "../../model/world/resourcetable.hpp"
+#include "../../model/world/tablemimedata.hpp"
+#include "../../model/world/universalid.hpp"
+
+#include "editmode.hpp"
+#include "pagedworldspacewidget.hpp"
+#include "mask.hpp"
+#include "object.hpp" // Something small needed regarding pointers from here ()
+#include "terrainselection.hpp"
+#include "worldspacewidget.hpp"
+
+CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidget, osg::Group* parentNode, QWidget *parent)
+: EditMode (worldspaceWidget, QIcon {":scenetoolbar/editing-terrain-shape"}, Mask_Terrain | Mask_Reference, "Terrain land editing", parent),
+    mBrushSize(0),
+    mBrushShape(0),
+    mShapeBrushScenetool(0),
+    mDragMode(InteractionType_None),
+    mParentNode(parentNode),
+    mIsEditing(false),
+    mTotalDiffY(0),
+    mShapeEditTool(0),
+    mShapeEditToolStrength(0),
+    mTargetHeight(0)
+{
+}
+
+void CSVRender::TerrainShapeMode::activate(CSVWidget::SceneToolbar* toolbar)
+{
+    if (!mTerrainShapeSelection)
+    {
+        mTerrainShapeSelection.reset(new TerrainSelection(mParentNode, &getWorldspaceWidget(), TerrainSelectionType::Shape));
+    }
+
+    if(!mShapeBrushScenetool)
+    {
+        mShapeBrushScenetool = new CSVWidget::SceneToolShapeBrush (toolbar, "scenetoolshapebrush", getWorldspaceWidget().getDocument());
+        connect(mShapeBrushScenetool, SIGNAL (clicked()), mShapeBrushScenetool, SLOT (activate()));
+        connect(mShapeBrushScenetool->mShapeBrushWindow, SIGNAL(passBrushSize(int)), this, SLOT(setBrushSize(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow, SIGNAL(passBrushShape(int)), this, SLOT(setBrushShape(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow->mSizeSliders->mBrushSizeSlider, SIGNAL(valueChanged(int)), this, SLOT(setBrushSize(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow->mToolSelector, SIGNAL(currentIndexChanged(int)), this, SLOT(setShapeEditTool(int)));
+        connect(mShapeBrushScenetool->mShapeBrushWindow->mToolStrengthSlider, SIGNAL(valueChanged(int)), this, SLOT(setShapeEditToolStrength(int)));
+    }
+
+    EditMode::activate(toolbar);
+    toolbar->addTool (mShapeBrushScenetool);
+}
+
+void CSVRender::TerrainShapeMode::deactivate(CSVWidget::SceneToolbar* toolbar)
+{
+    if(mShapeBrushScenetool)
+    {
+        toolbar->removeTool (mShapeBrushScenetool);
+        delete mShapeBrushScenetool;
+        mShapeBrushScenetool = 0;
+    }
+    EditMode::deactivate(toolbar);
+}
+
+void CSVRender::TerrainShapeMode::primaryOpenPressed (const WorldspaceHitResult& hit) // Apply changes here
+{
+}
+
+void CSVRender::TerrainShapeMode::primaryEditPressed(const WorldspaceHitResult& hit)
+{
+    mCellId = getWorldspaceWidget().getCellId (hit.worldPos);
+
+    if (hit.hit && hit.tag == 0)
+    {
+    }
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        paged->resetAllAlteredHeights();
+        mTotalDiffY = 0;
+    }
+}
+
+void CSVRender::TerrainShapeMode::primarySelectPressed(const WorldspaceHitResult& hit)
+{
+    if(hit.hit && hit.tag == 0)
+    {
+        selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 0, false);
+    }
+}
+
+void CSVRender::TerrainShapeMode::secondarySelectPressed(const WorldspaceHitResult& hit)
+{
+    if(hit.hit && hit.tag == 0)
+    {
+        selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 1, false);
+    }
+}
+
+bool CSVRender::TerrainShapeMode::primaryEditStartDrag (const QPoint& pos)
+{
+    WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+
+    mCellId = getWorldspaceWidget().getCellId (hit.worldPos);
+
+    mDragMode = InteractionType_PrimaryEdit;
+
+    if (hit.hit && hit.tag == 0)
+    {
+        mEditingPos = hit.worldPos;
+        mIsEditing = true;
+        if (mShapeEditTool == 4)
+        {
+            std::pair<int, int> vertexCoords = CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos);
+            std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
+            int inCellX = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
+            int inCellY = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
+
+            CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+            CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+                *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+            int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+                landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+            mTargetHeight = landShapePointer[inCellY * landSize + inCellX];
+        }
+    }
+
+    return true;
+}
+
+bool CSVRender::TerrainShapeMode::secondaryEditStartDrag (const QPoint& pos)
+{
+    return false;
+}
+
+bool CSVRender::TerrainShapeMode::primarySelectStartDrag (const QPoint& pos)
+{
+    WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+    mDragMode = InteractionType_PrimarySelect;
+    if (!hit.hit || hit.tag != 0)
+    {
+        mDragMode = InteractionType_None;
+        return false;
+    }
+    selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 0, true);
+    return false;
+}
+
+bool CSVRender::TerrainShapeMode::secondarySelectStartDrag (const QPoint& pos)
+{
+    WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+    mDragMode = InteractionType_SecondarySelect;
+    if (!hit.hit || hit.tag != 0)
+    {
+        mDragMode = InteractionType_None;
+        return false;
+    }
+    selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 1, true);
+    return false;
+}
+
+void CSVRender::TerrainShapeMode::drag (const QPoint& pos, int diffX, int diffY, double speedFactor)
+{
+    if (mDragMode == InteractionType_PrimaryEdit)
+    {
+        WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+        std::string cellId = getWorldspaceWidget().getCellId (hit.worldPos);
+        mTotalDiffY += diffY;
+        if (mIsEditing == true && mShapeEditTool == 0) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(mEditingPos), true);
+        if (mIsEditing == true && mShapeEditTool > 0) editTerrainShapeGrid(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), true);
+    }
+
+    if (mDragMode == InteractionType_PrimarySelect)
+    {
+        WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+        if (hit.hit && hit.tag == 0) selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 0, true);
+    }
+
+    if (mDragMode == InteractionType_SecondarySelect)
+    {
+        WorldspaceHitResult hit = getWorldspaceWidget().mousePick (pos, getWorldspaceWidget().getInteractionMask());
+        if (hit.hit && hit.tag == 0) selectTerrainShapes(CSMWorld::CellCoordinates::toVertexCoords(hit.worldPos), 1, true);
+    }
+}
+
+void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
+{
+    if (mDragMode == InteractionType_PrimaryEdit)
+    {
+        if (mIsEditing == true)
+        {
+            mTotalDiffY = 0;
+            mIsEditing = false;
+        }
+
+        std::sort(mAlteredCells.begin(), mAlteredCells.end());
+        std::set<CSMWorld::CellCoordinates> removeDuplicates(mAlteredCells.begin(), mAlteredCells.end());
+        mAlteredCells.assign(removeDuplicates.begin(), removeDuplicates.end());
+
+        CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+        CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+        CSMWorld::IdTable& ltexTable = dynamic_cast<CSMWorld::IdTable&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_LandTextures));
+
+        int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+        int landnormalsColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandNormalsIndex);
+
+        QUndoStack& undoStack = document.getUndoStack();
+
+        undoStack.beginMacro ("Edit shape and normal records");
+
+        for(CSMWorld::CellCoordinates cellCoordinates: mAlteredCells)
+        {
+            std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY());
+            undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, cellId));
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            CSMWorld::LandHeightsColumn::DataType landShapeNew(landShapePointer);
+            for(int i = 0; i < landSize; ++i)
+            {
+                for(int j = 0; j < landSize; ++j)
+                {
+                    if (CSVRender::PagedWorldspaceWidget *paged =
+                        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+                    {
+                        if (paged->getCellAlteredHeight(cellCoordinates, i, j))
+                            landShapeNew[j * landSize + i] = landShapePointer[j * landSize + i] + *paged->getCellAlteredHeight(cellCoordinates, i, j);
+                        else
+                            landShapeNew[j * landSize + i] = 0;
+                    }
+                }
+            }
+            if (allowLandShapeEditing(cellId) == true) pushEditToCommand(landShapeNew, document, landTable, cellId);
+        }
+
+        for(CSMWorld::CellCoordinates cellCoordinates: mAlteredCells)
+        {
+            std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY());
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            const CSMWorld::LandHeightsColumn::DataType landRightShapePointer = landTable.data(landTable.getModelIndex(CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY()), landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            const CSMWorld::LandHeightsColumn::DataType landDownShapePointer = landTable.data(landTable.getModelIndex(CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1), landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+            const CSMWorld::LandNormalsColumn::DataType landNormalsPointer = landTable.data(landTable.getModelIndex(cellId, landnormalsColumn)).value<CSMWorld::LandNormalsColumn::DataType>();
+            CSMWorld::LandNormalsColumn::DataType landNormalsNew(landNormalsPointer);
+
+            for(int i = 0; i < landSize; ++i)
+            {
+                for(int j = 0; j < landSize; ++j)
+                {
+                    float v1[3];
+                    float v2[3];
+                    float normal[3];
+                    float hyp;
+
+                    v1[0] = 128;
+                    v1[1] = 0;
+                    if (i < landSize - 1) v1[2] = landShapePointer[j*landSize+i+1] - landShapePointer[j*landSize+i];
+                    else
+                    {
+                        bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
+                        bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
+                        if (!noLand && !noCell)
+                            v1[2] = landRightShapePointer[j*landSize+1] - landShapePointer[j*landSize+i];
+                        else
+                            v1[2] = 0;
+                    }
+
+                    v2[0] = 0;
+                    v2[1] = 128;
+                    if (j < landSize - 1) v2[2] = landShapePointer[(j+1)*landSize+i] - landShapePointer[j*landSize+i];
+                    else
+                    {
+                        bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
+                        bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
+                        if (!noLand && !noCell)
+                            v2[2] = landDownShapePointer[landSize+i] - landShapePointer[j*landSize+i];
+                        else
+                            v2[2] = 0;
+                    }
+
+                    normal[1] = v1[2]*v2[0] - v1[0]*v2[2];
+                    normal[0] = v1[1]*v2[2] - v1[2]*v2[1];
+                    normal[2] = v1[0]*v2[1] - v1[1]*v2[0];
+
+                    hyp = sqrt(normal[0]*normal[0] + normal[1]*normal[1] + normal[2]*normal[2]) / 127.0f;
+
+                    normal[0] /= hyp;
+                    normal[1] /= hyp;
+                    normal[2] /= hyp;
+
+                    landNormalsNew[(j*landSize+i)*3+0] = normal[0];
+                    landNormalsNew[(j*landSize+i)*3+1] = normal[1];
+                    landNormalsNew[(j*landSize+i)*3+2] = normal[2];
+                }
+            }
+            if (allowLandShapeEditing(cellId) == true) pushNormalsEditToCommand(landNormalsNew, document, landTable, cellId);
+        }
+        undoStack.endMacro();
+        mAlteredCells.clear();
+
+        if (CSVRender::PagedWorldspaceWidget *paged =
+            dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+        {
+            paged->resetAllAlteredHeights();
+            mTotalDiffY = 0;
+        }
+    }
+}
+
+
+void CSVRender::TerrainShapeMode::dragAborted()
+{
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        paged->resetAllAlteredHeights();
+        mTotalDiffY = 0;
+    }
+}
+
+void CSVRender::TerrainShapeMode::dragWheel (int diff, double speedFactor)
+{
+}
+
+void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>& vertexCoords, bool dragOperation)
+{
+    int r = mBrushSize / 2;
+
+    std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
+    CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        if (mShapeEditTool == 0) paged->resetAllAlteredHeights();
+    }
+
+    if(allowLandShapeEditing(cellId)==true)
+    {
+        if (mBrushShape == 0)
+        {
+            int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
+            int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
+            if (mShapeEditTool == 0) alterHeight(cellCoords, x, y, mTotalDiffY);
+            if (mShapeEditTool == 1 || mShapeEditTool == 2) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+            if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+            if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+        }
+
+        if (mBrushShape == 1)
+        {
+            for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+            {
+                for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+                {
+                    cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
+                    cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                    int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
+                    int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
+                    if (mShapeEditTool == 0) alterHeight(cellCoords, x, y, mTotalDiffY);
+                    if (mShapeEditTool == 1 || mShapeEditTool == 2) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+                }
+            }
+        }
+
+        if (mBrushShape == 2)
+        {
+            for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+            {
+                for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+                {
+                    cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
+                    cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                    int distanceX = abs(i - vertexCoords.first);
+                    int distanceY = abs(j - vertexCoords.second);
+                    int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                    int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
+                    int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
+                    float distancePerRadius = 1.0f * distance / r;
+                    float smoothedByDistance = 0.0f;
+                    if (mShapeEditTool == 0) smoothedByDistance = mTotalDiffY - mTotalDiffY * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
+                    if (mShapeEditTool == 1 || mShapeEditTool == 2) smoothedByDistance = (r + mShapeEditToolStrength) - (r + mShapeEditToolStrength) * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
+                    if (distance < r)
+                    {
+                        if (mShapeEditTool >= 0 && mShapeEditTool < 3) alterHeight(cellCoords, x, y, smoothedByDistance);
+                        if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+                        if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+                    }
+                }
+            }
+        }
+        if (mBrushShape == 3)
+        {
+            if(!mCustomBrushShape.empty())
+            {
+                for(auto const& value: mCustomBrushShape)
+                {
+                    cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(vertexCoords.first + value.first, vertexCoords.second + value.second));
+                    cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                    int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first + value.first);
+                    int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second + value.second);
+                    if (mShapeEditTool == 0) alterHeight(cellCoords, x, y, mTotalDiffY);
+                    if (mShapeEditTool == 1 || mShapeEditTool == 2) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 3) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
+                }
+            }
+        }
+
+    }
+}
+
+void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float alteredHeight, bool useTool)
+{
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+    std::string cellRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
+    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+    std::string cellDownId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
+    std::string cellUpLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() - 1);
+    std::string cellUpRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY() - 1);
+    std::string cellDownLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() + 1);
+    std::string cellDownRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY() + 1);
+
+    if(allowLandShapeEditing(cellId)==true)
+    {
+        if (useTool) mAlteredCells.emplace_back(cellCoords);
+        if (CSVRender::PagedWorldspaceWidget *paged =
+            dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+        {
+            if (useTool)
+            {
+                if (mShapeEditTool == 0)
+                {
+                    // Get distance from modified land, alter land change based on zoom
+                    osg::Vec3d eye, center, up;
+                    paged->getCamera()->getViewMatrixAsLookAt(eye, center, up);
+                    osg::Vec3d distance = eye - mEditingPos;
+                    alteredHeight = alteredHeight * (distance.length() / 500);
+                }
+                if (mShapeEditTool == 1) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) + alteredHeight;
+                if (mShapeEditTool == 2) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) - alteredHeight;
+                if (mShapeEditTool == 3) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) + alteredHeight;
+            }
+
+            paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
+
+            // Change values of cornering cells
+            if (inCellX == 0 && inCellY == 0)
+            {
+                if(allowLandShapeEditing(cellUpLeftId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(-1, -1));
+                    paged->setCellAlteredHeight(cellCoords.move(-1, -1), landSize - 1, landSize - 1, alteredHeight);
+                }
+            }
+            else if (inCellX == 0 && inCellY == landSize - 1)
+            {
+                if(allowLandShapeEditing(cellDownLeftId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(-1, 1));
+                    paged->setCellAlteredHeight(cellCoords.move(-1, 1), landSize - 1, 0, alteredHeight);
+                }
+            }
+            else if (inCellX == landSize - 1 && inCellY == 0)
+            {
+                if(allowLandShapeEditing(cellUpRightId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(1, -1));
+                    paged->setCellAlteredHeight(cellCoords.move(1, -1), 0, landSize - 1, alteredHeight);
+                }
+            }
+            else if (inCellX == landSize - 1 && inCellY == landSize -1)
+            {
+                if(allowLandShapeEditing(cellDownRightId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(1, 1));
+                    paged->setCellAlteredHeight(cellCoords.move(1, 1), 0, 0, alteredHeight);
+                }
+            }
+
+            // Change values of edging cells
+            if (inCellX == 0)
+            {
+                if(allowLandShapeEditing(cellLeftId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(-1, 0));
+                    paged->setCellAlteredHeight(cellCoords.move(-1, 0), landSize - 1, inCellY, alteredHeight);
+                }
+            }
+            if (inCellY == 0)
+            {
+                if(allowLandShapeEditing(cellUpId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(0, -1));
+                    paged->setCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 1, alteredHeight);
+                }
+            }
+
+            if (inCellX == landSize - 1)
+            {
+                if(allowLandShapeEditing(cellRightId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(1, 0));
+                    paged->setCellAlteredHeight(cellCoords.move(1, 0), 0, inCellY, alteredHeight);
+                }
+            }
+            if (inCellY == landSize - 1)
+            {
+                if(allowLandShapeEditing(cellUpId)==true)
+                {
+                    if (useTool) mAlteredCells.emplace_back(cellCoords.move(0, 1));
+                    paged->setCellAlteredHeight(cellCoords.move(0, 1), inCellX, 0, alteredHeight);
+                }
+            }
+
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::smoothHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength)
+{
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+        CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+        int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+        std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+        const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+        // ### Variable naming key ###
+        // Variables here hold either the real value, or the altered value of current edit.
+        // this = this Cell
+        // left = x - 1, up = y - 1, right = x + 1, down = y + 1
+        // Altered = transient edit (in current edited)
+        float thisAlteredHeight = 0.0f;
+        if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) != nullptr)
+            thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
+        float thisHeight = landShapePointer[inCellY * landSize + inCellX];
+        float leftHeight = 0.0f;
+        float leftAlteredHeight = 0.0f;
+        float upAlteredHeight = 0.0f;
+        float rightHeight = 0.0f;
+        float rightAlteredHeight = 0.0f;
+        float downHeight = 0.0f;
+        float downAlteredHeight = 0.0f;
+        float upHeight = 0.0f;
+
+        if(allowLandShapeEditing(cellId)==true)
+        {
+            //Get key values for calculating average, handle cell edges, check for null pointers
+            if (inCellX == 0)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+                const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                leftHeight = landLeftShapePointer[inCellY * landSize + (landSize - 2)];
+                if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), inCellX, landSize - 2))
+                    leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY);
+            }
+            if (inCellY == 0)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+                const CSMWorld::LandHeightsColumn::DataType landUpShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                upHeight = landUpShapePointer[(landSize - 2) * landSize + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2))
+                    upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2);
+            }
+            if (inCellX > 0)
+            {
+                leftHeight = landShapePointer[inCellY * landSize + inCellX - 1];
+                leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY);
+            }
+            if (inCellY > 0)
+            {
+                upHeight = landShapePointer[(inCellY - 1) * landSize + inCellX];
+                upAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1);
+            }
+            if (inCellX == landSize - 1)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
+                const CSMWorld::LandHeightsColumn::DataType landRightShapePointer =
+                    landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                rightHeight = landRightShapePointer[inCellY * landSize + 1];
+                if (paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY))
+                {
+                    rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY);
+                }
+            }
+            if (inCellY == landSize - 1)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
+                const CSMWorld::LandHeightsColumn::DataType landDownShapePointer =
+                    landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                downHeight = landDownShapePointer[1 * landSize + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1))
+                {
+                    downAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1);
+                }
+            }
+            if (inCellX < landSize - 1)
+            {
+                rightHeight = landShapePointer[inCellY * landSize + inCellX + 1];
+                if(paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY))
+                    rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY);
+            }
+            if (inCellY < landSize - 1)
+            {
+                downHeight = landShapePointer[(inCellY + 1) * landSize + inCellX];
+                if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1))
+                    downAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1);
+            }
+
+            float averageHeight = (upHeight + downHeight + rightHeight + leftHeight +
+                upAlteredHeight + downAlteredHeight + rightAlteredHeight + leftAlteredHeight) / 4;
+            if ((thisHeight + thisAlteredHeight) != averageHeight) mAlteredCells.emplace_back(cellCoords);
+            if (toolStrength > abs(thisHeight + thisAlteredHeight - averageHeight) && toolStrength > 8.0f) toolStrength =
+                abs(thisHeight + thisAlteredHeight - averageHeight); //Cut down excessive changes
+            if (thisHeight + thisAlteredHeight > averageHeight) alterHeight(cellCoords, inCellX, inCellY, -toolStrength);
+            if (thisHeight + thisAlteredHeight < averageHeight) alterHeight(cellCoords, inCellX, inCellY, +toolStrength);
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::flattenHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength, int targetHeight)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+    float thisHeight = 0.0f;
+    float thisAlteredHeight = 0.0f;
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    bool noCell = document.getData().getCells().searchId (cellId) == -1;
+    bool noLand = document.getData().getLand().searchId (cellId) == -1;
+
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        if (!noCell && !noLand)
+        {
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+                landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+            if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY))
+                thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
+            thisHeight = landShapePointer[inCellY * landSize + inCellX];
+        }
+    }
+
+    if (toolStrength > abs(thisHeight - targetHeight) && toolStrength > 8.0f) toolStrength =
+        abs(thisHeight - targetHeight); //Cut down excessive changes
+    if (thisHeight + thisAlteredHeight > targetHeight) alterHeight(cellCoords, inCellX, inCellY, -toolStrength);
+    if (thisHeight + thisAlteredHeight < targetHeight) alterHeight(cellCoords, inCellX, inCellY, +toolStrength);
+}
+
+void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* thisHeight,
+    float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+    std::string cellUpLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY() - 1);
+    bool noCell = document.getData().getCells().searchId (cellId) == -1;
+    bool noLand = document.getData().getLand().searchId (cellId) == -1;
+    bool noLeftCell = document.getData().getCells().searchId (cellLeftId) == -1;
+    bool noLeftLand = document.getData().getLand().searchId (cellLeftId) == -1;
+    bool noUpCell = document.getData().getCells().searchId (cellUpId) == -1;
+    bool noUpLand = document.getData().getLand().searchId (cellUpId) == -1;
+
+    *thisHeight = 0.0f; // real + altered height
+    *thisAlteredHeight = 0.0f;  // only altered height
+    *leftHeight = 0.0f;
+    *leftAlteredHeight = 0.0f;
+    *upHeight = 0.0f;
+    *upAlteredHeight = 0.0f;
+
+    if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        if (!noCell && !noLand)
+        {
+            const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+                landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+            if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY))
+                *thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
+            *thisHeight = landShapePointer[inCellY * landSize + inCellX] + *thisAlteredHeight;
+
+            // In case of cell edge, and touching cell/land is not found, assume that left and up -heights would be the same
+            // This is to prevent unnecessary action at limitHeightChange()
+            *leftHeight = *thisHeight;
+            *upHeight = *thisHeight;
+
+            if (inCellX == 0)
+            {
+                if(!noLeftCell && !noLeftLand)
+                {
+                    const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer =
+                        landTable.data(landTable.getModelIndex(cellLeftId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                    *leftHeight = landLeftShapePointer[inCellY * landSize + (landSize - 2)];
+                    if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY))
+                    {
+                        *leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY);
+                        *leftHeight += *leftAlteredHeight;
+                    }
+                }
+            }
+            if (inCellY == 0)
+            {
+                cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+                if(!noUpCell && !noUpLand)
+                {
+                    const CSMWorld::LandHeightsColumn::DataType landUpShapePointer =
+                        landTable.data(landTable.getModelIndex(cellUpId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+                    *upHeight = landUpShapePointer[(landSize - 2) * landSize + inCellX];
+                    if (paged->getCellAlteredHeight(cellCoords.move(0,-1), inCellX, landSize - 2))
+                    {
+                        *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2);
+                        *upHeight += *upAlteredHeight;
+                    }
+                }
+            }
+            if (inCellX != 0)
+            {
+                *leftHeight = landShapePointer[inCellY * landSize + inCellX - 1];
+                if (paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY))
+                    *leftAlteredHeight += *paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY);
+                *leftHeight += *leftAlteredHeight;
+            }
+            if (inCellY != 0)
+            {
+                *upHeight = landShapePointer[(inCellY - 1) * landSize + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1))
+                    *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1);
+                *upHeight += *upAlteredHeight;
+            }
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::fixEdges(const CSMWorld::CellCoordinates& cellCoords)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+    std::string cellLeftId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
+    std::string cellRightId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
+    std::string cellUpId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
+    std::string cellDownId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
+    if (allowLandShapeEditing(cellId) == true)
+    {
+        const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer = landTable.data(landTable.getModelIndex(cellLeftId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landRightShapePointer = landTable.data(landTable.getModelIndex(cellRightId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landUpShapePointer = landTable.data(landTable.getModelIndex(cellUpId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        const CSMWorld::LandHeightsColumn::DataType landDownShapePointer = landTable.data(landTable.getModelIndex(cellDownId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+        CSMWorld::LandHeightsColumn::DataType landShapeNew(landShapePointer);
+        for(int i = 0; i < landSize; ++i)
+        {
+            if(document.getData().getCells().searchId (cellLeftId) != -1 && document.getData().getLand().searchId (cellLeftId) != -1 && landShapePointer[i * landSize] != landLeftShapePointer[i * landSize + landSize - 1]) landShapeNew[i * landSize] = landLeftShapePointer[i * landSize + landSize - 1];
+            if(document.getData().getCells().searchId (cellRightId) != -1 && document.getData().getLand().searchId (cellRightId) != -1 && landShapePointer[i * landSize + landSize - 1] != landRightShapePointer[i * landSize]) landShapeNew[i * landSize + landSize - 1] = landRightShapePointer[i * landSize];
+            if(document.getData().getCells().searchId (cellUpId) != -1 && document.getData().getLand().searchId (cellUpId) != -1 && landShapePointer[i] != landUpShapePointer[(landSize - 1) * landSize + i]) landShapeNew[i] = landUpShapePointer[(landSize - 1) * landSize + i];
+            if(document.getData().getCells().searchId (cellDownId) != -1 && document.getData().getLand().searchId (cellDownId) != -1 && landShapePointer[(landSize - 1) * landSize + i] != landDownShapePointer[i]) landShapeNew[(landSize - 1) * landSize + i] = landDownShapePointer[i];
+        }
+        pushEditToCommand(landShapeNew, document, landTable, cellId);
+    }
+}
+
+void CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    int landshapeColumn = landTable.findColumnIndex(CSMWorld::Columns::ColumnId_LandHeightsIndex);
+
+    std::string cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY());
+
+    int limitHeightChange = 1024.0f; // Limited by save format
+    bool noCell = document.getData().getCells().searchId (cellId) == -1;
+    bool noLand = document.getData().getLand().searchId (cellId) == -1;
+    bool dataAlteredAtThisCell = false;
+    int maxPasses = 5; //Multiple passes are needed if there are consecutive height differences over the limit
+
+    if (!noCell && !noLand)
+    {
+        const CSMWorld::LandHeightsColumn::DataType landShapePointer =
+            landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
+
+        for (int passes = 0; passes < maxPasses; ++passes)
+        {
+            for(int inCellX = 0; inCellX < landSize; ++inCellX)
+            {
+                for(int inCellY = 0; inCellY < landSize; ++inCellY)
+                {
+                    // ### Variable naming key ###
+                    // Variables here aim to hold the final value, which is (real_value + altered_value)
+                    // this = this Cell
+                    // left = x - 1, up = y - 1
+                    // Altered = transient edit (in current edited)
+                    // Binding = the last row or column, the one that binds cell land together
+
+                    float thisHeight = 0.0f;
+                    float thisAlteredHeight = 0.0f;
+                    float leftHeight = 0.0f;
+                    float leftAlteredHeight = 0.0f;
+                    float upHeight = 0.0f;
+                    float upAlteredHeight = 0.0f;
+
+                    updateKeyHeightValues(cellCoords, inCellX, inCellY, &thisHeight, &thisAlteredHeight, &leftHeight, &leftAlteredHeight,
+                        &upHeight, &upAlteredHeight);
+
+                    bool doChange = false;
+
+                    // Check for height limits, prioritize left over up, except in left-right -cell edges
+                    if (thisHeight - upHeight >= limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight + (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - upHeight <= -limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight - (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight >= limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight + (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight <= -limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight - (limitHeightChange / 2) - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+
+                    // Apply limits
+                    if (doChange == true)
+                    {
+                        alterHeight(cellCoords, inCellX, inCellY, thisAlteredHeight, false);
+                        dataAlteredAtThisCell = true;
+                    }
+                }
+            }
+
+            //Skip unneeded extra passes
+            if (dataAlteredAtThisCell == false)
+            {
+                passes = maxPasses;
+                continue;
+            }
+
+            //Inverse check (implement properly after default check works)
+            for(int inCellX = landSize - 1; inCellX >= 0; --inCellX)
+            {
+                for(int inCellY = landSize - 1; inCellY >= 0; --inCellY)
+                {
+                    // ### Variable naming key ###
+                    // Variables here aim to hold the final value, which is (real_value + altered_value)
+                    // this = this Cell
+                    // left = x - 1, up = y - 1
+                    // Altered = transient edit (in current edited)
+                    // Binding = the last row or column, the one that binds cell land together
+
+                    float thisHeight = 0.0f;
+                    float thisAlteredHeight = 0.0f;
+                    float leftHeight = 0.0f;
+                    float leftAlteredHeight = 0.0f;
+                    float upHeight = 0.0f;
+                    float upAlteredHeight = 0.0f;
+
+                    updateKeyHeightValues(cellCoords, inCellX, inCellY, &thisHeight, &thisAlteredHeight, &leftHeight, &leftAlteredHeight,
+                        &upHeight, &upAlteredHeight);
+
+                    bool doChange = false;
+
+                    // Check for height limits, prioritize left over up, except in left-right -cell edges
+                    if (thisHeight - upHeight >= limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight + limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - upHeight <= -limitHeightChange)
+                    {
+                        thisAlteredHeight = upHeight - limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight >= limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight + limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+                    if (thisHeight - leftHeight <= -limitHeightChange && !(doChange == true && (inCellX == 0 || inCellX == landSize - 1)))
+                    {
+                        thisAlteredHeight = leftHeight - limitHeightChange - landShapePointer[inCellY * landSize + inCellX];
+                        doChange = true;
+                    }
+
+                    // Apply limits
+                    if (doChange == true)
+                    {
+                        alterHeight(cellCoords, inCellX, inCellY, thisAlteredHeight, false);
+                        dataAlteredAtThisCell = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation)
+{
+    int r = mBrushSize / 2;
+    std::vector<std::pair<int, int>> selections;
+
+    if (mBrushShape == 0)
+    {
+        selections.emplace_back(vertexCoords);
+    }
+
+    if (mBrushShape == 1)
+    {
+        for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+        {
+            for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+            {
+                selections.emplace_back(std::make_pair(i, j));
+            }
+        }
+    }
+
+    if (mBrushShape == 2)
+    {
+        for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
+        {
+            for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
+            {
+                int distanceX = abs(i - vertexCoords.first);
+                int distanceY = abs(j - vertexCoords.second);
+                int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                if (distance < r) selections.emplace_back(std::make_pair(i, j));
+            }
+        }
+    }
+
+    if (mBrushShape == 3)
+    {
+        if(!mCustomBrushShape.empty())
+        {
+            for(auto const& value: mCustomBrushShape)
+            {
+                selections.emplace_back(std::make_pair(vertexCoords.first + value.first, vertexCoords.second + value.second));
+            }
+        }
+    }
+
+    if(selectMode == 0) mTerrainShapeSelection->onlySelect(selections);
+    if(selectMode == 1) mTerrainShapeSelection->toggleSelect(selections, dragOperation);
+
+}
+
+void CSVRender::TerrainShapeMode::pushEditToCommand(const CSMWorld::LandHeightsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+    CSMWorld::IdTable& landTable, std::string cellId)
+{
+    QVariant changedLand;
+    changedLand.setValue(newLandGrid);
+
+    QModelIndex index(landTable.getModelIndex (cellId, landTable.findColumnIndex (CSMWorld::Columns::ColumnId_LandHeightsIndex)));
+
+    QUndoStack& undoStack = document.getUndoStack();
+    undoStack.push (new CSMWorld::ModifyCommand(landTable, index, changedLand));
+}
+
+void CSVRender::TerrainShapeMode::pushNormalsEditToCommand(const CSMWorld::LandNormalsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+    CSMWorld::IdTable& landTable, std::string cellId)
+{
+    QVariant changedLand;
+    changedLand.setValue(newLandGrid);
+
+    QModelIndex index(landTable.getModelIndex (cellId, landTable.findColumnIndex (CSMWorld::Columns::ColumnId_LandNormalsIndex)));
+
+    QUndoStack& undoStack = document.getUndoStack();
+    undoStack.push (new CSMWorld::ModifyCommand(landTable, index, changedLand));
+}
+
+bool CSVRender::TerrainShapeMode::allowLandShapeEditing(std::string cellId)
+{
+    CSMDoc::Document& document = getWorldspaceWidget().getDocument();
+    CSMWorld::IdTable& landTable = dynamic_cast<CSMWorld::IdTable&> (
+        *document.getData().getTableModel (CSMWorld::UniversalId::Type_Land));
+    CSMWorld::IdTree& cellTable = dynamic_cast<CSMWorld::IdTree&> (
+            *document.getData().getTableModel (CSMWorld::UniversalId::Type_Cells));
+
+    bool noCell = document.getData().getCells().searchId (cellId)==-1;
+    bool noLand = document.getData().getLand().searchId (cellId)==-1;
+
+    if (noCell)
+    {
+        std::string mode = CSMPrefs::get()["3D Scene Editing"]["outside-landedit"].toString();
+
+        // target cell does not exist
+        if (mode=="Discard")
+            return false;
+
+        if (mode=="Create cell and land, then edit")
+        {
+            std::unique_ptr<CSMWorld::CreateCommand> createCommand (
+                new CSMWorld::CreateCommand (cellTable, cellId));
+            int parentIndex = cellTable.findColumnIndex (CSMWorld::Columns::ColumnId_Cell);
+            int index = cellTable.findNestedColumnIndex (parentIndex, CSMWorld::Columns::ColumnId_Interior);
+            createCommand->addNestedValue (parentIndex, index, false);
+            document.getUndoStack().push (createCommand.release());
+
+            if (CSVRender::PagedWorldspaceWidget *paged =
+                dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+            {
+                CSMWorld::CellSelection selection = paged->getCellSelection();
+                selection.add (CSMWorld::CellCoordinates::fromId (cellId).first);
+                paged->setCellSelection (selection);
+            }
+        }
+    }
+    else if (CSVRender::PagedWorldspaceWidget *paged =
+        dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
+    {
+        CSMWorld::CellSelection selection = paged->getCellSelection();
+        if (!selection.has (CSMWorld::CellCoordinates::fromId (cellId).first))
+        {
+            // target cell exists, but is not shown
+            std::string mode =
+                CSMPrefs::get()["3D Scene Editing"]["outside-visible-landedit"].toString();
+
+            if (mode=="Discard")
+                return false;
+
+            if (mode=="Show cell and edit")
+            {
+                selection.add (CSMWorld::CellCoordinates::fromId (cellId).first);
+                paged->setCellSelection (selection);
+            }
+        }
+    }
+
+    if (noLand)
+    {
+        std::string mode = CSMPrefs::get()["3D Scene Editing"]["outside-landedit"].toString();
+
+        // target cell does not exist
+        if (mode=="Discard")
+            return false;
+
+        if (mode=="Create cell and land, then edit")
+        {
+            document.getUndoStack().push (new CSMWorld::CreateCommand (landTable, cellId));
+            fixEdges(CSMWorld::CellCoordinates::fromId (cellId).first);
+        }
+    }
+
+    return true;
+}
+
+void CSVRender::TerrainShapeMode::dragMoveEvent (QDragMoveEvent *event)
+{
+}
+
+void CSVRender::TerrainShapeMode::setBrushSize(int brushSize)
+{
+    mBrushSize = brushSize;
+}
+
+void CSVRender::TerrainShapeMode::setBrushShape(int brushShape)
+{
+    mBrushShape = brushShape;
+
+    //Set custom brush shape
+    if (mBrushShape == 3 && !mTerrainShapeSelection->getTerrainSelection().empty())
+    {
+        auto terrainSelection = mTerrainShapeSelection->getTerrainSelection();
+        int selectionCenterX = 0;
+        int selectionCenterY = 0;
+        int selectionAmount = 0;
+
+        for(auto const& value: terrainSelection)
+        {
+            selectionCenterX = selectionCenterX + value.first;
+            selectionCenterY = selectionCenterY + value.second;
+            ++selectionAmount;
+        }
+        selectionCenterX = selectionCenterX / selectionAmount;
+        selectionCenterY = selectionCenterY / selectionAmount;
+
+        mCustomBrushShape.clear();
+        std::pair<int, int> differentialPos {};
+        for(auto const& value: terrainSelection)
+        {
+            differentialPos.first = value.first - selectionCenterX;
+            differentialPos.second = value.second - selectionCenterY;
+            mCustomBrushShape.push_back(differentialPos);
+        }
+    }
+}
+
+void CSVRender::TerrainShapeMode::setShapeEditTool(int shapeEditTool)
+{
+    mShapeEditTool = shapeEditTool;
+}
+
+void CSVRender::TerrainShapeMode::setShapeEditToolStrength(int shapeEditToolStrength)
+{
+    mShapeEditToolStrength = shapeEditToolStrength;
+}
+
+CSVRender::PagedWorldspaceWidget& CSVRender::TerrainShapeMode::getPagedWorldspaceWidget()
+{
+    return dynamic_cast<PagedWorldspaceWidget&>(getWorldspaceWidget());
+}

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -45,7 +45,7 @@
 CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidget, osg::Group* parentNode, QWidget *parent)
 : EditMode (worldspaceWidget, QIcon {":scenetoolbar/editing-terrain-shape"}, Mask_Terrain | Mask_Reference, "Terrain land editing", parent),
     mBrushSize(0),
-    mBrushShape(0),
+    mBrushShape(BrushShape_Point),
     mShapeBrushScenetool(0),
     mDragMode(InteractionType_None),
     mParentNode(parentNode),

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -150,7 +150,7 @@ bool CSVRender::TerrainShapeMode::primaryEditStartDrag (const QPoint& pos)
             const CSMWorld::LandHeightsColumn::DataType landShapePointer =
                 landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
 
-            mTargetHeight = landShapePointer[inCellY * landSize + inCellX];
+            mTargetHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX];
         }
     }
 
@@ -274,17 +274,17 @@ void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
             undoStack.push (new CSMWorld::TouchLandCommand(landTable, ltexTable, cellId));
             const CSMWorld::LandHeightsColumn::DataType landShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
             CSMWorld::LandHeightsColumn::DataType landShapeNew(landShapePointer);
-            for(int i = 0; i < landSize; ++i)
+            for(int i = 0; i < ESM::Land::LAND_SIZE; ++i)
             {
-                for(int j = 0; j < landSize; ++j)
+                for(int j = 0; j < ESM::Land::LAND_SIZE; ++j)
                 {
                     if (CSVRender::PagedWorldspaceWidget *paged =
                         dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
                     {
                         if (paged->getCellAlteredHeight(cellCoordinates, i, j))
-                            landShapeNew[j * landSize + i] = landShapePointer[j * landSize + i] + *paged->getCellAlteredHeight(cellCoordinates, i, j);
+                            landShapeNew[j * ESM::Land::LAND_SIZE + i] = landShapePointer[j * ESM::Land::LAND_SIZE + i] + *paged->getCellAlteredHeight(cellCoordinates, i, j);
                         else
-                            landShapeNew[j * landSize + i] = 0;
+                            landShapeNew[j * ESM::Land::LAND_SIZE + i] = 0;
                     }
                 }
             }
@@ -300,9 +300,9 @@ void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
             const CSMWorld::LandNormalsColumn::DataType landNormalsPointer = landTable.data(landTable.getModelIndex(cellId, landnormalsColumn)).value<CSMWorld::LandNormalsColumn::DataType>();
             CSMWorld::LandNormalsColumn::DataType landNormalsNew(landNormalsPointer);
 
-            for(int i = 0; i < landSize; ++i)
+            for(int i = 0; i < ESM::Land::LAND_SIZE; ++i)
             {
-                for(int j = 0; j < landSize; ++j)
+                for(int j = 0; j < ESM::Land::LAND_SIZE; ++j)
                 {
                     float v1[3];
                     float v2[3];
@@ -311,26 +311,26 @@ void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
 
                     v1[0] = 128;
                     v1[1] = 0;
-                    if (i < landSize - 1) v1[2] = landShapePointer[j*landSize+i+1] - landShapePointer[j*landSize+i];
+                    if (i < ESM::Land::LAND_SIZE - 1) v1[2] = landShapePointer[j * ESM::Land::LAND_SIZE + i + 1] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                     else
                     {
                         bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
                         bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
                         if (!noLand && !noCell)
-                            v1[2] = landRightShapePointer[j*landSize+1] - landShapePointer[j*landSize+i];
+                            v1[2] = landRightShapePointer[j * ESM::Land::LAND_SIZE + 1] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                         else
                             v1[2] = 0;
                     }
 
                     v2[0] = 0;
                     v2[1] = 128;
-                    if (j < landSize - 1) v2[2] = landShapePointer[(j+1)*landSize+i] - landShapePointer[j*landSize+i];
+                    if (j < ESM::Land::LAND_SIZE - 1) v2[2] = landShapePointer[(j + 1) * ESM::Land::LAND_SIZE + i] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                     else
                     {
                         bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
                         bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
                         if (!noLand && !noCell)
-                            v2[2] = landDownShapePointer[landSize+i] - landShapePointer[j*landSize+i];
+                            v2[2] = landDownShapePointer[ESM::Land::LAND_SIZE + i] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                         else
                             v2[2] = 0;
                     }
@@ -345,9 +345,9 @@ void CSVRender::TerrainShapeMode::dragCompleted(const QPoint& pos)
                     normal[1] /= hyp;
                     normal[2] /= hyp;
 
-                    landNormalsNew[(j*landSize+i)*3+0] = normal[0];
-                    landNormalsNew[(j*landSize+i)*3+1] = normal[1];
-                    landNormalsNew[(j*landSize+i)*3+2] = normal[2];
+                    landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 0] = normal[0];
+                    landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 1] = normal[1];
+                    landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 2] = normal[2];
                 }
             }
             if (allowLandShapeEditing(cellId) == true) pushNormalsEditToCommand(landNormalsNew, document, landTable, cellId);
@@ -499,52 +499,53 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
                 if (mShapeEditTool == 3) alteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) + alteredHeight;
             }
 
-            paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
+            if (inCellX != 0 && inCellY != 0 && inCellX != ESM::Land::LAND_SIZE - 1 && inCellY != ESM::Land::LAND_SIZE - 1)
+                paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
 
             // Change values of cornering cells
             if (inCellX == 0 && inCellY == 0)
             {
-                if(allowLandShapeEditing(cellUpLeftId)==true)
+                if(allowLandShapeEditing(cellUpLeftId) && allowLandShapeEditing(cellLeftId) && allowLandShapeEditing(cellUpId))
                 {
                     CSMWorld::CellCoordinates cornerCellCoords = cellCoords.move(-1, -1);
                     if (useTool) mAlteredCells.emplace_back(cornerCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), cornerCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(cornerCellCoords);
-                    paged->setCellAlteredHeight(cornerCellCoords, landSize - 1, landSize - 1, alteredHeight);
-                }
+                    paged->setCellAlteredHeight(cornerCellCoords, ESM::Land::LAND_SIZE - 1, ESM::Land::LAND_SIZE - 1, alteredHeight);
+                } else return;
             }
-            else if (inCellX == 0 && inCellY == landSize - 1)
+            else if (inCellX == 0 && inCellY == ESM::Land::LAND_SIZE - 1)
             {
-                if(allowLandShapeEditing(cellDownLeftId)==true)
+                if(allowLandShapeEditing(cellDownLeftId) && allowLandShapeEditing(cellLeftId) && allowLandShapeEditing(cellDownId))
                 {
                     CSMWorld::CellCoordinates cornerCellCoords = cellCoords.move(-1, 1);
                     if (useTool) mAlteredCells.emplace_back(cornerCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), cornerCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(cornerCellCoords);
-                    paged->setCellAlteredHeight(cornerCellCoords, landSize - 1, 0, alteredHeight);
-                }
+                    paged->setCellAlteredHeight(cornerCellCoords, ESM::Land::LAND_SIZE - 1, 0, alteredHeight);
+                } else return;
             }
-            else if (inCellX == landSize - 1 && inCellY == 0)
+            else if (inCellX == ESM::Land::LAND_SIZE - 1 && inCellY == 0)
             {
-                if(allowLandShapeEditing(cellUpRightId)==true)
+                if(allowLandShapeEditing(cellUpRightId) && allowLandShapeEditing(cellRightId) && allowLandShapeEditing(cellUpId))
                 {
                     CSMWorld::CellCoordinates cornerCellCoords = cellCoords.move(1, -1);
                     if (useTool) mAlteredCells.emplace_back(cornerCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), cornerCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(cornerCellCoords);
-                    paged->setCellAlteredHeight(cornerCellCoords, 0, landSize - 1, alteredHeight);
-                }
+                    paged->setCellAlteredHeight(cornerCellCoords, 0, ESM::Land::LAND_SIZE - 1, alteredHeight);
+                } else return;
             }
-            else if (inCellX == landSize - 1 && inCellY == landSize -1)
+            else if (inCellX == ESM::Land::LAND_SIZE - 1 && inCellY == ESM::Land::LAND_SIZE - 1)
             {
-                if(allowLandShapeEditing(cellDownRightId)==true)
+                if(allowLandShapeEditing(cellDownRightId) && allowLandShapeEditing(cellRightId) && allowLandShapeEditing(cellDownId))
                 {
                     CSMWorld::CellCoordinates cornerCellCoords = cellCoords.move(1, 1);
                     if (useTool) mAlteredCells.emplace_back(cornerCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), cornerCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(cornerCellCoords);
                     paged->setCellAlteredHeight(cornerCellCoords, 0, 0, alteredHeight);
-                }
+                } else return;
             }
 
             // Change values of edging cells
@@ -556,7 +557,8 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
                     if (useTool) mAlteredCells.emplace_back(edgeCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(edgeCellCoords);
-                    paged->setCellAlteredHeight(edgeCellCoords, landSize - 1, inCellY, alteredHeight);
+                    paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
+                    paged->setCellAlteredHeight(edgeCellCoords, ESM::Land::LAND_SIZE - 1, inCellY, alteredHeight);
                 }
             }
             if (inCellY == 0)
@@ -567,11 +569,12 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
                     if (useTool) mAlteredCells.emplace_back(edgeCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(edgeCellCoords);
-                    paged->setCellAlteredHeight(edgeCellCoords, inCellX, landSize - 1, alteredHeight);
+                    paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
+                    paged->setCellAlteredHeight(edgeCellCoords, inCellX, ESM::Land::LAND_SIZE - 1, alteredHeight);
                 }
             }
 
-            if (inCellX == landSize - 1)
+            if (inCellX == ESM::Land::LAND_SIZE - 1)
             {
                 if(allowLandShapeEditing(cellRightId)==true)
                 {
@@ -579,10 +582,11 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
                     if (useTool) mAlteredCells.emplace_back(edgeCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(edgeCellCoords);
+                    paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
                     paged->setCellAlteredHeight(edgeCellCoords, 0, inCellY, alteredHeight);
                 }
             }
-            if (inCellY == landSize - 1)
+            if (inCellY == ESM::Land::LAND_SIZE - 1)
             {
                 if(allowLandShapeEditing(cellDownId)==true)
                 {
@@ -590,6 +594,7 @@ void CSVRender::TerrainShapeMode::alterHeight(const CSMWorld::CellCoordinates& c
                     if (useTool) mAlteredCells.emplace_back(edgeCellCoords);
                     else if (!(std::find(mAlteredCells.begin(), mAlteredCells.end(), edgeCellCoords) != mAlteredCells.end()))
                         mAlteredCells.emplace_back(edgeCellCoords);
+                    paged->setCellAlteredHeight(cellCoords, inCellX, inCellY, alteredHeight);
                     paged->setCellAlteredHeight(edgeCellCoords, inCellX, 0, alteredHeight);
                 }
             }
@@ -619,7 +624,7 @@ void CSVRender::TerrainShapeMode::smoothHeight(const CSMWorld::CellCoordinates& 
         float thisAlteredHeight = 0.0f;
         if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY) != nullptr)
             thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
-        float thisHeight = landShapePointer[inCellY * landSize + inCellX];
+        float thisHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX];
         float leftHeight = 0.0f;
         float leftAlteredHeight = 0.0f;
         float upAlteredHeight = 0.0f;
@@ -636,59 +641,59 @@ void CSVRender::TerrainShapeMode::smoothHeight(const CSMWorld::CellCoordinates& 
             {
                 cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() - 1, cellCoords.getY());
                 const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                leftHeight = landLeftShapePointer[inCellY * landSize + (landSize - 2)];
-                if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), inCellX, landSize - 2))
-                    leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY);
+                leftHeight = landLeftShapePointer[inCellY * ESM::Land::LAND_SIZE + (ESM::Land::LAND_SIZE - 2)];
+                if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), inCellX, ESM::Land::LAND_SIZE - 2))
+                    leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), ESM::Land::LAND_SIZE - 2, inCellY);
             }
             if (inCellY == 0)
             {
                 cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() - 1);
                 const CSMWorld::LandHeightsColumn::DataType landUpShapePointer = landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                upHeight = landUpShapePointer[(landSize - 2) * landSize + inCellX];
-                if (paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2))
-                    upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2);
+                upHeight = landUpShapePointer[(ESM::Land::LAND_SIZE - 2) * ESM::Land::LAND_SIZE + inCellX];
+                if (paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, ESM::Land::LAND_SIZE - 2))
+                    upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, ESM::Land::LAND_SIZE - 2);
             }
             if (inCellX > 0)
             {
-                leftHeight = landShapePointer[inCellY * landSize + inCellX - 1];
+                leftHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX - 1];
                 leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY);
             }
             if (inCellY > 0)
             {
-                upHeight = landShapePointer[(inCellY - 1) * landSize + inCellX];
+                upHeight = landShapePointer[(inCellY - 1) * ESM::Land::LAND_SIZE + inCellX];
                 upAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1);
             }
-            if (inCellX == landSize - 1)
+            if (inCellX == ESM::Land::LAND_SIZE - 1)
             {
                 cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
                 const CSMWorld::LandHeightsColumn::DataType landRightShapePointer =
                     landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                rightHeight = landRightShapePointer[inCellY * landSize + 1];
+                rightHeight = landRightShapePointer[inCellY * ESM::Land::LAND_SIZE + 1];
                 if (paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY))
                 {
                     rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY);
                 }
             }
-            if (inCellY == landSize - 1)
+            if (inCellY == ESM::Land::LAND_SIZE - 1)
             {
                 cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
                 const CSMWorld::LandHeightsColumn::DataType landDownShapePointer =
                     landTable.data(landTable.getModelIndex(cellId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                downHeight = landDownShapePointer[1 * landSize + inCellX];
+                downHeight = landDownShapePointer[1 * ESM::Land::LAND_SIZE + inCellX];
                 if (paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1))
                 {
                     downAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1);
                 }
             }
-            if (inCellX < landSize - 1)
+            if (inCellX < ESM::Land::LAND_SIZE - 1)
             {
-                rightHeight = landShapePointer[inCellY * landSize + inCellX + 1];
+                rightHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX + 1];
                 if(paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY))
                     rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY);
             }
-            if (inCellY < landSize - 1)
+            if (inCellY < ESM::Land::LAND_SIZE - 1)
             {
-                downHeight = landShapePointer[(inCellY + 1) * landSize + inCellX];
+                downHeight = landShapePointer[(inCellY + 1) * ESM::Land::LAND_SIZE + inCellX];
                 if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1))
                     downAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1);
             }
@@ -727,7 +732,7 @@ void CSVRender::TerrainShapeMode::flattenHeight(const CSMWorld::CellCoordinates&
 
             if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY))
                 thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
-            thisHeight = landShapePointer[inCellY * landSize + inCellX];
+            thisHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX];
         }
     }
 
@@ -783,7 +788,7 @@ void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoor
 
             if(paged->getCellAlteredHeight(cellCoords, inCellX, inCellY))
                 *thisAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY);
-            *thisHeight = landShapePointer[inCellY * landSize + inCellX] + *thisAlteredHeight;
+            *thisHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX] + *thisAlteredHeight;
 
             // Default to the same value as thisHeight, which happens in the case of cell edge where next cell/land is not found,
             // which is to prevent unnecessary action at limitHeightChange().
@@ -799,10 +804,10 @@ void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoor
                 {
                     const CSMWorld::LandHeightsColumn::DataType landLeftShapePointer =
                         landTable.data(landTable.getModelIndex(cellLeftId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                    *leftHeight = landLeftShapePointer[inCellY * landSize + (landSize - 2)];
-                    if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY))
+                    *leftHeight = landLeftShapePointer[inCellY * ESM::Land::LAND_SIZE + (ESM::Land::LAND_SIZE - 2)];
+                    if (paged->getCellAlteredHeight(cellCoords.move(-1, 0), ESM::Land::LAND_SIZE - 2, inCellY))
                     {
-                        *leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), landSize - 2, inCellY);
+                        *leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(-1, 0), ESM::Land::LAND_SIZE - 2, inCellY);
                         *leftHeight += *leftAlteredHeight;
                     }
                 }
@@ -814,22 +819,22 @@ void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoor
                 {
                     const CSMWorld::LandHeightsColumn::DataType landUpShapePointer =
                         landTable.data(landTable.getModelIndex(cellUpId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                    *upHeight = landUpShapePointer[(landSize - 2) * landSize + inCellX];
-                    if (paged->getCellAlteredHeight(cellCoords.move(0,-1), inCellX, landSize - 2))
+                    *upHeight = landUpShapePointer[(ESM::Land::LAND_SIZE - 2) * ESM::Land::LAND_SIZE + inCellX];
+                    if (paged->getCellAlteredHeight(cellCoords.move(0,-1), inCellX, ESM::Land::LAND_SIZE - 2))
                     {
-                        *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, landSize - 2);
+                        *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, -1), inCellX, ESM::Land::LAND_SIZE - 2);
                         *upHeight += *upAlteredHeight;
                     }
                 }
             }
-            if (inCellX == landSize - 1)
+            if (inCellX == ESM::Land::LAND_SIZE - 1)
             {
                 cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX() + 1, cellCoords.getY());
                 if(!noRightCell && !noRightLand)
                 {
                     const CSMWorld::LandHeightsColumn::DataType landRightShapePointer =
                         landTable.data(landTable.getModelIndex(cellRightId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                    *rightHeight = landRightShapePointer[inCellY * landSize + 1];
+                    *rightHeight = landRightShapePointer[inCellY * ESM::Land::LAND_SIZE + 1];
                     if (paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY))
                     {
                         *rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(1, 0), 1, inCellY);
@@ -837,14 +842,14 @@ void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoor
                     }
                 }
             }
-            if (inCellY == landSize - 1)
+            if (inCellY == ESM::Land::LAND_SIZE - 1)
             {
                 cellId = CSMWorld::CellCoordinates::generateId(cellCoords.getX(), cellCoords.getY() + 1);
                 if(!noDownCell && !noDownLand)
                 {
                     const CSMWorld::LandHeightsColumn::DataType landDownShapePointer =
                         landTable.data(landTable.getModelIndex(cellDownId, landshapeColumn)).value<CSMWorld::LandHeightsColumn::DataType>();
-                    *downHeight = landDownShapePointer[landSize + inCellX];
+                    *downHeight = landDownShapePointer[ESM::Land::LAND_SIZE + inCellX];
                     if (paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1))
                     {
                         *downAlteredHeight = *paged->getCellAlteredHeight(cellCoords.move(0, 1), inCellX, 1);
@@ -856,28 +861,28 @@ void CSVRender::TerrainShapeMode::updateKeyHeightValues(const CSMWorld::CellCoor
            //If not at edge, get values from the same cell
             if (inCellX != 0)
             {
-                *leftHeight = landShapePointer[inCellY * landSize + inCellX - 1];
+                *leftHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX - 1];
                 if (paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY))
                     *leftAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX - 1, inCellY);
                 *leftHeight += *leftAlteredHeight;
             }
             if (inCellY != 0)
             {
-                *upHeight = landShapePointer[(inCellY - 1) * landSize + inCellX];
+                *upHeight = landShapePointer[(inCellY - 1) * ESM::Land::LAND_SIZE + inCellX];
                 if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1))
                     *upAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY - 1);
                 *upHeight += *upAlteredHeight;
             }
-            if (inCellX != landSize - 1)
+            if (inCellX != ESM::Land::LAND_SIZE - 1)
             {
-                *rightHeight = landShapePointer[inCellY * landSize + inCellX + 1];
+                *rightHeight = landShapePointer[inCellY * ESM::Land::LAND_SIZE + inCellX + 1];
                 if (paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY))
                     *rightAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX + 1, inCellY);
                 *rightHeight += *rightAlteredHeight;
             }
-            if (inCellY != landSize - 1)
+            if (inCellY != ESM::Land::LAND_SIZE - 1)
             {
-                *downHeight = landShapePointer[(inCellY + 1) * landSize + inCellX];
+                *downHeight = landShapePointer[(inCellY + 1) * ESM::Land::LAND_SIZE + inCellX];
                 if (paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1))
                     *downAlteredHeight = *paged->getCellAlteredHeight(cellCoords, inCellX, inCellY + 1);
                 *downHeight += *downAlteredHeight;
@@ -948,9 +953,9 @@ bool CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordi
 
         if (reverseMode == false)
         {
-            for(int inCellY = 0; inCellY < landSize; ++inCellY)
+            for(int inCellY = 0; inCellY < ESM::Land::LAND_SIZE; ++inCellY)
             {
-                for(int inCellX = 0; inCellX < landSize; ++inCellX)
+                for(int inCellX = 0; inCellX < ESM::Land::LAND_SIZE; ++inCellX)
                 {
                     float* limitedAlteredHeightXAxis = nullptr;
                     float* limitedAlteredHeightYAxis = nullptr;
@@ -979,9 +984,9 @@ bool CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordi
 
         if (reverseMode == true)
         {
-            for(int inCellY = landSize - 1; inCellY >= 0; --inCellY)
+            for(int inCellY = ESM::Land::LAND_SIZE - 1; inCellY >= 0; --inCellY)
             {
-                for(int inCellX = landSize - 1; inCellX >= 0; --inCellX)
+                for(int inCellX = ESM::Land::LAND_SIZE - 1; inCellX >= 0; --inCellX)
                 {
                     float* limitedAlteredHeightXAxis = nullptr;
                     float* limitedAlteredHeightYAxis = nullptr;

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -82,6 +82,16 @@ void CSVRender::TerrainShapeMode::activate(CSVWidget::SceneToolbar* toolbar)
 
 void CSVRender::TerrainShapeMode::deactivate(CSVWidget::SceneToolbar* toolbar)
 {
+    if(mShapeBrushScenetool)
+    {
+        toolbar->removeTool (mShapeBrushScenetool);
+    }
+
+    if (mTerrainShapeSelection)
+    {
+        mTerrainShapeSelection.reset();
+    }
+
     EditMode::deactivate(toolbar);
 }
 

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -310,13 +310,10 @@ void CSVRender::TerrainShapeMode::applyTerrainEditChanges()
         {
             for(int j = 0; j < ESM::Land::LAND_SIZE; ++j)
             {
-                if (paged)
-                {
-                    if (paged->getCellAlteredHeight(cellCoordinates, i, j))
-                        landShapeNew[j * ESM::Land::LAND_SIZE + i] = landShapePointer[j * ESM::Land::LAND_SIZE + i] + *paged->getCellAlteredHeight(cellCoordinates, i, j);
-                    else
-                        landShapeNew[j * ESM::Land::LAND_SIZE + i] = 0;
-                }
+                if (paged && paged->getCellAlteredHeight(cellCoordinates, i, j))
+                    landShapeNew[j * ESM::Land::LAND_SIZE + i] = landShapePointer[j * ESM::Land::LAND_SIZE + i] + *paged->getCellAlteredHeight(cellCoordinates, i, j);
+                else
+                    landShapeNew[j * ESM::Land::LAND_SIZE + i] = 0;
             }
         }
 

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -420,7 +420,12 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
         int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
         int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
         if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, mTotalDiffY);
-        if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+        if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower)
+        {
+            alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+            float smoothMultiplier = static_cast<float>(CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothstrength"].toDouble());
+            if (CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothpainting"].isTrue()) smoothHeight(cellCoords, x, y, mShapeEditToolStrength * smoothMultiplier);
+        }
         if (mShapeEditTool == ShapeEditTool_Smooth) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
         if (mShapeEditTool == ShapeEditTool_Flatten) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
     }
@@ -436,7 +441,12 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                 int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
                 int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
                 if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, mTotalDiffY);
-                if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower)
+                {
+                    alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    float smoothMultiplier = static_cast<float>(CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothstrength"].toDouble());
+                    if (CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothpainting"].isTrue()) smoothHeight(cellCoords, x, y, mShapeEditToolStrength * smoothMultiplier);
+                }
                 if (mShapeEditTool == ShapeEditTool_Smooth) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
                 if (mShapeEditTool == ShapeEditTool_Flatten) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
             }
@@ -462,8 +472,13 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                 if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower) smoothedByDistance = (r + mShapeEditToolStrength) - (r + mShapeEditToolStrength) * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);
                 if (distance <= r)
                 {
-                    if (mShapeEditTool == ShapeEditTool_Drag || mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower)
-                    alterHeight(cellCoords, x, y, smoothedByDistance);
+                    if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, smoothedByDistance);
+                    if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower)
+                    {
+                        alterHeight(cellCoords, x, y, smoothedByDistance);
+                        float smoothMultiplier = static_cast<float>(CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothstrength"].toDouble());
+                        if (CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothpainting"].isTrue()) smoothHeight(cellCoords, x, y, mShapeEditToolStrength * smoothMultiplier);
+                    }
                     if (mShapeEditTool == ShapeEditTool_Smooth) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
                     if (mShapeEditTool == ShapeEditTool_Flatten) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
                 }
@@ -481,7 +496,12 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                 int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first + value.first);
                 int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second + value.second);
                 if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, mTotalDiffY);
-                if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower) alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                if (mShapeEditTool == ShapeEditTool_PaintToRaise || mShapeEditTool == ShapeEditTool_PaintToLower)
+                {
+                    alterHeight(cellCoords, x, y, mShapeEditToolStrength);
+                    float smoothMultiplier = static_cast<float>(CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothstrength"].toDouble());
+                    if (CSMPrefs::get()["3D Scene Editing"]["landedit-post-smoothpainting"].isTrue()) smoothHeight(cellCoords, x, y, mShapeEditToolStrength * smoothMultiplier);
+                }
                 if (mShapeEditTool == ShapeEditTool_Smooth) smoothHeight(cellCoords, x, y, mShapeEditToolStrength);
                 if (mShapeEditTool == ShapeEditTool_Flatten) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
             }

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -13,6 +13,7 @@
 #include <QDrag>
 
 #include <osg/Group>
+#include <osg/Vec3f>
 
 #include <components/esm/loadland.hpp>
 #include <components/debug/debuglog.hpp>
@@ -327,50 +328,48 @@ void CSVRender::TerrainShapeMode::applyTerrainEditChanges()
         {
             for(int j = 0; j < ESM::Land::LAND_SIZE; ++j)
             {
-                float v1[3];
-                float v2[3];
-                float normal[3];
+                osg::Vec3f v1;
+                osg::Vec3f v2;
+                osg::Vec3f normal;
                 float hyp;
 
-                v1[0] = 128;
-                v1[1] = 0;
-                if (i < ESM::Land::LAND_SIZE - 1) v1[2] = landShapePointer[j * ESM::Land::LAND_SIZE + i + 1] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
+                v1.x() = 128;
+                v1.y() = 0;
+                if (i < ESM::Land::LAND_SIZE - 1) v1.z() = landShapePointer[j * ESM::Land::LAND_SIZE + i + 1] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                 else
                 {
                     bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
                     bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX() + 1, cellCoordinates.getY())) == -1;
                     if (!noLand && !noCell)
-                        v1[2] = landRightShapePointer[j * ESM::Land::LAND_SIZE + 1] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
+                        v1.z() = landRightShapePointer[j * ESM::Land::LAND_SIZE + 1] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                     else
-                        v1[2] = 0;
+                        v1.z() = 0;
                 }
 
-                v2[0] = 0;
-                v2[1] = 128;
-                if (j < ESM::Land::LAND_SIZE - 1) v2[2] = landShapePointer[(j + 1) * ESM::Land::LAND_SIZE + i] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
+                v2.x() = 0;
+                v2.y() = 128;
+                if (j < ESM::Land::LAND_SIZE - 1) v2.z() = landShapePointer[(j + 1) * ESM::Land::LAND_SIZE + i] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                 else
                 {
                     bool noCell = document.getData().getCells().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
                     bool noLand = document.getData().getLand().searchId (CSMWorld::CellCoordinates::generateId(cellCoordinates.getX(), cellCoordinates.getY() + 1)) == -1;
                     if (!noLand && !noCell)
-                        v2[2] = landDownShapePointer[ESM::Land::LAND_SIZE + i] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
+                        v2.z() = landDownShapePointer[ESM::Land::LAND_SIZE + i] - landShapePointer[j * ESM::Land::LAND_SIZE + i];
                     else
-                        v2[2] = 0;
+                        v2.z() = 0;
                 }
 
-                normal[1] = v1[2]*v2[0] - v1[0]*v2[2];
-                normal[0] = v1[1]*v2[2] - v1[2]*v2[1];
-                normal[2] = v1[0]*v2[1] - v1[1]*v2[0];
+                normal.y() = v1.z()*v2.x() - v1.x()*v2.z();
+                normal.x() = v1.y()*v2.z() - v1.z()*v2.y();
+                normal.z() = v1.x()*v2.y() - v1.y()*v2.x();
 
-                hyp = sqrt(normal[0]*normal[0] + normal[1]*normal[1] + normal[2]*normal[2]) / 127.0f;
+                hyp = normal.length() / 127.0f;
 
-                normal[0] /= hyp;
-                normal[1] /= hyp;
-                normal[2] /= hyp;
+                normal /= hyp;
 
-                landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 0] = normal[0];
-                landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 1] = normal[1];
-                landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 2] = normal[2];
+                landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 0] = normal.x();
+                landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 1] = normal.y();
+                landNormalsNew[(j * ESM::Land::LAND_SIZE + i) * 3 + 2] = normal.z();
             }
         }
         if (allowLandShapeEditing(cellId) == true) pushNormalsEditToCommand(landNormalsNew, document, landTable, cellId);

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -47,7 +47,7 @@ CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidge
 : EditMode (worldspaceWidget, QIcon {":scenetoolbar/editing-terrain-shape"}, Mask_Terrain | Mask_Reference, "Terrain land editing", parent),
     mBrushSize(1),
     mBrushShape(CSVWidget::BrushShape_Point),
-    mShapeBrushScenetool(0),
+    mShapeBrushScenetool(nullptr),
     mDragMode(InteractionType_None),
     mParentNode(parentNode),
     mIsEditing(false),

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -402,9 +402,6 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
     int r = mBrushSize / 2;
     if (r == 0) r = 1; // Prevent division by zero later, which might happen when mBrushSize == 1
 
-    std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
-    CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
-
     if (CSVRender::PagedWorldspaceWidget *paged =
         dynamic_cast<CSVRender::PagedWorldspaceWidget *> (&getWorldspaceWidget()))
     {
@@ -413,6 +410,8 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
 
     if (mBrushShape == CSVWidget::BrushShape_Point)
     {
+        std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(vertexCoords);
+        CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
         int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
         int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
         if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, mTotalDiffY);
@@ -432,8 +431,8 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
         {
             for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
             {
-                cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
-                cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
+                CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
                 int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
                 int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
                 if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, mTotalDiffY);
@@ -455,8 +454,8 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
         {
             for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
             {
-                cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
-                cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(i, j));
+                CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
                 int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
                 int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
                 int distanceX = abs(i - vertexCoords.first);
@@ -486,8 +485,8 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
         {
             for(auto const& value: mCustomBrushShape)
             {
-                cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(vertexCoords.first + value.first, vertexCoords.second + value.second));
-                cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
+                std::string cellId = CSMWorld::CellCoordinates::vertexGlobalToCellId(std::make_pair(vertexCoords.first + value.first, vertexCoords.second + value.second));
+                CSMWorld::CellCoordinates cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
                 int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first + value.first);
                 int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second + value.second);
                 if (mShapeEditTool == ShapeEditTool_Drag) alterHeight(cellCoords, x, y, mTotalDiffY);

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -80,12 +80,6 @@ void CSVRender::TerrainShapeMode::activate(CSVWidget::SceneToolbar* toolbar)
 
 void CSVRender::TerrainShapeMode::deactivate(CSVWidget::SceneToolbar* toolbar)
 {
-    if(mShapeBrushScenetool)
-    {
-        toolbar->removeTool (mShapeBrushScenetool);
-        delete mShapeBrushScenetool;
-        mShapeBrushScenetool = 0;
-    }
     EditMode::deactivate(toolbar);
 }
 
@@ -429,7 +423,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                     cellCoords = CSMWorld::CellCoordinates::fromId(cellId).first;
                     int distanceX = abs(i - vertexCoords.first);
                     int distanceY = abs(j - vertexCoords.second);
-                    int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                    float distance = sqrt(pow(distanceX, 2)+pow(distanceY, 2));
                     int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(i);
                     int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(j);
                     float distancePerRadius = 1.0f * distance / r;

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -39,7 +39,7 @@
 #include "editmode.hpp"
 #include "pagedworldspacewidget.hpp"
 #include "mask.hpp"
-#include "object.hpp" // Something small needed regarding pointers from here ()
+#include "tagbase.hpp"
 #include "terrainselection.hpp"
 #include "worldspacewidget.hpp"
 
@@ -252,7 +252,7 @@ void CSVRender::TerrainShapeMode::sortAndLimitAlteredCells()
     std::sort(mAlteredCells.begin(), mAlteredCells.end());
     mAlteredCells.erase(std::unique(mAlteredCells.begin(), mAlteredCells.end()), mAlteredCells.end());
 
-    while (passing == false) // Multiple passes are needed when steepness problems arise for both x and y axis simultaneously
+    while (!passing) // Multiple passes are needed when steepness problems arise for both x and y axis simultaneously
     {
         passing = true;
         for(CSMWorld::CellCoordinates cellCoordinates: mAlteredCells)
@@ -990,7 +990,7 @@ bool CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordi
         float downHeight = 0.0f;
         float downAlteredHeight = 0.0f;
 
-        if (reverseMode == false)
+        if (!reverseMode)
         {
             for(int inCellY = 0; inCellY < ESM::Land::LAND_SIZE; ++inCellY)
             {

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -388,7 +388,7 @@ void CSVRender::TerrainShapeMode::applyTerrainEditChanges()
     mAlteredCells.clear();
 }
 
-float CSVRender::TerrainShapeMode::calculateBumpShape(const float& distance, int radius, const float& height)
+float CSVRender::TerrainShapeMode::calculateBumpShape(float distance, int radius, float height)
 {
     float distancePerRadius = distance / radius;
     return height - height * (3 * distancePerRadius * distancePerRadius - 2 * distancePerRadius * distancePerRadius * distancePerRadius);

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -393,7 +393,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
 
     if(allowLandShapeEditing(cellId)==true)
     {
-        if (mBrushShape == 0)
+        if (mBrushShape == BrushShape_Point)
         {
             int x = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.first);
             int y = CSMWorld::CellCoordinates::vertexGlobalToInCellCoords(vertexCoords.second);
@@ -403,7 +403,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
             if (mShapeEditTool == 4) flattenHeight(cellCoords, x, y, mShapeEditToolStrength, mTargetHeight);
         }
 
-        if (mBrushShape == 1)
+        if (mBrushShape == BrushShape_Square)
         {
             for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
             {
@@ -421,7 +421,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
             }
         }
 
-        if (mBrushShape == 2)
+        if (mBrushShape == BrushShape_Circle)
         {
             for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
             {
@@ -447,7 +447,7 @@ void CSVRender::TerrainShapeMode::editTerrainShapeGrid(const std::pair<int, int>
                 }
             }
         }
-        if (mBrushShape == 3)
+        if (mBrushShape == BrushShape_Custom)
         {
             if(!mCustomBrushShape.empty())
             {
@@ -1037,12 +1037,12 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
     int r = mBrushSize / 2;
     std::vector<std::pair<int, int>> selections;
 
-    if (mBrushShape == 0)
+    if (mBrushShape == BrushShape_Point)
     {
         selections.emplace_back(vertexCoords);
     }
 
-    if (mBrushShape == 1)
+    if (mBrushShape == BrushShape_Square)
     {
         for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
         {
@@ -1053,7 +1053,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
         }
     }
 
-    if (mBrushShape == 2)
+    if (mBrushShape == BrushShape_Circle)
     {
         for(int i = vertexCoords.first - r; i <= vertexCoords.first + r; ++i)
         {
@@ -1067,7 +1067,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
         }
     }
 
-    if (mBrushShape == 3)
+    if (mBrushShape == BrushShape_Custom)
     {
         if(!mCustomBrushShape.empty())
         {
@@ -1196,7 +1196,7 @@ void CSVRender::TerrainShapeMode::setBrushShape(int brushShape)
     mBrushShape = brushShape;
 
     //Set custom brush shape
-    if (mBrushShape == 3 && !mTerrainShapeSelection->getTerrainSelection().empty())
+    if (mBrushShape == BrushShape_Custom && !mTerrainShapeSelection->getTerrainSelection().empty())
     {
         auto terrainSelection = mTerrainShapeSelection->getTerrainSelection();
         int selectionCenterX = 0;

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -977,27 +977,25 @@ bool CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordi
             {
                 for(int inCellX = 0; inCellX < ESM::Land::LAND_SIZE; ++inCellX)
                 {
-                    float* limitedAlteredHeightXAxis = nullptr;
-                    float* limitedAlteredHeightYAxis = nullptr;
+                    std::unique_ptr<float> limitedAlteredHeightXAxis(nullptr);
+                    std::unique_ptr<float> limitedAlteredHeightYAxis(nullptr);
                     updateKeyHeightValues(cellCoords, inCellX, inCellY, &thisHeight, &thisAlteredHeight, &leftHeight, &leftAlteredHeight,
                         &upHeight, &upAlteredHeight, &rightHeight, &rightAlteredHeight, &downHeight, &downAlteredHeight);
 
                     // Check for height limits on x-axis
                     if (leftHeight - thisHeight > limitHeightChange)
-                        limitedAlteredHeightXAxis = new float(leftHeight - limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightXAxis.reset(new float(leftHeight - limitHeightChange - (thisHeight - thisAlteredHeight)));
                     else if (leftHeight - thisHeight < -limitHeightChange)
-                        limitedAlteredHeightXAxis = new float(leftHeight + limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightXAxis.reset(new float(leftHeight + limitHeightChange - (thisHeight - thisAlteredHeight)));
 
                     // Check for height limits on y-axis
                     if (upHeight - thisHeight > limitHeightChange)
-                        limitedAlteredHeightYAxis = new float(upHeight - limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightYAxis.reset(new float(upHeight - limitHeightChange - (thisHeight - thisAlteredHeight)));
                     else if (upHeight - thisHeight < -limitHeightChange)
-                        limitedAlteredHeightYAxis = new float(upHeight + limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightYAxis.reset(new float(upHeight + limitHeightChange - (thisHeight - thisAlteredHeight)));
 
                     // Limit altered height value based on x or y, whichever is the smallest
-                    compareAndLimit(cellCoords, inCellX, inCellY, limitedAlteredHeightXAxis, limitedAlteredHeightYAxis, &steepnessIsWithinLimits);
-                    delete limitedAlteredHeightXAxis;
-                    delete limitedAlteredHeightYAxis;
+                    compareAndLimit(cellCoords, inCellX, inCellY, limitedAlteredHeightXAxis.get(), limitedAlteredHeightYAxis.get(), &steepnessIsWithinLimits);
                 }
             }
         }
@@ -1008,27 +1006,25 @@ bool CSVRender::TerrainShapeMode::limitAlteredHeights(const CSMWorld::CellCoordi
             {
                 for(int inCellX = ESM::Land::LAND_SIZE - 1; inCellX >= 0; --inCellX)
                 {
-                    float* limitedAlteredHeightXAxis = nullptr;
-                    float* limitedAlteredHeightYAxis = nullptr;
+                    std::unique_ptr<float> limitedAlteredHeightXAxis(nullptr);
+                    std::unique_ptr<float> limitedAlteredHeightYAxis(nullptr);
                     updateKeyHeightValues(cellCoords, inCellX, inCellY, &thisHeight, &thisAlteredHeight, &leftHeight, &leftAlteredHeight,
                         &upHeight, &upAlteredHeight, &rightHeight, &rightAlteredHeight, &downHeight, &downAlteredHeight);
 
                     // Check for height limits on x-axis
                     if (rightHeight - thisHeight > limitHeightChange)
-                        limitedAlteredHeightXAxis = new float(rightHeight - limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightXAxis.reset(new float(rightHeight - limitHeightChange - (thisHeight - thisAlteredHeight)));
                     else if (rightHeight - thisHeight < -limitHeightChange)
-                        limitedAlteredHeightXAxis = new float(rightHeight + limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightXAxis.reset(new float(rightHeight + limitHeightChange - (thisHeight - thisAlteredHeight)));
 
                     // Check for height limits on y-axis
                     if (downHeight - thisHeight > limitHeightChange)
-                        limitedAlteredHeightYAxis = new float(downHeight - limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightYAxis.reset(new float(downHeight - limitHeightChange - (thisHeight - thisAlteredHeight)));
                     else if (downHeight - thisHeight < -limitHeightChange)
-                        limitedAlteredHeightYAxis = new float(downHeight + limitHeightChange - (thisHeight - thisAlteredHeight));
+                        limitedAlteredHeightYAxis.reset(new float(downHeight + limitHeightChange - (thisHeight - thisAlteredHeight)));
 
                     // Limit altered height value based on x or y, whichever is the smallest
-                    compareAndLimit(cellCoords, inCellX, inCellY, limitedAlteredHeightXAxis, limitedAlteredHeightYAxis, &steepnessIsWithinLimits);
-                    delete limitedAlteredHeightXAxis;
-                    delete limitedAlteredHeightYAxis;
+                    compareAndLimit(cellCoords, inCellX, inCellY, limitedAlteredHeightXAxis.get(), limitedAlteredHeightYAxis.get(), &steepnessIsWithinLimits);
                 }
             }
         }

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -93,15 +93,16 @@ namespace CSVRender
             /// Do a single flattening height alteration for transient shape edit map
             void flattenHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength, int targetHeight);
 
-            /// Update the key values used in height calculations
+            /// Get altered height values around one vertex
             void updateKeyHeightValues(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* thisHeight,
-                float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight);
+                float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight,
+                float* rightHeight, float* rightAlteredHeight, float* downHeight, float* downAlteredHeight);
 
             /// Bind edge vertices to next cells
             void fixEdges(const CSMWorld::CellCoordinates& cellCoords);
 
             /// Check that the edit doesn't break save format limits, fix if necessary
-            void limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords);
+            void limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords, bool reverseMode = false);
 
             /// Handle brush mechanics for terrain shape selection
             void selectTerrainShapes (const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation);
@@ -145,7 +146,6 @@ namespace CSVRender
             void passBrushTexture(std::string brushTexture);
 
         public slots:
-            //void handleDropEvent(QDropEvent *event);
             void setBrushSize(int brushSize);
             void setBrushShape(int brushShape);
             void setShapeEditTool(int shapeEditTool);

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -98,9 +98,6 @@ namespace CSVRender
                 float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight,
                 float* rightHeight, float* rightAlteredHeight, float* downHeight, float* downAlteredHeight);
 
-            /// Bind edge vertices to next cells
-            void fixEdges(const CSMWorld::CellCoordinates& cellCoords);
-
             ///Limit steepness based on either X or Y and return false if steepness is limited
             void compareAndLimit(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* limitedAlteredHeightXAxis,
                 float* limitedAlteredHeightYAxis, bool* steepnessIsWithinLimits);

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -141,20 +141,20 @@ namespace CSVRender
 
             std::string mCellId;
             std::string mBrushTexture;
-            int mBrushSize;
-            CSVWidget::BrushShape mBrushShape;
+            int mBrushSize = 1;
+            CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;
             std::vector<std::pair<int, int>> mCustomBrushShape;
-            CSVWidget::SceneToolShapeBrush *mShapeBrushScenetool;
-            int mDragMode;
+            CSVWidget::SceneToolShapeBrush *mShapeBrushScenetool = nullptr;
+            int mDragMode = InteractionType_None;
             osg::Group* mParentNode;
-            bool mIsEditing;
+            bool mIsEditing = false;
             std::unique_ptr<TerrainSelection> mTerrainShapeSelection;
-            int mTotalDiffY;
+            int mTotalDiffY = 0;
             std::vector<CSMWorld::CellCoordinates> mAlteredCells;
             osg::Vec3d mEditingPos;
-            int mShapeEditTool;
-            int mShapeEditToolStrength;
-            int mTargetHeight;
+            int mShapeEditTool = ShapeEditTool_Drag;
+            int mShapeEditToolStrength = 8;
+            int mTargetHeight = 0;
 
             PagedWorldspaceWidget& getPagedWorldspaceWidget();
 

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -46,6 +46,14 @@ namespace CSVRender
                 InteractionType_None
             };
 
+            enum BrushShape
+            {
+                BrushShape_Point = 1,
+                BrushShape_Square = 2,
+                BrushShape_Circle = 3,
+                BrushShape_Custom = 4
+            };
+
             /// Editmode for terrain shape grid
             TerrainShapeMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
 

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -91,7 +91,11 @@ namespace CSVRender
             void dragMoveEvent (QDragMoveEvent *event) final;
 
         private:
-            /// Move pending alteredHeights changes to omwgame/omeaddon -data
+
+            /// Remove duplicates and sort mAlteredCells, then limitAlteredHeights forward and reverse
+            void sortAndLimitAlteredCells();
+
+            /// Move pending alteredHeights changes to omwgame/omwaddon -data
             void applyTerrainEditChanges();
 
             /// Handle brush mechanics for shape editing
@@ -136,10 +140,23 @@ namespace CSVRender
             void pushLodToCommand(const CSMWorld::LandMapLodColumn::DataType& newLandMapLod, CSMDoc::Document& document,
                 CSMWorld::IdTable& landTable, const std::string& cellId);
 
-            /// Create new cell and land if needed
-            bool allowLandShapeEditing(const std::string& textureFileName);
+            bool noCell(const std::string& cellId);
 
-            std::string mCellId;
+            bool noLand(const std::string& cellId);
+
+            bool noLandLoaded(const std::string& cellId);
+
+            bool isLandLoaded(const std::string& cellId);
+
+            /// Create new blank height record and new normals, if there are valid adjancent cell, take sample points and set the average height based on that
+            void createNewLandData(const CSMWorld::CellCoordinates& cellCoords);
+
+            /// Create new cell and land if needed, only user tools may ask for opening new cells (useTool == false is for automated land changes)
+            bool allowLandShapeEditing(const std::string& textureFileName, bool useTool = true);
+
+            /// Bind the edging vertice to the values of the adjancent cells
+            void fixEdges(CSMWorld::CellCoordinates cellCoords);
+
             std::string mBrushTexture;
             int mBrushSize = 1;
             CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -12,11 +12,11 @@
 #ifndef Q_MOC_RUN
 #include "../../model/world/data.hpp"
 #include "../../model/world/land.hpp"
-
 #include "../../model/doc/document.hpp"
 #include "../../model/world/commands.hpp"
 #include "../../model/world/idtable.hpp"
 #include "../../model/world/landtexture.hpp"
+#include "../widget/brushshapes.hpp"
 #endif
 
 #include "terrainselection.hpp"
@@ -46,12 +46,13 @@ namespace CSVRender
                 InteractionType_None
             };
 
-            enum BrushShape
+            enum ShapeEditTool
             {
-                BrushShape_Point = 0,
-                BrushShape_Square = 1,
-                BrushShape_Circle = 2,
-                BrushShape_Custom = 3
+                ShapeEditTool_Drag = 0,
+                ShapeEditTool_PaintToRaise = 1,
+                ShapeEditTool_PaintToLower = 2,
+                ShapeEditTool_Smooth = 3,
+                ShapeEditTool_Flatten = 4
             };
 
             /// Editmode for terrain shape grid
@@ -124,20 +125,24 @@ namespace CSVRender
 
             /// Push terrain shape edits to command macro
             void pushEditToCommand (const CSMWorld::LandHeightsColumn::DataType& newLandGrid, CSMDoc::Document& document,
-                CSMWorld::IdTable& landTable, std::string cellId);
+                CSMWorld::IdTable& landTable, const std::string& cellId);
 
             /// Push land normals edits to command macro
             void pushNormalsEditToCommand(const CSMWorld::LandNormalsColumn::DataType& newLandGrid, CSMDoc::Document& document,
-                CSMWorld::IdTable& landTable, std::string cellId);
+                CSMWorld::IdTable& landTable, const std::string& cellId);
+
+            /// Generate new land map LOD
+            void pushLodToCommand(const CSMWorld::LandMapLodColumn::DataType& newLandMapLod, CSMDoc::Document& document,
+                CSMWorld::IdTable& landTable, const std::string& cellId);
 
             /// Create new cell and land if needed
-            bool allowLandShapeEditing(std::string textureFileName);
+            bool allowLandShapeEditing(const std::string& textureFileName);
 
         private:
             std::string mCellId;
             std::string mBrushTexture;
             int mBrushSize;
-            int mBrushShape;
+            CSVWidget::BrushShape mBrushShape;
             std::vector<std::pair<int, int>> mCustomBrushShape;
             CSVWidget::SceneToolShapeBrush *mShapeBrushScenetool;
             int mDragMode;
@@ -158,7 +163,7 @@ namespace CSVRender
 
         public slots:
             void setBrushSize(int brushSize);
-            void setBrushShape(int brushShape);
+            void setBrushShape(CSVWidget::BrushShape brushShape);
             void setShapeEditTool(int shapeEditTool);
             void setShapeEditToolStrength(int shapeEditToolStrength);
     };

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -102,7 +102,7 @@ namespace CSVRender
             void editTerrainShapeGrid (const std::pair<int, int>& vertexCoords, bool dragOperation);
 
             /// Calculate height, when aiming for bump-shaped terrain change
-            float calculateBumpShape(const float& distance, int radius, const float& height);
+            float calculateBumpShape(float distance, int radius, float height);
 
             /// set the target height for flatten tool
             void setFlattenToolTargetHeight(const WorldspaceHitResult& hit);

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -48,10 +48,10 @@ namespace CSVRender
 
             enum BrushShape
             {
-                BrushShape_Point = 1,
-                BrushShape_Square = 2,
-                BrushShape_Circle = 3,
-                BrushShape_Custom = 4
+                BrushShape_Point = 0,
+                BrushShape_Square = 1,
+                BrushShape_Circle = 2,
+                BrushShape_Custom = 3
             };
 
             /// Editmode for terrain shape grid

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -137,10 +137,6 @@ namespace CSVRender
             int mShapeEditToolStrength;
             int mTargetHeight;
 
-            const int cellSize {ESM::Land::REAL_SIZE};
-            const int landSize {ESM::Land::LAND_SIZE};
-            const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
-
             PagedWorldspaceWidget& getPagedWorldspaceWidget();
 
         signals:

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -175,9 +175,6 @@ namespace CSVRender
 
             PagedWorldspaceWidget& getPagedWorldspaceWidget();
 
-        signals:
-            void passBrushTexture(std::string brushTexture);
-
         public slots:
             void setBrushSize(int brushSize);
             void setBrushShape(CSVWidget::BrushShape brushShape);

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -58,18 +58,18 @@ namespace CSVRender
             /// Editmode for terrain shape grid
             TerrainShapeMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
 
-            void primaryOpenPressed (const WorldspaceHitResult& hit);
+            void primaryOpenPressed (const WorldspaceHitResult& hit) final;
 
             /// Create single command for one-click shape editing
-            void primaryEditPressed (const WorldspaceHitResult& hit);
+            void primaryEditPressed (const WorldspaceHitResult& hit) final;
 
             /// Open brush settings window
-            void primarySelectPressed(const WorldspaceHitResult&);
+            void primarySelectPressed(const WorldspaceHitResult&) final;
 
-            void secondarySelectPressed(const WorldspaceHitResult&);
+            void secondarySelectPressed(const WorldspaceHitResult&) final;
 
-            void activate(CSVWidget::SceneToolbar*);
-            void deactivate(CSVWidget::SceneToolbar*);
+            void activate(CSVWidget::SceneToolbar*) final;
+            void deactivate(CSVWidget::SceneToolbar*) final;
 
             /// Start shape editing command macro
             bool primaryEditStartDrag (const QPoint& pos) final;

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -72,24 +72,25 @@ namespace CSVRender
             void deactivate(CSVWidget::SceneToolbar*);
 
             /// Start shape editing command macro
-            virtual bool primaryEditStartDrag (const QPoint& pos);
+            bool primaryEditStartDrag (const QPoint& pos) final;
 
-            virtual bool secondaryEditStartDrag (const QPoint& pos);
-            virtual bool primarySelectStartDrag (const QPoint& pos);
-            virtual bool secondarySelectStartDrag (const QPoint& pos);
+            bool secondaryEditStartDrag (const QPoint& pos) final;
+            bool primarySelectStartDrag (const QPoint& pos) final;
+            bool secondarySelectStartDrag (const QPoint& pos) final;
 
             /// Handle shape edit behavior during dragging
-            virtual void drag (const QPoint& pos, int diffX, int diffY, double speedFactor);
+            void drag (const QPoint& pos, int diffX, int diffY, double speedFactor) final;
 
             /// End shape editing command macro
-            virtual void dragCompleted(const QPoint& pos);
+            void dragCompleted(const QPoint& pos) final;
 
             /// Cancel shape editing, and reset all pending changes
-            virtual void dragAborted();
+            void dragAborted() final;
 
-            virtual void dragWheel (int diff, double speedFactor);
-            virtual void dragMoveEvent (QDragMoveEvent *event);
+            void dragWheel (int diff, double speedFactor) final;
+            void dragMoveEvent (QDragMoveEvent *event) final;
 
+        private:
             /// Move pending alteredHeights changes to omwgame/omeaddon -data
             void applyTerrainEditChanges();
 
@@ -138,7 +139,6 @@ namespace CSVRender
             /// Create new cell and land if needed
             bool allowLandShapeEditing(const std::string& textureFileName);
 
-        private:
             std::string mCellId;
             std::string mBrushTexture;
             int mBrushSize;

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -81,8 +81,14 @@ namespace CSVRender
             virtual void dragWheel (int diff, double speedFactor);
             virtual void dragMoveEvent (QDragMoveEvent *event);
 
+            /// Move pending alteredHeights changes to omwgame/omeaddon -data
+            void applyTerrainEditChanges();
+
             /// Handle brush mechanics for shape editing
             void editTerrainShapeGrid (const std::pair<int, int>& vertexCoords, bool dragOperation);
+
+            /// set the target height for flatten tool
+            void setFlattenToolTargetHeight(const WorldspaceHitResult& hit);
 
             /// Do a single height alteration for transient shape edit map
             void alterHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float alteredHeight, bool useTool = true);

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -101,6 +101,9 @@ namespace CSVRender
             /// Handle brush mechanics for shape editing
             void editTerrainShapeGrid (const std::pair<int, int>& vertexCoords, bool dragOperation);
 
+            /// Calculate height, when aiming for bump-shaped terrain change
+            float calculateBumpShape(const float& distance, int radius, const float& height);
+
             /// set the target height for flatten tool
             void setFlattenToolTargetHeight(const WorldspaceHitResult& hit);
 

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -101,8 +101,12 @@ namespace CSVRender
             /// Bind edge vertices to next cells
             void fixEdges(const CSMWorld::CellCoordinates& cellCoords);
 
-            /// Check that the edit doesn't break save format limits, fix if necessary
-            void limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords, bool reverseMode = false);
+            ///Limit steepness based on either X or Y and return false if steepness is limited
+            void compareAndLimit(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* limitedAlteredHeightXAxis,
+                float* limitedAlteredHeightYAxis, bool* steepnessIsWithinLimits);
+
+            /// Check that the edit doesn't break save format limits, fix if necessary, return true if slope steepness is within limits
+            bool limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords, bool reverseMode = false);
 
             /// Handle brush mechanics for terrain shape selection
             void selectTerrainShapes (const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation);

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -1,0 +1,157 @@
+#ifndef CSV_RENDER_TERRAINSHAPEMODE_H
+#define CSV_RENDER_TERRAINSHAPEMODE_H
+
+#include "editmode.hpp"
+
+#include <string>
+#include <memory>
+
+#include <QWidget>
+#include <QEvent>
+
+#ifndef Q_MOC_RUN
+#include "../../model/world/data.hpp"
+#include "../../model/world/land.hpp"
+
+#include "../../model/doc/document.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/idtable.hpp"
+#include "../../model/world/landtexture.hpp"
+#endif
+
+#include "terrainselection.hpp"
+
+namespace CSVWidget
+{
+    class SceneToolShapeBrush;
+}
+
+namespace CSVRender
+{
+    class PagedWorldspaceWidget;
+
+    /// \brief EditMode for handling the terrain shape editing
+    class TerrainShapeMode : public EditMode
+    {
+        Q_OBJECT
+
+        public:
+
+            enum InteractionType
+            {
+                InteractionType_PrimaryEdit,
+                InteractionType_PrimarySelect,
+                InteractionType_SecondaryEdit,
+                InteractionType_SecondarySelect,
+                InteractionType_None
+            };
+
+            /// Editmode for terrain shape grid
+            TerrainShapeMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
+
+            void primaryOpenPressed (const WorldspaceHitResult& hit);
+
+            /// Create single command for one-click shape editing
+            void primaryEditPressed (const WorldspaceHitResult& hit);
+
+            /// Open brush settings window
+            void primarySelectPressed(const WorldspaceHitResult&);
+
+            void secondarySelectPressed(const WorldspaceHitResult&);
+
+            void activate(CSVWidget::SceneToolbar*);
+            void deactivate(CSVWidget::SceneToolbar*);
+
+            /// Start shape editing command macro
+            virtual bool primaryEditStartDrag (const QPoint& pos);
+
+            virtual bool secondaryEditStartDrag (const QPoint& pos);
+            virtual bool primarySelectStartDrag (const QPoint& pos);
+            virtual bool secondarySelectStartDrag (const QPoint& pos);
+
+            /// Handle shape edit behavior during dragging
+            virtual void drag (const QPoint& pos, int diffX, int diffY, double speedFactor);
+
+            /// End shape editing command macro
+            virtual void dragCompleted(const QPoint& pos);
+
+            /// Cancel shape editing, and reset all pending changes
+            virtual void dragAborted();
+
+            virtual void dragWheel (int diff, double speedFactor);
+            virtual void dragMoveEvent (QDragMoveEvent *event);
+
+            /// Handle brush mechanics for shape editing
+            void editTerrainShapeGrid (const std::pair<int, int>& vertexCoords, bool dragOperation);
+
+            /// Do a single height alteration for transient shape edit map
+            void alterHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float alteredHeight, bool useTool = true);
+
+            /// Do a single smoothing height alteration for transient shape edit map
+            void smoothHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength);
+
+            /// Do a single flattening height alteration for transient shape edit map
+            void flattenHeight(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, int toolStrength, int targetHeight);
+
+            /// Update the key values used in height calculations
+            void updateKeyHeightValues(const CSMWorld::CellCoordinates& cellCoords, int inCellX, int inCellY, float* thisHeight,
+                float* thisAlteredHeight, float* leftHeight, float* leftAlteredHeight, float* upHeight, float* upAlteredHeight);
+
+            /// Bind edge vertices to next cells
+            void fixEdges(const CSMWorld::CellCoordinates& cellCoords);
+
+            /// Check that the edit doesn't break save format limits, fix if necessary
+            void limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords);
+
+            /// Handle brush mechanics for terrain shape selection
+            void selectTerrainShapes (const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation);
+
+            /// Push terrain shape edits to command macro
+            void pushEditToCommand (const CSMWorld::LandHeightsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+                CSMWorld::IdTable& landTable, std::string cellId);
+
+            /// Push land normals edits to command macro
+            void pushNormalsEditToCommand(const CSMWorld::LandNormalsColumn::DataType& newLandGrid, CSMDoc::Document& document,
+                CSMWorld::IdTable& landTable, std::string cellId);
+
+            /// Create new cell and land if needed
+            bool allowLandShapeEditing(std::string textureFileName);
+
+        private:
+            std::string mCellId;
+            std::string mBrushTexture;
+            int mBrushSize;
+            int mBrushShape;
+            std::vector<std::pair<int, int>> mCustomBrushShape;
+            CSVWidget::SceneToolShapeBrush *mShapeBrushScenetool;
+            int mDragMode;
+            osg::Group* mParentNode;
+            bool mIsEditing;
+            std::unique_ptr<TerrainSelection> mTerrainShapeSelection;
+            int mTotalDiffY;
+            std::vector<CSMWorld::CellCoordinates> mAlteredCells;
+            osg::Vec3d mEditingPos;
+            int mShapeEditTool;
+            int mShapeEditToolStrength;
+            int mTargetHeight;
+
+            const int cellSize {ESM::Land::REAL_SIZE};
+            const int landSize {ESM::Land::LAND_SIZE};
+            const int landTextureSize {ESM::Land::LAND_TEXTURE_SIZE};
+
+            PagedWorldspaceWidget& getPagedWorldspaceWidget();
+
+        signals:
+            void passBrushTexture(std::string brushTexture);
+
+        public slots:
+            //void handleDropEvent(QDropEvent *event);
+            void setBrushSize(int brushSize);
+            void setBrushShape(int brushShape);
+            void setShapeEditTool(int shapeEditTool);
+            void setShapeEditToolStrength(int shapeEditToolStrength);
+    };
+}
+
+
+#endif

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -128,13 +128,13 @@ namespace CSVRender
         return abs(getThisHeight(col, row, heightData) - getDownHeight(col, row, heightData));
     }
 
-    bool TerrainStorage::LeftOrUpIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const
+    bool TerrainStorage::leftOrUpIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const
     {
         return getHeightDifferenceToLeft(col, row, heightData) >= heightWarningLimit ||
             getHeightDifferenceToUp(col, row, heightData) >= heightWarningLimit;
     }
 
-    bool TerrainStorage::RightOrDownIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const
+    bool TerrainStorage::rightOrDownIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const
     {
         return getHeightDifferenceToRight(col, row, heightData) >= heightWarningLimit ||
             getHeightDifferenceToDown(col, row, heightData) >= heightWarningLimit;
@@ -144,8 +144,8 @@ namespace CSVRender
     {
         // Highlight broken height changes
         int heightWarningLimit = 1024;
-        if (((col > 0 && row > 0) && LeftOrUpIsOverTheLimit(col, row, heightWarningLimit, heightData)) ||
-            ((col < ESM::Land::LAND_SIZE - 1 && row < ESM::Land::LAND_SIZE - 1) && RightOrDownIsOverTheLimit(col, row, heightWarningLimit, heightData)))
+        if (((col > 0 && row > 0) && leftOrUpIsOverTheLimit(col, row, heightWarningLimit, heightData)) ||
+            ((col < ESM::Land::LAND_SIZE - 1 && row < ESM::Land::LAND_SIZE - 1) && rightOrDownIsOverTheLimit(col, row, heightWarningLimit, heightData)))
         {
             color.r() = 255;
             color.g() = 0;

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -50,13 +50,7 @@ namespace CSVRender
 
     void TerrainStorage::resetHeights()
     {
-        for (int x = 0; x < ESM::Land::LAND_SIZE; ++x)
-        {
-            for (int y = 0; y < ESM::Land::LAND_SIZE; ++y)
-            {
-                mAlteredHeight[y*ESM::Land::LAND_SIZE + x] = 0;
-            }
-        }
+        std::fill(std::begin(mAlteredHeight), std::end(mAlteredHeight), 0);
     }
 
     float TerrainStorage::getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY)

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -57,7 +57,7 @@ namespace CSVRender
         osg::ref_ptr<const ESMTerrain::LandObject> land = getLand (cellX, cellY);
         if (land)
         {
-            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VHGT) : 0;
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VHGT) : nullptr;
             if (data) height = getVertexHeight(data, inCellX, inCellY);
         }
         else return height;

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -72,173 +72,42 @@ namespace CSVRender
         return &mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX];
     }
 
-    void TerrainStorage::fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
-                                            osg::ref_ptr<osg::Vec3Array> positions,
-                                            osg::ref_ptr<osg::Vec3Array> normals,
-                                            osg::ref_ptr<osg::Vec4ubArray> colours)
-    {
-        // LOD level n means every 2^n-th vertex is kept
-        size_t increment = static_cast<size_t>(1) << lodLevel;
-
-        osg::Vec2f origin = center - osg::Vec2f(size/2.f, size/2.f);
-
-        int startCellX = static_cast<int>(std::floor(origin.x()));
-        int startCellY = static_cast<int>(std::floor(origin.y()));
-
-        size_t numVerts = static_cast<size_t>(size*(ESM::Land::LAND_SIZE - 1) / increment + 1);
-
-        positions->resize(numVerts*numVerts);
-        normals->resize(numVerts*numVerts);
-        colours->resize(numVerts*numVerts);
-
-        osg::Vec3f normal;
-        osg::Vec4ub color;
-
-        float vertY = 0;
-        float vertX = 0;
-
-        ESMTerrain::LandCache cache;
-
-        float vertY_ = 0; // of current cell corner
-        for (int cellY = startCellY; cellY < startCellY + std::ceil(size); ++cellY)
-        {
-            float vertX_ = 0; // of current cell corner
-            for (int cellX = startCellX; cellX < startCellX + std::ceil(size); ++cellX)
-            {
-                const ESMTerrain::LandObject* land = ESMTerrain::Storage::getLand(cellX, cellY, cache);
-                const ESM::Land::LandData *heightData = 0;
-                const ESM::Land::LandData *normalData = 0;
-                const ESM::Land::LandData *colourData = 0;
-                if (land)
-                {
-                    heightData = land->getData(ESM::Land::DATA_VHGT);
-                    normalData = land->getData(ESM::Land::DATA_VNML);
-                    colourData = land->getData(ESM::Land::DATA_VCLR);
-                }
-
-                int rowStart = 0;
-                int colStart = 0;
-                // Skip the first row / column unless we're at a chunk edge,
-                // since this row / column is already contained in a previous cell
-                // This is only relevant if we're creating a chunk spanning multiple cells
-                if (vertY_ != 0)
-                    colStart += increment;
-                if (vertX_ != 0)
-                    rowStart += increment;
-
-                // Only relevant for chunks smaller than (contained in) one cell
-                rowStart += (origin.x() - startCellX) * ESM::Land::LAND_SIZE;
-                colStart += (origin.y() - startCellY) * ESM::Land::LAND_SIZE;
-                int rowEnd = std::min(static_cast<int>(rowStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
-                int colEnd = std::min(static_cast<int>(colStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
-
-                vertY = vertY_;
-                for (int col=colStart; col<colEnd; col += increment)
-                {
-                    vertX = vertX_;
-                    for (int row=rowStart; row<rowEnd; row += increment)
-                    {
-                        int srcArrayIndex = col*ESM::Land::LAND_SIZE*3+row*3;
-
-                        assert(row >= 0 && row < ESM::Land::LAND_SIZE);
-                        assert(col >= 0 && col < ESM::Land::LAND_SIZE);
-
-                        assert (vertX < numVerts);
-                        assert (vertY < numVerts);
-
-                        float height = defaultHeight;
-                        if (heightData)
-                            height = heightData->mHeights[col*ESM::Land::LAND_SIZE + row];
-
-                        (*positions)[static_cast<unsigned int>(vertX*numVerts + vertY)]
-                            = osg::Vec3f((vertX / float(numVerts - 1) - 0.5f) * size * Constants::CellSizeInUnits,
-                                         (vertY / float(numVerts - 1) - 0.5f) * size * Constants::CellSizeInUnits,
-                                         height + mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)]);
-
-                        if (normalData)
-                        {
-                            for (int i=0; i<3; ++i)
-                                normal[i] = normalData->mNormals[srcArrayIndex+i];
-
-                            normal.normalize();
-                        }
-                        else
-                            normal = osg::Vec3f(0,0,1);
-
-                        // Normals apparently don't connect seamlessly between cells
-                        if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
-                            fixNormal(normal, cellX, cellY, col, row, cache);
-
-                        // some corner normals appear to be complete garbage (z < 0)
-                        if ((row == 0 || row == ESM::Land::LAND_SIZE-1) && (col == 0 || col == ESM::Land::LAND_SIZE-1))
-                            averageNormal(normal, cellX, cellY, col, row, cache);
-
-                        assert(normal.z() > 0);
-
-                        (*normals)[static_cast<unsigned int>(vertX*numVerts + vertY)] = normal;
-
-                        if (colourData)
-                        {
-                            for (int i=0; i<3; ++i)
-                                color[i] = colourData->mColours[srcArrayIndex+i];
-                        }
-                        else
-                        {
-                            color.r() = 255;
-                            color.g() = 255;
-                            color.b() = 255;
-                        }
-
-                        // Highlight broken height changes
-                        if ( ((col > 0 && row > 0) &&
-                            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
-                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
-                            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row - 1] +
-                            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row - 1)])) >= 1024 ) ||
-                            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
-                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
-                            (heightData->mHeights[(col - 1)*ESM::Land::LAND_SIZE + row] +
-                            mAlteredHeight[static_cast<unsigned int>((col - 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )) ||
-                            ((col < ESM::Land::LAND_SIZE - 1 && row < ESM::Land::LAND_SIZE - 1) &&
-                            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
-                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
-                            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row + 1] +
-                            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row + 1)])) >= 1024 ) ||
-                            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
-                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
-                            (heightData->mHeights[(col + 1)*ESM::Land::LAND_SIZE + row] +
-                            mAlteredHeight[static_cast<unsigned int>((col + 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )))
-                        {
-                            color.r() = 255;
-                            color.g() = 0;
-                            color.b() = 0;
-                        }
-
-                        // Unlike normals, colors mostly connect seamlessly between cells, but not always...
-                        if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
-                            fixColour(color, cellX, cellY, col, row, cache);
-
-                        color.a() = 255;
-
-                        (*colours)[static_cast<unsigned int>(vertX*numVerts + vertY)] = color;
-
-                        ++vertX;
-                    }
-                    ++vertY;
-                }
-                vertX_ = vertX;
-            }
-            vertY_ = vertY;
-
-            assert(vertX_ == numVerts); // Ensure we covered whole area
-        }
-        assert(vertY_ == numVerts);  // Ensure we covered whole area*/
-    }
-
     void TerrainStorage::getBounds(float &minX, float &maxX, float &minY, float &maxY)
     {
         // not needed at the moment - this returns the bounds of the whole world, but we only edit individual cells
         throw std::runtime_error("getBounds not implemented");
     }
 
+    void TerrainStorage::adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const
+    {
+        // Highlight broken height changes
+        if ( ((col > 0 && row > 0) &&
+            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row - 1] +
+            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row - 1)])) >= 1024 ) ||
+            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+            (heightData->mHeights[(col - 1)*ESM::Land::LAND_SIZE + row] +
+            mAlteredHeight[static_cast<unsigned int>((col - 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )) ||
+            ((col < ESM::Land::LAND_SIZE - 1 && row < ESM::Land::LAND_SIZE - 1) &&
+            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row + 1] +
+            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row + 1)])) >= 1024 ) ||
+            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+            (heightData->mHeights[(col + 1)*ESM::Land::LAND_SIZE + row] +
+            mAlteredHeight[static_cast<unsigned int>((col + 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )))
+        {
+            color.r() = 255;
+            color.g() = 0;
+            color.b() = 0;
+        }
+    }
+
+    float TerrainStorage::getAlteredHeight(int col, int row) const
+    {
+        return mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)];
+    }
 }

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -1,15 +1,25 @@
 #include "terrainstorage.hpp"
 
+#include <set>
+#include <memory>
+
 #include "../../model/world/land.hpp"
 #include "../../model/world/landtexture.hpp"
 
+#include <components/esmterrain/storage.hpp>
+#include <components/debug/debuglog.hpp>
+#include <components/misc/resourcehelpers.hpp>
+#include <components/vfs/manager.hpp>
+
 namespace CSVRender
 {
+    const float defaultHeight = ESM::Land::DEFAULT_HEIGHT;
 
     TerrainStorage::TerrainStorage(const CSMWorld::Data &data)
         : ESMTerrain::Storage(data.getResourceSystem()->getVFS())
         , mData(data)
     {
+        resetHeights();
     }
 
     osg::ref_ptr<const ESMTerrain::LandObject> TerrainStorage::getLand(int cellX, int cellY)
@@ -31,6 +41,209 @@ namespace CSVRender
             return nullptr;
 
         return &mData.getLandTextures().getRecord(row).get();
+    }
+
+    void TerrainStorage::setAlteredHeight(int inCellX, int inCellY, float height)
+    {
+        mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX] = height - fmod(height, 8); //Limit to divisible by 8 to avoid cell seam breakage
+    }
+
+    void TerrainStorage::resetHeights()
+    {
+        for (int x = 0; x < ESM::Land::LAND_SIZE; ++x)
+        {
+            for (int y = 0; y < ESM::Land::LAND_SIZE; ++y)
+            {
+                mAlteredHeight[y*ESM::Land::LAND_SIZE + x] = 0;
+            }
+        }
+    }
+
+    float TerrainStorage::getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY)
+    {
+        float height = 0.f;
+        osg::ref_ptr<const ESMTerrain::LandObject> land = getLand (cellX, cellY);
+        if (land)
+        {
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VHGT) : 0;
+            if (data) height = getVertexHeight(data, inCellX, inCellY);
+        }
+        else return height;
+        return mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX] + height;
+
+    }
+
+    float* TerrainStorage::getAlteredHeights()
+    {
+        return mAlteredHeight;
+    }
+
+    float* TerrainStorage::getAlteredHeight(int inCellX, int inCellY)
+    {
+        return &mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX];
+    }
+
+    void TerrainStorage::fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
+                                            osg::ref_ptr<osg::Vec3Array> positions,
+                                            osg::ref_ptr<osg::Vec3Array> normals,
+                                            osg::ref_ptr<osg::Vec4ubArray> colours)
+    {
+        // LOD level n means every 2^n-th vertex is kept
+        size_t increment = static_cast<size_t>(1) << lodLevel;
+
+        osg::Vec2f origin = center - osg::Vec2f(size/2.f, size/2.f);
+
+        int startCellX = static_cast<int>(std::floor(origin.x()));
+        int startCellY = static_cast<int>(std::floor(origin.y()));
+
+        size_t numVerts = static_cast<size_t>(size*(ESM::Land::LAND_SIZE - 1) / increment + 1);
+
+        positions->resize(numVerts*numVerts);
+        normals->resize(numVerts*numVerts);
+        colours->resize(numVerts*numVerts);
+
+        osg::Vec3f normal;
+        osg::Vec4ub color;
+
+        float vertY = 0;
+        float vertX = 0;
+
+        ESMTerrain::LandCache cache;
+
+        float vertY_ = 0; // of current cell corner
+        for (int cellY = startCellY; cellY < startCellY + std::ceil(size); ++cellY)
+        {
+            float vertX_ = 0; // of current cell corner
+            for (int cellX = startCellX; cellX < startCellX + std::ceil(size); ++cellX)
+            {
+                const ESMTerrain::LandObject* land = ESMTerrain::Storage::getLand(cellX, cellY, cache);
+                const ESM::Land::LandData *heightData = 0;
+                const ESM::Land::LandData *normalData = 0;
+                const ESM::Land::LandData *colourData = 0;
+                if (land)
+                {
+                    heightData = land->getData(ESM::Land::DATA_VHGT);
+                    normalData = land->getData(ESM::Land::DATA_VNML);
+                    colourData = land->getData(ESM::Land::DATA_VCLR);
+                }
+
+                int rowStart = 0;
+                int colStart = 0;
+                // Skip the first row / column unless we're at a chunk edge,
+                // since this row / column is already contained in a previous cell
+                // This is only relevant if we're creating a chunk spanning multiple cells
+                if (vertY_ != 0)
+                    colStart += increment;
+                if (vertX_ != 0)
+                    rowStart += increment;
+
+                // Only relevant for chunks smaller than (contained in) one cell
+                rowStart += (origin.x() - startCellX) * ESM::Land::LAND_SIZE;
+                colStart += (origin.y() - startCellY) * ESM::Land::LAND_SIZE;
+                int rowEnd = std::min(static_cast<int>(rowStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
+                int colEnd = std::min(static_cast<int>(colStart + std::min(1.f, size) * (ESM::Land::LAND_SIZE-1) + 1), static_cast<int>(ESM::Land::LAND_SIZE));
+
+                vertY = vertY_;
+                for (int col=colStart; col<colEnd; col += increment)
+                {
+                    vertX = vertX_;
+                    for (int row=rowStart; row<rowEnd; row += increment)
+                    {
+                        int srcArrayIndex = col*ESM::Land::LAND_SIZE*3+row*3;
+
+                        assert(row >= 0 && row < ESM::Land::LAND_SIZE);
+                        assert(col >= 0 && col < ESM::Land::LAND_SIZE);
+
+                        assert (vertX < numVerts);
+                        assert (vertY < numVerts);
+
+                        float height = defaultHeight;
+                        if (heightData)
+                            height = heightData->mHeights[col*ESM::Land::LAND_SIZE + row];
+
+                        (*positions)[static_cast<unsigned int>(vertX*numVerts + vertY)]
+                            = osg::Vec3f((vertX / float(numVerts - 1) - 0.5f) * size * Constants::CellSizeInUnits,
+                                         (vertY / float(numVerts - 1) - 0.5f) * size * Constants::CellSizeInUnits,
+                                         height + mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)]);
+
+                        if (normalData)
+                        {
+                            for (int i=0; i<3; ++i)
+                                normal[i] = normalData->mNormals[srcArrayIndex+i];
+
+                            normal.normalize();
+                        }
+                        else
+                            normal = osg::Vec3f(0,0,1);
+
+                        // Normals apparently don't connect seamlessly between cells
+                        if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
+                            fixNormal(normal, cellX, cellY, col, row, cache);
+
+                        // some corner normals appear to be complete garbage (z < 0)
+                        if ((row == 0 || row == ESM::Land::LAND_SIZE-1) && (col == 0 || col == ESM::Land::LAND_SIZE-1))
+                            averageNormal(normal, cellX, cellY, col, row, cache);
+
+                        assert(normal.z() > 0);
+
+                        (*normals)[static_cast<unsigned int>(vertX*numVerts + vertY)] = normal;
+
+                        if (colourData)
+                        {
+                            for (int i=0; i<3; ++i)
+                                color[i] = colourData->mColours[srcArrayIndex+i];
+                        }
+                        else
+                        {
+                            color.r() = 255;
+                            color.g() = 255;
+                            color.b() = 255;
+                        }
+
+                        // Highlight broken height changes
+                        if ( ((col > 0 && row > 0) &&
+                            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row - 1] +
+                            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row - 1)])) >= 1024 ) ||
+                            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col - 1)*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>((col - 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )) ||
+                            ((col < ESM::Land::LAND_SIZE - 1 && row < ESM::Land::LAND_SIZE - 1) &&
+                            ((abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col)*ESM::Land::LAND_SIZE + row + 1] +
+                            mAlteredHeight[static_cast<unsigned int>((col)*ESM::Land::LAND_SIZE + row + 1)])) >= 1024 ) ||
+                            abs(heightData->mHeights[col*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>(col*ESM::Land::LAND_SIZE + row)] -
+                            (heightData->mHeights[(col + 1)*ESM::Land::LAND_SIZE + row] +
+                            mAlteredHeight[static_cast<unsigned int>((col + 1)*ESM::Land::LAND_SIZE + row)]))  >= 1024 )))
+                        {
+                            color.r() = 255;
+                            color.g() = 0;
+                            color.b() = 0;
+                        }
+
+                        // Unlike normals, colors mostly connect seamlessly between cells, but not always...
+                        if (col == ESM::Land::LAND_SIZE-1 || row == ESM::Land::LAND_SIZE-1)
+                            fixColour(color, cellX, cellY, col, row, cache);
+
+                        color.a() = 255;
+
+                        (*colours)[static_cast<unsigned int>(vertX*numVerts + vertY)] = color;
+
+                        ++vertX;
+                    }
+                    ++vertY;
+                }
+                vertX_ = vertX;
+            }
+            vertY_ = vertY;
+
+            assert(vertX_ == numVerts); // Ensure we covered whole area
+        }
+        assert(vertY_ == numVerts);  // Ensure we covered whole area*/
     }
 
     void TerrainStorage::getBounds(float &minX, float &maxX, float &minY, float &maxY)

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -1,15 +1,9 @@
 #include "terrainstorage.hpp"
 
-#include <set>
-#include <memory>
-
 #include "../../model/world/land.hpp"
 #include "../../model/world/landtexture.hpp"
 
 #include <components/esmterrain/storage.hpp>
-#include <components/debug/debuglog.hpp>
-#include <components/misc/resourcehelpers.hpp>
-#include <components/vfs/manager.hpp>
 
 namespace CSVRender
 {

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -73,11 +73,6 @@ namespace CSVRender
 
     }
 
-    float* TerrainStorage::getAlteredHeights()
-    {
-        return mAlteredHeight;
-    }
-
     float* TerrainStorage::getAlteredHeight(int inCellX, int inCellY)
     {
         return &mAlteredHeight[inCellY*ESM::Land::LAND_SIZE + inCellX];

--- a/apps/opencs/view/render/terrainstorage.cpp
+++ b/apps/opencs/view/render/terrainstorage.cpp
@@ -13,8 +13,6 @@
 
 namespace CSVRender
 {
-    const float defaultHeight = ESM::Land::DEFAULT_HEIGHT;
-
     TerrainStorage::TerrainStorage(const CSMWorld::Data &data)
         : ESMTerrain::Storage(data.getResourceSystem()->getVFS())
         , mData(data)

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -39,8 +39,8 @@ namespace CSVRender
         int getHeightDifferenceToRight(int col, int row, const ESM::Land::LandData *heightData) const;
         int getHeightDifferenceToUp(int col, int row, const ESM::Land::LandData *heightData) const;
         int getHeightDifferenceToDown(int col, int row, const ESM::Land::LandData *heightData) const;
-        bool LeftOrUpIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
-        bool RightOrDownIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
+        bool leftOrUpIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
+        bool rightOrDownIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
 
         void adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const override;
         float getAlteredHeight(int col, int row) const override;

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -9,8 +9,6 @@
 
 namespace CSVRender
 {
-    class LandCache;
-
     /**
      * @brief A bridge between the terrain component and OpenCS's terrain data storage.
      */
@@ -30,13 +28,10 @@ namespace CSVRender
         virtual osg::ref_ptr<const ESMTerrain::LandObject> getLand (int cellX, int cellY) override;
         virtual const ESM::LandTexture* getLandTexture(int index, short plugin) override;
 
-        /// Draws temporarily altered land (transient change support)
-        void fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
-                        osg::ref_ptr<osg::Vec3Array> positions,
-                        osg::ref_ptr<osg::Vec3Array> normals,
-                        osg::ref_ptr<osg::Vec4ubArray> colours) override;
-
         virtual void getBounds(float& minX, float& maxX, float& minY, float& maxY) override;
+
+        void adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const override;
+        float getAlteredHeight(int col, int row) const override;
     };
 
 }

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -30,6 +30,18 @@ namespace CSVRender
 
         virtual void getBounds(float& minX, float& maxX, float& minY, float& maxY) override;
 
+        int getThisHeight(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getLeftHeight(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getRightHeight(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getUpHeight(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getDownHeight(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getHeightDifferenceToLeft(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getHeightDifferenceToRight(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getHeightDifferenceToUp(int col, int row, const ESM::Land::LandData *heightData) const;
+        int getHeightDifferenceToDown(int col, int row, const ESM::Land::LandData *heightData) const;
+        bool LeftOrUpIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
+        bool RightOrDownIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
+
         void adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const override;
         float getAlteredHeight(int col, int row) const override;
     };

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -1,6 +1,8 @@
 #ifndef OPENCS_RENDER_TERRAINSTORAGE_H
 #define OPENCS_RENDER_TERRAINSTORAGE_H
 
+#include <array>
+
 #include <components/esmterrain/storage.hpp>
 
 #include "../../model/world/data.hpp"
@@ -16,11 +18,10 @@ namespace CSVRender
     {
     public:
         TerrainStorage(const CSMWorld::Data& data);
-        float mAlteredHeight[ESM::Land::LAND_SIZE * ESM::Land::LAND_SIZE + ESM::Land::LAND_SIZE];
+        std::array<float, ESM::Land::LAND_SIZE * ESM::Land::LAND_SIZE> mAlteredHeight;
         void setAlteredHeight(int inCellX, int inCellY, float heightMap);
         void resetHeights();
         float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
-        float* getAlteredHeights();
         float* getAlteredHeight(int inCellX, int inCellY);
 
     private:

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -16,7 +16,6 @@ namespace CSVRender
     {
     public:
         TerrainStorage(const CSMWorld::Data& data);
-        std::array<float, ESM::Land::LAND_SIZE * ESM::Land::LAND_SIZE> mAlteredHeight;
         void setAlteredHeight(int inCellX, int inCellY, float heightMap);
         void resetHeights();
         float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
@@ -24,11 +23,12 @@ namespace CSVRender
 
     private:
         const CSMWorld::Data& mData;
+        std::array<float, ESM::Land::LAND_SIZE * ESM::Land::LAND_SIZE> mAlteredHeight;
 
-        virtual osg::ref_ptr<const ESMTerrain::LandObject> getLand (int cellX, int cellY) override;
-        virtual const ESM::LandTexture* getLandTexture(int index, short plugin) override;
+        osg::ref_ptr<const ESMTerrain::LandObject> getLand (int cellX, int cellY) final;
+        const ESM::LandTexture* getLandTexture(int index, short plugin) final;
 
-        virtual void getBounds(float& minX, float& maxX, float& minY, float& maxY) override;
+        void getBounds(float& minX, float& maxX, float& minY, float& maxY) final;
 
         int getThisHeight(int col, int row, const ESM::Land::LandData *heightData) const;
         int getLeftHeight(int col, int row, const ESM::Land::LandData *heightData) const;
@@ -42,8 +42,8 @@ namespace CSVRender
         bool leftOrUpIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
         bool rightOrDownIsOverTheLimit(int col, int row, int heightWarningLimit, const ESM::Land::LandData *heightData) const;
 
-        void adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const override;
-        float getAlteredHeight(int col, int row) const override;
+        void adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const final;
+        float getAlteredHeight(int col, int row) const final;
     };
 
 }

--- a/apps/opencs/view/render/terrainstorage.hpp
+++ b/apps/opencs/view/render/terrainstorage.hpp
@@ -7,6 +7,7 @@
 
 namespace CSVRender
 {
+    class LandCache;
 
     /**
      * @brief A bridge between the terrain component and OpenCS's terrain data storage.
@@ -15,11 +16,24 @@ namespace CSVRender
     {
     public:
         TerrainStorage(const CSMWorld::Data& data);
+        float mAlteredHeight[ESM::Land::LAND_SIZE * ESM::Land::LAND_SIZE + ESM::Land::LAND_SIZE];
+        void setAlteredHeight(int inCellX, int inCellY, float heightMap);
+        void resetHeights();
+        float getSumOfAlteredAndTrueHeight(int cellX, int cellY, int inCellX, int inCellY);
+        float* getAlteredHeights();
+        float* getAlteredHeight(int inCellX, int inCellY);
+
     private:
         const CSMWorld::Data& mData;
 
         virtual osg::ref_ptr<const ESMTerrain::LandObject> getLand (int cellX, int cellY) override;
         virtual const ESM::LandTexture* getLandTexture(int index, short plugin) override;
+
+        /// Draws temporarily altered land (transient change support)
+        void fillVertexBuffers (int lodLevel, float size, const osg::Vec2f& center,
+                        osg::ref_ptr<osg::Vec3Array> positions,
+                        osg::ref_ptr<osg::Vec3Array> normals,
+                        osg::ref_ptr<osg::Vec4ubArray> colours) override;
 
         virtual void getBounds(float& minX, float& maxX, float& minY, float& maxY) override;
     };

--- a/apps/opencs/view/render/unpagedworldspacewidget.cpp
+++ b/apps/opencs/view/render/unpagedworldspacewidget.cpp
@@ -150,6 +150,11 @@ CSVRender::Cell* CSVRender::UnpagedWorldspaceWidget::getCell(const osg::Vec3d& p
     return mCell.get();
 }
 
+CSVRender::Cell* CSVRender::UnpagedWorldspaceWidget::getCell(const CSMWorld::CellCoordinates& coords) const
+{
+    return mCell.get();
+}
+
 std::vector<osg::ref_ptr<CSVRender::TagBase> > CSVRender::UnpagedWorldspaceWidget::getSelection (
     unsigned int elementMask) const
 {

--- a/apps/opencs/view/render/unpagedworldspacewidget.hpp
+++ b/apps/opencs/view/render/unpagedworldspacewidget.hpp
@@ -17,6 +17,7 @@ namespace CSMDoc
 namespace CSMWorld
 {
     class IdTable;
+    class CellCoordinates;
 }
 
 namespace CSVRender
@@ -62,6 +63,8 @@ namespace CSVRender
             virtual std::string getCellId (const osg::Vec3f& point) const;
 
             virtual Cell* getCell(const osg::Vec3d& point) const;
+
+            virtual Cell* getCell(const CSMWorld::CellCoordinates& coords) const;
 
             virtual std::vector<osg::ref_ptr<TagBase> > getSelection (unsigned int elementMask)
                 const;

--- a/apps/opencs/view/render/worldspacewidget.hpp
+++ b/apps/opencs/view/render/worldspacewidget.hpp
@@ -17,6 +17,7 @@ namespace CSMPrefs
 
 namespace CSMWorld
 {
+    class CellCoordinates;
     class UniversalId;
 }
 
@@ -169,6 +170,8 @@ namespace CSVRender
 
             /// \note Returns the cell if it exists, otherwise a null pointer
             virtual Cell* getCell(const osg::Vec3d& point) const = 0;
+
+            virtual Cell* getCell(const CSMWorld::CellCoordinates& coords) const = 0;
 
             virtual std::vector<osg::ref_ptr<TagBase> > getSelection (unsigned int elementMask)
                 const = 0;

--- a/apps/opencs/view/widget/brushshapes.hpp
+++ b/apps/opencs/view/widget/brushshapes.hpp
@@ -1,0 +1,14 @@
+#ifndef CSV_WIDGET_BRUSHSHAPES_H
+#define CSV_WIDGET_BRUSHSHAPES_H
+
+namespace CSVWidget
+{
+    enum BrushShape
+    {
+        BrushShape_Point,
+        BrushShape_Square,
+        BrushShape_Circle,
+        BrushShape_Custom
+    };
+}
+#endif

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -35,10 +35,7 @@
 
 
 CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, QWidget *parent)
-    : QGroupBox(title, parent),
-    mLayoutSliderSize(new QHBoxLayout),
-    mBrushSizeSlider(new QSlider(Qt::Horizontal)),
-    mBrushSizeSpinBox(new QSpinBox)
+    : QGroupBox(title, parent)
 {
     mBrushSizeSlider->setTickPosition(QSlider::TicksBothSides);
     mBrushSizeSlider->setTickInterval(10);
@@ -48,19 +45,18 @@ CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, 
     mBrushSizeSpinBox->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
     mBrushSizeSpinBox->setSingleStep(1);
 
-    mLayoutSliderSize->addWidget(mBrushSizeSlider);
-    mLayoutSliderSize->addWidget(mBrushSizeSpinBox);
+    QHBoxLayout *layoutSliderSize = new QHBoxLayout;
+    layoutSliderSize->addWidget(mBrushSizeSlider);
+    layoutSliderSize->addWidget(mBrushSizeSpinBox);
 
     connect(mBrushSizeSlider, SIGNAL(valueChanged(int)), mBrushSizeSpinBox, SLOT(setValue(int)));
     connect(mBrushSizeSpinBox, SIGNAL(valueChanged(int)), mBrushSizeSlider, SLOT(setValue(int)));
 
-    setLayout(mLayoutSliderSize);
+    setLayout(layoutSliderSize);
 }
 
 CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent)
     : QFrame(parent, Qt::Popup),
-    mBrushShape(CSVWidget::BrushShape_Point),
-    mBrushSize(1),
     mDocument(document)
 {
     mButtonPoint = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-point")), "", this);

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -1,0 +1,265 @@
+#include "scenetoolshapebrush.hpp"
+
+#include <QFrame>
+#include <QIcon>
+#include <QTableWidget>
+#include <QHBoxLayout>
+
+#include <QWidget>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QGroupBox>
+#include <QSlider>
+#include <QEvent>
+#include <QDropEvent>
+#include <QButtonGroup>
+#include <QVBoxLayout>
+#include <QDragEnterEvent>
+#include <QDrag>
+#include <QTableWidget>
+#include <QHeaderView>
+#include <QApplication>
+#include <QSizePolicy>
+
+#include "scenetool.hpp"
+
+#include "../../model/doc/document.hpp"
+#include "../../model/prefs/state.hpp"
+#include "../../model/world/commands.hpp"
+#include "../../model/world/data.hpp"
+#include "../../model/world/idcollection.hpp"
+#include "../../model/world/idtable.hpp"
+#include "../../model/world/landtexture.hpp"
+#include "../../model/world/universalid.hpp"
+
+
+CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, QWidget *parent)
+    : QGroupBox(title, parent)
+{
+    mBrushSizeSlider = new QSlider(Qt::Horizontal);
+    mBrushSizeSlider->setTickPosition(QSlider::TicksBothSides);
+    mBrushSizeSlider->setTickInterval(10);
+    mBrushSizeSlider->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mBrushSizeSlider->setSingleStep(1);
+
+    mBrushSizeSpinBox = new QSpinBox;
+    mBrushSizeSpinBox->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mBrushSizeSpinBox->setSingleStep(1);
+
+    mLayoutSliderSize = new QHBoxLayout;
+    mLayoutSliderSize->addWidget(mBrushSizeSlider);
+    mLayoutSliderSize->addWidget(mBrushSizeSpinBox);
+
+    connect(mBrushSizeSlider, SIGNAL(valueChanged(int)), mBrushSizeSpinBox, SLOT(setValue(int)));
+    connect(mBrushSizeSpinBox, SIGNAL(valueChanged(int)), mBrushSizeSlider, SLOT(setValue(int)));
+
+    setLayout(mLayoutSliderSize);
+}
+
+CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent)
+    : QFrame(parent, Qt::Popup),
+    mBrushShape(0),
+    mBrushSize(0),
+    mDocument(document)
+{
+    mButtonPoint = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-point")), "", this);
+    mButtonSquare = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-square")), "", this);
+    mButtonCircle = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-circle")), "", this);
+    mButtonCustom = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-custom")), "", this);
+
+    mSizeSliders = new ShapeBrushSizeControls("Brush size", this);
+
+    QVBoxLayout *layoutMain = new QVBoxLayout;
+    layoutMain->setSpacing(0);
+    layoutMain->setContentsMargins(4,0,4,4);
+
+    QHBoxLayout *layoutHorizontal = new QHBoxLayout;
+    layoutHorizontal->setSpacing(0);
+    layoutHorizontal->setContentsMargins (QMargins (0, 0, 0, 0));
+
+    configureButtonInitialSettings(mButtonPoint);
+    configureButtonInitialSettings(mButtonSquare);
+    configureButtonInitialSettings(mButtonCircle);
+    configureButtonInitialSettings(mButtonCustom);
+
+    mButtonPoint->setToolTip (toolTipPoint);
+    mButtonSquare->setToolTip (toolTipSquare);
+    mButtonCircle->setToolTip (toolTipCircle);
+    mButtonCustom->setToolTip (toolTipCustom);
+
+    QButtonGroup* brushButtonGroup = new QButtonGroup(this);
+    brushButtonGroup->addButton(mButtonPoint);
+    brushButtonGroup->addButton(mButtonSquare);
+    brushButtonGroup->addButton(mButtonCircle);
+    brushButtonGroup->addButton(mButtonCustom);
+
+    brushButtonGroup->setExclusive(true);
+
+    layoutHorizontal->addWidget(mButtonPoint, 0, Qt::AlignTop);
+    layoutHorizontal->addWidget(mButtonSquare, 0, Qt::AlignTop);
+    layoutHorizontal->addWidget(mButtonCircle, 0, Qt::AlignTop);
+    layoutHorizontal->addWidget(mButtonCustom, 0, Qt::AlignTop);
+
+    mHorizontalGroupBox = new QGroupBox(tr(""));
+    mHorizontalGroupBox->setLayout(layoutHorizontal);
+
+    mToolSelector = new QComboBox(this);
+    mToolSelector->addItem(tr("Height (drag)"));
+    mToolSelector->addItem(tr("Height, raise (paint)"));
+    mToolSelector->addItem(tr("Height, lower (paint)"));
+    mToolSelector->addItem(tr("Smooth (paint)"));
+    mToolSelector->addItem(tr("Flatten (paint)"));
+
+    QLabel *brushStrengthLabel = new QLabel(this);
+    brushStrengthLabel->setText("Brush strength:");
+
+    mToolStrengthSlider = new QSlider(Qt::Horizontal);
+    mToolStrengthSlider->setTickPosition(QSlider::TicksBothSides);
+    mToolStrengthSlider->setTickInterval(8);
+    mToolStrengthSlider->setRange(8, 128);
+    mToolStrengthSlider->setSingleStep(8);
+
+    layoutMain->addWidget(mHorizontalGroupBox);
+    layoutMain->addWidget(mSizeSliders);
+    layoutMain->addWidget(mToolSelector);
+    layoutMain->addWidget(brushStrengthLabel);
+    layoutMain->addWidget(mToolStrengthSlider);
+
+    setLayout(layoutMain);
+
+    connect(mButtonPoint, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+    connect(mButtonSquare, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+    connect(mButtonCircle, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+    connect(mButtonCustom, SIGNAL(clicked()), this, SLOT(setBrushShape()));
+}
+
+void CSVWidget::ShapeBrushWindow::configureButtonInitialSettings(QPushButton *button)
+{
+  button->setSizePolicy (QSizePolicy (QSizePolicy::Fixed, QSizePolicy::Fixed));
+  button->setContentsMargins (QMargins (0, 0, 0, 0));
+  button->setIconSize (QSize (48-6, 48-6));
+  button->setFixedSize (48, 48);
+  button->setCheckable(true);
+}
+
+void CSVWidget::ShapeBrushWindow::setBrushSize(int brushSize)
+{
+    mBrushSize = brushSize;
+    emit passBrushSize(mBrushSize);
+}
+
+void CSVWidget::ShapeBrushWindow::setBrushShape()
+{
+    if(mButtonPoint->isChecked()) mBrushShape = 0;
+    if(mButtonSquare->isChecked()) mBrushShape = 1;
+    if(mButtonCircle->isChecked()) mBrushShape = 2;
+    if(mButtonCustom->isChecked()) mBrushShape = 3;
+    emit passBrushShape(mBrushShape);
+}
+
+void CSVWidget::SceneToolShapeBrush::adjustToolTips()
+{
+}
+
+CSVWidget::SceneToolShapeBrush::SceneToolShapeBrush (SceneToolbar *parent, const QString& toolTip, CSMDoc::Document& document)
+: SceneTool (parent, Type_TopAction),
+    mToolTip (toolTip),
+    mDocument (document),
+    mShapeBrushWindow(new ShapeBrushWindow(document, this))
+{
+    setAcceptDrops(true);
+    connect(mShapeBrushWindow, SIGNAL(passBrushShape(int)), this, SLOT(setButtonIcon(int)));
+    setButtonIcon(mShapeBrushWindow->mBrushShape);
+
+    mPanel = new QFrame (this, Qt::Popup);
+
+    QHBoxLayout *layout = new QHBoxLayout (mPanel);
+
+    layout->setContentsMargins (QMargins (0, 0, 0, 0));
+
+    mTable = new QTableWidget (0, 2, this);
+
+    mTable->setShowGrid (true);
+    mTable->verticalHeader()->hide();
+    mTable->horizontalHeader()->hide();
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    mTable->horizontalHeader()->setSectionResizeMode (0, QHeaderView::Stretch);
+    mTable->horizontalHeader()->setSectionResizeMode (1, QHeaderView::Stretch);
+#else
+    mTable->horizontalHeader()->setResizeMode (0, QHeaderView::Stretch);
+    mTable->horizontalHeader()->setResizeMode (1, QHeaderView::Stretch);
+#endif
+    mTable->setSelectionMode (QAbstractItemView::NoSelection);
+
+    layout->addWidget (mTable);
+
+    connect (mTable, SIGNAL (clicked (const QModelIndex&)),
+        this, SLOT (clicked (const QModelIndex&)));
+
+}
+
+void CSVWidget::SceneToolShapeBrush::setButtonIcon (int brushShape)
+{
+    QString tooltip = "Change brush settings <p>Currently selected: ";
+
+    switch (brushShape)
+    {
+        case 0:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-point")));
+            tooltip += mShapeBrushWindow->toolTipPoint;
+            break;
+
+        case 1:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-square")));
+            tooltip += mShapeBrushWindow->toolTipSquare;
+            break;
+
+        case 2:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-circle")));
+            tooltip += mShapeBrushWindow->toolTipCircle;
+            break;
+
+        case 3:
+
+            setIcon (QIcon (QPixmap (":scenetoolbar/brush-custom")));
+            tooltip += mShapeBrushWindow->toolTipCustom;
+            break;
+    }
+
+    setToolTip (tooltip);
+}
+
+void CSVWidget::SceneToolShapeBrush::showPanel (const QPoint& position)
+{
+}
+
+void CSVWidget::SceneToolShapeBrush::updatePanel ()
+{
+}
+
+void CSVWidget::SceneToolShapeBrush::clicked (const QModelIndex& index)
+{
+}
+
+void CSVWidget::SceneToolShapeBrush::activate ()
+{
+    QPoint position = QCursor::pos();
+    mShapeBrushWindow->mSizeSliders->mBrushSizeSlider->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mShapeBrushWindow->mSizeSliders->mBrushSizeSpinBox->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
+    mShapeBrushWindow->move (position);
+    mShapeBrushWindow->show();
+}
+
+void CSVWidget::SceneToolShapeBrush::dragEnterEvent (QDragEnterEvent *event)
+{
+    emit passEvent(event);
+    event->accept();
+}
+void CSVWidget::SceneToolShapeBrush::dropEvent (QDropEvent *event)
+{
+    emit passEvent(event);
+    event->accept();
+}

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -118,6 +118,7 @@ CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidge
     mToolStrengthSlider->setTickInterval(8);
     mToolStrengthSlider->setRange(8, 128);
     mToolStrengthSlider->setSingleStep(8);
+    mToolStrengthSlider->setValue(8);
 
     layoutMain->addWidget(mHorizontalGroupBox);
     layoutMain->addWidget(mSizeSliders);

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -59,7 +59,7 @@ CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, 
 CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent)
     : QFrame(parent, Qt::Popup),
     mBrushShape(0),
-    mBrushSize(0),
+    mBrushSize(1),
     mDocument(document)
 {
     mButtonPoint = new QPushButton(QIcon (QPixmap (":scenetoolbar/brush-point")), "", this);

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -58,7 +58,7 @@ CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, 
 
 CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent)
     : QFrame(parent, Qt::Popup),
-    mBrushShape(0),
+    mBrushShape(BrushShape_Point),
     mBrushSize(1),
     mDocument(document)
 {
@@ -151,10 +151,10 @@ void CSVWidget::ShapeBrushWindow::setBrushSize(int brushSize)
 
 void CSVWidget::ShapeBrushWindow::setBrushShape()
 {
-    if(mButtonPoint->isChecked()) mBrushShape = 0;
-    if(mButtonSquare->isChecked()) mBrushShape = 1;
-    if(mButtonCircle->isChecked()) mBrushShape = 2;
-    if(mButtonCustom->isChecked()) mBrushShape = 3;
+    if(mButtonPoint->isChecked()) mBrushShape = BrushShape_Point;
+    if(mButtonSquare->isChecked()) mBrushShape = BrushShape_Square;
+    if(mButtonCircle->isChecked()) mBrushShape = BrushShape_Circle;
+    if(mButtonCustom->isChecked()) mBrushShape = BrushShape_Custom;
     emit passBrushShape(mBrushShape);
 }
 

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -21,6 +21,7 @@
 #include <QApplication>
 #include <QSizePolicy>
 
+#include "brushshapes.hpp"
 #include "scenetool.hpp"
 
 #include "../../model/doc/document.hpp"
@@ -58,7 +59,7 @@ CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, 
 
 CSVWidget::ShapeBrushWindow::ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent)
     : QFrame(parent, Qt::Popup),
-    mBrushShape(BrushShape_Point),
+    mBrushShape(CSVWidget::BrushShape_Point),
     mBrushSize(1),
     mDocument(document)
 {
@@ -169,7 +170,7 @@ CSVWidget::SceneToolShapeBrush::SceneToolShapeBrush (SceneToolbar *parent, const
     mShapeBrushWindow(new ShapeBrushWindow(document, this))
 {
     setAcceptDrops(true);
-    connect(mShapeBrushWindow, SIGNAL(passBrushShape(int)), this, SLOT(setButtonIcon(int)));
+    connect(mShapeBrushWindow, SIGNAL(passBrushShape(CSVWidget::BrushShape)), this, SLOT(setButtonIcon(CSVWidget::BrushShape)));
     setButtonIcon(mShapeBrushWindow->mBrushShape);
 
     mPanel = new QFrame (this, Qt::Popup);
@@ -199,31 +200,31 @@ CSVWidget::SceneToolShapeBrush::SceneToolShapeBrush (SceneToolbar *parent, const
 
 }
 
-void CSVWidget::SceneToolShapeBrush::setButtonIcon (int brushShape)
+void CSVWidget::SceneToolShapeBrush::setButtonIcon (CSVWidget::BrushShape brushShape)
 {
     QString tooltip = "Change brush settings <p>Currently selected: ";
 
     switch (brushShape)
     {
-        case 0:
+        case BrushShape_Point:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-point")));
             tooltip += mShapeBrushWindow->toolTipPoint;
             break;
 
-        case 1:
+        case BrushShape_Square:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-square")));
             tooltip += mShapeBrushWindow->toolTipSquare;
             break;
 
-        case 2:
+        case BrushShape_Circle:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-circle")));
             tooltip += mShapeBrushWindow->toolTipCircle;
             break;
 
-        case 3:
+        case BrushShape_Custom:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-custom")));
             tooltip += mShapeBrushWindow->toolTipCustom;

--- a/apps/opencs/view/widget/scenetoolshapebrush.cpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.cpp
@@ -35,19 +35,19 @@
 
 
 CSVWidget::ShapeBrushSizeControls::ShapeBrushSizeControls(const QString &title, QWidget *parent)
-    : QGroupBox(title, parent)
+    : QGroupBox(title, parent),
+    mLayoutSliderSize(new QHBoxLayout),
+    mBrushSizeSlider(new QSlider(Qt::Horizontal)),
+    mBrushSizeSpinBox(new QSpinBox)
 {
-    mBrushSizeSlider = new QSlider(Qt::Horizontal);
     mBrushSizeSlider->setTickPosition(QSlider::TicksBothSides);
     mBrushSizeSlider->setTickInterval(10);
     mBrushSizeSlider->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
     mBrushSizeSlider->setSingleStep(1);
 
-    mBrushSizeSpinBox = new QSpinBox;
     mBrushSizeSpinBox->setRange(1, CSMPrefs::get()["3D Scene Editing"]["shapebrush-maximumsize"].toInt());
     mBrushSizeSpinBox->setSingleStep(1);
 
-    mLayoutSliderSize = new QHBoxLayout;
     mLayoutSliderSize->addWidget(mBrushSizeSlider);
     mLayoutSliderSize->addWidget(mBrushSizeSpinBox);
 

--- a/apps/opencs/view/widget/scenetoolshapebrush.hpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.hpp
@@ -40,9 +40,8 @@ namespace CSVWidget
             ShapeBrushSizeControls(const QString &title, QWidget *parent);
 
         private:
-            QHBoxLayout *mLayoutSliderSize;
-            QSlider *mBrushSizeSlider;
-            QSpinBox *mBrushSizeSpinBox;
+            QSlider *mBrushSizeSlider = new QSlider(Qt::Horizontal);
+            QSpinBox *mBrushSizeSpinBox = new QSpinBox;
 
         friend class SceneToolShapeBrush;
         friend class CSVRender::TerrainShapeMode;
@@ -64,8 +63,8 @@ namespace CSVWidget
             const QString toolTipCustom = "Paint with custom brush, defined by terrain selection";
 
         private:
-            CSVWidget::BrushShape mBrushShape;
-            int mBrushSize;
+            CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;
+            int mBrushSize = 1;
             CSMDoc::Document& mDocument;
             QGroupBox *mHorizontalGroupBox;
             QComboBox *mToolSelector;

--- a/apps/opencs/view/widget/scenetoolshapebrush.hpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.hpp
@@ -1,0 +1,130 @@
+#ifndef CSV_WIDGET_SCENETOOLSHAPEBRUSH_H
+#define CSV_WIDGET_SCENETOOLSHAPEBRUSH_H
+
+#include <QIcon>
+#include <QFrame>
+#include <QModelIndex>
+
+#include <QWidget>
+#include <QLabel>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QGroupBox>
+#include <QSlider>
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QPushButton>
+
+#ifndef Q_MOC_RUN
+#include "scenetool.hpp"
+
+#include "../../model/doc/document.hpp"
+#endif
+
+class QTableWidget;
+
+namespace CSVRender
+{
+    class TerrainShapeMode;
+}
+
+namespace CSVWidget
+{
+    class SceneToolShapeBrush;
+
+    /// \brief Layout-box for some brush button settings
+    class ShapeBrushSizeControls : public QGroupBox
+    {
+        Q_OBJECT
+
+        public:
+            ShapeBrushSizeControls(const QString &title, QWidget *parent);
+
+        private:
+            QHBoxLayout *mLayoutSliderSize;
+            QSlider *mBrushSizeSlider;
+            QSpinBox *mBrushSizeSpinBox;
+
+        friend class SceneToolShapeBrush;
+        friend class CSVRender::TerrainShapeMode;
+    };
+
+    class SceneToolShapeBrush;
+
+    /// \brief Brush settings window
+    class ShapeBrushWindow : public QFrame
+    {
+        Q_OBJECT
+
+        public:
+            ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent = 0);
+            void configureButtonInitialSettings(QPushButton *button);
+
+            const QString toolTipPoint = "Paint single point";
+            const QString toolTipSquare = "Paint with square brush";
+            const QString toolTipCircle = "Paint with circle brush";
+            const QString toolTipCustom = "Paint custom selection (not implemented yet)";
+
+        private:
+            int mBrushShape;
+            int mBrushSize;
+            CSMDoc::Document& mDocument;
+            QGroupBox *mHorizontalGroupBox;
+            QComboBox *mToolSelector;
+            QSlider *mToolStrengthSlider;
+            QPushButton *mButtonPoint;
+            QPushButton *mButtonSquare;
+            QPushButton *mButtonCircle;
+            QPushButton *mButtonCustom;
+            ShapeBrushSizeControls* mSizeSliders;
+
+        friend class SceneToolShapeBrush;
+        friend class CSVRender::TerrainShapeMode;
+
+        public slots:
+            void setBrushShape();
+            void setBrushSize(int brushSize);
+
+        signals:
+            void passBrushSize (int brushSize);
+            void passBrushShape(int brushShape);
+    };
+
+    class SceneToolShapeBrush : public SceneTool
+    {
+            Q_OBJECT
+
+            QString mToolTip;
+            CSMDoc::Document& mDocument;
+            QFrame *mPanel;
+            QTableWidget *mTable;
+            ShapeBrushWindow *mShapeBrushWindow;
+
+        private:
+
+            void adjustToolTips();
+
+        public:
+
+            SceneToolShapeBrush (SceneToolbar *parent, const QString& toolTip, CSMDoc::Document& document);
+
+            virtual void showPanel (const QPoint& position);
+            void updatePanel ();
+
+            void dropEvent (QDropEvent *event);
+            void dragEnterEvent (QDragEnterEvent *event);
+
+        friend class CSVRender::TerrainShapeMode;
+
+        public slots:
+            void setButtonIcon(int brushShape);
+            void clicked (const QModelIndex& index);
+            virtual void activate();
+
+        signals:
+            void passEvent(QDropEvent *event);
+            void passEvent(QDragEnterEvent *event);
+    };
+}
+
+#endif

--- a/apps/opencs/view/widget/scenetoolshapebrush.hpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.hpp
@@ -30,8 +30,6 @@ namespace CSVRender
 
 namespace CSVWidget
 {
-    class SceneToolShapeBrush;
-
     /// \brief Layout-box for some brush button settings
     class ShapeBrushSizeControls : public QGroupBox
     {
@@ -48,8 +46,6 @@ namespace CSVWidget
         friend class SceneToolShapeBrush;
         friend class CSVRender::TerrainShapeMode;
     };
-
-    class SceneToolShapeBrush;
 
     /// \brief Brush settings window
     class ShapeBrushWindow : public QFrame

--- a/apps/opencs/view/widget/scenetoolshapebrush.hpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.hpp
@@ -53,6 +53,15 @@ namespace CSVWidget
         Q_OBJECT
 
         public:
+
+            enum BrushShape
+            {
+                BrushShape_Point = 0,
+                BrushShape_Square = 1,
+                BrushShape_Circle = 2,
+                BrushShape_Custom = 3
+            };
+
             ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent = 0);
             void configureButtonInitialSettings(QPushButton *button);
 

--- a/apps/opencs/view/widget/scenetoolshapebrush.hpp
+++ b/apps/opencs/view/widget/scenetoolshapebrush.hpp
@@ -16,6 +16,7 @@
 #include <QPushButton>
 
 #ifndef Q_MOC_RUN
+#include "brushshapes.hpp"
 #include "scenetool.hpp"
 
 #include "../../model/doc/document.hpp"
@@ -54,24 +55,16 @@ namespace CSVWidget
 
         public:
 
-            enum BrushShape
-            {
-                BrushShape_Point = 0,
-                BrushShape_Square = 1,
-                BrushShape_Circle = 2,
-                BrushShape_Custom = 3
-            };
-
             ShapeBrushWindow(CSMDoc::Document& document, QWidget *parent = 0);
             void configureButtonInitialSettings(QPushButton *button);
 
             const QString toolTipPoint = "Paint single point";
             const QString toolTipSquare = "Paint with square brush";
             const QString toolTipCircle = "Paint with circle brush";
-            const QString toolTipCustom = "Paint custom selection (not implemented yet)";
+            const QString toolTipCustom = "Paint with custom brush, defined by terrain selection";
 
         private:
-            int mBrushShape;
+            CSVWidget::BrushShape mBrushShape;
             int mBrushSize;
             CSMDoc::Document& mDocument;
             QGroupBox *mHorizontalGroupBox;
@@ -92,7 +85,7 @@ namespace CSVWidget
 
         signals:
             void passBrushSize (int brushSize);
-            void passBrushShape(int brushShape);
+            void passBrushShape(CSVWidget::BrushShape brushShape);
     };
 
     class SceneToolShapeBrush : public SceneTool
@@ -122,7 +115,7 @@ namespace CSVWidget
         friend class CSVRender::TerrainShapeMode;
 
         public slots:
-            void setButtonIcon(int brushShape);
+            void setButtonIcon(CSVWidget::BrushShape brushShape);
             void clicked (const QModelIndex& index);
             virtual void activate();
 

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -1,7 +1,12 @@
 #ifndef COMPONENTS_ESM_TERRAIN_STORAGE_H
 #define COMPONENTS_ESM_TERRAIN_STORAGE_H
 
+#include <cassert>
+
 #include <OpenThreads/Mutex>
+
+#include <osg/Image>
+#include <osg/Plane>
 
 #include <components/terrain/storage.hpp>
 
@@ -13,10 +18,13 @@ namespace VFS
     class Manager;
 }
 
+namespace CSVRender
+{
+    class TerrainStorage;
+}
+
 namespace ESMTerrain
 {
-
-    class LandCache;
 
     /// @brief Wrapper around Land Data with reference counting. The wrapper needs to be held as long as the data is still in use
     class LandObject : public osg::Object
@@ -48,6 +56,13 @@ namespace ESMTerrain
         ESM::Land::LandData mData;
     };
 
+    class LandCache
+    {
+    public:
+        typedef std::map<std::pair<int, int>, osg::ref_ptr<const LandObject> > Map;
+        Map mMap;
+    };
+    
     /// @brief Feeds data from ESM terrain records (ESM::Land, ESM::LandTexture)
     ///        into the terrain component, converting it on the fly as needed.
     class Storage : public Terrain::Storage
@@ -110,14 +125,6 @@ namespace ESMTerrain
     private:
         const VFS::Manager* mVFS;
 
-        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
-        inline void fixColour (osg::Vec4ub& colour, int cellX, int cellY, int col, int row, LandCache& cache);
-        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
-
-        inline float getVertexHeight (const ESM::Land::LandData* data, int x, int y);
-
-        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache);
-
         // Since plugins can define new texture palettes, we need to know the plugin index too
         // in order to retrieve the correct texture name.
         // pair  <texture id, plugin id>
@@ -137,6 +144,103 @@ namespace ESMTerrain
         bool mAutoUseSpecularMaps;
 
         Terrain::LayerInfo getLayerInfo(const std::string& texture);
+
+    protected:
+
+        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache)
+        {
+            while (col >= ESM::Land::LAND_SIZE-1)
+            {
+                ++cellY;
+                col -= ESM::Land::LAND_SIZE-1;
+            }
+            while (row >= ESM::Land::LAND_SIZE-1)
+            {
+                ++cellX;
+                row -= ESM::Land::LAND_SIZE-1;
+            }
+            while (col < 0)
+            {
+                --cellY;
+                col += ESM::Land::LAND_SIZE-1;
+            }
+            while (row < 0)
+            {
+                --cellX;
+                row += ESM::Land::LAND_SIZE-1;
+            }
+
+            const LandObject* land = getLand(cellX, cellY, cache);
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VNML) : 0;
+            if (data)
+            {
+                normal.x() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3];
+                normal.y() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3+1];
+                normal.z() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3+2];
+                normal.normalize();
+            }
+            else
+                normal = osg::Vec3f(0,0,1);
+        };
+
+        inline void fixColour (osg::Vec4ub& color, int cellX, int cellY, int col, int row, LandCache& cache)
+        {
+            if (col == ESM::Land::LAND_SIZE-1)
+            {
+                ++cellY;
+                col = 0;
+            }
+            if (row == ESM::Land::LAND_SIZE-1)
+            {
+                ++cellX;
+                row = 0;
+            }
+
+            const LandObject* land = getLand(cellX, cellY, cache);
+            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VCLR) : 0;
+            if (data)
+            {
+                color.r() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3];
+                color.g() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+1];
+                color.b() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+2];
+            }
+            else
+            {
+                color.r() = 255;
+                color.g() = 255;
+                color.b() = 255;
+            }
+        };
+
+        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache)
+        {
+            osg::Vec3f n1,n2,n3,n4;
+            fixNormal(n1, cellX, cellY, col+1, row, cache);
+            fixNormal(n2, cellX, cellY, col-1, row, cache);
+            fixNormal(n3, cellX, cellY, col, row+1, cache);
+            fixNormal(n4, cellX, cellY, col, row-1, cache);
+            normal = (n1+n2+n3+n4);
+            normal.normalize();
+        };
+
+        inline float getVertexHeight (const ESM::Land::LandData* data, int x, int y)
+        {
+            assert(x < ESM::Land::LAND_SIZE);
+            assert(y < ESM::Land::LAND_SIZE);
+            return data->mHeights[y * ESM::Land::LAND_SIZE + x];
+        };
+
+        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache)
+        {
+            LandCache::Map::iterator found = cache.mMap.find(std::make_pair(cellX, cellY));
+            if (found != cache.mMap.end())
+                return found->second;
+            else
+            {
+                found = cache.mMap.insert(std::make_pair(std::make_pair(cellX, cellY), getLand(cellX, cellY))).first;
+                return found->second;
+            }
+        };
     };
 
 }

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -18,11 +18,6 @@ namespace VFS
     class Manager;
 }
 
-namespace CSVRender
-{
-    class TerrainStorage;
-}
-
 namespace ESMTerrain
 {
 
@@ -62,7 +57,7 @@ namespace ESMTerrain
         typedef std::map<std::pair<int, int>, osg::ref_ptr<const LandObject> > Map;
         Map mMap;
     };
-    
+
     /// @brief Feeds data from ESM terrain records (ESM::Land, ESM::LandTexture)
     ///        into the terrain component, converting it on the fly as needed.
     class Storage : public Terrain::Storage

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -5,9 +5,6 @@
 
 #include <OpenThreads/Mutex>
 
-#include <osg/Image>
-#include <osg/Plane>
-
 #include <components/terrain/storage.hpp>
 
 #include <components/esm/loadland.hpp>
@@ -20,6 +17,8 @@ namespace VFS
 
 namespace ESMTerrain
 {
+
+    class LandCache;
 
     /// @brief Wrapper around Land Data with reference counting. The wrapper needs to be held as long as the data is still in use
     class LandObject : public osg::Object
@@ -49,13 +48,6 @@ namespace ESMTerrain
         int mLoadFlags;
 
         ESM::Land::LandData mData;
-    };
-
-    class LandCache
-    {
-    public:
-        typedef std::map<std::pair<int, int>, osg::ref_ptr<const LandObject> > Map;
-        Map mMap;
     };
 
     /// @brief Feeds data from ESM terrain records (ESM::Land, ESM::LandTexture)
@@ -117,8 +109,24 @@ namespace ESMTerrain
 
         virtual int getBlendmapScale(float chunkSize);
 
+        float getVertexHeight (const ESM::Land::LandData* data, int x, int y)
+        {
+            assert(x < ESM::Land::LAND_SIZE);
+            assert(y < ESM::Land::LAND_SIZE);
+            return data->mHeights[y * ESM::Land::LAND_SIZE + x];
+        }
+
     private:
         const VFS::Manager* mVFS;
+
+        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
+        inline void fixColour (osg::Vec4ub& colour, int cellX, int cellY, int col, int row, LandCache& cache);
+        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache);
+
+        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache);
+
+        virtual void adjustColor(int col, int row, const ESM::Land::LandData *heightData, osg::Vec4ub& color) const;
+        virtual float getAlteredHeight(int col, int row) const;
 
         // Since plugins can define new texture palettes, we need to know the plugin index too
         // in order to retrieve the correct texture name.
@@ -139,103 +147,6 @@ namespace ESMTerrain
         bool mAutoUseSpecularMaps;
 
         Terrain::LayerInfo getLayerInfo(const std::string& texture);
-
-    protected:
-
-        inline void fixNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache)
-        {
-            while (col >= ESM::Land::LAND_SIZE-1)
-            {
-                ++cellY;
-                col -= ESM::Land::LAND_SIZE-1;
-            }
-            while (row >= ESM::Land::LAND_SIZE-1)
-            {
-                ++cellX;
-                row -= ESM::Land::LAND_SIZE-1;
-            }
-            while (col < 0)
-            {
-                --cellY;
-                col += ESM::Land::LAND_SIZE-1;
-            }
-            while (row < 0)
-            {
-                --cellX;
-                row += ESM::Land::LAND_SIZE-1;
-            }
-
-            const LandObject* land = getLand(cellX, cellY, cache);
-            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VNML) : 0;
-            if (data)
-            {
-                normal.x() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3];
-                normal.y() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3+1];
-                normal.z() = data->mNormals[col*ESM::Land::LAND_SIZE*3+row*3+2];
-                normal.normalize();
-            }
-            else
-                normal = osg::Vec3f(0,0,1);
-        };
-
-        inline void fixColour (osg::Vec4ub& color, int cellX, int cellY, int col, int row, LandCache& cache)
-        {
-            if (col == ESM::Land::LAND_SIZE-1)
-            {
-                ++cellY;
-                col = 0;
-            }
-            if (row == ESM::Land::LAND_SIZE-1)
-            {
-                ++cellX;
-                row = 0;
-            }
-
-            const LandObject* land = getLand(cellX, cellY, cache);
-            const ESM::Land::LandData* data = land ? land->getData(ESM::Land::DATA_VCLR) : 0;
-            if (data)
-            {
-                color.r() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3];
-                color.g() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+1];
-                color.b() = data->mColours[col*ESM::Land::LAND_SIZE*3+row*3+2];
-            }
-            else
-            {
-                color.r() = 255;
-                color.g() = 255;
-                color.b() = 255;
-            }
-        };
-
-        inline void averageNormal (osg::Vec3f& normal, int cellX, int cellY, int col, int row, LandCache& cache)
-        {
-            osg::Vec3f n1,n2,n3,n4;
-            fixNormal(n1, cellX, cellY, col+1, row, cache);
-            fixNormal(n2, cellX, cellY, col-1, row, cache);
-            fixNormal(n3, cellX, cellY, col, row+1, cache);
-            fixNormal(n4, cellX, cellY, col, row-1, cache);
-            normal = (n1+n2+n3+n4);
-            normal.normalize();
-        };
-
-        inline float getVertexHeight (const ESM::Land::LandData* data, int x, int y)
-        {
-            assert(x < ESM::Land::LAND_SIZE);
-            assert(y < ESM::Land::LAND_SIZE);
-            return data->mHeights[y * ESM::Land::LAND_SIZE + x];
-        };
-
-        inline const LandObject* getLand(int cellX, int cellY, LandCache& cache)
-        {
-            LandCache::Map::iterator found = cache.mMap.find(std::make_pair(cellX, cellY));
-            if (found != cache.mMap.end())
-                return found->second;
-            else
-            {
-                found = cache.mMap.insert(std::make_pair(std::make_pair(cellX, cellY), getLand(cellX, cellY))).first;
-                return found->second;
-            }
-        };
     };
 
 }


### PR DESCRIPTION
New version of https://github.com/OpenMW/openmw/pull/2167 to make reviewing easier. The previous PR had terrain selection changes included in the changelog.

Terrain editing feature limits the edits to the range of ESM file format. This PR now also implements a feature that highlights the broken land heights as red whenever the edit is about to go out of range.

Features:
- Terrain vertex selection.
- Terrain shape editing
- Transient land shape editing (press esc to undo). Changes made to land are held in float array until the drag end. Memory is not allocated runtime, but rather all cells constantly hold an extra float array. This feature overrides a function from Storage, shouldn't affect OpenMW game engine.
- quicker land height calculations (affects also terrain selection)

TODO:
- [x] Fix cell edges breaking, when cells are not pre-loaded.
- [x] Add drag-amount to heights change
- [x] Proper naming of variables and functions in alterheights and heightmap to alterheight and height
- [x] Limit land edits to steps of +-8, in order to avoid land tearing because of rounding when saving.
- [x] Limit slopes to fit land format (extreme changes will break the save)
- [x] Develop basic tools for land editing
- [x] Fix bug: saves break, investigate when and why (reason: missing ltex records)
- [x] Fix bug: limitHeightChanges function breaks land, remove duplicated code
- [x] Fix bug: limitHeightChanges still rarely breaks land corners and edges
- [x] Fix bug: Out-of-limits land-edits, strange hit values?
- [x] Fix bug: Land normals command is issued after land shape command (resulting in wrong normals)
- [x] Fix bug: Tool size 1 doesn't do anything with circle/square brush
- [x] Fix bug: Slope steepness limiter, while redesigned, is still failing at some extreme cases. Workaround (don't let failed limit efforts pass).
- [x] Fixed bug: Square tool breaks cell edges (alterHeight bug)
- [x] Fix bug ([5177](https://gitlab.com/OpenMW/openmw/issues/5177)): Mini-map gets corrupted
- [x] Fix bug: Brush button doesn't get deleted.
- [x] Fix bug: Land limiting fails when new land is automatically created at the edge of the world. New lands are created at height 0, and there is an automatic cell edge break. New lands should be automatically connected to valid edging land. 
- [x] Fix bugs: Some cells (e.g. -1, -17 in Morrowind) has a land record, but no land is visible, yet terrain heights are set to zero - currently dragging a land edit to a cell like this will result in a cascade of failure.
- [x] Improve: Generate new minimap (mWnam record) based on new heights.
- [x] Improve: Make smooth-tool properly paintable
- [x] Improve: limitHeightChanges follows strange logic, and it's unknown if it always works, it shouldn't have to fix cell edges. -> Fixed the logic, but still breaks some corners in special cases. Removed the whole limit feature, opting for broken land highlight and manual edit.
- [x] Improve: Ability to re-attach broken cell edges (already done: function fixEdges, also implemented in https://github.com/OpenMW/openmw/pull/2195 )
- [x] Improve: Highlight excessive height changes/broken land in view window
- [x] Improve: Add label to toolstrength-slider
- [x] Improve: When creating new land next to existing land, seam cell edge propely
- [x] Improve: Painting height on empty cell (no land) or non-existing cell should create new land. Note: Fundamentally works, but some cells (e.g. -1, -17) still refuse to be visible.
- [x] Optimize: Check whichever is faster way to read land heights, TerrainStorage::getSumOfAlteredAndTrueHeight or through CSMWorld::LandHeightsColumn. Likely the former. If proven, do this optimization at all places possible. -> Checked, didn't find a safe way to do this optimization.
- [x] Extra: Plateau/flatten -tool
- [x] Extra: Post-process smoothing & roughening, when raise or lower painting tool is used
- [x] Check, and then uncomment or remove commented stuff at terrain and terrainstorage.
- [x] Fix changelog (no hurry with this one though, merge conflict prevents useless builds while updating this)
- [x] Test: Does smooth tool next to a broken cell edge calculate the average properly? (solve this by fixing bugs that make the cell edge break) -> Tested. If land edge is broken, tools also don't function properly. This isn't a problem, measures have been taken to prevent cell edge tearing.
- [x] Final cleanup
-> Final review and merge?

Planning/feedback needed for:
1) UI/UX, feedback on tools and general usability.
2) Transient land change implementation (terrainstorage.cpp), any objections or better ideas?
3) C++ style in general
4) Memory management (I've tried to make it as automatic as possible). Should transient edits allocate memory dynamically, use std::vector instead of float[]?
5) Terrain vertex selection drawing, how does it look, tips on optimization
6) Limits and how they are implemented, currently limits are at terrainstorage (always steps of +-8 per change), and max height change is limited at command-phase (end of drag), limiting cuts extreme land edits to those that shouldn't break during mod save.
7) Currently circle brush is the only tool with soft edges, all other tools have hard edges. Hardness/softness can both be useful at times. Should there also be a user option for brush hardness, or some other default setting? Implementing hardness/softness for custom brush could be based on the distance from the center of the custom brush, or a gaussian blur on top of selection shape (using a gaussian blurred "opacity map" to determine the tool strength in any vertex).

https://youtu.be/B1FCAOFqy-M (new video, demonstrating the features of the editmode. Note that after this video was made, if slope steepness limiting fails, it won't be applied to data any more.)
https://youtu.be/YtEL6MMvw9w (old video, bugs seen here should be fixed by now)

Work for other PR's
- When slope steepnesses are checked during applying the edit (end of transient edit), the order of cells in std::vector could be changed to iterate through X and Y in order, instead of alphabetical sorting. Proper sorting should make automatic limiting more reliable. There are however no cases where alphabetical sorting has failed during testing. No need to fix if it's not broken.
- Make slope steepness limiting real-time. (not in the scope of this PR)
- Extra: Bump -tool (not in the scope of this PR)
- Add option to turn automatic land limiting functions off. This can be useful in some situations (e.g. you want to make a 
- Add option for Discard -mode that lets one change also the cell edge vertexes. This can be useful when you want to define the very edges of the world, without connecting to 