### PR TITLE
Make infinite fall failsafe logic more forgiving

### DIFF
--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -498,13 +498,13 @@ namespace MWWorld
         const auto player = MWBase::Environment::get().getWorld()->getPlayerPtr();
         navigator->update(player.getRefData().getPosition().asVec3());
 
-        const float fallThreshold = 90.f;
+        const float fallThreshold = 256.f;
         if (mCurrentCell && !mCurrentCell->isExterior() && pos.z() < mLowestPos - fallThreshold)
         {
             ESM::Position newPos;
             std::string cellName = mCurrentCell->getCell()->mName;
             MWBase::Environment::get().getWorld()->findInteriorPosition(cellName, newPos);
-            if (newPos.pos[2] >= mLowestPos - fallThreshold)
+            if (newPos.pos[2] >= mLowestPos)
                 MWWorld::ActionTeleport(cellName, newPos, false).execute(player);
         }
 


### PR DESCRIPTION
[As requested here.](https://gitlab.com/OpenMW/openmw/issues/5287)

The threshold was increased to 256 units, and the player will no longer be teleported if the new position after teleportation is going to be lower than the position of the lowest object in the cell (the character is going to fall down anyways in such cases).