### PR TITLE
Fix GCC9 warnings about implicit declarations

### DIFF
--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -344,6 +344,7 @@ namespace MWWorld
             ContainerStoreIteratorBase& operator++ ();
             ContainerStoreIteratorBase operator++ (int);
             ContainerStoreIteratorBase& operator= (const ContainerStoreIteratorBase& rhs);
+            ContainerStoreIteratorBase (const ContainerStoreIteratorBase& rhs) = default;
 
             int getType() const;
             const ContainerStore *getContainerStore() const;

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -92,6 +92,8 @@ namespace MWWorld
           : mIter(iter)
         {}
 
+        SharedIterator& operator=(const SharedIterator&) = default;
+
         SharedIterator &operator++() {
             ++mIter;
             return *this;

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -76,7 +76,14 @@ ParticleShooter::ParticleShooter()
 ParticleShooter::ParticleShooter(const ParticleShooter &copy, const osg::CopyOp &copyop)
     : osgParticle::Shooter(copy, copyop)
 {
-    *this = copy;
+    mMinSpeed = copy.mMinSpeed;
+    mMaxSpeed = copy.mMaxSpeed;
+    mHorizontalDir = copy.mHorizontalDir;
+    mHorizontalAngle = copy.mHorizontalAngle;
+    mVerticalDir = copy.mVerticalDir;
+    mVerticalAngle = copy.mVerticalAngle;
+    mLifetime = copy.mLifetime;
+    mLifetimeRandom = copy.mLifetimeRandom;
 }
 
 void ParticleShooter::shoot(osgParticle::Particle *particle) const
@@ -112,7 +119,9 @@ GrowFadeAffector::GrowFadeAffector()
 GrowFadeAffector::GrowFadeAffector(const GrowFadeAffector& copy, const osg::CopyOp& copyop)
     : osgParticle::Operator(copy, copyop)
 {
-    *this = copy;
+    mGrowTime = copy.mGrowTime;
+    mFadeTime = copy.mFadeTime;
+    mCachedDefaultSize = copy.mCachedDefaultSize;
 }
 
 void GrowFadeAffector::beginOperate(osgParticle::Program *program)
@@ -143,7 +152,7 @@ ParticleColorAffector::ParticleColorAffector()
 ParticleColorAffector::ParticleColorAffector(const ParticleColorAffector &copy, const osg::CopyOp &copyop)
     : osgParticle::Operator(copy, copyop)
 {
-    *this = copy;
+    mData = copy.mData;
 }
 
 void ParticleColorAffector::operate(osgParticle::Particle* particle, double /* dt */)
@@ -172,7 +181,13 @@ GravityAffector::GravityAffector()
 GravityAffector::GravityAffector(const GravityAffector &copy, const osg::CopyOp &copyop)
     : osgParticle::Operator(copy, copyop)
 {
-    *this = copy;
+    mForce = copy.mForce;
+    mType = copy.mType;
+    mPosition = copy.mPosition;
+    mDirection = copy.mDirection;
+    mDecay = copy.mDecay;
+    mCachedWorldPosition = copy.mCachedWorldPosition;
+    mCachedWorldDirection = copy.mCachedWorldDirection;
 }
 
 void GravityAffector::beginOperate(osgParticle::Program* program)

--- a/components/nifosg/particle.hpp
+++ b/components/nifosg/particle.hpp
@@ -78,6 +78,8 @@ namespace NifOsg
         ParticleShooter();
         ParticleShooter(const ParticleShooter& copy, const osg::CopyOp& copyop = osg::CopyOp::SHALLOW_COPY);
 
+        ParticleShooter& operator=(const ParticleShooter&) = delete;
+
         META_Object(NifOsg, ParticleShooter)
 
         virtual void shoot(osgParticle::Particle* particle) const;
@@ -135,6 +137,8 @@ namespace NifOsg
         GrowFadeAffector();
         GrowFadeAffector(const GrowFadeAffector& copy, const osg::CopyOp& copyop = osg::CopyOp::SHALLOW_COPY);
 
+        GrowFadeAffector& operator=(const GrowFadeAffector&) = delete;
+
         META_Object(NifOsg, GrowFadeAffector)
 
         virtual void beginOperate(osgParticle::Program* program);
@@ -155,6 +159,8 @@ namespace NifOsg
         ParticleColorAffector();
         ParticleColorAffector(const ParticleColorAffector& copy, const osg::CopyOp& copyop = osg::CopyOp::SHALLOW_COPY);
 
+        ParticleColorAffector& operator=(const ParticleColorAffector&) = delete;
+
         META_Object(NifOsg, ParticleColorAffector)
 
         virtual void operate(osgParticle::Particle* particle, double dt);
@@ -169,6 +175,8 @@ namespace NifOsg
         GravityAffector(const Nif::NiGravity* gravity);
         GravityAffector();
         GravityAffector(const GravityAffector& copy, const osg::CopyOp& copyop = osg::CopyOp::SHALLOW_COPY);
+
+        GravityAffector& operator=(const GravityAffector&) = delete;
 
         META_Object(NifOsg, GravityAffector)
 


### PR DESCRIPTION
Implicit declarations are deprecated in GCC now, so there is a spam in the build log.
Basically, GCC does not like when there is a user-defined copy constructor, but no copy assignment operator (or vice versa).