### PR TITLE
Avoid using getPtr for object search in scripting (bug #5220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@
     Bug #5211: Screen fades in if the first loaded save is in interior cell
     Bug #5213: SameFaction script function is broken
     Bug #5218: Crash when disabling ToggleBorders
+    Bug #5220: GetLOS crashes when actor isn't loaded
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -382,9 +382,11 @@ namespace MWScript
                     std::string actorID = runtime.getStringLiteral (runtime[0].mInteger);
                     runtime.pop();
 
-                    MWWorld::Ptr actor = MWBase::Environment::get().getWorld()->getPtr(actorID, true);
+                    MWWorld::Ptr actor = MWBase::Environment::get().getWorld()->searchPtr(actorID, true, false);
 
-                    Interpreter::Type_Integer value = MWBase::Environment::get().getMechanicsManager()->isActorDetected(actor, observer);
+                    Interpreter::Type_Integer value = 0;
+                    if (!actor.isEmpty())
+                        value = MWBase::Environment::get().getMechanicsManager()->isActorDetected(actor, observer);
 
                     runtime.push (value);
                 }
@@ -404,9 +406,9 @@ namespace MWScript
                     runtime.pop();
 
 
-                    MWWorld::Ptr dest = MWBase::Environment::get().getWorld()->getPtr(actorID,true);
+                    MWWorld::Ptr dest = MWBase::Environment::get().getWorld()->searchPtr(actorID, true, false);
                     bool value = false;
-                    if(dest != MWWorld::Ptr() && source.getClass().isActor() && dest.getClass().isActor())
+                    if (!dest.isEmpty() && source.getClass().isActor() && dest.getClass().isActor())
                     {
                         value = MWBase::Environment::get().getWorld()->getLOS(source,dest);
                     }
@@ -447,8 +449,9 @@ namespace MWScript
                     std::string targetID = runtime.getStringLiteral (runtime[0].mInteger);
                     runtime.pop();
 
-                    MWWorld::Ptr target = MWBase::Environment::get().getWorld()->getPtr(targetID, true);
-                    MWBase::Environment::get().getMechanicsManager()->startCombat(actor, target);
+                    MWWorld::Ptr target = MWBase::Environment::get().getWorld()->searchPtr(targetID, true, false);
+                    if (!target.isEmpty())
+                        MWBase::Environment::get().getMechanicsManager()->startCombat(actor, target);
                 }
         };
 

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1129,7 +1129,9 @@ namespace MWScript
                     return;
                 }
 
-                MWWorld::Ptr target = MWBase::Environment::get().getWorld()->getPtr (targetId, false);
+                MWWorld::Ptr target = MWBase::Environment::get().getWorld()->searchPtr(targetId, false, false);
+                if (target.isEmpty())
+                    return;
 
                 MWMechanics::CastSpell cast(ptr, target, false, true);
                 cast.playSpellCastingEffects(spell->mId, false);


### PR DESCRIPTION
[Bug #5220](https://gitlab.com/OpenMW/openmw/issues/5220).

As it throws an exception if the object isn't found, which is often undesired. More forgiving behavior is now used for the affected instructions/functions:
* GetDetected/GetLineOfSight will return 0.
* StartCombat and Cast will be no-op (in general case, when it comes to Cast).

Still used to find the reference object when the object is required.