### PR TITLE
Don't combine sneak idle with scripted/wander idles (bug #4284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
     Bug #4262: Rain settings are hardcoded
     Bug #4270: Closing doors while they are obstructed desyncs closing sfx
     Bug #4276: Resizing character window differs from vanilla
+    Bug #4284: ForceSneak behaviour is inconsistent if the target has AiWander package
     Bug #4329: Removed birthsign abilities are restored after reloading the save
     Bug #4341: Error message about missing GDB is too vague
     Bug #4383: Bow model obscures crosshair when arrow is drawn

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2249,7 +2249,7 @@ void CharacterController::update(float duration, bool animationOnly)
         if(movestate != CharState_None && !isTurning())
             clearAnimQueue();
 
-        if(mAnimQueue.empty() || inwater || sneak)
+        if(mAnimQueue.empty() || inwater || (sneak && mIdleState != CharState_SpecialIdle))
         {
             if (inwater)
                 idlestate = CharState_IdleSwim;


### PR DESCRIPTION
[Bug report.](https://gitlab.com/OpenMW/openmw/issues/4284)

Not switching the idle state seems to fix the issue in the general case. Not sure if it doesn't have side effects. 