### PR TITLE
Support movement deceleration for wander AI

### DIFF
--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -44,7 +44,7 @@ namespace MWMechanics
 
             void fastForward(const MWWorld::Ptr& actor, AiState& state);
 
-            virtual osg::Vec3f getDestination() { return osg::Vec3f(mX, mY, mZ); }
+            virtual osg::Vec3f getDestination() const { return osg::Vec3f(mX, mY, mZ); }
 
         private:
             std::string mCellId;

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -76,7 +76,7 @@ namespace MWMechanics
 
             void fastForward(const MWWorld::Ptr& actor, AiState& state);
 
-            virtual osg::Vec3f getDestination()
+            virtual osg::Vec3f getDestination() const
             {
                 MWWorld::Ptr target = getTarget();
                 if (target.isEmpty())

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -102,7 +102,7 @@ namespace MWMechanics
             /// Return true if this package should repeat. Currently only used for Wander packages.
             virtual bool getRepeat() const;
 
-            virtual osg::Vec3f getDestination() { return osg::Vec3f(0, 0, 0); }
+            virtual osg::Vec3f getDestination() const { return osg::Vec3f(0, 0, 0); }
 
             // Return true if any loaded actor with this AI package must be active.
             virtual bool alwaysActive() const { return false; }

--- a/apps/openmw/mwmechanics/aitravel.hpp
+++ b/apps/openmw/mwmechanics/aitravel.hpp
@@ -36,7 +36,7 @@ namespace MWMechanics
 
             virtual bool alwaysActive() const { return true; }
 
-            virtual osg::Vec3f getDestination() { return osg::Vec3f(mX, mY, mZ); }
+            virtual osg::Vec3f getDestination() const { return osg::Vec3f(mX, mY, mZ); }
 
         private:
             float mX;

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -97,6 +97,8 @@ namespace MWMechanics
 
             virtual int getTypeId() const;
 
+            virtual bool useVariableSpeed() const { return true;}
+
             virtual void writeState(ESM::AiSequence::AiSequence &sequence) const;
 
             virtual void fastForward(const MWWorld::Ptr& actor, AiState& state);
@@ -104,6 +106,14 @@ namespace MWMechanics
             bool getRepeat() const;
 
             osg::Vec3f getDestination(const MWWorld::Ptr& actor) const;
+
+            virtual osg::Vec3f getDestination() const
+            {
+                if (!mHasDestination)
+                    return osg::Vec3f(0, 0, 0);
+
+                return mDestination;
+            }
 
         private:
             // NOTE: mDistance and mDuration must be set already


### PR DESCRIPTION
Reportedly should be a thing (seems to be valid according to my own Morrowind.exe testing). It looks better this way anyway.

All getDestination methods don't (and shouldn't) modify the package class so I've added the corresponding const keyword into the declarations.