### PR TITLE
Fix AiWander stuck (bug #5237)

### DIFF
--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -197,7 +197,8 @@ bool MWMechanics::AiPackage::pathTo(const MWWorld::Ptr& actor, const osg::Vec3f&
     zTurn(actor, mPathFinder.getZAngleToNext(position.x(), position.y()));
     smoothTurn(actor, mPathFinder.getXAngleToNext(position.x(), position.y(), position.z()), 0);
 
-    mObstacleCheck.update(actor, duration);
+    const auto destination = mPathFinder.getPath().empty() ? dest : mPathFinder.getPath().front();
+    mObstacleCheck.update(actor, destination, duration);
 
     // handle obstacles on the way
     evadeObstacles(actor);

--- a/apps/openmw/mwmechanics/obstacle.cpp
+++ b/apps/openmw/mwmechanics/obstacle.cpp
@@ -77,89 +77,94 @@ namespace MWMechanics
     }
 
     ObstacleCheck::ObstacleCheck()
-      : mWalkState(State_Norm)
-      , mStuckDuration(0)
-      , mEvadeDuration(0)
-      , mDistSameSpot(-1) // avoid calculating it each time
+      : mWalkState(WalkState::Initial)
+      , mStateDuration(0)
       , mEvadeDirectionIndex(0)
     {
     }
 
     void ObstacleCheck::clear()
     {
-        mWalkState = State_Norm;
-        mStuckDuration = 0;
-        mEvadeDuration = 0;
+        mWalkState = WalkState::Initial;
     }
 
     bool ObstacleCheck::isEvading() const
     {
-        return mWalkState == State_Evade;
+        return mWalkState == WalkState::Evade;
     }
 
     /*
      * input   - actor, duration (time since last check)
      * output  - true if evasive action needs to be taken
      *
-     *  Walking state transitions (player greeting check not shown):
+     * Walking state transitions (player greeting check not shown):
      *
-     *  MoveNow <------------------------------------+
-     *    |                                         d|
-     *    |                                          |
-     *    +-> State_Norm <---> State_CheckStuck --> State_Evade
-     *         ^  ^   |    f      ^   |         t    ^   |  |
-     *         |  |   |           |   |              |   |  |
-     *         |  +---+           +---+              +---+  | u
-     *         |   any             < t                < u   |
-     *         +--------------------------------------------+
+     * Initial ----> Norm  <--------> CheckStuck -------> Evade ---+
+     *               ^ ^ | f             ^   |       t    ^   |    |
+     *               | | |               |   |            |   |    |
+     *               | +-+               +---+            +---+    | u
+     *               | any                < t              < u     |
+     *               +---------------------------------------------+
      *
      * f = one reaction time
-     * d = proximity to a closed door
      * t = how long before considered stuck
      * u = how long to move sideways
      *
      */
-    void ObstacleCheck::update(const MWWorld::Ptr& actor, float duration)
+    void ObstacleCheck::update(const MWWorld::Ptr& actor, const osg::Vec3f& destination, float duration)
     {
-        const osg::Vec3f pos = actor.getRefData().getPosition().asVec3();
+        const auto position = actor.getRefData().getPosition().asVec3();
 
-        if (mDistSameSpot == -1)
-            mDistSameSpot = DIST_SAME_SPOT * actor.getClass().getSpeed(actor);
-
-        const float distSameSpot = mDistSameSpot * duration;
-        const bool samePosition = (pos - mPrev).length2() < distSameSpot * distSameSpot;
-
-        mPrev = pos;
-
-        if (mWalkState != State_Evade)
+        if (mWalkState == WalkState::Initial)
         {
-            if(!samePosition)
+            mWalkState = WalkState::Norm;
+            mStateDuration = 0;
+            mPrev = position;
+            return;
+        }
+
+        if (mWalkState != WalkState::Evade)
+        {
+            const float distSameSpot = DIST_SAME_SPOT * actor.getClass().getSpeed(actor) * duration;
+            const float prevDistance = (destination - mPrev).length();
+            const float currentDistance = (destination - position).length();
+            const float movedDistance = prevDistance - currentDistance;
+
+            mPrev = position;
+
+            if (movedDistance >= distSameSpot)
             {
-                mWalkState = State_Norm;
-                mStuckDuration = 0;
-                mEvadeDuration = 0;
+                mWalkState = WalkState::Norm;
+                mStateDuration = 0;
                 return;
             }
 
-            mWalkState = State_CheckStuck;
-            mStuckDuration += duration;
-            // consider stuck only if position unchanges for a period
-            if(mStuckDuration < DURATION_SAME_SPOT)
-                return; // still checking, note duration added to timer
-            else
+            if (mWalkState == WalkState::Norm)
             {
-                mStuckDuration = 0;
-                mWalkState = State_Evade;
-                chooseEvasionDirection();
+                mWalkState = WalkState::CheckStuck;
+                mStateDuration = duration;
+                return;
             }
+
+            mStateDuration += duration;
+            if (mStateDuration < DURATION_SAME_SPOT)
+            {
+                return;
+            }
+
+            mWalkState = WalkState::Evade;
+            mStateDuration = 0;
+            chooseEvasionDirection();
+            return;
         }
 
-        mEvadeDuration += duration;
-        if(mEvadeDuration >= DURATION_TO_EVADE)
+        mStateDuration += duration;
+        if(mStateDuration >= DURATION_TO_EVADE)
         {
             // tried to evade, assume all is ok and start again
-            mWalkState = State_Norm;
-            mEvadeDuration = 0;
+            mWalkState = WalkState::Norm;
+            mStateDuration = 0;
+            mPrev = position;
         }
     }
 

--- a/apps/openmw/mwmechanics/obstacle.hpp
+++ b/apps/openmw/mwmechanics/obstacle.hpp
@@ -32,30 +32,27 @@ namespace MWMechanics
             bool isEvading() const;
 
             // Updates internal state, call each frame for moving actor
-            void update(const MWWorld::Ptr& actor, float duration);
+            void update(const MWWorld::Ptr& actor, const osg::Vec3f& destination, float duration);
 
             // change direction to try to fix "stuck" actor
             void takeEvasiveAction(MWMechanics::Movement& actorMovement) const;
 
         private:
-
-            // for checking if we're stuck
             osg::Vec3f mPrev;
 
             // directions to try moving in when get stuck
             static const float evadeDirections[NUM_EVADE_DIRECTIONS][2];
 
-            enum WalkState
+            enum class WalkState
             {
-                State_Norm,
-                State_CheckStuck,
-                State_Evade
+                Initial,
+                Norm,
+                CheckStuck,
+                Evade
             };
             WalkState mWalkState;
 
-            float mStuckDuration; // accumulate time here while in same spot
-            float mEvadeDuration;
-            float mDistSameSpot; // take account of actor's speed
+            float mStateDuration;
             int mEvadeDirectionIndex;
 
             void chooseEvasionDirection();

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -172,6 +172,8 @@ add_component_dir(detournavigator
     recastmeshobject
     navmeshtilescache
     settings
+    navigator
+    findrandompointaroundcircle
     )
 
 set (ESM_UI ${CMAKE_SOURCE_DIR}/files/ui/contentselector.ui

--- a/components/detournavigator/findrandompointaroundcircle.cpp
+++ b/components/detournavigator/findrandompointaroundcircle.cpp
@@ -1,0 +1,45 @@
+#include "findrandompointaroundcircle.hpp"
+#include "settings.hpp"
+#include "findsmoothpath.hpp"
+
+#include <components/misc/rng.hpp>
+
+#include <DetourCommon.h>
+#include <DetourNavMesh.h>
+#include <DetourNavMeshQuery.h>
+
+namespace DetourNavigator
+{
+    boost::optional<osg::Vec3f> findRandomPointAroundCircle(const dtNavMesh& navMesh, const osg::Vec3f& halfExtents,
+        const osg::Vec3f& start, const float maxRadius, const Flags includeFlags, const Settings& settings)
+    {
+        dtNavMeshQuery navMeshQuery;
+        initNavMeshQuery(navMeshQuery, navMesh, settings.mMaxNavMeshQueryNodes);
+
+        dtQueryFilter queryFilter;
+        queryFilter.setIncludeFlags(includeFlags);
+
+        dtPolyRef startRef = 0;
+        osg::Vec3f startPolygonPosition;
+        for (int i = 0; i < 3; ++i)
+        {
+            const auto status = navMeshQuery.findNearestPoly(start.ptr(), (halfExtents * (1 << i)).ptr(), &queryFilter,
+                &startRef, startPolygonPosition.ptr());
+            if (!dtStatusFailed(status) && startRef != 0)
+                break;
+        }
+
+        if (startRef == 0)
+            return boost::optional<osg::Vec3f>();
+
+        dtPolyRef resultRef = 0;
+        osg::Vec3f resultPosition;
+        navMeshQuery.findRandomPointAroundCircle(startRef, start.ptr(), maxRadius, &queryFilter,
+            &Misc::Rng::rollProbability, &resultRef, resultPosition.ptr());
+
+        if (resultRef == 0)
+            return boost::optional<osg::Vec3f>();
+
+        return boost::optional<osg::Vec3f>(resultPosition);
+    }
+}

--- a/components/detournavigator/findrandompointaroundcircle.hpp
+++ b/components/detournavigator/findrandompointaroundcircle.hpp
@@ -1,0 +1,20 @@
+#ifndef OPENMW_COMPONENTS_DETOURNAVIGATOR_FINDRANDOMPOINTAROUNDCIRCLE_H
+#define OPENMW_COMPONENTS_DETOURNAVIGATOR_FINDRANDOMPOINTAROUNDCIRCLE_H
+
+#include "flags.hpp"
+
+#include <boost/optional.hpp>
+
+#include <osg/Vec3f>
+
+class dtNavMesh;
+
+namespace DetourNavigator
+{
+    struct Settings;
+
+    boost::optional<osg::Vec3f> findRandomPointAroundCircle(const dtNavMesh& navMesh, const osg::Vec3f& halfExtents,
+        const osg::Vec3f& start, const float maxRadius, const Flags includeFlags, const Settings& settings);
+}
+
+#endif

--- a/components/detournavigator/navigator.cpp
+++ b/components/detournavigator/navigator.cpp
@@ -1,0 +1,20 @@
+#include "findrandompointaroundcircle.hpp"
+#include "navigator.hpp"
+
+namespace DetourNavigator
+{
+    boost::optional<osg::Vec3f> Navigator::findRandomPointAroundCircle(const osg::Vec3f& agentHalfExtents,
+        const osg::Vec3f& start, const float maxRadius, const Flags includeFlags) const
+    {
+        const auto navMesh = getNavMesh(agentHalfExtents);
+        if (!navMesh)
+            return boost::optional<osg::Vec3f>();
+        const auto settings = getSettings();
+        const auto result = DetourNavigator::findRandomPointAroundCircle(navMesh->lockConst()->getImpl(),
+            toNavMeshCoordinates(settings, agentHalfExtents), toNavMeshCoordinates(settings, start),
+            toNavMeshCoordinates(settings, maxRadius), includeFlags, settings);
+        if (!result)
+            return boost::optional<osg::Vec3f>();
+        return boost::optional<osg::Vec3f>(fromNavMeshCoordinates(settings, *result));
+    }
+}

--- a/components/detournavigator/navigator.hpp
+++ b/components/detournavigator/navigator.hpp
@@ -157,7 +157,6 @@ namespace DetourNavigator
          * @param out the beginning of the destination range.
          * @return Output iterator to the element in the destination range, one past the last element of found path.
          * Equal to out if no path is found.
-         * @throws InvalidArgument if there is no navmesh for given agentHalfExtents.
          */
         template <class OutputIterator>
         OutputIterator findPath(const osg::Vec3f& agentHalfExtents, const float stepSize, const osg::Vec3f& start,
@@ -194,6 +193,17 @@ namespace DetourNavigator
         virtual const Settings& getSettings() const = 0;
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats& stats) const = 0;
+
+        /**
+         * @brief findRandomPointAroundCircle returns random location on navmesh within the reach of specified location.
+         * @param agentHalfExtents allows to find navmesh for given actor.
+         * @param start path from given point.
+         * @param maxRadius limit maximum distance from start.
+         * @param includeFlags setup allowed surfaces for actor to walk.
+         * @return not empty optional with position if point is found and empty optional if point is not found.
+         */
+        boost::optional<osg::Vec3f> findRandomPointAroundCircle(const osg::Vec3f& agentHalfExtents,
+            const osg::Vec3f& start, const float maxRadius, const Flags includeFlags) const;
     };
 }
 


### PR DESCRIPTION
Should fix [#5237](https://gitlab.com/OpenMW/openmw/issues/5237).

1. Consider moved distance in direction to destination for obstacle check. Assume actor is stuck when it's not able to move in the destination direction with maximum speed. Approach to check moved distance from the previous point doesn't work good for slow and big actors. When they face obstacle they're trying to move along with oscillation so check is passing but they don't get any closer to the destination.

2. Use navmesh to find wander destination outside pathgrid for ground based actors. Use dtNavMeshQuery::findRandomPointAroundCircle from recastnavigation like suggested by [JDGBOLT ](https://gitlab.com/OpenMW/openmw/issues/5237#note_266239677).