### PR TITLE
Fix chance none logic for nested levelled lists (bug #5169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
     Bug #5166: Scripts still should be executed after player's death
     Bug #5167: Player can select and cast spells before magic menu is enabled
     Bug #5168: Force1stPerson and Force3rdPerson commands are not really force view change
+    Bug #5169: Nested levelled items/creatures have significantly higher chance not to spawn
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/levelledlist.hpp
+++ b/apps/openmw/mwmechanics/levelledlist.hpp
@@ -19,16 +19,14 @@ namespace MWMechanics
 {
 
     /// @return ID of resulting item, or empty if none
-    inline std::string getLevelledItem (const ESM::LevelledListBase* levItem, bool creature, unsigned char failChance=0)
+    inline std::string getLevelledItem (const ESM::LevelledListBase* levItem, bool creature)
     {
         const std::vector<ESM::LevelledListBase::LevelItem>& items = levItem->mList;
 
         const MWWorld::Ptr& player = getPlayer();
         int playerLevel = player.getClass().getCreatureStats(player).getLevel();
 
-        failChance += levItem->mChanceNone;
-
-        if (Misc::Rng::roll0to99() < failChance)
+        if (Misc::Rng::roll0to99() < levItem->mChanceNone)
             return std::string();
 
         std::vector<std::string> candidates;
@@ -76,9 +74,9 @@ namespace MWMechanics
         else
         {
             if (ref.getPtr().getTypeName() == typeid(ESM::ItemLevList).name())
-                return getLevelledItem(ref.getPtr().get<ESM::ItemLevList>()->mBase, false, failChance);
+                return getLevelledItem(ref.getPtr().get<ESM::ItemLevList>()->mBase, false);
             else
-                return getLevelledItem(ref.getPtr().get<ESM::CreatureLevList>()->mBase, true, failChance);
+                return getLevelledItem(ref.getPtr().get<ESM::CreatureLevList>()->mBase, true);
         }
     }
 


### PR DESCRIPTION
See my [bug report](https://gitlab.com/OpenMW/openmw/issues/5169) comment for more information.

Removed redundant failChance argument which was messing up the calculations for nested levelled lists. Should increase the chance for Bloodmoon creatures to spawn a lot.

Verified that there *is* a small possibility to find a berserker in the wild now. Previously the chance not to find one was 128%.