### PR TITLE
[Regression] Make creatures autoequip shields properly (bug #5243)

### DIFF
--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -504,14 +504,10 @@ void MWWorld::InventoryStore::autoEquipShield(const MWWorld::Ptr& actor, TSlots&
             continue;
         if (iter->getClass().canBeEquipped(*iter, actor).first != 1)
             continue;
-        if (iter->getClass().getItemHealth(*iter) <= 0)
-            continue;
         std::pair<std::vector<int>, bool> shieldSlots =
             iter->getClass().getEquipmentSlots(*iter);
-        if (shieldSlots.first.empty())
-            continue;
         int slot = shieldSlots.first[0];
-        const ContainerStoreIterator& shield = mSlots[slot];
+        const ContainerStoreIterator& shield = slots_[slot];
         if (shield != end()
                 && shield.getType() == Type_Armor && shield->get<ESM::Armor>()->mBase->mData.mType == ESM::Armor::Shield)
         {


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5243)
It's not obvious from the test case, but apparently creatures started to autoequip the last "good" shield available in their inventory by akortunov's mistake: creature's currently equipped shield (that is, nothing) was used for checking whether the new shield is more durable than the old one rather than the shields that previously passed the testing. That was fixed, and two redundant checks were removed, they're already covered by canBeEquipped logic.

That said, the visual discrepancy where ground models of shields are displayed on creatures instead of body part models is not fixed, but that's a different issue.