### PR TITLE
Vanilla-style rain

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -615,6 +615,8 @@ namespace MWBase
 
             /// Return physical half extents of the given actor to be used in pathfinding
             virtual osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const = 0;
+
+            virtual void emitWaterRipple(const osg::Vec3f& pos) = 0;
     };
 }
 

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1556,7 +1556,14 @@ void SkyManager::updateRainParameters(float duration, bool paused)
     float y = radius * sin(angle);
     float z = mRainMinHeight + (mRainMaxHeight - mRainMinHeight) * Misc::Rng::rollClosedProbability();
 
-    mRaindropsToCreate += (mRainMaxRaindrops - mRainNode->getNumChildren()) * duration / mRainEntranceSpeed * mAmbientSoundVolume;
+    int numActive = 0;
+    for (unsigned int i = 0; i < mRainNode->getNumChildren(); i++)
+    {
+        if (mRainNode->getChild(i)->getNodeMask() != 0)
+            numActive++;
+    }
+
+    mRaindropsToCreate += (mRainMaxRaindrops - numActive) * duration / mRainEntranceSpeed * mAmbientSoundVolume;
 
     float rainAngle = -std::atan(mWindSpeed/50.f);
     osg::Vec3f velocity(0, mRainSpeed*std::sin(rainAngle) * duration, -mRainSpeed/std::cos(rainAngle) * duration);

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -44,7 +44,7 @@ namespace MWRender
     class RainShooter;
     class RainFader;
     class AlphaFader;
-    class UnderwaterSwitchCallback;
+    class CameraRelativeTransform;
 
     struct WeatherResult
     {
@@ -81,6 +81,7 @@ namespace MWRender
         float mNightFade; // fading factor for night skybox
 
         bool mIsStorm;
+        bool mFastForwardRain;
 
         std::string mAmbientLoopSoundID;
         float mAmbientSoundVolume;
@@ -89,12 +90,13 @@ namespace MWRender
         std::string mRainEffect;
         float mEffectFade;
 
+
         float mRainDiameter;
         float mRainMinHeight;
         float mRainMaxHeight;
         float mRainSpeed;
         float mRainEntranceSpeed;
-        int mRainMaxRaindrops;
+        unsigned int mRainMaxRaindrops;
     };
 
     struct MoonState
@@ -148,7 +150,7 @@ namespace MWRender
         void setMoonColour (bool red);
         ///< change Secunda colour to red
 
-        void setWeather(const WeatherResult& weather);
+        void setWeather(const WeatherResult& weather, float duration, bool paused);
 
         void sunEnable();
 
@@ -187,21 +189,19 @@ namespace MWRender
 
         void createRain();
         void destroyRain();
-        void switchUnderwaterRain();
-        void updateRainParameters();
+        void updateRainParameters(float duration, bool paused);
 
         Resource::SceneManager* mSceneManager;
 
         osg::Camera *mCamera;
         osg::Uniform *mRainIntensityUniform;
 
-        osg::ref_ptr<osg::Group> mRootNode;
+        osg::ref_ptr<CameraRelativeTransform> mRootNode;
         osg::ref_ptr<osg::Group> mEarlyRenderBinRoot;
 
         osg::ref_ptr<osg::PositionAttitudeTransform> mParticleNode;
         osg::ref_ptr<osg::Node> mParticleEffect;
         std::vector<osg::ref_ptr<AlphaFader> > mParticleFaders;
-        osg::ref_ptr<UnderwaterSwitchCallback> mUnderwaterSwitch;
 
         osg::ref_ptr<osg::PositionAttitudeTransform> mCloudNode;
 
@@ -223,10 +223,6 @@ namespace MWRender
         std::unique_ptr<Moon> mSecunda;
 
         osg::ref_ptr<osg::Group> mRainNode;
-        osg::ref_ptr<osgParticle::ParticleSystem> mRainParticleSystem;
-        osg::ref_ptr<osgParticle::BoxPlacer> mPlacer;
-        osg::ref_ptr<RainCounter> mCounter;
-        osg::ref_ptr<RainShooter> mRainShooter;
         osg::ref_ptr<RainFader> mRainFader;
 
         bool mCreated;
@@ -254,8 +250,6 @@ namespace MWRender
 
         std::string mCurrentParticleEffect;
 
-        float mRemainingTransitionTime;
-
         bool mRainEnabled;
         std::string mRainEffect;
         float mRainSpeed;
@@ -263,11 +257,16 @@ namespace MWRender
         float mRainMinHeight;
         float mRainMaxHeight;
         float mRainEntranceSpeed;
-        int mRainMaxRaindrops;
+        unsigned int mRainMaxRaindrops;
         float mWindSpeed;
+        float mRaindropsToCreate;
+        float mWaterHeight;
+        float mAmbientSoundVolume;
+        osg::Vec3 mPreviousCameraPosition;
 
         bool mEnabled;
         bool mSunEnabled;
+        bool mWaterEnabled;
 
         float mWeatherAlpha;
 

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -804,7 +804,7 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
     mRendering.setAmbientColour(mResult.mAmbientColor);
     mRendering.setSunColour(mResult.mSunColor, mResult.mSunColor * mResult.mGlareView * glareFade);
 
-    mRendering.getSkyManager()->setWeather(mResult);
+    mRendering.getSkyManager()->setWeather(mResult, duration, paused);
 
     // Play sounds
     if (mPlayingSoundID != mResult.mAmbientLoopSoundID)
@@ -1141,6 +1141,8 @@ inline void WeatherManager::calculateResult(const int weatherID, const float gam
     mResult.mRainMaxHeight = current.mRainMaxHeight;
     mResult.mRainMaxRaindrops = current.mRainMaxRaindrops;
 
+    mResult.mFastForwardRain = false;
+
     mResult.mParticleEffect = current.mParticleEffect;
     mResult.mRainEffect = current.mRainEffect;
 
@@ -1208,6 +1210,8 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
     mResult.mSunColor = lerp(current.mSunColor, other.mSunColor, factor);
     mResult.mSkyColor = lerp(current.mSkyColor, other.mSkyColor, factor);
 
+    mResult.mFastForwardRain = true;
+
     mResult.mAmbientColor = lerp(current.mAmbientColor, other.mAmbientColor, factor);
     mResult.mSunDiscColor = lerp(current.mSunDiscColor, other.mSunDiscColor, factor);
     mResult.mFogDepth = lerp(current.mFogDepth, other.mFogDepth, factor);
@@ -1228,7 +1232,7 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
     if (threshold <= 0)
         threshold = 0.5f;
 
-    if(factor < threshold)
+    if(factor <= threshold)
     {
         mResult.mIsStorm = current.mIsStorm;
         mResult.mParticleEffect = current.mParticleEffect;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3147,6 +3147,11 @@ namespace MWWorld
             mProjectileManager->launchProjectile(actor, projectile, worldPos, orient, bow, speed, attackStrength);
     }
 
+    void World::emitWaterRipple(const osg::Vec3f& pos)
+    {
+        mRendering->emitWaterRipple(pos);
+    }
+
     void World::launchMagicBolt (const std::string &spellId, const MWWorld::Ptr& caster, const osg::Vec3f& fallbackDirection)
     {
         mProjectileManager->launchMagicBolt(spellId, caster, fallbackDirection);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -720,6 +720,8 @@ namespace MWWorld
 
             /// Return physical half extents of the given actor to be used in pathfinding
             osg::Vec3f getPathfindingHalfExtents(const MWWorld::ConstPtr& actor) const override;
+
+            void emitWaterRipple(const osg::Vec3f& pos) override;
     };
 }
 


### PR DESCRIPTION
An attempt to implement a vanilla-style rain using a reverse-engeneered logic from Morrowind.
Should fix the [bug #3404](https://gitlab.com/OpenMW/openmw/issues/3404).

Unfortunately, a particles-based rain works faster than a drawables-based approach.
So we basically should decide - either we keep a backward compatibility here and sacrifice performance, or we claim our current approach to be a more advanced and close mentioned bug as WON'T FIX.