### PR TITLE
Fix Boost 1.70+ detection

### DIFF
--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -2,6 +2,7 @@
 
 brew update
 brew outdated pkgconfig || brew upgrade pkgconfig
+brew install cmake
 brew install qt
 brew install ccache
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,8 @@ if (DEFINED ENV{TRAVIS_BRANCH} OR DEFINED ENV{APPVEYOR})
     set(REQUIRED_BULLET_VERSION 283) # but for build testing, 283 is fine
 endif()
 
+set(Boost_NO_BOOST_CMAKE ON)
+
 find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 find_package(MyGUI 3.2.2 REQUIRED)
 find_package(SDL2 REQUIRED)


### PR DESCRIPTION
In Boost 1.70 they changed a way to detect Boost component via CMake.

Now Boost provides a separate CMake config for every component, so detection should look like this:

```
find_package(Boost REQUIRED COMPONENTS thread timer)

target_link_libraries(...
    Boost::thread
    Boost::timer
    ...)
```

But since we support older Boost and CMake, we can tell CMake to use its own config, as earlier:

```
set(Boost_NO_BOOST_CMAKE ON)

find_package(Boost REQUIRED COMPONENTS thread timer)

include_directories(${Boost_INCLUDE_DIRS}
    ...)

link_directories(${Boost_LIBRARY_DIRS}
    ...)

target_link_libraries(...
    ${Boost_LIBRARIES}
    ...)
```