### PR TITLE
Initialize variables to avoid GCC warnings

### DIFF
--- a/apps/openmw/mwrender/util.cpp
+++ b/apps/openmw/mwrender/util.cpp
@@ -23,7 +23,7 @@ class TextureOverrideVisitor : public osg::NodeVisitor
 
         virtual void apply(osg::Node& node)
         {
-            int index;
+            int index = 0;
             osg::ref_ptr<osg::Node> nodePtr(&node);
             if (node.getUserValue("overrideFx", index))
             {

--- a/components/detournavigator/recastmeshmanager.hpp
+++ b/components/detournavigator/recastmeshmanager.hpp
@@ -30,7 +30,7 @@ namespace DetourNavigator
     public:
         struct Water
         {
-            int mCellSize;
+            int mCellSize = 0;
             btTransform mTransform;
         };
 


### PR DESCRIPTION
These warnings are not real bugs, but it still would be nice to initialize variables just for sure.