### PR TITLE
Fix water ripple cleanup (bug #5246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@
     Bug #5239: OpenMW-CS does not support non-ASCII characters in path names
     Bug #5241: On-self absorb spells cannot be detected
     Bug #5242: ExplodeSpell behavior differs from Cast behavior
+    Bug #5246: Water ripples persist after cell change
     Bug #5249: Wandering NPCs start walking too soon after they hello
     Bug #5250: Creatures display shield ground mesh instead of shield body part
     Bug #5255: "GetTarget, player" doesn't return 1 during NPC hello

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -1106,6 +1106,7 @@ namespace MWRender
     void RenderingManager::notifyWorldSpaceChanged()
     {
         mEffectManager->clear();
+        mWater->clearRipples();
     }
 
     void RenderingManager::clear()


### PR DESCRIPTION
drummyfish really accidentally removed the clean up of **normal** water ripples upon worldspace change when he refactored **rain** ripple cleanup. [The issue](https://gitlab.com/OpenMW/openmw/issues/5246) is no longer reproducible in Iskuss' cell in my testing.