### PR TITLE
Terrain selection fixes

### DIFF
--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -44,9 +44,9 @@ namespace CSVRender
 
             std::vector<std::pair<int, int>> getTerrainSelection() const;
 
-        protected:
-
             void update();
+
+        protected:
 
             void drawShapeSelection(const osg::ref_ptr<osg::Vec3Array> vertices);
             void drawTextureSelection(const osg::ref_ptr<osg::Vec3Array> vertices);

--- a/apps/opencs/view/render/terrainselection.hpp
+++ b/apps/opencs/view/render/terrainselection.hpp
@@ -55,6 +55,14 @@ namespace CSVRender
 
         private:
 
+            bool noCell(const std::string& cellId);
+
+            bool noLand(const std::string& cellId);
+
+            bool noLandLoaded(const std::string& cellId);
+
+            bool isLandLoaded(const std::string& cellId);
+            
             osg::Group* mParentNode;
             WorldspaceWidget *mWorldspaceWidget;
             osg::ref_ptr<osg::PositionAttitudeTransform> mBaseNode;

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -131,6 +131,9 @@ namespace CSVRender
             /// Check that the edit doesn't break save format limits, fix if necessary, return true if slope steepness is within limits
             bool limitAlteredHeights(const CSMWorld::CellCoordinates& cellCoords, bool reverseMode = false);
 
+            /// Check if global selection coordinate belongs to cell in view
+            bool isInCellSelection(int globalSelectionX, int globalSelectionY);
+
             /// Handle brush mechanics for terrain shape selection
             void selectTerrainShapes (const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation);
 

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -95,6 +95,9 @@ namespace CSVRender
             /// Remove duplicates and sort mAlteredCells, then limitAlteredHeights forward and reverse
             void sortAndLimitAlteredCells();
 
+            /// Reset everything in the current edit
+            void clearTransientEdits();
+
             /// Move pending alteredHeights changes to omwgame/omwaddon -data
             void applyTerrainEditChanges();
 


### PR DESCRIPTION
Attempts to fix the bugs described here: https://gitlab.com/OpenMW/openmw/issues/5200

Problem: These fixes don't do anything to a visual glitch arising from rendering vertex selection at the edge of visible cells (aka cell selection edge). As for the global coordinates, x and y are handled in sizes of 64 x 64, whereas there is actually 65 x 65 grid when edges are taken in account. CellCoordinates calculations for global coordinates don't take in account the extra line, therefore anything at 65th row or column is seen as belonging to the next cell's vertex coordinate 0, which isn't always loaded). It's probably possible to fix this, yet terrain texture editing has a similar problem, but slightly more troublesome, as terrain textures overlap between cells and have a special offset. I intend to fix this (preferably all selection-related stuff in this PR), but in case this turns out to be more complex or time consuming, this PR may be reviewed and merged separately.