### PR TITLE
Implement mouse wheel bindings (bug #2679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     Bug #1515: Opening console masks dialogue, inventory menu
     Bug #1933: Actors can have few stocks of the same item
     Bug #2395: Duplicated plugins in the launcher when multiple data directories provide the same plugin
+    Bug #2679: Unable to map mouse wheel under control settings
     Bug #2969: Scripted items can stack
     Bug #2976: Data lines in global openmw.cfg take priority over user openmw.cfg
     Bug #2987: Editor: some chance and AI data fields can overflow

--- a/CHANGELOG_PR.md
+++ b/CHANGELOG_PR.md
@@ -44,6 +44,7 @@ New Editor Features:
 - Land heightmap/shape editing and vertex selection (#5170)
 
 Bug Fixes:
+- The Mouse Wheel can now be used for key bindings (#2679)
 - Scripted Items cannot be stacked anymore to avoid multiple script execution (#2969)
 - Stray text after an "else" statement is now ignored, like in the original engine, to handle mods which erroneously use "else if" statements (#3006)
 - "SetPos" and "SetPosition" commands now more closely replicate the original engine's behaviour (#3109)

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -84,7 +84,6 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
 
     // Input Settings
-    loadSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");
     loadSettingBool(grabCursorCheckBox, "grab cursor", "Input");
     loadSettingBool(toggleSneakCheckBox, "toggle sneak", "Input");
 
@@ -145,7 +144,6 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
 
     // Input Settings
-    saveSettingBool(allowThirdPersonZoomCheckBox, "allow third person zoom", "Input");
     saveSettingBool(grabCursorCheckBox, "grab cursor", "Input");
     saveSettingBool(toggleSneakCheckBox, "toggle sneak", "Input");
 

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -500,8 +500,11 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
         if(boost::filesystem::exists(input2)) {
             boost::filesystem::copy_file(input2, keybinderUser);
             keybinderUserExists = boost::filesystem::exists(keybinderUser);
+            Log(Debug::Info) << "Loading keybindings file: " << keybinderUser;
         }
     }
+    else
+        Log(Debug::Info) << "Loading keybindings file: " << keybinderUser;
 
     // find correct path to the game controller bindings
     // File format for controller mappings is different for SDL <= 2.0.4, 2.0.5, and >= 2.0.6

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -56,6 +56,7 @@ struct SDL_Window;
 
 namespace MWInput
 {
+    const float ZOOM_SCALE = 120.f; /// Used for scrolling camera in and out
 
     /**
     * @brief Class that handles all input and key bindings for OpenMW.
@@ -120,6 +121,8 @@ namespace MWInput
         virtual void mouseReleased( const SDL_MouseButtonEvent &arg, Uint8 id );
         virtual void mouseMoved( const SDLUtil::MouseMotionEvent &arg );
 
+        virtual void mouseWheelMoved( const SDL_MouseWheelEvent &arg);
+
         virtual void buttonPressed(int deviceID, const SDL_ControllerButtonEvent &arg);
         virtual void buttonReleased(int deviceID, const SDL_ControllerButtonEvent &arg);
         virtual void axisMoved(int deviceID, const SDL_ControllerAxisEvent &arg);
@@ -133,14 +136,17 @@ namespace MWInput
 
         virtual void channelChanged(ICS::Channel* channel, float currentValue, float previousValue);
 
-        virtual void mouseAxisBindingDetected(ICS::InputControlSystem* ICS, ICS::Control* control
-            , ICS::InputControlSystem::NamedAxis axis, ICS::Control::ControlChangingDirection direction);
-
         virtual void keyBindingDetected(ICS::InputControlSystem* ICS, ICS::Control* control
             , SDL_Scancode key, ICS::Control::ControlChangingDirection direction);
 
+        virtual void mouseAxisBindingDetected(ICS::InputControlSystem* ICS, ICS::Control* control
+            , ICS::InputControlSystem::NamedAxis axis, ICS::Control::ControlChangingDirection direction);
+
         virtual void mouseButtonBindingDetected(ICS::InputControlSystem* ICS, ICS::Control* control
             , unsigned int button, ICS::Control::ControlChangingDirection direction);
+
+        virtual void mouseWheelBindingDetected(ICS::InputControlSystem* ICS, ICS::Control* control
+            , ICS::InputControlSystem::MouseWheelClick click, ICS::Control::ControlChangingDirection direction);
 
         virtual void joystickAxisBindingDetected(ICS::InputControlSystem* ICS, int deviceID, ICS::Control* control
             , int axis, ICS::Control::ControlChangingDirection direction);
@@ -268,33 +274,33 @@ namespace MWInput
 
             A_Unused,
 
-            A_Screenshot,     // Take a screenshot
+            A_Screenshot,               // Take a screenshot
 
-            A_Inventory,      // Toggle inventory screen
+            A_Inventory,                // Toggle inventory screen
 
-            A_Console,        // Toggle console screen
+            A_Console,                  // Toggle console screen
 
-            A_MoveLeft,       // Move player left / right
+            A_MoveLeft,                 // Move player left / right
             A_MoveRight,
-            A_MoveForward,    // Forward / Backward
+            A_MoveForward,              // Forward / Backward
             A_MoveBackward,
 
             A_Activate,
 
-            A_Use,        //Use weapon, spell, etc.
+            A_Use,                      //Use weapon, spell, etc.
             A_Jump,
-            A_AutoMove,   //Toggle Auto-move forward
-            A_Rest,       //Rest
-            A_Journal,    //Journal
-            A_Weapon,     //Draw/Sheath weapon
-            A_Spell,      //Ready/Unready Casting
-            A_Run,        //Run when held
-            A_CycleSpellLeft, //cycling through spells
+            A_AutoMove,                 //Toggle Auto-move forward
+            A_Rest,                     //Rest
+            A_Journal,                  //Journal
+            A_Weapon,                   //Draw/Sheath weapon
+            A_Spell,                    //Ready/Unready Casting
+            A_Run,                      //Run when held
+            A_CycleSpellLeft,           //cycling through spells
             A_CycleSpellRight,
-            A_CycleWeaponLeft,//Cycling through weapons
+            A_CycleWeaponLeft,          //Cycling through weapons
             A_CycleWeaponRight,
-            A_ToggleSneak,    //Toggles Sneak
-            A_AlwaysRun, //Toggle Walking/Running
+            A_ToggleSneak,              //Toggles Sneak
+            A_AlwaysRun,                //Toggle Walking/Running
             A_Sneak,
 
             A_QuickSave,
@@ -322,12 +328,15 @@ namespace MWInput
 
             A_ToggleDebug,
 
-            A_LookUpDown,         //Joystick look
+            A_LookUpDown,               //Joystick look
             A_LookLeftRight,
             A_MoveForwardBackward,
             A_MoveLeftRight,
 
-            A_Last            // Marker for the last item
+            A_ZoomIn,
+            A_ZoomOut,
+
+            A_Last                      // Marker for the last item
         };
     };
 }

--- a/components/sdlutil/events.hpp
+++ b/components/sdlutil/events.hpp
@@ -30,6 +30,7 @@ public:
     virtual void mouseMoved( const MouseMotionEvent &arg ) = 0;
     virtual void mousePressed( const SDL_MouseButtonEvent &arg, Uint8 id ) = 0;
     virtual void mouseReleased( const SDL_MouseButtonEvent &arg, Uint8 id ) = 0;
+    virtual void mouseWheelMoved( const SDL_MouseWheelEvent &arg) = 0;
 };
 
 class KeyListener

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -77,6 +77,7 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
                     break;
                 case SDL_MOUSEWHEEL:
                     mMouseListener->mouseMoved(_packageMouseMotion(evt));
+                    mMouseListener->mouseWheelMoved(evt.wheel);
                     break;
                 case SDL_MOUSEBUTTONDOWN:
                     mMouseListener->mousePressed(evt.button, evt.button.button);

--- a/docs/source/reference/modding/settings/input.rst
+++ b/docs/source/reference/modding/settings/input.rst
@@ -54,18 +54,6 @@ based on whether the caps lock key was on or off at the time you exited.
 
 This settings can be toggled in game by pressing the CapsLock key and exiting.
 
-allow third person zoom
------------------------
-
-:Type:		boolean
-:Range:		True/False
-:Default:	False
-
-Allow zooming in and out using the middle mouse wheel in third person view.
-This feature may not work correctly if the mouse wheel is bound to other actions,
-and may be triggered accidentally in some cases, so is disabled by default.
-This setting can only be configured by editing the settings configuration file.
-
 camera sensitivity
 ------------------
 

--- a/extern/oics/ICSInputControlSystem.cpp
+++ b/extern/oics/ICSInputControlSystem.cpp
@@ -226,6 +226,15 @@ namespace ICS
 
 				loadJoystickButtonBinders(xmlControl);
 
+				/* ----------------------------------------------------------------------------------------
+				 * OPENMW CODE STARTS HERE
+				 * Mouse Wheel support added by Michael Stopa (Stomy) */
+
+				loadMouseWheelBinders(xmlControl);
+
+				/* OPENMW CODE ENDS HERE
+				 * ------------------------------------------------------------------------------------- */
+
 				// Attach controls to channels
 				TiXmlElement* xmlChannel = xmlControl->FirstChildElement("Channel");
 				while(xmlChannel)
@@ -306,6 +315,15 @@ namespace ICS
 		mControlsKeyBinderMap.clear();
 		mControlsMouseButtonBinderMap.clear();
 		mControlsJoystickButtonBinderMap.clear();
+
+		/* ----------------------------------------------------------------------------------------
+		 * OPENMW CODE STARTS HERE
+		 * Mouse Wheel support added by Michael Stopa (Stomy) */
+
+		mControlsMouseWheelBinderMap.clear();
+
+		/* OPENMW CODE ENDS HERE
+		 * ------------------------------------------------------------------------------------- */
 
 		ICS_LOG(" - InputControlSystem deleted - ");
 	}
@@ -490,6 +508,67 @@ namespace ICS
 				binder.SetAttribute( "direction", "DECREASE" );
 				control.InsertEndChild(binder);
 			}
+
+			/* ----------------------------------------------------------------------------------------
+			 * OPENMW CODE STARTS HERE
+			 * Mouse Wheel support added by Stomy */
+
+			if(getMouseWheelBinding(*o, Control::INCREASE) != MouseWheelClick::UNASSIGNED)
+			{
+				TiXmlElement binder( "MouseWheelBinder" );
+				MouseWheelClick click = getMouseWheelBinding(*o, Control::INCREASE);
+				bool skip = false;
+				switch (click) {
+					case MouseWheelClick::UP: {
+						binder.SetAttribute("button", "UP");
+					} break;
+					case MouseWheelClick::DOWN: {
+						binder.SetAttribute("button", "DOWN");
+					} break;
+					case MouseWheelClick::RIGHT: {
+						binder.SetAttribute("button", "RIGHT");
+					} break;
+					case MouseWheelClick::LEFT: {
+						binder.SetAttribute("button", "LEFT");
+					} break;
+					default: {
+						skip = true;
+					} break;
+				}
+				binder.SetAttribute( "direction", "INCREASE" );
+				if (!skip)
+					control.InsertEndChild(binder);
+			}
+
+			if(getMouseWheelBinding(*o, Control::DECREASE) != MouseWheelClick::UNASSIGNED)
+			{
+				TiXmlElement binder( "MouseWheelBinder" );
+				MouseWheelClick click = getMouseWheelBinding(*o, Control::INCREASE);
+				bool skip = false;
+				switch (click) {
+					case MouseWheelClick::UP: {
+						binder.SetAttribute("button", "UP");
+					} break;
+					case MouseWheelClick::DOWN: {
+						binder.SetAttribute("button", "DOWN");
+					} break;
+					case MouseWheelClick::RIGHT: {
+						binder.SetAttribute("button", "RIGHT");
+					} break;
+					case MouseWheelClick::LEFT: {
+						binder.SetAttribute("button", "LEFT");
+					} break;
+					default: {
+						skip = true;
+					} break;
+				}
+				binder.SetAttribute( "direction", "DECREASE" );
+				if (!skip)
+					control.InsertEndChild(binder);
+			}
+
+			/* OPENMW CODE ENDS HERE
+			 * ------------------------------------------------------------------------------------- */
 
 			if(getMouseButtonBinding(*o, Control/*::ControlChangingDirection*/::INCREASE)
 				!= ICS_MAX_DEVICE_BUTTONS)

--- a/extern/oics/ICSInputControlSystem.h
+++ b/extern/oics/ICSInputControlSystem.h
@@ -214,6 +214,26 @@ namespace ICS
 
 		Uint16 mClientWidth;
 		Uint16 mClientHeight;
+
+		/* ----------------------------------------------------------------------------------------
+		 * OPENMW CODE STARTS HERE
+		 * Mouse Wheel support added by Michael Stopa (Stomy) */
+
+	public:
+		enum class MouseWheelClick : int { UNASSIGNED = 0, UP = 1, DOWN = 2, LEFT = 3, RIGHT = 4};
+
+		void mouseWheelMoved(const SDL_MouseWheelEvent &evt);
+		void addMouseWheelBinding(Control* control, MouseWheelClick click, Control::ControlChangingDirection direction);
+		void removeMouseWheelBinding(MouseWheelClick click);
+		MouseWheelClick getMouseWheelBinding(Control* control, ICS::Control::ControlChangingDirection direction);
+		bool isMouseWheelBound(MouseWheelClick button) const;
+
+	protected:
+		void loadMouseWheelBinders(TiXmlElement* xmlControlNode);
+		ControlsButtonBinderMapType mControlsMouseWheelBinderMap;
+
+		/* OPENMW CODE ENDS HERE
+		 * ------------------------------------------------------------------------------------- */
 	};
 
 	class DllExport DetectingBindingListener
@@ -234,6 +254,16 @@ namespace ICS
 		virtual void joystickButtonBindingDetected(InputControlSystem* ICS, int deviceID, Control* control
 			, unsigned int button, Control::ControlChangingDirection direction);
 
+		/* ----------------------------------------------------------------------------------------
+		 * OPENMW CODE STARTS HERE
+		 * Mouse Wheel support added by Michael Stopa (Stomy) */
+
+		virtual void mouseWheelBindingDetected(InputControlSystem* ICS, Control* control,
+		                                       InputControlSystem::MouseWheelClick click,
+		                                       Control::ControlChangingDirection direction);
+
+		/* OPENMW CODE ENDS HERE
+		 * ------------------------------------------------------------------------------------- */
 	};
 
 	extern const float ICS_MAX;

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -348,9 +348,6 @@ toggle sneak = false
 # Player is running by default.
 always run = false
 
-# Zoom in and out from player in third person view with mouse wheel.
-allow third person zoom = false
-
 # Camera sensitivity when not in GUI mode. (>0.0, e.g. 0.1 to 5.0).
 camera sensitivity = 1.0
 

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -179,16 +179,6 @@
          </property>
          <layout class="QVBoxLayout" name="inputGroupVerticalLayout">
           <item>
-           <widget class="QCheckBox" name="allowThirdPersonZoomCheckBox">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allow zooming in and out using the middle mouse wheel in third person view. This feature may not work correctly if the mouse wheel is bound to other actions, and may be triggered accidentally in some cases, so is disabled by default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Allow third person zoom</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="grabCursorCheckBox">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;OpenMW will capture control of the cursor if this setting is true.&lt;/p&gt;&lt;p&gt;In “look mode”, OpenMW will center the cursor regardless of the value of this setting (since the cursor/crosshair is always centered in the OpenMW window). However, in GUI mode, this setting determines the behavior when the cursor is moved outside the OpenMW window. If true, the cursor movement stops at the edge of the window preventing access to other applications. If false, the cursor is allowed to move freely on the desktop.&lt;/p&gt;&lt;p&gt;This setting does not apply to the screen where escape has been pressed, where the cursor is never captured. Regardless of this setting “Alt-Tab” or some other operating system dependent key sequence can be used to allow the operating system to regain control of the mouse cursor. This setting interacts with the minimize on focus loss setting by affecting what counts as a focus loss. Specifically on a two-screen configuration it may be more convenient to access the second screen with setting disabled.&lt;/p&gt;&lt;p&gt;Note for developers: it’s desirable to have this setting disabled when running the game in a debugger, to prevent the mouse cursor from becoming unusable when the game pauses on a breakpoint.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>


### PR DESCRIPTION
Basically, cleaned up version of [MR97](https://gitlab.com/OpenMW/openmw/merge_requests/97) with resolved conflicts and a couple of bugfixes (Stomy is inactive ATM).

Known issue: mouse wheel bindings do not work for actions which require to hold button (e.g. movement - actionIsActive() does not work for mouse wheel movemnt bindings) - the channel value is 0, and it is unclear how to fix it. May be not a blocker, though.