### PR TITLE
Resolving 0.46.0 release shadow-related blockers

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -45,6 +45,7 @@ Launcher::GraphicsPage::GraphicsPage(Files::ConfigurationManager &cfg, Settings:
     connect(standardRadioButton, SIGNAL(toggled(bool)), this, SLOT(slotStandardToggled(bool)));
     connect(screenComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(screenChanged(int)));
     connect(framerateLimitCheckBox, SIGNAL(toggled(bool)), this, SLOT(slotFramerateLimitToggled(bool)));
+    connect(shadowDistanceCheckBox, SIGNAL(toggled(bool)), this, SLOT(slotShadowDistLimitToggled(bool)));
 
 }
 
@@ -129,6 +130,33 @@ bool Launcher::GraphicsPage::loadSettings()
         framerateLimitSpinBox->setValue(fpsLimit);
     }
 
+    if (mEngineSettings.getBool("actor shadows", "Shadows"))
+        actorShadowsCheckBox->setCheckState(Qt::Checked);
+    if (mEngineSettings.getBool("player shadows", "Shadows"))
+        playerShadowsCheckBox->setCheckState(Qt::Checked);
+    if (mEngineSettings.getBool("terrain shadows", "Shadows"))
+        objectShadowsCheckBox->setCheckState(Qt::Checked);
+    if (mEngineSettings.getBool("object shadows", "Shadows"))
+        objectShadowsCheckBox->setCheckState(Qt::Checked);
+    if (mEngineSettings.getBool("enable indoor shadows", "Shadows"))
+        indoorShadowsCheckBox->setCheckState(Qt::Checked);
+
+    int shadowDistLimit = mEngineSettings.getInt("maximum shadow map distance", "Shadows");
+    if (shadowDistLimit > 0)
+    {
+        shadowDistanceCheckBox->setCheckState(Qt::Checked);
+        shadowDistanceSpinBox->setValue(shadowDistLimit);
+    }
+
+    float shadowFadeStart = mEngineSettings.getFloat("shadow fade start", "Shadows");
+    if (shadowFadeStart != 0)
+        fadeStartSpinBox->setValue(shadowFadeStart);
+
+    int shadowRes = mEngineSettings.getInt("shadow map resolution", "Shadows");
+    int shadowResIndex = shadowResolutionComboBox->findText(QString::number(shadowRes));
+    if (shadowResIndex != -1)
+        shadowResolutionComboBox->setCurrentIndex(shadowResIndex);
+
     return true;
 }
 
@@ -185,6 +213,52 @@ void Launcher::GraphicsPage::saveSettings()
     {
         mEngineSettings.setFloat("framerate limit", "Video", 0);
     }
+
+    int cShadowDist = shadowDistanceCheckBox->checkState() ? shadowDistanceSpinBox->value() : 0;
+    if (mEngineSettings.getInt("maximum shadow map distance", "Shadows") != cShadowDist)
+        mEngineSettings.setInt("maximum shadow map distance", "Shadows", cShadowDist);
+    float cFadeStart = fadeStartSpinBox->value();
+    if (cShadowDist > 0 && mEngineSettings.getFloat("shadow fade start", "Shadows") != cFadeStart)
+        mEngineSettings.setFloat("shadow fade start", "Shadows", cFadeStart);
+
+    bool cActorShadows = actorShadowsCheckBox->checkState();
+    bool cObjectShadows = objectShadowsCheckBox->checkState();
+    bool cTerrainShadows = terrainShadowsCheckBox->checkState();
+    bool cPlayerShadows = playerShadowsCheckBox->checkState();
+    if (cActorShadows || cObjectShadows || cTerrainShadows || cPlayerShadows)
+    {
+        if (mEngineSettings.getBool("enable shadows", "Shadows") != true)
+            mEngineSettings.setBool("enable shadows", "Shadows", true);
+        if (mEngineSettings.getBool("actor shadows", "Shadows") != cActorShadows)
+            mEngineSettings.setBool("actor shadows", "Shadows", cActorShadows);
+        if (mEngineSettings.getBool("player shadows", "Shadows") != cPlayerShadows)
+            mEngineSettings.setBool("player shadows", "Shadows", cPlayerShadows);
+        if (mEngineSettings.getBool("object shadows", "Shadows") != cObjectShadows)
+            mEngineSettings.setBool("object shadows", "Shadows", cObjectShadows);
+        if (mEngineSettings.getBool("terrain shadows", "Shadows") != cTerrainShadows)
+            mEngineSettings.setBool("terrain shadows", "Shadows", cTerrainShadows);
+    }
+    else
+    {
+        if (mEngineSettings.getBool("enable shadows", "Shadows"))
+            mEngineSettings.setBool("enable shadows", "Shadows", false);
+        if (mEngineSettings.getBool("actor shadows", "Shadows"))
+            mEngineSettings.setBool("actor shadows", "Shadows", false);
+        if (mEngineSettings.getBool("player shadows", "Shadows"))
+            mEngineSettings.setBool("player shadows", "Shadows", false);
+        if (mEngineSettings.getBool("object shadows", "Shadows"))
+            mEngineSettings.setBool("object shadows", "Shadows", false);
+        if (mEngineSettings.getBool("terrain shadows", "Shadows"))
+            mEngineSettings.setBool("terrain shadows", "Shadows", false);
+    }
+
+    bool cIndoorShadows = indoorShadowsCheckBox->checkState();
+    if (mEngineSettings.getBool("enable indoor shadows", "Shadows") != cIndoorShadows)
+        mEngineSettings.setBool("enable indoor shadows", "Shadows", cIndoorShadows);
+
+    int cShadowRes = shadowResolutionComboBox->currentText().toInt();
+    if (cShadowRes != mEngineSettings.getInt("shadow map resolution", "Shadows"))
+        mEngineSettings.setInt("shadow map resolution", "Shadows", cShadowRes);
 }
 
 QStringList Launcher::GraphicsPage::getAvailableResolutions(int screen)
@@ -289,4 +363,11 @@ void Launcher::GraphicsPage::slotStandardToggled(bool checked)
 void Launcher::GraphicsPage::slotFramerateLimitToggled(bool checked)
 {
     framerateLimitSpinBox->setEnabled(checked);
+}
+
+
+void Launcher::GraphicsPage::slotShadowDistLimitToggled(bool checked)
+{
+    shadowDistanceSpinBox->setEnabled(checked);
+    fadeStartSpinBox->setEnabled(checked);
 }

--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -365,7 +365,6 @@ void Launcher::GraphicsPage::slotFramerateLimitToggled(bool checked)
     framerateLimitSpinBox->setEnabled(checked);
 }
 
-
 void Launcher::GraphicsPage::slotShadowDistLimitToggled(bool checked)
 {
     shadowDistanceSpinBox->setEnabled(checked);

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -32,6 +32,7 @@ namespace Launcher
         void slotFullScreenChanged(int state);
         void slotStandardToggled(bool checked);
         void slotFramerateLimitToggled(bool checked);
+        void slotShadowDistLimitToggled(bool checked);
 
     private:
         Files::ConfigurationManager &mCfgMgr;

--- a/components/sceneutil/mwshadowtechnique.cpp
+++ b/components/sceneutil/mwshadowtechnique.cpp
@@ -843,6 +843,11 @@ void SceneUtil::MWShadowTechnique::setPolygonOffset(float factor, float units)
     }
 }
 
+void SceneUtil::MWShadowTechnique::setShadowFadeStart(float shadowFadeStart)
+{
+    _shadowFadeStart = shadowFadeStart;
+}
+
 void SceneUtil::MWShadowTechnique::enableFrontFaceCulling()
 {
     _useFrontFaceCulling = true;
@@ -1492,6 +1497,9 @@ void MWShadowTechnique::createShaders()
 
     osg::ref_ptr<osg::Uniform> baseTextureUnit = new osg::Uniform("baseTextureUnit",(int)_baseTextureUnit);
     _uniforms.push_back(baseTextureUnit.get());
+
+    _uniforms.push_back(new osg::Uniform("maximumShadowMapDistance", (float)settings->getMaximumShadowMapDistance()));
+    _uniforms.push_back(new osg::Uniform("shadowFadeStart", (float)_shadowFadeStart));
 
     for(unsigned int sm_i=0; sm_i<settings->getNumShadowMapsPerLight(); ++sm_i)
     {

--- a/components/sceneutil/mwshadowtechnique.hpp
+++ b/components/sceneutil/mwshadowtechnique.hpp
@@ -76,6 +76,8 @@ namespace SceneUtil {
 
         virtual void setPolygonOffset(float factor, float units);
 
+        virtual void setShadowFadeStart(float shadowFadeStart);
+
         virtual void enableFrontFaceCulling();
 
         virtual void disableFrontFaceCulling();
@@ -256,6 +258,8 @@ namespace SceneUtil {
         float                                   _polygonOffsetUnits = 4.0;
 
         bool                                    _useFrontFaceCulling = true;
+
+        float                                   _shadowFadeStart = 0.0;
 
         class DebugHUD : public osg::Referenced
         {

--- a/components/sceneutil/shadow.cpp
+++ b/components/sceneutil/shadow.cpp
@@ -27,6 +27,14 @@ namespace SceneUtil
         mShadowSettings->setNumShadowMapsPerLight(numberOfShadowMapsPerLight);
         mShadowSettings->setBaseShadowTextureUnit(8 - numberOfShadowMapsPerLight);
 
+        const float maximumShadowMapDistance = Settings::Manager::getFloat("maximum shadow map distance", "Shadows");
+        if (maximumShadowMapDistance > 0)
+        {
+            const float shadowFadeStart = std::min(std::max(0.f, Settings::Manager::getFloat("shadow fade start", "Shadows")), 1.f);
+            mShadowSettings->setMaximumShadowMapDistance(maximumShadowMapDistance);
+            mShadowTechnique->setShadowFadeStart(maximumShadowMapDistance * shadowFadeStart);
+        }
+
         mShadowSettings->setMinimumShadowMapNearFarRatio(Settings::Manager::getFloat("minimum lispsm near far ratio", "Shadows"));
         if (Settings::Manager::getBool("compute tight scene bounds", "Shadows"))
             mShadowSettings->setComputeNearFarModeOverride(osg::CullSettings::COMPUTE_NEAR_FAR_USING_PRIMITIVES);
@@ -117,6 +125,8 @@ namespace SceneUtil
 
         definesWithShadows["shadowNormalOffset"] = std::to_string(Settings::Manager::getFloat("normal offset distance", "Shadows"));
 
+        definesWithShadows["limitShadowMapDistance"] = Settings::Manager::getFloat("maximum shadow map distance", "Shadows") > 0 ? "1" : "0";
+
         return definesWithShadows;
     }
 
@@ -137,6 +147,8 @@ namespace SceneUtil
         definesWithoutShadows["disableNormalOffsetShadows"] = "0";
 
         definesWithoutShadows["shadowNormalOffset"] = "0.0";
+
+        definesWithoutShadows["limitShadowMapDistance"] = "0";
 
         return definesWithoutShadows;
     }

--- a/docs/source/reference/modding/settings/shadows.rst
+++ b/docs/source/reference/modding/settings/shadows.rst
@@ -16,7 +16,6 @@ Unlike in the original Morrowind engine, 'Shadow Mapping' is used, which can hav
 Bear in mind that this will force OpenMW to use shaders as if :ref:`force shaders` was enabled.
 A keen developer may be able to implement compatibility with fixed-function mode using the advice of `this post <https://github.com/OpenMW/openmw/pull/1547#issuecomment-369657381>`_, but it may be more difficult than it seems.
 
-
 number of shadow maps
 ---------------------
 
@@ -27,6 +26,28 @@ number of shadow maps
 Control how many shadow maps to use - more of these means each shadow map texel covers less area, producing better-looking shadows, but may decrease performance.
 Using too many shadow maps will lead to them overriding texture slots used for other effects, producing unpleasant artefacts.
 A value of three is recommended in most cases, but other values may produce better results or performance.
+
+maximum shadow map distance
+---------------------------
+
+:Type:		float
+:Range:		The whole range of 32-bit floating point
+:Default:	8192
+
+The maximum distance from the camera shadows cover, limiting their overall area coverage
+and improving their quality and performance at the cost of removing shadows of distant objects or terrain.
+Set this to a non-positive value to remove the limit.
+
+shadow fade start
+-------------------
+
+:Type:		float
+:Range:		0.0-1.0
+:Default:	0.9
+
+The fraction of the maximum shadow map distance at which the shadows will begin to fade away.
+Tweaking it will make the transition proportionally more or less smooth.
+This setting has no effect if the maximum shadow map distance is non-positive (infinite).
 
 allow shadow map overlap
 ------------------------

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -746,6 +746,12 @@ enable shadows = false
 # How many shadow maps to use - more of these means each shadow map texel covers less area, producing better looking shadows, but may decrease performance.
 number of shadow maps = 3
 
+# The distance from the camera at which shadows fade away completely. Set to 0 to make the distance infinite.
+maximum shadow map distance = 8192
+
+# Fraction of the maximum distance at which shadows begin to gradually fade away.
+shadow fade start = 0.9
+
 # If true, allow shadow maps to overlap. Counter-intuitively, will produce better results when the light is behind the camera. When enabled, OpenMW uses Cascaded Shadow Maps and when disabled, it uses Parallel Split Shadow Maps.
 allow shadow map overlap = true
 

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -114,7 +114,7 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, decalTex.xyz, decalTex.a);
 #endif
 
-    float shadowing = unshadowedLightRatio();
+    float shadowing = unshadowedLightRatio(depth);
 
 #if !PER_PIXEL_LIGHTING
 

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -66,7 +66,7 @@ void main()
     gl_FragData[0].a *= texture2D(blendMap, blendMapUV).a;
 #endif
 
-    float shadowing = unshadowedLightRatio();
+    float shadowing = unshadowedLightRatio(depth);
 
 #if !PER_PIXEL_LIGHTING
 

--- a/files/shaders/water_fragment.glsl
+++ b/files/shaders/water_fragment.glsl
@@ -160,7 +160,7 @@ void main(void)
     vec2 UV = worldPos.xy / (8192.0*5.0) * 3.0;
     UV.y *= -1.0;
 
-    float shadow = unshadowedLightRatio();
+    float shadow = unshadowedLightRatio(depthPassthrough);
 
     vec2 screenCoords = screenCoordsPassthrough.xy / screenCoordsPassthrough.z;
     screenCoords.y = (1.0-screenCoords.y);

--- a/files/ui/graphicspage.ui
+++ b/files/ui/graphicspage.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>GraphicsPage</class>
  <widget class="QWidget" name="GraphicsPage">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>437</width>
-    <height>343</height>
-   </rect>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="displayGroup">
@@ -172,6 +164,145 @@
         </property>
         <property name="value">
          <double>300</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="shadowGroup">
+     <property name="title">
+      <string>Shadows</string>
+     </property>
+     <layout class="QGridLayout" name="shadowsLayout" columnstretch="0,0,0">
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="actorShadowsCheckBox">
+        <property name="text">
+         <string>Enable Actor Shadows</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="terrainShadowsCheckBox">
+        <property name="text">
+         <string>Enable Terrain Shadows</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="objectShadowsCheckBox">
+        <property name="text">
+         <string>Enable Object Shadows</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="shadowDistanceCheckBox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The distance from the camera at which shadows completely disappear&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Shadow Distance Limit:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" alignment="Qt::AlignLeft">
+       <widget class="QLabel" name="shadowResolutionLabel">
+        <property name="text">
+         <string>Shadow Map Resolution:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="shadowResolutionComboBox">
+        <item>
+         <property name="text">
+          <string>512</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1024</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2048</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4096</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="playerShadowsCheckBox">
+        <property name="text">
+         <string>Enable Player Shadows</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QSpinBox" name="shadowDistanceSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;64 game units is 1 real life yard or about 0.9 m&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="suffix">
+         <string> unit(s)</string>
+        </property>
+        <property name="minimum">
+         <number>512</number>
+        </property>
+        <property name="maximum">
+         <number>81920</number>
+        </property>
+        <property name="value">
+         <number>8192</number>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="fadeStartLabel">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The fraction of the limit above at which shadows begin to gradually fade away&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Fade Start Multiplier:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QDoubleSpinBox" name="fadeStartSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>0.05</double>
+        </property>
+        <property name="maximum">
+         <double>1</double>
+        </property>
+        <property name="value">
+         <double>0.90</double>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="indoorShadowsCheckBox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if at least one of the options above is not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Enable Indoor Shadows</string>
         </property>
        </widget>
       </item>

--- a/files/ui/graphicspage.ui
+++ b/files/ui/graphicspage.ui
@@ -204,7 +204,7 @@
           <item row="6" column="0">
            <widget class="QCheckBox" name="shadowDistanceCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The distance from the camera at which shadows completely disappear&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The distance from the camera at which shadows completely disappear.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Shadow Distance Limit:</string>
@@ -236,7 +236,7 @@
           <item row="7" column="0">
            <widget class="QLabel" name="fadeStartLabel">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The fraction of the limit above at which shadows begin to gradually fade away&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The fraction of the limit above at which shadows begin to gradually fade away.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Fade Start Multiplier:</string>
@@ -269,6 +269,9 @@
           </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="actorShadowsCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable shadows for NPCs and creatures besides the player character. May have a minor performance impact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="text">
              <string>Enable Actor Shadows</string>
             </property>
@@ -276,6 +279,9 @@
           </item>
           <item row="3" column="0" alignment="Qt::AlignLeft">
            <widget class="QCheckBox" name="terrainShadowsCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable shadows for the terrain including distant terrain. May have a significant performance and shadow quality impact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="text">
              <string>Enable Terrain Shadows</string>
             </property>
@@ -290,7 +296,7 @@
              <number>2</number>
             </property>
             <property name="minimum">
-             <double>0.05</double>
+             <double>0</double>
             </property>
             <property name="maximum">
              <double>1</double>
@@ -302,6 +308,9 @@
           </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="playerShadowsCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable shadows exclusively for the player character. May have a very minor performance impact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="text">
              <string>Enable Player Shadows</string>
             </property>
@@ -309,6 +318,9 @@
           </item>
           <item row="5" column="0" alignment="Qt::AlignLeft">
            <widget class="QLabel" name="shadowResolutionLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The resolution of each individual shadow map. Increasing it significantly improves shadow quality but may have a minor performance impact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="text">
              <string>Shadow Map Resolution:</string>
             </property>
@@ -316,6 +328,9 @@
           </item>
           <item row="2" column="0">
            <widget class="QCheckBox" name="objectShadowsCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable shadows for primarily inanimate objects. May have a significant performance impact.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
             <property name="text">
              <string>Enable Object Shadows</string>
             </property>
@@ -324,7 +339,7 @@
           <item row="4" column="0">
            <widget class="QCheckBox" name="indoorShadowsCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if actor shadows are not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if actor/player shadows are not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Enable Indoor Shadows</string>

--- a/files/ui/graphicspage.ui
+++ b/files/ui/graphicspage.ui
@@ -2,325 +2,341 @@
 <ui version="4.0">
  <class>GraphicsPage</class>
  <widget class="QWidget" name="GraphicsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>340</height>
+   </rect>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="displayGroup">
-     <property name="title">
-      <string>Display</string>
+    <widget class="QTabWidget" name="DisplayTabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,1">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="vSyncCheckBox">
-        <property name="text">
-         <string>Vertical Sync</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="fullScreenCheckBox">
-        <property name="text">
-         <string>Full Screen</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="windowBorderCheckBox">
-        <property name="text">
-         <string>Window Border</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="antiAliasingLabel">
-        <property name="text">
-         <string>Anti-aliasing:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="screenLabel">
-        <property name="text">
-         <string>Screen:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="resolutionLabel">
-        <property name="text">
-         <string>Resolution:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QCheckBox" name="framerateLimitCheckBox">
-        <property name="text">
-         <string>Framerate Limit:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="antiAliasingComboBox">
-        <item>
-         <property name="text">
-          <string>0</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>2</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>4</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>8</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>16</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="screenComboBox"/>
-      </item>
-      <item row="5" column="1">
-       <layout class="QGridLayout" name="resolutionLayout">
-        <item row="1" column="2">
-         <layout class="QHBoxLayout" name="customResolutionLayout" stretch="1,0,1">
-          <item>
-           <widget class="QSpinBox" name="customWidthSpinBox">
-            <property name="minimum">
-             <number>800</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="multiplyLabel">
+     <widget class="QWidget" name="DisplayWrapper">
+      <attribute name="title">
+       <string>Display</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QWidget" name="DisplayWidget">
+         <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0">
+          <item row="3" column="0">
+           <widget class="QLabel" name="antiAliasingLabel">
             <property name="text">
-             <string> x </string>
+             <string>Anti-aliasing:</string>
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QSpinBox" name="customHeightSpinBox">
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="framerateLimitCheckBox">
+            <property name="text">
+             <string>Framerate Limit:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <layout class="QGridLayout" name="resolutionLayout">
+            <item row="1" column="2">
+             <layout class="QHBoxLayout" name="customResolutionLayout" stretch="1,0,1">
+              <item>
+               <widget class="QSpinBox" name="customWidthSpinBox">
+                <property name="minimum">
+                 <number>800</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="multiplyLabel">
+                <property name="text">
+                 <string> x </string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="customHeightSpinBox">
+                <property name="minimum">
+                 <number>600</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="1">
+             <widget class="QRadioButton" name="customRadioButton">
+              <property name="text">
+               <string>Custom:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QRadioButton" name="standardRadioButton">
+              <property name="text">
+               <string>Standard:</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QComboBox" name="resolutionComboBox"/>
+            </item>
+           </layout>
+          </item>
+          <item row="6" column="1">
+           <widget class="QDoubleSpinBox" name="framerateLimitSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string> FPS</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
             <property name="minimum">
-             <number>600</number>
+             <double>1</double>
+            </property>
+            <property name="maximum">
+             <double>1000</double>
+            </property>
+            <property name="singleStep">
+             <double>15</double>
+            </property>
+            <property name="value">
+             <double>300</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="windowBorderCheckBox">
+            <property name="text">
+             <string>Window Border</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="fullScreenCheckBox">
+            <property name="text">
+             <string>Full Screen</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="resolutionLabel">
+            <property name="text">
+             <string>Resolution:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="screenComboBox"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="screenLabel">
+            <property name="text">
+             <string>Screen:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="antiAliasingComboBox">
+            <item>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>8</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>16</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="vSyncCheckBox">
+            <property name="text">
+             <string>Vertical Sync</string>
             </property>
            </widget>
           </item>
          </layout>
-        </item>
-        <item row="1" column="1">
-         <widget class="QRadioButton" name="customRadioButton">
-          <property name="text">
-           <string>Custom:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QRadioButton" name="standardRadioButton">
-          <property name="text">
-           <string>Standard:</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QComboBox" name="resolutionComboBox"/>
-        </item>
-       </layout>
-      </item>
-      <item row="6" column="1">
-       <widget class="QDoubleSpinBox" name="framerateLimitSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="suffix">
-         <string> FPS</string>
-        </property>
-        <property name="decimals">
-         <number>1</number>
-        </property>
-        <property name="minimum">
-         <double>1</double>
-        </property>
-        <property name="maximum">
-         <double>1000</double>
-        </property>
-        <property name="singleStep">
-         <double>15</double>
-        </property>
-        <property name="value">
-         <double>300</double>
-        </property>
-       </widget>
-      </item>
-     </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="ShadowWrapper">
+      <attribute name="title">
+       <string>Shadows</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QWidget" name="ShadowWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>1</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QGridLayout" name="shadowsLayout" columnstretch="0,0">
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="shadowDistanceCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The distance from the camera at which shadows completely disappear&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Shadow Distance Limit:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="shadowDistanceSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;64 game units is 1 real life yard or about 0.9 m&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="suffix">
+             <string> unit(s)</string>
+            </property>
+            <property name="minimum">
+             <number>512</number>
+            </property>
+            <property name="maximum">
+             <number>81920</number>
+            </property>
+            <property name="value">
+             <number>8192</number>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="fadeStartLabel">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The fraction of the limit above at which shadows begin to gradually fade away&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Fade Start Multiplier:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="shadowResolutionComboBox">
+            <item>
+             <property name="text">
+              <string>512</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>1024</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2048</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4096</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="actorShadowsCheckBox">
+            <property name="text">
+             <string>Enable Actor Shadows</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" alignment="Qt::AlignLeft">
+           <widget class="QCheckBox" name="terrainShadowsCheckBox">
+            <property name="text">
+             <string>Enable Terrain Shadows</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QDoubleSpinBox" name="fadeStartSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="minimum">
+             <double>0.05</double>
+            </property>
+            <property name="maximum">
+             <double>1</double>
+            </property>
+            <property name="value">
+             <double>0.90</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="playerShadowsCheckBox">
+            <property name="text">
+             <string>Enable Player Shadows</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" alignment="Qt::AlignLeft">
+           <widget class="QLabel" name="shadowResolutionLabel">
+            <property name="text">
+             <string>Shadow Map Resolution:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="objectShadowsCheckBox">
+            <property name="text">
+             <string>Enable Object Shadows</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="indoorShadowsCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if at least one of the options above is not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Enable Indoor Shadows</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="shadowGroup">
-     <property name="title">
-      <string>Shadows</string>
-     </property>
-     <layout class="QGridLayout" name="shadowsLayout" columnstretch="0,0,0">
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="actorShadowsCheckBox">
-        <property name="text">
-         <string>Enable Actor Shadows</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QCheckBox" name="terrainShadowsCheckBox">
-        <property name="text">
-         <string>Enable Terrain Shadows</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="objectShadowsCheckBox">
-        <property name="text">
-         <string>Enable Object Shadows</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QCheckBox" name="shadowDistanceCheckBox">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The distance from the camera at which shadows completely disappear&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Shadow Distance Limit:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" alignment="Qt::AlignLeft">
-       <widget class="QLabel" name="shadowResolutionLabel">
-        <property name="text">
-         <string>Shadow Map Resolution:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QComboBox" name="shadowResolutionComboBox">
-        <item>
-         <property name="text">
-          <string>512</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>1024</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>2048</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>4096</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="playerShadowsCheckBox">
-        <property name="text">
-         <string>Enable Player Shadows</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QSpinBox" name="shadowDistanceSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;64 game units is 1 real life yard or about 0.9 m&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="suffix">
-         <string> unit(s)</string>
-        </property>
-        <property name="minimum">
-         <number>512</number>
-        </property>
-        <property name="maximum">
-         <number>81920</number>
-        </property>
-        <property name="value">
-         <number>8192</number>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="fadeStartLabel">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The fraction of the limit above at which shadows begin to gradually fade away&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Fade Start Multiplier:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QDoubleSpinBox" name="fadeStartSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="decimals">
-         <number>2</number>
-        </property>
-        <property name="minimum">
-         <double>0.05</double>
-        </property>
-        <property name="maximum">
-         <double>1</double>
-        </property>
-        <property name="value">
-         <double>0.90</double>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="indoorShadowsCheckBox">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if at least one of the options above is not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Enable Indoor Shadows</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>61</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/files/ui/graphicspage.ui
+++ b/files/ui/graphicspage.ui
@@ -324,7 +324,7 @@
           <item row="4" column="0">
            <widget class="QCheckBox" name="indoorShadowsCheckBox">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if at least one of the options above is not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.&lt;/p&gt;&lt;p&gt;Has no effect if actor shadows are not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Enable Indoor Shadows</string>


### PR DESCRIPTION
As requested by AnyOldName3, I've rewritten bzzt's shadow fading and max distance settings. I've documented them, adjusted the default values, reverted back to "dumb" shadow distance calculations out of performance concerns (there would have been very slight overhead for every pixel even if shadows aren't enabled, IMO shadow distance is very much related to fog and frustum clipping and it's not like it's that jarring) and added a global define which toggles shadow distance limit calculations on or off. Also I made some stylistic adjustments to keep them in line with the existing shadow code.
I changed the committeer to bzzt even though I didn't amend changes of his commit and rather did them "from scratch", although I suspect bzzt won't be entirely happy whether I make him the author of the commit or not.
As mentioned earlier, shadow distance limit improves the shadow quality and performance significantly if the viewing distance is very large at the cost of removing shadows from distant objects, while shadow fading just makes the transition from "shadows" to "no shadows" smooth.
Seems to work well enough in my testing. Here's how shadows look like with the settings deliberately exaggerated (max distance set to 1024, fade start set to 0.5, i.e. shadows start fading away at 512 units).
![screenshot096](https://user-images.githubusercontent.com/21265616/67948147-3585d280-fbf6-11e9-83aa-3eff81b33916.png)

The viewing distance is 81920. You will notice that the shadows obviously look extremely fine up-close, especially with a higher shadow map resolution (here it's 2048).
![screenshot097](https://user-images.githubusercontent.com/21265616/67948293-7c73c800-fbf6-11e9-87b8-d38ec27689ff.png)

I'm unable to add shadow settings into the game settings (they need specific runtime handling), so I made a compromise, adding them into the launcher like it was requested earlier. These are some of the most basic, non-complicated settings that are unlikely to confuse players and make them wonder where did their life go wrong if they mess something up. They have some ~~arbitrary~~ sensible default values set up and they also have tooltips. Here's how Graphics tab should look now. The two spin boxes are normally disabled unless shadow distance limit check box is enabled.

![twotabs](https://user-images.githubusercontent.com/21265616/67969542-93c4ac80-fc1a-11e9-8bd0-a9a465242182.png)

I didn't adjust other default settings. They're probably fine as they are.