### PR TITLE
Attempt to fix a regression - crash on ARM

### DIFF
--- a/components/esm/loadregn.hpp
+++ b/components/esm/loadregn.hpp
@@ -33,14 +33,14 @@ struct Region
         // the engine uses mA as "snow" and mB as "blizard"
                 mA, mB;
     }; // 10 bytes
+#pragma pack(pop)
 
     // Reference to a sound that is played randomly in this region
     struct SoundRef
     {
         std::string   mSound;
         unsigned char mChance;
-    }; // 33 bytes
-#pragma pack(pop)
+    };
 
     WEATstruct mData;
     int mMapColor; // RGBA

--- a/components/esm/loadscpt.hpp
+++ b/components/esm/loadscpt.hpp
@@ -33,7 +33,7 @@ public:
     {
         std::string         mName;
         Script::SCHDstruct  mData;
-    }; // 52 bytes
+    };
 
     std::string mId;
 


### PR DESCRIPTION
1. Do not use `pragma pack` for `SoundRef` struct since it now has a varying size
2. Remove outdated comments about struct size.

Requires testing on Android.