### PR TITLE
Editor: Implement brush outlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,7 @@
     Feature #5170: Editor: Land shape editing, land selection
     Feature #5172: Editor: Delete instances/references with keypress in scene window
     Feature #5193: Weapon sheathing
+    Feature #5201: Editor: Show tool outline in scene view, when using editmodes
     Feature #5219: Impelement TestCells console command
     Feature #5224: Handle NiKeyframeController for NiTriShape
     Feature #5274: Editor: Keyboard shortcut to drop objects to ground/obstacle in scene view

--- a/apps/opencs/CMakeLists.txt
+++ b/apps/opencs/CMakeLists.txt
@@ -89,7 +89,7 @@ opencs_units (view/render
     scenewidget worldspacewidget pagedworldspacewidget unpagedworldspacewidget
     previewwidget editmode instancemode instanceselectionmode instancemovemode
     orbitcameramode pathgridmode selectionmode pathgridselectionmode cameracontroller
-    cellwater terraintexturemode actor terrainselection terrainshapemode
+    cellwater terraintexturemode actor terrainselection terrainshapemode brushdraw
     )
 
 opencs_units_noqt (view/render

--- a/apps/opencs/model/world/cellcoordinates.cpp
+++ b/apps/opencs/model/world/cellcoordinates.cpp
@@ -91,9 +91,14 @@ std::pair<int, int> CSMWorld::CellCoordinates::toVertexCoords(const osg::Vec3d& 
     return std::make_pair(x, y);
 }
 
-float CSMWorld::CellCoordinates::textureGlobalToWorldCoords(int textureGlobal)
+float CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(int textureGlobal)
 {
-    return ESM::Land::REAL_SIZE * static_cast<float>(textureGlobal) / ESM::Land::LAND_TEXTURE_SIZE;
+    return ESM::Land::REAL_SIZE * (static_cast<float>(textureGlobal) + 0.25f) / ESM::Land::LAND_TEXTURE_SIZE;
+}
+
+float CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(int textureGlobal)
+{
+    return ESM::Land::REAL_SIZE * (static_cast<float>(textureGlobal) - 0.25f) / ESM::Land::LAND_TEXTURE_SIZE;
 }
 
 float CSMWorld::CellCoordinates::vertexGlobalToWorldCoords(int vertexGlobal)

--- a/apps/opencs/model/world/cellcoordinates.hpp
+++ b/apps/opencs/model/world/cellcoordinates.hpp
@@ -54,8 +54,11 @@ namespace CSMWorld
             ///Converts worldspace coordinates to global vertex selection.
             static std::pair<int, int> toVertexCoords(const osg::Vec3d& worldPos);
 
-            ///Converts global texture coordinate to worldspace coordinate that is at the upper left corner of the selected texture.
-            static float textureGlobalToWorldCoords(int textureGlobal);
+            ///Converts global texture coordinate X to worldspace coordinate, offset by 0.25f.
+            static float textureGlobalXToWorldCoords(int textureGlobal);
+
+            ///Converts global texture coordinate Y to worldspace coordinate, offset by 0.25f.
+            static float textureGlobalYToWorldCoords(int textureGlobal);
 
             ///Converts global vertex coordinate to worldspace coordinate
             static float vertexGlobalToWorldCoords(int vertexGlobal);

--- a/apps/opencs/view/render/brushdraw.cpp
+++ b/apps/opencs/view/render/brushdraw.cpp
@@ -1,0 +1,136 @@
+#include "brushdraw.hpp"
+
+#include <osg/Group>
+#include <osg/Geometry>
+#include <osg/Array>
+#include <osg/BlendFunc>
+#include <osg/CullFace>
+#include <osg/Material>
+
+#include <osgUtil/LineSegmentIntersector>
+
+#include "mask.hpp"
+
+CSVRender::BrushDraw::BrushDraw(osg::Group* parentNode) :
+    mParentNode(parentNode)
+{
+    mBrushDrawNode = new osg::Group();
+    mGeometry = new osg::Geometry();
+    mBrushDrawNode->addChild(mGeometry);
+    mParentNode->addChild(mBrushDrawNode);
+}
+
+CSVRender::BrushDraw::~BrushDraw()
+{
+    if (mBrushDrawNode->containsNode(mGeometry)) mBrushDrawNode->removeChild(mGeometry);
+    if (mParentNode->containsNode(mBrushDrawNode)) mParentNode->removeChild(mBrushDrawNode);
+}
+
+float CSVRender::BrushDraw::getIntersectionHeight (const osg::Vec3d& point)
+{
+    osg::Vec3d start = point;
+    osg::Vec3d end = point;
+    start.z() += 8000.0f; // these numbers need fixing
+    end.z() -= 8000.0f;
+    osg::Vec3d direction = end - start;
+
+    // Get intersection
+    osg::ref_ptr<osgUtil::LineSegmentIntersector> intersector (new osgUtil::LineSegmentIntersector(
+        osgUtil::Intersector::MODEL, start, end) );
+    intersector->setIntersectionLimit(osgUtil::LineSegmentIntersector::NO_LIMIT);
+    osgUtil::IntersectionVisitor visitor(intersector);
+
+    visitor.setTraversalMask(Mask_Terrain);
+
+    mParentNode->accept(visitor);
+
+    for (osgUtil::LineSegmentIntersector::Intersections::iterator it = intersector->getIntersections().begin();
+         it != intersector->getIntersections().end(); ++it)
+    {
+        osgUtil::LineSegmentIntersector::Intersection intersection = *it;
+
+        // reject back-facing polygons
+        if (direction * intersection.getWorldIntersectNormal() > 0)
+        {
+            continue;
+        }
+
+        return intersection.getWorldIntersectPoint().z();
+    }
+    return 0.0f;
+}
+
+
+void CSVRender::BrushDraw::buildGeometry(const float& radius, const osg::Vec3d& point, int amountOfPoints)
+{
+    osg::ref_ptr<osg::Geometry> geom = new osg::Geometry();
+    osg::ref_ptr<osg::Vec3Array> vertices (new osg::Vec3Array());
+    osg::ref_ptr<osg::Vec4Array> colors (new osg::Vec4Array());
+    const float step ((osg::PI * 2.0f) / static_cast<float>(amountOfPoints));
+
+    for (int i = 0; i < amountOfPoints + 2; i++)
+    {
+        float angle (static_cast<float>(i) * step);
+        vertices->push_back(osg::Vec3d(
+            point.x() + radius * cosf(angle),
+            point.y() + radius * sinf(angle),
+            getIntersectionHeight(osg::Vec3d(
+                point.x() + radius * cosf(angle),
+                point.y() + radius * sinf(angle),
+                point.z()) )));
+        colors->push_back(osg::Vec4f(
+            50.0f,
+            50.0f,
+            50.0f,
+            100.0f));
+        angle = static_cast<float>(i + 1) * step;
+        vertices->push_back(osg::Vec3d(
+            point.x() + radius * cosf(angle),
+            point.y() + radius * sinf(angle),
+            getIntersectionHeight(osg::Vec3d(
+                point.x() + radius * cosf(angle),
+                point.y() + radius * sinf(angle),
+                point.z()) ) + 200.0f));
+        colors->push_back(osg::Vec4f(
+            50.0f,
+            50.0f,
+            50.0f,
+            100.0f));
+    }
+
+    geom->setVertexArray(vertices);
+    geom->setColorArray(colors, osg::Array::BIND_PER_VERTEX);
+    geom->addPrimitiveSet(new osg::DrawArrays(osg::PrimitiveSet::TRIANGLE_STRIP, 0, (amountOfPoints + 2) * 2 - 2));
+    mGeometry = geom;
+}
+
+void CSVRender::BrushDraw::update(osg::Vec3d point, int brushSize)
+{
+    if (mBrushDrawNode->containsNode(mGeometry)) mBrushDrawNode->removeChild(mGeometry);
+    mBrushDrawNode->setNodeMask (Mask_EditModeCursor);
+    float radius = static_cast<float>(brushSize * mLandSizeFactor);
+    int amountOfPoints = (osg::PI * 2.0f) * radius / 20;
+
+    buildGeometry(radius, point, amountOfPoints);
+
+    osg::BlendFunc* blendFunc = new osg::BlendFunc(osg::BlendFunc::SRC_ALPHA, osg::BlendFunc::ONE_MINUS_SRC_ALPHA);
+    mGeometry->getOrCreateStateSet()->setAttributeAndModes(blendFunc);
+
+    mGeometry->getOrCreateStateSet()->setMode( GL_CULL_FACE, osg::StateAttribute::OFF );
+
+    osg::ref_ptr<osg::Material> material = new osg::Material;
+    material->setColorMode(osg::Material::AMBIENT);
+    material->setAmbient (osg::Material::FRONT_AND_BACK, osg::Vec4(0.3, 0.3, 0.3, 1));
+    material->setAlpha(osg::Material::FRONT_AND_BACK, 0.5);
+
+    mGeometry->getOrCreateStateSet()->setAttributeAndModes(material.get(), osg::StateAttribute::ON);
+    mGeometry->getOrCreateStateSet()->setMode(GL_BLEND, osg::StateAttribute::ON);
+    mGeometry->getOrCreateStateSet()->setRenderingHint (osg::StateSet::TRANSPARENT_BIN);
+
+    mBrushDrawNode->addChild(mGeometry);
+}
+
+void CSVRender::BrushDraw::hide()
+{
+    if (mBrushDrawNode->containsNode(mGeometry)) mBrushDrawNode->removeChild(mGeometry);
+}

--- a/apps/opencs/view/render/brushdraw.cpp
+++ b/apps/opencs/view/render/brushdraw.cpp
@@ -67,7 +67,7 @@ float CSVRender::BrushDraw::getIntersectionHeight (const osg::Vec3d& point)
 
 void CSVRender::BrushDraw::buildPointGeometry(const osg::Vec3d& point)
 {
-    osg::ref_ptr<osg::Geometry> geom = new osg::Geometry();
+    osg::ref_ptr<osg::Geometry> geom (new osg::Geometry());
     osg::ref_ptr<osg::Vec3Array> vertices (new osg::Vec3Array());
     osg::ref_ptr<osg::Vec4Array> colors (new osg::Vec4Array());
     const float brushOutlineHeight (1.0f);
@@ -115,7 +115,7 @@ void CSVRender::BrushDraw::buildPointGeometry(const osg::Vec3d& point)
 
 void CSVRender::BrushDraw::buildSquareGeometry(const float& radius, const osg::Vec3d& point)
 {
-    osg::ref_ptr<osg::Geometry> geom = new osg::Geometry();
+    osg::ref_ptr<osg::Geometry> geom (new osg::Geometry());
     osg::ref_ptr<osg::Vec3Array> vertices (new osg::Vec3Array());
     osg::ref_ptr<osg::Vec4Array> colors (new osg::Vec4Array());
 
@@ -212,7 +212,7 @@ void CSVRender::BrushDraw::buildSquareGeometry(const float& radius, const osg::V
 
 void CSVRender::BrushDraw::buildCircleGeometry(const float& radius, const osg::Vec3d& point)
 {
-    osg::ref_ptr<osg::Geometry> geom = new osg::Geometry();
+    osg::ref_ptr<osg::Geometry> geom (new osg::Geometry());
     osg::ref_ptr<osg::Vec3Array> vertices (new osg::Vec3Array());
     osg::ref_ptr<osg::Vec4Array> colors (new osg::Vec4Array());
     const int amountOfPoints = (osg::PI * 2.0f) * radius / 20;
@@ -222,7 +222,7 @@ void CSVRender::BrushDraw::buildCircleGeometry(const float& radius, const osg::V
 
     for (int i = 0; i < amountOfPoints + 2; i++)
     {
-        float angle (static_cast<float>(i) * step);
+        float angle (i * step);
         vertices->push_back(osg::Vec3d(
             point.x() + radius * cosf(angle),
             point.y() + radius * sinf(angle),

--- a/apps/opencs/view/render/brushdraw.cpp
+++ b/apps/opencs/view/render/brushdraw.cpp
@@ -8,10 +8,10 @@
 
 #include <osgUtil/LineSegmentIntersector>
 
+#include <components/sceneutil/vismask.hpp>
+
 #include "../../model/world/cellcoordinates.hpp"
 #include "../widget/brushshapes.hpp"
-
-#include "mask.hpp"
 
 CSVRender::BrushDraw::BrushDraw(osg::ref_ptr<osg::Group> parentNode, bool textureMode) :
     mParentNode(parentNode), mTextureMode(textureMode)
@@ -44,7 +44,7 @@ float CSVRender::BrushDraw::getIntersectionHeight (const osg::Vec3d& point)
     intersector->setIntersectionLimit(osgUtil::LineSegmentIntersector::NO_LIMIT);
     osgUtil::IntersectionVisitor visitor(intersector);
 
-    visitor.setTraversalMask(Mask_Terrain);
+    visitor.setTraversalMask(SceneUtil::Mask_Terrain);
 
     mParentNode->accept(visitor);
 
@@ -255,7 +255,7 @@ void CSVRender::BrushDraw::buildCustomGeometry(const float& radius, const osg::V
 void CSVRender::BrushDraw::update(osg::Vec3d point, int brushSize, CSVWidget::BrushShape toolShape)
 {
     if (mBrushDrawNode->containsNode(mGeometry)) mBrushDrawNode->removeChild(mGeometry);
-    mBrushDrawNode->setNodeMask (Mask_EditModeCursor);
+    mBrushDrawNode->setNodeMask (SceneUtil::Mask_GUI);
     float radius = (mLandSizeFactor * brushSize) / 2;
     osg::Vec3d snapToGridPoint = point;
     if (mTextureMode)

--- a/apps/opencs/view/render/brushdraw.cpp
+++ b/apps/opencs/view/render/brushdraw.cpp
@@ -20,7 +20,8 @@ CSVRender::BrushDraw::BrushDraw(osg::ref_ptr<osg::Group> parentNode, bool textur
     mGeometry = new osg::Geometry();
     mBrushDrawNode->addChild(mGeometry);
     mParentNode->addChild(mBrushDrawNode);
-    if (mTextureMode) mLandSizeFactor = ESM::Land::REAL_SIZE / ESM::Land::LAND_TEXTURE_SIZE;
+    if (mTextureMode)
+        mLandSizeFactor = ESM::Land::REAL_SIZE / ESM::Land::LAND_TEXTURE_SIZE;
     else mLandSizeFactor = ESM::Land::REAL_SIZE / ESM::Land::LAND_SIZE;
 }
 
@@ -254,7 +255,8 @@ void CSVRender::BrushDraw::buildCustomGeometry(const float& radius, const osg::V
 
 void CSVRender::BrushDraw::update(osg::Vec3d point, int brushSize, CSVWidget::BrushShape toolShape)
 {
-    if (mBrushDrawNode->containsNode(mGeometry)) mBrushDrawNode->removeChild(mGeometry);
+    if (mBrushDrawNode->containsNode(mGeometry))
+        mBrushDrawNode->removeChild(mGeometry);
     mBrushDrawNode->setNodeMask (SceneUtil::Mask_GUI);
     float radius = (mLandSizeFactor * brushSize) / 2;
     osg::Vec3d snapToGridPoint = point;
@@ -301,5 +303,6 @@ void CSVRender::BrushDraw::update(osg::Vec3d point, int brushSize, CSVWidget::Br
 
 void CSVRender::BrushDraw::hide()
 {
-    if (mBrushDrawNode->containsNode(mGeometry)) mBrushDrawNode->removeChild(mGeometry);
+    if (mBrushDrawNode->containsNode(mGeometry))
+        mBrushDrawNode->removeChild(mGeometry);
 }

--- a/apps/opencs/view/render/brushdraw.hpp
+++ b/apps/opencs/view/render/brushdraw.hpp
@@ -5,26 +5,30 @@
 #include <osg/Geometry>
 
 #include <components/esm/loadland.hpp>
+#include "../widget/brushshapes.hpp"
 
 namespace CSVRender
 {
     class BrushDraw
     {
         public:
-            BrushDraw(osg::Group* parentNode);
+            BrushDraw(osg::ref_ptr<osg::Group> parentNode, bool textureMode = false);
             ~BrushDraw();
 
-            void update(osg::Vec3d point, int brushSize);
+            void update(osg::Vec3d point, int brushSize, CSVWidget::BrushShape toolShape);
             void hide();
 
         private:
-            void buildGeometry(const float& radius, const osg::Vec3d& point, int amountOfPoints);
+            void buildPointGeometry(const float& radius, const osg::Vec3d& point);
+            void buildSquareGeometry(const float& radius, const osg::Vec3d& point);
+            void buildCircleGeometry(const float& radius, const osg::Vec3d& point);
+            void buildCustomGeometry(const float& radius, const osg::Vec3d& point);
             float getIntersectionHeight (const osg::Vec3d& point);
 
-            osg::Group* mParentNode;
+            osg::ref_ptr<osg::Group> mParentNode;
             osg::ref_ptr<osg::Group> mBrushDrawNode;
             osg::ref_ptr<osg::Geometry> mGeometry;
-            float mLandSizeFactor = ESM::Land::REAL_SIZE / ESM::Land::LAND_SIZE / 2;
+            float mLandSizeFactor;
     };
 }
 

--- a/apps/opencs/view/render/brushdraw.hpp
+++ b/apps/opencs/view/render/brushdraw.hpp
@@ -19,7 +19,7 @@ namespace CSVRender
             void hide();
 
         private:
-            void buildPointGeometry(const float& radius, const osg::Vec3d& point);
+            void buildPointGeometry(const osg::Vec3d& point);
             void buildSquareGeometry(const float& radius, const osg::Vec3d& point);
             void buildCircleGeometry(const float& radius, const osg::Vec3d& point);
             void buildCustomGeometry(const float& radius, const osg::Vec3d& point);
@@ -28,6 +28,7 @@ namespace CSVRender
             osg::ref_ptr<osg::Group> mParentNode;
             osg::ref_ptr<osg::Group> mBrushDrawNode;
             osg::ref_ptr<osg::Geometry> mGeometry;
+            bool mTextureMode;
             float mLandSizeFactor;
     };
 }

--- a/apps/opencs/view/render/brushdraw.hpp
+++ b/apps/opencs/view/render/brushdraw.hpp
@@ -1,0 +1,31 @@
+#ifndef CSV_RENDER_BRUSHDRAW_H
+#define CSV_RENDER_BRUSHDRAW_H
+
+#include <osg/Group>
+#include <osg/Geometry>
+
+#include <components/esm/loadland.hpp>
+
+namespace CSVRender
+{
+    class BrushDraw
+    {
+        public:
+            BrushDraw(osg::Group* parentNode);
+            ~BrushDraw();
+
+            void update(osg::Vec3d point, int brushSize);
+            void hide();
+
+        private:
+            void buildGeometry(const float& radius, const osg::Vec3d& point, int amountOfPoints);
+            float getIntersectionHeight (const osg::Vec3d& point);
+
+            osg::Group* mParentNode;
+            osg::ref_ptr<osg::Group> mBrushDrawNode;
+            osg::ref_ptr<osg::Geometry> mGeometry;
+            float mLandSizeFactor = ESM::Land::REAL_SIZE / ESM::Land::LAND_SIZE / 2;
+    };
+}
+
+#endif

--- a/apps/opencs/view/render/editmode.cpp
+++ b/apps/opencs/view/render/editmode.cpp
@@ -73,6 +73,8 @@ void CSVRender::EditMode::dropEvent (QDropEvent *event) {}
 
 void CSVRender::EditMode::dragMoveEvent (QDragMoveEvent *event) {}
 
+void CSVRender::EditMode::mouseMoveEvent (QMouseEvent *event) {}
+
 int CSVRender::EditMode::getSubMode() const
 {
     return -1;

--- a/apps/opencs/view/render/editmode.hpp
+++ b/apps/opencs/view/render/editmode.hpp
@@ -98,6 +98,8 @@ namespace CSVRender
             /// Default-implementation: ignored
             virtual void dragMoveEvent (QDragMoveEvent *event);
 
+            virtual void mouseMoveEvent (QMouseEvent *event);
+
             /// Default: return -1
             virtual int getSubMode() const;
     };

--- a/apps/opencs/view/render/terrainselection.cpp
+++ b/apps/opencs/view/render/terrainselection.cpp
@@ -171,9 +171,6 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
 {
     if (!mSelection.empty())
     {
-        // Nudge selection by 1/4th of a texture size, similar how blendmaps are nudged
-        const float nudgePercentage = 0.25f;
-        const int nudgeOffset = (ESM::Land::REAL_SIZE / ESM::Land::LAND_TEXTURE_SIZE) * nudgePercentage;
         const int landHeightsNudge = (ESM::Land::REAL_SIZE / ESM::Land::LAND_SIZE) / (ESM::Land::LAND_SIZE - 1); // Does this work with all land size configurations?
 
         const int textureSizeToLandSizeModifier = (ESM::Land::LAND_SIZE - 1) / ESM::Land::LAND_TEXTURE_SIZE;
@@ -196,10 +193,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+(i-1), y2)+2));
-                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y + 1) - nudgeOffset, calculateLandHeight(x1+i, y2)+2));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX, CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y + 1), calculateLandHeight(x1+(i-1), y2)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX, CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y + 1), calculateLandHeight(x1+i, y2)+2));
                 }
             }
 
@@ -208,10 +205,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(drawPreviousX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+(i-1), y1)+2));
-                    vertices->push_back(osg::Vec3f(drawCurrentX + nudgeOffset, CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) - nudgeOffset, calculateLandHeight(x1+i, y1)+2));
+                    float drawPreviousX = CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x) + (i - 1) *(ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentX = CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(drawPreviousX, CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y), calculateLandHeight(x1+(i-1), y1)+2));
+                    vertices->push_back(osg::Vec3f(drawCurrentX, CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y), calculateLandHeight(x1+i, y1)+2));
                 }
             }
 
@@ -220,10 +217,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x + 1) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x2, y1+(i-1))+2));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x + 1) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x2, y1+i)+2));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x + 1), drawPreviousY, calculateLandHeight(x2, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x + 1), drawCurrentY, calculateLandHeight(x2, y1+i)+2));
                 }
             }
 
@@ -232,10 +229,10 @@ void CSVRender::TerrainSelection::drawTextureSelection(const osg::ref_ptr<osg::V
             {
                 for(int i = 1; i < (textureSizeToLandSizeModifier + 1); i++)
                 {
-                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + nudgeOffset, drawPreviousY - nudgeOffset, calculateLandHeight(x1, y1+(i-1))+2));
-                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalToWorldCoords(x) + nudgeOffset, drawCurrentY - nudgeOffset, calculateLandHeight(x1, y1+i)+2));
+                    float drawPreviousY = CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y) + (i - 1) * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    float drawCurrentY = CSMWorld::CellCoordinates::textureGlobalYToWorldCoords(y) + i * (ESM::Land::REAL_SIZE / (ESM::Land::LAND_SIZE - 1));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x), drawPreviousY, calculateLandHeight(x1, y1+(i-1))+2));
+                    vertices->push_back(osg::Vec3f(CSMWorld::CellCoordinates::textureGlobalXToWorldCoords(x), drawCurrentY, calculateLandHeight(x1, y1+i)+2));
                 }
             }
         }

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -50,12 +50,6 @@ CSVRender::TerrainShapeMode::TerrainShapeMode (WorldspaceWidget *worldspaceWidge
 {
 }
 
-CSVRender::TerrainShapeMode::~TerrainShapeMode ()
-{
-    if (mBrushDraw)
-        mBrushDraw.reset();
-}
-
 void CSVRender::TerrainShapeMode::activate(CSVWidget::SceneToolbar* toolbar)
 {
     if (!mTerrainShapeSelection)

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -93,6 +93,9 @@ void CSVRender::TerrainShapeMode::deactivate(CSVWidget::SceneToolbar* toolbar)
         mTerrainShapeSelection.reset();
     }
 
+    if (mBrushDraw)
+        mBrushDraw.reset();
+
     EditMode::deactivate(toolbar);
 }
 
@@ -1395,7 +1398,7 @@ void CSVRender::TerrainShapeMode::dragMoveEvent (QDragMoveEvent *event)
 void CSVRender::TerrainShapeMode::mouseMoveEvent (QMouseEvent *event)
 {
     WorldspaceHitResult hit = getWorldspaceWidget().mousePick(event->pos(), getInteractionMask());
-    if (hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->update(hit.worldPos, mBrushSize);
+    if (hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
     if (!hit.hit && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->hide();
 }
 

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1398,8 +1398,10 @@ void CSVRender::TerrainShapeMode::dragMoveEvent (QDragMoveEvent *event)
 void CSVRender::TerrainShapeMode::mouseMoveEvent (QMouseEvent *event)
 {
     WorldspaceHitResult hit = getWorldspaceWidget().mousePick(event->pos(), getInteractionMask());
-    if (hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
-    if (!hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->hide();
+    if (hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing))
+        mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
+    if (!hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing))
+        mBrushDraw->hide();
 }
 
 void CSVRender::TerrainShapeMode::setBrushSize(int brushSize)

--- a/apps/opencs/view/render/terrainshapemode.cpp
+++ b/apps/opencs/view/render/terrainshapemode.cpp
@@ -1399,7 +1399,7 @@ void CSVRender::TerrainShapeMode::mouseMoveEvent (QMouseEvent *event)
 {
     WorldspaceHitResult hit = getWorldspaceWidget().mousePick(event->pos(), getInteractionMask());
     if (hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
-    if (!hit.hit && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->hide();
+    if (!hit.hit && mBrushDraw && !(mShapeEditTool == ShapeEditTool_Drag && mIsEditing)) mBrushDraw->hide();
 }
 
 void CSVRender::TerrainShapeMode::setBrushSize(int brushSize)

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -58,7 +58,6 @@ namespace CSVRender
 
             /// Editmode for terrain shape grid
             TerrainShapeMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
-            ~TerrainShapeMode();
 
             void primaryOpenPressed (const WorldspaceHitResult& hit) final;
 

--- a/apps/opencs/view/render/terrainshapemode.hpp
+++ b/apps/opencs/view/render/terrainshapemode.hpp
@@ -19,6 +19,7 @@
 #include "../widget/brushshapes.hpp"
 #endif
 
+#include "brushdraw.hpp"
 #include "terrainselection.hpp"
 
 namespace CSVWidget
@@ -57,6 +58,7 @@ namespace CSVRender
 
             /// Editmode for terrain shape grid
             TerrainShapeMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
+            ~TerrainShapeMode();
 
             void primaryOpenPressed (const WorldspaceHitResult& hit) final;
 
@@ -89,6 +91,7 @@ namespace CSVRender
 
             void dragWheel (int diff, double speedFactor) final;
             void dragMoveEvent (QDragMoveEvent *event) final;
+            void mouseMoveEvent (QMouseEvent *event) final;
 
         private:
 
@@ -168,6 +171,7 @@ namespace CSVRender
             std::string mBrushTexture;
             int mBrushSize = 1;
             CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;
+            std::unique_ptr<BrushDraw> mBrushDraw;
             std::vector<std::pair<int, int>> mCustomBrushShape;
             CSVWidget::SceneToolShapeBrush *mShapeBrushScenetool = nullptr;
             int mDragMode = InteractionType_None;

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -725,7 +725,7 @@ void CSVRender::TerrainTextureMode::mouseMoveEvent (QMouseEvent *event)
 {
     WorldspaceHitResult hit = getWorldspaceWidget().mousePick(event->pos(), getInteractionMask());
     if (hit.hit && mBrushDraw) mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
-    if (!hit.hit) mBrushDraw->hide();
+    if (!hit.hit && mBrushDraw) mBrushDraw->hide();
 }
 
 

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -342,9 +342,7 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
     std::string mBrushTextureInt = mBrushTexture.substr (hashlocation+1);
     int brushInt = stoi(mBrushTexture.substr (hashlocation+1))+1; // All indices are offset by +1
 
-    int rf = mBrushSize / 2;
-    int r = mBrushSize / 2 + 1;
-    int distance = 0;
+    int r = static_cast<float>(mBrushSize) / 2;
 
     if (mBrushShape == CSVWidget::BrushShape_Point)
     {
@@ -433,7 +431,6 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
                     {
                         for(int j = 0; j < landTextureSize; j++)
                         {
-
                             if (i_cell == cellX && j_cell == cellY && abs(i-xHitInCell) < r && abs(j-yHitInCell) < r)
                             {
                                 int distanceX(0);
@@ -444,7 +441,8 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
                                 if (j_cell > cellY) distanceY = -yHitInCell + landTextureSize * abs(j_cell-cellY) + j;
                                 if (i_cell == cellX) distanceX = abs(i-xHitInCell);
                                 if (j_cell == cellY) distanceY = abs(j-yHitInCell);
-                                distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                                float distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                                float rf = static_cast<float>(mBrushSize) / 2;
                                 if (distance < rf) newTerrain[j*landTextureSize+i] = brushInt;
                             }
                             else
@@ -457,7 +455,8 @@ void CSVRender::TerrainTextureMode::editTerrainTextureGrid(const WorldspaceHitRe
                                 if (j_cell > cellY) distanceY = -yHitInCell + landTextureSize * abs(j_cell-cellY) + j;
                                 if (i_cell == cellX) distanceX = abs(i-xHitInCell);
                                 if (j_cell == cellY) distanceY = abs(j-yHitInCell);
-                                distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                                float distance = std::round(sqrt(pow(distanceX, 2)+pow(distanceY, 2)));
+                                float rf = static_cast<float>(mBrushSize) / 2;
                                 if (distance < rf) newTerrain[j*landTextureSize+i] = brushInt;
                             }
                         }
@@ -548,7 +547,8 @@ void CSVRender::TerrainTextureMode::selectTerrainTextures(const std::pair<int, i
             for (int j = -r; j <= r; j++)
             {
                 osg::Vec2f coords(i,j);
-                if (std::round(coords.length()) < r)
+                float rf = static_cast<float>(mBrushSize) / 2;
+                if (std::round(coords.length()) < rf)
                 {
                     int x = i + texCoords.first;
                     int y = j + texCoords.second;

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -44,7 +44,7 @@ CSVRender::TerrainTextureMode::TerrainTextureMode (WorldspaceWidget *worldspaceW
 : EditMode (worldspaceWidget, QIcon {":scenetoolbar/editing-terrain-texture"}, SceneUtil::Mask_Terrain | SceneUtil::Mask_EditorReference, "Terrain texture editing", parent),
     mBrushTexture("L0#0"),
     mBrushSize(1),
-    mBrushShape(0),
+    mBrushShape(CSVWidget::BrushShape_Point),
     mTextureBrushScenetool(nullptr),
     mDragMode(InteractionType_None),
     mParentNode(parentNode),

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -52,12 +52,6 @@ CSVRender::TerrainTextureMode::TerrainTextureMode (WorldspaceWidget *worldspaceW
 {
 }
 
-CSVRender::TerrainTextureMode::~TerrainTextureMode ()
-{
-    if (mBrushDraw)
-        mBrushDraw.reset();
-}
-
 void CSVRender::TerrainTextureMode::activate(CSVWidget::SceneToolbar* toolbar)
 {
     if(!mTextureBrushScenetool)

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -707,6 +707,8 @@ void CSVRender::TerrainTextureMode::dragMoveEvent (QDragMoveEvent *event)
 {
 }
 
+void CSVRender::TerrainTextureMode::mouseMoveEvent (QMouseEvent *event) {}
+
 void CSVRender::TerrainTextureMode::setBrushSize(int brushSize)
 {
     mBrushSize = brushSize;

--- a/apps/opencs/view/render/terraintexturemode.cpp
+++ b/apps/opencs/view/render/terraintexturemode.cpp
@@ -724,8 +724,10 @@ void CSVRender::TerrainTextureMode::dragMoveEvent (QDragMoveEvent *event)
 void CSVRender::TerrainTextureMode::mouseMoveEvent (QMouseEvent *event)
 {
     WorldspaceHitResult hit = getWorldspaceWidget().mousePick(event->pos(), getInteractionMask());
-    if (hit.hit && mBrushDraw) mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
-    if (!hit.hit && mBrushDraw) mBrushDraw->hide();
+    if (hit.hit && mBrushDraw)
+        mBrushDraw->update(hit.worldPos, mBrushSize, mBrushShape);
+    if (!hit.hit && mBrushDraw)
+        mBrushDraw->hide();
 }
 
 

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -52,7 +52,6 @@ namespace CSVRender
 
             /// \brief Editmode for terrain texture grid
             TerrainTextureMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
-            ~TerrainTextureMode();
 
             void primaryOpenPressed (const WorldspaceHitResult& hit) final;
 
@@ -107,15 +106,15 @@ namespace CSVRender
             bool allowLandTextureEditing(std::string textureFileName);
 
             std::string mCellId;
-            std::string mBrushTexture = "L0#0";
-            int mBrushSize = 1;
-            CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;
+            std::string mBrushTexture;
+            int mBrushSize;
+            CSVWidget::BrushShape mBrushShape;
             std::unique_ptr<BrushDraw> mBrushDraw;
             std::vector<std::pair<int, int>> mCustomBrushShape;
-            CSVWidget::SceneToolTextureBrush *mTextureBrushScenetool = nullptr;
-            int mDragMode = InteractionType_None;
+            CSVWidget::SceneToolTextureBrush *mTextureBrushScenetool;
+            int mDragMode;
             osg::Group* mParentNode;
-            bool mIsEditing = false;
+            bool mIsEditing;
             std::unique_ptr<TerrainSelection> mTerrainTextureSelection;
 
             const int cellSize {ESM::Land::REAL_SIZE};

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -17,6 +17,8 @@
 #include "../../model/world/commands.hpp"
 #include "../../model/world/idtable.hpp"
 #include "../../model/world/landtexture.hpp"
+#include "../widget/brushshapes.hpp"
+#include "brushdraw.hpp"
 #endif
 
 #include "terrainselection.hpp"
@@ -50,6 +52,7 @@ namespace CSVRender
 
             /// \brief Editmode for terrain texture grid
             TerrainTextureMode(WorldspaceWidget*, osg::Group* parentNode, QWidget* parent = nullptr);
+            ~TerrainTextureMode();
 
             void primaryOpenPressed (const WorldspaceHitResult& hit) final;
 
@@ -104,14 +107,15 @@ namespace CSVRender
             bool allowLandTextureEditing(std::string textureFileName);
 
             std::string mCellId;
-            std::string mBrushTexture;
-            int mBrushSize;
-            int mBrushShape;
+            std::string mBrushTexture = "L0#0";
+            int mBrushSize = 1;
+            CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;
+            std::unique_ptr<BrushDraw> mBrushDraw;
             std::vector<std::pair<int, int>> mCustomBrushShape;
-            CSVWidget::SceneToolTextureBrush *mTextureBrushScenetool;
-            int mDragMode;
+            CSVWidget::SceneToolTextureBrush *mTextureBrushScenetool = nullptr;
+            int mDragMode = InteractionType_None;
             osg::Group* mParentNode;
-            bool mIsEditing;
+            bool mIsEditing = false;
             std::unique_ptr<TerrainSelection> mTerrainTextureSelection;
 
             const int cellSize {ESM::Land::REAL_SIZE};
@@ -123,7 +127,7 @@ namespace CSVRender
         public slots:
             void handleDropEvent(QDropEvent *event);
             void setBrushSize(int brushSize);
-            void setBrushShape(int brushShape);
+            void setBrushShape(CSVWidget::BrushShape brushShape);
             void setBrushTexture(std::string brushShape);
     };
 }

--- a/apps/opencs/view/render/terraintexturemode.hpp
+++ b/apps/opencs/view/render/terraintexturemode.hpp
@@ -81,6 +81,8 @@ namespace CSVRender
             void dragWheel (int diff, double speedFactor) final;
             void dragMoveEvent (QDragMoveEvent *event) final;
 
+            void mouseMoveEvent (QMouseEvent *event) final;
+
         private:
             /// \brief Handle brush mechanics, maths regarding worldspace hit etc.
             void editTerrainTextureGrid (const WorldspaceHitResult& hit);

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -613,6 +613,8 @@ void CSVRender::WorldspaceWidget::updateOverlay()
 
 void CSVRender::WorldspaceWidget::mouseMoveEvent (QMouseEvent *event)
 {
+    dynamic_cast<CSVRender::EditMode&> (*mEditMode->getCurrent()).mouseMoveEvent (event);
+
     if (mDragging)
     {
         int diffX = event->x() - mDragX;

--- a/apps/opencs/view/widget/scenetooltexturebrush.cpp
+++ b/apps/opencs/view/widget/scenetooltexturebrush.cpp
@@ -204,10 +204,14 @@ void CSVWidget::TextureBrushWindow::setBrushSize(int brushSize)
 
 void CSVWidget::TextureBrushWindow::setBrushShape()
 {
-    if(mButtonPoint->isChecked()) mBrushShape = CSVWidget::BrushShape_Point;
-    if(mButtonSquare->isChecked()) mBrushShape = CSVWidget::BrushShape_Square;
-    if(mButtonCircle->isChecked()) mBrushShape = CSVWidget::BrushShape_Circle;
-    if(mButtonCustom->isChecked()) mBrushShape = CSVWidget::BrushShape_Custom;
+    if (mButtonPoint->isChecked())
+        mBrushShape = CSVWidget::BrushShape_Point;
+    if (mButtonSquare->isChecked())
+        mBrushShape = CSVWidget::BrushShape_Square;
+    if (mButtonCircle->isChecked())
+        mBrushShape = CSVWidget::BrushShape_Circle;
+    if (mButtonCustom->isChecked())
+        mBrushShape = CSVWidget::BrushShape_Custom;
     emit passBrushShape(mBrushShape);
 }
 

--- a/apps/opencs/view/widget/scenetooltexturebrush.cpp
+++ b/apps/opencs/view/widget/scenetooltexturebrush.cpp
@@ -57,9 +57,6 @@ CSVWidget::BrushSizeControls::BrushSizeControls(const QString &title, QWidget *p
 
 CSVWidget::TextureBrushWindow::TextureBrushWindow(CSMDoc::Document& document, QWidget *parent)
     : QFrame(parent, Qt::Popup),
-    mBrushShape(0),
-    mBrushSize(1),
-    mBrushTexture("L0#0"),
     mDocument(document)
 {
     mBrushTextureLabel = "Selected texture: " + mBrushTexture + " ";
@@ -207,10 +204,10 @@ void CSVWidget::TextureBrushWindow::setBrushSize(int brushSize)
 
 void CSVWidget::TextureBrushWindow::setBrushShape()
 {
-    if(mButtonPoint->isChecked()) mBrushShape = 0;
-    if(mButtonSquare->isChecked()) mBrushShape = 1;
-    if(mButtonCircle->isChecked()) mBrushShape = 2;
-    if(mButtonCustom->isChecked()) mBrushShape = 3;
+    if(mButtonPoint->isChecked()) mBrushShape = CSVWidget::BrushShape_Point;
+    if(mButtonSquare->isChecked()) mBrushShape = CSVWidget::BrushShape_Square;
+    if(mButtonCircle->isChecked()) mBrushShape = CSVWidget::BrushShape_Circle;
+    if(mButtonCustom->isChecked()) mBrushShape = CSVWidget::BrushShape_Custom;
     emit passBrushShape(mBrushShape);
 }
 
@@ -228,7 +225,7 @@ CSVWidget::SceneToolTextureBrush::SceneToolTextureBrush (SceneToolbar *parent, c
     mBrushHistory[0] = "L0#0";
 
     setAcceptDrops(true);
-    connect(mTextureBrushWindow, SIGNAL(passBrushShape(int)), this, SLOT(setButtonIcon(int)));
+    connect(mTextureBrushWindow, SIGNAL(passBrushShape(CSVWidget::BrushShape)), this, SLOT(setButtonIcon(CSVWidget::BrushShape)));
     setButtonIcon(mTextureBrushWindow->mBrushShape);
 
     mPanel = new QFrame (this, Qt::Popup);
@@ -258,31 +255,31 @@ CSVWidget::SceneToolTextureBrush::SceneToolTextureBrush (SceneToolbar *parent, c
 
 }
 
-void CSVWidget::SceneToolTextureBrush::setButtonIcon (int brushShape)
+void CSVWidget::SceneToolTextureBrush::setButtonIcon (CSVWidget::BrushShape brushShape)
 {
     QString tooltip = "Change brush settings <p>Currently selected: ";
 
     switch (brushShape)
     {
-        case 0:
+        case BrushShape_Point:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-point")));
             tooltip += mTextureBrushWindow->toolTipPoint;
             break;
 
-        case 1:
+        case BrushShape_Square:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-square")));
             tooltip += mTextureBrushWindow->toolTipSquare;
             break;
 
-        case 2:
+        case BrushShape_Circle:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-circle")));
             tooltip += mTextureBrushWindow->toolTipCircle;
             break;
 
-        case 3:
+        case BrushShape_Custom:
 
             setIcon (QIcon (QPixmap (":scenetoolbar/brush-custom")));
             tooltip += mTextureBrushWindow->toolTipCustom;

--- a/apps/opencs/view/widget/scenetooltexturebrush.hpp
+++ b/apps/opencs/view/widget/scenetooltexturebrush.hpp
@@ -15,6 +15,7 @@
 #include <QPushButton>
 
 #ifndef Q_MOC_RUN
+#include "brushshapes.hpp"
 #include "scenetool.hpp"
 
 #include "../../model/doc/document.hpp"
@@ -65,9 +66,9 @@ namespace CSVWidget
             const QString toolTipCustom = "Paint custom selection (not implemented yet)";
 
         private:
-            int mBrushShape;
-            int mBrushSize;
-            std::string mBrushTexture;
+            CSVWidget::BrushShape mBrushShape = CSVWidget::BrushShape_Point;
+            int mBrushSize = 1;
+            std::string mBrushTexture = "L0#0";
             CSMDoc::Document& mDocument;
             QLabel *mSelectedBrush;
             QGroupBox *mHorizontalGroupBox;
@@ -88,7 +89,7 @@ namespace CSVWidget
 
         signals:
             void passBrushSize (int brushSize);
-            void passBrushShape(int brushShape);
+            void passBrushShape(CSVWidget::BrushShape brushShape);
             void passTextureId(std::string brushTexture);
     };
 
@@ -120,7 +121,7 @@ namespace CSVWidget
         friend class CSVRender::TerrainTextureMode;
 
         public slots:
-            void setButtonIcon(int brushShape);
+            void setButtonIcon(CSVWidget::BrushShape brushShape);
             void updateBrushHistory (const std::string& mBrushTexture);
             void clicked (const QModelIndex& index);
             virtual void activate();


### PR DESCRIPTION
Implements a tool outline for TerrainShapeMode and TerrainTextureMode.

Notes:
-  Point tool is represented by a small cross. For some reason, when I tried to use osg::PrimitiveSet::POINTS the pointer became invisible. All outlines use LINES in this PR, but on the other hand, TRIANGLES could be used to generate 3d meshes.
- Circle and Square tool are implemented as mathematical representations of size, but the actual edits that go to data are rounded to nearest, therefore outline might feel strange at some brush sizes. It might be more intuitive to have exact representations, but if the underlying data is changed (e.g. cell size is different, the exact representation has to take this into account).
- Custom tool shape is not implemented. I suggest to cut this feature out to a separate PR.
- Outline snaps to vertex or texture grid.
- Color of the outline is white, it's the same color as terrain selection. Is that correct?
- some if-oneliners (I will fix this)
- Updates terrainselection to use CSMWorld::CellCoordinates::textureGlobalXToWorldCoords and CSMWorld::CellCoordinates::textureGlobalYToWorldCoords in order to make it more readable, but also to be consistent on the method with selection and outline drawing.
- Updates terraintexturemode's variables to use same formatting as terrainshapemode, this is needed for brush shape so that brushdraw gets consistent values.

Lines-implementation https://imgur.com/a/2E4eR99

https://gitlab.com/OpenMW/openmw/issues/5201