### PR TITLE
Change rescaling to be more inline with vanilla (fixes #5214)

### DIFF
--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -204,12 +204,11 @@ namespace
     struct InsertVisitor
     {
         MWWorld::CellStore& mCell;
-        bool mRescale;
         Loading::Listener& mLoadingListener;
 
         std::vector<MWWorld::Ptr> mToInsert;
 
-        InsertVisitor (MWWorld::CellStore& cell, bool rescale, Loading::Listener& loadingListener);
+        InsertVisitor (MWWorld::CellStore& cell, Loading::Listener& loadingListener);
 
         bool operator() (const MWWorld::Ptr& ptr);
 
@@ -217,8 +216,8 @@ namespace
         void insert(AddObject&& addObject);
     };
 
-    InsertVisitor::InsertVisitor (MWWorld::CellStore& cell, bool rescale, Loading::Listener& loadingListener)
-    : mCell (cell), mRescale (rescale), mLoadingListener (loadingListener)
+    InsertVisitor::InsertVisitor (MWWorld::CellStore& cell, Loading::Listener& loadingListener)
+    : mCell (cell), mLoadingListener (loadingListener)
     {}
 
     bool InsertVisitor::operator() (const MWWorld::Ptr& ptr)
@@ -234,14 +233,6 @@ namespace
     {
         for (MWWorld::Ptr& ptr : mToInsert)
         {
-            if (mRescale)
-            {
-                if (ptr.getCellRef().getScale()<0.5)
-                    ptr.getCellRef().setScale(0.5);
-                else if (ptr.getCellRef().getScale()>2)
-                    ptr.getCellRef().setScale(2);
-            }
-
             if (!ptr.getRefData().isDeleted() && ptr.getRefData().isEnabled())
             {
                 try
@@ -427,8 +418,7 @@ namespace MWWorld
                 cell->respawn();
 
             // ... then references. This is important for adjustPosition to work correctly.
-            /// \todo rescale depending on the state of a new GMST
-            insertCell (*cell, true, loadingListener);
+            insertCell (*cell, loadingListener);
 
             mRendering.addCell(cell);
             MWBase::Environment::get().getWindowManager()->addCell(cell);
@@ -769,9 +759,9 @@ namespace MWWorld
         mCellChanged = false;
     }
 
-    void Scene::insertCell (CellStore &cell, bool rescale, Loading::Listener* loadingListener)
+    void Scene::insertCell (CellStore &cell, Loading::Listener* loadingListener)
     {
-        InsertVisitor insertVisitor (cell, rescale, *loadingListener);
+        InsertVisitor insertVisitor (cell, *loadingListener);
         cell.forEach (insertVisitor);
         insertVisitor.insert([&] (const MWWorld::Ptr& ptr) { addObject(ptr, *mPhysics, mRendering); });
         insertVisitor.insert([&] (const MWWorld::Ptr& ptr) { addObject(ptr, *mPhysics, mNavigator); });

--- a/apps/openmw/mwworld/scene.hpp
+++ b/apps/openmw/mwworld/scene.hpp
@@ -85,7 +85,7 @@ namespace MWWorld
 
             osg::Vec3f mLastPlayerPos;
 
-            void insertCell (CellStore &cell, bool rescale, Loading::Listener* loadingListener);
+            void insertCell (CellStore &cell, Loading::Listener* loadingListener);
 
             // Load and unload cells as necessary to create a cell grid with "X" and "Y" in the center
             void changeCellGrid (int playerCellX, int playerCellY, bool changeEvent = true);

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -145,7 +145,12 @@ void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory, bool
     }
 
     if (mScale != 1.0) {
-        esm.writeHNT("XSCL", mScale);
+        float scale = mScale;
+        if (scale < 0.5)
+            scale = 0.5;
+        else if (scale > 2)
+            scale = 2;
+        esm.writeHNT("XSCL", scale);
     }
 
     esm.writeHNOCString("ANAM", mOwner);

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -67,6 +67,10 @@ void ESM::CellRef::loadData(ESMReader &esm, bool &isDeleted)
                 break;
             case ESM::FourCC<'X','S','C','L'>::value:
                 esm.getHT(mScale);
+                if (mScale < 0.5)
+                    mScale = 0.5;
+                else if (mScale > 2)
+                    mScale = 2;
                 break;
             case ESM::FourCC<'A','N','A','M'>::value:
                 mOwner = esm.getHString();


### PR DESCRIPTION
Vanilla save files can contain XSCL records with values outside the [0.5, 2] range.

Interestingly SetScale 10 on Fargoth saved a value of 0.8, while SetScale 8 saved a value of 7. (At least, I think I used 8, might have actually been 7. Doesn't really matter either way.)