### PR TITLE
Make sure quick key 0 (tenth quick key) shortcut is not saved or loaded

### DIFF
--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -504,7 +504,8 @@ namespace MWGui
 
         ESM::QuickKeys keys;
 
-        for (int i=0; i<10; ++i)
+        // NB: The quick key with index 9 always has Hand-to-Hand type and must not be saved
+        for (int i=0; i<9; ++i)
         {
             ItemWidget* button = mKey[i].button;
 
@@ -553,7 +554,8 @@ namespace MWGui
         int i=0;
         for (ESM::QuickKeys::QuickKey& quickKey : keys.mKeys)
         {
-            if (i >= 10)
+            // NB: The quick key with index 9 always has Hand-to-Hand type and must not be loaded
+            if (i >= 9)
                 return;
 
             mSelected = &mKey[i];


### PR DESCRIPTION
This minor oversight caused oddities with older saves when they're loaded in 0.45.0 or later revisions of OpenMW (e.g. [see here](https://www.reddit.com/r/OpenMW/comments/dychlg/quick_key_bug/)). Basically, quick key 0 or hand-to-hand shortcut could be bound to an action in 0.44.0 and earlier and then when in 0.45.0 that functionality was removed (to replicate Morrowind behavior) the quick key could only be assigned to that exact action in the saves where it was reallocated.

Now it's not saved or loaded, so it's dropped from the save where it was touched erroneously. The saved game format isn't changed, both backward and forward compatibility of the saved games is kept thanks to the current design of quick keys saving being flexible enough (you can load the save made with this fix in 0.45.0 and it will not have the issue). It even makes saves an extremely small bit smaller.

Should be minor enough not to require a changelog entry.