### PR TITLE
Fix GetEffect result when running on dead actors

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1826,6 +1826,7 @@ namespace MWMechanics
                 // One case where we need this is to make sure bound items are removed upon death
                 stats.modifyMagicEffects(MWMechanics::MagicEffects());
                 stats.getActiveSpells().clear();
+                stats.getSpells().clear();
                 // Make sure spell effects are removed
                 purgeSpellEffects(stats.getActorId());
 

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -441,7 +441,7 @@ namespace MWScript
 
                     MWMechanics::MagicEffects effects = stats.getSpells().getMagicEffects();
                     effects += stats.getActiveSpells().getMagicEffects();
-                    if (ptr.getClass().hasInventoryStore(ptr))
+                    if (ptr.getClass().hasInventoryStore(ptr) && !stats.isDeathAnimationFinished())
                     {
                         MWWorld::InventoryStore& store = ptr.getClass().getInventoryStore(ptr);
                         effects += store.getMagicEffects();


### PR DESCRIPTION
Since GetEffect emulates the creature stats' getMagicEffects() to have more precise timing, it recalculates the magic effects based on the current state of effect sources, however the actual magic effects (in the mechanics) can differ. For dead actors magic effects are reset and no longer updated so getMagicEffects() of creature stats returns a valid value, but the effect sources aren't actually cleared so GetEffect thinks there really are active effects on the actor.

Permanent spell sources are now cleared.
Enchantment effects are now ignored in GetEffect for actors which finished playing their death animation. getMagicEffects() of the inventory store isn't used anywhere else otherwise (and shouldn't really be).

Should resolve some inconsistencies akortunov encountered.