### PR TITLE
Allow ActionOpen and ActionTalk only for player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@
     Bug #5196: Dwarven ghosts do not use idle animations
     Bug #5206: A "class does not have NPC stats" error when player's follower kills an enemy with damage spell
     Bug #5209: Spellcasting ignores race height
+    Bug #5210: AiActivate allows actors to open dialogue and inventory windows
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -3,6 +3,7 @@
 #include <components/esm/aisequence.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/windowmanager.hpp"
 #include "../mwbase/world.hpp"
 
 #include "../mwworld/class.hpp"
@@ -58,7 +59,7 @@ bool AiPursue::execute (const MWWorld::Ptr& actor, CharacterController& characte
     if (pathTo(actor, dest, duration, pathTolerance) &&
         std::abs(dest.z() - actorPos.z()) < pathTolerance) // check the true distance in case the target is far away in Z-direction
     {
-        target.getClass().activate(target,actor).get()->execute(actor); //Arrest player when reached
+        MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Dialogue, actor); //Arrest player when reached
         return true;
     }
 

--- a/apps/openmw/mwworld/actionopen.cpp
+++ b/apps/openmw/mwworld/actionopen.cpp
@@ -18,6 +18,9 @@ namespace MWWorld
         if (!MWBase::Environment::get().getWindowManager()->isAllowed(MWGui::GW_Inventory))
             return;
 
+        if (actor != MWMechanics::getPlayer())
+            return;
+
         if (!MWBase::Environment::get().getMechanicsManager()->onOpen(getTarget()))
             return;
 

--- a/apps/openmw/mwworld/actiontalk.cpp
+++ b/apps/openmw/mwworld/actiontalk.cpp
@@ -3,12 +3,15 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
 
+#include "../mwmechanics/actorutil.hpp"
+
 namespace MWWorld
 {
     ActionTalk::ActionTalk (const Ptr& actor) : Action (false, actor) {}
 
     void ActionTalk::executeImp (const Ptr& actor)
     {
-        MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Dialogue, getTarget());
+        if (actor == MWMechanics::getPlayer())
+            MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Dialogue, getTarget());
     }
 }


### PR DESCRIPTION
Fixes [bug #5210](https://gitlab.com/OpenMW/openmw/issues/5210)

I see no reasons to replicate ALL AiActivate quirks, but we should not allow actors excepts player to initiate dialogue and open container windows.
It should be enough to make the buggy script from Laura Craft mod to work.

Note: using an another approach in AiPursue - open dialogue directly instead of using ActionTalk, as we do in ForceGreeting handler.