### PR TITLE
Add an infinite fall failsafe (feature 1415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@
     Bug #5261: Creatures can sometimes become stuck playing idles and never wander again
     Bug #5269: Editor: Cell lighting in resaved cleaned content files is corrupted
     Bug #5278: Console command Show doesn't fall back to global variable after local var not found
+    Feature #1415: Infinite fall failsafe
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwworld/scene.hpp
+++ b/apps/openmw/mwworld/scene.hpp
@@ -84,6 +84,7 @@ namespace MWWorld
             float mPredictionTime;
 
             osg::Vec3f mLastPlayerPos;
+            float mLowestPos;
 
             void insertCell (CellStore &cell, Loading::Listener* loadingListener, bool test = false);
 


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/issues/1415)

It's a bit more simple. Into the visitor that adjusts the position of every object in the cell that has just been loaded (inserted into the scene) I've added a lowest position field that is filled with the lowest position of a non-actor object inserted into the cell. When the player moves to a new position while being in an interior cell, their new vertical position is compared with that minimal position and if it's sufficiently low the player is attempted to be teleported to the destination used for CenterOnCell (note that sometimes it's not a position that has a valid surface underneath, e.g. in Census and Excise office).

Typically the position of an object is in the basement of its bounding box, so it should be a good enough fast approximation of the original behavior which would have required particle system-less bounding boxes to be computed for everything which most likely isn't really that performance-friendly.