### PR TITLE
improve storage of vertex colors in gpu buffers

### DIFF
--- a/apps/opencs/model/prefs/setting.cpp
+++ b/apps/opencs/model/prefs/setting.cpp
@@ -61,6 +61,12 @@ double CSMPrefs::Setting::toDouble() const
     return mValues->getFloat (mKey, mParent->getKey());
 }
 
+float CSMPrefs::Setting::toFloat() const
+{
+    QMutexLocker lock(mMutex);
+    return mValues->getFloat(mKey, mParent->getKey());
+}
+
 std::string CSMPrefs::Setting::toString() const
 {
     QMutexLocker lock (mMutex);

--- a/apps/opencs/model/prefs/setting.hpp
+++ b/apps/opencs/model/prefs/setting.hpp
@@ -62,6 +62,8 @@ namespace CSMPrefs
 
             double toDouble() const;
 
+            float toFloat() const;
+
             std::string toString() const;
 
             bool isTrue() const;

--- a/apps/opencs/view/render/cellarrow.cpp
+++ b/apps/opencs/view/render/cellarrow.cpp
@@ -148,12 +148,13 @@ void CSVRender::CellArrow::buildShape()
 
     geometry->addPrimitiveSet (primitives);
 
-    osg::Vec4Array *colours = new osg::Vec4Array;
+    osg::ref_ptr<osg::Vec4ubArray> colours = new osg::Vec4ubArray;
+    colours->setNormalize(true);
 
     for (int i=0; i<6; ++i)
-        colours->push_back (osg::Vec4f (1.0f, 0.0f, 0.0f, 1.0f));
+        colours->push_back (osg::Vec4ub (255, 0, 0, 0));
     for (int i=0; i<6; ++i)
-        colours->push_back (osg::Vec4f (0.8f, (i==2 || i==5) ? 0.6f : 0.4f, 0.0f, 1.0f));
+        colours->push_back (osg::Vec4ub (204, (i==2 || i==5) ? 153 : 102, 0, 255));
 
     geometry->setColorArray (colours, osg::Array::BIND_PER_VERTEX);
 

--- a/apps/opencs/view/render/cellborder.cpp
+++ b/apps/opencs/view/render/cellborder.cpp
@@ -62,8 +62,9 @@ void CSVRender::CellBorder::buildShape(const ESM::Land& esmLand)
     geometry->setVertexArray(vertices);
 
     // Color
-    osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array();
-    colors->push_back(osg::Vec4f(0.f, 0.5f, 0.f, 1.f));
+    osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray();
+    colors->setNormalize(true);
+    colors->push_back(osg::Vec4ub(0, 128, 0, 255));
 
     geometry->setColorArray(colors, osg::Array::BIND_PER_PRIMITIVE_SET);
 

--- a/apps/opencs/view/render/object.hpp
+++ b/apps/opencs/view/render/object.hpp
@@ -99,7 +99,7 @@ namespace CSVRender
             int mOverrideFlags;
             osg::ref_ptr<osg::Node> mMarker[3];
             int mSubMode;
-            float mMarkerTransparency;
+            unsigned char mMarkerTransparency;
             std::unique_ptr<Actor> mActor;
 
             /// Not implemented

--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -49,8 +49,9 @@ namespace
         texcoords->push_back(osg::Vec2f(rightTexCoord, 1.f-topTexCoord));
         texcoords->push_back(osg::Vec2f(rightTexCoord, 1.f-bottomTexCoord));
 
-        osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array;
-        colors->push_back(osg::Vec4(1.f, 1.f, 1.f, 1.f));
+        osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray;
+        colors->setNormalize(true);
+        colors->push_back(osg::Vec4ub(255, 255, 255, 255));
         geom->setColorArray(colors, osg::Array::BIND_OVERALL);
 
         geom->setTexCoordArray(0, texcoords, osg::Array::BIND_PER_VERTEX);

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -92,8 +92,9 @@ namespace
         texcoords->push_back(osg::Vec2f(1, 1));
         texcoords->push_back(osg::Vec2f(1, 0));
 
-        osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array;
-        colors->push_back(osg::Vec4(1.f, 1.f, 1.f, 1.f));
+        osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray;
+        colors->setNormalize(true);
+        colors->push_back(osg::Vec4ub(255, 255, 255, 255));
         geom->setColorArray(colors, osg::Array::BIND_OVERALL);
 
         for (int i=0; i<numUvSets; ++i)
@@ -356,7 +357,9 @@ public:
         if (!geom)
             return;
 
-        osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array(geom->getVertexArray()->getNumElements());
+        osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray(geom->getVertexArray()->getNumElements());
+        colors->setNormalize(true);
+
         for (unsigned int i=0; i<colors->size(); ++i)
         {
             float alpha = 1.f;
@@ -378,7 +381,7 @@ public:
                     alpha = 1.f;
             }
 
-            (*colors)[i] = osg::Vec4f(0.f, 0.f, 0.f, alpha);
+            (*colors)[i] = osg::Vec4ub(0, 0, 0, SceneUtil::makeOsgColorUbComponent(alpha));
         }
 
         geom->setColorArray(colors, osg::Array::BIND_PER_VERTEX);

--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -1,5 +1,6 @@
 #include "data.hpp"
 #include "node.hpp"
+#include "components/sceneutil/util.hpp"
 
 namespace Nif
 {
@@ -45,7 +46,15 @@ void ShapeData::read(NIFStream *nif)
     radius = nif->getFloat();
 
     if (nif->getBoolean())
-        nif->getVector4s(colors, verts);
+    {
+        std::vector<osg::Vec4f> colorsFloat;
+        nif->getVector4s(colorsFloat, verts);
+
+        colors.clear();
+        colors.reserve(colorsFloat.size());
+        for (auto& color : colorsFloat)
+            colors.emplace_back(SceneUtil::colourUbFromColourF(color));
+    }
 
     // Only the first 6 bits are used as a count. I think the rest are
     // flags of some sort.

--- a/components/nif/data.hpp
+++ b/components/nif/data.hpp
@@ -36,7 +36,7 @@ class ShapeData : public Record
 {
 public:
     std::vector<osg::Vec3f> vertices, normals;
-    std::vector<osg::Vec4f> colors;
+    std::vector<osg::Vec4ub> colors;
     std::vector< std::vector<osg::Vec2f> > uvlist;
     osg::Vec3f center;
     float radius;

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -904,7 +904,7 @@ namespace NifOsg
                 const osg::Vec3f& position = particledata->vertices.at(particle.vertex);
                 created->setPosition(position);
 
-                osg::Vec4f partcolor (1.f,1.f,1.f,1.f);
+                osg::Vec4ub partcolor (255, 255, 255, 255);
                 if (particle.vertex < int(particledata->colors.size()))
                     partcolor = particledata->colors.at(particle.vertex);
 
@@ -1065,15 +1065,24 @@ namespace NifOsg
             }
         }
 
-        void triCommonToGeometry(osg::Geometry *geometry, const std::vector<osg::Vec3f>& vertices, const std::vector<osg::Vec3f>& normals, const std::vector<std::vector<osg::Vec2f>>& uvlist, const std::vector<osg::Vec4f>& colors, const std::vector<unsigned int>& boundTextures, const std::string& name)
+        void triCommonToGeometry(osg::Geometry *geometry, const std::vector<osg::Vec3f>& vertices, const std::vector<osg::Vec3f>& normals, const std::vector<std::vector<osg::Vec2f>>& uvlist, const std::vector<osg::Vec4ub>& colors, const std::vector<unsigned int>& boundTextures, const std::string& name)
         {
             if (!vertices.empty())
-                geometry->setVertexArray(new osg::Vec3Array(vertices.size(), vertices.data()));
+            {
+                osg::ref_ptr<osg::Vec3Array> vertexBuffer = new osg::Vec3Array(vertices.size(), vertices.data());
+                geometry->setVertexArray(vertexBuffer.get());
+            }
             if (!normals.empty())
-                geometry->setNormalArray(new osg::Vec3Array(normals.size(), normals.data()), osg::Array::BIND_PER_VERTEX);
+            {
+                osg::ref_ptr<osg::Vec3Array> normalBuffer = new osg::Vec3Array(normals.size(), normals.data());
+                geometry->setNormalArray(normalBuffer.get(), osg::Array::BIND_PER_VERTEX);
+            }
             if (!colors.empty())
-                geometry->setColorArray(new osg::Vec4Array(colors.size(), colors.data()), osg::Array::BIND_PER_VERTEX);
-
+            {
+                osg::ref_ptr<osg::Vec4ubArray> colorsBuffer = new osg::Vec4ubArray(colors.size(), colors.data());
+                colorsBuffer->setNormalize(true);
+                geometry->setColorArray(colorsBuffer.get(), osg::Array::BIND_PER_VERTEX);
+            }
             int textureStage = 0;
             for (const unsigned int uvSet : boundTextures)
             {

--- a/components/resource/stats.cpp
+++ b/components/resource/stats.cpp
@@ -162,7 +162,7 @@ void StatsHandler::setUpHUDCamera(osgViewer::ViewerBase* viewer)
     _initialized = true;
 }
 
-osg::Geometry* createBackgroundRectangle(const osg::Vec3& pos, const float width, const float height, osg::Vec4& color)
+osg::Geometry* createBackgroundRectangle(const osg::Vec3& pos, const float width, const float height, osg::Vec4ub& color)
 {
     osg::StateSet *ss = new osg::StateSet;
 
@@ -171,7 +171,7 @@ osg::Geometry* createBackgroundRectangle(const osg::Vec3& pos, const float width
     geometry->setUseDisplayList(false);
     geometry->setStateSet(ss);
 
-    osg::Vec3Array* vertices = new osg::Vec3Array;
+    osg::ref_ptr<osg::Vec3Array> vertices = new osg::Vec3Array;
     geometry->setVertexArray(vertices);
 
     vertices->push_back(osg::Vec3(pos.x(), pos.y(), 0));
@@ -179,7 +179,8 @@ osg::Geometry* createBackgroundRectangle(const osg::Vec3& pos, const float width
     vertices->push_back(osg::Vec3(pos.x()+width, pos.y()-height,0));
     vertices->push_back(osg::Vec3(pos.x()+width, pos.y(),0));
 
-    osg::Vec4Array* colors = new osg::Vec4Array;
+    osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray;
+    colors->setNormalize(true);
     colors->push_back(color);
     geometry->setColorArray(colors, osg::Array::BIND_OVERALL);
 
@@ -257,7 +258,7 @@ void StatsHandler::setUpScene(osgViewer::ViewerBase *viewer)
 #endif
 
     osg::Vec3 pos(_statsWidth-420.f, _statsHeight-500.0f,0.0f);
-    osg::Vec4 backgroundColor(0.0, 0.0, 0.0f, 0.3);
+    osg::Vec4ub backgroundColor(0, 0, 0, 77);
     osg::Vec4 staticTextColor(1.0, 1.0, 0.0f, 1.0);
     osg::Vec4 dynamicTextColor(1.0, 1.0, 1.0f, 1.0);
     float backgroundMargin = 5;

--- a/components/sceneutil/detourdebugdraw.cpp
+++ b/components/sceneutil/detourdebugdraw.cpp
@@ -60,7 +60,8 @@ namespace SceneUtil
     {
         mMode = mode;
         mVertices = new osg::Vec3Array;
-        mColors = new osg::Vec4Array;
+        mColors = new osg::Vec4ubArray;
+        mColors->setNormalize(true);
         mSize = size * mRecastInvertedScaleFactor;
     }
 
@@ -77,7 +78,7 @@ namespace SceneUtil
     void DebugDraw::vertex(const float x, const float y, const float z, unsigned color)
     {
         addVertex(osg::Vec3f(x, y, z));
-        addColor(SceneUtil::colourFromRGBA(color));
+        addColor(SceneUtil::colourUbFromRGBA(color));
     }
 
     void DebugDraw::vertex(const float* pos, unsigned color, const float* uv)
@@ -117,7 +118,7 @@ namespace SceneUtil
         mVertices->push_back(position * mRecastInvertedScaleFactor + mShift);
     }
 
-    void DebugDraw::addColor(osg::Vec4f&& value)
+    void DebugDraw::addColor(osg::Vec4ub&& value)
     {
         mColors->push_back(value);
     }

--- a/components/sceneutil/detourdebugdraw.hpp
+++ b/components/sceneutil/detourdebugdraw.hpp
@@ -44,11 +44,11 @@ namespace SceneUtil
         osg::PrimitiveSet::Mode mMode;
         float mSize;
         osg::ref_ptr<osg::Vec3Array> mVertices;
-        osg::ref_ptr<osg::Vec4Array> mColors;
+        osg::ref_ptr<osg::Vec4ubArray> mColors;
 
         void addVertex(osg::Vec3f&& position);
 
-        void addColor(osg::Vec4f&& value);
+        void addColor(osg::Vec4ub&& value);
     };
 }
 

--- a/components/sceneutil/pathgridutil.cpp
+++ b/components/sceneutil/pathgridutil.cpp
@@ -59,19 +59,19 @@ namespace SceneUtil
         1, 2, 3, 4
     };
 
-    const osg::Vec4f DiamondColors[DiamondVertexCount] =
+    const osg::Vec4ub DiamondColors[DiamondVertexCount] =
     {
-        osg::Vec4f(0.f, 0.f, 1.f, 1.f),
-        osg::Vec4f(0.f, .05f, .95f, 1.f),
-        osg::Vec4f(0.f, .1f, .95f, 1.f),
-        osg::Vec4f(0.f, .15f, .95f, 1.f),
-        osg::Vec4f(0.f, .2f, .95f, 1.f),
-        osg::Vec4f(0.f, .25f, 9.f, 1.f)
+        osg::Vec4ub(0, 0, 255, 255),
+        osg::Vec4ub(0, 13, 242, 255),
+        osg::Vec4ub(0, 26, 242, 255),
+        osg::Vec4ub(0, 38, 242, 255),
+        osg::Vec4ub(0, 51, 242, 255),
+        osg::Vec4ub(0, 64, 230, 255)
     };
 
-    const osg::Vec4f DiamondEdgeColor = osg::Vec4f(0.5f, 1.f, 1.f, 1.f);
-    const osg::Vec4f DiamondWireColor = osg::Vec4f(0.72f, 0.f, 0.96f, 1.f);
-    const osg::Vec4f DiamondFocusWireColor = osg::Vec4f(0.91f, 0.66f, 1.f, 1.f);
+    const osg::Vec4ub DiamondEdgeColor = osg::Vec4ub(128, 255, 255, 255);
+    const osg::Vec4ub DiamondWireColor = osg::Vec4ub(184, 0, 245, 255);
+    const osg::Vec4ub DiamondFocusWireColor = osg::Vec4ub(232, 168, 255, 255);
 
     osg::ref_ptr<osg::Geometry> createPathgridGeometry(const ESM::Pathgrid& pathgrid)
     {
@@ -86,7 +86,8 @@ namespace SceneUtil
         osg::ref_ptr<osg::Geometry> gridGeometry = new osg::Geometry();
 
         osg::ref_ptr<osg::Vec3Array> vertices = new osg::Vec3Array(VertexCount);
-        osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array(ColorCount);
+        osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray(ColorCount);
+        colors->setNormalize(true);
         osg::ref_ptr<osg::DrawElementsUShort> pointIndices =
             new osg::DrawElementsUShort(osg::PrimitiveSet::TRIANGLES, PointIndexCount);
         osg::ref_ptr<osg::DrawElementsUShort> lineIndices =
@@ -185,7 +186,8 @@ namespace SceneUtil
         osg::ref_ptr<osg::Geometry> wireframeGeometry = new osg::Geometry();
 
         osg::ref_ptr<osg::Vec3Array> vertices = new osg::Vec3Array(VertexCount);
-        osg::ref_ptr<osg::Vec4Array> colors = new osg::Vec4Array(ColorCount);
+        osg::ref_ptr<osg::Vec4ubArray> colors = new osg::Vec4ubArray(ColorCount);
+        colors->setNormalize(true);
         osg::ref_ptr<osg::DrawElementsUShort> indices =
             new osg::DrawElementsUShort(osg::PrimitiveSet::LINES, IndexCount);
 

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -221,7 +221,7 @@ float makeOsgColorComponent(unsigned int value, unsigned int shift)
 
 unsigned char makeOsgColorUbComponent(unsigned int value, unsigned int shift)
 {
-    return unsigned char((value >> shift) & 0xFFu);
+    return static_cast<unsigned char>((value >> shift) & 0xFFu);
 }
 
 unsigned char makeOsgColorUbComponent(float value)

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -179,9 +179,17 @@ void transformBoundingSphere (const osg::Matrixf& matrix, osg::BoundingSphere& b
 
 osg::Vec4f colourFromRGB(unsigned int clr)
 {
-    osg::Vec4f colour(((clr >> 0) & 0xFF) / 255.0f,
-                      ((clr >> 8) & 0xFF) / 255.0f,
-                      ((clr >> 16) & 0xFF) / 255.0f, 1.f);
+    osg::Vec4f colour(makeOsgColorComponent(clr, 0),
+        makeOsgColorComponent(clr, 8),
+        makeOsgColorComponent(clr, 16), 1.f);
+    return colour;
+}
+
+osg::Vec4ub colourUbFromRGB(unsigned int clr)
+{
+    osg::Vec4ub colour(makeOsgColorUbComponent(clr, 0),
+        makeOsgColorUbComponent(clr, 8),
+        makeOsgColorUbComponent(clr, 16), 255);
     return colour;
 }
 
@@ -191,9 +199,35 @@ osg::Vec4f colourFromRGBA(unsigned int value)
                       makeOsgColorComponent(value, 16), makeOsgColorComponent(value, 24));
 }
 
+osg::Vec4ub colourUbFromRGBA(unsigned int value)
+{
+    return osg::Vec4ub(makeOsgColorUbComponent(value, 0), makeOsgColorUbComponent(value, 8),
+        makeOsgColorUbComponent(value, 16), makeOsgColorUbComponent(value, 24));
+}
+
+osg::Vec4ub colourUbFromColourF(const osg::Vec4f& color)
+{
+    osg::Vec4ub result;
+    for (int i = 0; i < result.num_components; ++i)
+        result[i] = makeOsgColorUbComponent(color[i]);
+
+    return result;
+}
+
 float makeOsgColorComponent(unsigned int value, unsigned int shift)
 {
-    return float((value >> shift) & 0xFFu) / 255.0f;
+    return makeOsgColorUbComponent(value, shift) / 255.0f;
+}
+
+unsigned char makeOsgColorUbComponent(unsigned int value, unsigned int shift)
+{
+    return unsigned char((value >> shift) & 0xFFu);
+}
+
+unsigned char makeOsgColorUbComponent(float value)
+{
+    float component = std::min(1.0f, std::max(0.0f, value));
+    return static_cast<unsigned char>(std::lroundf(component * 255.0f));
 }
 
 bool hasUserDescription(const osg::Node* node, const std::string pattern)

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -53,9 +53,17 @@ namespace SceneUtil
 
     osg::Vec4f colourFromRGB (unsigned int clr);
 
+    osg::Vec4ub colourUbFromRGB (unsigned int clr);
+
     osg::Vec4f colourFromRGBA (unsigned int value);
 
+    osg::Vec4ub colourUbFromRGBA (unsigned int clr);
+
+    osg::Vec4ub colourUbFromColourF(const osg::Vec4f& color);
+
     float makeOsgColorComponent (unsigned int value, unsigned int shift);
+    unsigned char makeOsgColorUbComponent (unsigned int value, unsigned int shift);
+    unsigned char makeOsgColorUbComponent(float value);
 
     bool hasUserDescription(const osg::Node* node, const std::string pattern);
 


### PR DESCRIPTION
This patch reduces the storage of colors by using bytes instead of floats. This should result in some nice reduction in GPU memory use.