### PR TITLE
Add safety checks for door state

### DIFF
--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -34,7 +34,7 @@ namespace MWClass
     class DoorCustomData : public MWWorld::CustomData
     {
     public:
-        MWWorld::DoorState mDoorState;
+        MWWorld::DoorState mDoorState = MWWorld::DoorState::Idle;
 
         virtual MWWorld::CustomData *clone() const;
 
@@ -344,8 +344,6 @@ namespace MWClass
         if (!ptr.getRefData().getCustomData())
         {
             std::unique_ptr<DoorCustomData> data(new DoorCustomData);
-
-            data->mDoorState = MWWorld::DoorState::Idle;
             ptr.getRefData().setCustomData(data.release());
         }
     }

--- a/components/esm/doorstate.cpp
+++ b/components/esm/doorstate.cpp
@@ -3,6 +3,8 @@
 #include "esmreader.hpp"
 #include "esmwriter.hpp"
 
+#include <components/debug/debuglog.hpp>
+
 namespace ESM
 {
 
@@ -12,11 +14,19 @@ namespace ESM
 
         mDoorState = 0;
         esm.getHNOT (mDoorState, "ANIM");
+        if (mDoorState < 0 || mDoorState > 2)
+            Log(Debug::Warning) << "Dropping invalid door state (" << mDoorState << ") for door \"" << mRef.mRefID << "\"";
     }
 
     void DoorState::save(ESMWriter &esm, bool inInventory) const
     {
         ObjectState::save(esm, inInventory);
+
+        if (mDoorState < 0 || mDoorState > 2)
+        {
+            Log(Debug::Warning) << "Dropping invalid door state (" << mDoorState << ") for door \"" << mRef.mRefID << "\"";
+            return;
+        }
 
         if (mDoorState != 0)
             esm.writeHNT ("ANIM", mDoorState);

--- a/components/esm/doorstate.hpp
+++ b/components/esm/doorstate.hpp
@@ -9,7 +9,7 @@ namespace ESM
 
     struct DoorState : public ObjectState
     {
-        int mDoorState;
+        int mDoorState = 0;
 
         virtual void load (ESMReader &esm);
         virtual void save (ESMWriter &esm, bool inInventory = false) const;


### PR DESCRIPTION
I noticed that sometimes DoorState for teleporting doors has garbage values (especially for chargen doors) in my saves. From what I can tell, we do not initialize mDoorState in the `ESM::DoorState`, if a door has no custom data, so we write a random unused value in save.

So I init `mDoorState` variables by zero just for sure, also I reset value and print a warning in case when door state has an invalid value.

It should be enough to clean up old saves (and reduce their size a bit), but if we will get these warnings on new saves, we have an another bug to track down and fix.