### PR TITLE
Hostile followers travel with player bugfix

### DIFF
--- a/apps/openmw/mwworld/actionteleport.cpp
+++ b/apps/openmw/mwworld/actionteleport.cpp
@@ -78,9 +78,7 @@ namespace MWWorld
             if (follower.getClass().getCreatureStats(follower).getAiSequence().isInCombat(world->getPlayerPtr()))
             {
                 if(inCombatSet)
-                {
                     inCombatSet->insert(follower);
-                }
                 continue;
             } 
             if ((follower.getRefData().getPosition().asVec3() - actor.getRefData().getPosition().asVec3()).length2() <= 800*800)

--- a/apps/openmw/mwworld/actionteleport.cpp
+++ b/apps/openmw/mwworld/actionteleport.cpp
@@ -24,14 +24,13 @@ namespace MWWorld
         {
             // Find any NPCs that are following the actor and teleport them with him
             std::set<MWWorld::Ptr> followers;
-            std::set<MWWorld::Ptr> *inCombat = new std::set<MWWorld::Ptr>;
-            getFollowersToTeleport(actor, followers, inCombat);
+            std::set<MWWorld::Ptr> inCombat;
+            getFollowersToTeleport(actor, followers, &inCombat);
 
             for (std::set<MWWorld::Ptr>::iterator it = followers.begin(); it != followers.end(); ++it)
                 teleport(*it);
-            for (std::set<MWWorld::Ptr>::iterator it = inCombat->begin(); it != inCombat->end(); ++it)
+            for (std::set<MWWorld::Ptr>::iterator it = inCombat.begin(); it != inCombat.end(); ++it)
                 it->getClass().getCreatureStats(*it).getAiSequence().stopCombat();
-            delete inCombat;
         }
 
         teleport(actor);

--- a/apps/openmw/mwworld/actionteleport.hpp
+++ b/apps/openmw/mwworld/actionteleport.hpp
@@ -28,8 +28,8 @@ namespace MWWorld
             /// @param teleportFollowers Whether to teleport any following actors of the target actor as well.
             ActionTeleport (const std::string& cellName, const ESM::Position& position, bool teleportFollowers);
 
-            /// Outputs every actor follower who is in teleport range and wasn't ordered to not enter interiors
-            static void getFollowersToTeleport(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out);
+            /// Outputs every actor follower who is in teleport range, wasn't ordered to not enter interiors and is not currently in combat with player.
+            static void getFollowersToTeleport(const MWWorld::Ptr& actor, std::set<MWWorld::Ptr>& out, std::set<MWWorld::Ptr>* inCombatSet = nullptr);
     };
 }
 


### PR DESCRIPTION
[Bug #5101](https://gitlab.com/OpenMW/openmw/issues/5101)
As it is my first time contributing I wanted to make my change as much non-invasive as possible and that's the cleanest solution I could think of. 
1) getFollowersToTeleport() function **must** insert only viable followers into passed set as it is used not only by executeImp() function but also other functions like the one that counts price for travel. 
2) Since we want to stopCombat() only after the teleportation was made (and not, for example, after prices were counted) executeImp() needs to know the list of followers who were in combat with the player in order to stopCombat().

To do that, I added a null by default pointer to a set of followers that are currently in combat with the player as an argument in getFollowersToTeleport(). Obviously, now thanks to appropriate condition nothing will be inserted into this set if the set was not specified in the function call.
I tested it in-game and everything works as expected. It still is not Morrowind behavior though. The player will not have to pay for summoned creature nor will he travel with the summoned creature. But when he returns back the creature will disappear, which is intended OpenMW behavior that I shouldn't change.