### PR TITLE
Try to parse strings as number literals (bug #5097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
     Bug #5089: Swimming/Underwater creatures only swim around ground level
     Bug #5092: NPCs with enchanted weapons play sound when out of charges
     Bug #5093: Hand to hand sound plays on knocked out enemies
+    Bug #5097: String arguments can't be parsed as number literals in scripts
     Bug #5099: Non-swimming enemies will enter water if player is water walking
     Bug #5103: Sneaking state behavior is still inconsistent
     Bug #5104: Black Dart's enchantment doesn't trigger at low Enchant levels

--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <stack>
 #include <iterator>
+#include <sstream>
 
 #include <components/misc/stringops.hpp>
 
@@ -324,6 +325,21 @@ namespace Compiler
                 mExplicit = name2;
                 return true;
             }
+
+            // This is terrible, but of course we must have this for legacy content.
+            // Convert the string to a number even if it's impossible and use it as a number literal.
+            // Can't use stof/atof or to_string out of locale concerns.
+            float number;
+            std::stringstream stream(name2);
+            stream >> number;
+            stream.str(std::string());
+            stream.clear();
+            stream << number;
+
+            pushFloatLiteral(number);
+            mTokenLoc = loc;
+            getErrorHandler().warning ("Parsing a non-variable string as a number: " + stream.str(), loc);
+            return true;
         }
         else
         {


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5097)

It has been a month since the last activity on the other relevant PR, so I decided to add the hack myself.

Using a stringstream to convert the string into a number and back (for the warning message) because it doesn't care about the locale. Also warning the user that something weird could have happened due to this.