### PR TITLE
Do not stack initially added scripted items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
     Bug #5124: Arrow remains attached to actor if pulling animation was cancelled
     Bug #5126: Swimming creatures without RunForward animations are motionless during combat
     Bug #5134: Doors rotation by "Lock" console command is inconsistent
+    Bug #5136: LegionUniform script: can not access local variables
     Bug #5137: Textures with Clamp Mode set to Clamp instead of Wrap are too dark outside the boundaries
     Bug #5149: Failing lock pick attempts isn't always a crime
     Bug #5155: Lock/unlock behavior differs from vanilla

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -94,6 +94,7 @@ namespace MWWorld
             mutable bool mWeightUpToDate;
             ContainerStoreIterator addImp (const Ptr& ptr, int count);
             void addInitialItem (const std::string& id, const std::string& owner, int count, bool topLevel=true, const std::string& levItem = "");
+            void addInitialItemImp (const MWWorld::Ptr& ptr, const std::string& owner, int count, bool topLevel=true, const std::string& levItem = "");
 
             template<typename T>
             ContainerStoreIterator getState (CellRefList<T>& collection,


### PR DESCRIPTION
Initially we allowed to stack scripted items, but changed this behaviour later. But restocking is still designed to work with an old behaviour. As a result, scripted items still can form stacks if they were initially present in container or were added via restocking.

This PR adds scripted items one by one during initial filling or restocking, as we already do with the `addItem` console command. As a side effect, this PR also fixes [bug #5136](https://gitlab.com/OpenMW/openmw/issues/5136), for old saves too.