### PR TITLE
Display magic effects according to research page

### DIFF
--- a/apps/esmtool/labels.cpp
+++ b/apps/esmtool/labels.cpp
@@ -807,8 +807,10 @@ std::string magicEffectFlags(int flags)
     if (flags & ESM::MagicEffect::CastSelf) properties += "CastSelf ";
     if (flags & ESM::MagicEffect::CastTouch) properties += "CastTouch ";
     if (flags & ESM::MagicEffect::CastTarget) properties += "CastTarget ";
-    if (flags & ESM::MagicEffect::UncappedDamage) properties += "UncappedDamage ";
+    if (flags & ESM::MagicEffect::AppliedOnce) properties += "AppliedOnce ";
+    if (flags & ESM::MagicEffect::Stealth) properties += "Stealth ";
     if (flags & ESM::MagicEffect::NonRecastable) properties += "NonRecastable ";
+    if (flags & ESM::MagicEffect::IllegalDaedra) properties += "IllegalDaedra ";
     if (flags & ESM::MagicEffect::Unreflectable) properties += "Unreflectable ";
     if (flags & ESM::MagicEffect::CasterLinked) properties += "CasterLinked ";
     if (flags & ESM::MagicEffect::AllowSpellmaking) properties += "AllowSpellmaking ";

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -90,7 +90,7 @@ namespace MWMechanics
             const ESM::MagicEffect* magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(
                         it->mEffectID);
 
-            if (!(magicEffect->mData.mFlags & ESM::MagicEffect::UncappedDamage))
+            if (!(magicEffect->mData.mFlags & ESM::MagicEffect::AppliedOnce))
                 x = std::max(1.f, x);
 
             x *= 0.1f * magicEffect->mData.mBaseCost;

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -331,7 +331,7 @@ namespace MWMechanics
         for (std::vector<ESM::ENAMstruct>::const_iterator effectIt = spell->mEffects.mList.begin(); effectIt != spell->mEffects.mList.end(); ++effectIt, ++i)
         {
             const ESM::MagicEffect * magicEffect = MWBase::Environment::get().getWorld()->getStore().get<ESM::MagicEffect>().find(effectIt->mEffectID);
-            if ((effectIt->mEffectID != ESM::MagicEffect::Corprus) && (magicEffect->mData.mFlags & ESM::MagicEffect::UncappedDamage)) // APPLIED_ONCE
+            if ((effectIt->mEffectID != ESM::MagicEffect::Corprus) && (magicEffect->mData.mFlags & ESM::MagicEffect::AppliedOnce))
             {
                 float random = 1.f;
                 if (mSpells[spell].mEffectRands.find(i) != mSpells[spell].mEffectRands.end())

--- a/components/esm/loadmgef.hpp
+++ b/components/esm/loadmgef.hpp
@@ -30,15 +30,17 @@ struct MagicEffect
         CastSelf = 0x40, // Allows range - cast on self.
         CastTouch = 0x80, // Allows range - cast on touch.
         CastTarget = 0x100, // Allows range - cast on target.
-        UncappedDamage = 0x1000, // Negates multiple cap behaviours. Allows an effect to reduce an attribute below zero; removes the normal minimum effect duration of 1 second.
+        AppliedOnce = 0x1000, // An effect that is applied once it lands, instead of continuously. Allows an effect to reduce an attribute below zero; removes the normal minimum effect duration of 1 second.
+        Stealth = 0x2000, // Unused
         NonRecastable = 0x4000, // Does not land if parent spell is already affecting target. Shows "you cannot re-cast" message for self target.
+        IllegalDaedra = 0x8000, // Unused
         Unreflectable = 0x10000, // Cannot be reflected, the effect always lands normally.
         CasterLinked = 0x20000, // Must quench if caster is dead, or not an NPC/creature. Not allowed in containter/door trap spells.
 
         // Originally modifiable flags
         AllowSpellmaking = 0x200, // Can be used for spellmaking
         AllowEnchanting = 0x400, // Can be used for enchanting
-        NegativeLight = 0x800 // Negative light source
+        NegativeLight = 0x800 // Unused
     };
 
     enum MagnitudeDisplayType


### PR DESCRIPTION
Just print magic effects according to our [research](https://wiki.openmw.org/index.php?title=Research:Magic#Effect_flags) page.