### PR TITLE
Make sure summoned creatures are removed upon caster death (#5183)

### DIFF
--- a/apps/openmw/mwmechanics/summoning.cpp
+++ b/apps/openmw/mwmechanics/summoning.cpp
@@ -86,9 +86,10 @@ namespace MWMechanics
         }
 
         // Update summon effects
+        bool casterDead = creatureStats.isDead();
         for (std::map<CreatureStats::SummonKey, int>::iterator it = creatureMap.begin(); it != creatureMap.end(); )
         {
-            bool found = mActiveEffects.find(it->first) != mActiveEffects.end();
+            bool found = !casterDead && mActiveEffects.find(it->first) != mActiveEffects.end();
             if (!found)
             {
                 // Effect has ended


### PR DESCRIPTION
[Regression report](https://gitlab.com/OpenMW/openmw/issues/5183).

It was a thing because summoned creature cleanup happening at the moment of caster death assumed the magic effects were already removed.

Morrowind apparently despawns summoned creatures specifically at the moment of actor death like in 0.45.0 and not when the magic effect should really be removed (the end of the death animation), so I added a special case for that into summoned creature cleanup. The alternative of removing specifically summon effects specifically when the death happens doesn't seem to be nice.

Summoned creature effects are still only removed when the death animation is finished.