### PR TITLE
Make sure empty cell name subrecords are saved (bug #5222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
     Bug #5213: SameFaction script function is broken
     Bug #5218: Crash when disabling ToggleBorders
     Bug #5220: GetLOS crashes when actor isn't loaded
+    Bug #5222: Empty cell name subrecords are not saved
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/components/esm/loadcell.cpp
+++ b/components/esm/loadcell.cpp
@@ -160,7 +160,7 @@ namespace ESM
 
     void Cell::save(ESMWriter &esm, bool isDeleted) const
     {
-        esm.writeHNOCString("NAME", mName);
+        esm.writeHNCString("NAME", mName);
         esm.writeHNT("DATA", mData, 12);
 
         if (isDeleted)


### PR DESCRIPTION
[Bug 5222](https://gitlab.com/OpenMW/openmw/issues/5222).

A NAME subrecord is added into the CELL record even if there's no name to speak of. Improves original ESM format compatibility as described in the report.

Right, only changes a single line.