### PR TITLE
Make map cameras and pending images update run once per frame again

### DIFF
--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -856,13 +856,18 @@ namespace MWGui
 
     void MapWindow::cellExplored(int x, int y)
     {
-        mGlobalMapRender->cleanupCameras();
         mGlobalMapRender->exploreCell(x, y, mLocalMapRender->getMapTexture(x, y));
+    }
+
+    void MapWindow::cleanupCameras()
+    {
+        mGlobalMapRender->cleanupCameras();
     }
 
     void MapWindow::onFrame(float dt)
     {
         LocalMapBase::onFrame(dt);
+        cleanupCameras();
         NoDrop::onFrame(dt);
     }
 

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -222,6 +222,8 @@ namespace MWGui
         // reveals this cell's map on the global map
         void cellExplored(int x, int y);
 
+        void cleanupCameras();
+
         void setGlobalMapPlayerPosition (float worldX, float worldY);
         void setGlobalMapPlayerDir(const float x, const float y);
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1040,6 +1040,9 @@ namespace MWGui
 
         mDragAndDrop->onFrame();
 
+        if (!mMap->isVisible())
+            mMap->cleanupCameras();
+
         mHud->onFrame(frameDuration);
 
         mDebugWindow->onFrame(frameDuration);


### PR DESCRIPTION
Apparently this bzzt's change caused issues, probably like the issue in [this](https://gitlab.com/OpenMW/openmw/issues/5176) report.

cleanupCameras is supposed to be run once per frame (note how it gives time to draw thread to run and now the last few visited cells, the same number as there were frames, get dropped upon saving and loading). Due to the changes it was run once per cell exploration so pending images and cameras weren't updated properly, causing the last few explored cells not getting added into the overlay image and saved. It should probably be safe to just clean up cameras and not revert the commit completely, although cleanupCameras now gets called after cell exploration event fires, so I did that.