### PR TITLE
Remove unused field QuadTreeBuilder::mLodFactor

### DIFF
--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -210,7 +210,6 @@ public:
 private:
     Terrain::Storage* mStorage;
 
-    float mLodFactor;
     float mMinX, mMaxX, mMinY, mMaxY;
     float mMinSize;
 


### PR DESCRIPTION
The field is unused since ebcf8ca062857da2bc3bed52395329464612896d