### PR TITLE
Take in account caster's race height when launch magic bolt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@
     Bug #5190: On-strike enchantments can be applied to and used with non-projectile ranged weapons
     Bug #5196: Dwarven ghosts do not use idle animations
     Bug #5206: A "class does not have NPC stats" error when player's follower kills an enemy with damage spell
+    Bug #5209: Spellcasting ignores race height
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -262,7 +262,7 @@ namespace MWWorld
         {
             // Spawn at 0.75 * ActorHeight
             // Note: we ignore the collision box offset, this is required to make some flying creatures work as intended.
-            pos.z() += mPhysics->getHalfExtents(caster).z() * 2 * 0.75;
+            pos.z() += mPhysics->getRenderingHalfExtents(caster).z() * 2 * 0.75;
         }
 
         if (MWBase::Environment::get().getWorld()->isUnderwater(caster.getCell(), pos)) // Underwater casting not possible


### PR DESCRIPTION
Fixes [bug #5209](https://gitlab.com/OpenMW/openmw/issues/5209).
Now all races have the same visible launch position (Bosmers no longer launch magic bolts from their  heads). Aiming now looks the same in the 1st-person view for different races.

As a solution of this bug, I use the rendering half extents, as we do in the drowning check.