### PR TITLE
Avoid heap corruption while reading SCVR (bug #4680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
     Bug #4600: Crash when no sound output is available or --no-sound is used.
     Bug #4639: Black screen after completing first mages guild mission + training
     Bug #4650: Focus is lost after pressing ESC in confirmation dialog inside savegame dialog
+    Bug #4680: Heap corruption on faulty esp
     Bug #4701: PrisonMarker record is not hardcoded like other markers
     Bug #4703: Editor: it's possible to preview levelled list records
     Bug #4705: Editor: unable to open exterior cell views from Instances table


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4680).

Avoid unsafe operations like getting the pointer to the first element and looking for carriage return characters potentially beyond the end of the string table vector memory. std::replace now replaces all carriage return characters with null characters while an additional null character terminates the last string of the table if it's not null-terminated. It's probably stupid but it should work around the issue (and then again, the engine itself doesn't care about SCVR contents).

Variable names list no longer includes empty strings if the stated number of variables is larger than the actual number of strings in the string table.