### PR TITLE
Make PCSkipEquip and OnPCEquip behavior vanilla-like (bug #4141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
     Bug #3977: Non-ASCII characters in object ID's are not supported
     Bug #4009: Launcher does not show data files on the first run after installing
     Bug #4077: Enchanted items are not recharged if they are not in the player's inventory
+    Bug #4141: PCSkipEquip isn't set to 1 when reading books/scrolls
     Bug #4202: Open .omwaddon files without needing toopen openmw-cs first
     Bug #4240: Ash storm origin coordinates and hand shielding animation behavior are incorrect
     Bug #4262: Rain settings are hardcoded

--- a/apps/openmw/mwgui/inventorywindow.hpp
+++ b/apps/openmw/mwgui/inventorywindow.hpp
@@ -93,8 +93,6 @@ namespace MWGui
             MyGUI::Button* mFilterMagic;
             MyGUI::Button* mFilterMisc;
 
-            MWWorld::Ptr mSkippedToEquip;
-
             GuiMode mGuiMode;
 
             int mLastXSize;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/4141)

Replace our wacky hacks with vanilla wacky hacks based on the research of Hrnchamd and NullCascade.

Basically, this should be the case:
1. If PCSkipEquip is set to 1, OnPCEquip is set to 1 (for books as well) and equipment attempt is ignored. This is consistent with the behavior expected in bug 5182 report which I previously fixed.
2. If it's not and the items otherwise can be equipped (aren't broken or , OnPCEquip is set to 1 for everything except ingredients, books and repair tools. Ingredients are understandable because they are removed immediately, the repair hammer thing I'm not sure. Potions are removed as well, but they still have OnPCEquip set for some reason. I decided to copy all of this precisely.
3. For books, PCSkipEquip is set to 1, OnPCEquip stays 0. Don't ask why.

This fixes PCSkipEquip and OnPCEquip handling in scripts, so all things that rely on their state in the current frame should work fine, e.g. Morrowind Scripting for Dummies template which a bunch of TR scripts and many mods as well rely on and some other scripts that aren't based on this template, including one from the bug report and vanilla scripts, work exactly as in vanilla in my testing. Some book scripts still aren't fully compatible because there's some kind of an unclear issue with Activate understanding. OnActivate/Activate behavior is not obvious in vanilla scripting, as OnActivate can affect the script behavior merely by its presence anywhere in it. But their behavior is still much closer to vanilla.

As far as I can tell Morrowind doesn't run the script in the middle of the frame here like we did and doesn't save skipped equipment attempts in any way (it's unnecessary). So the behavior is actually more simple now.