### PR TITLE
Editor: Delete instances via hotkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,7 @@
     Feature #5146: Safe Dispose corpse
     Feature #5147: Show spell magicka cost in spell buying window
     Feature #5170: Editor: Land shape editing, land selection
+    Feature #5172: Editor: Delete instances/references with keypress in scene window
     Feature #5193: Weapon sheathing
     Feature #5219: Impelement TestCells console command
     Feature #5224: Handle NiKeyframeController for NiTriShape

--- a/CHANGELOG_PR.md
+++ b/CHANGELOG_PR.md
@@ -42,6 +42,7 @@ New Editor Features:
 - "Faction Ranks" table for "Faction" records (#4209)
 - Changes to height editing can be cancelled without changes to data (press esc to cancel) (#4840)
 - Land heightmap/shape editing and vertex selection (#5170)
+- Deleting instances with a keypress (#5172)
 
 Bug Fixes:
 - The Mouse Wheel can now be used for key bindings (#2679)

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -355,6 +355,7 @@ void CSMPrefs::State::declare()
     declareShortcut ("scene-select-secondary", "Secondary Select",
         QKeySequence(Qt::ControlModifier | (int)Qt::MiddleButton));
     declareModifier ("scene-speed-modifier", "Speed Modifier", Qt::Key_Shift);
+    declareShortcut ("scene-delete", "Delete Instance", QKeySequence(Qt::Key_Delete));
     declareShortcut ("scene-load-cam-cell", "Load Camera Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_5));
     declareShortcut ("scene-load-cam-eastcell", "Load East Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_6));
     declareShortcut ("scene-load-cam-northcell", "Load North Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_8));

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -92,6 +92,7 @@ namespace CSVRender
         private slots:
 
             void subModeChanged (const std::string& id);
+            void deleteSelectedInstances(bool active);
     };
 }
 


### PR DESCRIPTION
https://gitlab.com/OpenMW/openmw/issues/5172

In scene view, delete selected instances via hotkey, delete button by default. Previously this was only possible via selection menu (right click on selectionmode button in sceneview), which was cumbersome.

I'm not absolutely sure if the shortcut is the correct method to implement this feature though, but seems like the most obvious method.

My concerns (should be tested before merge):
- Is selection cleared after delete, should it be? (done, clear after delete)
- Is function called multiple times without reason, is this a problem? (might be called during keypress multiple times, not a major problem)
- Clean-up (no need for braces in `for` and `if`) (done)