### PR TITLE
Use Open action as fallback for companion activation (bug #5161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
     Bug #5134: Doors rotation by "Lock" console command is inconsistent
     Bug #5137: Textures with Clamp Mode set to Clamp instead of Wrap are too dark outside the boundaries
     Bug #5149: Failing lock pick attempts isn't always a crime
+    Bug #5161: Creature companions can't be activated when they are knocked down
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -454,18 +454,15 @@ namespace MWClass
             // otherwise wait until death animation
             if(stats.isDeathAnimationFinished())
                 return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr));
-
-            // death animation is not finished, do nothing
-            return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
         }
+        else if (!stats.getAiSequence().isInCombat() && !stats.getKnockedDown())
+            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
 
-        if(stats.getAiSequence().isInCombat())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
+        // Tribunal and some mod companions oddly enough must use open action as fallback
+        if (!getScript(ptr).empty() && ptr.getRefData().getLocals().getIntVar(getScript(ptr), "companion"))
+            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr));
 
-        if(stats.getKnockedDown())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
-
-        return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
+        return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
     }
 
     MWWorld::ContainerStore& Creature::getContainerStore (const MWWorld::Ptr& ptr) const

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -884,22 +884,22 @@ namespace MWClass
             // otherwise wait until death animation
             if(stats.isDeathAnimationFinished())
                 return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr));
+        }
+        else if (!stats.getAiSequence().isInCombat())
+        {
+            if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak) || stats.getKnockedDown())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
 
-            // death animation is not finished, do nothing
-            return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
+            // Can't talk to werewolves
+            if (!getNpcStats(ptr).isWerewolf())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
         }
 
-        if(stats.getAiSequence().isInCombat())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::FailedAction(""));
+        // Tribunal and some mod companions oddly enough must use open action as fallback
+        if (!getScript(ptr).empty() && ptr.getRefData().getLocals().getIntVar(getScript(ptr), "companion"))
+            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr));
 
-        if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak) || stats.getKnockedDown())
-            return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
-
-        // Can't talk to werewolfs
-        if(getNpcStats(ptr).isWerewolf())
-            return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
-
-        return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
+        return std::shared_ptr<MWWorld::Action> (new MWWorld::FailedAction(""));
     }
 
     MWWorld::ContainerStore& Npc::getContainerStore (const MWWorld::Ptr& ptr)


### PR DESCRIPTION
[Bug 5161](https://gitlab.com/OpenMW/openmw/issues/5161)

Apparently in case of Tribunal companions or any mod that uses companion variable from Tribunal Open action must be used as fallback for activation in *any case* when the dialogue window can't be opened. The main case being KO'ed actor. This is why the luggage can be opened while it's down from fatigue damage and normal creatures cannot be.

This leads to some weird behavior at times but there could be a mod that exploits it and it also makes the mod work properly, so I think it should be good enough.