### PR TITLE
Make dtMeshTile POD

### DIFF
--- a/extern/recastnavigation/Detour/Include/DetourNavMesh.h
+++ b/extern/recastnavigation/Detour/Include/DetourNavMesh.h
@@ -306,9 +306,6 @@ struct dtMeshTile
 	int dataSize;							///< Size of the tile data.
 	int flags;								///< Tile flags. (See: #dtTileFlags)
 	dtMeshTile* next;						///< The next free tile, or the next tile in the spatial grid.
-private:
-	dtMeshTile(const dtMeshTile&);
-	dtMeshTile& operator=(const dtMeshTile&);
 };
 
 /// Get flags for edge in detail triangle.


### PR DESCRIPTION
Fixes this warning:

```
/home/travis/build/OpenMW/openmw/extern/recastnavigation/Detour/Source/DetourNavMesh.cpp: In member function ‘dtStatus dtNavMesh::init(const dtNavMeshParams*)’:
/home/travis/build/OpenMW/openmw/extern/recastnavigation/Detour/Source/DetourNavMesh.cpp:243:50: warning: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct dtMeshTile’ with no trivial copy-assignment [-Wclass-memaccess]
  memset(m_tiles, 0, sizeof(dtMeshTile)*m_maxTiles);
                                                  ^
In file included from /home/travis/build/OpenMW/openmw/extern/recastnavigation/Detour/Source/DetourNavMesh.cpp:22:
/home/travis/build/OpenMW/openmw/extern/recastnavigation/Detour/Include/DetourNavMesh.h:276:8: note: ‘struct dtMeshTile’ declared here
 struct dtMeshTile
        ^~~~~~~~~~
```

Private constructors without implementation (a pre-C++11 hack to mark constructors as "deleted") make dtMeshTile struct non-POD, so `memset` can not be used to initialize it.

The simplest solution is to remove such constructors, so dtMeshTile becomes POD, and compilers will not try to optimize data alignment.

R&D developers are not going to fix this issue in their upstream code.