### PR TITLE
Read parameters of NiPathController

### DIFF
--- a/components/nif/controller.cpp
+++ b/components/nif/controller.cpp
@@ -117,12 +117,11 @@ namespace Nif
     {
         Controller::read(nif);
 
-        /*
-           int = 1
-           2xfloat
-           short = 0 or 1
-        */
-        nif->skip(14);
+        bankDirection = nif->getUInt();
+        maxBankAngle = nif->getFloat();
+        smoothing = nif->getFloat();
+        followAxis = nif->getUShort() > 0;
+
         posData.read(nif);
         floatData.read(nif);
     }

--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -92,6 +92,11 @@ public:
 class NiPathController : public Controller
 {
 public:
+    int bankDirection;
+    float maxBankAngle;
+    float smoothing;
+    bool followAxis;
+
     NiPosDataPtr posData;
     NiFloatDataPtr floatData;
 


### PR DESCRIPTION
NiPathController is just a simplified version of NiPathInterpolator from GameBryo.
So it uses pretty same parameters (but does not have its own flags).