### PR TITLE
Fix LineSegmentIntersector usage

### DIFF
--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -150,12 +150,12 @@ void QuadTreeNode::traverseTo(ViewData* vd, float size, const osg::Vec2f& center
     }
 }
 
-void QuadTreeNode::intersect(ViewData* vd, TerrainLineIntersector* intersector)
+void QuadTreeNode::intersect(ViewData* vd, TerrainLineIntersector& intersector)
 {
     if (!hasValidBounds())
         return;
 
-    if (!intersector->intersectAndClip(getBoundingBox()))
+    if (!intersector.intersectAndClip(getBoundingBox()))
         return;
 
     if (getNumChildren() == 0)

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -20,6 +20,14 @@ namespace Terrain
             _parent = intersector;
         }
 
+        TerrainLineIntersector(osgUtil::LineSegmentIntersector* intersector) :
+            osgUtil::LineSegmentIntersector(intersector->getStart(), intersector->getEnd())
+        {
+            setPrecisionHint(intersector->getPrecisionHint());
+            _intersectionLimit = intersector->getIntersectionLimit();
+            _parent = intersector;
+        }
+
         bool intersectAndClip(const osg::BoundingBox& bbInput)
         {
             osg::Vec3d s(_start), e(_end);
@@ -98,7 +106,7 @@ namespace Terrain
         void traverseTo(ViewData* vd, float size, const osg::Vec2f& center);
 
         /// Adds all leaf nodes which intersect the line from start to end
-        void intersect(ViewData* vd, TerrainLineIntersector* intersector);
+        void intersect(ViewData* vd, TerrainLineIntersector& intersector);
 
     private:
         QuadTreeNode* mParent;

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -362,11 +362,17 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
             if (!lineIntersector)
                 throw std::runtime_error("Cannot update QuadTreeWorld: node visitor is not LineSegmentIntersector");
 
-            osg::Matrix matrix = osg::Matrix::identity();
             if (lineIntersector->getCoordinateFrame() == osgUtil::Intersector::CoordinateFrame::MODEL && iv->getModelMatrix() == 0)
-                matrix = lineIntersector->getTransformation(*iv, osgUtil::Intersector::CoordinateFrame::MODEL);
-            osg::ref_ptr<TerrainLineIntersector> terrainIntersector (new TerrainLineIntersector(lineIntersector, matrix));
-            mRootNode->intersect(vd, terrainIntersector);
+            {
+                TerrainLineIntersector terrainIntersector(lineIntersector);
+                mRootNode->intersect(vd, terrainIntersector);
+            }
+            else
+            {
+                osg::Matrix matrix(lineIntersector->getTransformation(*iv, lineIntersector->getCoordinateFrame()));
+                TerrainLineIntersector terrainIntersector(lineIntersector, matrix);
+                mRootNode->intersect(vd, terrainIntersector);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes [regression #5283](https://gitlab.com/OpenMW/openmw/issues/5283), which is my stupid error (a wrong "if" condition).

Summary of changes:
1. Fix wrong "if" condition
2. Do not create a matrix, when it is not needed
3. Create the TerrainLineIntersector on stack instead of heap to do not mess with smart pointers

Notes:
1. `TerrainLineIntersector` is just a class, which provides a public wrapper for protected `osgUtil::LineSegmentIntersector::intersectAndClip()` function, which is required for bzzt's simplified intersection logic for the Distant Terrain. Originally bzzt in his PR just copy-pasted the whole `LineSegmentIntersector`'s implementation to the `QuadTreeNode` instead.
2. It is importart to create a separate intersector to do not change a state of original one. `TerrainLineIntersector`'s constructor is based on the `osgUtil::LineSegmentIntersector::clone()`.