### PR TITLE
[Regression] Make sure instant FX abilities get detected when they're supposed to

### DIFF
--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -465,16 +465,6 @@ namespace MWScript
                     {
                         // Apply looping particles immediately for constant effects
                         MWBase::Environment::get().getWorld()->applyLoopingParticles(ptr);
-
-                        // The spell may have an instant effect which must be handled immediately.
-                        for (const auto& effect : creatureStats.getSpells().getMagicEffects())
-                        {
-                            if (effect.second.getMagnitude() <= 0)
-                               continue;
-                            MWMechanics::CastSpell cast(ptr, ptr);
-                            if (cast.applyInstantEffect(ptr, ptr, effect.first, effect.second.getMagnitude()))
-                                creatureStats.getSpells().purgeEffect(effect.first.mId);
-                        }
                     }
                 }
         };
@@ -491,7 +481,18 @@ namespace MWScript
                     std::string id = runtime.getStringLiteral (runtime[0].mInteger);
                     runtime.pop();
 
-                    ptr.getClass().getCreatureStats (ptr).getSpells().remove (id);
+                    MWMechanics::CreatureStats& creatureStats = ptr.getClass().getCreatureStats(ptr);
+                    // The spell may have an instant effect which must be handled before the spell's removal.
+                    for (const auto& effect : creatureStats.getSpells().getMagicEffects())
+                    {
+                        if (effect.second.getMagnitude() <= 0)
+                            continue;
+                        MWMechanics::CastSpell cast(ptr, ptr);
+                        if (cast.applyInstantEffect(ptr, ptr, effect.first, effect.second.getMagnitude()))
+                            creatureStats.getSpells().purgeEffect(effect.first.mId);
+                    }
+
+                    creatureStats.getSpells().remove (id);
 
                     MWBase::WindowManager *wm = MWBase::Environment::get().getWindowManager();
 


### PR DESCRIPTION
Julan the Ashlander mod had issues with Intervention effect Julan casts on the player not being properly detected by the follower's scripts. It's handled via an ability with an Intervention effect. It worked properly before because the effects weren't handled and purged immediately. This probably isn't how it works in Morrowind, but I've set up a workaround that allows "permanent" instant effects to both trigger when AddSpell and RemoveSpell calls are done in the same frame and be detected for one frame when they aren't. Now the effects are deliberately handled in RemoveSpell if they weren't handled before (supposedly when they're added in a permanent ability that's about to be removed).