### PR TITLE
Fix clang-tidy issues

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -241,7 +241,7 @@ namespace MWGui
         MyGUI::FactoryManager::getInstance().registerFactory<ResourceImageSetPointerFix>("Resource", "ResourceImageSetPointer");
         MyGUI::FactoryManager::getInstance().registerFactory<AutoSizedResourceSkin>("Resource", "AutoSizedResourceSkin");
         MyGUI::ResourceManager::getInstance().load("core.xml");
-        loadUserFonts();
+        WindowManager::loadUserFonts();
 
         bool keyboardNav = Settings::Manager::getBool("keyboard navigation", "GUI");
         mKeyboardNavigation.reset(new KeyboardNavigation());

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -633,7 +633,7 @@ namespace MWRender
 
     Animation::~Animation()
     {
-        setLightEffect(0.f);
+        Animation::setLightEffect(0.f);
 
         if (mObjectRoot)
             mInsert->removeChild(mObjectRoot);

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -515,13 +515,11 @@ namespace MWRender
     protected:
         virtual void setDefaults(osg::StateSet* stateset)
         {
-            osg::Material* material = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
-
             osg::BlendFunc* blendfunc (new osg::BlendFunc);
             stateset->setAttributeAndModes(blendfunc, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
 
             // FIXME: overriding diffuse/ambient/emissive colors
-            material = new osg::Material;
+            osg::Material* material = new osg::Material;
             material->setColorMode(osg::Material::OFF);
             material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,mAlpha));
             material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -1489,7 +1489,7 @@ OpenAL_Output::OpenAL_Output(SoundManager &mgr)
 
 OpenAL_Output::~OpenAL_Output()
 {
-    deinit();
+    OpenAL_Output::deinit();
 }
 
 }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -1362,7 +1362,7 @@ namespace MWSound
 
     void SoundManager::clear()
     {
-        stopMusic();
+        SoundManager::stopMusic();
 
         for(SoundMap::value_type &snd : mActiveSounds)
         {

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -27,7 +27,7 @@ ParticleSystem::ParticleSystem(const ParticleSystem &copy, const osg::CopyOp &co
 {
     // For some reason the osgParticle constructor doesn't copy the particles
     for (int i=0;i<copy.numParticles()-copy.numDeadParticles();++i)
-        createParticle(copy.getParticle(i));
+        ParticleSystem::createParticle(copy.getParticle(i));
 }
 
 void ParticleSystem::setQuota(int quota)

--- a/components/sceneutil/mwshadowtechnique.hpp
+++ b/components/sceneutil/mwshadowtechnique.hpp
@@ -261,18 +261,18 @@ namespace SceneUtil {
 
         float                                   _shadowFadeStart = 0.0;
 
-        class DebugHUD : public osg::Referenced
+        class DebugHUD final : public osg::Referenced
         {
         public:
             DebugHUD(int numberOfShadowMapsPerLight);
 
-            virtual void draw(osg::ref_ptr<osg::Texture2D> texture, unsigned int shadowMapNumber, const osg::Matrixd &matrix, osgUtil::CullVisitor& cv);
+            void draw(osg::ref_ptr<osg::Texture2D> texture, unsigned int shadowMapNumber, const osg::Matrixd &matrix, osgUtil::CullVisitor& cv);
 
-            virtual void releaseGLObjects(osg::State* state = 0) const;
+            void releaseGLObjects(osg::State* state = 0) const;
 
-            virtual void setFrustumVertices(osg::ref_ptr<osg::Vec3Array> vertices, unsigned int traversalNumber);
+            void setFrustumVertices(osg::ref_ptr<osg::Vec3Array> vertices, unsigned int traversalNumber);
         protected:
-            virtual void addAnotherShadowMap();
+            void addAnotherShadowMap();
 
             static const int sDebugTextureUnit = 0;
 

--- a/components/sceneutil/shadow.hpp
+++ b/components/sceneutil/shadow.hpp
@@ -19,15 +19,13 @@ namespace SceneUtil
 
         ShadowManager(osg::ref_ptr<osg::Group> sceneRoot, osg::ref_ptr<osg::Group> rootNode, unsigned int outdoorShadowCastingMask, unsigned int indoorShadowCastingMask, Shader::ShaderManager &shaderManager);
 
-        virtual ~ShadowManager() = default;
+        void setupShadowSettings();
 
-        virtual void setupShadowSettings();
+        Shader::ShaderManager::DefineMap getShadowDefines();
 
-        virtual Shader::ShaderManager::DefineMap getShadowDefines();
+        void enableIndoorMode();
 
-        virtual void enableIndoorMode();
-
-        virtual void enableOutdoorMode();
+        void enableOutdoorMode();
     protected:
         bool mEnableShadows;
 

--- a/components/sdlutil/sdlgraphicswindow.cpp
+++ b/components/sdlutil/sdlgraphicswindow.cpp
@@ -20,7 +20,7 @@ GraphicsWindowSDL2::GraphicsWindowSDL2(osg::GraphicsContext::Traits *traits)
     _traits = traits;
 
     init();
-    if(valid())
+    if(GraphicsWindowSDL2::valid())
     {
         setState(new osg::State);
         getState()->setGraphicsContext(this);

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -28,7 +28,7 @@ TerrainGrid::~TerrainGrid()
 {
     while (!mGrid.empty())
     {
-        unloadCell(mGrid.begin()->first.first, mGrid.begin()->first.second);
+        TerrainGrid::unloadCell(mGrid.begin()->first.first, mGrid.begin()->first.second);
     }
 }
 


### PR DESCRIPTION
Mostly related to virtual calls in constructors and destructors. Technically it's ok, but explicit calls are easier to understand. Also some virtual modifiers are not used, these are removed.