### PR TITLE
Make Wizard less shy (bug #4493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4449: Value returned by GetWindSpeed is incorrect
     Bug #4456: AiActivate should not be cancelled after target activation
+    Bug #4493: If the setup doesn't find what it is expecting, it fails silently and displays the requester again instead of letting the user know what wasn't found.
     Bug #4523: "player->ModCurrentFatigue -0.001" in global script does not cause the running player to fall
     Bug #4540: Rain delay when exiting water
     Bug #4594: Actors without AI packages don't use Hello dialogue

--- a/apps/wizard/installationpage.cpp
+++ b/apps/wizard/installationpage.cpp
@@ -154,6 +154,14 @@ void Wizard::InstallationPage::showFileDialog(Wizard::Component component)
         name = QLatin1String("Bloodmoon");
         break;
     }
+    logTextEdit->appendHtml(tr("<p>Attempting to install component %1.</p>").arg(name));
+    mWizard->addLogText(tr("Attempting to install component %1.").arg(name));
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("%1 Installation").arg(name));
+    msgBox.setIcon(QMessageBox::Information);
+    msgBox.setText(QObject::tr("Select a valid %1 installation media.<br><b>Hint</b>: make sure that it contains at least one <b>.cab</b> file.").arg(name));
+    msgBox.exec();
 
     QString path = QFileDialog::getExistingDirectory(this,
                                                      tr("Select %1 installation media").arg(name),

--- a/apps/wizard/unshield/unshieldworker.cpp
+++ b/apps/wizard/unshield/unshieldworker.cpp
@@ -493,7 +493,9 @@ bool Wizard::UnshieldWorker::setupComponent(Component component)
 
         }
 
-        if (!found) {
+        if (!found)
+        {
+            emit textChanged(tr("Failed to find a valid archive containing %1.bsa! Retrying.").arg(name));
             QReadLocker readLock(&mLock);
             emit requestFileDialog(component);
             mWait.wait(&mLock);


### PR DESCRIPTION
Wizard will now log its repeating attempts to restart installation media selection dialog and annoy the user with in-the-face messageboxes a bit more. It will tell the user what it couldn't find in the requested folder if the user (either accidentally or deliberately) chooses an invalid installation media/folder for Morrowind or its expansion, e.g. like this:
![изображение](https://user-images.githubusercontent.com/21265616/72933319-8f6be380-3d72-11ea-9280-acbcc403acf7.png)