### PR TITLE
Remove on-strike enchantment support for ranged weapon types (bug #5190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@
     Bug #5177: Editor: Unexplored map tiles get corrupted after a file with terrain is saved
     Bug #5182: OnPCEquip doesn't trigger on skipped beast race attempts to equip something not equippable by beasts
     Bug #5186: Equipped item enchantments don't affect creatures
+    Bug #5190: On-strike enchantments can be applied to and used with non-projectile ranged weapons
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/combat.cpp
+++ b/apps/openmw/mwmechanics/combat.cpp
@@ -245,10 +245,8 @@ namespace MWMechanics
 
         reduceWeaponCondition(damage, validVictim, weapon, attacker);
 
-        // Apply "On hit" effect of the weapon & projectile
-        bool appliedEnchantment = applyOnStrikeEnchantment(attacker, victim, weapon, hitPosition, true);
-        if (weapon != projectile)
-            appliedEnchantment = applyOnStrikeEnchantment(attacker, victim, projectile, hitPosition, true);
+        // Apply "On hit" effect of the projectile
+        bool appliedEnchantment = applyOnStrikeEnchantment(attacker, victim, projectile, hitPosition, true);
 
         if (validVictim)
         {

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -14,6 +14,7 @@
 #include "creaturestats.hpp"
 #include "spellcasting.hpp"
 #include "actorutil.hpp"
+#include "weapontype.hpp"
 
 namespace MWMechanics
 {
@@ -25,13 +26,13 @@ namespace MWMechanics
     void Enchanting::setOldItem(const MWWorld::Ptr& oldItem)
     {
         mOldItemPtr=oldItem;
+        mWeaponType = -1;
+        mObjectType.clear();
         if(!itemEmpty())
         {
             mObjectType = mOldItemPtr.getTypeName();
-        }
-        else
-        {
-            mObjectType="";
+            if (mObjectType == typeid(ESM::Weapon).name())
+                mWeaponType = mOldItemPtr.get<ESM::Weapon>()->mBase->mData.mType;
         }
     }
 
@@ -119,7 +120,7 @@ namespace MWMechanics
                     return;
             }
         }
-        else if(mObjectType == typeid(ESM::Weapon).name())
+        else if (mWeaponType != -1)
         { // Weapon
             switch(mCastStyle)
             {
@@ -129,11 +130,13 @@ namespace MWMechanics
                 case ESM::Enchantment::WhenUsed:
                     if (powerfulSoul)
                         mCastStyle = ESM::Enchantment::ConstantEffect;
-                    else
+                    else if (getWeaponType(mWeaponType)->mWeaponClass != ESM::WeaponType::Ranged)
                         mCastStyle = ESM::Enchantment::WhenStrikes;
                     return;
                 default: // takes care of Constant effect too
-                    mCastStyle = ESM::Enchantment::WhenStrikes;
+                    mCastStyle = ESM::Enchantment::WhenUsed;
+                    if (getWeaponType(mWeaponType)->mWeaponClass != ESM::WeaponType::Ranged)
+                        mCastStyle = ESM::Enchantment::WhenStrikes;
                     return;
             }
         }

--- a/apps/openmw/mwmechanics/enchanting.hpp
+++ b/apps/openmw/mwmechanics/enchanting.hpp
@@ -23,6 +23,7 @@ namespace MWMechanics
 
             std::string mNewItemName;
             std::string mObjectType;
+            int mWeaponType;
 
         public:
             Enchanting();


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5190).

I just copied vanilla+MCP fix behavior. On-strike enchantment type doesn't appear in the enchanting window and the on-strike enchantment of a ranged weapon (but not the projectile) isn't applied.