### PR TITLE
Fix build with libc++

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -270,6 +270,8 @@ endif()
 # Fix for not visible pthreads functions for linker with glibc 2.15
 if (UNIX AND NOT APPLE)
 target_link_libraries(components ${CMAKE_THREAD_LIBS_INIT})
+find_package(ZLIB REQUIRED)
+target_link_libraries(components ZLIB::ZLIB)
 endif()
 
 if (BUILD_WITH_CODE_COVERAGE)


### PR DESCRIPTION
Now if `-stdlib=libc++` flag is used, then linker fails on openmw binary with error:
```
[100%] Linking CXX executable ../../openmw
/usr/bin/ld: /home/elsid/dev/OpenSceneGraph/build/clang/release/lib/libosgDB.so: undefined reference to symbol 'inflateEnd'
//lib/x86_64-linux-gnu/libz.so.1: error adding symbols: DSO missing from command line
clang: error: linker command failed with exit code 1 (use -v to see invocation)
apps/openmw/CMakeFiles/openmw.dir/build.make:3962: recipe for target 'openmw' failed
make[2]: *** [openmw] Error 1
CMakeFiles/Makefile2:710: recipe for target 'apps/openmw/CMakeFiles/openmw.dir/all' failed
make[1]: *** [apps/openmw/CMakeFiles/openmw.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2
```
