### PR TITLE
Allow to enchant multiple projectiles at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls
     Feature #3442: Default values for fallbacks from ini file
+    Feature #3517: Multiple projectiles enchantment
     Feature #3610: Option to invert X axis
     Feature #3871: Editor: Terrain Selection
     Feature #3893: Implicit target for "set" function in console

--- a/apps/openmw/mwmechanics/enchanting.hpp
+++ b/apps/openmw/mwmechanics/enchanting.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <components/esm/effectlist.hpp>
+#include <components/esm/loadench.hpp>
 
 #include "../mwworld/ptr.hpp"
 
@@ -25,6 +26,8 @@ namespace MWMechanics
             std::string mObjectType;
             int mWeaponType;
 
+            const ESM::Enchantment* getRecord(const ESM::Enchantment& newEnchantment) const;
+
         public:
             Enchanting();
             void setEnchanter(const MWWorld::Ptr& enchanter);
@@ -45,6 +48,8 @@ namespace MWMechanics
             int getMaxEnchantValue() const;
             int getGemCharge() const;
             int getEnchantChance() const;
+            int getEnchantItemsCount() const;
+            float getTypeMultiplier() const;
             bool soulEmpty() const; //Return true if empty
             bool itemEmpty() const; //Return true if empty
             void payForEnchantment() const;

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -106,6 +106,11 @@ namespace MWWorld
             return iter;
         }
 
+        SharedIterator &operator+=(int advance) {
+            mIter += advance;
+            return *this;
+        }
+
         SharedIterator &operator--() {
             --mIter;
             return *this;

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -282,3 +282,19 @@ equivalent to the one introduced by the equivalent Morrowind Code Patch feature.
 This makes the movement speed behavior more fair between different races.
 
 This setting can be controlled in Advanced tab of the launcher.
+
+projectiles enchant multiplier
+------------------------------
+
+:Type:		floating point
+:Range:		0.0 to 1.0
+:Default:	0.0
+
+The value of this setting determines how many projectiles (thrown weapons, arrows and bolts) you can enchant at once according to the following formula:
+
+count = (soul gem charge * projectiles enchant multiplier) / enchantment strength
+
+A value of 0 means that you can only enchant one projectile.
+If you want to have Morrowind Code Patch-like count of projectiles being enchanted at once, set this value to 0.25 (i.e. 25% of the charge).
+
+This setting can only be configured by editing the settings configuration file.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -267,6 +267,11 @@ use magic item animations = false
 # Don't use race weight in NPC movement speed calculations
 normalise race speed = false
 
+# Adjusts the number of projectiles you can enchant at once:
+# count = (soul gem charge * projectiles enchant multiplier) / enchantment strength
+# A value of 0 means that you can only enchant one projectile.
+projectiles enchant multiplier = 0
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).


### PR DESCRIPTION
Implements [feature #3517](https://gitlab.com/OpenMW/openmw/issues/3517).

Summary of changes:
1. Allow to enchant multiple projectiles at once (depending on soulgem charge), as in MCP. Disabled by default.
2. Do not create a new dynamic enchantment record, if there is an existing dynamic enchantment with same stats. We already use the same approach for potions.
3. Do not allow to create ConstantEffect and WhenUsed enchantments for projectiles, as in Morrowind.

Note: maybe it is worth to store an original ID as optional field for manually enchanted items. In this case if an original item ID, enchanted item's name and enchantment stats are the same, we can use an existing dynamic item record instead of creating a new one every time.
It would allow us to stack manually enchanted scrolls and projectiles with same stats.
Unfortunately, it will require a savegame format change.