### PR TITLE
Allow selecting cell edges everywhere

### DIFF
--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1047,9 +1047,16 @@ void CSVRender::TerrainShapeMode::handleSelection(int globalSelectionX, int glob
         int moduloY = globalSelectionY % (ESM::Land::LAND_SIZE - 1);
         bool xIsAtCellBorder = moduloX == 0;
         bool yIsAtCellBorder = moduloY == 0;
-        if (isInCellSelection(globalSelectionX - 1, globalSelectionY) && xIsAtCellBorder && !yIsAtCellBorder) selections->emplace_back(globalSelectionX, globalSelectionY);
-        if (isInCellSelection(globalSelectionX, globalSelectionY - 1) && !xIsAtCellBorder && yIsAtCellBorder) selections->emplace_back(globalSelectionX, globalSelectionY);
-        if (isInCellSelection(globalSelectionX - 1, globalSelectionY - 1) && xIsAtCellBorder && yIsAtCellBorder) selections->emplace_back(globalSelectionX, globalSelectionY);
+        if (!xIsAtCellBorder && !yIsAtCellBorder)
+            return;
+        int selectionX = globalSelectionX;
+        int selectionY = globalSelectionY;
+        if (xIsAtCellBorder)
+            selectionX--;
+        if (yIsAtCellBorder)
+            selectionY--;
+        if (isInCellSelection(selectionX, selectionY))
+            selections->emplace_back(globalSelectionX, globalSelectionY);
     }
 }
 

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1095,7 +1095,6 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
             for(auto const& value: mCustomBrushShape)
             {
                 std::pair<int, int> localVertexCoords (vertexCoords.first + value.first, vertexCoords.second + value.second);
-                std::string cellId (CSMWorld::CellCoordinates::vertexGlobalToCellId(localVertexCoords));
                 handleSelection(localVertexCoords.first, localVertexCoords.second, &selections);
             }
         }

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1038,6 +1038,21 @@ bool CSVRender::TerrainShapeMode::isInCellSelection(int globalSelectionX, int gl
     return false;
 }
 
+void CSVRender::TerrainShapeMode::handleSelection(int globalSelectionX, int globalSelectionY, std::vector<std::pair<int, int>>* selections)
+{
+    if (isInCellSelection(globalSelectionX, globalSelectionY)) selections->emplace_back(globalSelectionX, globalSelectionY);
+    else
+    {
+        int moduloX = globalSelectionX % (ESM::Land::LAND_SIZE - 1);
+        int moduloY = globalSelectionY % (ESM::Land::LAND_SIZE - 1);
+        bool xIsAtCellBorder = moduloX == 0;
+        bool yIsAtCellBorder = moduloY == 0;
+        if (isInCellSelection(globalSelectionX - 1, globalSelectionY) && xIsAtCellBorder && !yIsAtCellBorder) selections->emplace_back(globalSelectionX, globalSelectionY);
+        if (isInCellSelection(globalSelectionX, globalSelectionY - 1) && !xIsAtCellBorder && yIsAtCellBorder) selections->emplace_back(globalSelectionX, globalSelectionY);
+        if (isInCellSelection(globalSelectionX - 1, globalSelectionY - 1) && xIsAtCellBorder && yIsAtCellBorder) selections->emplace_back(globalSelectionX, globalSelectionY);
+    }
+}
+
 void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation)
 {
     int r = mBrushSize / 2;
@@ -1045,7 +1060,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
 
     if (mBrushShape == CSVWidget::BrushShape_Point)
     {
-        if (isInCellSelection(vertexCoords.first, vertexCoords.second)) selections.emplace_back(vertexCoords.first, vertexCoords.second);
+        handleSelection(vertexCoords.first, vertexCoords.second, &selections);
     }
 
     if (mBrushShape == CSVWidget::BrushShape_Square)
@@ -1054,7 +1069,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
         {
             for(int j = vertexCoords.second - r; j <= vertexCoords.second + r; ++j)
             {
-                if (isInCellSelection(i, j)) selections.emplace_back(i, j);
+                handleSelection(i, j, &selections);
             }
         }
     }
@@ -1068,7 +1083,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
                 int distanceX = abs(i - vertexCoords.first);
                 int distanceY = abs(j - vertexCoords.second);
                 int distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
-                if (isInCellSelection(i, j) && distance <= r) selections.emplace_back(i, j);
+                if (distance <= r) handleSelection(i, j, &selections);
             }
         }
     }
@@ -1081,7 +1096,7 @@ void CSVRender::TerrainShapeMode::selectTerrainShapes(const std::pair<int, int>&
             {
                 std::pair<int, int> localVertexCoords (vertexCoords.first + value.first, vertexCoords.second + value.second);
                 std::string cellId (CSMWorld::CellCoordinates::vertexGlobalToCellId(localVertexCoords));
-                if (isInCellSelection(localVertexCoords.first, localVertexCoords.second)) selections.emplace_back(localVertexCoords);
+                handleSelection(localVertexCoords.first, localVertexCoords.second, &selections);
             }
         }
     }

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -134,6 +134,9 @@ namespace CSVRender
             /// Check if global selection coordinate belongs to cell in view
             bool isInCellSelection(int globalSelectionX, int globalSelectionY);
 
+            /// Select vertex at global selection coordinate
+            void handleSelection(int globalSelectionX, int globalSelectionY, std::vector<std::pair<int, int>>* selections);
+
             /// Handle brush mechanics for terrain shape selection
             void selectTerrainShapes (const std::pair<int, int>& vertexCoords, unsigned char selectMode, bool dragOperation);
 


### PR DESCRIPTION
Enables vertex selection at 64th row and column (at the cell edge), when the next cell isn't visible (aka in cell selection).

Explanation: Global CellCoordinates calculations don't take in account the 64th vertex, but always treat it as the 0th vertex of the next cell. Because of this, when the selection was at 64th vertex, the logic was to check if the next cell was loaded. This PR adds checks for these special cases, and therefore enables selecting 64th vertex even when the next cell isn't visible. I don't really know what's the real use case for this, but this makes vertex selection have more consistent behavior.