### PR TITLE
More minor NIF improvements

### DIFF
--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -112,7 +112,7 @@ class NiUVController : public Controller
 {
 public:
     NiUVDataPtr data;
-    int uvSet;
+    unsigned int uvSet;
 
     void read(NIFStream *nif);
     void post(NIFFile *nif);

--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -102,12 +102,12 @@ void NiTriStripsData::read(NIFStream *nif)
     std::vector<unsigned short> lengths;
     nif->getUShorts(lengths, numStrips);
 
+    if (!numStrips)
+        return;
+
+    strips.resize(numStrips);
     for (int i = 0; i < numStrips; i++)
-    {
-        std::vector<unsigned short> strip;
-        nif->getUShorts(strip, lengths[i]);
-        strips.emplace_back(strip);
-    }
+        nif->getUShorts(strips[i], lengths[i]);
 }
 
 void NiAutoNormalParticlesData::read(NIFStream *nif)

--- a/components/nif/property.cpp
+++ b/components/nif/property.cpp
@@ -18,14 +18,13 @@ void NiTexturingProperty::Texture::read(NIFStream *nif)
     if(!inUse) return;
 
     texture.read(nif);
-    clamp = nif->getInt();
-    filter = nif->getInt();
-    uvSet = nif->getInt();
+    clamp = nif->getUInt();
+    nif->skip(4); // Filter mode. Ignoring because global filtering settings are more sensible
+    uvSet = nif->getUInt();
 
-    // I have no idea, but I think these are actually two
-    // PS2-specific shorts (ps2L and ps2K), followed by an unknown
-    // short.
-    nif->skip(6);
+    // Two PS2-specific shorts.
+    nif->skip(4);
+    nif->skip(2); // Unknown short
 }
 
 void NiTexturingProperty::Texture::post(NIFFile *nif)
@@ -36,26 +35,25 @@ void NiTexturingProperty::Texture::post(NIFFile *nif)
 void NiTexturingProperty::read(NIFStream *nif)
 {
     Property::read(nif);
-    apply = nif->getInt();
+    apply = nif->getUInt();
 
-    // Unknown, always 7. Probably the number of textures to read
-    // below
-    nif->getInt();
+    unsigned int numTextures = nif->getUInt();
 
-    textures[0].read(nif); // Base
-    textures[1].read(nif); // Dark
-    textures[2].read(nif); // Detail
-    textures[3].read(nif); // Gloss (never present)
-    textures[4].read(nif); // Glow
-    textures[5].read(nif); // Bump map
-    if(textures[5].inUse)
+    if (!numTextures)
+        return;
+
+    textures.resize(numTextures);
+    for (unsigned int i = 0; i < numTextures; i++)
     {
+        textures[i].read(nif);
         // Ignore these at the moment
-        /*float lumaScale =*/ nif->getFloat();
-        /*float lumaOffset =*/ nif->getFloat();
-        /*const Vector4 *lumaMatrix =*/ nif->getVector4();
+        if (i == 5 && textures[5].inUse) // Bump map settings
+        {
+            /*float lumaScale =*/ nif->getFloat();
+            /*float lumaOffset =*/ nif->getFloat();
+            /*const Vector4 *lumaMatrix =*/ nif->getVector4();
+        }
     }
-    textures[6].read(nif); // Decal
 }
 
 void NiTexturingProperty::post(NIFFile *nif)

--- a/components/nif/property.hpp
+++ b/components/nif/property.hpp
@@ -51,17 +51,10 @@ public:
         3 - wrapS wrapT
         */
 
-        /* Filter:
-        0 - nearest
-        1 - bilinear
-        2 - trilinear
-        3, 4, 5 - who knows
-        */
         bool inUse;
         NiSourceTexturePtr texture;
 
-        int clamp, uvSet, filter;
-        short unknown2;
+        unsigned int clamp, uvSet;
 
         void read(NIFStream *nif);
         void post(NIFFile *nif);
@@ -74,7 +67,7 @@ public:
         3 - hilight  // These two are for PS2 only?
         4 - hilight2
     */
-    int apply;
+    unsigned int apply;
 
     /*
      * The textures in this list are as follows:
@@ -82,7 +75,7 @@ public:
      * 0 - Base texture
      * 1 - Dark texture
      * 2 - Detail texture
-     * 3 - Gloss texture (never used?)
+     * 3 - Gloss texture
      * 4 - Glow texture
      * 5 - Bump map texture
      * 6 - Decal texture
@@ -96,10 +89,9 @@ public:
         GlowTexture = 4,
         BumpTexture = 5,
         DecalTexture = 6,
-        NumTextures = 7 // Sentry value
     };
 
-    Texture textures[7];
+    std::vector<Texture> textures;
 
     void read(NIFStream *nif);
     void post(NIFFile *nif);

--- a/components/nif/recordptr.hpp
+++ b/components/nif/recordptr.hpp
@@ -143,31 +143,31 @@ class NiAutoNormalParticlesData;
 class NiPalette;
 struct NiParticleModifier;
 
-typedef RecordPtrT<Node> NodePtr;
-typedef RecordPtrT<Extra> ExtraPtr;
-typedef RecordPtrT<NiUVData> NiUVDataPtr;
-typedef RecordPtrT<NiPosData> NiPosDataPtr;
-typedef RecordPtrT<NiVisData> NiVisDataPtr;
-typedef RecordPtrT<Controller> ControllerPtr;
-typedef RecordPtrT<Named> NamedPtr;
-typedef RecordPtrT<NiSkinData> NiSkinDataPtr;
-typedef RecordPtrT<NiMorphData> NiMorphDataPtr;
-typedef RecordPtrT<NiPixelData> NiPixelDataPtr;
-typedef RecordPtrT<NiFloatData> NiFloatDataPtr;
-typedef RecordPtrT<NiColorData> NiColorDataPtr;
-typedef RecordPtrT<NiKeyframeData> NiKeyframeDataPtr;
-typedef RecordPtrT<NiTriShapeData> NiTriShapeDataPtr;
-typedef RecordPtrT<NiTriStripsData> NiTriStripsDataPtr;
-typedef RecordPtrT<NiSkinInstance> NiSkinInstancePtr;
-typedef RecordPtrT<NiSourceTexture> NiSourceTexturePtr;
-typedef RecordPtrT<NiRotatingParticlesData> NiRotatingParticlesDataPtr;
-typedef RecordPtrT<NiAutoNormalParticlesData> NiAutoNormalParticlesDataPtr;
-typedef RecordPtrT<NiPalette> NiPalettePtr;
-typedef RecordPtrT<NiParticleModifier> NiParticleModifierPtr;
+using NodePtr = RecordPtrT<Node>;
+using ExtraPtr = RecordPtrT<Extra>;
+using NiUVDataPtr = RecordPtrT<NiUVData>;
+using NiPosDataPtr = RecordPtrT<NiPosData>;
+using NiVisDataPtr = RecordPtrT<NiVisData>;
+using ControllerPtr = RecordPtrT<Controller>;
+using NamedPtr = RecordPtrT<Named>;
+using NiSkinDataPtr = RecordPtrT<NiSkinData>;
+using NiMorphDataPtr = RecordPtrT<NiMorphData>;
+using NiPixelDataPtr = RecordPtrT<NiPixelData>;
+using NiFloatDataPtr = RecordPtrT<NiFloatData>;
+using NiColorDataPtr = RecordPtrT<NiColorData>;
+using NiKeyframeDataPtr = RecordPtrT<NiKeyframeData>;
+using NiTriShapeDataPtr = RecordPtrT<NiTriShapeData>;
+using NiTriStripsDataPtr = RecordPtrT<NiTriStripsData>;
+using NiSkinInstancePtr = RecordPtrT<NiSkinInstance>;
+using NiSourceTexturePtr = RecordPtrT<NiSourceTexture>;
+using NiRotatingParticlesDataPtr = RecordPtrT<NiRotatingParticlesData>;
+using NiAutoNormalParticlesDataPtr = RecordPtrT<NiAutoNormalParticlesData>;
+using NiPalettePtr = RecordPtrT<NiPalette>;
+using NiParticleModifierPtr = RecordPtrT<NiParticleModifier>;
 
-typedef RecordListT<Node> NodeList;
-typedef RecordListT<Property> PropertyList;
-typedef RecordListT<NiSourceTexture> NiSourceTextureList;
+using NodeList = RecordListT<Node>;
+using PropertyList = RecordListT<Property>;
+using NiSourceTextureList = RecordListT<NiSourceTexture>;
 
 } // Namespace
 #endif


### PR DESCRIPTION
Some more small NIF changes ported from my NIF branch that apply to Morrowind version of the format.

1. Make sure UV set numbers and texture clamp modes are always unsigned values.
    This allows to get rid of some unnecessary casts to signed/unsigned integers.
2. Get rid of filter mode from textures.
    It corresponds to trilinear/bilinear/nearest neighbor/whatever filtering. But I assume we'll always use global filtering settings because doing otherwise is not very sensible except for very specific situations. Also it was unused.
3. Turn NiTexturingProperty texture array into a vector.
    This will be necessary in the future and possibly even now. The list of textures must not have a hardcoded size, so now the number of loaded textures depends on the declared number of textures in the property. Any textures beyond the normal 7 won't be handled atm. Morrowind seems to support more than one decal map but meshes with more than one decal texture simply won't be loaded atm, this remedies that slightly.
4. Simplify NiTriStripsData loading.
    It was a bit too complex for no reason.
5. More signedness consistency in texture-related locations.
6. Convert C-style typedefs to `using` directives to improve readability.