### PR TITLE
[Regression] Fix pickpocket crashes

### DIFF
--- a/apps/openmw/mwgui/pickpocketitemmodel.cpp
+++ b/apps/openmw/mwgui/pickpocketitemmodel.cpp
@@ -98,7 +98,7 @@ namespace MWGui
         if (pickpocket.finish())
         {
             MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
+                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, std::string(), 0, true);
             MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
             mPickpocketDetected = true;
         }
@@ -126,7 +126,7 @@ namespace MWGui
         if (pickpocket.pick(item, count))
         {
             MWBase::Environment::get().getMechanicsManager()->commitCrime(
-                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, 0, true);
+                        player, mActor, MWBase::MechanicsManager::OT_Pickpocket, std::string(), 0, true);
             MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Container);
             mPickpocketDetected = true;
             return false;


### PR DESCRIPTION
These two commitCrime() calls were overlooked and caused either exceptions (GCC) or total crashes (Clang, MSVC, I think).

The internet says binding a temporary to a **const** reference is ok and it doesn't seem to cause anything similar so I left that alone.