### PR TITLE
Switch torches to shields for hostile NPCs (bug #5300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@
     Bug #5264: "Damage Fatigue" Magic Effect Can Bring Fatigue below 0
     Bug #5269: Editor: Cell lighting in resaved cleaned content files is corrupted
     Bug #5278: Console command Show doesn't fall back to global variable after local var not found
+    Bug #5300: NPCs don't switch from torch to shield when starting combat
     Feature #1415: Infinite fall failsafe
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1234,6 +1234,11 @@ namespace MWMechanics
                         if (heldIter != inventoryStore.end() && heldIter->getTypeName() != typeid(ESM::Light).name())
                             inventoryStore.unequipItem(*heldIter, ptr);
                     }
+                    else if (heldIter == inventoryStore.end() || heldIter->getTypeName() == typeid(ESM::Light).name())
+                    {
+                        // For hostile NPCs, see if they have anything better to equip first
+                        inventoryStore.autoEquip(ptr);
+                    }
 
                     heldIter = inventoryStore.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/issues/5300).

If an actor in combat currently doesn't have anything in the carried left slot or carries a torch, they will try to autoequip something better or equip a torch anyway if there's nothing better to do.