### PR TITLE
Minor sheathing-related changes

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -82,6 +82,9 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     loadSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
     loadSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
+    loadSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
+    loadSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
+    loadSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
 
     // Input Settings
     loadSettingBool(grabCursorCheckBox, "grab cursor", "Input");
@@ -142,6 +145,9 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     saveSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
     saveSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
+    saveSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
+    saveSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
+    saveSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
 
     // Input Settings
     saveSettingBool(grabCursorCheckBox, "grab cursor", "Input");

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -84,8 +84,11 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
     connect(animSourcesCheckBox, SIGNAL(toggled(bool)), this, SLOT(slotAnimSourcesToggled(bool)));
     loadSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
-    loadSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
-    loadSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
+    if (animSourcesCheckBox->checkState())
+    {
+        loadSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
+        loadSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
+    }
 
     // Input Settings
     loadSettingBool(grabCursorCheckBox, "grab cursor", "Input");
@@ -146,11 +149,6 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     saveSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
     saveSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
-    if (animSourcesCheckBox->checkState())
-    {
-        saveSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
-        saveSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
-    }
     saveSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
     saveSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
     saveSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
@@ -201,4 +199,9 @@ void Launcher::AdvancedPage::slotAnimSourcesToggled(bool checked)
 {
     weaponSheathingCheckBox->setEnabled(checked);
     shieldSheathingCheckBox->setEnabled(checked);
+    if (!checked)
+    {
+        weaponSheathingCheckBox->setCheckState(Qt::Unchecked);
+        shieldSheathingCheckBox->setCheckState(Qt::Unchecked);
+    }
 }

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -82,9 +82,10 @@ bool Launcher::AdvancedPage::loadSettings()
     loadSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     loadSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
     loadSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
+    connect(animSourcesCheckBox, SIGNAL(toggled(bool)), this, SLOT(slotAnimSourcesToggled(bool)));
+    loadSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
     loadSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
     loadSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
-    loadSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
 
     // Input Settings
     loadSettingBool(grabCursorCheckBox, "grab cursor", "Input");
@@ -145,9 +146,14 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(requireAppropriateAmmunitionCheckBox, "only appropriate ammunition bypasses resistance", "Game");
     saveSettingBool(magicItemAnimationsCheckBox, "use magic item animations", "Game");
     saveSettingBool(normaliseRaceSpeedCheckBox, "normalise race speed", "Game");
+    if (animSourcesCheckBox->checkState())
+    {
+        saveSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
+        saveSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
+    }
+    saveSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
     saveSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
     saveSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
-    saveSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
 
     // Input Settings
     saveSettingBool(grabCursorCheckBox, "grab cursor", "Input");
@@ -189,4 +195,10 @@ void Launcher::AdvancedPage::saveSettingBool(QCheckBox *checkbox, const std::str
 void Launcher::AdvancedPage::slotLoadedCellsChanged(QStringList cellNames)
 {
     loadCellsForAutocomplete(cellNames);
+}
+
+void Launcher::AdvancedPage::slotAnimSourcesToggled(bool checked)
+{
+    weaponSheathingCheckBox->setEnabled(checked);
+    shieldSheathingCheckBox->setEnabled(checked);
 }

--- a/apps/launcher/advancedpage.hpp
+++ b/apps/launcher/advancedpage.hpp
@@ -29,6 +29,7 @@ namespace Launcher
     private slots:
         void on_skipMenuCheckBox_stateChanged(int state);
         void on_runScriptAfterStartupBrowseButton_clicked();
+        void slotAnimSourcesToggled(bool checked);
 
     private:
         Files::ConfigurationManager &mCfgMgr;

--- a/docs/source/reference/modding/extended.rst
+++ b/docs/source/reference/modding/extended.rst
@@ -197,10 +197,6 @@ The appearance and count of shown ammunition depends on type and count of equipp
 
 It is important to make sure the names of empty nodes start with ``"Bip01 "``, or the engine will optimize them out.
 
-4. Shields
-
-Shield holstering is not supported at the moment since it conflicts with any mods which use pseudo-shields as held items (such as Animated Morrowind and Hold It).
-
 An example of a mod which uses this feature is `Weapon Sheathing`_.
 
 

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -169,6 +169,36 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="weaponSheathingCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered weapons (with quivers and scabbards), requires modded assets&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Weapon sheathing</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="shieldSheathingCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered shield, requires modded assets&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Shield sheathing</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="animSourcesCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load per-group KF-files and skeleton files from Animations folder&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Use additional animation sources</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -170,26 +170,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="weaponSheathingCheckBox">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered weapons (with quivers and scabbards), requires modded assets&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Weapon sheathing</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="shieldSheathingCheckBox">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered shield, requires modded assets&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Shield sheathing</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="animSourcesCheckBox">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load per-group KF-files and skeleton files from Animations folder&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -197,6 +177,53 @@
             <property name="text">
              <string>Use additional animation sources</string>
             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="sheathingGroup" native="true">
+            <layout class="QVBoxLayout" name="sheathingLayout">
+             <property name="spacing">
+              <number>6</number>
+             </property>
+             <property name="leftMargin">
+              <number>20</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="shieldSheathingCheckBox">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered shield, requires modded assets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Shield sheathing</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="weaponSheathingCheckBox">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered weapons (with quivers and scabbards), requires modded assets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Weapon sheathing</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -198,19 +198,6 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QCheckBox" name="shieldSheathingCheckBox">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered shield, requires modded assets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="text">
-                <string>Shield sheathing</string>
-               </property>
-              </widget>
-             </item>
-             <item>
               <widget class="QCheckBox" name="weaponSheathingCheckBox">
                <property name="enabled">
                 <bool>false</bool>
@@ -220,6 +207,19 @@
                </property>
                <property name="text">
                 <string>Weapon sheathing</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="shieldSheathingCheckBox">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Render holstered shield, requires modded assets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Shield sheathing</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
* Add weapon and shield sheathing and use additional anim sources checkboxes into the Advanced tab of the launcher
* Remove outdated information from the documentation

The checkboxes are all in Game section of the tab for now. Maybe it'll become nicer and less cluttered later, like Graphics tab did.
Given that shield sheathing is now a thing, the relevant part of extended modding documentation became outdated. It likely needs to be actually written, but given that the documentation isn't included with OpenMW builds (and the rules on its maintenance are extremely loose anyway) it's not as important and it can be done at any time. At least it doesn't include blatantly incorrect information anymore.