### PR TITLE
Editor: Add a reset to defaults button to keybindings (feature #4068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@
     Feature #3980: In-game option to disable controller
     Feature #3999: Shift + Double Click should maximize/restore menu size
     Feature #4001: Toggle sneak controller shortcut
+    Feature #4068: OpenMW-CS: Add a button to reset key bindings to defaults
     Feature #4129: Beta Comment to File
     Feature #4209: Editor: Faction rank sub-table
     Feature #4255: Handle broken RepairedOnMe script function

--- a/apps/opencs/view/prefs/keybindingpage.cpp
+++ b/apps/opencs/view/prefs/keybindingpage.cpp
@@ -4,11 +4,13 @@
 
 #include <QComboBox>
 #include <QGridLayout>
+#include <QPushButton>
 #include <QStackedLayout>
 #include <QVBoxLayout>
 
 #include "../../model/prefs/setting.hpp"
 #include "../../model/prefs/category.hpp"
+#include "../../model/prefs/state.hpp"
 
 namespace CSVPrefs
 {
@@ -29,8 +31,18 @@ namespace CSVPrefs
         mPageSelector = new QComboBox();
         connect(mPageSelector, SIGNAL(currentIndexChanged(int)), mStackedLayout, SLOT(setCurrentIndex(int)));
 
+        QFrame* lineSeparator = new QFrame(topWidget);
+        lineSeparator->setFrameShape(QFrame::HLine);
+        lineSeparator->setFrameShadow(QFrame::Sunken);
+
+        // Reset key bindings button
+        QPushButton* resetButton = new QPushButton ("Reset to Defaults", topWidget);
+        connect(resetButton, SIGNAL(clicked()), this, SLOT(resetKeyBindings()));
+
         topLayout->addWidget(mPageSelector);
         topLayout->addWidget(stackedWidget);
+        topLayout->addWidget(lineSeparator);
+        topLayout->addWidget(resetButton);
         topLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
 
         // Add each option
@@ -84,5 +96,10 @@ namespace CSVPrefs
                 mPageSelector->addItem(QString::fromUtf8(setting->getLabel().c_str()));
             }
         }
+    }
+
+    void KeyBindingPage::resetKeyBindings()
+    {
+        CSMPrefs::State::get().resetCategory("Key Bindings");
     }
 }

--- a/apps/opencs/view/prefs/keybindingpage.hpp
+++ b/apps/opencs/view/prefs/keybindingpage.hpp
@@ -29,6 +29,10 @@ namespace CSVPrefs
             QStackedLayout* mStackedLayout;
             QGridLayout* mPageLayout;
             QComboBox* mPageSelector;
+
+        private slots:
+
+            void resetKeyBindings();
     };
 }
 


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/issues/4068)

It's just a wrapper over the global reset category thing specific to key bindings page and looks the same as in Thunderforge's original proposition.
![keybindings](https://user-images.githubusercontent.com/21265616/72227337-554d5580-35ac-11ea-8a51-ddd041aff436.png)

So it resets all key bindings to defaults when clicked.