### PR TITLE
Separate grass handling

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -21,7 +21,7 @@ add_openmw_dir (mwrender
     actors objects renderingmanager animation rotatecontroller sky npcanimation vismask
     creatureanimation effectmanager util renderinginterface pathgrid rendermode weaponanimation
     bulletdebugdraw globalmap characterpreview camera viewovershoulder localmap water terrainstorage ripplesimulation
-    renderbin actoranimation landmanager navmesh actorspaths recastmesh fogmanager objectpaging
+    renderbin actoranimation landmanager navmesh actorspaths recastmesh fogmanager objectpaging grass
     )
 
 add_openmw_dir (mwinput

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -454,7 +454,8 @@ namespace MWBase
             ///< Apply a health difference to any actors colliding with \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
 
-            virtual float getWindSpeed() = 0;
+            virtual float getBaseWindSpeed() const = 0;
+            virtual float getWindSpeed() const = 0;
 
             virtual void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) = 0;
             ///< get all containers in active cells owned by this Npc

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -53,7 +53,6 @@ namespace MWRender
             return;
 
         float windSpeed = MWBase::Environment::get().getWorld()->getBaseWindSpeed();
-        windSpeed *= 4.f; // Note: actual wind speed is usually larger than base one from config
         mWindSpeedUpdater->setWindSpeed(windSpeed);
     }
 

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -96,6 +96,17 @@ namespace MWRender
         stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
         stateset->setAttributeAndModes(defaultMat, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
 
+        const static bool useGrass = Settings::Manager::getBool("animation", "Grass");
+        if(useGrass)
+        {
+            // @grass preprocessor define would be great
+            stateset->addUniform(new osg::Uniform("isGrass", true));
+            // for some reason this uniform is added to other objects too? not only for grass
+            mStormDirectionUniform = new osg::Uniform("WindDirection", (osg::Vec3f) osg::Vec3f(0.0, 0.0, 0.0));
+            stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));
+            stateset->addUniform(mStormDirectionUniform.get());
+        }
+
         mNode = insert;
     }
 
@@ -126,6 +137,15 @@ namespace MWRender
         float fadeRatio = (dist - fadeStartDistance)/(fadeEndDistance - fadeStartDistance);
         if (fadeRatio > 0)
             visibilityRatio -= std::max(0.f, fadeRatio);
+
+        // having its own updateUniform function would be better, need to update it even for non visible grass
+        const static bool useGrass = Settings::Manager::getBool("animation", "Grass");
+        if (useGrass)
+        {
+            // TODO: actually support storm
+            float windSpeed = MWBase::Environment::get().getWorld()->getBaseWindSpeed();
+            mStormDirectionUniform->set((osg::Vec3f) osg::Vec3f(0, 0, windSpeed));
+        }
 
         visibilityRatio = std::min(1.f, visibilityRatio);
 

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -123,12 +123,13 @@ namespace MWRender
 
         rs->getSceneManager()->getInstance("meshes\\" + mModel, insert);
 
+        osg::StateSet* stateset = insert->getOrCreateStateSet();
+        // @grass preprocessor define would be great
+        stateset->addUniform(new osg::Uniform("isGrass", true));
+
         const static bool useAnimation = Settings::Manager::getBool("animation", "Grass");
         if(useAnimation)
         {
-            osg::StateSet* stateset = insert->getOrCreateStateSet();
-            // @grass preprocessor define would be great
-            stateset->addUniform(new osg::Uniform("isGrass", true));
             // for some reason this uniform is added to other objects too? not only for grass
             mWindSpeedUniform = new osg::Uniform("windSpeed", 0.0f);
             stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -118,8 +118,6 @@ namespace MWRender
             osg::Quat(mPos.rot[0], osg::Vec3(-1, 0, 0)));
 
         insert->setNodeMask(Mask_Grass);
-        osg::ref_ptr<SceneUtil::LightListCallback> lightListCallback = new SceneUtil::LightListCallback;
-        insert->addCullCallback(lightListCallback);
 
         rs->getSceneManager()->getInstance("meshes\\" + mModel, insert);
 

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -102,9 +102,9 @@ namespace MWRender
             // @grass preprocessor define would be great
             stateset->addUniform(new osg::Uniform("isGrass", true));
             // for some reason this uniform is added to other objects too? not only for grass
-            mStormDirectionUniform = new osg::Uniform("WindDirection", (osg::Vec3f) osg::Vec3f(0.0, 0.0, 0.0));
+            mWindSpeedUniform = new osg::Uniform("windSpeed", 0.0f);
             stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));
-            stateset->addUniform(mStormDirectionUniform.get());
+            stateset->addUniform(mWindSpeedUniform.get());
         }
 
         mNode = insert;
@@ -142,9 +142,9 @@ namespace MWRender
         const static bool useGrass = Settings::Manager::getBool("animation", "Grass");
         if (useGrass)
         {
-            // TODO: actually support storm
             float windSpeed = MWBase::Environment::get().getWorld()->getBaseWindSpeed();
-            mStormDirectionUniform->set((osg::Vec3f) osg::Vec3f(0, 0, windSpeed));
+            windSpeed *= 4.f; // Note: actual wind speed is usually larger than base one from config
+            mWindSpeedUniform->set(windSpeed);
         }
 
         visibilityRatio = std::min(1.f, visibilityRatio);
@@ -178,9 +178,9 @@ namespace MWRender
                 // @grass preprocessor define would be great
                 stateset->addUniform(new osg::Uniform("isGrass", true));
                 // for some reason this uniform is added to other objects too? not only for grass
-                mStormDirectionUniform = new osg::Uniform("WindDirection", (osg::Vec3f) osg::Vec3f(0.0, 0.0, 0.0));
+                mWindSpeedUniform = new osg::Uniform("windSpeed", 0.0f);
                 stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));
-                stateset->addUniform(mStormDirectionUniform.get());
+                stateset->addUniform(mWindSpeedUniform.get());
             }
             mNode->removeUpdateCallback(mAlphaUpdater);
             mAlphaUpdater = nullptr;

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -15,23 +15,30 @@
 
 namespace MWRender
 {
-    void WindSpeedUpdater::setDefaults(osg::StateSet *stateset)
+    void GrassUpdater::setDefaults(osg::StateSet *stateset)
     {
         osg::ref_ptr<osg::Uniform> windUniform = new osg::Uniform("windSpeed", 0.0f);
         stateset->addUniform(windUniform.get());
+
+        osg::ref_ptr<osg::Uniform> playerPosUniform = new osg::Uniform("playerPos", osg::Vec3f(0.f, 0.f, 0.f));
+        stateset->addUniform(playerPosUniform.get());
     }
 
-    void WindSpeedUpdater::apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
+    void GrassUpdater::apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
     {
         osg::ref_ptr<osg::Uniform> windUniform = stateset->getUniform("windSpeed");
         if (windUniform != nullptr)
             windUniform->set(mWindSpeed);
+
+        osg::ref_ptr<osg::Uniform> playerPosUniform = stateset->getUniform("playerPos");
+        if (playerPosUniform != nullptr)
+            playerPosUniform->set(mPlayerPos);
     }
 
     Grass::Grass()
     {
         blank();
-        mWindSpeedUpdater = new WindSpeedUpdater;
+        mGrassUpdater = new GrassUpdater;
         mUseAnimation = Settings::Manager::getBool("animation", "Grass");
     }
 
@@ -53,7 +60,8 @@ namespace MWRender
             return;
 
         float windSpeed = MWBase::Environment::get().getWorld()->getBaseWindSpeed();
-        mWindSpeedUpdater->setWindSpeed(windSpeed);
+        mGrassUpdater->setWindSpeed(windSpeed);
+        mGrassUpdater->setPlayerPos(playerPos);
     }
 
     void Grass::insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs)
@@ -71,7 +79,7 @@ namespace MWRender
 
         if (mUseAnimation)
         {
-            grassGroup->addUpdateCallback(mWindSpeedUpdater);
+            grassGroup->addUpdateCallback(mGrassUpdater);
         }
     }
 

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -181,6 +181,12 @@ namespace MWRender
                 mWindSpeedUniform = new osg::Uniform("windSpeed", 0.0f);
                 stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));
                 stateset->addUniform(mWindSpeedUniform.get());
+                osg::ref_ptr<osg::Material> defaultMat (new osg::Material);
+                defaultMat->setColorMode(osg::Material::OFF);
+                defaultMat->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+                defaultMat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+                stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+                stateset->setAttributeAndModes(defaultMat, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
             }
             mNode->removeUpdateCallback(mAlphaUpdater);
             mAlphaUpdater = nullptr;

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -170,17 +170,20 @@ namespace MWRender
         }
         else
         {
+            if (mNode->getStateSet())
+            {
+                // FIXME: probably there is a better way to reset stateset
+                mNode->setStateSet(nullptr);
+                osg::StateSet* stateset = mNode->getOrCreateStateSet();
+                // @grass preprocessor define would be great
+                stateset->addUniform(new osg::Uniform("isGrass", true));
+                // for some reason this uniform is added to other objects too? not only for grass
+                mStormDirectionUniform = new osg::Uniform("WindDirection", (osg::Vec3f) osg::Vec3f(0.0, 0.0, 0.0));
+                stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));
+                stateset->addUniform(mStormDirectionUniform.get());
+            }
             mNode->removeUpdateCallback(mAlphaUpdater);
             mAlphaUpdater = nullptr;
         }
-
-        if (alpha != 1.f)
-        {
-            osg::StateSet* stateset = mNode->getOrCreateStateSet();
-            stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
-            stateset->setRenderBinMode(osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
-        }
-        else if (osg::StateSet* stateset = mNode->getStateSet())
-            stateset->setRenderBinToInherit();
     }
 }

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -34,8 +34,39 @@ namespace MWRender
     {
         for (MWRender::GrassItem& item : mItems)
         {
-            item.attachToNode(cellnode, rs, mWindSpeedUniform.get(), mIsGrassUniform.get());
+            attachToNode(item, cellnode, rs);
         }
+    }
+
+    void Grass::attachToNode(MWRender::GrassItem& item, osg::Group* cellnode, Resource::ResourceSystem* rs)
+    {
+        osg::ref_ptr<SceneUtil::PositionAttitudeTransform> insert (new SceneUtil::PositionAttitudeTransform);
+        cellnode->addChild(insert);
+
+        insert->setPosition(item.mPos.asVec3());
+        insert->setScale(osg::Vec3f(item.mScale, item.mScale, item.mScale));
+        insert->setAttitude(
+            osg::Quat(item.mPos.rot[2], osg::Vec3(0, 0, -1)) *
+            osg::Quat(item.mPos.rot[1], osg::Vec3(0, -1, 0)) *
+            osg::Quat(item.mPos.rot[0], osg::Vec3(-1, 0, 0)));
+
+        insert->setNodeMask(Mask_Grass);
+
+        rs->getSceneManager()->getInstance("meshes\\" + item.mModel, insert);
+
+        osg::StateSet* stateset = insert->getOrCreateStateSet();
+        // @grass preprocessor define would be great
+        stateset->addUniform(mIsGrassUniform);
+
+        const static bool useAnimation = Settings::Manager::getBool("animation", "Grass");
+        if(useAnimation)
+        {
+            // for some reason this uniform is added to other objects too? not only for grass
+            stateset->addUniform(new osg::Uniform("Rotz", (float) item.mPos.rot[2]));
+            stateset->addUniform(mWindSpeedUniform.get());
+        }
+
+        item.mNode = insert;
     }
 
     bool Grass::isGrassItem(const std::string& model)
@@ -94,36 +125,5 @@ namespace MWRender
         }
         else
             mNode->setNodeMask(Mask_Grass);
-    }
-
-    void GrassItem::attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs, osg::Uniform* windUniform, osg::Uniform* isGrassUniform)
-    {
-        osg::ref_ptr<SceneUtil::PositionAttitudeTransform> insert (new SceneUtil::PositionAttitudeTransform);
-        cellnode->addChild(insert);
-
-        insert->setPosition(mPos.asVec3());
-        insert->setScale(osg::Vec3f(mScale, mScale, mScale));
-        insert->setAttitude(
-            osg::Quat(mPos.rot[2], osg::Vec3(0, 0, -1)) *
-            osg::Quat(mPos.rot[1], osg::Vec3(0, -1, 0)) *
-            osg::Quat(mPos.rot[0], osg::Vec3(-1, 0, 0)));
-
-        insert->setNodeMask(Mask_Grass);
-
-        rs->getSceneManager()->getInstance("meshes\\" + mModel, insert);
-
-        osg::StateSet* stateset = insert->getOrCreateStateSet();
-        // @grass preprocessor define would be great
-        stateset->addUniform(isGrassUniform);
-
-        const static bool useAnimation = Settings::Manager::getBool("animation", "Grass");
-        if(useAnimation)
-        {
-            // for some reason this uniform is added to other objects too? not only for grass
-            stateset->addUniform(new osg::Uniform("Rotz", (float) mPos.rot[2]));
-            stateset->addUniform(windUniform);
-        }
-
-        mNode = insert;
     }
 }

--- a/apps/openmw/mwrender/grass.cpp
+++ b/apps/openmw/mwrender/grass.cpp
@@ -1,0 +1,166 @@
+#include "grass.hpp"
+
+#include <components/misc/stringops.hpp>
+
+#include <components/sceneutil/lightmanager.hpp>
+#include <components/sceneutil/positionattitudetransform.hpp>
+
+#include <components/settings/settings.hpp>
+
+#include "../mwmechanics/actorutil.hpp"
+
+#include "vismask.hpp"
+
+namespace MWRender
+{
+    void Grass::updateGrassVisibility()
+    {
+        osg::Vec3f playerPos(MWMechanics::getPlayer().getRefData().getPosition().asVec3());
+        for (MWRender::GrassItem& item : mItems)
+        {
+            item.updateVisibility(playerPos);
+        }
+    }
+
+    void Grass::insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs)
+    {
+        for (MWRender::GrassItem& item : mItems)
+        {
+            item.attachToNode(cellnode, rs);
+        }
+    }
+
+    bool Grass::isGrassItem(const std::string& model)
+    {
+        std::string mesh = Misc::StringUtils::lowerCase (model);
+        if (mesh.find("grass\\") == 0)
+            return true;
+
+        return false;
+    }
+
+    bool Grass::isEnabled(const std::string& model)
+    {
+        static const float density = Settings::Manager::getFloat("density", "Grass");
+
+        mCurrentGrass += density;
+        if (mCurrentGrass < 1.f)
+            return false;
+
+        mCurrentGrass -= 1.f;
+        return true;
+    }
+
+    bool Grass::loadGrassItem(const std::string& model, ESM::Position& pos, const float scale)
+    {
+        if (isGrassItem(model))
+        {
+            if (isEnabled(model))
+            {
+                GrassItem grass;
+                grass.mModel = model;
+                grass.mPos = pos;
+                grass.mScale = scale;
+                mItems.push_back(grass);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    void GrassItem::attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs)
+    {
+        osg::ref_ptr<SceneUtil::PositionAttitudeTransform> insert (new SceneUtil::PositionAttitudeTransform);
+        cellnode->addChild(insert);
+
+        insert->setPosition(mPos.asVec3());
+        insert->setScale(osg::Vec3f(mScale, mScale, mScale));
+        insert->setAttitude(
+            osg::Quat(mPos.rot[2], osg::Vec3(0, 0, -1)) *
+            osg::Quat(mPos.rot[1], osg::Vec3(0, -1, 0)) *
+            osg::Quat(mPos.rot[0], osg::Vec3(-1, 0, 0)));
+
+        insert->setNodeMask(Mask_Grass);
+        osg::ref_ptr<SceneUtil::LightListCallback> lightListCallback = new SceneUtil::LightListCallback;
+        insert->addCullCallback(lightListCallback);
+
+        rs->getSceneManager()->getInstance("meshes\\" + mModel, insert);
+
+        osg::ref_ptr<osg::Material> defaultMat (new osg::Material);
+        defaultMat->setColorMode(osg::Material::OFF);
+        defaultMat->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+        defaultMat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+        osg::StateSet* stateset = insert->getOrCreateStateSet();
+        stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+        stateset->setAttributeAndModes(defaultMat, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+
+        mNode = insert;
+    }
+
+    void GrassItem::updateVisibility(osg::Vec3f& playerPos)
+    {
+        static const int grassDistance = Settings::Manager::getInt("distance", "Grass");
+        if (grassDistance <= 0) return;
+
+        osg::Vec3f grassPos(mPos.asVec3());
+        float dist = (playerPos - grassPos).length();
+        if (mNode == nullptr) return;
+
+        if (dist > grassDistance)
+        {
+            mNode->setNodeMask(0);
+            return;
+        }
+        else
+            mNode->setNodeMask(Mask_Grass);
+
+        static const float fadeStart = std::max(0.f, Settings::Manager::getFloat("fade start", "Grass"));
+        if (fadeStart >= 1.f)
+            return;
+
+        float visibilityRatio = 1.0;
+        float fadeStartDistance = grassDistance*fadeStart;
+        float fadeEndDistance = grassDistance;
+        float fadeRatio = (dist - fadeStartDistance)/(fadeEndDistance - fadeStartDistance);
+        if (fadeRatio > 0)
+            visibilityRatio -= std::max(0.f, fadeRatio);
+
+        visibilityRatio = std::min(1.f, visibilityRatio);
+
+        setAlpha(visibilityRatio);
+    }
+
+    void GrassItem::setAlpha(float alpha)
+    {
+        if (mVisibility == alpha)
+            return;
+
+        mVisibility = alpha;
+        if (alpha != 1.f)
+        {
+            if (mAlphaUpdater == nullptr)
+            {
+                mAlphaUpdater = new MWRender::GrassUpdater(alpha);
+                mNode->addUpdateCallback(mAlphaUpdater);
+            }
+            else
+                mAlphaUpdater->setAlpha(alpha);
+        }
+        else
+        {
+            mNode->removeUpdateCallback(mAlphaUpdater);
+            mAlphaUpdater = nullptr;
+        }
+
+        if (alpha != 1.f)
+        {
+            osg::StateSet* stateset = mNode->getOrCreateStateSet();
+            stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+            stateset->setRenderBinMode(osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
+        }
+        else if (osg::StateSet* stateset = mNode->getStateSet())
+            stateset->setRenderBinToInherit();
+    }
+}

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <osg/BlendFunc>
 #include <osg/Group>
 #include <osg/Material>
 
@@ -26,12 +27,26 @@ namespace MWRender
         }
 
     protected:
+        virtual void setDefaults(osg::StateSet* stateset)
+        {
+            osg::BlendFunc* blendfunc (new osg::BlendFunc);
+            stateset->setAttributeAndModes(blendfunc, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+
+            stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+            stateset->setRenderBinMode(osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
+
+            osg::Material* material = new osg::Material;
+            material->setColorMode(osg::Material::OFF);
+            material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,mAlpha));
+            //material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+            stateset->setAttributeAndModes(material, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+            stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+        }
+
         virtual void apply(osg::StateSet* stateset, osg::NodeVisitor* /*nv*/)
         {
-            osg::Material* mat = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
-            osg::Vec4f diffuse = mat->getDiffuse(osg::Material::FRONT_AND_BACK);
-            diffuse.a() = mAlpha;
-            mat->setDiffuse(osg::Material::FRONT_AND_BACK, diffuse);
+            osg::Material* material = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
+            material->setAlpha(osg::Material::FRONT_AND_BACK, mAlpha);
         }
 
     private:

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -45,6 +45,8 @@ namespace MWRender
         float mScale;
         osg::ref_ptr<osg::Group> mNode;
 
+        osg::ref_ptr<osg::Uniform> mStormDirectionUniform;
+
         void updateVisibility(osg::Vec3f& playerPos);
         void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs);
 

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -21,7 +21,6 @@ namespace MWRender
         osg::ref_ptr<osg::Group> mNode;
 
         void updateVisibility(osg::Vec3f& playerPos);
-        void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs, osg::Uniform* windUniform, osg::Uniform* isGrassUniform);
     };
 
     struct Grass
@@ -49,6 +48,7 @@ namespace MWRender
             mCurrentGrass = 0;
         }
 
+        void attachToNode(MWRender::GrassItem& item, osg::Group* cellnode, Resource::ResourceSystem* rs);
         void update();
     };
 }

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -16,17 +16,23 @@ namespace Resource
 
 namespace MWRender
 {
-    class WindSpeedUpdater : public SceneUtil::StateSetUpdater
+    class GrassUpdater : public SceneUtil::StateSetUpdater
     {
     public:
-        WindSpeedUpdater()
+        GrassUpdater()
             : mWindSpeed(0.f)
+            , mPlayerPos(osg::Vec3f())
         {
         }
 
         void setWindSpeed(float windSpeed)
         {
             mWindSpeed = windSpeed;
+        }
+
+        void setPlayerPos(osg::Vec3f playerPos)
+        {
+            mPlayerPos = playerPos;
         }
 
     protected:
@@ -36,6 +42,7 @@ namespace MWRender
 
     private:
         float mWindSpeed;
+        osg::Vec3f mPlayerPos;
     };
 
     struct GrassItem
@@ -53,7 +60,7 @@ namespace MWRender
         std::vector<GrassItem> mItems;
         float mCurrentGrass = 0;
         bool mUseAnimation = false;
-        osg::ref_ptr<WindSpeedUpdater> mWindSpeedUpdater;
+        osg::ref_ptr<GrassUpdater> mGrassUpdater;
 
         Grass();
         void blank();

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -29,9 +29,6 @@ namespace MWRender
     protected:
         virtual void setDefaults(osg::StateSet* stateset)
         {
-            osg::BlendFunc* blendfunc (new osg::BlendFunc);
-            stateset->setAttributeAndModes(blendfunc, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
-
             stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
             stateset->setRenderBinMode(osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
 

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -13,60 +13,17 @@
 
 namespace MWRender
 {
-    class GrassUpdater : public SceneUtil::StateSetUpdater
-    {
-    public:
-        GrassUpdater(const float alpha)
-            : mAlpha(alpha)
-        {
-        }
-
-        void setAlpha(const float alpha)
-        {
-            mAlpha = alpha;
-        }
-
-    protected:
-        virtual void setDefaults(osg::StateSet* stateset)
-        {
-            stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
-            stateset->setRenderBinMode(osg::StateSet::OVERRIDE_RENDERBIN_DETAILS);
-
-            osg::Material* material = new osg::Material;
-            material->setColorMode(osg::Material::OFF);
-            material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,mAlpha));
-            material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
-            stateset->setAttributeAndModes(material, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
-            stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
-        }
-
-        virtual void apply(osg::StateSet* stateset, osg::NodeVisitor* /*nv*/)
-        {
-            osg::Material* material = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
-            material->setAlpha(osg::Material::FRONT_AND_BACK, mAlpha);
-        }
-
-    private:
-        float mAlpha;
-    };
-
     struct GrassItem
     {
         std::string mModel;
         ESM::Position mPos;
         float mScale;
         osg::ref_ptr<osg::Group> mNode;
-
         osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
 
         void updateVisibility(osg::Vec3f& playerPos);
         void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs);
-
-    private:
-        void setAlpha(float alpha);
-
-        float mVisibility = 1.f;
-        osg::ref_ptr<MWRender::GrassUpdater> mAlphaUpdater;
+        void update();
     };
 
     struct Grass
@@ -75,7 +32,6 @@ namespace MWRender
         float mCurrentGrass = 0;
 
         bool loadGrassItem(const std::string& model, ESM::Position& pos, const float scale);
-        void updateGrassVisibility();
         void insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs);
         bool isEnabled(const std::string& model);
         static bool isGrassItem(const std::string& model);
@@ -85,6 +41,8 @@ namespace MWRender
             mItems.clear();
             mCurrentGrass = 0;
         }
+
+        void update();
     };
 }
 

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -7,6 +7,8 @@
 
 #include <components/esm/defs.hpp>
 
+#include <components/sceneutil/statesetupdater.hpp>
+
 namespace Resource
 {
     class ResourceSystem;
@@ -14,6 +16,28 @@ namespace Resource
 
 namespace MWRender
 {
+    class WindSpeedUpdater : public SceneUtil::StateSetUpdater
+    {
+    public:
+        WindSpeedUpdater()
+            : mWindSpeed(0.f)
+        {
+        }
+
+        void setWindSpeed(float windSpeed)
+        {
+            mWindSpeed = windSpeed;
+        }
+
+    protected:
+        virtual void setDefaults(osg::StateSet *stateset);
+
+        virtual void apply(osg::StateSet *stateset, osg::NodeVisitor *nv);
+
+    private:
+        float mWindSpeed;
+    };
+
     struct GrassItem
     {
         std::string mModel;
@@ -29,7 +53,7 @@ namespace MWRender
         std::vector<GrassItem> mItems;
         float mCurrentGrass = 0;
         bool mUseAnimation = false;
-        osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
+        osg::ref_ptr<WindSpeedUpdater> mWindSpeedUpdater;
 
         Grass();
         void blank();

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -1,0 +1,77 @@
+#ifndef GAME_MWRENDER_GRASS_H
+#define GAME_MWRENDER_GRASS_H
+
+#include <string>
+
+#include <osg/Group>
+#include <osg/Material>
+
+#include <components/resource/scenemanager.hpp>
+
+#include "animation.hpp"
+
+namespace MWRender
+{
+    class GrassUpdater : public SceneUtil::StateSetUpdater
+    {
+    public:
+        GrassUpdater(const float alpha)
+            : mAlpha(alpha)
+        {
+        }
+
+        void setAlpha(const float alpha)
+        {
+            mAlpha = alpha;
+        }
+
+    protected:
+        virtual void apply(osg::StateSet* stateset, osg::NodeVisitor* /*nv*/)
+        {
+            osg::Material* mat = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
+            osg::Vec4f diffuse = mat->getDiffuse(osg::Material::FRONT_AND_BACK);
+            diffuse.a() = mAlpha;
+            mat->setDiffuse(osg::Material::FRONT_AND_BACK, diffuse);
+        }
+
+    private:
+        float mAlpha;
+    };
+
+    struct GrassItem
+    {
+        std::string mModel;
+        ESM::Position mPos;
+        float mScale;
+        osg::ref_ptr<osg::Group> mNode;
+
+        void updateVisibility(osg::Vec3f& playerPos);
+        void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs);
+
+    private:
+        void setAlpha(float alpha);
+
+        float mVisibility = 1.f;
+        osg::ref_ptr<MWRender::GrassUpdater> mAlphaUpdater;
+    };
+
+    struct Grass
+    {
+        std::vector<GrassItem> mItems;
+        float mCurrentGrass = 0;
+
+        bool loadGrassItem(const std::string& model, ESM::Position& pos, const float scale);
+        void updateGrassVisibility();
+        void insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs);
+        bool isEnabled(const std::string& model);
+        static bool isGrassItem(const std::string& model);
+
+        void blank()
+        {
+            mItems.clear();
+            mCurrentGrass = 0;
+        }
+    };
+}
+
+#endif

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -19,11 +19,9 @@ namespace MWRender
         ESM::Position mPos;
         float mScale;
         osg::ref_ptr<osg::Group> mNode;
-        osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
 
         void updateVisibility(osg::Vec3f& playerPos);
-        void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs);
-        void update();
+        void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs, osg::Uniform* windUniform, osg::Uniform* isGrassUniform);
     };
 
     struct Grass
@@ -35,6 +33,15 @@ namespace MWRender
         void insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs);
         bool isEnabled(const std::string& model);
         static bool isGrassItem(const std::string& model);
+        osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
+        osg::ref_ptr<osg::Uniform> mIsGrassUniform;
+
+        Grass()
+        {
+            blank();
+            mWindSpeedUniform = new osg::Uniform("windSpeed", 0.0f);
+            mIsGrassUniform = new osg::Uniform("isGrass", true);
+        }
 
         void blank()
         {

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -38,7 +38,7 @@ namespace MWRender
             osg::Material* material = new osg::Material;
             material->setColorMode(osg::Material::OFF);
             material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,mAlpha));
-            //material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
+            material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
             stateset->setAttributeAndModes(material, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
             stateset->addUniform(new osg::Uniform("colorMode", 0), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
         }
@@ -60,7 +60,7 @@ namespace MWRender
         float mScale;
         osg::ref_ptr<osg::Group> mNode;
 
-        osg::ref_ptr<osg::Uniform> mStormDirectionUniform;
+        osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
 
         void updateVisibility(osg::Vec3f& playerPos);
         void attachToNode(osg::Group* cellnode, Resource::ResourceSystem* rs);

--- a/apps/openmw/mwrender/grass.hpp
+++ b/apps/openmw/mwrender/grass.hpp
@@ -3,13 +3,14 @@
 
 #include <string>
 
-#include <osg/BlendFunc>
 #include <osg/Group>
-#include <osg/Material>
 
-#include <components/resource/scenemanager.hpp>
+#include <components/esm/defs.hpp>
 
-#include "animation.hpp"
+namespace Resource
+{
+    class ResourceSystem;
+}
 
 namespace MWRender
 {
@@ -27,26 +28,15 @@ namespace MWRender
     {
         std::vector<GrassItem> mItems;
         float mCurrentGrass = 0;
+        bool mUseAnimation = false;
+        osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
 
+        Grass();
+        void blank();
         bool loadGrassItem(const std::string& model, ESM::Position& pos, const float scale);
         void insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs);
         bool isEnabled(const std::string& model);
         static bool isGrassItem(const std::string& model);
-        osg::ref_ptr<osg::Uniform> mWindSpeedUniform;
-        osg::ref_ptr<osg::Uniform> mIsGrassUniform;
-
-        Grass()
-        {
-            blank();
-            mWindSpeedUniform = new osg::Uniform("windSpeed", 0.0f);
-            mIsGrassUniform = new osg::Uniform("isGrass", true);
-        }
-
-        void blank()
-        {
-            mItems.clear();
-            mCurrentGrass = 0;
-        }
 
         void attachToNode(MWRender::GrassItem& item, osg::Group* cellnode, Resource::ResourceSystem* rs);
         void update();

--- a/apps/openmw/mwrender/objectpaging.cpp
+++ b/apps/openmw/mwrender/objectpaging.cpp
@@ -30,6 +30,7 @@
 #include "apps/openmw/mwbase/environment.hpp"
 #include "apps/openmw/mwbase/world.hpp"
 
+#include "grass.hpp"
 #include "vismask.hpp"
 
 namespace MWRender
@@ -450,6 +451,8 @@ namespace MWRender
         float minSize = mMinSize;
         if (mMinSizeMergeFactor)
             minSize *= mMinSizeMergeFactor;
+
+        static const bool grassEnabled = Settings::Manager::getBool("enabled", "Grass");
         for (const auto& pair : refs)
         {
             const ESM::CellRef& ref = pair.second;
@@ -478,6 +481,7 @@ namespace MWRender
             int type = store.findStatic(ref.mRefID);
             std::string model = getModel(type, ref.mRefID, store);
             if (model.empty()) continue;
+            if (grassEnabled && Grass::isGrassItem(model)) continue;
             model = "meshes/" + model;
 
             if (activeGrid && type != ESM::REC_STAT)

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -8,6 +8,7 @@
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/class.hpp"
+#include "../mwworld/cellstore.hpp"
 
 #include "animation.hpp"
 #include "npcanimation.hpp"
@@ -66,6 +67,24 @@ void Objects::insertBegin(const MWWorld::Ptr& ptr)
     insert->setScale(scaleVec);
 
     ptr.getRefData().setBaseNode(insert);
+}
+
+void Objects::insertGrass(MWWorld::CellStore* cell)
+{
+    osg::ref_ptr<osg::Group> cellnode;
+
+    CellMap::iterator found = mCellSceneNodes.find(cell);
+    if (found == mCellSceneNodes.end())
+    {
+        cellnode = new osg::Group;
+        cellnode->setName("Cell Root");
+        mRootNode->addChild(cellnode);
+        mCellSceneNodes[cell] = cellnode;
+    }
+    else
+        cellnode = found->second;
+
+    cell->insertGrass(cellnode, mResourceSystem);
 }
 
 void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh, bool animated, bool allowLight)

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -77,6 +77,7 @@ public:
     /// @param animated Attempt to load separate keyframes from a .kf file matching the model file?
     /// @param allowLight If false, no lights will be created, and particles systems will be removed.
     void insertModel(const MWWorld::Ptr& ptr, const std::string &model, bool animated=false, bool allowLight=true);
+    void insertGrass(MWWorld::CellStore* cell);
 
     void insertNPC(const MWWorld::Ptr& ptr);
     void insertCreature (const MWWorld::Ptr& ptr, const std::string& model, bool weaponsShields);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -248,6 +248,7 @@ namespace MWRender
         globalDefines["clamp"] = Settings::Manager::getBool("clamp lighting", "Shaders") ? "1" : "0";
         globalDefines["preLightEnv"] = Settings::Manager::getBool("apply lighting to environment maps", "Shaders") ? "1" : "0";
         globalDefines["radialFog"] = Settings::Manager::getBool("radial fog", "Shaders") ? "1" : "0";
+        globalDefines["grassAnimation"] = Settings::Manager::getBool("animation", "Grass") ? "1" : "0";
 
         // It is unnecessary to stop/start the viewer as no frames are being rendered yet.
         mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(globalDefines);
@@ -372,6 +373,7 @@ namespace MWRender
 
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("near", mNearClip));
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("far", mViewDistance));
+        mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("isGrass", false));
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("simpleWater", false));
 
         mUniformNear = mRootNode->getOrCreateStateSet()->getUniform("near");

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -206,8 +206,13 @@ namespace MWRender
     {
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
         resourceSystem->getSceneManager()->setShaderPath(resourcePath + "/shaders");
-        // Shadows and radial fog have problems with fixed-function mode
-        bool forceShaders = Settings::Manager::getBool("radial fog", "Shaders") || Settings::Manager::getBool("force shaders", "Shaders") || Settings::Manager::getBool("enable shadows", "Shadows");
+        // Shadows and radial fog have problems with fixed-function mode.
+        // Grass fading and animation are implemented via shader too.
+        bool forceShaders =
+            Settings::Manager::getBool("radial fog", "Shaders") ||
+            Settings::Manager::getBool("force shaders", "Shaders") ||
+            Settings::Manager::getBool("enable shadows", "Shadows") ||
+            Settings::Manager::getBool("enabled", "Grass");
         resourceSystem->getSceneManager()->setForceShaders(forceShaders);
         // FIXME: calling dummy method because terrain needs to know whether lighting is clamped
         resourceSystem->getSceneManager()->setClampLighting(Settings::Manager::getBool("clamp lighting", "Shaders"));

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -1075,7 +1075,7 @@ namespace MWRender
         mIntersectionVisitor->setIntersector(intersector);
 
         int mask = ~0;
-        mask &= ~(Mask_RenderToTexture|Mask_Sky|Mask_Debug|Mask_Effect|Mask_Water|Mask_SimpleWater);
+        mask &= ~(Mask_RenderToTexture|Mask_Sky|Mask_Debug|Mask_Effect|Mask_Water|Mask_SimpleWater|Mask_Grass);
         if (ignorePlayer)
             mask &= ~(Mask_Player);
         if (ignoreActors)

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -249,6 +249,8 @@ namespace MWRender
         globalDefines["preLightEnv"] = Settings::Manager::getBool("apply lighting to environment maps", "Shaders") ? "1" : "0";
         globalDefines["radialFog"] = Settings::Manager::getBool("radial fog", "Shaders") ? "1" : "0";
         globalDefines["grassAnimation"] = Settings::Manager::getBool("animation", "Grass") ? "1" : "0";
+        globalDefines["grassFadeStart"] = std::to_string(Settings::Manager::getFloat("distance", "Grass") * Settings::Manager::getFloat("fade start", "Grass"));
+        globalDefines["grassFadeEnd"] = std::to_string(Settings::Manager::getFloat("distance", "Grass"));
 
         // It is unnecessary to stop/start the viewer as no frames are being rendered yet.
         mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(globalDefines);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -380,7 +380,6 @@ namespace MWRender
 
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("near", mNearClip));
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("far", mViewDistance));
-        mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("isGrass", false));
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("simpleWater", false));
 
         mUniformNear = mRootNode->getOrCreateStateSet()->getUniform("near");

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -69,6 +69,7 @@ namespace MWRender
         float mDLFogFactor;
         float mDLFogOffset;
 
+        float mBaseWindSpeed;
         float mWindSpeed;
         float mCurrentWindSpeed;
         float mNextWindSpeed;

--- a/apps/openmw/mwrender/vismask.hpp
+++ b/apps/openmw/mwrender/vismask.hpp
@@ -53,7 +53,9 @@ namespace MWRender
         Mask_PreCompile = (1<<18),
 
         // Set on a camera's cull mask to enable the LightManager
-        Mask_Lighting = (1<<19)
+        Mask_Lighting = (1<<19),
+
+        Mask_Grass = (1<<20),
     };
 
 }

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -739,9 +739,9 @@ namespace MWWorld
         refNumToID[ref.mRefNum] = ref.mRefID;
     }
 
-    void CellStore::updateGrassVisibility()
+    void CellStore::updateGrass()
     {
-        mGrass.updateGrassVisibility();
+        mGrass.update();
     }
 
     void CellStore::insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs)

--- a/apps/openmw/mwworld/cellstore.cpp
+++ b/apps/openmw/mwworld/cellstore.cpp
@@ -530,17 +530,6 @@ namespace MWWorld
 
                     Misc::StringUtils::lowerCaseInPlace (ref.mRefID);
 
-                    static const bool grassEnabled = Settings::Manager::getBool("enabled", "Grass");
-                    if (grassEnabled && mStore.find(ref.mRefID) == ESM::REC_STAT)
-                    {
-                        const ESM::Static* staticRecord = mStore.get<ESM::Static>().find(ref.mRefID);
-                        if (!staticRecord->mModel.empty())
-                        {
-                            if (mGrass.isGrassItem(staticRecord->mModel) && !mGrass.isEnabled(staticRecord->mModel))
-                                continue;
-                        }
-                    }
-
                     mIds.push_back (ref.mRefID);
                 }
             }

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -32,6 +32,8 @@
 #include <components/esm/loadmisc.hpp>
 #include <components/esm/loadbody.hpp>
 
+#include "../mwrender/grass.hpp"
+
 #include "timestamp.hpp"
 #include "ptr.hpp"
 
@@ -254,6 +256,10 @@ namespace MWWorld
 
             void setWaterLevel (float level);
 
+            void updateGrassVisibility();
+
+            void insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs);
+
             void setFog (ESM::FogState* fog);
             ///< \note Takes ownership of the pointer
 
@@ -408,6 +414,8 @@ namespace MWWorld
             ///< Make case-adjustments to \a ref and insert it into the respective container.
             ///
             /// Invalid \a ref objects are silently dropped.
+
+            MWRender::Grass mGrass;
     };
 
     template<>

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -256,7 +256,7 @@ namespace MWWorld
 
             void setWaterLevel (float level);
 
-            void updateGrassVisibility();
+            void updateGrass();
 
             void insertGrass(osg::Group* cellnode, Resource::ResourceSystem* rs);
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -427,6 +427,8 @@ namespace MWWorld
             // ... then references. This is important for adjustPosition to work correctly.
             insertCell (*cell, loadingListener, test);
 
+            mRendering.getObjects().insertGrass(cell);
+
             mRendering.addCell(cell);
             if (!test)
             {

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -533,6 +533,7 @@ WeatherManager::WeatherManager(MWRender::RenderingManager& rendering, MWWorld::E
     , mWeatherSettings()
     , mMasser("Masser")
     , mSecunda("Secunda")
+    , mBaseWindSpeed(0.f)
     , mWindSpeed(0.f)
     , mCurrentWindSpeed(0.f)
     , mNextWindSpeed(0.f)
@@ -708,6 +709,7 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
     {
         mRendering.setSkyEnabled(false);
         stopSounds();
+        mBaseWindSpeed = 0.f;
         mWindSpeed = 0.f;
         mCurrentWindSpeed = 0.f;
         mNextWindSpeed = 0.f;
@@ -718,6 +720,7 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
 
     if (!paused)
     {
+        mBaseWindSpeed = mResult.mBaseWindSpeed;
         mWindSpeed = mResult.mWindSpeed;
         mCurrentWindSpeed = mResult.mCurrentWindSpeed;
         mNextWindSpeed = mResult.mNextWindSpeed;
@@ -827,6 +830,11 @@ void WeatherManager::stopSounds()
         MWBase::Environment::get().getSoundManager()->stopSound(mAmbientSound);
     mAmbientSound = nullptr;
     mPlayingSoundID.clear();
+}
+
+float WeatherManager::getBaseWindSpeed() const
+{
+    return mBaseWindSpeed;
 }
 
 float WeatherManager::getWindSpeed() const
@@ -1125,6 +1133,7 @@ inline void WeatherManager::calculateResult(const int weatherID, const float gam
     mResult.mCloudBlendFactor = 0;
     mResult.mNextWindSpeed = 0;
     mResult.mWindSpeed = mResult.mCurrentWindSpeed = calculateWindSpeed(weatherID, mWindSpeed);
+    mResult.mBaseWindSpeed = mWeatherSettings[weatherID].mWindSpeed;
 
     mResult.mCloudSpeed = current.mCloudSpeed;
     mResult.mGlareView = current.mGlareView;
@@ -1216,6 +1225,7 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
 
     mResult.mCurrentWindSpeed = calculateWindSpeed(mCurrentWeather, mCurrentWindSpeed);
     mResult.mNextWindSpeed = calculateWindSpeed(mNextWeather, mNextWindSpeed);
+    mResult.mBaseWindSpeed = lerp(current.mBaseWindSpeed, other.mBaseWindSpeed, factor);
 
     mResult.mWindSpeed = lerp(mResult.mCurrentWindSpeed, mResult.mNextWindSpeed, factor);
     mResult.mCloudSpeed = lerp(current.mCloudSpeed, other.mCloudSpeed, factor);

--- a/apps/openmw/mwworld/weather.hpp
+++ b/apps/openmw/mwworld/weather.hpp
@@ -293,6 +293,7 @@ namespace MWWorld
 
         void stopSounds();
 
+        float getBaseWindSpeed() const;
         float getWindSpeed() const;
         NightDayMode getNightDayMode() const;
 
@@ -337,6 +338,7 @@ namespace MWWorld
         MoonModel mMasser;
         MoonModel mSecunda;
 
+        float mBaseWindSpeed;
         float mWindSpeed;
         float mCurrentWindSpeed;
         float mNextWindSpeed;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2653,7 +2653,15 @@ namespace MWWorld
         }
     }
 
-    float World::getWindSpeed()
+    float World::getBaseWindSpeed() const
+    {
+        if (isCellExterior() || isCellQuasiExterior())
+            return mWeatherManager->getBaseWindSpeed();
+        else
+            return 0.f;
+    }
+
+    float World::getWindSpeed() const
     {
         if (isCellExterior() || isCellQuasiExterior())
             return mWeatherManager->getWindSpeed();

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1784,7 +1784,7 @@ namespace MWWorld
     {
         for (CellStore* cellstore : mWorldScene->getActiveCells())
         {
-            cellstore->updateGrassVisibility();
+            cellstore->updateGrass();
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1780,6 +1780,14 @@ namespace MWWorld
         return mStore.insert(record);
     }
 
+    void World::updateGrass()
+    {
+        for (CellStore* cellstore : mWorldScene->getActiveCells())
+        {
+            cellstore->updateGrassVisibility();
+        }
+    }
+
     void World::update (float duration, bool paused)
     {
         if (mGoToJail && !paused)
@@ -1815,6 +1823,10 @@ namespace MWWorld
             mSpellPreloadTimer = 0.1f;
             preloadSpells();
         }
+
+        static const bool grassEnabled = Settings::Manager::getBool("enabled", "Grass");
+        if (grassEnabled)
+            updateGrass();
     }
 
     void World::updatePhysics (float duration, bool paused)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -564,7 +564,8 @@ namespace MWWorld
             ///< Apply a health difference to any actors colliding with \a object.
             /// To hurt actors, healthPerSecond should be a positive value. For a negative value, actors will be healed.
 
-            float getWindSpeed() override;
+            float getBaseWindSpeed() const override;
+            float getWindSpeed() const override;
 
             void getContainersOwnedBy (const MWWorld::ConstPtr& npc, std::vector<MWWorld::Ptr>& out) override;
             ///< get all containers in active cells owned by this Npc

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -161,6 +161,8 @@ namespace MWWorld
 
             void updateNavigator();
 
+            void updateGrass();
+
             bool updateNavigatorObject(const MWPhysics::Object* object);
 
             void ensureNeededRecords();

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -242,11 +242,16 @@ namespace Resource
         return mForceShaders;
     }
 
-    void SceneManager::recreateShaders(osg::ref_ptr<osg::Node> node)
+    void SceneManager::recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix)
     {
-        osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor(createShaderVisitor());
+        osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor(createShaderVisitor(shaderPrefix));
         shaderVisitor->setAllowedToModifyStateSets(false);
         node->accept(*shaderVisitor);
+    }
+
+    void SceneManager::recreateShaders(osg::ref_ptr<osg::Node> node)
+    {
+        recreateShaders(node, "objects");
     }
 
     void SceneManager::setClampLighting(bool clamp)
@@ -510,7 +515,7 @@ namespace Resource
             SetFilterSettingsControllerVisitor setFilterSettingsControllerVisitor(mMinFilter, mMagFilter, mMaxAnisotropy);
             loaded->accept(setFilterSettingsControllerVisitor);
 
-            osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor (createShaderVisitor());
+            osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor (createShaderVisitor("objects"));
             loaded->accept(*shaderVisitor);
 
             // share state
@@ -761,9 +766,9 @@ namespace Resource
         stats->setAttribute(frameNumber, "Node Instance", mInstanceCache->getCacheSize());
     }
 
-    Shader::ShaderVisitor *SceneManager::createShaderVisitor()
+    Shader::ShaderVisitor *SceneManager::createShaderVisitor(const std::string& shaderPrefix)
     {
-        Shader::ShaderVisitor* shaderVisitor = new Shader::ShaderVisitor(*mShaderManager.get(), *mImageManager, "objects_vertex.glsl", "objects_fragment.glsl");
+        Shader::ShaderVisitor* shaderVisitor = new Shader::ShaderVisitor(*mShaderManager.get(), *mImageManager, shaderPrefix+"_vertex.glsl", shaderPrefix+"_fragment.glsl");
         shaderVisitor->setForceShaders(mForceShaders);
         shaderVisitor->setAutoUseNormalMaps(mAutoUseNormalMaps);
         shaderVisitor->setNormalMapPattern(mNormalMapPattern);

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -52,6 +52,7 @@ namespace Resource
 
         /// Re-create shaders for this node, need to call this if texture stages or vertex color mode have changed.
         void recreateShaders(osg::ref_ptr<osg::Node> node);
+        void recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix);
 
         /// @see ShaderVisitor::setForceShaders
         void setForceShaders(bool force);
@@ -146,7 +147,7 @@ namespace Resource
 
     private:
 
-        Shader::ShaderVisitor* createShaderVisitor();
+        Shader::ShaderVisitor* createShaderVisitor(const std::string& shaderPrefix);
 
         std::unique_ptr<Shader::ShaderManager> mShaderManager;
         bool mForceShaders;

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -933,4 +933,4 @@ density = 1.0
 distance = 8192
 
 # Enable grass animation, force shaders should be true.
-animation = false
+animation = true

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -916,3 +916,18 @@ object shadows = false
 
 # Allow shadows indoors. Due to limitations with Morrowind's data, only actors can cast shadows indoors, which some might feel is distracting.
 enable indoor shadows = true
+
+[Grass]
+
+# enable separate grass handling
+enabled = false
+
+# configure grass fade out threshold
+fade start = 1.0
+
+# A grass density (0.0 <= value <= 1.0)
+# 1.0 means 100% density
+density = 1.0
+
+# A maximum distance on which grass is rendered.
+distance = 8192

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -931,3 +931,6 @@ density = 1.0
 
 # A maximum distance on which grass is rendered.
 distance = 8192
+
+# Enable grass animation, force shaders should be true.
+animation = false

--- a/files/shaders/CMakeLists.txt
+++ b/files/shaders/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SDIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(DDIRRELATIVE resources/shaders)
 
 set(SHADER_FILES
+    grass_vertex.glsl
+    grass_fragment.glsl
     water_vertex.glsl
     water_fragment.glsl
     water_nm.png

--- a/files/shaders/grass_fragment.glsl
+++ b/files/shaders/grass_fragment.glsl
@@ -1,0 +1,79 @@
+#version 120
+
+#if @diffuseMap
+uniform sampler2D diffuseMap;
+varying vec2 diffuseMapUV;
+#endif
+
+#define PER_PIXEL_LIGHTING @forcePPL
+
+varying float euclideanDepth;
+varying float linearDepth;
+
+#if !@forcePPL
+centroid varying vec4 lighting;
+centroid varying vec3 shadowDiffuseLighting;
+#endif
+centroid varying vec4 passColor;
+varying vec3 passViewPos;
+varying vec3 passNormal;
+
+#include "shadows_fragment.glsl"
+#include "lighting.glsl"
+
+void main()
+{
+#if @diffuseMap
+    vec2 adjustedDiffuseUV = diffuseMapUV;
+#endif
+
+#if @forcePPL
+    vec3 viewNormal = gl_NormalMatrix * normalize(passNormal);
+#endif
+
+#if @diffuseMap
+    gl_FragData[0] = texture2D(diffuseMap, adjustedDiffuseUV);
+#else
+    gl_FragData[0] = vec4(1.0);
+#endif
+
+    float shadowing = unshadowedLightRatio(linearDepth);
+    if (euclideanDepth > @grassFadeStart)
+        gl_FragData[0].a *= 1.0-smoothstep(@grassFadeStart, @grassFadeEnd, euclideanDepth);
+
+#if !@forcePPL
+
+#if @clamp
+    gl_FragData[0] *= clamp(lighting + vec4(shadowDiffuseLighting * shadowing, 0), vec4(0.0), vec4(1.0));
+#else
+    gl_FragData[0] *= lighting + vec4(shadowDiffuseLighting * shadowing, 0);
+#endif
+
+#else
+    if(gl_FragData[0].a != 0.0)
+        gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, true);
+#endif
+
+    float shininess = gl_FrontMaterial.shininess;
+    vec3 matSpec;
+    if (colorMode == ColorMode_Specular)
+        matSpec = passColor.xyz;
+    else
+        matSpec = gl_FrontMaterial.specular.xyz;
+
+    if (matSpec != vec3(0.0))
+    {
+#if !@forcePPL
+        vec3 viewNormal = gl_NormalMatrix * normalize(passNormal);
+#endif
+        gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;
+    }
+#if @radialFog
+    float fogValue = clamp((euclideanDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
+#else
+    float fogValue = clamp((linearDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
+#endif
+    gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
+
+    applyShadowDebugOverlay();
+}

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -57,7 +57,9 @@ vec2 grassDisplacement(vec4 worldpos, float h)
 
     float d = length(worldpos.xy - FootPos.xy);
     vec2 stomp = vec2(0.0);
-    if(d < 150.0) stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
+    if (d < 150.0 && d > 0)
+        stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
+
     return clamp(0.02 * h, 0.0, 1.0) * (harmonics * displace + stomp);
 }
 

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -54,13 +54,11 @@ vec2 grassDisplacement(vec4 worldpos, float h)
     if(d < 150.0) stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
     return clamp(0.004 * h, 0.0, 1.0) * (harmonics * displace + stomp);
 }
-#endif
 
 void main(void)
 {
-    vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);
+    vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
 
-#if @grassAnimation
     vec4 displacedVertex = gl_Vertex;
     vec4 worldPos = osg_ViewMatrixInverse * vec4(viewPos.xyz, 1.0);
     float height = 1.0-(gl_ModelViewMatrix[0].z-gl_Vertex.z);
@@ -68,8 +66,12 @@ void main(void)
     vec2 grassVertex = min(vec2(10.0), displ);
 
     displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);
-    gl_Position = (gl_ModelViewProjectionMatrix * displacedVertex);
+    gl_Position = gl_ModelViewProjectionMatrix * displacedVertex;
 #else
+
+void main(void)
+{
+    vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
 #endif
 

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -30,6 +30,7 @@ uniform float osg_SimulationTime;
 uniform mat4 osg_ViewMatrixInverse;
 uniform float windSpeed;
 uniform float Rotz;
+uniform vec3 playerPos;
 
 vec2 rotate(vec2 v, float a)
 {
@@ -42,7 +43,7 @@ vec2 rotate(vec2 v, float a)
 vec2 grassDisplacement(vec4 worldpos, float h)
 {
     vec2 windDirection = vec2(1.0);
-    vec3 FootPos = osg_ViewMatrixInverse[3].xyz;
+    vec3 FootPos = playerPos;
     vec3 WindVec = vec3(windSpeed * windDirection, 1.0);
 
     float v = length(WindVec);

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -55,12 +55,12 @@ vec2 grassDisplacement(vec4 worldpos, float h)
     harmonics += vec2((1.0 + 0.14*v) * sin(3.0*osg_SimulationTime + worldpos.xy / 500.0));
     harmonics += vec2((1.0 + 0.28*v) * sin(5.0*osg_SimulationTime + worldpos.xy / 200.0));
 
-    float d = length(worldpos.xy - FootPos.xy);
-    vec2 stomp = vec2(0.0);
+    float d = length(worldpos.xyz - FootPos.xyz);
+    vec3 stomp = vec3(0.0);
     if (d < 150.0 && d > 0)
-        stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
+        stomp = (60.0 / d - 0.4) * (worldpos.xyz - FootPos.xyz);
 
-    return clamp(0.02 * h, 0.0, 1.0) * (harmonics * displace + stomp);
+    return clamp(0.02 * h, 0.0, 1.0) * (harmonics * displace + stomp.xy);
 }
 
 void main(void)

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -1,0 +1,98 @@
+#version 120
+
+#if @diffuseMap
+varying vec2 diffuseMapUV;
+#endif
+
+#define PER_PIXEL_LIGHTING @forcePPL
+
+varying float euclideanDepth;
+varying float linearDepth;
+
+#if !@forcePPL
+centroid varying vec4 lighting;
+centroid varying vec3 shadowDiffuseLighting;
+#endif
+centroid varying vec4 passColor;
+varying vec3 passViewPos;
+varying vec3 passNormal;
+
+#include "shadows_vertex.glsl"
+#include "lighting.glsl"
+
+#if @grassAnimation
+uniform float osg_SimulationTime;
+uniform mat4 osg_ViewMatrixInverse;
+uniform float windSpeed;
+uniform float Rotz;
+
+vec2 rotate(vec2 v, float a)
+{
+    float s = sin(a);
+    float c = cos(a);
+    mat2 m = mat2(c, -s, s, c);
+    return m * v;
+}
+
+vec2 grassDisplacement(vec4 worldpos, float h)
+{
+    vec2 windDirection = vec2(1.0);
+    vec3 FootPos = osg_ViewMatrixInverse[3].xyz;
+    vec3 WindVec = vec3(windSpeed * windDirection, 1.0);
+
+    float v = length(WindVec);
+    vec2 displace = vec2(2.0 * WindVec + 0.1);
+    vec2 harmonics = vec2(0.0);
+
+    harmonics += vec2((1.0 - 0.10*v) * sin(1.0*osg_SimulationTime + worldpos.xy / 1100.0));
+    harmonics += vec2((1.0 - 0.04*v) * cos(2.0*osg_SimulationTime + worldpos.xy / 750.0));
+    harmonics += vec2((1.0 + 0.14*v) * sin(3.0*osg_SimulationTime + worldpos.xy / 500.0));
+    harmonics += vec2((1.0 + 0.28*v) * sin(5.0*osg_SimulationTime + worldpos.xy / 200.0));
+
+    float d = length(worldpos.xy - FootPos.xy);
+    vec2 stomp = vec2(0.0);
+    if(d < 150.0) stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
+    return clamp(0.004 * h, 0.0, 1.0) * (harmonics * displace + stomp);
+}
+#endif
+
+void main(void)
+{
+    vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);
+
+#if @grassAnimation
+    vec4 displacedVertex = gl_Vertex;
+    vec4 worldPos = osg_ViewMatrixInverse * vec4(viewPos.xyz, 1.0);
+    float height = 1.0-(gl_ModelViewMatrix[0].z-gl_Vertex.z);
+    vec2 displ = grassDisplacement(worldPos, height);
+    vec2 grassVertex = min(vec2(10.0), displ);
+
+    displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);
+    gl_Position = (gl_ModelViewProjectionMatrix * displacedVertex);
+#else
+    gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+#endif
+
+    gl_ClipVertex = viewPos;
+    euclideanDepth = length(viewPos.xyz);
+    linearDepth = gl_Position.z;
+
+#if (!@forcePPL || @shadows_enabled)
+    vec3 viewNormal = normalize((gl_NormalMatrix * gl_Normal).xyz);
+#endif
+
+#if @diffuseMap
+    diffuseMapUV = (gl_TextureMatrix[@diffuseMapUV] * gl_MultiTexCoord@diffuseMapUV).xy;
+#endif
+
+#if !@forcePPL
+    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting, true);
+#endif
+    passColor = gl_Color;
+    passViewPos = viewPos.xyz;
+    passNormal = gl_Normal.xyz;
+
+#if (@shadows_enabled)
+    setupShadowCoords(viewPos, viewNormal);
+#endif
+}

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -57,7 +57,7 @@ vec2 grassDisplacement(vec4 worldpos, float h)
     float d = length(worldpos.xy - FootPos.xy);
     vec2 stomp = vec2(0.0);
     if(d < 150.0) stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
-    return clamp(0.004 * h, 0.0, 1.0) * (harmonics * displace + stomp);
+    return clamp(0.02 * h, 0.0, 1.0) * (harmonics * displace + stomp);
 }
 
 void main(void)
@@ -66,8 +66,7 @@ void main(void)
 
     vec4 displacedVertex = gl_Vertex;
     vec4 worldPos = osg_ViewMatrixInverse * vec4(viewPos.xyz, 1.0);
-    float height = 1.0-(gl_ModelViewMatrix[0].z-gl_Vertex.z);
-    vec2 displ = grassDisplacement(worldPos, height);
+    vec2 displ = grassDisplacement(worldPos, gl_Vertex.z);
     vec2 grassVertex = min(vec2(10.0), displ);
 
     displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -4,12 +4,17 @@
 varying vec2 diffuseMapUV;
 #endif
 
-#define PER_PIXEL_LIGHTING @forcePPL
+#if @normalMap
+varying vec2 normalMapUV;
+varying vec4 passTangent;
+#endif
+
+#define PER_PIXEL_LIGHTING (@normalMap || @forcePPL)
 
 varying float euclideanDepth;
 varying float linearDepth;
 
-#if !@forcePPL
+#if !PER_PIXEL_LIGHTING
 centroid varying vec4 lighting;
 centroid varying vec3 shadowDiffuseLighting;
 #endif
@@ -79,7 +84,7 @@ void main(void)
     euclideanDepth = length(viewPos.xyz);
     linearDepth = gl_Position.z;
 
-#if (!@forcePPL || @shadows_enabled)
+#if (!PER_PIXEL_LIGHTING || @shadows_enabled)
     vec3 viewNormal = normalize((gl_NormalMatrix * gl_Normal).xyz);
 #endif
 
@@ -87,7 +92,12 @@ void main(void)
     diffuseMapUV = (gl_TextureMatrix[@diffuseMapUV] * gl_MultiTexCoord@diffuseMapUV).xy;
 #endif
 
-#if !@forcePPL
+#if @normalMap
+    normalMapUV = (gl_TextureMatrix[@normalMapUV] * gl_MultiTexCoord@normalMapUV).xy;
+    passTangent = gl_MultiTexCoord7.xyzw;
+#endif
+
+#if !PER_PIXEL_LIGHTING
     lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting, true);
 #endif
     passColor = gl_Color;

--- a/files/shaders/grass_vertex.glsl
+++ b/files/shaders/grass_vertex.glsl
@@ -69,8 +69,7 @@ void main(void)
 
     vec4 displacedVertex = gl_Vertex;
     vec4 worldPos = osg_ViewMatrixInverse * vec4(viewPos.xyz, 1.0);
-    vec2 displ = grassDisplacement(worldPos, gl_Vertex.z);
-    vec2 grassVertex = min(vec2(10.0), displ);
+    vec2 grassVertex = grassDisplacement(worldPos, gl_Vertex.z);
 
     displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);
     gl_Position = gl_ModelViewProjectionMatrix * displacedVertex;

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -153,6 +153,11 @@ void main()
 #endif
 
     float shadowing = unshadowedLightRatio(linearDepth);
+    if (isGrass)
+    {
+        if (euclideanDepth > @grassFadeStart)
+            gl_FragData[0].a *= 1.0-smoothstep(@grassFadeStart, @grassFadeEnd, euclideanDepth);
+    }
 
 #if !PER_PIXEL_LIGHTING
 
@@ -163,7 +168,8 @@ void main()
 #endif
 
 #else
-    gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, isGrass);
+    if(gl_FragData[0].a != 0.0)
+        gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, isGrass);
 #endif
 
 #if @envMap && !@preLightEnv
@@ -208,10 +214,4 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
     applyShadowDebugOverlay();
-
-    if (isGrass)
-    {
-        if (euclideanDepth > @grassFadeStart)
-            gl_FragData[0].a *= 1.0-smoothstep(@grassFadeStart, @grassFadeEnd, euclideanDepth);
-    }
 }

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -51,8 +51,6 @@ uniform mat2 bumpMapMatrix;
 
 uniform bool simpleWater;
 
-uniform bool isGrass;
-
 varying float euclideanDepth;
 varying float linearDepth;
 
@@ -153,11 +151,6 @@ void main()
 #endif
 
     float shadowing = unshadowedLightRatio(linearDepth);
-    if (isGrass)
-    {
-        if (euclideanDepth > @grassFadeStart)
-            gl_FragData[0].a *= 1.0-smoothstep(@grassFadeStart, @grassFadeEnd, euclideanDepth);
-    }
 
 #if !PER_PIXEL_LIGHTING
 
@@ -168,8 +161,7 @@ void main()
 #endif
 
 #else
-    if(gl_FragData[0].a != 0.0)
-        gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, isGrass);
+    gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, false);
 #endif
 
 #if @envMap && !@preLightEnv

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -163,7 +163,7 @@ void main()
 #endif
 
 #else
-    gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing);
+    gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, isGrass);
 #endif
 
 #if @envMap && !@preLightEnv

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -51,6 +51,10 @@ uniform mat2 bumpMapMatrix;
 
 uniform bool simpleWater;
 
+#if @grassAnimation
+uniform bool isGrass;
+#endif
+
 varying float euclideanDepth;
 varying float linearDepth;
 
@@ -206,4 +210,10 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
     applyShadowDebugOverlay();
+
+    if (isGrass)
+    {
+        if (euclideanDepth > @grassFadeStart)
+            gl_FragData[0].a *= 1.0-smoothstep(@grassFadeStart, @grassFadeEnd, euclideanDepth);
+    }
 }

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -51,9 +51,7 @@ uniform mat2 bumpMapMatrix;
 
 uniform bool simpleWater;
 
-#if @grassAnimation
 uniform bool isGrass;
-#endif
 
 varying float euclideanDepth;
 varying float linearDepth;

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -54,65 +54,11 @@ varying vec3 passNormal;
 
 #include "lighting.glsl"
 
-uniform bool isGrass;
-
-#if @grassAnimation
-uniform float osg_SimulationTime;
-uniform mat4 osg_ViewMatrixInverse;
-uniform float windSpeed;
-uniform float Rotz;
-
-vec2 rotate(vec2 v, float a)
-{
-    float s = sin(a);
-    float c = cos(a);
-    mat2 m = mat2(c, -s, s, c);
-    return m * v;
-}
-
-vec2 grassDisplacement(vec4 worldpos, float h)
-{
-    vec2 windDirection = vec2(1.0);
-    vec3 FootPos = osg_ViewMatrixInverse[3].xyz;
-    vec3 WindVec = vec3(windSpeed * windDirection, 1.0);
-
-    float v = length(WindVec);
-    vec2 displace = vec2(2.0 * WindVec + 0.1);
-    vec2 harmonics = vec2(0.0);
-
-    harmonics += vec2((1.0 - 0.10*v) * sin(1.0*osg_SimulationTime + worldpos.xy / 1100.0));
-    harmonics += vec2((1.0 - 0.04*v) * cos(2.0*osg_SimulationTime + worldpos.xy / 750.0));
-    harmonics += vec2((1.0 + 0.14*v) * sin(3.0*osg_SimulationTime + worldpos.xy / 500.0));
-    harmonics += vec2((1.0 + 0.28*v) * sin(5.0*osg_SimulationTime + worldpos.xy / 200.0));
-
-    float d = length(worldpos.xy - FootPos.xy);
-    vec2 stomp = vec2(0.0);
-    if(d < 150.0) stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
-    return clamp(0.004 * h, 0.0, 1.0) * (harmonics * displace + stomp);
-}
-#endif
-
 void main(void)
 {
-    vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);
-
-#if @grassAnimation
-if(isGrass)
-{
-    vec4 displacedVertex = gl_Vertex;
-    vec4 worldPos = osg_ViewMatrixInverse * vec4(viewPos.xyz, 1.0);
-    float height = 1.0-(gl_ModelViewMatrix[0].z-gl_Vertex.z);
-    vec2 displ = grassDisplacement(worldPos, height);
-    vec2 grassVertex = min(vec2(10.0), displ);
-
-    displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);
-    gl_Position = (gl_ModelViewProjectionMatrix * displacedVertex);
-}
-else
-#endif
-
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
 
+    vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);
     gl_ClipVertex = viewPos;
     euclideanDepth = length(viewPos.xyz);
     linearDepth = gl_Position.z;
@@ -162,7 +108,7 @@ else
 #endif
 
 #if !PER_PIXEL_LIGHTING
-    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting, isGrass);
+    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting, false);
 #endif
     passColor = gl_Color;
     passViewPos = viewPos.xyz;

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -54,7 +54,6 @@ varying vec3 passNormal;
 
 #include "lighting.glsl"
 
-
 #if @grassAnimation
 uniform float osg_SimulationTime;
 uniform mat4 osg_ViewMatrixInverse;

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -54,10 +54,11 @@ varying vec3 passNormal;
 
 #include "lighting.glsl"
 
+uniform bool isGrass;
+
 #if @grassAnimation
 uniform float osg_SimulationTime;
 uniform mat4 osg_ViewMatrixInverse;
-uniform bool isGrass;
 uniform float windSpeed;
 uniform float Rotz;
 
@@ -161,7 +162,7 @@ else
 #endif
 
 #if !PER_PIXEL_LIGHTING
-    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting);
+    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting, isGrass);
 #endif
     passColor = gl_Color;
     passViewPos = viewPos.xyz;

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -72,7 +72,7 @@ vec2 rotate(vec2 v, float a)
 
 vec2 grassDisplacement(vec4 worldpos, float h)
 {
-    float windSpeed = WindDirection.z * 2.0;
+    float windSpeed = WindDirection.z * 4.0;
     vec2 windDirection = (WindDirection.xy == vec2(0.0)) ? vec2(1.0) : WindDirection.xy;
 
     vec3 FootPos = osg_ViewMatrixInverse[3].xyz;

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -59,7 +59,7 @@ varying vec3 passNormal;
 uniform float osg_SimulationTime;
 uniform mat4 osg_ViewMatrixInverse;
 uniform bool isGrass;
-uniform vec3 WindDirection;
+uniform float windSpeed;
 uniform float Rotz;
 
 vec2 rotate(vec2 v, float a)
@@ -72,9 +72,7 @@ vec2 rotate(vec2 v, float a)
 
 vec2 grassDisplacement(vec4 worldpos, float h)
 {
-    float windSpeed = WindDirection.z * 4.0;
-    vec2 windDirection = (WindDirection.xy == vec2(0.0)) ? vec2(1.0) : WindDirection.xy;
-
+    vec2 windDirection = vec2(1.0);
     vec3 FootPos = osg_ViewMatrixInverse[3].xyz;
     vec3 WindVec = vec3(windSpeed * windDirection, 1.0);
 
@@ -82,10 +80,10 @@ vec2 grassDisplacement(vec4 worldpos, float h)
     vec2 displace = vec2(2.0 * WindVec + 0.1);
     vec2 harmonics = vec2(0.0);
 
-    harmonics += vec2((1.0 - 0.10*v) * sin(1.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 1100.0));
-    harmonics += vec2((1.0 - 0.04*v) * cos(2.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 750.0));
-    harmonics += vec2((1.0 + 0.14*v) * sin(3.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 500.0));
-    harmonics += vec2((1.0 + 0.28*v) * sin(5.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 200.0));
+    harmonics += vec2((1.0 - 0.10*v) * sin(1.0*osg_SimulationTime + worldpos.xy / 1100.0));
+    harmonics += vec2((1.0 - 0.04*v) * cos(2.0*osg_SimulationTime + worldpos.xy / 750.0));
+    harmonics += vec2((1.0 + 0.14*v) * sin(3.0*osg_SimulationTime + worldpos.xy / 500.0));
+    harmonics += vec2((1.0 + 0.28*v) * sin(5.0*osg_SimulationTime + worldpos.xy / 200.0));
 
     float d = length(worldpos.xy - FootPos.xy);
     vec2 stomp = vec2(0.0);
@@ -106,12 +104,6 @@ if(isGrass)
     float height = 1.0-(gl_ModelViewMatrix[0].z-gl_Vertex.z);
     vec2 displ = grassDisplacement(worldPos, height);
     vec2 grassVertex = min(vec2(10.0), displ);
-
-    if(WindDirection.xy != vec2(0.0))
-    {
-        grassVertex.xy += height*(WindDirection.xy);
-        displacedVertex.z -= 0.3 * length(displ.xy);
-    }
 
     displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);
     gl_Position = (gl_ModelViewProjectionMatrix * displacedVertex);

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -54,11 +54,73 @@ varying vec3 passNormal;
 
 #include "lighting.glsl"
 
+
+#if @grassAnimation
+uniform float osg_SimulationTime;
+uniform mat4 osg_ViewMatrixInverse;
+uniform bool isGrass;
+uniform vec3 WindDirection;
+uniform float Rotz;
+
+vec2 rotate(vec2 v, float a)
+{
+    float s = sin(a);
+    float c = cos(a);
+    mat2 m = mat2(c, -s, s, c);
+    return m * v;
+}
+
+vec2 grassDisplacement(vec4 worldpos, float h)
+{
+    float windSpeed = WindDirection.z * 2.0;
+    vec2 windDirection = (WindDirection.xy == vec2(0.0)) ? vec2(1.0) : WindDirection.xy;
+
+    vec3 FootPos = osg_ViewMatrixInverse[3].xyz;
+    vec3 WindVec = vec3(windSpeed * windDirection, 1.0);
+
+    float v = length(WindVec);
+    vec2 displace = vec2(2.0 * WindVec + 0.1);
+    vec2 harmonics = vec2(0.0);
+
+    harmonics += vec2((1.0 - 0.10*v) * sin(1.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 1100.0));
+    harmonics += vec2((1.0 - 0.04*v) * cos(2.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 750.0));
+    harmonics += vec2((1.0 + 0.14*v) * sin(3.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 500.0));
+    harmonics += vec2((1.0 + 0.28*v) * sin(5.0*osg_SimulationTime + (h*WindDirection.xy) + worldpos.xy / 200.0));
+
+    float d = length(worldpos.xy - FootPos.xy);
+    vec2 stomp = vec2(0.0);
+    if(d < 150.0) stomp = (60.0 / d - 0.4) * (worldpos.xy - FootPos.xy);
+    return clamp(0.004 * h, 0.0, 1.0) * (harmonics * displace + stomp);
+}
+#endif
+
 void main(void)
 {
+    vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);
+
+#if @grassAnimation
+if(isGrass)
+{
+    vec4 displacedVertex = gl_Vertex;
+    vec4 worldPos = osg_ViewMatrixInverse * vec4(viewPos.xyz, 1.0);
+    float height = 1.0-(gl_ModelViewMatrix[0].z-gl_Vertex.z);
+    vec2 displ = grassDisplacement(worldPos, height);
+    vec2 grassVertex = min(vec2(10.0), displ);
+
+    if(WindDirection.xy != vec2(0.0))
+    {
+        grassVertex.xy += height*(WindDirection.xy);
+        displacedVertex.z -= 0.3 * length(displ.xy);
+    }
+
+    displacedVertex.xy += rotate(grassVertex.xy, -1.0*Rotz);
+    gl_Position = (gl_ModelViewProjectionMatrix * displacedVertex);
+}
+else
+#endif
+
     gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
 
-    vec4 viewPos = (gl_ModelViewMatrix * gl_Vertex);
     gl_ClipVertex = viewPos;
     euclideanDepth = length(viewPos.xyz);
     linearDepth = gl_Position.z;

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -79,7 +79,7 @@ void main()
 #endif
 
 #else
-    gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing);
+    gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing, false);
 #endif
 
 #if @specularMap

--- a/files/shaders/terrain_vertex.glsl
+++ b/files/shaders/terrain_vertex.glsl
@@ -32,7 +32,7 @@ void main(void)
 #endif
 
 #if !PER_PIXEL_LIGHTING
-    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting);
+    lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting, false);
 #endif
     passColor = gl_Color;
     passNormal = gl_Normal.xyz;


### PR DESCRIPTION
This PR handles grass objects from enabled plugins separately from other objects.

Also there is an [another](https://github.com/akortunov/openmw/tree/grass_paging) implementation, which is based on ObjectPaging (unfortunately, grass animations do not work).

Summary of changes:
1. Attach grass nodes directly to cell node, without creating a cellref and animation object just for every grass shape. As a result, grass almost does not affect cell loading speed, does not have collisions and does not block objects (e.g. corpses).
2. Use a separate mask for grass nodes, so grass objects do not cast shadows (but still receive them) and do not present in reflections. It allows to use grass when shadows and/or object reflections are enabled.
3. Implemented a grass density setting. A density algorithm is deterministic, so the grass should be in the same place every time when the same density is used.
4. Implemented a grass rendering distance setting. Grass objects near rendering border fade away. Allows to increase performance and avoid pop-ins. Requires an AlphaProperty for groundcover objects.
5. Grass is animated via separate shader - it takes in account wind speed from openmw.cfg and player's position to emulate stomping.

It is recommended to test this PR with the [Aesthesia Groundcover](https://www.nexusmods.com/morrowind/mods/46377?tab=files).

An example of settings:

```
[Grass]
enabled = true
fade start = 0.75
density = 0.3
distance = 6144
animation = true
```

Known limitations:
1. There is no batching system, so large grass density still significally increases CPU loading and may lead to noticable performance drops on Draw-limited setups.
2. MGE uses custom lighting shaders (some grass replacers even use custom shaders), so some MGE-specific grass mods may do not work as intended. 
3. Some mods may add groundcover objects, which are not supposed to be animated (stones, mushrooms, etc). Such objects also have no alpha property, so fading does not work for them too.
4. Grass is rendered/animated only for active grid.

![Screenshot_20200112_230045](https://user-images.githubusercontent.com/26434804/72224130-1ad5bf80-3590-11ea-9a61-43e3d6471a58.png)

The main question - can we use such system, or our current approach is to do nothing and wait until a skilled OpenGL developer implements a procedure-generated grass for us for free?
