### PR TITLE
Don't try to attach absent (empty path) shield models to NPCs

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -1011,9 +1011,11 @@ void NpcAnimation::showCarriedLeft(bool show)
             if (!bodyparts.empty())
                 mesh = getShieldBodypartMesh(bodyparts, !mNpc->isMale());
         }
-        if (addOrReplaceIndividualPart(ESM::PRT_Shield, MWWorld::InventoryStore::Slot_CarriedLeft, 1,
-                                   mesh, !iter->getClass().getEnchantment(*iter).empty(), &glowColor))
+        if (mesh.empty() || addOrReplaceIndividualPart(ESM::PRT_Shield, MWWorld::InventoryStore::Slot_CarriedLeft, 1,
+                                        mesh, !iter->getClass().getEnchantment(*iter).empty(), &glowColor))
         {
+            if (mesh.empty())
+                reserveIndividualPart(ESM::PRT_Shield, MWWorld::InventoryStore::Slot_CarriedLeft, 1);
             if (iter->getTypeName() == typeid(ESM::Light).name() && mObjectParts[ESM::PRT_Shield])
                 addExtraLight(mObjectParts[ESM::PRT_Shield]->getNode()->asGroup(), iter->get<ESM::Light>()->mBase);
         }


### PR DESCRIPTION
Morrowind seems to hide such shields instead of trying to find a model with no path given, so let's do the same thing.