### PR TITLE
Make uncapped Damage Fatigue optional (bug #5264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@
     Bug #5250: Creatures display shield ground mesh instead of shield body part
     Bug #5255: "GetTarget, player" doesn't return 1 during NPC hello
     Bug #5261: Creatures can sometimes become stuck playing idles and never wander again
+    Bug #5264: "Damage Fatigue" Magic Effect Can Bring Fatigue below 0
     Bug #5269: Editor: Cell lighting in resaved cleaned content files is corrupted
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -89,6 +89,7 @@ bool Launcher::AdvancedPage::loadSettings()
         loadSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
         loadSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
     }
+    loadSettingBool(uncappedDamageFatigueCheckBox, "uncapped damage fatigue", "Game");
 
     // Input Settings
     loadSettingBool(grabCursorCheckBox, "grab cursor", "Input");
@@ -152,6 +153,7 @@ void Launcher::AdvancedPage::saveSettings()
     saveSettingBool(animSourcesCheckBox, "use additional anim sources", "Game");
     saveSettingBool(weaponSheathingCheckBox, "weapon sheathing", "Game");
     saveSettingBool(shieldSheathingCheckBox, "shield sheathing", "Game");
+    saveSettingBool(uncappedDamageFatigueCheckBox, "uncapped damage fatigue", "Game");
 
     // Input Settings
     saveSettingBool(grabCursorCheckBox, "grab cursor", "Input");

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -1199,10 +1199,10 @@ namespace MWMechanics
         return false;
     }
 
-    void adjustDynamicStat(CreatureStats& creatureStats, int index, float magnitude)
+    void adjustDynamicStat(CreatureStats& creatureStats, int index, float magnitude, bool allowDecreaseBelowZero = false)
     {
         DynamicStat<float> stat = creatureStats.getDynamic(index);
-        stat.setCurrent(stat.getCurrent() + magnitude, index == 2);
+        stat.setCurrent(stat.getCurrent() + magnitude, allowDecreaseBelowZero);
         creatureStats.setDynamic(index, stat);
     }
 
@@ -1241,9 +1241,12 @@ namespace MWMechanics
 
         case ESM::MagicEffect::DamageMagicka:
         case ESM::MagicEffect::DamageFatigue:
-            adjustDynamicStat(creatureStats, effectKey.mId-ESM::MagicEffect::DamageHealth, -magnitude);
+        {
+            int index = effectKey.mId-ESM::MagicEffect::DamageHealth;
+            static const bool uncappedDamageFatigue = Settings::Manager::getBool("uncapped damage fatigue", "Game");
+            adjustDynamicStat(creatureStats, index, -magnitude, index == 2 && uncappedDamageFatigue);
             break;
-
+        }
         case ESM::MagicEffect::AbsorbHealth:
             if (magnitude > 0.f)
                 receivedMagicDamage = true;

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -298,3 +298,20 @@ A value of 0 means that you can only enchant one projectile.
 If you want to have Morrowind Code Patch-like count of projectiles being enchanted at once, set this value to 0.25 (i.e. 25% of the charge).
 
 This setting can only be configured by editing the settings configuration file.
+
+uncapped damage fatigue
+-----------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+There are four ways to decrease an actor's Fatigue stat in Morrowind gameplay mechanics:
+Drain, Absorb, Damage Fatigue magic effects and hand-to-hand combat.
+However, in Morrowind you can't knock down an actor with a Damage Fatigue spell or an Absorb Fatigue spell.
+Morrowind Code Patch adds an option to make it possible for Damage Fatigue spells. This is the equivalent of that option.
+
+Setting the value of this setting to true will remove the 0 lower cap from the value,
+allowing Damage Fatigue to reduce Fatigue to a value below zero.
+
+This setting can be controlled in Advanced tab of the launcher.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -272,6 +272,10 @@ normalise race speed = false
 # A value of 0 means that you can only enchant one projectile.
 projectiles enchant multiplier = 0
 
+# Make Damage Fatigue magic effect uncapped like Drain Fatigue effect.
+# This means that unlike Morrowind you will be able to knock down actors using this effect.
+uncapped damage fatigue = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -226,6 +226,16 @@
             </layout>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="uncappedDamageFatigueCheckBox">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make Damage Fatigue magic effect uncapped like Drain Fatigue effect.&lt;/p&gt;&lt;p&gt;This means that unlike Morrowind you will be able to knock down actors using this effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Uncapped Damage Fatigue</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5264)

A competitor to #2682.

In comparison to Assumeru's approach, this:
1) Updates the documentation
2) Adds the setting into Advanced tab of the launcher
3) Makes Absorb Fatigue strictly vanilla-like
4) Probably has slightly better performance as the setting value is truly read-only
5) And basically acts as a 1:1 MCP option equivalent.