### PR TITLE
Do not show shields in the 1st-person view when shield sheathing is enabled

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -113,7 +113,7 @@ bool ActorAnimation::updateCarriedLeftVisible(const int weaptype) const
         {
             SceneUtil::FindByNameVisitor findVisitor ("Bip01 AttachShield");
             mObjectRoot->accept(findVisitor);
-            if (findVisitor.mFoundNode)
+            if (findVisitor.mFoundNode || (mPtr == MWMechanics::getPlayer() && mPtr.isInCell() && MWBase::Environment::get().getWorld()->isFirstPerson()))
             {
                 const MWWorld::InventoryStore& inv = cls.getInventoryStore(mPtr);
                 const MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);


### PR DESCRIPTION
Fixes a regression from #2569.
Since 1st-person skeleton has no sheathing bone, we disable this feature for 1st-person meshes, and show shield when weapon is sheathed, which is not right.
With this patch we still use shield sheathing for player in the 1st-person view, we just do not show holstered shield because of missing sheath bone.