### PR TITLE
Use shield body part model for creatures (bug #5250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@
     Bug #5239: OpenMW-CS does not support non-ASCII characters in path names
     Bug #5241: On-self absorb spells cannot be detected
     Bug #5242: ExplodeSpell behavior differs from Cast behavior
+    Bug #5250: Creatures display shield ground mesh instead of shield body part
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -518,14 +518,14 @@ std::string NpcAnimation::getShieldMesh(MWWorld::ConstPtr shield) const
 {
     std::string mesh = shield.getClass().getModel(shield);
     const ESM::Armor *armor = shield.get<ESM::Armor>()->mBase;
-    std::vector<ESM::PartReference> bodyparts = armor->mParts.mParts;
+    const std::vector<ESM::PartReference>& bodyparts = armor->mParts.mParts;
     if (!bodyparts.empty())
     {
         const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
         const MWWorld::Store<ESM::BodyPart> &partStore = store.get<ESM::BodyPart>();
 
-        // For NPCs try to get shield model from bodyparts first, with ground model as fallback
-        for (auto & part : bodyparts)
+        // Try to get shield model from bodyparts first, with ground model as fallback
+        for (const auto& part : bodyparts)
         {
             if (part.mPart != ESM::PRT_Shield)
                 continue;
@@ -538,15 +538,20 @@ std::string NpcAnimation::getShieldMesh(MWWorld::ConstPtr shield) const
 
             if (!bodypartName.empty())
             {
-                const ESM::BodyPart *bodypart = 0;
-                bodypart = partStore.search(bodypartName);
+                const ESM::BodyPart *bodypart = partStore.search(bodypartName);
                 if (bodypart == nullptr || bodypart->mData.mType != ESM::BodyPart::MT_Armor)
-                    return "";
+                    return std::string();
                 else if (!bodypart->mModel.empty())
+                {
                     mesh = "meshes\\" + bodypart->mModel;
+                    break;
+                }
             }
         }
     }
+
+    if (mesh.empty())
+        return std::string();
 
     std::string holsteredName = mesh;
     holsteredName = holsteredName.replace(holsteredName.size()-4, 4, "_sh.nif");


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5250)

According to rot, both biped and non-biped creatures use the body part model of the shield in vanilla. 

So I added a look up for that model which will be used instead of the ground model when possible. Shields seem to look fine now.