### PR TITLE
Rework 'prevent merchant equipping' feature

### DIFF
--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -112,7 +112,6 @@ namespace MWWorld
             virtual void storeEquipmentState (const MWWorld::LiveCellRefBase& ref, int index, ESM::InventoryState& inventory) const;
             virtual void readEquipmentState (const MWWorld::ContainerStoreIterator& iter, int index, const ESM::InventoryState& inventory);
 
-            bool canActorAutoEquip(const MWWorld::Ptr& actor, const MWWorld::Ptr& item);
             ContainerStoreIterator findSlot (int slot) const;
 
         public:
@@ -160,6 +159,8 @@ namespace MWWorld
 
             void autoEquip (const MWWorld::Ptr& actor);
             ///< Auto equip items according to stats and item value.
+
+            bool canActorAutoEquip(const MWWorld::Ptr& actor);
 
             const MWMechanics::MagicEffects& getMagicEffects() const;
             ///< Return magic effects from worn items.


### PR DESCRIPTION
Summary of changes:
1. Restore functionality of feature after we decided to do not store owners for items in container stores. Now we really check if a target actor is a trader, if yes - allow to auto equip items only once, during initial autoequipping.
2. This settings now does not break autoequipping for player (e.g. when changing race or class via console) - we did not store owners for items in player's inventory anyway, so there were no items which player could autoequip.
3. Now we remove bound items after actor's death and re-equip weapons when spell expires (traders do not re-equip weapons when the setting is true).

Not sure if we need separate changelog entries since most of this PR fixes regressions.

Note: I had to disable light equipping for traders when the setting is active since in this case autoequipping is disabled for them.