### PR TITLE
Reset holstered shield before rebuilding an NPC animation

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -409,6 +409,7 @@ void NpcAnimation::setRenderBin()
 void NpcAnimation::rebuild()
 {
     mScabbard.reset();
+    mHolsteredShield.reset();
     updateNpcBase();
 
     MWBase::Environment::get().getMechanicsManager()->forceStateUpdate(mPtr);


### PR DESCRIPTION
Allows to avoid `Part "X" has no parents` warning during view change when shield is holstered.