### PR TITLE
Reset idle animation only when play movement animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@
     Bug #5182: OnPCEquip doesn't trigger on skipped beast race attempts to equip something not equippable by beasts
     Bug #5186: Equipped item enchantments don't affect creatures
     Bug #5190: On-strike enchantments can be applied to and used with non-projectile ranged weapons
+    Bug #5196: Dwarven ghosts do not use idle animations
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls


### PR DESCRIPTION
Fixes [bug #5196](https://gitlab.com/OpenMW/openmw/issues/5196).

Just reset movement state, if there is no suitable animation found (including fallbacks).