### PR TITLE
Rework greeting timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@
     Bug #5239: OpenMW-CS does not support non-ASCII characters in path names
     Bug #5241: On-self absorb spells cannot be detected
     Bug #5242: ExplodeSpell behavior differs from Cast behavior
+    Bug #5249: Wandering NPCs start walking too soon after they hello
     Bug #5250: Creatures display shield ground mesh instead of shield body part
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -142,8 +142,9 @@ void getRestorationPerHourOfSleep (const MWWorld::Ptr& ptr, float& health, float
 
 namespace MWMechanics
 {
-    static const int GREETING_SHOULD_START = 4; //how many updates should pass before NPC can greet player
-    static const int GREETING_SHOULD_END = 10;
+    static const int GREETING_SHOULD_START = 4; // how many updates should pass before NPC can greet player
+    static const int GREETING_SHOULD_END = 20;  // how many updates should pass before NPC stops turning to player
+    static const int GREETING_COOLDOWN = 40;    // how many updates should pass before NPC can continue movement
     static const float DECELERATE_DISTANCE = 512.f;
 
     class GetStuntedMagickaDuration : public MWMechanics::EffectSourceVisitor
@@ -519,9 +520,10 @@ namespace MWMechanics
         {
             greetingTimer++;
 
-            turnActorToFacePlayer(actor, dir);
+            if (greetingTimer <= GREETING_SHOULD_END || MWBase::Environment::get().getSoundManager()->sayActive(actor))
+                turnActorToFacePlayer(actor, dir);
 
-            if (greetingTimer >= GREETING_SHOULD_END)
+            if (greetingTimer >= GREETING_COOLDOWN)
             {
                 greetingState = Greet_Done;
                 greetingTimer = 0;


### PR DESCRIPTION
Fixes [bug #5249](https://gitlab.com/OpenMW/openmw/issues/5249).

Now timeouts are closer to vanilla:
1. 1 second before NPC starts to greet player.
2. 4 seconds for greeting itself - NPC turns to player even if he already finished the speech.
3. 5 seconds for cooldown - NPC turns to player only if he did not finish his speech.

As a result, NPC's at least will wait for several seconds before continue their travelling after greeting.

Note: I am not sure about `sayActive` check in the step 3 - it will be true for scripted saying as well.