### PR TITLE
Fix most of deprecated API usage

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -5,6 +5,10 @@
 #include <QMessageBox>
 #include <QDir>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QScreen>
+#endif
+
 #ifdef MAC_OS_X_VERSION_MIN_REQUIRED
 #undef MAC_OS_X_VERSION_MIN_REQUIRED
 // We need to do this because of Qt: https://bugreports.qt-project.org/browse/QTBUG-22154
@@ -311,6 +315,17 @@ QStringList Launcher::GraphicsPage::getAvailableResolutions(int screen)
 QRect Launcher::GraphicsPage::getMaximumResolution()
 {
     QRect max;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    for (QScreen* screen : QGuiApplication::screens())
+    {
+        QRect res = screen->geometry();
+        if (res.width() > max.width())
+            max.setWidth(res.width());
+        if (res.height() > max.height())
+            max.setHeight(res.height());
+    }
+#else
     int screens = QApplication::desktop()->screenCount();
     for (int i = 0; i < screens; ++i)
     {
@@ -320,6 +335,7 @@ QRect Launcher::GraphicsPage::getMaximumResolution()
         if (res.height() > max.height())
             max.setHeight(res.height());
     }
+#endif
     return max;
 }
 

--- a/apps/opencs/view/doc/newgame.cpp
+++ b/apps/opencs/view/doc/newgame.cpp
@@ -6,6 +6,10 @@
 #include <QDialogButtonBox>
 #include <QPushButton>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QScreen>
+#endif
+
 #include "filewidget.hpp"
 #include "adjusterwidget.hpp"
 
@@ -46,7 +50,11 @@ CSVDoc::NewGameDialogue::NewGameDialogue()
     connect (mFileWidget, SIGNAL (nameChanged (const QString&, bool)),
         mAdjusterWidget, SLOT (setName (const QString&, bool)));
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    QRect scr = QGuiApplication::primaryScreen()->geometry();
+#else
     QRect scr = QApplication::desktop()->screenGeometry();
+#endif
     QRect rect = geometry();
     move (scr.center().x() - rect.center().x(), scr.center().y() - rect.center().y());
 }

--- a/apps/opencs/view/doc/startup.cpp
+++ b/apps/opencs/view/doc/startup.cpp
@@ -10,6 +10,10 @@
 #include <QIcon>
 #include <QPushButton>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QScreen>
+#endif
+
 QPushButton *CSVDoc::StartupDialogue::addButton (const QString& label, const QIcon& icon)
 {
     int column = mColumn--;
@@ -119,7 +123,12 @@ CSVDoc::StartupDialogue::StartupDialogue() : mWidth (0), mColumn (2)
 
     setLayout (layout);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    QRect scr = QGuiApplication::primaryScreen()->geometry();
+#else
     QRect scr = QApplication::desktop()->screenGeometry();
+#endif
+
     QRect rect = geometry();
     move (scr.center().x() - rect.center().x(), scr.center().y() - rect.center().y());
 }

--- a/apps/opencs/view/doc/view.cpp
+++ b/apps/opencs/view/doc/view.cpp
@@ -15,6 +15,10 @@
 #include <QDesktopWidget>
 #include <QScrollBar>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QScreen>
+#endif
+
 #include "../../model/doc/document.hpp"
 #include "../../model/prefs/state.hpp"
 #include "../../model/prefs/shortcut.hpp"
@@ -1050,7 +1054,7 @@ void CSVDoc::View::updateWidth(bool isGrowLimit, int minSubViewWidth)
     if (isGrowLimit)
         rect = dw->screenGeometry(this);
     else
-        rect = dw->screenGeometry(dw->screen(dw->screenNumber(this)));
+        rect = QGuiApplication::screens().at(dw->screenNumber(this))->geometry();
 
     if (!mScrollbarOnly && mScroll && mSubViews.size() > 1)
     {

--- a/apps/opencs/view/prefs/dialogue.cpp
+++ b/apps/opencs/view/prefs/dialogue.cpp
@@ -8,6 +8,10 @@
 #include <QStackedWidget>
 #include <QListWidgetItem>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QScreen>
+#endif
+
 #include <components/debug/debuglog.hpp>
 
 #include "../../model/prefs/state.hpp"
@@ -34,7 +38,12 @@ void CSVPrefs::Dialogue::buildCategorySelector (QSplitter *main)
         ++iter)
     {
         QString label = QString::fromUtf8 (iter->second.getKey().c_str());
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
+        maxWidth = std::max (maxWidth, metrics.horizontalAdvance (label));
+#else
         maxWidth = std::max (maxWidth, metrics.width (label));
+#endif
 
         list->addItem (label);
     }
@@ -107,8 +116,15 @@ void CSVPrefs::Dialogue::show()
     }
     else
     {
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+        QRect scr = QGuiApplication::primaryScreen()->geometry();
+#else
+        QRect scr = QApplication::desktop()->screenGeometry();
+#endif
+
         // otherwise place at the centre of the screen
-        QPoint screenCenter = QApplication::desktop()->screenGeometry().center();
+        QPoint screenCenter = scr.center();
+
         move (screenCenter - QPoint(frameGeometry().width()/2, frameGeometry().height()/2));
     }
 

--- a/apps/opencs/view/widget/coloreditor.cpp
+++ b/apps/opencs/view/widget/coloreditor.cpp
@@ -6,6 +6,10 @@
 #include <QPainter>
 #include <QShowEvent>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+#include <QScreen>
+#endif
+
 #include "colorpickerpopup.hpp"
 
 CSVWidget::ColorEditor::ColorEditor(const QColor &color, QWidget *parent, const bool popupOnStart)
@@ -95,7 +99,11 @@ QPoint CSVWidget::ColorEditor::calculatePopupPosition()
 {
     QRect editorGeometry = geometry();
     QRect popupGeometry = mColorPicker->geometry();
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+    QRect screenGeometry = QGuiApplication::primaryScreen()->geometry();
+#else
     QRect screenGeometry = QApplication::desktop()->screenGeometry();
+#endif
 
     // Center the popup horizontally relative to the editor
     int localPopupX = (editorGeometry.width() - popupGeometry.width()) / 2;

--- a/apps/opencs/view/world/enumdelegate.cpp
+++ b/apps/opencs/view/world/enumdelegate.cpp
@@ -134,7 +134,12 @@ QSize CSVWorld::EnumDelegate::sizeHint(const QStyleOptionViewItem &option, const
         itemOption.state = option.state;
 
         const QString &valueText = mValues.at(valueIndex).second;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
+        QSize valueSize = QSize(itemOption.fontMetrics.horizontalAdvance(valueText), itemOption.fontMetrics.height());
+#else
         QSize valueSize = QSize(itemOption.fontMetrics.width(valueText), itemOption.fontMetrics.height());
+#endif
 
         itemOption.currentText = valueText;
         return QApplication::style()->sizeFromContents(QStyle::CT_ComboBox, &itemOption, valueSize);

--- a/apps/opencs/view/world/scriptedit.cpp
+++ b/apps/opencs/view/world/scriptedit.cpp
@@ -205,7 +205,12 @@ bool CSVWorld::ScriptEdit::stringNeedsQuote (const std::string& id) const
 void CSVWorld::ScriptEdit::setTabWidth()
 {
     // Set tab width to specified number of characters using current font.
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
+    setTabStopDistance(mTabCharCount * fontMetrics().horizontalAdvance(' '));
+#else
     setTabStopWidth(mTabCharCount * fontMetrics().width(' '));
+#endif
+
 }
 
 void CSVWorld::ScriptEdit::wrapLines(bool wrap)
@@ -285,7 +290,11 @@ int CSVWorld::ScriptEdit::lineNumberAreaWidth()
         ++digits;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
+    int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+#else
     int space = 3 + fontMetrics().width(QLatin1Char('9')) * digits;
+#endif
 
     return space;
 }


### PR DESCRIPTION
There are many warnings in the editor and the launcher when you build them against Qt 5.13+ (as in our MacOS CI). This PR fixes most of them:

1. The `QGuiApplication::primaryScreen()->geometry();` and the `QApplication::desktop()->screenGeometry();` return the same QRect (at least, if you have a single display) and the former is the proper way to get screen dimensions in the Qt5.

2. The `tabStopWidth` and font width were renamed for some reason in Qt 5.11

It would be nice if someone could test this PR on multi-display setup.

Also probably it is worth to drop Qt4 support at all. In this case we should limit target Qt version in CMake and search for Qt5 by default (-DDESIRED_QT_VERSION).