### PR TITLE
Disallow resting if the fall height hasn't been reset (bug #4802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
     Bug #4787: Sneaking makes 1st person walking/bobbing animation super-slow
     Bug #4797: Player sneaking and running stances are not accounted for when in air
     Bug #4800: Standing collisions are not updated immediately when an object is teleported without a cell change
+    Bug #4802: You can rest before taking falling damage from landing from a jump
     Bug #4803: Stray special characters before begin statement break script compilation
     Bug #4804: Particle system with the "Has Sizes = false" causes an exception
     Bug #4805: NPC movement speed calculations do not take race Weight into account

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -426,6 +426,11 @@ namespace MWMechanics
         mFallHeight += height;
     }
 
+    float CreatureStats::getFallHeight() const
+    {
+        return mFallHeight;
+    }
+
     float CreatureStats::land(bool isPlayer)
     {
         if (isPlayer)

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -115,6 +115,7 @@ namespace MWMechanics
         bool needToRecalcDynamicStats();
         void setNeedRecalcDynamicStats(bool val);
 
+        float getFallHeight() const;
         void addToFallHeight(float height);
 
         /// Reset the fall height

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2513,7 +2513,9 @@ namespace MWWorld
         if (isUnderwater(currentCell, playerPos) || isWalkingOnWater(player))
             return Rest_PlayerIsUnderwater;
 
-        if ((actor->getCollisionMode() && !mPhysics->isOnSolidGround(player)) || isFlying(player))
+        float fallHeight = player.getClass().getCreatureStats(player).getFallHeight();
+        float epsilon = 1e-4;
+        if ((actor->getCollisionMode() && (!mPhysics->isOnSolidGround(player) || fallHeight >= epsilon)) || isFlying(player))
             return Rest_PlayerIsInAir;
 
         if((currentCell->getCell()->mData.mFlags&ESM::Cell::NoSleep) || player.getClass().getNpcStats(player).isWerewolf())


### PR DESCRIPTION
[Bug report.](https://gitlab.com/OpenMW/openmw/issues/4802)

Compare the falling height with an epsilon of 0.0001 to make sure falling height is reset and falling damage is applied before the player can open the waiting dialog. I haven't been able to reproduce the issue with this, but it's pretty difficult to do anyways.