### PR TITLE
Rework prevent merchant equipping setting again

### DIFF
--- a/apps/openmw/mwgui/companionitemmodel.cpp
+++ b/apps/openmw/mwgui/companionitemmodel.cpp
@@ -25,12 +25,12 @@ namespace MWGui
     {
     }
 
-    MWWorld::Ptr CompanionItemModel::copyItem (const ItemStack& item, size_t count)
+    MWWorld::Ptr CompanionItemModel::copyItem (const ItemStack& item, size_t count, bool allowAutoEquip)
     {
         if (hasProfit(mActor))
             modifyProfit(mActor, item.mBase.getClass().getValue(item.mBase) * count);
 
-        return InventoryItemModel::copyItem(item, count);
+        return InventoryItemModel::copyItem(item, count, allowAutoEquip);
     }
 
     void CompanionItemModel::removeItem (const ItemStack& item, size_t count)

--- a/apps/openmw/mwgui/companionitemmodel.hpp
+++ b/apps/openmw/mwgui/companionitemmodel.hpp
@@ -13,7 +13,7 @@ namespace MWGui
     public:
         CompanionItemModel (const MWWorld::Ptr& actor);
 
-        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count);
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool allowAutoEquip = true);
         virtual void removeItem (const ItemStack& item, size_t count);
 
         bool hasProfit(const MWWorld::Ptr& actor);

--- a/apps/openmw/mwgui/containeritemmodel.cpp
+++ b/apps/openmw/mwgui/containeritemmodel.cpp
@@ -91,12 +91,12 @@ ItemModel::ModelIndex ContainerItemModel::getIndex (ItemStack item)
     return -1;
 }
 
-MWWorld::Ptr ContainerItemModel::copyItem (const ItemStack& item, size_t count)
+MWWorld::Ptr ContainerItemModel::copyItem (const ItemStack& item, size_t count, bool allowAutoEquip)
 {
     const MWWorld::Ptr& source = mItemSources[mItemSources.size()-1];
     if (item.mBase.getContainerStore() == &source.getClass().getContainerStore(source))
         throw std::runtime_error("Item to copy needs to be from a different container!");
-    return *source.getClass().getContainerStore(source).add(item.mBase, count, source);
+    return *source.getClass().getContainerStore(source).add(item.mBase, count, source, allowAutoEquip);
 }
 
 void ContainerItemModel::removeItem (const ItemStack& item, size_t count)

--- a/apps/openmw/mwgui/containeritemmodel.hpp
+++ b/apps/openmw/mwgui/containeritemmodel.hpp
@@ -26,7 +26,7 @@ namespace MWGui
         virtual ModelIndex getIndex (ItemStack item);
         virtual size_t getItemCount();
 
-        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count);
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool allowAutoEquip = true);
         virtual void removeItem (const ItemStack& item, size_t count);
 
         virtual void update();

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -38,7 +38,7 @@ namespace MWGui
     public:
         WorldItemModel(float left, float top) : mLeft(left), mTop(top) {}
         virtual ~WorldItemModel() {}
-        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count)
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool /*allowAutoEquip*/)
         {
             MWBase::World* world = MWBase::Environment::get().getWorld();
 

--- a/apps/openmw/mwgui/inventoryitemmodel.cpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.cpp
@@ -46,11 +46,11 @@ ItemModel::ModelIndex InventoryItemModel::getIndex (ItemStack item)
     return -1;
 }
 
-MWWorld::Ptr InventoryItemModel::copyItem (const ItemStack& item, size_t count)
+MWWorld::Ptr InventoryItemModel::copyItem (const ItemStack& item, size_t count, bool allowAutoEquip)
 {
     if (item.mBase.getContainerStore() == &mActor.getClass().getContainerStore(mActor))
         throw std::runtime_error("Item to copy needs to be from a different container!");
-    return *mActor.getClass().getContainerStore(mActor).add(item.mBase, count, mActor);
+    return *mActor.getClass().getContainerStore(mActor).add(item.mBase, count, mActor, allowAutoEquip);
 }
 
 void InventoryItemModel::removeItem (const ItemStack& item, size_t count)

--- a/apps/openmw/mwgui/inventoryitemmodel.hpp
+++ b/apps/openmw/mwgui/inventoryitemmodel.hpp
@@ -17,7 +17,7 @@ namespace MWGui
 
         virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
-        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count);
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool allowAutoEquip = true);
         virtual void removeItem (const ItemStack& item, size_t count);
 
         /// Move items from this model to \a otherModel.

--- a/apps/openmw/mwgui/itemmodel.cpp
+++ b/apps/openmw/mwgui/itemmodel.cpp
@@ -116,9 +116,9 @@ namespace MWGui
         return mSourceModel->allowedToUseItems();
     }
 
-    MWWorld::Ptr ProxyItemModel::copyItem (const ItemStack& item, size_t count)
+    MWWorld::Ptr ProxyItemModel::copyItem (const ItemStack& item, size_t count, bool allowAutoEquip)
     {
-        return mSourceModel->copyItem (item, count);
+        return mSourceModel->copyItem (item, count, allowAutoEquip);
     }
 
     void ProxyItemModel::removeItem (const ItemStack& item, size_t count)

--- a/apps/openmw/mwgui/itemmodel.hpp
+++ b/apps/openmw/mwgui/itemmodel.hpp
@@ -65,9 +65,7 @@ namespace MWGui
         /// @note Derived implementations may return an empty Ptr if the move was unsuccessful.
         virtual MWWorld::Ptr moveItem (const ItemStack& item, size_t count, ItemModel* otherModel);
 
-        /// @param setNewOwner If true, set the copied item's owner to the actor we are copying to,
-        ///                    otherwise reset owner to ""
-        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count) = 0;
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool allowAutoEquip = true) = 0;
         virtual void removeItem (const ItemStack& item, size_t count) = 0;
 
         /// Is the player allowed to use items from this item model? (default true)
@@ -97,7 +95,7 @@ namespace MWGui
         virtual bool onDropItem(const MWWorld::Ptr &item, int count);
         virtual bool onTakeItem(const MWWorld::Ptr &item, int count);
 
-        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count);
+        virtual MWWorld::Ptr copyItem (const ItemStack& item, size_t count, bool allowAutoEquip = true);
         virtual void removeItem (const ItemStack& item, size_t count);
         virtual ModelIndex getIndex (ItemStack item);
 

--- a/apps/openmw/mwgui/tradeitemmodel.cpp
+++ b/apps/openmw/mwgui/tradeitemmodel.cpp
@@ -1,6 +1,7 @@
 #include "tradeitemmodel.hpp"
 
 #include <components/misc/stringops.hpp>
+#include <components/settings/settings.hpp>
 
 #include "../mwworld/class.hpp"
 #include "../mwworld/containerstore.hpp"
@@ -139,8 +140,9 @@ namespace MWGui
                 throw std::runtime_error("The borrowed item disappeared");
 
             const ItemStack& item = sourceModel->getItem(i);
+            static const bool prevent = Settings::Manager::getBool("prevent merchant equipping", "Game");
             // copy the borrowed items to our model
-            copyItem(item, itemStack.mCount);
+            copyItem(item, itemStack.mCount, !prevent);
             // then remove them from the source model
             sourceModel->removeItem(item, itemStack.mCount);
         }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -313,7 +313,7 @@ namespace MWMechanics
             if (actor.getClass().getCreatureStats(actor).isDead())
                 return;
 
-            if (!actor.getClass().hasInventoryStore(actor) || !actor.getClass().getInventoryStore(actor).canActorAutoEquip(actor))
+            if (!actor.getClass().hasInventoryStore(actor))
                 return;
 
             if (actor.getClass().isNpc() && actor.getClass().getNpcStats(actor).isWerewolf())
@@ -1220,7 +1220,7 @@ namespace MWMechanics
                     heldIter = inventoryStore.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
 
                     // If we have a torch and can equip it, then equip it now.
-                    if (heldIter == inventoryStore.end() && inventoryStore.canActorAutoEquip(ptr))
+                    if (heldIter == inventoryStore.end())
                     {
                         inventoryStore.equip(MWWorld::InventoryStore::Slot_CarriedLeft, torch, ptr);
                     }

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -266,7 +266,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add(const std::string &
     return add(ref.getPtr(), count, actorPtr);
 }
 
-MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr, int count, const Ptr& actorPtr)
+MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr, int count, const Ptr& actorPtr, bool /*allowAutoEquip*/)
 {
     Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -138,15 +138,13 @@ namespace MWWorld
 
             bool hasVisibleItems() const;
 
-            virtual ContainerStoreIterator add (const Ptr& itemPtr, int count, const Ptr& actorPtr);
+            virtual ContainerStoreIterator add (const Ptr& itemPtr, int count, const Ptr& actorPtr, bool allowAutoEquip = true);
             ///< Add the item pointed to by \a ptr to this container. (Stacks automatically if needed)
             ///
             /// \note The item pointed to is not required to exist beyond this function call.
             ///
             /// \attention Do not add items to an existing stack by increasing the count instead of
             /// calling this function!
-            ///
-            /// @param setOwner Set the owner of the added item to \a actorPtr? If false, the owner is reset to "".
             ///
             /// @return if stacking happened, return iterator to the item that was stacked against, otherwise iterator to the newly inserted item.
 

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -124,16 +124,14 @@ namespace MWWorld
 
             virtual InventoryStore* clone() { return new InventoryStore(*this); }
 
-            virtual ContainerStoreIterator add (const Ptr& itemPtr, int count, const Ptr& actorPtr);
+            virtual ContainerStoreIterator add (const Ptr& itemPtr, int count, const Ptr& actorPtr, bool allowAutoEquip = true);
             ///< Add the item pointed to by \a ptr to this container. (Stacks automatically if needed)
-            /// Auto-equip items if specific conditions are fulfilled (see the implementation).
+            /// Auto-equip items if specific conditions are fulfilled and allowAutoEquip is true (see the implementation).
             ///
             /// \note The item pointed to is not required to exist beyond this function call.
             ///
             /// \attention Do not add items to an existing stack by increasing the count instead of
             /// calling this function!
-            ///
-            /// @param setOwner Set the owner of the added item to \a actorPtr?
             ///
             /// @return if stacking happened, return iterator to the item that was stacked against, otherwise iterator to the newly inserted item.
 
@@ -159,8 +157,6 @@ namespace MWWorld
 
             void autoEquip (const MWWorld::Ptr& actor);
             ///< Auto equip items according to stats and item value.
-
-            bool canActorAutoEquip(const MWWorld::Ptr& actor);
 
             const MWMechanics::MagicEffects& getMagicEffects() const;
             ///< Return magic effects from worn items.


### PR DESCRIPTION
prevent merchant equipping started to work in general case after the previous rework, but there were issues with mods that triggered autoequip through scripting like Melchior's Mage Robes. MCP's fix doesn't cancel merchant autoequip in this case.

We (akortunov and myself) couldn't figure out the exact way the fix works (also, a Wine regression prevents us from checking it) but this seems to emulate it well enough according to third party testing.

TradeItemModel's item transfer, triggered when a barter deal successfully ends, now avoids triggering inventory store's autoequip while scripting doesn't. The approach isn't particularly beautiful (all item models that override copyItem had to be adjusted), but it resolves a release blocker and hopefully we can improve this once the great dehardcoding™ comes or earlier.