### PR TITLE
Improve faction items handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
     Bug #5149: Failing lock pick attempts isn't always a crime
     Bug #5159: NiMaterialColorController can only control the diffuse color
     Bug #5161: Creature companions can't be activated when they are knocked down
+    Bug #5164: Faction owned items handling is incorrect
     Bug #5188: Objects without a name don't fallback to their ID
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     Bug #3109: SetPos/Position handles actors differently
     Bug #3282: Unintended behaviour when assigning F3 and Windows keys
     Bug #3550: Companion from mod attacks the air after combat has ended
+    Bug #3609: Items from evidence chest are not considered to be stolen if player is allowed to use the chest
     Bug #3623: Display scaling breaks mouse recognition
     Bug #3725: Using script function in a non-conditional expression breaks script compilation
     Bug #3733: Normal maps are inverted on mirrored UVs

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -130,8 +130,8 @@ namespace MWBase
              *                    If this parameter is false, it will be determined by a line-of-sight and awareness check.
              * @return was the crime seen?
              */
-            virtual bool commitCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
-                                      OffenseType type, int arg=0, bool victimAware=false) = 0;
+            virtual bool commitCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim, OffenseType type,
+                                      const std::string& factionId="", int arg=0, bool victimAware=false) = 0;
             /// @return false if the attack was considered a "friendly hit" and forgiven
             virtual bool actorAttacked (const MWWorld::Ptr& victim, const MWWorld::Ptr& attacker) = 0;
 

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -275,9 +275,11 @@ namespace MWClass
         if (ptr.getCellRef().getTrap() != "")
             text += "\n#{sTrapped}";
 
-        if (MWBase::Environment::get().getWindowManager()->getFullHelp()) {
-            text += MWGui::ToolTips::getCellRefString(ptr.getCellRef());
+        if (MWBase::Environment::get().getWindowManager()->getFullHelp())
+        {   text += MWGui::ToolTips::getCellRefString(ptr.getCellRef());
             text += MWGui::ToolTips::getMiscString(ref->mBase->mScript, "Script");
+            if (Misc::StringUtils::ciEqual(ptr.getCellRef().getRefId(), "stolen_goods"))
+                text += "\nYou can not use evidence chests";
         }
 
         info.text = text;

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -651,9 +651,22 @@ namespace MWGui
     {
         std::string ret;
         ret += getMiscString(cellref.getOwner(), "Owner");
-        ret += getMiscString(cellref.getFaction(), "Faction");
-        if (cellref.getFactionRank() > 0)
-            ret += getValueString(cellref.getFactionRank(), "Rank");
+        const std::string factionId = cellref.getFaction();
+        ret += getMiscString(factionId, "Faction");
+        if (!factionId.empty() && cellref.getFactionRank() >= 0)
+        {
+            const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
+            const ESM::Faction *fact = store.get<ESM::Faction>().search(factionId);
+            if (fact != nullptr)
+            {
+                int rank = cellref.getFactionRank();
+                const std::string rankName = fact->mRanks[rank];
+                if (rankName.empty())
+                    ret += getValueString(cellref.getFactionRank(), "Rank");
+                else
+                    ret += getMiscString(rankName, "Rank");
+            }
+        }
 
         std::vector<std::pair<std::string, int> > itemOwners =
                 MWBase::Environment::get().getMechanicsManager()->getStolenItemOwners(cellref.getRefId());

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -950,6 +950,7 @@ namespace MWMechanics
             return true;
 
         const MWWorld::CellRef& cellref = target.getCellRef();
+
         // there is no harm to use unlocked doors
         int lockLevel = cellref.getLockLevel();
         if (target.getClass().isDoor() &&
@@ -1004,6 +1005,10 @@ namespace MWMechanics
 
         if (!cellref.getOwner().empty())
             victim = MWBase::Environment::get().getWorld()->searchPtr(cellref.getOwner(), true, false);
+
+        // A special case for evidence chest - we should not allow to take items even if it is technically permitted
+        if (Misc::StringUtils::ciEqual(cellref.getRefId(), "stolen_goods"))
+            return false;
 
         return (!isOwned && !isFactionOwned);
     }

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -130,7 +130,7 @@ namespace MWMechanics
              * @return was the crime seen?
              */
             virtual bool commitCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
-                                      OffenseType type, int arg=0, bool victimAware=false) override;
+                                      OffenseType type, const std::string& factionId="", int arg=0, bool victimAware=false) override;
             /// @return false if the attack was considered a "friendly hit" and forgiven
             virtual bool actorAttacked (const MWWorld::Ptr& victim, const MWWorld::Ptr& attacker) override;
 
@@ -247,7 +247,7 @@ namespace MWMechanics
             bool canReportCrime(const MWWorld::Ptr &actor, const MWWorld::Ptr &victim, std::set<MWWorld::Ptr> &playerFollowers);
 
             bool reportCrime (const MWWorld::Ptr& ptr, const MWWorld::Ptr& victim,
-                                      OffenseType type, int arg=0);
+                                      OffenseType type, const std::string& factionId, int arg=0);
     };
 }
 


### PR DESCRIPTION
Fixes [bug #3609](https://gitlab.com/OpenMW/openmw/issues/3609) and [bug #5164](https://gitlab.com/OpenMW/openmw/issues/5164).

Summary of changes:
1. Consider using of evidence chest to be a crime against of chest owner even if it is technically allowed (a player has a high rank in the Imperial Legion, for example).
2. Improve tooltips handling with TFH - display a faction rank namy, display a warning about evidence chests.
3. Pass object's cellref faction to the commitCrime, so we can expell player when he commits crime against faction itself, not againts faction members.