### PR TITLE
Do not use screen fading during game loading if there is no current cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@
     Bug #5206: A "class does not have NPC stats" error when player's follower kills an enemy with damage spell
     Bug #5209: Spellcasting ignores race height
     Bug #5210: AiActivate allows actors to open dialogue and inventory windows
+    Bug #5211: Screen fades in if the first loaded save is in interior cell
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -683,11 +683,9 @@ namespace MWWorld
     void Scene::changeToInteriorCell (const std::string& cellName, const ESM::Position& position, bool adjustPlayerPos, bool changeEvent)
     {
         CellStore *cell = MWBase::Environment::get().getWorld()->getInterior(cellName);
-        bool loadcell = (mCurrentCell == nullptr);
-        if(!loadcell)
-            loadcell = *mCurrentCell != *cell;
-
-        MWBase::Environment::get().getWindowManager()->fadeScreenOut(0.5);
+        bool useFading = (mCurrentCell != nullptr);
+        if (useFading)
+            MWBase::Environment::get().getWindowManager()->fadeScreenOut(0.5);
 
         Loading::Listener* loadingListener = MWBase::Environment::get().getWindowManager()->getLoadingScreen();
         int messagesCount = MWBase::Environment::get().getWindowManager()->getMessagesCount();
@@ -695,7 +693,7 @@ namespace MWWorld
         loadingListener->setLabel(loadingInteriorText, false, messagesCount > 0);
         Loading::ScopedLoad load(loadingListener);
 
-        if(!loadcell)
+        if(mCurrentCell != nullptr && *mCurrentCell == *cell)
         {
             MWBase::World *world = MWBase::Environment::get().getWorld();
             world->moveObject(world->getPlayerPtr(), position.pos[0], position.pos[1], position.pos[2]);
@@ -734,7 +732,8 @@ namespace MWWorld
         if (changeEvent)
             mCellChanged = true;
 
-        MWBase::Environment::get().getWindowManager()->fadeScreenIn(0.5);
+        if (useFading)
+            MWBase::Environment::get().getWindowManager()->fadeScreenIn(0.5);
 
         MWBase::Environment::get().getWindowManager()->changeCell(mCurrentCell);
     }


### PR DESCRIPTION
Fixes [bug #5211](https://gitlab.com/OpenMW/openmw/issues/5211).

Just do not use fading when there is no current cell during save loading (when player loads savegame in the first time after game launch).