### PR TITLE
Copy transformations data when we clone node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
     Bug #5159: NiMaterialColorController can only control the diffuse color
     Bug #5161: Creature companions can't be activated when they are knocked down
     Bug #5164: Faction owned items handling is incorrect
+    Bug #5163: UserData is not copied during node cloning
     Bug #5166: Scripts still should be executed after player's death
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/components/sceneutil/clone.cpp
+++ b/components/sceneutil/clone.cpp
@@ -6,8 +6,9 @@
 #include <osgParticle/ParticleSystemUpdater>
 #include <osgParticle/Emitter>
 
-#include <components/sceneutil/morphgeometry.hpp>
+#include <components/nifosg/userdata.hpp>
 
+#include <components/sceneutil/morphgeometry.hpp>
 #include <components/sceneutil/riggeometry.hpp>
 
 namespace SceneUtil
@@ -28,6 +29,15 @@ namespace SceneUtil
         if (stateset->getDataVariance() == osg::StateSet::DYNAMIC)
             return osg::clone(stateset, *this);
         return const_cast<osg::StateSet*>(stateset);
+    }
+
+    osg::Object* CopyOp::operator ()(const osg::Object* node) const
+    {
+        // We should copy node transformations when we copy node
+        if (const NifOsg::NodeUserData* data = dynamic_cast<const NifOsg::NodeUserData*>(node))
+            return osg::clone(data, *this);
+
+        return osg::CopyOp::operator()(node);
     }
 
     osg::Node* CopyOp::operator ()(const osg::Node* node) const

--- a/components/sceneutil/clone.hpp
+++ b/components/sceneutil/clone.hpp
@@ -32,6 +32,7 @@ namespace SceneUtil
         virtual osg::Drawable* operator() (const osg::Drawable* drawable) const;
 
         virtual osg::StateSet* operator() (const osg::StateSet* stateset) const;
+        virtual osg::Object* operator ()(const osg::Object* node) const;
 
     private:
         // maps new ParticleProcessor to their old ParticleSystem pointer


### PR DESCRIPTION
Fixes [bug #5163](https://gitlab.com/OpenMW/openmw/issues/5163).

In the master branch we do not copy NodeUserData when we make a copy of node (despite we are supposed to do it by design), so userdata nodes are shared and animation transformations can affect all instances of given node.

So the suggested solution is to copy NodeUserData as well.

Notes:
1. I know that dynamic casts are bad, but the time spent to casts here is much lesser than the time spent to clone NodeUserData nodes (basically, we have one for every NiNode in scene and preloaded objects).
2. Savegame loading becomes slightly slower (it may take a several milliseconds more time depending on scene). In other cases there should not be much difference since we ususally clone objects during preloading.
3. A different possible approach is to use the `osg::CopyOp::DEEP_COPY_OBJECTS`, but in this case we will copy **everything** that is derived from `osg::Object`