### PR TITLE
Add final modifier to fix warnings

### DIFF
--- a/apps/openmw/mwgui/backgroundimage.hpp
+++ b/apps/openmw/mwgui/backgroundimage.hpp
@@ -9,7 +9,7 @@ namespace MWGui
     /**
      * @brief A variant of MyGUI::ImageBox with aspect ratio correction using black bars
      */
-    class BackgroundImage : public MyGUI::ImageBox
+    class BackgroundImage final : public MyGUI::ImageBox
     {
     MYGUI_RTTI_DERIVED(BackgroundImage)
 
@@ -22,8 +22,8 @@ namespace MWGui
          */
         void setBackgroundImage (const std::string& image, bool fixedRatio=true, bool stretch=true);
 
-        virtual void setSize (const MyGUI::IntSize &_value);
-        virtual void setCoord (const MyGUI::IntCoord &_value);
+        void setSize (const MyGUI::IntSize &_value) final;
+        void setCoord (const MyGUI::IntCoord &_value) final;
 
     private:
         MyGUI::ImageBox* mChild;

--- a/apps/openmw/mwgui/bookpage.cpp
+++ b/apps/openmw/mwgui/bookpage.cpp
@@ -817,7 +817,7 @@ namespace
     };
 }
 
-class PageDisplay : public MyGUI::ISubWidgetText
+class PageDisplay final : public MyGUI::ISubWidgetText
 {
     MYGUI_RTTI_DERIVED(PageDisplay)
 protected:
@@ -1140,7 +1140,7 @@ public:
                 i->second->createDrawItem (mNode);
     }
 
-    void setVisible (bool newVisible)
+    void setVisible (bool newVisible) final
     {
         if (mVisible == newVisible)
             return;
@@ -1162,7 +1162,7 @@ public:
         }
     }
 
-    void createDrawItem(MyGUI::ITexture* texture, MyGUI::ILayerNode* node)
+    void createDrawItem(MyGUI::ITexture* texture, MyGUI::ILayerNode* node) final
     {
         mNode = node;
 
@@ -1230,9 +1230,9 @@ public:
 
     // ISubWidget should not necessarily be a drawitem
     // in this case, it is not...
-    void doRender() { }
+    void doRender() final { }
 
-    void _updateView ()
+    void _updateView () final
     {
         _checkMargin();
 
@@ -1241,7 +1241,7 @@ public:
                 mNode->outOfDate (i->second->mRenderItem);
     }
 
-    void _correctView()
+    void _correctView() final
     {
         _checkMargin ();
 
@@ -1251,7 +1251,7 @@ public:
 
     }
 
-    void destroyDrawItem()
+    void destroyDrawItem() final
     {
         for (ActiveTextFormats::iterator i = mActiveTextFormats.begin (); i != mActiveTextFormats.end (); ++i)
             i->second->destroyDrawItem (mNode);
@@ -1261,7 +1261,7 @@ public:
 };
 
 
-class BookPageImpl : public BookPage
+class BookPageImpl final : public BookPage
 {
 MYGUI_RTTI_DERIVED(BookPage)
 public:
@@ -1271,24 +1271,24 @@ public:
     {
     }
 
-    void showPage (TypesetBook::Ptr book, size_t page)
+    void showPage (TypesetBook::Ptr book, size_t page) final
     {
         mPageDisplay->showPage (book, page);
     }
 
-    void adviseLinkClicked (std::function <void (InteractiveId)> linkClicked)
+    void adviseLinkClicked (std::function <void (InteractiveId)> linkClicked) final
     {
         mPageDisplay->mLinkClicked = linkClicked;
     }
 
-    void unadviseLinkClicked ()
+    void unadviseLinkClicked () final
     {
         mPageDisplay->mLinkClicked = std::function <void (InteractiveId)> ();
     }
 
 protected:
 
-    virtual void initialiseOverride()
+    void initialiseOverride() final
     {
         Base::initialiseOverride();
 
@@ -1302,24 +1302,24 @@ protected:
         }
     }
 
-    void onMouseLostFocus(Widget* _new)
+    void onMouseLostFocus(Widget* _new) final
     {
         // NOTE: MyGUI also fires eventMouseLostFocus for widgets that are about to be destroyed (if they had focus).
         // Child widgets may already be destroyed! So be careful.
         mPageDisplay->onMouseLostFocus ();
     }
 
-    void onMouseMove(int left, int top)
+    void onMouseMove(int left, int top) final
     {
         mPageDisplay->onMouseMove (left, top);
     }
 
-    void onMouseButtonPressed (int left, int top, MyGUI::MouseButton id)
+    void onMouseButtonPressed (int left, int top, MyGUI::MouseButton id) final
     {
         mPageDisplay->onMouseButtonPressed (left, top, id);
     }
 
-    void onMouseButtonReleased(int left, int top, MyGUI::MouseButton id)
+    void onMouseButtonReleased(int left, int top, MyGUI::MouseButton id) final
     {
         mPageDisplay->onMouseButtonReleased (left, top, id);
     }

--- a/apps/openmw/mwgui/controllers.hpp
+++ b/apps/openmw/mwgui/controllers.hpp
@@ -14,14 +14,14 @@ namespace MWGui
     namespace Controllers
     {
         /// Automatically positions a widget below the mouse cursor.
-        class ControllerFollowMouse :
+        class ControllerFollowMouse final :
             public MyGUI::ControllerItem
         {
             MYGUI_RTTI_DERIVED( ControllerFollowMouse )
 
         private:
-            bool addTime(MyGUI::Widget* _widget, float _time);
-            void prepareItem(MyGUI::Widget* _widget);
+            bool addTime(MyGUI::Widget* _widget, float _time) final;
+            void prepareItem(MyGUI::Widget* _widget) final;
         };
     }
 }

--- a/apps/openmw/mwgui/cursor.hpp
+++ b/apps/openmw/mwgui/cursor.hpp
@@ -11,7 +11,7 @@ namespace MWGui
     ///        ResourceImageSetPointer that we need.
     /// \example MyGUI::FactoryManager::getInstance().registerFactory<ResourceImageSetPointerFix>("Resource", "ResourceImageSetPointer");
     ///          MyGUI::ResourceManager::getInstance().load("core.xml");
-    class ResourceImageSetPointerFix :
+    class ResourceImageSetPointerFix final :
         public MyGUI::IPointer
     {
         MYGUI_RTTI_DERIVED( ResourceImageSetPointerFix )
@@ -20,17 +20,17 @@ namespace MWGui
         ResourceImageSetPointerFix();
         virtual ~ResourceImageSetPointerFix();
 
-        virtual void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version);
+        void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version) final;
 
-        virtual void setImage(MyGUI::ImageBox* _image);
-        virtual void setPosition(MyGUI::ImageBox* _image, const MyGUI::IntPoint& _point);
+        void setImage(MyGUI::ImageBox* _image) final;
+        void setPosition(MyGUI::ImageBox* _image, const MyGUI::IntPoint& _point) final;
 
         //and now for the whole point of this class, allow us to get
         //the hot spot, the image and the size of the cursor.
-        virtual MyGUI::ResourceImageSetPtr getImageSet();
-        virtual MyGUI::IntPoint getHotSpot();
-        virtual MyGUI::IntSize getSize();
-        virtual int getRotation();
+        MyGUI::ResourceImageSetPtr getImageSet();
+        MyGUI::IntPoint getHotSpot();
+        MyGUI::IntSize getSize();
+        int getRotation();
 
     private:
         MyGUI::IntPoint mPoint;

--- a/apps/openmw/mwgui/itemchargeview.hpp
+++ b/apps/openmw/mwgui/itemchargeview.hpp
@@ -21,7 +21,7 @@ namespace MWGui
     class ItemModel;
     class ItemWidget;
 
-    class ItemChargeView : public MyGUI::Widget
+    class ItemChargeView final : public MyGUI::Widget
     {
         MYGUI_RTTI_DERIVED(ItemChargeView)
         public:
@@ -36,7 +36,7 @@ namespace MWGui
             /// Register needed components with MyGUI's factory manager
             static void registerComponents();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
             /// Takes ownership of \a model
             void setModel(ItemModel* model);
@@ -47,8 +47,8 @@ namespace MWGui
             void layoutWidgets();
             void resetScrollbars();
 
-            virtual void setSize(const MyGUI::IntSize& value);
-            virtual void setCoord(const MyGUI::IntCoord& value);
+            void setSize(const MyGUI::IntSize& value) final;
+            void setCoord(const MyGUI::IntCoord& value) final;
 
             MyGUI::delegates::CMultiDelegate2<MyGUI::Widget*, const MWWorld::Ptr&> eventItemClicked;
 

--- a/apps/openmw/mwgui/itemview.hpp
+++ b/apps/openmw/mwgui/itemview.hpp
@@ -8,7 +8,7 @@
 namespace MWGui
 {
 
-    class ItemView : public MyGUI::Widget
+    class ItemView final : public MyGUI::Widget
     {
     MYGUI_RTTI_DERIVED(ItemView)
     public:
@@ -33,12 +33,12 @@ namespace MWGui
         void resetScrollBars();
 
     private:
-        virtual void initialiseOverride();
+        void initialiseOverride() final;
 
         void layoutWidgets();
 
-        virtual void setSize(const MyGUI::IntSize& _value);
-        virtual void setCoord(const MyGUI::IntCoord& _value);
+        void setSize(const MyGUI::IntSize& _value) final;
+        void setCoord(const MyGUI::IntCoord& _value) final;
 
         void onSelectedItem (MyGUI::Widget* sender);
         void onSelectedBackground (MyGUI::Widget* sender);

--- a/apps/openmw/mwgui/itemwidget.hpp
+++ b/apps/openmw/mwgui/itemwidget.hpp
@@ -41,7 +41,7 @@ namespace MWGui
         void setFrame (const std::string& frame, const MyGUI::IntCoord& coord);
 
     protected:
-        virtual void initialiseOverride();
+        void initialiseOverride() final;
 
         MyGUI::ImageBox* mItem;
         MyGUI::ImageBox* mItemShadow;

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -54,7 +54,7 @@ namespace
 
 
     /// @brief A widget that changes its color when hovered.
-    class MarkerWidget: public MyGUI::Widget
+    class MarkerWidget final : public MyGUI::Widget
     {
         MYGUI_RTTI_DERIVED(MarkerWidget)
 
@@ -74,12 +74,12 @@ namespace
         MyGUI::Colour mNormalColour;
         MyGUI::Colour mHoverColour;
 
-        void onMouseLostFocus(MyGUI::Widget* _new)
+        void onMouseLostFocus(MyGUI::Widget* _new) final
         {
             setColour(mNormalColour);
         }
 
-        void onMouseSetFocus(MyGUI::Widget* _old)
+        void onMouseSetFocus(MyGUI::Widget* _old) final
         {
             setColour(mHoverColour);
         }

--- a/apps/openmw/mwgui/resourceskin.hpp
+++ b/apps/openmw/mwgui/resourceskin.hpp
@@ -5,12 +5,12 @@
 
 namespace MWGui
 {
-    class AutoSizedResourceSkin : public MyGUI::ResourceSkin
+    class AutoSizedResourceSkin final : public MyGUI::ResourceSkin
     {
         MYGUI_RTTI_DERIVED( AutoSizedResourceSkin )
 
     public:
-        virtual void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version);
+        void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version) final;
     };
 
 }

--- a/apps/openmw/mwgui/spellview.hpp
+++ b/apps/openmw/mwgui/spellview.hpp
@@ -19,7 +19,7 @@ namespace MWGui
     class SpellModel;
 
     ///@brief Displays a SpellModel in a list widget
-    class SpellView : public MyGUI::Widget
+    class SpellView final : public MyGUI::Widget
     {
         MYGUI_RTTI_DERIVED(SpellView)
     public:
@@ -47,10 +47,10 @@ namespace MWGui
         /// Fired when a spell was clicked
         EventHandle_ModelIndex eventSpellClicked;
 
-        virtual void initialiseOverride();
+        void initialiseOverride() final;
 
-        virtual void setSize(const MyGUI::IntSize& _value);
-        virtual void setCoord(const MyGUI::IntCoord& _value);
+        void setSize(const MyGUI::IntSize& _value) final;
+        void setCoord(const MyGUI::IntCoord& _value) final;
 
         void resetScrollbars();
 

--- a/apps/openmw/mwgui/widgets.hpp
+++ b/apps/openmw/mwgui/widgets.hpp
@@ -90,7 +90,7 @@ namespace MWGui
 
         typedef std::vector<SpellEffectParams> SpellEffectList;
 
-        class MWSkill : public MyGUI::Widget
+        class MWSkill final : public MyGUI::Widget
         {
             MYGUI_RTTI_DERIVED( MWSkill )
         public:
@@ -116,7 +116,7 @@ namespace MWGui
         protected:
             virtual ~MWSkill();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
             void onClicked(MyGUI::Widget* _sender);
 
@@ -131,7 +131,7 @@ namespace MWGui
         };
         typedef MWSkill* MWSkillPtr;
 
-        class MWAttribute : public MyGUI::Widget
+        class MWAttribute final : public MyGUI::Widget
         {
             MYGUI_RTTI_DERIVED( MWAttribute )
         public:
@@ -156,7 +156,7 @@ namespace MWGui
         protected:
             virtual ~MWAttribute();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
             void onClicked(MyGUI::Widget* _sender);
 
@@ -175,7 +175,7 @@ namespace MWGui
          * @todo remove this class and use MWEffectList instead
          */
         class MWSpellEffect;
-        class MWSpell : public MyGUI::Widget
+        class MWSpell final : public MyGUI::Widget
         {
             MYGUI_RTTI_DERIVED( MWSpell )
         public:
@@ -199,7 +199,7 @@ namespace MWGui
         protected:
             virtual ~MWSpell();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
         private:
             void updateWidgets();
@@ -209,7 +209,7 @@ namespace MWGui
         };
         typedef MWSpell* MWSpellPtr;
 
-        class MWEffectList : public MyGUI::Widget
+        class MWEffectList final : public MyGUI::Widget
         {
             MYGUI_RTTI_DERIVED( MWEffectList )
         public:
@@ -241,7 +241,7 @@ namespace MWGui
         protected:
             virtual ~MWEffectList();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
         private:
             void updateWidgets();
@@ -250,7 +250,7 @@ namespace MWGui
         };
         typedef MWEffectList* MWEffectListPtr;
 
-        class MWSpellEffect : public MyGUI::Widget
+        class MWSpellEffect final : public MyGUI::Widget
         {
             MYGUI_RTTI_DERIVED( MWSpellEffect )
         public:
@@ -265,7 +265,7 @@ namespace MWGui
         protected:
             virtual ~MWSpellEffect();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
         private:
             static const int sIconOffset = 24;
@@ -279,7 +279,7 @@ namespace MWGui
         };
         typedef MWSpellEffect* MWSpellEffectPtr;
 
-        class MWDynamicStat : public MyGUI::Widget
+        class MWDynamicStat final : public MyGUI::Widget
         {
             MYGUI_RTTI_DERIVED( MWDynamicStat )
         public:
@@ -294,7 +294,7 @@ namespace MWGui
         protected:
             virtual ~MWDynamicStat();
 
-            virtual void initialiseOverride();
+            void initialiseOverride() final;
 
         private:
 

--- a/components/myguiplatform/additivelayer.hpp
+++ b/components/myguiplatform/additivelayer.hpp
@@ -14,7 +14,7 @@ namespace osgMyGUI
 {
 
     /// @brief A Layer rendering with additive blend mode.
-    class AdditiveLayer : public MyGUI::OverlappedLayer
+    class AdditiveLayer final : public MyGUI::OverlappedLayer
     {
     public:
         MYGUI_RTTI_DERIVED( AdditiveLayer )
@@ -22,7 +22,7 @@ namespace osgMyGUI
         AdditiveLayer();
         ~AdditiveLayer();
 
-        virtual void renderToTarget(MyGUI::IRenderTarget* _target, bool _update);
+        void renderToTarget(MyGUI::IRenderTarget* _target, bool _update) final;
 
     private:
         osg::ref_ptr<osg::StateSet> mStateSet;

--- a/components/myguiplatform/scalinglayer.hpp
+++ b/components/myguiplatform/scalinglayer.hpp
@@ -8,18 +8,18 @@ namespace osgMyGUI
 
     ///@brief A Layer that lays out and renders widgets in screen-relative coordinates. The "Size" property determines the size of the virtual screen,
     /// which is then upscaled to the real screen size during rendering. The aspect ratio is kept intact, adding blanks to the sides when necessary.
-    class ScalingLayer : public MyGUI::OverlappedLayer
+    class ScalingLayer final : public MyGUI::OverlappedLayer
     {
     public:
         MYGUI_RTTI_DERIVED(ScalingLayer)
 
-        virtual void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version);
+        void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version) final;
 
-        virtual MyGUI::ILayerItem* getLayerItemByPoint(int _left, int _top) const;
-        virtual MyGUI::IntPoint getPosition(int _left, int _top) const;
-        virtual void renderToTarget(MyGUI::IRenderTarget* _target, bool _update);
+        MyGUI::ILayerItem* getLayerItemByPoint(int _left, int _top) const final;
+        MyGUI::IntPoint getPosition(int _left, int _top) const final;
+        void renderToTarget(MyGUI::IRenderTarget* _target, bool _update) final;
 
-        virtual void resizeView(const MyGUI::IntSize& _viewSize);
+        void resizeView(const MyGUI::IntSize& _viewSize) final;
 
     private:
         void screenToLayerCoords(int& _left, int& _top) const;

--- a/components/widgets/box.hpp
+++ b/components/widgets/box.hpp
@@ -44,11 +44,11 @@ namespace Gui
         MYGUI_RTTI_DERIVED( AutoSizedTextBox )
 
     public:
-        virtual MyGUI::IntSize getRequestedSize();
-        virtual void setCaption(const MyGUI::UString& _value);
+        MyGUI::IntSize getRequestedSize() final;
+        void setCaption(const MyGUI::UString& _value) final;
 
     protected:
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
         std::string mFontSize;
     };
 
@@ -58,14 +58,14 @@ namespace Gui
 
     public:
 
-        virtual MyGUI::IntSize getRequestedSize();
-        virtual void setCaption(const MyGUI::UString& _value);
+        MyGUI::IntSize getRequestedSize() final;
+        void setCaption(const MyGUI::UString& _value) final;
 
-        virtual void initialiseOverride();
+        void initialiseOverride() final;
 
     protected:
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
-        virtual int getWidth();
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
+        int getWidth();
         std::string mFontSize;
         bool mShrink = false;
         bool mWasResized = false;
@@ -77,11 +77,11 @@ namespace Gui
         MYGUI_RTTI_DERIVED( AutoSizedButton )
 
     public:
-        virtual MyGUI::IntSize getRequestedSize();
-        virtual void setCaption(const MyGUI::UString& _value);
+        MyGUI::IntSize getRequestedSize() final;
+        void setCaption(const MyGUI::UString& _value) final;
 
     protected:
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
         std::string mFontSize;
     };
 
@@ -114,7 +114,7 @@ namespace Gui
     public:
         Spacer();
 
-        virtual MyGUI::IntSize getRequestedSize() { return MyGUI::IntSize(0,0); }
+        MyGUI::IntSize getRequestedSize() final { return MyGUI::IntSize(0,0); }
     };
 
     class HBox : public Box, public MyGUI::Widget
@@ -122,18 +122,18 @@ namespace Gui
         MYGUI_RTTI_DERIVED( HBox )
 
     public:
-        virtual void setSize (const MyGUI::IntSize &_value);
-        virtual void setCoord (const MyGUI::IntCoord &_value);
+        void setSize (const MyGUI::IntSize &_value) final;
+        void setCoord (const MyGUI::IntCoord &_value) final;
 
     protected:
-        virtual void initialiseOverride();
+        void initialiseOverride() final;
 
-        virtual void align();
-        virtual MyGUI::IntSize getRequestedSize();
+        void align() final;
+        MyGUI::IntSize getRequestedSize() final;
 
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
 
-        virtual void onWidgetCreated(MyGUI::Widget* _widget);
+        void onWidgetCreated(MyGUI::Widget* _widget) final;
     };
 
     class VBox : public Box, public MyGUI::Widget
@@ -141,18 +141,18 @@ namespace Gui
         MYGUI_RTTI_DERIVED( VBox)
 
     public:
-        virtual void setSize (const MyGUI::IntSize &_value);
-        virtual void setCoord (const MyGUI::IntCoord &_value);
+        void setSize (const MyGUI::IntSize &_value) final;
+        void setCoord (const MyGUI::IntCoord &_value) final;
 
     protected:
-        virtual void initialiseOverride();
+        void initialiseOverride() final;
 
-        virtual void align();
-        virtual MyGUI::IntSize getRequestedSize();
+        void align() final;
+        MyGUI::IntSize getRequestedSize() final;
 
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
 
-        virtual void onWidgetCreated(MyGUI::Widget* _widget);
+        void onWidgetCreated(MyGUI::Widget* _widget) final;
     };
 
 }

--- a/components/widgets/imagebutton.hpp
+++ b/components/widgets/imagebutton.hpp
@@ -9,7 +9,7 @@ namespace Gui
     /**
      * @brief allows using different image textures depending on the button state
      */
-    class ImageButton : public MyGUI::ImageBox
+    class ImageButton final : public MyGUI::ImageBox
     {
         MYGUI_RTTI_DERIVED(ImageButton)
 
@@ -31,13 +31,13 @@ namespace Gui
         static bool sDefaultNeedKeyFocus;
 
     protected:
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
-        virtual void onMouseLostFocus(MyGUI::Widget* _new);
-        virtual void onMouseSetFocus(MyGUI::Widget* _old);
-        virtual void onMouseButtonPressed(int _left, int _top, MyGUI::MouseButton _id);
-        virtual void onMouseButtonReleased(int _left, int _top, MyGUI::MouseButton _id);
-        virtual void onKeySetFocus(MyGUI::Widget* _old);
-        virtual void onKeyLostFocus(MyGUI::Widget* _new);
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
+        void onMouseLostFocus(MyGUI::Widget* _new) final;
+        void onMouseSetFocus(MyGUI::Widget* _old) final;
+        void onMouseButtonPressed(int _left, int _top, MyGUI::MouseButton _id) final;
+        void onMouseButtonReleased(int _left, int _top, MyGUI::MouseButton _id) final;
+        void onKeySetFocus(MyGUI::Widget* _old) final;
+        void onKeyLostFocus(MyGUI::Widget* _new) final;
 
         std::string mImageHighlighted;
         std::string mImageNormal;

--- a/components/widgets/list.hpp
+++ b/components/widgets/list.hpp
@@ -48,10 +48,10 @@ namespace Gui
 
         void scrollToTop();
 
-        virtual void setPropertyOverride(const std::string& _key, const std::string& _value);
+        void setPropertyOverride(const std::string& _key, const std::string& _value) final;
 
     protected:
-        void initialiseOverride();
+        void initialiseOverride() final;
 
         void redraw(bool scrollbarShown = false);
 

--- a/components/widgets/numericeditbox.hpp
+++ b/components/widgets/numericeditbox.hpp
@@ -11,7 +11,7 @@ namespace Gui
     /**
      * @brief A variant of the EditBox that only allows integer inputs
      */
-    class NumericEditBox : public FontWrapper<MyGUI::EditBox>
+    class NumericEditBox final : public FontWrapper<MyGUI::EditBox>
     {
         MYGUI_RTTI_DERIVED(NumericEditBox)
 
@@ -22,8 +22,8 @@ namespace Gui
         {
         }
 
-        void initialiseOverride();
-        void shutdownOverride();
+        void initialiseOverride() final;
+        void shutdownOverride() final;
 
         typedef MyGUI::delegates::CMultiDelegate1<int> EventHandle_ValueChanged;
         EventHandle_ValueChanged eventValueChanged;
@@ -36,8 +36,8 @@ namespace Gui
         void setMaxValue(int maxValue);
     private:
         void onEditTextChange(MyGUI::EditBox* sender);
-        void onKeyLostFocus(MyGUI::Widget* _new);
-        void onKeyButtonPressed(MyGUI::KeyCode key, MyGUI::Char character);
+        void onKeyLostFocus(MyGUI::Widget* _new) final;
+        void onKeyButtonPressed(MyGUI::KeyCode key, MyGUI::Char character) final;
 
         int mValue;
 

--- a/components/widgets/sharedstatebutton.hpp
+++ b/components/widgets/sharedstatebutton.hpp
@@ -13,7 +13,7 @@ namespace Gui
     typedef std::vector<SharedStateButton*> ButtonGroup;
 
     /// @brief A button that applies its own state changes to other widgets, to do this you define it as part of a ButtonGroup.
-    class SharedStateButton : public FontWrapper<MyGUI::Button>
+    class SharedStateButton final : public FontWrapper<MyGUI::Button>
     {
     MYGUI_RTTI_DERIVED(SharedStateButton)
 
@@ -23,13 +23,13 @@ namespace Gui
     protected:
         void updateButtonState();
 
-        virtual void onMouseButtonPressed(int _left, int _top, MyGUI::MouseButton _id);
-        virtual void onMouseButtonReleased(int _left, int _top, MyGUI::MouseButton _id);
-        virtual void onMouseSetFocus(MyGUI::Widget* _old);
-        virtual void onMouseLostFocus(MyGUI::Widget* _new);
-        virtual void baseUpdateEnable();
+        void onMouseButtonPressed(int _left, int _top, MyGUI::MouseButton _id) final;
+        void onMouseButtonReleased(int _left, int _top, MyGUI::MouseButton _id) final;
+        void onMouseSetFocus(MyGUI::Widget* _old) final;
+        void onMouseLostFocus(MyGUI::Widget* _new) final;
+        void baseUpdateEnable() final;
 
-        virtual void shutdownOverride();
+        void shutdownOverride() final;
 
         bool _setState(const std::string &_value);
 

--- a/components/widgets/windowcaption.hpp
+++ b/components/widgets/windowcaption.hpp
@@ -8,17 +8,17 @@ namespace Gui
 
     /// Window caption that automatically adjusts "Left" and "Right" widgets in its skin
     /// based on the text size of the caption in the middle
-    class WindowCaption : public MyGUI::EditBox
+    class WindowCaption final : public MyGUI::EditBox
     {
         MYGUI_RTTI_DERIVED(WindowCaption)
     public:
         WindowCaption();
 
-        virtual void setCaption(const MyGUI::UString &_value);
-        virtual void initialiseOverride();
+        void setCaption(const MyGUI::UString &_value) final;
+        void initialiseOverride() final;
 
-        virtual void setSize(const MyGUI::IntSize& _value);
-        virtual void setCoord(const MyGUI::IntCoord& _value);
+        void setSize(const MyGUI::IntSize& _value) final;
+        void setCoord(const MyGUI::IntCoord& _value) final;
 
     private:
         MyGUI::Widget* mLeft;


### PR DESCRIPTION
Example:
```
In file included from openmw/components/myguiplatform/scalinglayer.cpp:1:
openmw/components/myguiplatform/scalinglayer.hpp:16:22: warning: 'deserialization' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual void deserialization(MyGUI::xml::ElementPtr _node, MyGUI::Version _version);
                     ^
mygui/build/clang/release/include/MYGUI/MyGUI_OverlappedLayer.h:26:8: note: overridden virtual function is here
                void deserialization(xml::ElementPtr _node, Version _version) override;
                     ^
```