### PR TITLE
Don't apply 1.6 magic value to NiGravity decay factor (#5266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@
     Bug #5249: Wandering NPCs start walking too soon after they hello
     Bug #5250: Creatures display shield ground mesh instead of shield body part
     Bug #5255: "GetTarget, player" doesn't return 1 during NPC hello
+    Bug #5266: Incorrect NiGravity decay implementation
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -203,12 +203,12 @@ void GravityAffector::beginOperate(osgParticle::Program* program)
 
 void GravityAffector::operate(osgParticle::Particle *particle, double dt)
 {
-    const float magic = 1.6f;
+    // Reverse-engineered value.
+    float decayFactor = 1.6f;
     switch (mType)
     {
         case Type_Wind:
         {
-            float decayFactor = 1.f;
             if (mDecay != 0.f)
             {
                 osg::Plane gravityPlane(mCachedWorldDirection, mCachedWorldPosition);
@@ -216,21 +216,19 @@ void GravityAffector::operate(osgParticle::Particle *particle, double dt)
                 decayFactor = std::exp(-1.f * mDecay * distance);
             }
 
-            particle->addVelocity(mCachedWorldDirection * mForce * dt * decayFactor * magic);
+            particle->addVelocity(mCachedWorldDirection * mForce * dt * decayFactor);
 
             break;
         }
         case Type_Point:
         {
             osg::Vec3f diff = mCachedWorldPosition - particle->getPosition();
-
-            float decayFactor = 1.f;
             if (mDecay != 0.f)
                 decayFactor = std::exp(-1.f * mDecay * diff.length());
 
             diff.normalize();
 
-            particle->addVelocity(diff * mForce * dt * decayFactor * magic);
+            particle->addVelocity(diff * mForce * dt * decayFactor);
             break;
         }
     }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5266)

It's the default velocity mult which is replaced by the distance-dependent decay factor if the decay is not zero. Now Trueflame, Hopesfire and all the meshes that have non-zero decay set explicitly should look correct.