### PR TITLE
Continue scripts execution after player's death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,10 +139,11 @@
     Bug #5134: Doors rotation by "Lock" console command is inconsistent
     Bug #5137: Textures with Clamp Mode set to Clamp instead of Wrap are too dark outside the boundaries
     Bug #5149: Failing lock pick attempts isn't always a crime
+    Bug #5158: Objects without a name don't fallback to their ID
     Bug #5159: NiMaterialColorController can only control the diffuse color
     Bug #5161: Creature companions can't be activated when they are knocked down
     Bug #5164: Faction owned items handling is incorrect
-    Bug #5188: Objects without a name don't fallback to their ID
+    Bug #5166: Scripts still should be executed after player's death
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -112,8 +112,8 @@ bool OMW::Engine::frame(float frametime)
         bool guiActive = mEnvironment.getWindowManager()->isGuiMode();
 
         osg::Timer_t beforeScriptTick = osg::Timer::instance()->tick();
-        if (mEnvironment.getStateManager()->getState()==
-            MWBase::StateManager::State_Running)
+        if (mEnvironment.getStateManager()->getState()!=
+            MWBase::StateManager::State_NoGame)
         {
             if (!paused)
             {


### PR DESCRIPTION
Fixes [bug #5166](https://gitlab.com/OpenMW/openmw/issues/5166).

Just treat scripts as an any other part of game simulation (such as game mechanics, physics and world update).