### PR TITLE
Allow targeting non-unique actors with StartScript. Fixes #2311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 
     Bug #1952: Incorrect particle lighting
+    Bug #2311: Targeted scripts are not properly supported on non-unique RefIDs
     Bug #3676: NiParticleColorModifier isn't applied properly
     Bug #5358: ForceGreeting always resets the dialogue window completely
     Bug #5363: Enchantment autocalc not always 0/1

--- a/apps/openmw/mwbase/scriptmanager.hpp
+++ b/apps/openmw/mwbase/scriptmanager.hpp
@@ -35,7 +35,7 @@ namespace MWBase
 
             virtual ~ScriptManager() {}
 
-            virtual void run (const std::string& name, Interpreter::Context& interpreterContext) = 0;
+            virtual bool run (const std::string& name, Interpreter::Context& interpreterContext) = 0;
             ///< Run the script with the given name (compile first, if not compiled yet)
 
             virtual bool compile (const std::string& name) = 0;

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -189,6 +189,8 @@ namespace MWBase
             virtual MWWorld::Ptr searchPtrViaActorId (int actorId) = 0;
             ///< Search is limited to the active cells.
 
+            virtual MWWorld::Ptr searchPtrViaRefNum (const std::string& id, const ESM::RefNum& refNum) = 0;
+
             virtual MWWorld::Ptr findContainer (const MWWorld::ConstPtr& ptr) = 0;
             ///< Return a pointer to a liveCellRef which contains \a ptr.
             /// \note Search is limited to the active cells.

--- a/apps/openmw/mwscript/interpretercontext.hpp
+++ b/apps/openmw/mwscript/interpretercontext.hpp
@@ -1,7 +1,12 @@
 #ifndef GAME_SCRIPT_INTERPRETERCONTEXT_H
 #define GAME_SCRIPT_INTERPRETERCONTEXT_H
 
+#include <memory>
+#include <stdexcept>
+
 #include <components/interpreter/context.hpp>
+
+#include "globalscripts.hpp"
 
 #include "../mwworld/ptr.hpp"
 
@@ -19,17 +24,17 @@ namespace MWScript
 {
     class Locals;
 
+    class MissingImplicitRefError : public std::runtime_error
+    {
+        public:
+            MissingImplicitRefError();
+    };
+
     class InterpreterContext : public Interpreter::Context
     {
             Locals *mLocals;
             mutable MWWorld::Ptr mReference;
-
-            std::string mTargetId;
-
-            /// If \a id is empty, a reference the script is run from is returned or in case
-            /// of a non-local script the reference derived from the target ID.
-            MWWorld::Ptr getReferenceImp (const std::string& id = "", bool activeOnly = false,
-                bool doThrow=true);
+            std::shared_ptr<GlobalScriptDesc> mGlobalScriptDesc;
 
             /// If \a id is empty, a reference the script is run from is returned or in case
             /// of a non-local script the reference derived from the target ID.
@@ -47,9 +52,9 @@ namespace MWScript
                 char type) const;
 
         public:
+            InterpreterContext (std::shared_ptr<GlobalScriptDesc> globalScriptDesc);
 
-            InterpreterContext (MWScript::Locals *locals, const MWWorld::Ptr& reference,
-                const std::string& targetId = "");
+            InterpreterContext (MWScript::Locals *locals, const MWWorld::Ptr& reference);
             ///< The ownership of \a locals is not transferred. 0-pointer allowed.
 
             virtual int getLocalShort (int index) const;
@@ -153,8 +158,6 @@ namespace MWScript
 
             void updatePtr(const MWWorld::Ptr& base, const MWWorld::Ptr& updated);
             ///< Update the Ptr stored in mReference, if there is one stored there. Should be called after the reference has been moved to a new cell.
-
-            virtual std::string getTargetId() const;
     };
 }
 

--- a/apps/openmw/mwscript/scriptmanagerimp.hpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.hpp
@@ -55,7 +55,7 @@ namespace MWScript
                 Compiler::Context& compilerContext, int warningsMode,
                 const std::vector<std::string>& scriptBlacklist);
 
-            virtual void run (const std::string& name, Interpreter::Context& interpreterContext);
+            virtual bool run (const std::string& name, Interpreter::Context& interpreterContext);
             ///< Run the script with the given name (compile first, if not compiled yet)
 
             virtual bool compile (const std::string& name);

--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -5,6 +5,7 @@
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/defs.hpp>
 #include <components/esm/cellstate.hpp>
+#include <components/esm/cellref.hpp>
 #include <components/loadinglistener/loadinglistener.hpp>
 #include <components/settings/settings.hpp>
 
@@ -268,6 +269,37 @@ MWWorld::Ptr MWWorld::Cells::getPtr (const std::string& name)
 
     // giving up
     return Ptr();
+}
+
+MWWorld::Ptr MWWorld::Cells::getPtr (const std::string& id, const ESM::RefNum& refNum)
+{
+    for (auto& pair : mInteriors)
+    {
+        Ptr ptr = getPtr(pair.second, id, refNum);
+        if (!ptr.isEmpty())
+            return ptr;
+    }
+    for (auto& pair : mExteriors)
+    {
+        Ptr ptr = getPtr(pair.second, id, refNum);
+        if (!ptr.isEmpty())
+            return ptr;
+    }
+    return Ptr();
+}
+
+MWWorld::Ptr MWWorld::Cells::getPtr(CellStore& cellStore, const std::string& id, const ESM::RefNum& refNum)
+{
+    if (cellStore.getState() == CellStore::State_Unloaded)
+        cellStore.preload();
+    if (cellStore.getState() == CellStore::State_Preloaded)
+    {
+        if (cellStore.hasId(id))
+            cellStore.load();
+        else
+            return Ptr();
+    }
+    return cellStore.searchViaRefNum(refNum);
 }
 
 void MWWorld::Cells::getExteriorPtrs(const std::string &name, std::vector<MWWorld::Ptr> &out)

--- a/apps/openmw/mwworld/cells.hpp
+++ b/apps/openmw/mwworld/cells.hpp
@@ -13,6 +13,7 @@ namespace ESM
     class ESMWriter;
     struct CellId;
     struct Cell;
+    struct RefNum;
 }
 
 namespace Loading
@@ -41,6 +42,8 @@ namespace MWWorld
 
             Ptr getPtrAndCache (const std::string& name, CellStore& cellStore);
 
+            Ptr getPtr(CellStore& cellStore, const std::string& id, const ESM::RefNum& refNum);
+
             void writeCell (ESM::ESMWriter& writer, CellStore& cell) const;
 
         public:
@@ -61,6 +64,8 @@ namespace MWWorld
 
             /// @note name must be lower case
             Ptr getPtr (const std::string& name);
+
+            Ptr getPtr(const std::string& id, const ESM::RefNum& refNum);
 
             void rest (double hours);
             void recharge (float duration);

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -6,6 +6,7 @@
 
 #include <components/esm/cellstate.hpp>
 #include <components/esm/cellid.hpp>
+#include <components/esm/cellref.hpp>
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/objectstate.hpp>
@@ -433,6 +434,32 @@ namespace MWWorld
         }
 
         return Ptr();
+    }
+
+    class RefNumSearchVisitor
+    {
+        const ESM::RefNum& mRefNum;
+    public:
+        RefNumSearchVisitor(const ESM::RefNum& refNum) : mRefNum(refNum) {}
+
+        Ptr mFound;
+
+        bool operator()(const Ptr& ptr)
+        {
+            if (ptr.getCellRef().getRefNum() == mRefNum)
+            {
+                mFound = ptr;
+                return false;
+            }
+            return true;
+        }
+    };
+
+    Ptr CellStore::searchViaRefNum (const ESM::RefNum& refNum)
+    {
+        RefNumSearchVisitor searchVisitor(refNum);
+        forEach(searchVisitor);
+        return searchVisitor.mFound;
     }
 
     float CellStore::getWaterLevel() const

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -41,6 +41,7 @@ namespace ESM
     struct CellState;
     struct FogState;
     struct CellId;
+    struct RefNum;
 }
 
 namespace MWWorld
@@ -241,6 +242,11 @@ namespace MWWorld
 
             Ptr searchViaActorId (int id);
             ///< Will return an empty Ptr if cell is not loaded.
+
+            Ptr searchViaRefNum (const ESM::RefNum& refNum);
+            ///< Will return an empty Ptr if cell is not loaded. Does not check references in
+            /// containers.
+            /// @note Triggers CellStore hasState flag.
 
             float getWaterLevel() const;
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -11,6 +11,7 @@
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>
 #include <components/esm/cellid.hpp>
+#include <components/esm/cellref.hpp>
 
 #include <components/misc/constants.hpp>
 #include <components/misc/resourcehelpers.hpp>
@@ -752,6 +753,11 @@ namespace MWWorld
         return mWorldScene->searchPtrViaActorId (actorId);
     }
 
+    Ptr World::searchPtrViaRefNum (const std::string& id, const ESM::RefNum& refNum)
+    {
+        return mCells.getPtr (id, refNum);
+    }
+
     struct FindContainerVisitor
     {
         ConstPtr mContainedPtr;
@@ -1290,6 +1296,7 @@ namespace MWWorld
                     mRendering->updatePtr(ptr, newPtr);
                     MWBase::Environment::get().getSoundManager()->updatePtr (ptr, newPtr);
                     mPhysics->updatePtr(ptr, newPtr);
+                    MWBase::Environment::get().getScriptManager()->getGlobalScripts().updatePtrs(ptr, newPtr);
 
                     MWBase::MechanicsManager *mechMgr = MWBase::Environment::get().getMechanicsManager();
                     mechMgr->updateCell(ptr, newPtr);

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -297,6 +297,8 @@ namespace MWWorld
             Ptr searchPtrViaActorId (int actorId) override;
             ///< Search is limited to the active cells.
 
+            Ptr searchPtrViaRefNum (const std::string& id, const ESM::RefNum& refNum) override;
+
             MWWorld::Ptr findContainer (const MWWorld::ConstPtr& ptr) override;
             ///< Return a pointer to a liveCellRef which contains \a ptr.
             /// \note Search is limited to the active cells.

--- a/components/esm/globalscript.cpp
+++ b/components/esm/globalscript.cpp
@@ -12,7 +12,11 @@ void ESM::GlobalScript::load (ESMReader &esm)
     mRunning = 0;
     esm.getHNOT (mRunning, "RUN_");
 
-    mTargetId = esm.getHNOString ("TARG");
+    mTargetRef.unset();
+    if (esm.peekNextSub("TARG"))
+        mTargetId = esm.getHNString ("TARG");
+    if (esm.peekNextSub("FRMR"))
+        mTargetRef.load(esm, true, "FRMR");
 }
 
 void ESM::GlobalScript::save (ESMWriter &esm) const
@@ -24,5 +28,10 @@ void ESM::GlobalScript::save (ESMWriter &esm) const
     if (mRunning)
         esm.writeHNT ("RUN_", mRunning);
 
-    esm.writeHNOString ("TARG", mTargetId);
+    if (!mTargetId.empty())
+    {
+        esm.writeHNOString ("TARG", mTargetId);
+        if (mTargetRef.hasContentFile())
+            mTargetRef.save (esm, true, "FRMR");
+    }
 }

--- a/components/esm/globalscript.hpp
+++ b/components/esm/globalscript.hpp
@@ -2,6 +2,7 @@
 #define OPENMW_ESM_GLOBALSCRIPT_H
 
 #include "locals.hpp"
+#include "cellref.hpp"
 
 namespace ESM
 {
@@ -16,6 +17,7 @@ namespace ESM
         Locals mLocals;
         int mRunning;
         std::string mTargetId; // for targeted scripts
+        RefNum mTargetRef;
 
         void load (ESMReader &esm);
         void save (ESMWriter &esm) const;

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -5,7 +5,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 5;
+int ESM::SavedGame::sCurrentFormat = 6;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {

--- a/components/interpreter/context.hpp
+++ b/components/interpreter/context.hpp
@@ -108,8 +108,6 @@ namespace Interpreter
 
             virtual void setMemberFloat (const std::string& id, const std::string& name, float value, bool global)
                 = 0;
-
-            virtual std::string getTargetId() const = 0;
     };
 }
 

--- a/components/interpreter/scriptopcodes.hpp
+++ b/components/interpreter/scriptopcodes.hpp
@@ -26,7 +26,7 @@ namespace Interpreter
             {
                 std::string name = runtime.getStringLiteral (runtime[0].mInteger);
                 runtime.pop();
-                runtime.getContext().startScript (name, runtime.getContext().getTargetId());
+                runtime.getContext().startScript (name);
             }
     };
 


### PR DESCRIPTION
Note that this makes new saves incompatible with older OpenMW versions.