### PR TITLE
Add High DPI support for Windows (Launcher / Wizard / OpenMW-CS)

### DIFF
--- a/apps/launcher/CMakeLists.txt
+++ b/apps/launcher/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LAUNCHER
     utils/lineedit.cpp
 
     ${CMAKE_SOURCE_DIR}/files/windows/launcher.rc
+    ${CMAKE_SOURCE_DIR}/files/windows/qt.exe.manifest
 )
 
 set(LAUNCHER_HEADER

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (OPENCS_SRC main.cpp
     ${CMAKE_SOURCE_DIR}/files/windows/opencs.rc
+    ${CMAKE_SOURCE_DIR}/files/windows/qt.exe.manifest
     )
 
 opencs_units (. editor)

--- a/apps/wizard/CMakeLists.txt
+++ b/apps/wizard/CMakeLists.txt
@@ -17,6 +17,7 @@ set(WIZARD
 
 if(WIN32)
     list(APPEND WIZARD ${CMAKE_SOURCE_DIR}/files/windows/openmw-wizard.rc)
+    list(APPEND WIZARD ${CMAKE_SOURCE_DIR}/files/windows/qt.exe.manifest)
 endif()
 
 set(WIZARD_HEADER

--- a/files/windows/qt.exe.manifest
+++ b/files/windows/qt.exe.manifest
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
+  <!-- Enable use of version 6 of the common controls (Win XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32"
+                        name="Microsoft.Windows.Common-Controls"
+                        version="6.0.0.0"
+                        processorArchitecture="*"
+                        publicKeyToken="6595b64144ccf1df"
+                        language="*" />
+    </dependentAssembly>
+  </dependency>
+
+  <!-- Indicate UAC compliance, with no need for elevated privileges -->
+  <!-- (if you need enhanced privileges, set the level to "highestAvailable" or "requireAdministrator") -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <!-- Indicate high API awareness (Win Vista and later) -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+  <!-- Declare support for various versions of Windows -->
+  <ms_compatibility:compatibility xmlns:ms_compatibility="urn:schemas-microsoft-com:compatibility.v1" xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <ms_compatibility:application>
+      <!-- Windows Vista/Server 2008 -->
+      <ms_compatibility:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+      <!-- Windows 7/Server 2008 R2 -->
+      <ms_compatibility:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <!-- Windows 8/Server 2012 -->
+      <ms_compatibility:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <!-- Windows 8.1/Server 2012 R2 -->
+      <ms_compatibility:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <!-- Windows 10 -->
+      <ms_compatibility:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </ms_compatibility:application>
+  </ms_compatibility:compatibility>
+</assembly>


### PR DESCRIPTION
The launcher, wizard and OpenMW-CS now support High DPI screen for Windows. And with multiple screens (the scale is automatic when the window pass to a High DPI screen to standard). Before, windows (so applications) could not be used because of scale issues.

Tested on Windows 10. But normally work on Windows Vista/7/8/8.1.