### PR TITLE
Do not store gold-specific value for everything

### DIFF
--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -168,9 +168,8 @@ void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory, bool
     if (mChargeInt != -1)
         esm.writeHNT("INTV", mChargeInt);
 
-    if (mGoldValue != 1) {
+    if (mGoldValue > 1)
         esm.writeHNT("NAM9", mGoldValue);
-    }
 
     if (!inInventory && mTeleport)
     {
@@ -208,7 +207,7 @@ void ESM::CellRef::blank()
     mChargeInt = -1;
     mChargeIntRemainder = 0.0f;
     mEnchantmentCharge = -1;
-    mGoldValue = 0;
+    mGoldValue = 1;
     mDestCell.clear();
     mLockLevel = 0;
     mKey.clear();


### PR DESCRIPTION
The mGoldValue field is used only for gold stacks, for other objects it is always 0. So there is no point to store zero values for every object. It allows to decrease save size up to 5% and speedup saving/loading process a bit.
Does not require a savegame format change.

Note: for some reason we did not store mGoldValue = 1, while we init it by 0 by default, so the value became 0 after save/load. Not sure if it is right, more likely it was an oversight or typo.