### PR TITLE
Improve resurrection handling

### DIFF
--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -225,7 +225,7 @@ namespace MWBase
             virtual bool isAggressive (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target) = 0;
 
             /// Resurrects the player if necessary
-            virtual void keepPlayerAlive() = 0;
+            virtual void resurrect(const MWWorld::Ptr& ptr) = 0;
 
             virtual bool isCastingSpell (const MWWorld::Ptr& ptr) const = 0;
             virtual bool isReadyToBlock (const MWWorld::Ptr& ptr) const = 0;

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1637,6 +1637,20 @@ namespace MWMechanics
         ++mDeathCount[Misc::StringUtils::lowerCase(actor.getCellRef().getRefId())];
     }
 
+    void Actors::resurrect(const MWWorld::Ptr &ptr)
+    {
+        PtrActorMap::iterator iter = mActors.find(ptr);
+        if(iter != mActors.end())
+        {
+            if(iter->second->getCharacterController()->isDead())
+            {
+                // Actor has been resurrected. Notify the CharacterController and re-enable collision.
+                MWBase::Environment::get().getWorld()->enableActorCollision(iter->first, true);
+                iter->second->getCharacterController()->resurrect();
+            }
+        }
+    }
+
     void Actors::killDeadActors()
     {
         for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
@@ -1645,17 +1659,7 @@ namespace MWMechanics
             CreatureStats &stats = cls.getCreatureStats(iter->first);
 
             if(!stats.isDead())
-            {
-                if(iter->second->getCharacterController()->isDead())
-                {
-                    // Actor has been resurrected. Notify the CharacterController and re-enable collision.
-                    MWBase::Environment::get().getWorld()->enableActorCollision(iter->first, true);
-                    iter->second->getCharacterController()->resurrect();
-                }
-
-                if(!stats.isDead())
-                    continue;
-            }
+                continue;
 
             MWBase::Environment::get().getWorld()->removeActorPath(iter->first);
             CharacterController::KillResult killResult = iter->second->getCharacterController()->kill();

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -94,6 +94,8 @@ namespace MWMechanics
             ///
             /// \note Ignored, if \a ptr is not a registered actor.
 
+            void resurrect (const MWWorld::Ptr& ptr);
+
             void castSpell(const MWWorld::Ptr& ptr, const std::string spellId, bool manualSpell=false);
 
             void updateActor(const MWWorld::Ptr &old, const MWWorld::Ptr& ptr);

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -198,9 +198,6 @@ namespace MWMechanics
             mDynamic[index].setModifier(0);
             mDynamic[index].setCurrentModifier(0);
             mDynamic[index].setCurrent(0);
-
-            if (MWBase::Environment::get().getWorld()->getGodModeState())
-                MWBase::Environment::get().getMechanicsManager()->keepPlayerAlive();
         }
     }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1820,12 +1820,14 @@ namespace MWMechanics
         return (fight >= 100);
     }
 
-    void MechanicsManager::keepPlayerAlive()
+    void MechanicsManager::resurrect(const MWWorld::Ptr &ptr)
     {
-        MWWorld::Ptr player = getPlayer();
-        CreatureStats& stats = player.getClass().getCreatureStats(player);
+        CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
         if (stats.isDead())
+        {
             stats.resurrect();
+            mActors.resurrect(ptr);
+        }
     }
 
     bool MechanicsManager::isCastingSpell(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -197,7 +197,7 @@ namespace MWMechanics
 
             virtual bool isAggressive (const MWWorld::Ptr& ptr, const MWWorld::Ptr& target) override;
 
-            virtual void keepPlayerAlive() override;
+            virtual void resurrect(const MWWorld::Ptr& ptr) override;
 
             virtual bool isCastingSpell (const MWWorld::Ptr& ptr) const override;
 

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -1184,7 +1184,7 @@ namespace MWScript
 
                     if (ptr == MWMechanics::getPlayer())
                     {
-                        ptr.getClass().getCreatureStats(ptr).resurrect();
+                        MWBase::Environment::get().getMechanicsManager()->resurrect(ptr);
                         if (MWBase::Environment::get().getStateManager()->getState() == MWBase::StateManager::State_Ended)
                             MWBase::Environment::get().getStateManager()->resumeGame();
                     }


### PR DESCRIPTION
1. Wipe out the `keepPlayerAlive` function, which is a remnants of an old god mode implementation, which was supposed to immediately resurrect player when his health reaches 0.
2. Instead of checking for every dead actor in every frame if he was resurrected, resurrect actor immediately by demand. It should be ok since we actually use resurrection only for player using the `resurrect` console command. Also this change allows to switch view mode properly via scripts immediately after player's resurrection.