### PR TITLE
Launcher: improve first run and missing game data dialogues (bug #4009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     Bug #3812: Wrong multiline tooltips width when word-wrapping is enabled
     Bug #3894: Hostile spell effects not detected/present on first frame of OnPCHitMe
     Bug #3977: Non-ASCII characters in object ID's are not supported
+    Bug #4009: Launcher does not show data files on the first run after installing
     Bug #4077: Enchanted items are not recharged if they are not in the player's inventory
     Bug #4202: Open .omwaddon files without needing toopen openmw-cs first
     Bug #4240: Ash storm origin coordinates and hand shielding animation behavior are incorrect


### PR DESCRIPTION
Fixes some oversights in these dialogues as reported by scrawl [here](https://gitlab.com/OpenMW/openmw/issues/4009).

1. Skip Button of missing game data dialogue is now really called Skip. Instead of making both buttons Cancel (and make both exit the launcher), I decided to make it consistent with the first run dialog.
2. Missing game data dialog isn't shown if the first Skip is pressed.
3. It is, however, shown if the game data ended up being missing due to a run of Wizard. Pressing Skip will allow you to get out of the "loop" if you decide to run the Wizard a few times. Previously you could manage not to actually setup the game in the Wizard and get into the empty launcher.
4. Widgets really were created twice due to a setup() hack in wizardFinished() event, which actually made missing game data dialogue horribly broken (it created another launcher which didn't react to settings changes, and that's actually the issue in the report, as noted by akortunov). Just removing the call won't work, as it makes some other necessary changes and it is necessary if pages are never created before it's called in wizard finished event. I've added a workaround into createPages() which seems to work: the pages are no longer recreated unnecessarily and the launcher gets properly reloaded.

Also I cleaned up how first run dialog and game data dialog states were managed a little.