### PR TITLE
Do not interrupt greeting update when Hello = 0 or actor starts to swim

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -452,28 +452,23 @@ namespace MWMechanics
             return;
 
         CreatureStats &stats = actor.getClass().getCreatureStats(actor);
-        int hello = stats.getAiSetting(CreatureStats::AI_Hello).getModified();
-        if (hello == 0)
-            return;
-
-        if (MWBase::Environment::get().getWorld()->isSwimming(actor))
-            return;
-
-        MWWorld::Ptr player = getPlayer();
-        osg::Vec3f playerPos(player.getRefData().getPosition().asVec3());
-        osg::Vec3f actorPos(actor.getRefData().getPosition().asVec3());
-        osg::Vec3f dir = playerPos - actorPos;
-
         const MWMechanics::AiSequence& seq = stats.getAiSequence();
         int packageId = seq.getTypeId();
 
-        if (seq.isInCombat() || (packageId != AiPackage::TypeIdWander && packageId != AiPackage::TypeIdTravel && packageId != -1))
+        if (seq.isInCombat() ||
+            MWBase::Environment::get().getWorld()->isSwimming(actor) ||
+            (packageId != AiPackage::TypeIdWander && packageId != AiPackage::TypeIdTravel && packageId != -1))
         {
             stats.setTurningToPlayer(false);
             stats.setGreetingTimer(0);
             stats.setGreetingState(Greet_None);
             return;
         }
+
+        MWWorld::Ptr player = getPlayer();
+        osg::Vec3f playerPos(player.getRefData().getPosition().asVec3());
+        osg::Vec3f actorPos(actor.getRefData().getPosition().asVec3());
+        osg::Vec3f dir = playerPos - actorPos;
 
         if (stats.isTurningToPlayer())
         {
@@ -492,11 +487,10 @@ namespace MWMechanics
             return;
 
         // Play a random voice greeting if the player gets too close
-        float helloDistance = static_cast<float>(hello);
         static int iGreetDistanceMultiplier = MWBase::Environment::get().getWorld()->getStore()
             .get<ESM::GameSetting>().find("iGreetDistanceMultiplier")->mValue.getInteger();
 
-        helloDistance *= iGreetDistanceMultiplier;
+        float helloDistance = static_cast<float>(stats.getAiSetting(CreatureStats::AI_Hello).getModified() * iGreetDistanceMultiplier);
 
         int greetingTimer = stats.getGreetingTimer();
         GreetingState greetingState = stats.getGreetingState();


### PR DESCRIPTION
Fixes [bug #5248](https://gitlab.com/OpenMW/openmw/issues/5248).

When Hello = 0, we skip greeting update, so when you set Hello to 0 via scripting during greeting, we skip greeting update as well, and target get stuck in the Greet_InProgress state.
In theory, the same thing should be when actor starts to swim for some reason.

Suggested solution:
1. Remove early-out when Hello is 0. Since greeting distance is `hello * iGreetDistanceMultiplier`, the greeting distance is 0 when Hello is 0 anyway.
2. Cancel greeting for swimming actors just as for actors in combat.