### PR TITLE
Weather-related fixes (incl. bug #4783)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
     Bug #4768: Fallback numerical value recovery chokes on invalid arguments
     Bug #4775: Slowfall effect resets player jumping flag
     Bug #4778: Interiors of Illusion puzzle in Sotha Sil Expanded mod is broken
+    Bug #4783: Blizzard behavior is incorrect
     Bug #4787: Sneaking makes 1st person walking/bobbing animation super-slow
     Bug #4797: Player sneaking and running stances are not accounted for when in air
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -225,7 +225,7 @@ protected:
     virtual void apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
     {
         osg::TexMat* texMat = static_cast<osg::TexMat*>(stateset->getTextureAttribute(0, osg::StateAttribute::TEXMAT));
-        texMat->setMatrix(osg::Matrix::translate(osg::Vec3f(0, mAnimationTimer, 0.f)));
+        texMat->setMatrix(osg::Matrix::translate(osg::Vec3f(0, -mAnimationTimer, 0.f)));
 
         stateset->setTextureAttribute(0, mTexture, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
         stateset->setTextureAttribute(1, mTexture, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
@@ -1108,7 +1108,7 @@ SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneMana
     , mMonth(0)
     , mCloudAnimationTimer(0.f)
     , mRainTimer(0.f)
-    , mStormDirection(0,-1,0)
+    , mStormDirection(0,1,0)
     , mClouds()
     , mNextClouds()
     , mCloudBlendFactor(0.0f)
@@ -1597,10 +1597,14 @@ void SkyManager::update(float duration)
         osg::Quat quat;
         quat.makeRotate(osg::Vec3f(0,1,0), mStormDirection);
 
-        if (mParticleNode)
-            mParticleNode->setAttitude(quat);
-
         mCloudNode->setAttitude(quat);
+        if (mParticleNode)
+        {
+            // Morrowind deliberately rotates the blizzard mesh, so so should we.
+            if (mCurrentParticleEffect == "meshes\\blizzard.nif")
+                quat.makeRotate(osg::Vec3f(-1,0,0), mStormDirection);
+            mParticleNode->setAttitude(quat);
+        }
     }
     else
         mCloudNode->setAttitude(osg::Quat());
@@ -1636,7 +1640,7 @@ void SkyManager::updateRainParameters()
 {
     if (mRainShooter)
     {
-        float angle = -std::atan2(1, 50.f/mWindSpeed);
+        float angle = -std::atan(mWindSpeed/50.f);
         mRainShooter->setVelocity(osg::Vec3f(0, mRainSpeed*std::sin(angle), -mRainSpeed/std::cos(angle)));
         mRainShooter->setAngle(angle);
 

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -661,17 +661,6 @@ void WeatherManager::playerTeleported(const std::string& playerRegion, bool isEx
     }
 }
 
-osg::Vec3f WeatherManager::calculateStormDirection()
-{
-    osg::Vec3f playerPos (MWMechanics::getPlayer().getRefData().getPosition().asVec3());
-    playerPos.z() = 0;
-    osg::Vec3f redMountainPos (25000, 70000, 0);
-    osg::Vec3f stormDirection = (playerPos - redMountainPos);
-    stormDirection.normalize();
-
-    return stormDirection;
-}
-
 float WeatherManager::calculateWindSpeed(int weatherId, float currentSpeed)
 {
     float targetSpeed = std::min(8.0f * mWeatherSettings[weatherId].mWindSpeed, 70.f);
@@ -682,15 +671,7 @@ float WeatherManager::calculateWindSpeed(int weatherId, float currentSpeed)
     float updatedSpeed = (Misc::Rng::rollClosedProbability() - 0.5f) * multiplier * targetSpeed + currentSpeed;
 
     if (updatedSpeed > 0.5f * targetSpeed && updatedSpeed < 2.f * targetSpeed)
-    {
         currentSpeed = updatedSpeed;
-    }
-
-    // Take in account direction to the Red Mountain, when needed
-    if (weatherId == 6 || weatherId == 7)
-    {
-        currentSpeed = (calculateStormDirection() * currentSpeed).length();
-    }
 
     return currentSpeed;
 }
@@ -750,7 +731,16 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
 
     if (mIsStorm)
     {
-        mStormDirection = calculateStormDirection();
+        osg::Vec3f stormDirection(0, 1, 0);
+        if (mResult.mParticleEffect == "meshes\\ashcloud.nif" || mResult.mParticleEffect == "meshes\\blightcloud.nif")
+        {
+            osg::Vec3f playerPos (MWMechanics::getPlayer().getRefData().getPosition().asVec3());
+            playerPos.z() = 0;
+            osg::Vec3f redMountainPos (25000, 70000, 0);
+            stormDirection = (playerPos - redMountainPos);
+            stormDirection.normalize();
+        }
+        mStormDirection = stormDirection;
         mRendering.getSkyManager()->setStormDirection(mStormDirection);
     }
 

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -370,7 +370,6 @@ namespace MWWorld
         bool updateWeatherRegion(const std::string& playerRegion);
         void updateWeatherTransitions(const float elapsedRealSeconds);
         void forceWeather(const int weatherID);
-        osg::Vec3f calculateStormDirection();
 
         bool inTransition();
         void addWeatherTransition(const int weatherID);


### PR DESCRIPTION
1. Simplify some calculations
    Some calculations added by akortunov to conform to the vanilla research were extraneous.
    In storm direction calculations, storm direction is a 1-unit length vector, so multiplied by wind speed its length would just be wind speed.  I removed that part from wind speed calculations.
   In rain angle calculation, both atan2 arguments are positive (mWindSpeed is non-negative), so it is possible to use atan and a single argument. This also allows to avoid a division by zero if the rain weather Morrowind.ini wind speed is somehow 0.

2. Fix Blizzard weather direction ([bug 4783](https://gitlab.com/OpenMW/openmw/issues/4783))
   Blizzard is no longer considered a glorified ash storm and moves from south to north instead of Red Mountain to player. Blizzard model is now rotated by 90 degrees clockwise like in Morrowind to look correct. The clouds rotation still uses the normal rotation quaternion to look as intended. Practical storm direction for hand shielding purposes is still correct. I also moved the whole storm direction calculations into weather update because it actually only calculated ash storm direction and not storm direction.

3. Fix clouds direction
  Now they should consistently move from south to north or follow the storm particle direction. Their direction could be reverse in some situations.

I decided to use model checks instead of weather ID checks to avoid confusion between different storm weathers during transitions and to make it easier to dehardcode clearly Morrowind-specific ash/blight weathers in the future.