### PR TITLE
Limit frequency for navmesh updates

### DIFF
--- a/components/detournavigator/settings.cpp
+++ b/components/detournavigator/settings.cpp
@@ -40,6 +40,7 @@ namespace DetourNavigator
         navigatorSettings.mNavMeshPathPrefix = ::Settings::Manager::getString("nav mesh path prefix", "Navigator");
         navigatorSettings.mEnableRecastMeshFileNameRevision = ::Settings::Manager::getBool("enable recast mesh file name revision", "Navigator");
         navigatorSettings.mEnableNavMeshFileNameRevision = ::Settings::Manager::getBool("enable nav mesh file name revision", "Navigator");
+        navigatorSettings.mMinUpdateInterval = std::chrono::milliseconds(::Settings::Manager::getInt("min update interval ms", "Navigator"));
 
         return navigatorSettings;
     }

--- a/components/detournavigator/settings.hpp
+++ b/components/detournavigator/settings.hpp
@@ -4,6 +4,7 @@
 #include <boost/optional.hpp>
 
 #include <string>
+#include <chrono>
 
 namespace DetourNavigator
 {
@@ -38,6 +39,7 @@ namespace DetourNavigator
         std::size_t mTrianglesPerChunk = 0;
         std::string mRecastMeshPathPrefix;
         std::string mNavMeshPathPrefix;
+        std::chrono::milliseconds mMinUpdateInterval;
     };
 
     boost::optional<Settings> makeSettingsFromSettingsManager();

--- a/docs/source/reference/modding/settings/navigator.rst
+++ b/docs/source/reference/modding/settings/navigator.rst
@@ -74,6 +74,20 @@ Game will not eat all memory at once.
 Memory will be consumed in approximately linear dependency from number of nav mesh updates.
 But only for new locations or already dropped from cache.
 
+min update interval ms
+----------------
+
+:Type:		integer
+:Range:		>= 0
+:Default:	250
+
+Minimum time duration required to pass before next navmesh update for the same tile in milliseconds.
+Only tiles affected where objects are transformed.
+Next update for tile with added or removed object will not be delayed.
+Visible ingame effect is navmesh update around opening or closing door.
+Primary usage is for rotating signs like in Seyda Neen at Arrille's Tradehouse entrance.
+Decreasing this value may increase CPU usage by background threads.
+
 Developer's settings
 ********************
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -776,6 +776,9 @@ enable recast mesh render = false
 # Max number of navmesh tiles (value >= 0)
 max tiles number = 512
 
+# Min time duration for the same tile update in milliseconds (value >= 0)
+min update interval ms = 250
+
 [Shadows]
 
 # Enable or disable shadows. Bear in mind that this will force OpenMW to use shaders as if "[Shaders]/force shaders" was set to true.


### PR DESCRIPTION
This pr mitigates the issue with constantly transforming objects like sing in Seyda Neen described in [bug 4917](https://gitlab.com/OpenMW/openmw/issues/4917). The idea is to limit frequency of updates per navmesh tile. Added of removed objects from scene are not affected. Visible changes are:
* CPU usage. It drops from 141% to 105% on my machine for default settings with 60 fps limit and 250 ms navmesh update interval for the first 2000 frames since game is loaded in Seyda Neen location.  Save: [1.zip](https://github.com/OpenMW/openmw/files/4240150/1.zip).
* Navmesh change around opening/closing door.
  * master: https://streamable.com/8wf4w
  * pr: https://streamable.com/rq8ms