### PR TITLE
Avoid copying strings in SearchVisitor and readReferenceCollection (#5195)

### DIFF
--- a/apps/openmw/mwworld/cellref.cpp
+++ b/apps/openmw/mwworld/cellref.cpp
@@ -25,6 +25,11 @@ namespace MWWorld
         return mCellRef.mRefID;
     }
 
+    const std::string* CellRef::getRefIdPtr() const
+    {
+        return &mCellRef.mRefID;
+    }
+
     bool CellRef::getTeleport() const
     {
         return mCellRef.mTeleport;

--- a/apps/openmw/mwworld/cellref.hpp
+++ b/apps/openmw/mwworld/cellref.hpp
@@ -34,6 +34,9 @@ namespace MWWorld
         // Id of object being referenced
         std::string getRefId() const;
 
+        // Pointer to ID of the object being referenced
+        const std::string* getRefIdPtr() const;
+
         // For doors - true if this door teleports to somewhere else, false
         // if it should open through animation.
         bool getTeleport() const;

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -137,7 +137,7 @@ namespace
         {
             for (typename MWWorld::CellRefList<T>::List::iterator iter (collection.mList.begin());
                 iter!=collection.mList.end(); ++iter)
-                if (iter->mRef.getRefNum()==state.mRef.mRefNum && iter->mRef.getRefId() == state.mRef.mRefID)
+                if (iter->mRef.getRefNum()==state.mRef.mRefNum && *iter->mRef.getRefIdPtr() == state.mRef.mRefID)
                 {
                     // overwrite existing reference
                     iter->load (state);
@@ -390,7 +390,7 @@ namespace MWWorld
         const std::string *mIdToFind;
         bool operator()(const PtrType& ptr)
         {
-            if (ptr.getCellRef().getRefId() == *mIdToFind)
+            if (*ptr.getCellRef().getRefIdPtr() == *mIdToFind)
             {
                 mFound = ptr;
                 return false;


### PR DESCRIPTION
[Tracker page](https://gitlab.com/OpenMW/openmw/issues/5195)

As suggested by icecream95, just add a pointer variant of the cell reference getRefId() method for now and only use it in SearchVisitor and readReferenceCollection, to avoid string copy overhead. In my testing, a single record search is now at least 3 times faster, down from 15-45 microseconds to 5-10 microseconds on average. Loading a saved game of ~60 hours takes about 9% less time.