### PR TITLE
CoverityScan fixes, part 2

### DIFF
--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1418,8 +1418,12 @@ void CSVRender::TerrainShapeMode::setBrushShape(CSVWidget::BrushShape brushShape
             selectionCenterY = selectionCenterY + value.second;
             ++selectionAmount;
         }
-        selectionCenterX = selectionCenterX / selectionAmount;
-        selectionCenterY = selectionCenterY / selectionAmount;
+
+        if (selectionAmount != 0)
+        {
+            selectionCenterX /= selectionAmount;
+            selectionCenterY /= selectionAmount;
+        }
 
         mCustomBrushShape.clear();
         std::pair<int, int> differentialPos {};

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -527,9 +527,7 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
 
     // Add animated textures
     std::vector<osg::ref_ptr<osg::Texture2D> > textures;
-    int frameCount = Fallback::Map::getInt("Water_SurfaceFrameCount");
-    frameCount = std::min(std::max(frameCount, 0), 320);
-
+    int frameCount = std::max(0, std::min(Fallback::Map::getInt("Water_SurfaceFrameCount"), 320));
     const std::string& texture = Fallback::Map::getString("Water_SurfaceTexture");
     for (int i=0; i<frameCount; ++i)
     {
@@ -645,9 +643,7 @@ Water::~Water()
 
 void Water::listAssetsToPreload(std::vector<std::string> &textures)
 {
-    int frameCount = Fallback::Map::getInt("Water_SurfaceFrameCount");
-    frameCount = std::min(std::max(frameCount, 0), 320);
-
+    int frameCount = std::max(0, std::min(Fallback::Map::getInt("Water_SurfaceFrameCount"), 320));
     const std::string& texture = Fallback::Map::getString("Water_SurfaceTexture");
     for (int i=0; i<frameCount; ++i)
     {


### PR DESCRIPTION
1. 276136 - we missed an another division by zero
2. 276132 and 276143 - for some reason, CoverityScan still does not like the `Water_SurfaceFrameCount` handling. Now I try to use exactly the same formatting, as in other similar cases. If it will not work, just close these reports as false-positives.
3. 152166 and 152181 - there are no much gain from move assignment in our cases. These reports can be discarded.
4. 276133 and 276135 - it is an intended usage of atan2, consistent with our codebase. Can be discarded.
5. 276139 - complaint about incomplete input validation in OICS. Again, it is unclear how to shut the CoverityScan up here.