### PR TITLE
Make Show fallback to global variables when sensible (bug #5278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@
     Bug #5255: "GetTarget, player" doesn't return 1 during NPC hello
     Bug #5261: Creatures can sometimes become stuck playing idles and never wander again
     Bug #5269: Editor: Cell lighting in resaved cleaned content files is corrupted
+    Bug #5278: Console command Show doesn't fall back to global variable after local var not found
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -923,11 +923,7 @@ namespace MWScript
                 if (!ptr.isEmpty())
                 {
                     const std::string& script = ptr.getClass().getScript(ptr);
-                    if (script.empty())
-                    {
-                        output << ptr.getCellRef().getRefId() << " has no script " << std::endl;
-                    }
-                    else
+                    if (!script.empty())
                     {
                         const Compiler::Locals& locals =
                             MWBase::Environment::get().getScriptManager()->getLocals(script);
@@ -941,13 +937,11 @@ namespace MWScript
                         case 'f':
                             output << ptr.getCellRef().getRefId() << "." << var << ": " << ptr.getRefData().getLocals().getFloatVar(script, var);
                             break;
-                        default:
-                            output << "unknown local '" << var << "' for '" << ptr.getCellRef().getRefId() << "'";
-                            break;
+                        // Do nothing otherwise
                         }
                     }
                 }
-                else
+                if (output.rdbuf()->in_avail() == 0)
                 {
                     MWBase::World *world = MWBase::Environment::get().getWorld();
                     char type = world->getGlobalVariableType (var);
@@ -964,7 +958,7 @@ namespace MWScript
                         output << runtime.getContext().getGlobalFloat (var);
                         break;
                     default:
-                        output << "unknown global variable";
+                        output << "unknown variable";
                     }
                 }
                 runtime.getContext().report(output.str());

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -928,16 +928,18 @@ namespace MWScript
                         const Compiler::Locals& locals =
                             MWBase::Environment::get().getScriptManager()->getLocals(script);
                         char type = locals.getType(var);
+                        std::string refId = ptr.getCellRef().getRefId();
+                        if (refId.find(' ') != std::string::npos)
+                            refId = '"' + refId + '"';
                         switch (type)
                         {
                         case 'l':
                         case 's':
-                            output << ptr.getCellRef().getRefId() << "." << var << ": " << ptr.getRefData().getLocals().getIntVar(script, var);
+                            output << refId << "." << var << " = " << ptr.getRefData().getLocals().getIntVar(script, var);
                             break;
                         case 'f':
-                            output << ptr.getCellRef().getRefId() << "." << var << ": " << ptr.getRefData().getLocals().getFloatVar(script, var);
+                            output << refId << "." << var << " = " << ptr.getRefData().getLocals().getFloatVar(script, var);
                             break;
-                        // Do nothing otherwise
                         }
                     }
                 }
@@ -949,13 +951,13 @@ namespace MWScript
                     switch (type)
                     {
                     case 's':
-                        output << runtime.getContext().getGlobalShort (var);
+                        output << var << " = " << runtime.getContext().getGlobalShort (var);
                         break;
                     case 'l':
-                        output << runtime.getContext().getGlobalLong (var);
+                        output << var << " = " << runtime.getContext().getGlobalLong (var);
                         break;
                     case 'f':
-                        output << runtime.getContext().getGlobalFloat (var);
+                        output << var << " = " << runtime.getContext().getGlobalFloat (var);
                         break;
                     default:
                         output << "unknown variable";


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5278).

In case there isn't a local variable for the given object, Show will try to find a global namesake.

The way stringstream emptiness is detected is somewhat clunky, but I don't want to actually recover the string that is put into it before it's actually necessary.