### PR TITLE
Use random attack strength if there's no wind up animation (bug #5059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
     Bug #5050: Invalid spell effects are not handled gracefully
     Bug #5055: Mark, Recall, Intervention magic effect abilities have no effect when added and removed in the same frame
     Bug #5056: Calling Cast function on player doesn't equip the spell but casts it
+    Bug #5059: Modded animation with combined attack keys always does max damage and can double damage
     Bug #5060: Magic effect visuals stop when death animation begins instead of when it ends
     Bug #5063: Shape named "Tri Shadow" in creature mesh is visible if it isn't hidden
     Bug #5067: Ranged attacks on unaware opponents ("critical hits") differ from the vanilla engine

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1629,7 +1629,9 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         if(mUpperBodyState == UpperCharState_MinAttackToMaxAttack && !isKnockedDown())
         {
             float attackStrength = complete;
-            if (!mPtr.getClass().isNpc())
+            float minAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"min attack");
+            float maxAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"max attack");
+            if (minAttackTime == maxAttackTime)
             {
                 // most creatures don't actually have an attack wind-up animation, so use a uniform random value
                 // (even some creatures that can use weapons don't have a wind-up animation either, e.g. Rieklings)
@@ -1735,7 +1737,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             {
                 // If actor is already stopped preparing attack, do not play the "min attack -> max attack" part.
                 // Happens if the player did not hold the attack button.
-                // Note: if the "min attack"->"max attack" is a stub, "play" it anyway. Attack strength will be 1.
+                // Note: if the "min attack"->"max attack" is a stub, "play" it anyway. Attack strength will be random.
                 float minAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"min attack");
                 float maxAttackTime = mAnimation->getTextKeyTime(mCurrentWeapon+": "+mAttackType+" "+"max attack");
                 if (mAttackingOrSpell || minAttackTime == maxAttackTime)


### PR DESCRIPTION
Use a ~~hack~~ workaround that compares the animation time like in another similar case instead of a check for whether it's a creature or not. Seems to work well enough according to my trusty infallible debug — doesn't break normal NPC attacks, riekling attacks and fixes the NPC test case from the [report](https://gitlab.com/OpenMW/openmw/issues/5059), both anim sets.

Not sure about the double damage issue, if it was a thing it's not obvious anymore.