### PR TITLE
UI textures scaling corrections

### DIFF
--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -4,6 +4,7 @@
 #include <MyGUI_Button.h>
 #include <MyGUI_Gui.h>
 #include <MyGUI_ImageBox.h>
+#include <MyGUI_RenderManager.h>
 
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/quickkeys.hpp>
@@ -257,7 +258,12 @@ namespace MWGui
         mSelected->id = item.getCellRef().getRefId();
         mSelected->name = item.getClass().getName(item);
 
-        mSelected->button->setFrame("textures\\menu_icon_select_magic_magic.dds", MyGUI::IntCoord(2, 2, 40, 40));
+        float scale = 1.f;
+        MyGUI::ITexture* texture = MyGUI::RenderManager::getInstance().getTexture("textures\\menu_icon_select_magic_magic.dds");
+        if (texture)
+            scale = texture->getHeight() / 64.f;
+
+        mSelected->button->setFrame("textures\\menu_icon_select_magic_magic.dds", MyGUI::IntCoord(0, 0, 44*scale, 44*scale));
         mSelected->button->setIcon(item);
 
         mSelected->button->setUserString("ToolTipType", "ItemPtr");
@@ -292,7 +298,12 @@ namespace MWGui
         path.insert(slashPos+1, "b_");
         path = MWBase::Environment::get().getWindowManager()->correctIconPath(path);
 
-        mSelected->button->setFrame("textures\\menu_icon_select_magic.dds", MyGUI::IntCoord(2, 2, 40, 40));
+        float scale = 1.f;
+        MyGUI::ITexture* texture = MyGUI::RenderManager::getInstance().getTexture("textures\\menu_icon_select_magic.dds");
+        if (texture)
+            scale = texture->getHeight() / 64.f;
+
+        mSelected->button->setFrame("textures\\menu_icon_select_magic.dds", MyGUI::IntCoord(0, 0, 44*scale, 44*scale));
         mSelected->button->setIcon(path);
 
         if (mMagicSelectionDialog)

--- a/components/widgets/imagebutton.hpp
+++ b/components/widgets/imagebutton.hpp
@@ -23,6 +23,8 @@ namespace Gui
         /// Set mImageNormal, mImageHighlighted and mImagePushed based on file convention (image_idle.ext, image_over.ext and image_pressed.ext)
         void setImage(const std::string& image);
 
+        void setTextureRect(MyGUI::IntCoord coord);
+
     private:
         void updateImage();
 
@@ -44,6 +46,9 @@ namespace Gui
         bool mMouseFocus;
         bool mMousePress;
         bool mKeyFocus;
+        bool mUseWholeTexture;
+
+        MyGUI::IntCoord mTextureRect;
     };
 
 }

--- a/files/mygui/openmw_journal.layout
+++ b/files/mygui/openmw_journal.layout
@@ -65,12 +65,14 @@
       <Widget type="BookPage" skin="MW_BookPage" position="75 10 92 260" name="CenterTopicIndex"/>
       <Widget type="BookPage" skin="MW_BookPage" position="130 10 92 260" name="RightTopicIndex"/>
 
-      <Widget type="ImageButton" skin="ImageBox" position="71 15 100 20" Align="Top|Left" name="ShowActiveBTN">
+      <Widget type="ImageButton" skin="ImageBox" position="76 15 96 32" Align="Top|Left" name="ShowActiveBTN">
         <!-- Image set at runtime since it may not be available in all versions of the game -->
+        <Property key="TextureRect" value="0 0 96 32"/>
       </Widget>
 
-      <Widget type="ImageButton" skin="ImageBox" position="85 15 72 20" Align="Top|Left" name="ShowAllBTN">
+      <Widget type="ImageButton" skin="ImageBox" position="83 15 72 32" Align="Top|Left" name="ShowAllBTN">
         <!-- Image set at runtime since it may not be available in all versions of the game -->
+        <Property key="TextureRect" value="0 0 72 32"/>
       </Widget>
 
       <Widget type="MWList" skin="MW_QuestList" position="8 40 226 212" name="TopicsList" align="Right VStretch">

--- a/files/mygui/openmw_quickkeys_menu.layout
+++ b/files/mygui/openmw_quickkeys_menu.layout
@@ -17,16 +17,16 @@
 
         <Widget type="Widget" skin="" position="15 55 332 128" align="Left Bottom HCenter">
 
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="0 0 60 59" name="QuickKey1"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="68 0 60 59" name="QuickKey2"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="136 0 60 59" name="QuickKey3"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="204 0 60 59" name="QuickKey4"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="272 0 60 59" name="QuickKey5"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="0 67 60 59" name="QuickKey6"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="68 67 60 59" name="QuickKey7"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="136 67 60 59" name="QuickKey8"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="204 67 60 59" name="QuickKey9"/>
-            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="272 67 60 59" name="QuickKey10"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="0 0 60 60" name="QuickKey1"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="68 0 60 60" name="QuickKey2"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="136 0 60 60" name="QuickKey3"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="204 0 60 60" name="QuickKey4"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="272 0 60 60" name="QuickKey5"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="0 67 60 60" name="QuickKey6"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="68 67 60 60" name="QuickKey7"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="136 67 60 60" name="QuickKey8"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="204 67 60 60" name="QuickKey9"/>
+            <Widget type="ItemWidget" skin="MW_ItemIconBox" position="272 67 60 60" name="QuickKey10"/>
 
         </Widget>
 


### PR DESCRIPTION
1. Restore normal size for Show All / Show Active buttons in journal.
2. Crop redundant texture space for them.
3. Implement scaling for quick keys widgets.

Notes:
1. Not sure if it possible to center mentioned buttons properly since on different localizations textures have different offset.
2. These buttons were tested only on English and Russian localizations.