### PR TITLE
Cast Random result to float (bug #5175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
     Bug #5167: Player can select and cast spells before magic menu is enabled
     Bug #5168: Force1stPerson and Force3rdPerson commands are not really force view change
     Bug #5169: Nested levelled items/creatures have significantly higher chance not to spawn
+    Bug #5175: Random script function returns an integer value
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -489,7 +489,7 @@ namespace Compiler
                 parseArguments ("l", scanner);
 
                 Generator::random (mCode);
-                mOperands.push_back ('l');
+                mOperands.push_back ('f');
 
                 mNextOperand = false;
                 return true;

--- a/components/interpreter/miscopcodes.hpp
+++ b/components/interpreter/miscopcodes.hpp
@@ -190,9 +190,7 @@ namespace Interpreter
                     throw std::runtime_error (
                         "random: argument out of range (Don't be so negative!)");
 
-                Type_Integer value = Misc::Rng::rollDice(limit); // [o, limit)
-
-                runtime[0].mInteger = value;
+                runtime[0].mFloat = static_cast<Type_Float>(Misc::Rng::rollDice(limit)); // [o, limit)
             }
     };
 


### PR DESCRIPTION
[Pull request 5175](https://gitlab.com/OpenMW/openmw/issues/5175)
Apparently Morrowind does this for Random script function.
So now the division works as intended for the value Random returns.