### PR TITLE
Default visual settings tweaks

### DIFF
--- a/docs/source/reference/modding/settings/shadows.rst
+++ b/docs/source/reference/modding/settings/shadows.rst
@@ -85,11 +85,11 @@ compute tight scene bounds
 
 :Type:		boolean
 :Range:		True/False
-:Default:	False
+:Default:	True
 
 With this setting enabled, attempt to better use the shadow map(s) by making them cover a smaller area.
 This can be especially helpful when looking downwards with a high viewing distance but will be less useful with the default value.
-The performance impact of this may be very large.
+May have a minor to major performance impact.
 
 shadow map resolution
 ---------------------
@@ -200,10 +200,10 @@ use front face culling
 
 :Type:		boolean
 :Range:		True/False
-:Default:	True
+:Default:	False
 
 Excludes theoretically unnecessary faces from shadow maps, slightly increasing performance.
-In practice, Peter Panning can be much less visible with these faces included, so if you have high polygon offset values, disabling this may help minimise the side effects.
+In practice, Peter Panning can be much less visible with these faces included, so if you have high polygon offset values, leaving this off may help minimise the side effects.
 
 split point uniform logarithmic ratio
 -------------------------------------

--- a/docs/source/reference/modding/settings/terrain.rst
+++ b/docs/source/reference/modding/settings/terrain.rst
@@ -68,7 +68,7 @@ composite map level
 
 :Type:		integer
 :Range:		>= -3
-:Default:	-2
+:Default:	0
 
 Controls at which minimum size (in 2^value cell units) terrain chunks will start to use a composite map instead of the high-detail textures.
 With value -3 composite maps are used everywhere.
@@ -76,7 +76,7 @@ With value -3 composite maps are used everywhere.
 A composite map is a pre-rendered texture that contains all the texture layers combined.
 Note that resolution of composite maps is currently always fixed at 'composite map resolution',
 regardless of the resolution of the underlying terrain textures.
-If high-detail texture replacers are used, probably it is worth to increase 'composite map resolution' setting value.
+If high resolution texture replacers are used, it is recommended to increase 'composite map resolution' setting value.
 
 composite map resolution
 ------------------------

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -98,7 +98,7 @@ vertex lod mod = 0
 
 # Controls when the distant terrain will flip to composited textures instead of high-detail textures, should be >= -3.
 # Higher value is more detailed textures.
-composite map level = -2
+composite map level = 0
 
 # Controls the resolution of composite maps.
 composite map resolution = 512
@@ -767,8 +767,8 @@ enable debug hud = false
 # Enable the debug overlay to see where each shadow map affects.
 enable debug overlay = false
 
-# Attempt to better use the shadow map by making them cover a smaller area. Especially helpful when looking downwards with a high viewing distance. The performance impact of this may be very large.
-compute tight scene bounds = false
+# Attempt to better use the shadow map by making them cover a smaller area. Especially helpful when looking downwards. May have a minor to major performance impact.
+compute tight scene bounds = true
 
 # How large to make the shadow map(s). Higher values increase GPU load, but can produce better-looking results. Power-of-two values may turn out to be faster on some GPU/driver combinations.
 shadow map resolution = 1024
@@ -785,8 +785,8 @@ polygon offset units = 4.0
 # How far along the surface normal to project shadow coordinates. Higher values significantly reduce shadow flicker, usually with a lower increase of Peter Panning than the Polygon Offset settings. This value is in in-game units, so 1.0 is roughly 1.4 cm.
 normal offset distance = 1.0
 
-# Excludes theoretically unnecessary faces from shadow maps, slightly increasing performance. In practice, Peter Panning can be much less visible with these faces included, so if you have high polygon offset values, disabling this may help minimise the side effects.
-use front face culling = true
+# Excludes theoretically unnecessary faces from shadow maps, slightly increasing performance. In practice, Peter Panning can be much less visible with these faces included, so if you have high polygon offset values, leave this off to minimise the side effects.
+use front face culling = false
 
 # Allow actors to cast shadows. Potentially decreases performance.
 actor shadows = false


### PR DESCRIPTION
I adjusted the default values of three certain settings to maintain a consistent visual quality level in 0.46.0 release:

1. composite map level was reverted from -2 to 0.
   Unfortunately negative values of the setting as they are lead to a currently unavoidable unpleasant shimmering of the terrain relatively close to the player since composite maps don't have filtering. While such values increase the performance, they worsen the look of the terrain proportionally and IMO noticeably. Maybe another time.

2. shadow front face culling is now disabled by default.
  It doesn't seem like it helps with anything in the area of shadow flickering (which is mostly absent now) but due to Morrowind's poor normals (probably?) most users would have seen pretty bad peter-panning in most situations. It probably shouldn't be removed just yet because it may improve performance in the situations where assets are more well done. So I simply disabled it.

3. tight scene bounds are computed by default.
  While it was observed in the past that while there *is* a certain performance impact when tight scene bounds are computed (5-8%), it's insignificant compared to other sources of shadows' infamous performance impact and to the quality improvement it brings in the general case (when the player looks at the ground). So I enabled it.

Both the shadow setting adjustments *do* make a noticeable difference with the default viewing distance.