### PR TITLE
Make ModCurrentFatigue knock down the actor when necessary (bug #4523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
     Bug #4411: Reloading a saved game while falling prevents damage in some cases
     Bug #4449: Value returned by GetWindSpeed is incorrect
     Bug #4456: AiActivate should not be cancelled after target activation
+    Bug #4523: "player->ModCurrentFatigue -0.001" in global script does not cause the running player to fall
     Bug #4540: Rain delay when exiting water
     Bug #4594: Actors without AI packages don't use Hello dialogue
     Bug #4598: Script parser does not support non-ASCII characters

--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -291,8 +291,15 @@ namespace MWScript
                     MWMechanics::DynamicStat<float> stat (ptr.getClass().getCreatureStats (ptr)
                         .getDynamic (mIndex));
 
-                    // for fatigue, a negative current value is allowed and means the actor will be knocked down
-                    bool allowDecreaseBelowZero = (mIndex == 2);
+                    bool allowDecreaseBelowZero = false;
+                    if (mIndex == 2) // Fatigue-specific logic
+                    {
+                        // For fatigue, a negative current value is allowed and means the actor will be knocked down
+                        allowDecreaseBelowZero = true;
+                        // Knock down the actor immediately if a non-positive new value is the case
+                        if (diff + current <= 0.f)
+                            ptr.getClass().getCreatureStats(ptr).setKnockedDown(true);
+                    }
                     stat.setCurrent (diff + current, allowDecreaseBelowZero);
 
                     ptr.getClass().getCreatureStats (ptr).setDynamic (mIndex, stat);


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4523)

akortunov just made a guess, but knocking down the actor when the new fatigue is non-positive is really what vanilla does as I have learned. Fixes the issue in my testing.