### PR TITLE
Implement vanilla-style AiActivate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
+    Bug #4456: AiActivate should not be cancelled after target activation
     Bug #4540: Rain delay when exiting water
     Bug #4600: Crash when no sound output is available or --no-sound is used.
     Bug #4639: Black screen after completing first mages guild mission + training

--- a/apps/openmw/mwmechanics/aiactivate.cpp
+++ b/apps/openmw/mwmechanics/aiactivate.cpp
@@ -9,6 +9,7 @@
 
 #include "creaturestats.hpp"
 #include "movement.hpp"
+#include "steering.hpp"
 
 namespace MWMechanics
 {
@@ -33,16 +34,18 @@ namespace MWMechanics
         if (target == MWWorld::Ptr() || !target.getRefData().getCount() || !target.getRefData().isEnabled())
             return true;
 
-        //Set the target destination for the actor
-        const osg::Vec3f dest = target.getRefData().getPosition().asVec3();
+        // Turn to target and move to it directly, without pathfinding.
+        const osg::Vec3f targetDir = target.getRefData().getPosition().asVec3() - actor.getRefData().getPosition().asVec3();
 
-        if (pathTo(actor, dest, duration, MWBase::Environment::get().getWorld()->getMaxActivationDistance())) //Stop when you get in activation range
+        zTurn(actor, std::atan2(targetDir.x(), targetDir.y()), 0.f);
+        actor.getClass().getMovementSettings(actor).mPosition[1] = 1;
+        actor.getClass().getMovementSettings(actor).mPosition[0] = 0;
+
+        if (MWBase::Environment::get().getWorld()->getMaxActivationDistance() >= targetDir.length())
         {
-            // activate when reached
+            // Note: we intentionally do not cancel package after activation here for backward compatibility with original engine.
             MWBase::Environment::get().getWorld()->activate(target, actor);
-            return true;
         }
-
         return false;
     }
 


### PR DESCRIPTION
Fixes [bug #4456](https://gitlab.com/OpenMW/openmw/issues/4456).

Now AiActivate uses Morrowind's approach - just move directly to target without pathfinding and activate it every frame once it is in activation range.

Note: according to Zini and Capostrophic, we should not implement a "reset" flag from MCP, so we will have only "broken" package version.
