### PR TITLE
Fix OnStrike bows charges

### DIFF
--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -830,7 +830,7 @@ namespace MWMechanics
         {
             int type = item.get<ESM::Weapon>()->mBase->mData.mType;
             ESM::WeaponType::Class weapclass = MWMechanics::getWeaponType(type)->mWeaponClass;
-            isProjectile = (weapclass == ESM::WeaponType::Thrown || weapclass == ESM::WeaponType::Ranged);
+            isProjectile = (weapclass == ESM::WeaponType::Thrown || weapclass == ESM::WeaponType::Ammo);
         }
         int type = enchantment->mData.mType;
 


### PR DESCRIPTION
Fixes [regression #5191](https://gitlab.com/OpenMW/openmw/issues/5191).

We are not supposed to reduce charges for projectiles, but due to my coding error in weapon types refactoring we do not reduce charges for thrown weapons, bows and crossbows.