### PR TITLE
Minor summoned creature cleanup fixes

### DIFF
--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -248,6 +248,12 @@ namespace MWGui
                         MWScript::InterpreterContext interpreterContext (&mPtr.getRefData().getLocals(), mPtr);
                         MWBase::Environment::get().getScriptManager()->run (script, interpreterContext);
                     }
+
+                    // Clean up summoned creatures as well
+                    std::map<MWMechanics::CreatureStats::SummonKey, int>& creatureMap = creatureStats.getSummonedCreatureMap();
+                    for (const auto& creature : creatureMap)
+                        MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(mPtr, creature.second);
+                    creatureMap.clear();
                 }
 
                 MWBase::Environment::get().getWorld()->deleteObject(mPtr);

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1884,6 +1884,13 @@ namespace MWMechanics
             if (fx)
                 MWBase::Environment::get().getWorld()->spawnEffect("meshes\\" + fx->mModel,
                     "", ptr.getRefData().getPosition().asVec3());
+
+            // Remove the summoned creature's summoned creatures as well
+            MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
+            std::map<CreatureStats::SummonKey, int>& creatureMap = stats.getSummonedCreatureMap();
+            for (const auto& creature : creatureMap)
+                cleanupSummonedCreature(stats, creature.second);
+            creatureMap.clear();
         }
         else if (creatureActorId != -1)
         {

--- a/apps/openmw/mwmechanics/summoning.cpp
+++ b/apps/openmw/mwmechanics/summoning.cpp
@@ -86,10 +86,9 @@ namespace MWMechanics
         }
 
         // Update summon effects
-        bool casterDead = creatureStats.isDead();
         for (std::map<CreatureStats::SummonKey, int>::iterator it = creatureMap.begin(); it != creatureMap.end(); )
         {
-            bool found = !casterDead && mActiveEffects.find(it->first) != mActiveEffects.end();
+            bool found = mActiveEffects.find(it->first) != mActiveEffects.end();
             if (!found)
             {
                 // Effect has ended
@@ -100,25 +99,11 @@ namespace MWMechanics
             ++it;
         }
 
-        std::vector<int>& graveyard = creatureStats.getSummonedCreatureGraveyard();
-        for (std::vector<int>::iterator it = graveyard.begin(); it != graveyard.end(); )
-        {
-            MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->searchPtrViaActorId(*it);
-            if (!ptr.isEmpty())
-            {
-                it = graveyard.erase(it);
+        std::vector<int> graveyard = creatureStats.getSummonedCreatureGraveyard();
+        creatureStats.getSummonedCreatureGraveyard().clear();
 
-                const ESM::Static* fx = MWBase::Environment::get().getWorld()->getStore().get<ESM::Static>()
-                        .search("VFX_Summon_End");
-                if (fx)
-                    MWBase::Environment::get().getWorld()->spawnEffect("meshes\\" + fx->mModel,
-                        "", ptr.getRefData().getPosition().asVec3());
-
-                MWBase::Environment::get().getWorld()->deleteObject(ptr);
-            }
-            else
-                ++it;
-        }
+        for (const int creature : graveyard)
+            MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(mActor, creature);
 
         if (!cleanup)
             return;


### PR DESCRIPTION
1. Summoned creatures of summoned creatures that recently became possible weren't properly cleared. I added a workaround for that.
2. I ignored my own good advice and forgot again that I should test the vanilla deaths using the normal damage instead of SetHealth 0. Summoned creatures are still supposed to be removed *after* the caster's death animation according to my testing. Also this fixes the issue where the despawn VFX are played twice (upon the summoned creature despawn and upon the caster's death animation end) in some situations.
3. If a summoned creature's despawn is postponed, it didn't trigger the linked spell effects removal from other actors like a normal cleanupSummonedCreature call. But the main purpose of the workaround I've added is to make sure all summoned creatures are removed even if said removal is postponed. There's a plan to expand on that, hm, later, as summoned creature mechanics are not exactly consistent yet.