### PR TITLE
Implement vanilla-style wind speed calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     Bug #4383: Bow model obscures crosshair when arrow is drawn
     Bug #4384: Resist Normal Weapons only checks ammunition for ranged weapons
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
+    Bug #4449: Value returned by GetWindSpeed is incorrect
     Bug #4540: Rain delay when exiting water
     Bug #4600: Crash when no sound output is available or --no-sound is used.
     Bug #4639: Black screen after completing first mages guild mission + training

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1625,7 +1625,8 @@ void SkyManager::updateRainParameters()
 {
     if (mRainShooter)
     {
-        float windFactor = mWindSpeed/3.f;
+        // Note: an arbitrary value. An original engine seems to use a different approach to rotate raindrops.
+        float windFactor = mWindSpeed/32.f;
         float angle = windFactor * osg::PI/4;
         mRainShooter->setVelocity(osg::Vec3f(0, mRainSpeed * windFactor, -mRainSpeed));
         mRainShooter->setAngle(angle);

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -68,6 +68,8 @@ namespace MWRender
         float mDLFogOffset;
 
         float mWindSpeed;
+        float mCurrentWindSpeed;
+        float mNextWindSpeed;
 
         float mCloudSpeed;
 

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -325,6 +325,8 @@ namespace MWWorld
         MoonModel mSecunda;
 
         float mWindSpeed;
+        float mCurrentWindSpeed;
+        float mNextWindSpeed;
         bool mIsStorm;
         bool mPrecipitation;
         osg::Vec3f mStormDirection;
@@ -355,6 +357,7 @@ namespace MWWorld
         bool updateWeatherRegion(const std::string& playerRegion);
         void updateWeatherTransitions(const float elapsedRealSeconds);
         void forceWeather(const int weatherID);
+        osg::Vec3f calculateStormDirection();
 
         bool inTransition();
         void addWeatherTransition(const int weatherID);
@@ -362,6 +365,7 @@ namespace MWWorld
         void calculateWeatherResult(const float gameHour, const float elapsedSeconds, const bool isPaused);
         void calculateResult(const int weatherID, const float gameHour);
         void calculateTransitionResult(const float factor, const float gameHour);
+        float calculateWindSpeed(int weatherId, float currentSpeed);
     };
 }
 


### PR DESCRIPTION
Fixes [bug #4449](https://gitlab.com/OpenMW/openmw/issues/4449)

Based on  Morrowind's logic, reverse-engeneered by Hrnchamd.

Basically, instead or reading the wind speed from config file, we simulate wind speed every frame for current weather, and next one when the weather transition is active.
The resulting wind speed is a linear inrterpolation between simulated wind speed for current weather and the wind speed for the next one. If there is no next weather, just take the simulated wind speed for current weather.

Note: As a side effect, raindrops now have a variable angle. Not sure if it is a desired behaviour - Morrowind seems to do not take the wind speed in account at all for raindrops.