### PR TITLE
Improve BetaComment handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@
     Feature #3980: In-game option to disable controller
     Feature #3999: Shift + Double Click should maximize/restore menu size
     Feature #4001: Toggle sneak controller shortcut
+    Feature #4129: Beta Comment to File
     Feature #4209: Editor: Faction rank sub-table
     Feature #4255: Handle broken RepairedOnMe script function
     Feature #4316: Implement RaiseRank/LowerRank functions properly

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -400,17 +400,7 @@ namespace MWGui
         struct tm* timeinfo;
         timeinfo = localtime(&time);
 
-        // Use system/environment locale settings for datetime formatting
-        char* oldLctime = setlocale(LC_TIME, nullptr);
-        setlocale(LC_TIME, "");
-
-        const int size=1024;
-        char buffer[size];
-        if (std::strftime(buffer, size, "%x %X", timeinfo) > 0)
-            text << buffer << "\n";
-
-        // reset
-        setlocale(LC_TIME, oldLctime);
+        text << std::put_time(timeinfo, "%d.%m.%Y %T") << "\n";
 
         text << "#{sLevel} " << mCurrentSlot->mProfile.mPlayerLevel << "\n";
         text << "#{sCell=" << mCurrentSlot->mProfile.mPlayerCell << "}\n";

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -400,7 +400,7 @@ namespace MWGui
         struct tm* timeinfo;
         timeinfo = localtime(&time);
 
-        text << std::put_time(timeinfo, "%d.%m.%Y %T") << "\n";
+        text << std::put_time(timeinfo, "%Y.%m.%d %T") << "\n";
 
         text << "#{sLevel} " << mCurrentSlot->mProfile.mPlayerLevel << "\n";
         text << "#{sCell=" << mCurrentSlot->mProfile.mPlayerCell << "}\n";

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1228,7 +1228,7 @@ namespace MWScript
                 msg << "Report time: ";
 
                 std::time_t currentTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-                msg << std::put_time(std::gmtime(&currentTime), "%d.%m.%Y %T UTC") << std::endl;
+                msg << std::put_time(std::gmtime(&currentTime), "%Y.%m.%d %T UTC") << std::endl;
 
                 msg << "Content file: ";
 

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1,9 +1,12 @@
 #include "miscextensions.hpp"
 
 #include <cstdlib>
+#include <iomanip>
 
 #include <components/compiler/opcodes.hpp>
 #include <components/compiler/locals.hpp>
+
+#include <components/debug/debuglog.hpp>
 
 #include <components/interpreter/interpreter.hpp>
 #include <components/interpreter/runtime.hpp>
@@ -1222,6 +1225,11 @@ namespace MWScript
 
                 std::stringstream msg;
 
+                msg << "Report time: ";
+
+                std::time_t currentTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+                msg << std::put_time(std::gmtime(&currentTime), "%d.%m.%Y %T UTC") << std::endl;
+
                 msg << "Content file: ";
 
                 if (!ptr.getCellRef().hasContentFile())
@@ -1262,6 +1270,8 @@ namespace MWScript
                         msg << "Notes: " << notes << std::endl;
                     --arg0;
                 }
+
+                Log(Debug::Warning) << "\n" << msg.str();
 
                 runtime.getContext().report(msg.str());
             }


### PR DESCRIPTION
Implements [feature #4129](https://gitlab.com/OpenMW/openmw/issues/4129).

Summary of changes:
1. Print BetaComment output to cout and openmw.log
2. Print report time in the same format as for savegames (but in UTC instead of local time):
```
Report time: 2020.01.06 04:43:31 UTC
```
Morrowind prints report time too.
3. Use a C++11-syile approach in the loading menu as well to unify used API and simplify the code.

Notes:
1. An another approach would be to use a separate file for BetaComments, but not definely a better one.
2. If we ever add timestamps to log, we will need to print report time only to debug console.