### PR TITLE
Make sure not to pick the ground shield model incorrectly for NPCs

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -81,6 +81,34 @@ std::string getVampireHead(const std::string& race, bool female)
     return "meshes\\" + bodyPart->mModel;
 }
 
+std::string getShieldBodypartMesh(const std::vector<ESM::PartReference>& bodyparts, bool female)
+{
+    const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
+    const MWWorld::Store<ESM::BodyPart> &partStore = store.get<ESM::BodyPart>();
+    for (const auto& part : bodyparts)
+    {
+        if (part.mPart != ESM::PRT_Shield)
+            continue;
+
+        std::string bodypartName;
+        if (female && !part.mFemale.empty())
+            bodypartName = part.mFemale;
+        else if (!part.mMale.empty())
+            bodypartName = part.mMale;
+
+        if (!bodypartName.empty())
+        {
+            const ESM::BodyPart *bodypart = partStore.search(bodypartName);
+            if (bodypart == nullptr || bodypart->mData.mType != ESM::BodyPart::MT_Armor)
+                return std::string();
+            if (!bodypart->mModel.empty())
+                return "meshes\\" + bodypart->mModel;
+        }
+    }
+
+    return std::string();
+}
+
 }
 
 
@@ -519,36 +547,9 @@ std::string NpcAnimation::getShieldMesh(MWWorld::ConstPtr shield) const
     std::string mesh = shield.getClass().getModel(shield);
     const ESM::Armor *armor = shield.get<ESM::Armor>()->mBase;
     const std::vector<ESM::PartReference>& bodyparts = armor->mParts.mParts;
+    // Try to recover the body part model, use ground model as a fallback otherwise.
     if (!bodyparts.empty())
-    {
-        const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
-        const MWWorld::Store<ESM::BodyPart> &partStore = store.get<ESM::BodyPart>();
-
-        // Try to get shield model from bodyparts first, with ground model as fallback
-        for (const auto& part : bodyparts)
-        {
-            if (part.mPart != ESM::PRT_Shield)
-                continue;
-
-            std::string bodypartName;
-            if (!mNpc->isMale() && !part.mFemale.empty())
-                bodypartName = part.mFemale;
-            else if (!part.mMale.empty())
-                bodypartName = part.mMale;
-
-            if (!bodypartName.empty())
-            {
-                const ESM::BodyPart *bodypart = partStore.search(bodypartName);
-                if (bodypart == nullptr || bodypart->mData.mType != ESM::BodyPart::MT_Armor)
-                    return std::string();
-                else if (!bodypart->mModel.empty())
-                {
-                    mesh = "meshes\\" + bodypart->mModel;
-                    break;
-                }
-            }
-        }
-    }
+        mesh = getShieldBodypartMesh(bodyparts, !mNpc->isMale());
 
     if (mesh.empty())
         return std::string();
@@ -1002,6 +1003,14 @@ void NpcAnimation::showCarriedLeft(bool show)
     {
         osg::Vec4f glowColor = iter->getClass().getEnchantmentColor(*iter);
         std::string mesh = iter->getClass().getModel(*iter);
+        // For shields we must try to use the body part model
+        if (iter->getTypeName() == typeid(ESM::Armor).name())
+        {
+            const ESM::Armor *armor = iter->get<ESM::Armor>()->mBase;
+            const std::vector<ESM::PartReference>& bodyparts = armor->mParts.mParts;
+            if (!bodyparts.empty())
+                mesh = getShieldBodypartMesh(bodyparts, !mNpc->isMale());
+        }
         if (addOrReplaceIndividualPart(ESM::PRT_Shield, MWWorld::InventoryStore::Slot_CarriedLeft, 1,
                                    mesh, !iter->getClass().getEnchantment(*iter).empty(), &glowColor))
         {


### PR DESCRIPTION
Another one of the myriads of shield model ground-bodypart confusion oversights. I'm not filing an issue because there's already a bunch of related things up (shield sheathing, creature ground model issue, etc.).

Basically, while we pick the correct shield model on the first equipment, it got replaced with the ground model when showCarriedLeft was called in succession due to two-handed weapon or hand-to-hand combat switch for example. Sometimes it got corrected automatically to be the right thing. This should not happen anymore.

For example, this can happen when a buggy Shield of Light in the current Patch for Purists release (December 2019, version 3.2.1) is used. It was updated to be a netch leather shield-like thing but it still references the imperial shield biped object. Due to the issue that was fixed it used either model depending on the phase of Secunda.

I tried to avoid excessive code duplication this time.