### PR TITLE
Fix essimporter script header and inventory item conversion

### DIFF
--- a/apps/essimporter/convertscpt.cpp
+++ b/apps/essimporter/convertscpt.cpp
@@ -9,7 +9,7 @@ namespace ESSImport
 
     void convertSCPT(const SCPT &scpt, ESM::GlobalScript &out)
     {
-        out.mId = Misc::StringUtils::lowerCase(scpt.mSCHD.mName);
+        out.mId = Misc::StringUtils::lowerCase(scpt.mSCHD.mName.toString());
         out.mRunning = scpt.mRunning;
         convertSCRI(scpt.mSCRI, out.mLocals);
     }

--- a/apps/essimporter/importinventory.cpp
+++ b/apps/essimporter/importinventory.cpp
@@ -13,11 +13,11 @@ namespace ESSImport
     {
         while (esm.isNextSub("NPCO"))
         {
-            ESM::ContItem contItem;
+            ContItem contItem;
             esm.getHT(contItem);
 
             InventoryItem item;
-            item.mId = contItem.mItem;
+            item.mId = contItem.mItem.toString();
             item.mCount = contItem.mCount;
             item.mRelativeEquipmentSlot = -1;
             item.mLockLevel = 0;

--- a/apps/essimporter/importinventory.hpp
+++ b/apps/essimporter/importinventory.hpp
@@ -5,6 +5,8 @@
 #include <string>
 
 #include <components/esm/cellref.hpp>
+#include <components/esm/esmcommon.hpp>
+
 #include "importscri.hpp"
 
 namespace ESM
@@ -14,6 +16,12 @@ namespace ESM
 
 namespace ESSImport
 {
+
+    struct ContItem
+    {
+        int mCount;
+        ESM::NAME32 mItem;
+    };
 
     struct Inventory
     {

--- a/apps/essimporter/importscpt.hpp
+++ b/apps/essimporter/importscpt.hpp
@@ -13,10 +13,16 @@ namespace ESM
 namespace ESSImport
 {
 
+    struct SCHD
+    {
+        ESM::NAME32              mName;
+        ESM::Script::SCHDstruct  mData;
+    };
+
     // A running global script
     struct SCPT
     {
-        ESM::Script::SCHD mSCHD;
+        SCHD mSCHD;
 
         // values of local variables
         SCRI mSCRI;


### PR DESCRIPTION
SCHD and ContItem now for better or worse internally use a format different from the one in the ESM files (std::strings instead of fixed size strings) and their size in bytes cannot be used to recover a subrecord of such type in getHT() as it includes the length of the string saved in std::string. So akortunov's changes broke the conversion of the mentioned things and thus most normal ESS files.

The workaround I used: add an alternative variant of SCHD and ContItem structs that use fixed size strings and load the subrecords into that. ESSImporter seems to work ok now, at least it's not as horribly broken.