### PR TITLE
Re-work wandering outside of initial cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,7 @@
     Bug #5249: Wandering NPCs start walking too soon after they hello
     Bug #5250: Creatures display shield ground mesh instead of shield body part
     Bug #5255: "GetTarget, player" doesn't return 1 during NPC hello
+    Bug #5261: Creatures can sometimes become stuck playing idles and never wander again
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -54,8 +54,9 @@ namespace MWMechanics
         stats.setMovementFlag(CreatureStats::Flag_Run, false);
         stats.setDrawState(DrawState_Nothing);
 
+        // Note: we should cancel internal "return after combat" package, if original location is too far away
         if (!isWithinMaxRange(targetPos, actorPos))
-            return false;
+            return mHidden;
 
         // Unfortunately, with vanilla assets destination is sometimes blocked by other actor.
         // If we got close to target, check for actors nearby. If they are, finish AI package.

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -27,8 +27,6 @@ namespace MWMechanics
     {
         float mReaction; // update some actions infrequently
 
-        const MWWorld::CellStore* mCell; // for detecting cell change
-
         // AiWander states
         enum WanderState
         {
@@ -60,7 +58,6 @@ namespace MWMechanics
 
         AiWanderStorage():
             mReaction(0),
-            mCell(nullptr),
             mState(Wander_ChooseAction),
             mIsWanderingManually(false),
             mCanWanderAlongPathGrid(true),
@@ -125,8 +122,7 @@ namespace MWMechanics
             void onIdleStatePerFrameActions(const MWWorld::Ptr& actor, float duration, AiWanderStorage& storage);
             void onWalkingStatePerFrameActions(const MWWorld::Ptr& actor, float duration, AiWanderStorage& storage);
             void onChooseActionStatePerFrameActions(const MWWorld::Ptr& actor, AiWanderStorage& storage);
-            bool reactionTimeActions(const MWWorld::Ptr& actor, AiWanderStorage& storage,
-            const MWWorld::CellStore*& currentCell, bool cellChange, ESM::Position& pos);
+            bool reactionTimeActions(const MWWorld::Ptr& actor, AiWanderStorage& storage, ESM::Position& pos);
             bool isPackageCompleted(const MWWorld::Ptr& actor, AiWanderStorage& storage);
             void wanderNearStart(const MWWorld::Ptr &actor, AiWanderStorage &storage, int wanderDistance);
             bool destinationIsAtWater(const MWWorld::Ptr &actor, const osg::Vec3f& destination);
@@ -141,7 +137,7 @@ namespace MWMechanics
             bool mRepeat;
 
             bool mStoredInitialActorPosition;
-            osg::Vec3f mInitialActorPosition;
+            osg::Vec3f mInitialActorPosition; // Note: an original engine does not reset coordinates even when actor changes a cell
 
             bool mHasDestination;
             osg::Vec3f mDestination;


### PR DESCRIPTION
Fixes [bug #5261](https://gitlab.com/OpenMW/openmw/issues/5261), [bug #5262](https://gitlab.com/OpenMW/openmw/issues/5261). Also partially fixes [bug #5217](https://gitlab.com/OpenMW/openmw/issues/5217) (the bug can still re-appear when actor is not in his initiall cell after save/load).

Summary of changes:
1. Do not reset wandering distance to 0 when actor in cell without pathgrid crosses cell borders (fixes 5261 for new saves).
2. Do not reset an initial position when actor crosses cell borders or enters combat (we reset temporary AI storage in this case) (fixes 5262).
3. Do not try to return actor to his pre-combat position, if he moved too far away from it (due to AiTravel limitations).

Note: we need to determine actor's initial cell and use it to build pathgrid (instead of actor's current cell) to fix the 5217 properly.