### PR TITLE
[Regression] Attempt to fix idle state reset again

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -576,6 +576,13 @@ void CharacterController::refreshMovementAnims(const std::string& weapShortGroup
         mCurrentMovement = movementAnimName;
         if(!mCurrentMovement.empty())
         {
+            if (resetIdle)
+            {
+                mAnimation->disable(mCurrentIdle);
+                mIdleState = CharState_None;
+                idle = CharState_None;
+            }
+
             // For non-flying creatures, MW uses the Walk animation to calculate the animation velocity
             // even if we are running. This must be replicated, otherwise the observed speed would differ drastically.
             std::string anim = mCurrentMovement;
@@ -615,9 +622,6 @@ void CharacterController::refreshMovementAnims(const std::string& weapShortGroup
 
             mAnimation->play(mCurrentMovement, Priority_Movement, movemask, false,
                              1.f, "start", "stop", startpoint, ~0ul, true);
-
-            if (resetIdle)
-                mAnimation->disable(mCurrentIdle);
         }
         else
             mMovementState = CharState_None;
@@ -1656,6 +1660,7 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
             mIdleState != CharState_IdleSneak && mIdleState != CharState_IdleSwim)
         {
             mAnimation->disable(mCurrentIdle);
+            mIdleState = CharState_None;
         }
 
         animPlaying = mAnimation->getInfo(mCurrentWeapon, &complete);


### PR DESCRIPTION
Guess I didn't look well enough.
Sneaking check in movement animation refresh didn't work properly because sneak idle state was never reset even if the animation was disabled. Caused issues with movement animation speed in first person view. Briefly hold the sneak button while moving and you'll notice that the running/walking animation becomes super fast, and so do the footsteps.

Now it's actually reset. I had to move idle reset to an earlier moment and reset both the pending and the current idle states to make sure the check returns a valid value. Obviously there could be something I overlooked...