### PR TITLE
Revert to 0.45.0 comments-in-the-middle settings parsing behavior 

### DIFF
--- a/components/fallback/fallback.cpp
+++ b/components/fallback/fallback.cpp
@@ -1,8 +1,8 @@
 #include "fallback.hpp"
 
-#include <components/debug/debuglog.hpp>
+#include <sstream>
 
-#include <boost/lexical_cast.hpp>
+#include <components/debug/debuglog.hpp>
 
 namespace Fallback
 {
@@ -28,16 +28,10 @@ namespace Fallback
         const std::string& fallback = getString(fall);
         if (!fallback.empty())
         {
-            try
-            {
-                // We have to rely on Boost because std::stof from C++11 uses the current locale
-                // for separators (which is undesired) and it often silently ignores parsing errors.
-                return boost::lexical_cast<float>(fallback);
-            }
-            catch (boost::bad_lexical_cast&)
-            {
-                Log(Debug::Error) << "Error: '" << fall << "' setting value (" << fallback << ") is not a valid number, using 0 as a fallback";
-            }
+            std::stringstream stream(fallback);
+            float number = 0.f;
+            stream >> number;
+            return number;
         }
 
         return 0;
@@ -48,18 +42,10 @@ namespace Fallback
         const std::string& fallback = getString(fall);
         if (!fallback.empty())
         {
-            try
-            {
-                return std::stoi(fallback);
-            }
-            catch (const std::invalid_argument&)
-            {
-                Log(Debug::Error) << "Error: '" << fall << "' setting value (" << fallback << ") is not a valid number, using 0 as a fallback";
-            }
-            catch (const std::out_of_range&)
-            {
-                Log(Debug::Error) << "Error: '" << fall << "' setting value (" << fallback << ") is out of range, using 0 as a fallback";
-            }
+            std::stringstream stream(fallback);
+            int number = 0;
+            stream >> number;
+            return number;
         }
 
         return 0;

--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -1,10 +1,9 @@
 #include "settings.hpp"
 #include "parser.hpp"
 
-#include <components/debug/debuglog.hpp>
-#include <components/misc/stringops.hpp>
+#include <sstream>
 
-#include <boost/lexical_cast.hpp>
+#include <components/misc/stringops.hpp>
 
 namespace Settings
 {
@@ -55,32 +54,20 @@ std::string Manager::getString(const std::string &setting, const std::string &ca
 
 float Manager::getFloat (const std::string& setting, const std::string& category)
 {
-    const std::string value = getString(setting, category);
-    try
-    {
-        // We have to rely on Boost because std::stof from C++11 uses the current locale
-        // for separators (which is undesired) and it often silently ignores parsing errors.
-        return boost::lexical_cast<float>(value);
-    }
-    catch (boost::bad_lexical_cast&)
-    {
-        Log(Debug::Warning) << "Cannot parse setting '" << setting << "' (invalid setting value: " << value << ").";
-        return 0.f;
-    }
+    const std::string& value = getString(setting, category);
+    std::stringstream stream(value);
+    float number = 0.f;
+    stream >> number;
+    return number;
 }
 
 int Manager::getInt (const std::string& setting, const std::string& category)
 {
-    const std::string value = getString(setting, category);
-    try
-    {
-        return std::stoi(value);
-    }
-    catch(const std::exception& e)
-    {
-        Log(Debug::Warning) << "Cannot parse setting '" << setting << "' (invalid setting value: " << value << ").";
-        return 0;
-    }
+    const std::string& value = getString(setting, category);
+    std::stringstream stream(value);
+    int number = 0;
+    stream >> number;
+    return number;
 }
 
 bool Manager::getBool (const std::string& setting, const std::string& category)


### PR DESCRIPTION
Use stringstreams again to avoid issues with stoi arising when comments are used that break users' games. A possible better solution is left up to further discussion.

Note that while error logging was removed it doesn't revert the intended "fix" for issue 4768.

There are actually less dependencies now.