### PR TITLE
Set OnPCEquip properly when a race can't equip an item (bug #5182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
     Bug #5169: Nested levelled items/creatures have significantly higher chance not to spawn
     Bug #5175: Random script function returns an integer value
     Bug #5177: Editor: Unexplored map tiles get corrupted after a file with terrain is saved
+    Bug #5182: OnPCEquip doesn't trigger on skipped beast race attempts to equip something not equippable by beasts
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -526,7 +526,11 @@ namespace MWGui
 
                 if (canEquip.first == 0)
                 {
-                    MWBase::Environment::get().getWindowManager()->messageBox(canEquip.second);
+                    /// If PCSkipEquip is set, set OnPCEquip to 1 and don't message anything
+                    if (!script.empty() && ptr.getRefData().getLocals().getIntVar(script, "pcskipequip") == 1)
+                        ptr.getRefData().getLocals().setVarByInt(script, "onpcequip", 1);
+                    else
+                        MWBase::Environment::get().getWindowManager()->messageBox(canEquip.second);
                     updateItemView();
                     return;
                 }


### PR DESCRIPTION
Seems to fix the test case in [the report](https://gitlab.com/OpenMW/openmw/issues/5182).

I don't know if there are any more quirks of the vanilla behavior in this specific area.