### PR TITLE
Unify streams usage to support non-ASCII paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
     Bug #5223: Bow replacement during attack animation removes attached arrow
     Bug #5226: Reputation should be capped
     Bug #5229: Crash if mesh controller node has no data node
+    Bug #5239: OpenMW-CS does not support non-ASCII characters in path names
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/essimporter/importer.cpp
+++ b/apps/essimporter/importer.cpp
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
 #include <osgDB/ReadFile>
@@ -349,7 +350,7 @@ namespace ESSImport
 
         writer.setFormat (ESM::SavedGame::sCurrentFormat);
 
-        std::ofstream stream(mOutFile.c_str(), std::ios::binary);
+        boost::filesystem::ofstream stream(boost::filesystem::path(mOutFile), std::ios::out | std::ios::binary);
         // all unused
         writer.setVersion(0);
         writer.setType(0);

--- a/components/detournavigator/debug.cpp
+++ b/components/detournavigator/debug.cpp
@@ -4,14 +4,15 @@
 
 #include <DetourNavMesh.h>
 
-#include <fstream>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 namespace DetourNavigator
 {
     void writeToFile(const RecastMesh& recastMesh, const std::string& pathPrefix, const std::string& revision)
     {
         const auto path = pathPrefix + "recastmesh" + revision + ".obj";
-        std::ofstream file(path);
+        boost::filesystem::ofstream file(boost::filesystem::path(path), std::ios::out);
         if (!file.is_open())
             throw NavigatorException("Open file failed: " + path);
         file.exceptions(std::ios::failbit | std::ios::badbit);
@@ -64,7 +65,7 @@ namespace DetourNavigator
         };
 
         const auto path = pathPrefix + "all_tiles_navmesh" + revision + ".bin";
-        std::ofstream file(path, std::ios::binary);
+        boost::filesystem::ofstream file(boost::filesystem::path(path), std::ios::out | std::ios::binary);
         if (!file.is_open())
             throw NavigatorException("Open file failed: " + path);
         file.exceptions(std::ios::failbit | std::ios::badbit);


### PR DESCRIPTION
Fixes [bug #5239](https://gitlab.com/OpenMW/openmw/issues/5239).

Allows us to use the editor, importer and recast debugging with non-ASCII paths since boost streams support Unicode paths.

Tested on Windows with Russian characters in user's name.