### PR TITLE
Fix iterator usage when destroying cell borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@
     Bug #5210: AiActivate allows actors to open dialogue and inventory windows
     Bug #5211: Screen fades in if the first loaded save is in interior cell
     Bug #5213: SameFaction script function is broken
+    Bug #5218: Crash when disabling ToggleBorders
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/components/terrain/cellborder.cpp
+++ b/components/terrain/cellborder.cpp
@@ -91,8 +91,9 @@ void CellBorder::destroyCellBorderGeometry(int x, int y)
 
 void CellBorder::destroyCellBorderGeometry()
 {
-    for (CellGrid::iterator it = mCellBorderNodes.begin(); it != mCellBorderNodes.end(); ++it)
-        destroyCellBorderGeometry(it->first.first,it->first.second);
+    for (const auto& v : mCellBorderNodes)
+        mRoot->removeChild(v.second);
+    mCellBorderNodes.clear();
 }
 
 }


### PR DESCRIPTION
Fixes [bug #5218](https://gitlab.com/OpenMW/openmw/issues/5218).

Since we are going to remove all items from map anyway, just remove scene nodes in loop and clear the map.