### PR TITLE
Several languages for the launcher

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,6 +74,7 @@ Programmers
     Fil Krynicki (filkry)
     Finbar Crago (finbar-crago)
     Florian Weber (Florianjw)
+    Gaëtan Dezeiraud (Brouilles)
     Gašper Sedej
     Gijsbert ter Horst (Ghostbird)
     Gohan1989

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include <QApplication>
+#include <QTranslator>
 #include <QTextCodec>
 #include <QDir>
 #include <QDebug>
@@ -25,6 +26,13 @@ int main(int argc, char *argv[])
 #endif
 
         QApplication app(argc, argv);
+
+        // Internationalization 
+        QString locale = QLocale::system().name().section('_', 0, 0);
+
+        QTranslator appTranslator;
+        appTranslator.load(":/translations/" + locale + ".qm");
+        app.installTranslator(&appTranslator);
 
         // Now we make sure the current dir is set to application path
         QDir dir(QCoreApplication::applicationDirPath());

--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -55,6 +55,7 @@ Launcher::MainDialog::MainDialog(QWidget *parent)
     iconWidget->setFlow(QListView::LeftToRight);
 
     QPushButton *playButton = new QPushButton(tr("Play"));
+    buttonBox->button(QDialogButtonBox::Close)->setText(tr("Close"));
     buttonBox->addButton(playButton, QDialogButtonBox::AcceptRole);
 
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(close()));

--- a/apps/launcher/settingspage.cpp
+++ b/apps/launcher/settingspage.cpp
@@ -27,13 +27,13 @@ Launcher::SettingsPage::SettingsPage(Files::ConfigurationManager &cfg,
     setupUi(this);
 
     QStringList languages;
-    languages << QLatin1String("English")
-              << QLatin1String("French")
-              << QLatin1String("German")
-              << QLatin1String("Italian")
-              << QLatin1String("Polish")
-              << QLatin1String("Russian")
-              << QLatin1String("Spanish");
+    languages << tr("English")
+              << tr("French")
+              << tr("German")
+              << tr("Italian")
+              << tr("Polish")
+              << tr("Russian")
+              << tr("Spanish");
 
     languageComboBox->addItems(languages);
 


### PR DESCRIPTION
The integration of QTranslator into the Launcher. Because it's an element that is used by a lambda user, it seemed like a good idea to be able to translate it.

The application get the local language `fr-FR` for example and search a `fr.qm` file with the two first characters (So it's also working gor fr-CA). If the translation doesn't exist, the launcher is in English.

I have added a partial translation for french (just all tooltips are not translated) but the rest is.