### PR TITLE
Additional de-boosting

### DIFF
--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -7,8 +7,6 @@
 #include <MyGUI_Gui.h>
 #include <MyGUI_TabControl.h>
 
-#include <boost/algorithm/string.hpp>
-
 #include <SDL_video.h>
 
 #include <iomanip>
@@ -45,10 +43,10 @@ namespace
     void parseResolution (int &x, int &y, const std::string& str)
     {
         std::vector<std::string> split;
-        boost::algorithm::split (split, str, boost::is_any_of("@(x"));
+        Misc::StringUtils::split (str, split, "@(x");
         assert (split.size() >= 2);
-        boost::trim(split[0]);
-        boost::trim(split[1]);
+        Misc::StringUtils::trim(split[0]);
+        Misc::StringUtils::trim(split[1]);
         x = MyGUI::utility::parseInt (split[0]);
         y = MyGUI::utility::parseInt (split[1]);
     }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -22,6 +22,8 @@
 
 #include <components/debug/debuglog.hpp>
 
+#include <components/misc/stringops.hpp>
+
 #include <components/resource/resourcesystem.hpp>
 #include <components/resource/imagemanager.hpp>
 #include <components/resource/scenemanager.hpp>
@@ -46,8 +48,6 @@
 #include <components/fallback/fallback.hpp>
 
 #include <components/detournavigator/navigator.hpp>
-
-#include <boost/algorithm/string.hpp>
 
 #include "../mwworld/cellstore.hpp"
 #include "../mwworld/class.hpp"
@@ -767,7 +767,7 @@ namespace MWRender
         int screenshotMapping = 0;
 
         std::vector<std::string> settingArgs;
-        boost::algorithm::split(settingArgs,settingStr,boost::is_any_of(" "));
+        Misc::StringUtils::split(settingStr, settingArgs);
 
         if (settingArgs.size() > 0)
         {

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -217,7 +217,6 @@ add_library(components STATIC ${COMPONENT_FILES} ${MOC_SRCS} ${ESM_UI_HDR})
 target_link_libraries(components
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_IOSTREAMS_LIBRARY}
     ${OSG_LIBRARIES}

--- a/components/esmterrain/storage.cpp
+++ b/components/esmterrain/storage.cpp
@@ -7,10 +7,9 @@
 #include <osg/Image>
 #include <osg/Plane>
 
-#include <boost/algorithm/string.hpp>
-
 #include <components/debug/debuglog.hpp>
 #include <components/misc/resourcehelpers.hpp>
+#include <components/misc/stringops.hpp>
 #include <components/vfs/manager.hpp>
 
 namespace ESMTerrain
@@ -564,7 +563,7 @@ namespace ESMTerrain
         if (mAutoUseNormalMaps)
         {
             std::string texture_ = texture;
-            boost::replace_last(texture_, ".", mNormalHeightMapPattern + ".");
+            Misc::StringUtils::replaceLast(texture_, ".", mNormalHeightMapPattern + ".");
             if (mVFS->exists(texture_))
             {
                 info.mNormalMap = texture_;
@@ -573,7 +572,7 @@ namespace ESMTerrain
             else
             {
                 texture_ = texture;
-                boost::replace_last(texture_, ".", mNormalMapPattern + ".");
+                Misc::StringUtils::replaceLast(texture_, ".", mNormalMapPattern + ".");
                 if (mVFS->exists(texture_))
                     info.mNormalMap = texture_;
             }
@@ -582,7 +581,7 @@ namespace ESMTerrain
         if (mAutoUseSpecularMaps)
         {
             std::string texture_ = texture;
-            boost::replace_last(texture_, ".", mSpecularMapPattern + ".");
+            Misc::StringUtils::replaceLast(texture_, ".", mSpecularMapPattern + ".");
             if (mVFS->exists(texture_))
             {
                 info.mDiffuseMap = texture_;

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -1,6 +1,7 @@
 #ifndef MISC_STRINGOPS_H
 #define MISC_STRINGOPS_H
 
+#include <cctype>
 #include <string>
 #include <algorithm>
 

--- a/components/misc/stringops.hpp
+++ b/components/misc/stringops.hpp
@@ -245,6 +245,58 @@ public:
     {
         return format(fmt.c_str(), args ...);
     }
+
+    static inline void trim(std::string &s)
+    {
+        // left trim
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch)
+        {
+            return !std::isspace(ch);
+        }));
+
+        // right trim
+        s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch)
+        {
+            return !std::isspace(ch);
+        }).base(), s.end());
+    }
+
+    template <class Container>
+    static inline void split(const std::string& str, Container& cont, const std::string& delims = " ")
+    {
+        std::size_t current, previous = 0;
+        current = str.find_first_of(delims);
+        while (current != std::string::npos)
+        {
+            cont.push_back(str.substr(previous, current - previous));
+            previous = current + 1;
+            current = str.find_first_of(delims, previous);
+        }
+        cont.push_back(str.substr(previous, current - previous));
+    }
+
+    // TODO: use the std::string_view once we will use the C++17.
+    // It should allow us to avoid data copying while we still will support both string and literal arguments.
+
+    static inline void replaceAll(std::string& data, std::string toSearch, std::string replaceStr)
+    {
+        size_t pos = data.find(toSearch);
+
+        while( pos != std::string::npos)
+        {
+            data.replace(pos, toSearch.size(), replaceStr);
+            pos = data.find(toSearch, pos + replaceStr.size());
+        }
+    }
+
+     static inline void replaceLast(std::string& str, std::string substr, std::string with)
+     {
+         size_t pos = str.rfind(substr);
+         if (pos == std::string::npos)
+             return;
+
+         str.replace(pos, substr.size(), with);
+     }
 };
 
 }

--- a/components/settings/parser.cpp
+++ b/components/settings/parser.cpp
@@ -3,10 +3,9 @@
 #include <sstream>
 
 #include <components/debug/debuglog.hpp>
+#include <components/misc/stringops.hpp>
 
 #include <boost/filesystem/fstream.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 
 void Settings::SettingsFileParser::loadSettingsFile(const std::string& file, CategorySettingValueMap& settings)
 {
@@ -36,7 +35,7 @@ void Settings::SettingsFileParser::loadSettingsFile(const std::string& file, Cat
                 fail("unterminated category");
 
             currentCategory = line.substr(i+1, end - (i+1));
-            boost::algorithm::trim(currentCategory);
+            Misc::StringUtils::trim(currentCategory);
             i = end+1;
         }
 
@@ -51,11 +50,11 @@ void Settings::SettingsFileParser::loadSettingsFile(const std::string& file, Cat
             fail("unterminated setting name");
 
         std::string setting = line.substr(i, (settingEnd-i));
-        boost::algorithm::trim(setting);
+        Misc::StringUtils::trim(setting);
 
         size_t valueBegin = settingEnd+1;
         std::string value = line.substr(valueBegin);
-        boost::algorithm::trim(value);
+        Misc::StringUtils::trim(value);
 
         if (settings.insert(std::make_pair(std::make_pair(currentCategory, setting), value)).second == false)
             fail(std::string("duplicate setting: [" + currentCategory + "] " + setting));
@@ -142,7 +141,7 @@ void Settings::SettingsFileParser::saveSettingsFile(const std::string& file, con
 
             // Update the current category.
             currentCategory = line.substr(i+1, end - (i+1));
-            boost::algorithm::trim(currentCategory);
+            Misc::StringUtils::trim(currentCategory);
 
             // Write the (new) current category to the file.
             ostream << "[" << currentCategory << "]" << std::endl;
@@ -176,12 +175,12 @@ void Settings::SettingsFileParser::saveSettingsFile(const std::string& file, con
             continue;
         }
         std::string setting = line.substr(i, (settingEnd-i));
-        boost::algorithm::trim(setting);
+        Misc::StringUtils::trim(setting);
 
         // Get the existing value so we can see if we've changed it.
         size_t valueBegin = settingEnd+1;
         std::string value = line.substr(valueBegin);
-        boost::algorithm::trim(value);
+        Misc::StringUtils::trim(value);
 
         // Construct the setting map key to determine whether the setting has already been
         // written to the file.

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -8,9 +8,9 @@
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <components/debug/debuglog.hpp>
+#include <components/misc/stringops.hpp>
 
 namespace Shader
 {
@@ -60,7 +60,7 @@ namespace Shader
 
     bool parseIncludes(boost::filesystem::path shaderPath, std::string& source)
     {
-        boost::replace_all(source, "\r\n", "\n");
+        Misc::StringUtils::replaceAll(source, "\r\n", "\n");
 
         std::set<boost::filesystem::path> includedFiles;
         size_t foundPos = 0;
@@ -165,7 +165,7 @@ namespace Shader
             std::string list = source.substr(listStart, listEnd - listStart);
             std::vector<std::string> listElements;
             if (list != "")
-                boost::split(listElements, list, boost::is_any_of(","));
+                Misc::StringUtils::split (list, listElements, ",");
 
             size_t contentStart = source.find_first_not_of("\n\r", listEnd);
             size_t contentEnd = source.find("$endforeach", contentStart);

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -6,9 +6,8 @@
 
 #include <osgUtil/TangentSpaceGenerator>
 
-#include <boost/algorithm/string.hpp>
-
 #include <components/debug/debuglog.hpp>
+#include <components/misc/stringops.hpp>
 #include <components/resource/imagemanager.hpp>
 #include <components/vfs/manager.hpp>
 #include <components/sceneutil/riggeometry.hpp>
@@ -145,7 +144,7 @@ namespace Shader
                 osg::ref_ptr<osg::Image> image;
                 bool normalHeight = false;
                 std::string normalHeightMap = normalMapFileName;
-                boost::replace_last(normalHeightMap, ".", mNormalHeightMapPattern + ".");
+                Misc::StringUtils::replaceLast(normalHeightMap, ".", mNormalHeightMapPattern + ".");
                 if (mImageManager.getVFS()->exists(normalHeightMap))
                 {
                     image = mImageManager.getImage(normalHeightMap);
@@ -153,7 +152,7 @@ namespace Shader
                 }
                 else
                 {
-                    boost::replace_last(normalMapFileName, ".", mNormalMapPattern + ".");
+                    Misc::StringUtils::replaceLast(normalMapFileName, ".", mNormalMapPattern + ".");
                     if (mImageManager.getVFS()->exists(normalMapFileName))
                     {
                         image = mImageManager.getImage(normalMapFileName);
@@ -184,7 +183,7 @@ namespace Shader
             if (mAutoUseSpecularMaps && diffuseMap != nullptr && specularMap == nullptr && diffuseMap->getImage(0))
             {
                 std::string specularMapFileName = diffuseMap->getImage(0)->getFileName();
-                boost::replace_last(specularMapFileName, ".", mSpecularMapPattern + ".");
+                Misc::StringUtils::replaceLast(specularMapFileName, ".", mSpecularMapPattern + ".");
                 if (mImageManager.getVFS()->exists(specularMapFileName))
                 {
                     osg::ref_ptr<osg::Image> image (mImageManager.getImage(specularMapFileName));


### PR DESCRIPTION
Summary of changes:
1. Implement strings trimming, splitting and substring replacement to get rid of boost::algorithm.
2. Do not link Boost threads library since we do not use it now.