### PR TITLE
Make SameFaction work (bug #5213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
     Bug #5209: Spellcasting ignores race height
     Bug #5210: AiActivate allows actors to open dialogue and inventory windows
     Bug #5211: Screen fades in if the first loaded save is in interior cell
+    Bug #5213: SameFaction script function is broken
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwscript/dialogueextensions.cpp
+++ b/apps/openmw/mwscript/dialogueextensions.cpp
@@ -210,7 +210,7 @@ namespace MWScript
 
                     MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
 
-                    player.getClass().getNpcStats (player).isInFaction(ptr.getClass().getPrimaryFaction(ptr));
+                    runtime.push(player.getClass().getNpcStats (player).isInFaction(ptr.getClass().getPrimaryFaction(ptr)));
                 }
         };
 


### PR DESCRIPTION
Restored the previous behavior before scrawl broke it in January 2015, where it actually does something useful and sensible. Seems to work OK now, the scripts using it won't break anymore and it returns valid values.