### PR TITLE
Fix some issues, found by CoverityScan

### DIFF
--- a/apps/esmtool/labels.cpp
+++ b/apps/esmtool/labels.cpp
@@ -712,7 +712,7 @@ std::string creatureFlags(int flags)
     if (flags & ESM::Creature::Respawn) properties += "Respawn ";
     if (flags & ESM::Creature::Weapon) properties += "Weapon ";
     if (flags & ESM::Creature::Essential) properties += "Essential ";
-    int unused = (0xFF ^
+    int unused = (0xFFFFFFFF ^
                   (ESM::Creature::Base|
                    ESM::Creature::Walks|
                    ESM::Creature::Swims|

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1227,7 +1227,7 @@ void CSVRender::TerrainShapeMode::createNewLandData(const CSMWorld::CellCoordina
 
             ++averageDivider;
             downCellSampleHeight = landDownShapePointer[ESM::Land::LAND_SIZE / 2];
-            if(paged->getCellAlteredHeight(cellLeftCoords, ESM::Land::LAND_SIZE / 2, 0))
+            if(paged->getCellAlteredHeight(cellDownCoords, ESM::Land::LAND_SIZE / 2, 0))
                 downCellSampleHeight += *paged->getCellAlteredHeight(cellDownCoords, ESM::Land::LAND_SIZE / 2, 0);
         }
     }

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -730,8 +730,12 @@ void CSVRender::TerrainTextureMode::setBrushShape(int brushShape)
             selectionCenterY += value.second;
             ++selectionAmount;
         }
-        selectionCenterX /= selectionAmount;
-        selectionCenterY /= selectionAmount;
+
+        if (selectionAmount != 0)
+        {
+            selectionCenterX /= selectionAmount;
+            selectionCenterY /= selectionAmount;
+        }
 
         mCustomBrushShape.clear();
         for (auto const& value: terrainSelection)

--- a/apps/openmw/mwgui/windowbase.cpp
+++ b/apps/openmw/mwgui/windowbase.cpp
@@ -149,7 +149,7 @@ float BookWindowBase::adjustButton (char const * name)
     Gui::ImageButton* button;
     WindowBase::getWidget (button, name);
     MyGUI::IntSize requested = button->getRequestedSize();
-    float scale = requested.height / button->getSize().height;
+    float scale = float(requested.height) / button->getSize().height;
     MyGUI::IntSize newSize = requested;
     newSize.width /= scale;
     newSize.height /= scale;

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -21,6 +21,7 @@ namespace MWMechanics
     Enchanting::Enchanting()
         : mCastStyle(ESM::Enchantment::CastOnce)
         , mSelfEnchanting(false)
+        , mWeaponType(-1)
     {}
 
     void Enchanting::setOldItem(const MWWorld::Ptr& oldItem)

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -539,7 +539,7 @@ std::string NpcAnimation::getShieldMesh(MWWorld::ConstPtr shield) const
             {
                 const ESM::BodyPart *bodypart = 0;
                 bodypart = partStore.search(bodypartName);
-                if (bodypart->mData.mType != ESM::BodyPart::MT_Armor)
+                if (bodypart == nullptr || bodypart->mData.mType != ESM::BodyPart::MT_Armor)
                     return "";
                 else if (!bodypart->mModel.empty())
                     mesh = "meshes\\" + bodypart->mModel;

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -528,6 +528,8 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
     // Add animated textures
     std::vector<osg::ref_ptr<osg::Texture2D> > textures;
     int frameCount = Fallback::Map::getInt("Water_SurfaceFrameCount");
+    frameCount = std::min(std::max(frameCount, 0), 320);
+
     const std::string& texture = Fallback::Map::getString("Water_SurfaceTexture");
     for (int i=0; i<frameCount; ++i)
     {
@@ -644,6 +646,8 @@ Water::~Water()
 void Water::listAssetsToPreload(std::vector<std::string> &textures)
 {
     int frameCount = Fallback::Map::getInt("Water_SurfaceFrameCount");
+    frameCount = std::min(std::max(frameCount, 0), 320);
+
     const std::string& texture = Fallback::Map::getString("Water_SurfaceTexture");
     for (int i=0; i<frameCount; ++i)
     {

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -49,7 +49,7 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
         std::string fname = mast.name;
         int index = ~0;
         for (int i = 0; i < esm.getIndex(); i++) {
-            const std::string &candidate = allPlugins->at(i).getContext().filename;
+            const std::string candidate = allPlugins->at(i).getContext().filename;
             std::string fnamecandidate = boost::filesystem::path(candidate).filename().string();
             if (Misc::StringUtils::ciEqual(fname, fnamecandidate)) {
                 index = i;

--- a/components/compiler/exprparser.cpp
+++ b/components/compiler/exprparser.cpp
@@ -347,8 +347,6 @@ namespace Compiler
             scanner.putbackName (name, loc);
             return false;
         }
-
-        return Parser::parseName (name, loc, scanner);
     }
 
     bool ExprParser::parseKeyword (int keyword, const TokenLoc& loc, Scanner& scanner)

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -301,7 +301,7 @@ namespace NifOsg
 
     private:
         Vec3Interpolator mData;
-        TargetColor mTargetColor;
+        TargetColor mTargetColor = Ambient;
     };
 
     class FlipController : public SceneUtil::StateSetUpdater, public SceneUtil::Controller

--- a/components/sceneutil/shadow.cpp
+++ b/components/sceneutil/shadow.cpp
@@ -66,6 +66,8 @@ namespace SceneUtil
     void ShadowManager::disableShadowsForStateSet(osg::ref_ptr<osg::StateSet> stateset)
     {
         int numberOfShadowMapsPerLight = Settings::Manager::getInt("number of shadow maps", "Shadows");
+        numberOfShadowMapsPerLight = std::max(1, std::min(numberOfShadowMapsPerLight, 8));
+
         int baseShadowTextureUnit = 8 - numberOfShadowMapsPerLight;
         
         osg::ref_ptr<osg::Image> fakeShadowMapImage = new osg::Image();

--- a/components/terrain/chunkmanager.hpp
+++ b/components/terrain/chunkmanager.hpp
@@ -36,7 +36,6 @@ namespace Terrain
 
         osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags);
 
-        void setCullingActive(bool active) { mCullingActive = active; }
         void setCompositeMapSize(unsigned int size) { mCompositeMapSize = size; }
         void setCompositeMapLevel(float level) { mCompositeMapLevel = level; }
         void setMaxCompositeGeometrySize(float maxCompGeometrySize) { mMaxCompGeometrySize = maxCompGeometrySize; }
@@ -65,8 +64,6 @@ namespace Terrain
         unsigned int mCompositeMapSize;
         float mCompositeMapLevel;
         float mMaxCompGeometrySize;
-
-        bool mCullingActive;
     };
 
 }


### PR DESCRIPTION
Should fix most of newly-detected issues. As for things left:
1. atan2 issues are false-positives.
2. Missing RefData move constructor (an old report from 2016 year) does not seem to be an issue, IMO.
3. A complaint about tainted value in OICS is not our issue too. There is just missing validation for values from XML, and I doubt that we will implement it.

2 and 3 more likely are just old discarded reports, which reappeared because we modified related files (when we implemented mouse wheel bindings, for example).