### PR TITLE
Fix warning -Woverloaded-virtual

### DIFF
--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -108,7 +108,7 @@ void QuadTreeNode::initNeighbours()
         getChild(i)->initNeighbours();
 }
 
-void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist)
+void QuadTreeNode::traverseNodes(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist)
 {
     if (!hasValidBounds())
         return;
@@ -124,7 +124,7 @@ void QuadTreeNode::traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallba
     else
     {
         for (unsigned int i=0; i<getNumChildren(); ++i)
-            getChild(i)->traverse(vd, viewPoint, lodCallback, maxDist);
+            getChild(i)->traverseNodes(vd, viewPoint, lodCallback, maxDist);
     }
 }
 

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -92,7 +92,7 @@ namespace Terrain
         const osg::Vec2f& getCenter() const;
 
         /// Traverse nodes according to LOD selection.
-        void traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist);
+        void traverseNodes(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist);
 
         /// Traverse to a specific node and add only that node.
         void traverseTo(ViewData* vd, float size, const osg::Vec2f& center);

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -353,7 +353,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
                 mRootNode->traverseTo(vd, 1, osg::Vec2f(x+0.5,y+0.5));
             }
             else
-                mRootNode->traverse(vd, cv->getViewPoint(), mLodCallback, mViewDistance);
+                mRootNode->traverseNodes(vd, cv->getViewPoint(), mLodCallback, mViewDistance);
         }
         else
         {
@@ -446,7 +446,7 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, std::atomic
 
     ViewData* vd = static_cast<ViewData*>(view);
     vd->setViewPoint(viewPoint);
-    mRootNode->traverse(vd, viewPoint, mLodCallback, mViewDistance);
+    mRootNode->traverseNodes(vd, viewPoint, mLodCallback, mViewDistance);
 
     for (unsigned int i=0; i<vd->getNumEntries() && !abort; ++i)
     {


### PR DESCRIPTION
```
In file included from openmw/components/terrain/quadtreeworld.cpp:10:
openmw/components/terrain/quadtreenode.hpp:95:14: warning: 'Terrain::QuadTreeNode::traverse' hides overloaded virtual function [-Woverloaded-virtual]
        void traverse(ViewData* vd, const osg::Vec3f& viewPoint, LodCallback* lodCallback, float maxDist);
             ^
OpenSceneGraph/build/clang/release/include/osg/Group:43:22: note: hidden overloaded virtual function 'osg::Group::traverse' declared here: different number of parameters (1 vs 4)
        virtual void traverse(NodeVisitor& nv);
                     ^
1 warning generated.
```