### PR TITLE
Fix reported spellcasting discrepancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@
     Bug #5226: Reputation should be capped
     Bug #5229: Crash if mesh controller node has no data node
     Bug #5239: OpenMW-CS does not support non-ASCII characters in path names
+    Bug #5241: On-self absorb spells cannot be detected
+    Bug #5242: ExplodeSpell behavior differs from Cast behavior
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -554,16 +554,11 @@ namespace MWMechanics
 
                     // Avoid applying absorb effects if the caster is the target
                     // We still need the spell to be added
-                    if (caster == target)
+                    if (caster == target
+                        && effectIt->mEffectID >= ESM::MagicEffect::AbsorbAttribute
+                        && effectIt->mEffectID <= ESM::MagicEffect::AbsorbSkill)
                     {
-                        for (int i=0; i<5; ++i)
-                        {
-                            if (effectIt->mEffectID == ESM::MagicEffect::AbsorbAttribute+i)
-                            {
-                                effect.mMagnitude = 0;
-                                break;
-                            }
-                        }
+                        effect.mMagnitude = 0;
                     }
 
                     bool hasDuration = !(magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration);
@@ -614,22 +609,19 @@ namespace MWMechanics
                         // magnitude, since we're transferring stats from the target to the caster
                         if (!caster.isEmpty() && caster != target && caster.getClass().isActor())
                         {
-                            for (int i=0; i<5; ++i)
+                            if (effectIt->mEffectID >= ESM::MagicEffect::AbsorbAttribute &&
+                                effectIt->mEffectID <= ESM::MagicEffect::AbsorbSkill)
                             {
-                                if (effectIt->mEffectID == ESM::MagicEffect::AbsorbAttribute+i)
-                                {
-                                    std::vector<ActiveSpells::ActiveEffect> absorbEffects;
-                                    ActiveSpells::ActiveEffect effect_ = effect;
-                                    effect_.mMagnitude *= -1;
-                                    absorbEffects.push_back(effect_);
-                                    if (reflected && Settings::Manager::getBool("classic reflected absorb spells behavior", "Game"))
-                                        target.getClass().getCreatureStats(target).getActiveSpells().addSpell("", true,
-                                            absorbEffects, mSourceName, caster.getClass().getCreatureStats(caster).getActorId());
-                                    else
-                                        caster.getClass().getCreatureStats(caster).getActiveSpells().addSpell("", true,
-                                            absorbEffects, mSourceName, target.getClass().getCreatureStats(target).getActorId());
-                                    break;
-                                }
+                                std::vector<ActiveSpells::ActiveEffect> absorbEffects;
+                                ActiveSpells::ActiveEffect effect_ = effect;
+                                effect_.mMagnitude *= -1;
+                                absorbEffects.push_back(effect_);
+                                if (reflected && Settings::Manager::getBool("classic reflected absorb spells behavior", "Game"))
+                                    target.getClass().getCreatureStats(target).getActiveSpells().addSpell("", true,
+                                        absorbEffects, mSourceName, caster.getClass().getCreatureStats(caster).getActorId());
+                                else
+                                    caster.getClass().getCreatureStats(caster).getActiveSpells().addSpell("", true,
+                                        absorbEffects, mSourceName, target.getClass().getCreatureStats(target).getActorId());
                             }
                         }
                     }

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -447,9 +447,9 @@ namespace MWMechanics
             if (!checkEffectTarget(effectIt->mEffectID, target, caster, castByPlayer))
                 continue;
 
-            // caster needs to be an actor that's not the target for linked effects (e.g. Absorb)
+            // caster needs to be an actor for linked effects (e.g. Absorb)
             if (magicEffect->mData.mFlags & ESM::MagicEffect::CasterLinked
-                    && (caster.isEmpty() || !caster.getClass().isActor() || caster == target))
+                    && (caster.isEmpty() || !caster.getClass().isActor()))
                 continue;
 
             // If player is healing someone, show the target's HP bar
@@ -552,6 +552,20 @@ namespace MWMechanics
                     effect.mArg = MWMechanics::EffectKey(*effectIt).mArg;
                     effect.mMagnitude = magnitude;
 
+                    // Avoid applying absorb effects if the caster is the target
+                    // We still need the spell to be added
+                    if (caster == target)
+                    {
+                        for (int i=0; i<5; ++i)
+                        {
+                            if (effectIt->mEffectID == ESM::MagicEffect::AbsorbAttribute+i)
+                            {
+                                effect.mMagnitude = 0;
+                                break;
+                            }
+                        }
+                    }
+
                     bool hasDuration = !(magicEffect->mData.mFlags & ESM::MagicEffect::NoDuration);
                     if (hasDuration && effectIt->mDuration == 0)
                     {
@@ -614,6 +628,7 @@ namespace MWMechanics
                                     else
                                         caster.getClass().getCreatureStats(caster).getActiveSpells().addSpell("", true,
                                             absorbEffects, mSourceName, target.getClass().getCreatureStats(target).getActorId());
+                                    break;
                                 }
                             }
                         }

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -1111,10 +1111,7 @@ namespace MWScript
 
                 if (ptr == MWMechanics::getPlayer())
                 {
-                    MWWorld::InventoryStore& store = ptr.getClass().getInventoryStore(ptr);
-                    store.setSelectedEnchantItem(store.end());
-                    MWBase::Environment::get().getWindowManager()->setSelectedSpell(spellId, int(MWMechanics::getSpellSuccessChance(spellId, ptr)));
-                    MWBase::Environment::get().getWindowManager()->updateSpellWindow();
+                    MWBase::Environment::get().getWorld()->getPlayer().setSelectedSpell(spellId);
                     return;
                 }
 
@@ -1122,7 +1119,6 @@ namespace MWScript
                 {
                     MWMechanics::AiCast castPackage(targetId, spellId, true);
                     ptr.getClass().getCreatureStats (ptr).getAiSequence().stack(castPackage, ptr);
-
                     return;
                 }
 
@@ -1158,10 +1154,7 @@ namespace MWScript
 
                 if (ptr == MWMechanics::getPlayer())
                 {
-                    MWWorld::InventoryStore& store = ptr.getClass().getInventoryStore(ptr);
-                    store.setSelectedEnchantItem(store.end());
-                    MWBase::Environment::get().getWindowManager()->setSelectedSpell(spellId, int(MWMechanics::getSpellSuccessChance(spellId, ptr)));
-                    MWBase::Environment::get().getWindowManager()->updateSpellWindow();
+                    MWBase::Environment::get().getWorld()->getPlayer().setSelectedSpell(spellId);
                     return;
                 }
 

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -11,6 +11,7 @@
 #include <components/esm/loadbsgn.hpp>
 
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/inventorystore.hpp"
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -19,6 +20,7 @@
 
 #include "../mwmechanics/movement.hpp"
 #include "../mwmechanics/npcstats.hpp"
+#include "../mwmechanics/spellcasting.hpp"
 
 #include "class.hpp"
 #include "ptr.hpp"
@@ -491,5 +493,15 @@ namespace MWWorld
     void Player::erasePreviousItem(const std::string& boundItemId)
     {
         mPreviousItems.erase(boundItemId);
+    }
+
+    void Player::setSelectedSpell(const std::string& spellId)
+    {
+        Ptr player = getPlayer();
+        InventoryStore& store = player.getClass().getInventoryStore(player);
+        store.setSelectedEnchantItem(store.end());
+        int castChance = int(MWMechanics::getSpellSuccessChance(spellId, player));
+        MWBase::Environment::get().getWindowManager()->setSelectedSpell(spellId, castChance);
+        MWBase::Environment::get().getWindowManager()->updateSpellWindow();
     }
 }

--- a/apps/openmw/mwworld/player.hpp
+++ b/apps/openmw/mwworld/player.hpp
@@ -135,6 +135,8 @@ namespace MWWorld
         void setPreviousItem(const std::string& boundItemId, const std::string& previousItemId);
         std::string getPreviousItem(const std::string& boundItemId);
         void erasePreviousItem(const std::string& boundItemId);
+
+        void setSelectedSpell(const std::string& spellId);
     };
 }
 #endif


### PR DESCRIPTION
[5241](https://gitlab.com/OpenMW/openmw/issues/5241), [5242](https://gitlab.com/OpenMW/openmw/issues/5242).

Absorb spells are still applied to the target if the caster is the target, but their magnitude is zero. Hopefully this will allow a certain scripted sequence from TR to work.

ExplodeSpell now mostly works like Cast with the difference that the spell's target is the casting object/actor.

Cast can now work with permanent abilities like in vanilla again. For whatever reason you're able to cast them even though akortunov assumed otherwise.