### PR TITLE
Make GetTarget return 1 during actor greeting (bug #5255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@
     Bug #5242: ExplodeSpell behavior differs from Cast behavior
     Bug #5249: Wandering NPCs start walking too soon after they hello
     Bug #5250: Creatures display shield ground mesh instead of shield body part
+    Bug #5255: "GetTarget, player" doesn't return 1 during NPC hello
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -25,6 +25,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+#include "../mwbase/soundmanager.hpp"
 
 #include "interpretercontext.hpp"
 #include "ref.hpp"
@@ -434,6 +435,14 @@ namespace MWScript
                     {
                         if (!targetPtr.isEmpty() && targetPtr.getCellRef().getRefId() == testedTargetId)
                             targetsAreEqual = true;
+                    }
+                    else
+                    {
+                        bool turningToPlayer = creatureStats.isTurningToPlayer();
+                        bool greeting = creatureStats.getGreetingState() == MWMechanics::Greet_InProgress;
+                        bool sayActive = MWBase::Environment::get().getSoundManager()->sayActive(actor);
+                        if (turningToPlayer || (greeting && sayActive))
+                            targetsAreEqual = (testedTargetId == "player"); // Currently the player ID is hardcoded
                     }
                     runtime.push(int(targetsAreEqual));
                 }


### PR DESCRIPTION
GetTarget will return 1 if: the actor is not in combat, and
1) the actor is turning towards the player to greet the player, or
2) the actor is greeting the player and the greeting is still playing

Based on [the report](https://gitlab.com/OpenMW/openmw/issues/5255) it doesn't seem like Morrowind behavior is consistent enough to warrant a precise reimplementation.