### PR TITLE
Return various cell reference fields by reference (#5195)

### DIFF
--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -20,7 +20,7 @@ namespace MWWorld
         mCellRef.mRefNum.unset();
     }
 
-    std::string CellRef::getRefId() const
+    const std::string& CellRef::getRefId() const
     {
         return mCellRef.mRefID;
     }
@@ -30,12 +30,12 @@ namespace MWWorld
         return mCellRef.mTeleport;
     }
 
-    ESM::Position CellRef::getDoorDest() const
+    const ESM::Position& CellRef::getDoorDest() const
     {
         return mCellRef.mDoorDest;
     }
 
-    std::string CellRef::getDestCell() const
+    const std::string& CellRef::getDestCell() const
     {
         return mCellRef.mDestCell;
     }
@@ -54,7 +54,7 @@ namespace MWWorld
         }
     }
 
-    ESM::Position CellRef::getPosition() const
+    const ESM::Position& CellRef::getPosition() const
     {
         return mCellRef.mPos;
     }
@@ -141,12 +141,12 @@ namespace MWWorld
         }
     }
 
-    std::string CellRef::getOwner() const
+    const std::string& CellRef::getOwner() const
     {
         return mCellRef.mOwner;
     }
 
-    std::string CellRef::getGlobalVariable() const
+    const std::string& CellRef::getGlobalVariable() const
     {
         return mCellRef.mGlobalVariable;
     }
@@ -183,7 +183,7 @@ namespace MWWorld
         }
     }
 
-    std::string CellRef::getSoul() const
+    const std::string& CellRef::getSoul() const
     {
         return mCellRef.mSoul;
     }
@@ -197,7 +197,7 @@ namespace MWWorld
         }
     }
 
-    std::string CellRef::getFaction() const
+    const std::string& CellRef::getFaction() const
     {
         return mCellRef.mFaction;
     }
@@ -238,12 +238,12 @@ namespace MWWorld
         setLockLevel(-abs(mCellRef.mLockLevel)); //Makes lockLevel negative
     }
 
-    std::string CellRef::getKey() const
+    const std::string& CellRef::getKey() const
     {
         return mCellRef.mKey;
     }
 
-    std::string CellRef::getTrap() const
+    const std::string& CellRef::getTrap() const
     {
         return mCellRef.mTrap;
     }

--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -32,17 +32,17 @@ namespace MWWorld
         bool hasContentFile() const;
 
         // Id of object being referenced
-        std::string getRefId() const;
+        const std::string& getRefId() const;
 
         // For doors - true if this door teleports to somewhere else, false
         // if it should open through animation.
         bool getTeleport() const;
 
         // Teleport location for the door, if this is a teleporting door.
-        ESM::Position getDoorDest() const;
+        const ESM::Position& getDoorDest() const;
 
         // Destination cell for doors (optional)
-        std::string getDestCell() const;
+        const std::string& getDestCell() const;
 
         // Scale applied to mesh
         float getScale() const;
@@ -50,7 +50,7 @@ namespace MWWorld
 
         // The *original* position and rotation as it was given in the Construction Set.
         // Current position and rotation of the object is stored in RefData.
-        ESM::Position getPosition() const;
+        const ESM::Position& getPosition() const;
         void setPosition (const ESM::Position& position);
 
         // Remaining enchantment charge. This could be -1 if the charge was not touched yet (i.e. full).
@@ -71,23 +71,23 @@ namespace MWWorld
         void applyChargeRemainderToBeSubtracted(float chargeRemainder); // Stores remainders and applies if > 1
 
         // The NPC that owns this object (and will get angry if you steal it)
-        std::string getOwner() const;
+        const std::string& getOwner() const;
         void setOwner(const std::string& owner);
 
         // Name of a global variable. If the global variable is set to '1', using the object is temporarily allowed
         // even if it has an Owner field.
         // Used by bed rent scripts to allow the player to use the bed for the duration of the rent.
-        std::string getGlobalVariable() const;
+        const std::string& getGlobalVariable() const;
 
         void resetGlobalVariable();
 
         // ID of creature trapped in this soul gem
-        std::string getSoul() const;
+        const std::string& getSoul() const;
         void setSoul(const std::string& soul);
 
         // The faction that owns this object (and will get angry if
         // you take it and are not a faction member)
-        std::string getFaction() const;
+        const std::string& getFaction() const;
         void setFaction (const std::string& faction);
 
         // PC faction rank required to use the item. Sometimes is -1, which means "any rank".
@@ -102,8 +102,8 @@ namespace MWWorld
         void lock(int lockLevel);
         void unlock();
          // Key and trap ID names, if any
-        std::string getKey() const;
-        std::string getTrap() const;
+        const std::string& getKey() const;
+        const std::string& getTrap() const;
         void setTrap(const std::string& trap);
 
         // This is 5 for Gold_005 references, 100 for Gold_100 and so on.


### PR DESCRIPTION
[Bug tracker page](https://gitlab.com/OpenMW/openmw/issues/5195).

Strings (obviously) and Positions (two float vectors in the struct, i.e. 24 bytes) of a cell reference are now returned by reference. Doesn't seem to be any adverse effect to this. Now it'll work the way it did before scrawl added change tracking in 2014, i.e. without making lots of string copies for no reason (critical for performance-critical code). I'm not adding a changelog entry because it's an optimization most likely not obvious to the end user.