### PR TITLE
Cap reputation values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@
     Bug #5218: Crash when disabling ToggleBorders
     Bug #5220: GetLOS crashes when actor isn't loaded
     Bug #5222: Empty cell name subrecords are not saved
+    Bug #5226: Reputation should be capped
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -370,7 +370,8 @@ int MWMechanics::NpcStats::getReputation() const
 
 void MWMechanics::NpcStats::setReputation(int reputation)
 {
-    mReputation = reputation;
+    // Reputation is capped in original engine
+    mReputation = std::min(255, std::max(0, reputation));
 }
 
 int MWMechanics::NpcStats::getCrimeId() const


### PR DESCRIPTION
Fixes [bug #5226](https://gitlab.com/OpenMW/openmw/issues/5226).

Note: I did not change a savegame format, it can be done in the [task #5191](https://gitlab.com/OpenMW/openmw/issues/5194) after 0.46 release, if needed.