### PR TITLE
Rework corprus implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     Bug #1952: Incorrect particle lighting
     Bug #2311: Targeted scripts are not properly supported on non-unique RefIDs
     Bug #3676: NiParticleColorModifier isn't applied properly
+    Bug #3714: Savegame fails to load due to conflict between SpellState and MagicEffects
+    Bug #4623: Corprus implementation is incorrect
     Bug #4774: Guards are ignorant of an invisible player that tries to attack them
     Bug #5108: Savegame bloating due to inefficient fog textures format
     Bug #5165: Active spells should use real time intead of timestamps

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -280,6 +280,8 @@ namespace MWBase
             virtual float getAngleToPlayer(const MWWorld::Ptr& ptr) const  = 0;
             virtual MWMechanics::GreetingState getGreetingState(const MWWorld::Ptr& ptr) const = 0;
             virtual bool isTurningToPlayer(const MWWorld::Ptr& ptr) const = 0;
+
+            virtual void restoreStatsAfterCorprus(const MWWorld::Ptr& actor, const std::string& sourceId) = 0;
     };
 }
 

--- a/apps/openmw/mwgui/jailscreen.cpp
+++ b/apps/openmw/mwgui/jailscreen.cpp
@@ -81,6 +81,12 @@ namespace MWGui
         MWBase::Environment::get().getMechanicsManager()->rest(mDays * 24, true);
         MWBase::Environment::get().getWorld()->advanceTime(mDays * 24);
 
+        // We should not worsen corprus when in prison
+        for (auto& spell : player.getClass().getCreatureStats(player).getCorprusSpells())
+        {
+            spell.second.mNextWorsening += mDays * 24;
+        }
+
         std::set<int> skills;
         for (int day=0; day<mDays; ++day)
         {

--- a/apps/openmw/mwmechanics/activespells.hpp
+++ b/apps/openmw/mwmechanics/activespells.hpp
@@ -99,6 +99,8 @@ namespace MWMechanics
             bool isSpellActive (const std::string& id) const;
             ///< case insensitive
 
+            void purgeCorprusDisease();
+
             const MagicEffects& getMagicEffects() const;
 
             void visitEffectSources (MWMechanics::EffectSourceVisitor& visitor) const;

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -551,6 +551,14 @@ namespace MWMechanics
         state.mHasAiSettings = true;
         for (int i=0; i<4; ++i)
             mAiSettings[i].writeState (state.mAiSettings[i]);
+
+        for (auto it = mCorprusSpells.begin(); it != mCorprusSpells.end(); ++it)
+        {
+            for (int i=0; i<ESM::Attribute::Length; ++i)
+                state.mCorprusSpells[it->first].mWorsenings[i] = mCorprusSpells.at(it->first).mWorsenings[i];
+
+            state.mCorprusSpells[it->first].mNextWorsening = mCorprusSpells.at(it->first).mNextWorsening.toEsm();
+        }
     }
 
     void CreatureStats::readState (const ESM::CreatureStats& state)
@@ -589,7 +597,7 @@ namespace MWMechanics
         mTimeOfDeath = MWWorld::TimeStamp(state.mTimeOfDeath);
         //mHitAttemptActorId = state.mHitAttemptActorId;
 
-        mSpells.readState(state.mSpells);
+        mSpells.readState(state.mSpells, this);
         mActiveSpells.readState(state.mActiveSpells);
         mAiSequence.readState(state.mAiSequence);
         mMagicEffects.readState(state.mMagicEffects);
@@ -600,6 +608,15 @@ namespace MWMechanics
         if (state.mHasAiSettings)
             for (int i=0; i<4; ++i)
                 mAiSettings[i].readState(state.mAiSettings[i]);
+
+        mCorprusSpells.clear();
+        for (auto it = state.mCorprusSpells.begin(); it != state.mCorprusSpells.end(); ++it)
+        {
+            for (int i=0; i<ESM::Attribute::Length; ++i)
+                mCorprusSpells[it->first].mWorsenings[i] = state.mCorprusSpells.at(it->first).mWorsenings[i];
+
+            mCorprusSpells[it->first].mNextWorsening = MWWorld::TimeStamp(state.mCorprusSpells.at(it->first).mNextWorsening);
+        }
     }
 
     void CreatureStats::setLastRestockTime(MWWorld::TimeStamp tradeTime)
@@ -674,5 +691,24 @@ namespace MWMechanics
     std::vector<int>& CreatureStats::getSummonedCreatureGraveyard()
     {
         return mSummonGraveyard;
+    }
+
+    std::map<std::string, CorprusStats> &CreatureStats::getCorprusSpells()
+    {
+        return mCorprusSpells;
+    }
+
+    void CreatureStats::addCorprusSpell(const std::string& sourceId, CorprusStats& stats)
+    {
+        mCorprusSpells[sourceId] = stats;
+    }
+
+    void CreatureStats::removeCorprusSpell(const std::string& sourceId)
+    {
+        auto corprusIt = mCorprusSpells.find(sourceId);
+        if (corprusIt != mCorprusSpells.end())
+        {
+            mCorprusSpells.erase(corprusIt);
+        }
     }
 }

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -12,6 +12,8 @@
 #include "aisequence.hpp"
 #include "drawstate.hpp"
 
+#include <components/esm/attr.hpp>
+
 namespace ESM
 {
     struct CreatureStats;
@@ -19,6 +21,14 @@ namespace ESM
 
 namespace MWMechanics
 {
+    struct CorprusStats
+    {
+        static const int sWorseningPeriod = 24;
+
+        int mWorsenings[ESM::Attribute::Length];
+        MWWorld::TimeStamp mNextWorsening;
+    };
+
     /// \brief Common creature stats
     ///
     ///
@@ -26,7 +36,7 @@ namespace MWMechanics
     {
         static int sActorId;
         DrawState_ mDrawState;
-        AttributeValue mAttributes[8];
+        AttributeValue mAttributes[ESM::Attribute::Length];
         DynamicStat<float> mDynamic[3]; // health, magicka, fatigue
         Spells mSpells;
         ActiveSpells mActiveSpells;
@@ -78,6 +88,8 @@ namespace MWMechanics
         // Contains ActorIds of summoned creatures with an expired lifetime that have not been deleted yet.
         // This may be necessary when the creature is in an inactive cell.
         std::vector<int> mSummonGraveyard;
+
+        std::map<std::string, CorprusStats> mCorprusSpells;
 
     protected:
         int mLevel;
@@ -280,6 +292,12 @@ namespace MWMechanics
         /// assigned this function will return false).
 
         static void cleanup();
+
+        std::map<std::string, CorprusStats> & getCorprusSpells();
+
+        void addCorprusSpell(const std::string& sourceId, CorprusStats& stats);
+
+        void removeCorprusSpell(const std::string& sourceId);
     };
 }
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -289,6 +289,24 @@ namespace MWMechanics
         mWatched = ptr;
     }
 
+    void MechanicsManager::restoreStatsAfterCorprus(const MWWorld::Ptr& actor, const std::string& sourceId)
+    {
+        auto& stats = actor.getClass().getCreatureStats (actor);
+        auto& corprusSpells = stats.getCorprusSpells();
+
+        auto corprusIt = corprusSpells.find(sourceId);
+
+        if (corprusIt != corprusSpells.end())
+        {
+            for (int i = 0; i < ESM::Attribute::Length; ++i)
+            {
+                MWMechanics::AttributeValue attr = stats.getAttribute(i);
+                attr.restore(corprusIt->second.mWorsenings[i]);
+                actor.getClass().getCreatureStats(actor).setAttribute(i, attr);
+            }
+        }
+    }
+
     void MechanicsManager::update(float duration, bool paused)
     {
         if(!mWatched.isEmpty())

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -247,6 +247,8 @@ namespace MWMechanics
             virtual GreetingState getGreetingState(const MWWorld::Ptr& ptr) const override;
             virtual bool isTurningToPlayer(const MWWorld::Ptr& ptr) const override;
 
+            virtual void restoreStatsAfterCorprus(const MWWorld::Ptr& actor, const std::string& sourceId) override;
+
         private:
             bool canCommitCrimeAgainst(const MWWorld::Ptr& victim, const MWWorld::Ptr& attacker);
             bool canReportCrime(const MWWorld::Ptr &actor, const MWWorld::Ptr &victim, std::set<MWWorld::Ptr> &playerFollowers);

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -7,9 +7,13 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 
+#include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
 
+#include "actorutil.hpp"
+#include "creaturestats.hpp"
 #include "magiceffects.hpp"
+#include "stat.hpp"
 
 namespace MWMechanics
 {
@@ -63,12 +67,6 @@ namespace MWMechanics
                 }
             }
         }
-
-        for (std::map<SpellKey, MagicEffects>::const_iterator it = mPermanentSpellEffects.begin(); it != mPermanentSpellEffects.end(); ++it)
-        {
-            mEffects += it->second;
-            mSourcedEffects[it->first] += it->second;
-        }
     }
 
     bool Spells::hasSpell(const std::string &spell) const
@@ -101,15 +99,6 @@ namespace MWMechanics
                 }
             }
 
-            if (hasCorprusEffect(spell))
-            {
-                CorprusStats corprus;
-                corprus.mWorsenings = 0;
-                corprus.mNextWorsening = MWBase::Environment::get().getWorld()->getTimeStamp() + CorprusStats::sWorseningPeriod;
-
-                mCorprusSpells[spell] = corprus;
-            }
-
             SpellParams params;
             params.mEffectRands = random;
             mSpells.insert (std::make_pair (spell, params));
@@ -126,27 +115,6 @@ namespace MWMechanics
     {
         const ESM::Spell* spell = getSpell(spellId);
         TContainer::iterator iter = mSpells.find (spell);
-
-        std::map<SpellKey, CorprusStats>::iterator corprusIt = mCorprusSpells.find(spell);
-
-        // if it's corprus, remove negative and keep positive effects
-        if (corprusIt != mCorprusSpells.end())
-        {
-            worsenCorprus(spell);
-            if (mPermanentSpellEffects.find(spell) != mPermanentSpellEffects.end())
-            {
-                MagicEffects & effects = mPermanentSpellEffects[spell];
-                for (MagicEffects::Collection::const_iterator effectIt = effects.begin(); effectIt != effects.end();)
-                {
-                    const ESM::MagicEffect * magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectIt->first.mId);
-                    if (magicEffect->mData.mFlags & ESM::MagicEffect::Harmful)
-                        effects.remove((effectIt++)->first);
-                    else
-                        ++effectIt;
-                }
-            }
-            mCorprusSpells.erase(corprusIt);
-        }
 
         if (iter!=mSpells.end())
         {
@@ -320,31 +288,6 @@ namespace MWMechanics
         }
     }
 
-    void Spells::worsenCorprus(const ESM::Spell* spell)
-    {
-        mCorprusSpells[spell].mNextWorsening = MWBase::Environment::get().getWorld()->getTimeStamp() + CorprusStats::sWorseningPeriod;
-        mCorprusSpells[spell].mWorsenings++;
-
-        // update worsened effects
-        mPermanentSpellEffects[spell] = MagicEffects();
-        int i=0;
-        for (std::vector<ESM::ENAMstruct>::const_iterator effectIt = spell->mEffects.mList.begin(); effectIt != spell->mEffects.mList.end(); ++effectIt, ++i)
-        {
-            const ESM::MagicEffect * magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectIt->mEffectID);
-            if ((effectIt->mEffectID != ESM::MagicEffect::Corprus) && (magicEffect->mData.mFlags & ESM::MagicEffect::AppliedOnce))
-            {
-                float random = 1.f;
-                if (mSpells[spell].mEffectRands.find(i) != mSpells[spell].mEffectRands.end())
-                    random = mSpells[spell].mEffectRands.at(i);
-
-                float magnitude = effectIt->mMagnMin + (effectIt->mMagnMax - effectIt->mMagnMin) * random;
-                magnitude *= std::max(1, mCorprusSpells[spell].mWorsenings);
-                mPermanentSpellEffects[spell].add(MWMechanics::EffectKey(*effectIt), MWMechanics::EffectParam(magnitude));
-                mSpellsChanged = true;
-            }
-        }
-    }
-
     bool Spells::hasCorprusEffect(const ESM::Spell *spell)
     {
         for (std::vector<ESM::ENAMstruct>::const_iterator effectIt = spell->mEffects.mList.begin(); effectIt != spell->mEffects.mList.end(); ++effectIt)
@@ -355,11 +298,6 @@ namespace MWMechanics
             }
         }
         return false;
-    }
-
-    const std::map<Spells::SpellKey, Spells::CorprusStats> &Spells::getCorprusSpells() const
-    {
-        return mCorprusSpells;
     }
 
     void Spells::purgeEffect(int effectId)
@@ -412,7 +350,7 @@ namespace MWMechanics
         mUsedPowers[spell] = MWBase::Environment::get().getWorld()->getTimeStamp();
     }
 
-    void Spells::readState(const ESM::SpellState &state)
+    void Spells::readState(const ESM::SpellState &state, CreatureStats* creatureStats)
     {
         for (ESM::SpellState::TContainer::const_iterator it = state.mSpells.begin(); it != state.mSpells.end(); ++it)
         {
@@ -436,6 +374,32 @@ namespace MWMechanics
             mUsedPowers[spell] = MWWorld::TimeStamp(it->second);
         }
 
+        for (std::map<std::string, ESM::SpellState::CorprusStats>::const_iterator it = state.mCorprusSpells.begin(); it != state.mCorprusSpells.end(); ++it)
+        {
+            const ESM::Spell * spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(it->first);
+            if (!spell)
+                continue;
+
+            CorprusStats stats;
+
+            int worsening = state.mCorprusSpells.at(it->first).mWorsenings;
+
+            for (int i=0; i<ESM::Attribute::Length; ++i)
+                stats.mWorsenings[i] = 0;
+
+            for (auto& effect : spell->mEffects.mList)
+            {
+                if (effect.mEffectID == ESM::MagicEffect::DrainAttribute)
+                    stats.mWorsenings[effect.mAttribute] = worsening;
+            }
+            stats.mNextWorsening = MWWorld::TimeStamp(state.mCorprusSpells.at(it->first).mNextWorsening);
+
+            creatureStats->addCorprusSpell(it->first, stats);
+        }
+
+        mSpellsChanged = true;
+
+        // Permanent effects are used only to keep the custom magnitude of corprus spells effects (after cure too), and only in old saves. Convert data to the new approach.
         for (std::map<std::string, std::vector<ESM::SpellState::PermanentSpellEffectInfo> >::const_iterator it =
             state.mPermanentSpellEffects.begin(); it != state.mPermanentSpellEffects.end(); ++it)
         {
@@ -443,24 +407,31 @@ namespace MWMechanics
             if (!spell)
                 continue;
 
-            mPermanentSpellEffects[spell] = MagicEffects();
+            // Import data only for player, other actors should not suffer from corprus worsening.
+            MWWorld::Ptr player = getPlayer();
+            if (creatureStats->getActorId() != player.getClass().getCreatureStats(player).getActorId())
+                return;
+
+            // Note: if target actor has the Restore attirbute effects, stats will be restored.
             for (std::vector<ESM::SpellState::PermanentSpellEffectInfo>::const_iterator effectIt = it->second.begin(); effectIt != it->second.end(); ++effectIt)
             {
-                mPermanentSpellEffects[spell].add(EffectKey(effectIt->mId, effectIt->mArg), effectIt->mMagnitude);
+                // Applied corprus effects are already in loaded stats modifiers
+                if (effectIt->mId == ESM::MagicEffect::FortifyAttribute)
+                {
+                    AttributeValue attr = creatureStats->getAttribute(effectIt->mArg);
+                    attr.setModifier(attr.getModifier() - effectIt->mMagnitude);
+                    attr.damage(-effectIt->mMagnitude);
+                    creatureStats->setAttribute(effectIt->mArg, attr);
+                }
+                else if (effectIt->mId == ESM::MagicEffect::DrainAttribute)
+                {
+                    AttributeValue attr = creatureStats->getAttribute(effectIt->mArg);
+                    attr.setModifier(attr.getModifier() + effectIt->mMagnitude);
+                    attr.damage(effectIt->mMagnitude);
+                    creatureStats->setAttribute(effectIt->mArg, attr);
+                }
             }
         }
-
-        mCorprusSpells.clear();
-        for (std::map<std::string, ESM::SpellState::CorprusStats>::const_iterator it = state.mCorprusSpells.begin(); it != state.mCorprusSpells.end(); ++it)
-        {
-            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(it->first);
-            if (!spell) // Discard unavailable corprus spells
-                continue;
-            mCorprusSpells[spell].mWorsenings = state.mCorprusSpells.at(it->first).mWorsenings;
-            mCorprusSpells[spell].mNextWorsening = MWWorld::TimeStamp(state.mCorprusSpells.at(it->first).mNextWorsening);
-        }
-
-        mSpellsChanged = true;
     }
 
     void Spells::writeState(ESM::SpellState &state) const
@@ -477,26 +448,5 @@ namespace MWMechanics
 
         for (std::map<SpellKey, MWWorld::TimeStamp>::const_iterator it = mUsedPowers.begin(); it != mUsedPowers.end(); ++it)
             state.mUsedPowers[it->first->mId] = it->second.toEsm();
-
-        for (std::map<SpellKey, MagicEffects>::const_iterator it = mPermanentSpellEffects.begin(); it != mPermanentSpellEffects.end(); ++it)
-        {
-            std::vector<ESM::SpellState::PermanentSpellEffectInfo> effectList;
-            for (MagicEffects::Collection::const_iterator effectIt = it->second.begin(); effectIt != it->second.end(); ++effectIt)
-            {
-                ESM::SpellState::PermanentSpellEffectInfo info;
-                info.mId = effectIt->first.mId;
-                info.mArg = effectIt->first.mArg;
-                info.mMagnitude = effectIt->second.getModifier();
-
-                effectList.push_back(info);
-            }
-            state.mPermanentSpellEffects[it->first->mId] = effectList;
-        }
-
-        for (std::map<SpellKey, CorprusStats>::const_iterator it = mCorprusSpells.begin(); it != mCorprusSpells.end(); ++it)
-        {
-            state.mCorprusSpells[it->first->mId].mWorsenings = mCorprusSpells.at(it->first).mWorsenings;
-            state.mCorprusSpells[it->first->mId].mNextWorsening = mCorprusSpells.at(it->first).mNextWorsening.toEsm();
-        }
     }
 }

--- a/apps/openmw/mwmechanics/spells.hpp
+++ b/apps/openmw/mwmechanics/spells.hpp
@@ -22,6 +22,8 @@ namespace ESM
 
 namespace MWMechanics
 {
+    class CreatureStats;
+
     class MagicEffects;
 
     /// \brief Spell list
@@ -33,7 +35,8 @@ namespace MWMechanics
         public:
 
             typedef const ESM::Spell* SpellKey;
-            struct SpellParams {
+            struct SpellParams
+            {
                 std::map<int, float> mEffectRands; // <effect index, normalised random magnitude>
                 std::set<int> mPurgedEffects; // indices of purged effects
             };
@@ -41,26 +44,13 @@ namespace MWMechanics
             typedef std::map<SpellKey, SpellParams> TContainer;
             typedef TContainer::const_iterator TIterator;
 
-            struct CorprusStats
-            {
-                static const int sWorseningPeriod = 24;
-
-                int mWorsenings;
-                MWWorld::TimeStamp mNextWorsening;
-            };
-
         private:
             TContainer mSpells;
-
-            // spell-tied effects that will be applied even after removing the spell (currently used to keep positive effects when corprus is removed)
-            std::map<SpellKey, MagicEffects> mPermanentSpellEffects;
 
             // Note: this is the spell that's about to be cast, *not* the spell selected in the GUI (which may be different)
             std::string mSelectedSpell;
 
             std::map<SpellKey, MWWorld::TimeStamp> mUsedPowers;
-
-            std::map<SpellKey, CorprusStats> mCorprusSpells;
 
             mutable bool mSpellsChanged;
             mutable MagicEffects mEffects;
@@ -73,9 +63,7 @@ namespace MWMechanics
         public:
             Spells();
 
-            void worsenCorprus(const ESM::Spell* spell);
             static bool hasCorprusEffect(const ESM::Spell *spell);
-            const std::map<SpellKey, CorprusStats> & getCorprusSpells() const;
 
             void purgeEffect(int effectId);
             void purgeEffect(int effectId, const std::string & sourceId);
@@ -128,7 +116,7 @@ namespace MWMechanics
 
             void visitEffectSources (MWMechanics::EffectSourceVisitor& visitor) const;
 
-            void readState (const ESM::SpellState& state);
+            void readState (const ESM::SpellState& state, CreatureStats* creatureStats);
             void writeState (ESM::SpellState& state) const;
     };
 }

--- a/apps/openmw/mwmechanics/stat.cpp
+++ b/apps/openmw/mwmechanics/stat.cpp
@@ -256,10 +256,17 @@ namespace MWMechanics
 
     void AttributeValue::damage(float damage)
     {
-        mDamage += std::min(damage, (float)getModified());
+        float threshold = mBase + mModifier;
+
+        if (mDamage + damage > threshold)
+            mDamage = threshold;
+        else
+            mDamage += damage;
     }
     void AttributeValue::restore(float amount)
     {
+        if (mDamage <= 0) return;
+
         mDamage -= std::min(mDamage, amount);
     }
 

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -499,6 +499,7 @@ namespace MWScript
                             creatureStats.getSpells().purgeEffect(effect.first.mId);
                     }
 
+                    MWBase::Environment::get().getMechanicsManager()->restoreStatsAfterCorprus(ptr, id);
                     creatureStats.getSpells().remove (id);
 
                     MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -921,16 +921,16 @@ void MWWorld::InventoryStore::visitEffectSources(MWMechanics::EffectSourceVisito
     }
 }
 
-void MWWorld::InventoryStore::purgeEffect(short effectId)
+void MWWorld::InventoryStore::purgeEffect(short effectId, bool wholeSpell)
 {
     for (TSlots::const_iterator it = mSlots.begin(); it != mSlots.end(); ++it)
     {
         if (*it != end())
-            purgeEffect(effectId, (*it)->getCellRef().getRefId());
+            purgeEffect(effectId, (*it)->getCellRef().getRefId(), wholeSpell);
     }
 }
 
-void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sourceId)
+void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sourceId, bool wholeSpell)
 {
     TEffectMagnitudes::iterator effectMagnitudeIt = mPermanentMagicEffectMagnitudes.find(sourceId);
     if (effectMagnitudeIt == mPermanentMagicEffectMagnitudes.end())
@@ -962,6 +962,12 @@ void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sou
             {
                 if (effectIt->mEffectID != effectId)
                     continue;
+
+                if (wholeSpell)
+                {
+                    mPermanentMagicEffectMagnitudes.erase(sourceId);
+                    return;
+                }
 
                 float magnitude = effectIt->mMagnMin + (effectIt->mMagnMax - effectIt->mMagnMin) * params[i].mRandom;
                 magnitude *= params[i].mMultiplier;

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -203,10 +203,10 @@ namespace MWWorld
 
             void visitEffectSources (MWMechanics::EffectSourceVisitor& visitor);
 
-            void purgeEffect (short effectId);
+            void purgeEffect (short effectId, bool wholeSpell = false);
             ///< Remove a magic effect
 
-            void purgeEffect (short effectId, const std::string& sourceId);
+            void purgeEffect (short effectId, const std::string& sourceId, bool wholeSpell = false);
             ///< Remove a magic effect
 
             virtual void clear();

--- a/components/esm/attr.hpp
+++ b/components/esm/attr.hpp
@@ -21,7 +21,7 @@ struct Attribute
         Endurance = 5,
         Personality = 6,
         Luck = 7,
-        Length
+        Length = 8
     };
 
     AttributeID mId;

--- a/components/esm/creaturestats.cpp
+++ b/components/esm/creaturestats.cpp
@@ -134,6 +134,17 @@ void ESM::CreatureStats::load (ESMReader &esm)
         for (int i=0; i<4; ++i)
             mAiSettings[i].load(esm);
     }
+
+    while (esm.isNextSub("CORP"))
+    {
+        std::string id = esm.getHString();
+
+        CorprusStats stats;
+        esm.getHNT(stats.mWorsenings, "WORS");
+        esm.getHNT(stats.mNextWorsening, "TIME");
+
+        mCorprusSpells[id] = stats;
+    }
 }
 
 void ESM::CreatureStats::save (ESMWriter &esm) const
@@ -218,6 +229,15 @@ void ESM::CreatureStats::save (ESMWriter &esm) const
         for (int i=0; i<4; ++i)
             mAiSettings[i].save(esm);
     }
+
+    for (std::map<std::string, CorprusStats>::const_iterator it = mCorprusSpells.begin(); it != mCorprusSpells.end(); ++it)
+    {
+        esm.writeHNString("CORP", it->first);
+
+        const CorprusStats & stats = it->second;
+        esm.writeHNT("WORS", stats.mWorsenings);
+        esm.writeHNT("TIME", stats.mNextWorsening);
+    }
 }
 
 void ESM::CreatureStats::blank()
@@ -245,4 +265,5 @@ void ESM::CreatureStats::blank()
     mDrawState = 0;
     mDeathAnimation = -1;
     mLevel = 1;
+    mCorprusSpells.clear();
 }

--- a/components/esm/creaturestats.hpp
+++ b/components/esm/creaturestats.hpp
@@ -9,6 +9,7 @@
 
 #include "defs.hpp"
 
+#include "attr.hpp"
 #include "spellstate.hpp"
 #include "activespells.hpp"
 #include "magiceffects.hpp"
@@ -22,7 +23,13 @@ namespace ESM
     // format 0, saved games only
     struct CreatureStats
     {
-        StatState<int> mAttributes[8];
+        struct CorprusStats
+        {
+            int mWorsenings[Attribute::Length];
+            TimeStamp mNextWorsening;
+        };
+
+        StatState<int> mAttributes[Attribute::Length];
         StatState<float> mDynamic[3];
 
         MagicEffects mMagicEffects;
@@ -76,9 +83,9 @@ namespace ESM
         int mDrawState;
         signed char mDeathAnimation;
         ESM::TimeStamp mTimeOfDeath;
-
         int mLevel;
 
+        std::map<std::string, CorprusStats> mCorprusSpells;
         SpellState mSpells;
         ActiveSpells mActiveSpells;
 

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -5,7 +5,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 9;
+int ESM::SavedGame::sCurrentFormat = 10;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {

--- a/components/esm/spellstate.hpp
+++ b/components/esm/spellstate.hpp
@@ -29,15 +29,16 @@ namespace ESM
             float mMagnitude;
         };
 
-        struct SpellParams {
+        struct SpellParams
+        {
             std::map<int, float> mEffectRands;
             std::set<int> mPurgedEffects;
         };
         typedef std::map<std::string, SpellParams> TContainer;
         TContainer mSpells;
 
+        // FIXME: obsolete, used only for old saves
         std::map<std::string, std::vector<PermanentSpellEffectInfo> > mPermanentSpellEffects;
-
         std::map<std::string, CorprusStats> mCorprusSpells;
 
         std::map<std::string, TimeStamp> mUsedPowers;


### PR DESCRIPTION
Fixes [bug #4623](https://gitlab.com/OpenMW/openmw/issues/4623) and [bug #3714](https://gitlab.com/OpenMW/openmw/issues/3714).

**Warning: this PR changes a savegame format!**

Our current corprus implementation is horribly incorrect.

When Morrowind worsens corprus, it just damages attributes by positive or negative amount. This PR replicates such behaviour. 
The `mPermanentEffects` map is redundant now, and I do not use data from it.

An additional bonus - added a workaround to load saves which failed to load due to design flaw of our old corprus implementation.

Note: the "Restore attribute to 1 point below base value" seems to be a rounding error. I see no reason to replicate such behaviour and restore attributes to their base values after curing the corprus.

Known Morrowind's quirks here:
1. It is possible to create a spell or enchantment with corprus effect in Morrowind. They should work too.
2. Morrowind seems to remember how many points of each attribute it needs to restore, but it does not store such info in savegame. As a result, when there is a save-load between corprus worsening and curing, atrributes may not be restored properly.
3. Morrowind does not apply corprus worsening for NPC's.
4. When temporary corprus effect from spell expires, Morrowind removes the whole spell.
5. Worsening should use effect's magnitude, applied to target, instead of 1.
6. Worsening does not happen in Morrowind during time fast-forwarding in prison.