### PR TITLE
Implement actors movement deceleration (feature #4544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@
     Feature #4255: Handle broken RepairedOnMe script function
     Feature #4316: Implement RaiseRank/LowerRank functions properly
     Feature #4360: Improve default controller bindings
+    Feature #4544: Actors movement deceleration
     Feature #4673: Weapon sheathing
     Feature #4675: Support for NiRollController
     Feature #4730: Native animated containers support

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -556,6 +556,8 @@ namespace MWClass
         if(getMovementSettings(ptr).mPosition[0] != 0 && getMovementSettings(ptr).mPosition[1] == 0)
             moveSpeed *= 0.75f;
 
+        moveSpeed *= ptr.getClass().getMovementSettings(ptr).mSpeedFactor;
+
         return moveSpeed;
     }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -990,6 +990,8 @@ namespace MWClass
         if(npcdata->mNpcStats.isWerewolf() && running && npcdata->mNpcStats.getDrawState() == MWMechanics::DrawState_Nothing)
             moveSpeed *= gmst.fWereWolfRunMult->mValue.getFloat();
 
+        moveSpeed *= ptr.getClass().getMovementSettings(ptr).mSpeedFactor;
+
         return moveSpeed;
     }
 

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -121,6 +121,7 @@ namespace MWMechanics
             void engageCombat(const MWWorld::Ptr& actor1, const MWWorld::Ptr& actor2, std::map<const MWWorld::Ptr, const std::set<MWWorld::Ptr> >& cachedAllies, bool againstPlayer);
 
             void playIdleDialogue(const MWWorld::Ptr& actor);
+            void updateMovementSpeed(const MWWorld::Ptr& actor);
             void updateGreetingState(const MWWorld::Ptr& actor, bool turnOnly);
             void turnActorToFacePlayer(const MWWorld::Ptr& actor, const osg::Vec3f& dir);
 

--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -36,11 +36,15 @@ namespace MWMechanics
 
             virtual int getTypeId() const;
 
+            virtual bool useVariableSpeed() const { return true;}
+
             virtual bool sideWithTarget() const { return true; }
 
             void writeState(ESM::AiSequence::AiSequence &sequence) const;
 
             void fastForward(const MWWorld::Ptr& actor, AiState& state);
+
+            virtual osg::Vec3f getDestination() { return osg::Vec3f(mX, mY, mZ); }
 
         private:
             std::string mCellId;

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -7,6 +7,8 @@
 
 #include <components/esm/defs.hpp>
 
+#include "../mwworld/ptr.hpp"
+
 #include "pathfinding.hpp"
 
 namespace ESM
@@ -61,6 +63,8 @@ namespace MWMechanics
 
             virtual int getTypeId() const;
 
+            virtual bool useVariableSpeed() const { return true;}
+
             /// Returns the actor being followed
             std::string getFollowedActor();
 
@@ -71,6 +75,15 @@ namespace MWMechanics
             int getFollowIndex() const;
 
             void fastForward(const MWWorld::Ptr& actor, AiState& state);
+
+            virtual osg::Vec3f getDestination()
+            {
+                MWWorld::Ptr target = getTarget();
+                if (target.isEmpty())
+                    return osg::Vec3f(0, 0, 0);
+
+                return target.getRefData().getPosition().asVec3();
+            }
 
         private:
             /// This will make the actor always follow.

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -73,6 +73,9 @@ namespace MWMechanics
             /// Higher number is higher priority (0 being the lowest)
             virtual unsigned int getPriority() const {return 0;}
 
+            /// Check if package use movement with variable speed
+            virtual bool useVariableSpeed() const { return false;}
+
             virtual void writeState (ESM::AiSequence::AiSequence& sequence) const {}
 
             /// Simulates the passing of time
@@ -98,6 +101,8 @@ namespace MWMechanics
 
             /// Return true if this package should repeat. Currently only used for Wander packages.
             virtual bool getRepeat() const;
+
+            virtual osg::Vec3f getDestination() { return osg::Vec3f(0, 0, 0); }
 
             /// Reset pathfinding state
             void reset();

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -388,6 +388,11 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor, boo
     }
 }
 
+bool MWMechanics::AiSequence::isEmpty() const
+{
+    return mPackages.empty();
+}
+
 AiPackage* MWMechanics::AiSequence::getActivePackage()
 {
     if(mPackages.empty())

--- a/apps/openmw/mwmechanics/aisequence.hpp
+++ b/apps/openmw/mwmechanics/aisequence.hpp
@@ -132,6 +132,8 @@ namespace MWMechanics
                 \see ESM::AIPackageList **/
             void fill (const ESM::AIPackageList& list);
 
+            bool isEmpty() const;
+
             void writeState (ESM::AiSequence::AiSequence& sequence) const;
             void readState (const ESM::AiSequence::AiSequence& sequence);
     };

--- a/apps/openmw/mwmechanics/aitravel.hpp
+++ b/apps/openmw/mwmechanics/aitravel.hpp
@@ -32,6 +32,10 @@ namespace MWMechanics
 
             virtual int getTypeId() const;
 
+            virtual bool useVariableSpeed() const { return true;}
+
+            virtual osg::Vec3f getDestination() { return osg::Vec3f(mX, mY, mZ); }
+
         private:
             float mX;
             float mY;

--- a/apps/openmw/mwmechanics/movement.hpp
+++ b/apps/openmw/mwmechanics/movement.hpp
@@ -10,11 +10,13 @@ namespace MWMechanics
     {
         float mPosition[3];
         float mRotation[3];
+        float mSpeedFactor;
 
         Movement()
         {
             mPosition[0] = mPosition[1] = mPosition[2] = 0.0f;
             mRotation[0] = mRotation[1] = mRotation[2] = 0.0f;
+            mSpeedFactor = 1.f;
         }
 
         osg::Vec3f asVec3()


### PR DESCRIPTION
Implements [feature #4544](https://gitlab.com/OpenMW/openmw/issues/4544) by using related formula from Morrowind.

The formula is a bit strange, though (deceleration is a very fast, so on ranges < 450 movement speed almost always has the 0.7x multiplier).