### PR TITLE
Make search fields behave more consistently

### DIFF
--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -48,9 +48,6 @@ CompanionWindow::CompanionWindow(DragAndDrop *dragAndDrop, MessageBoxManager* ma
     getWidget(mEncumbranceBar, "EncumbranceBar");
     getWidget(mFilterEdit, "FilterEdit");
     getWidget(mItemView, "ItemView");
-
-    mFilterEdit->setUserString("AcceptTab", "true");
-
     mItemView->eventBackgroundClicked += MyGUI::newDelegate(this, &CompanionWindow::onBackgroundSelected);
     mItemView->eventItemClicked += MyGUI::newDelegate(this, &CompanionWindow::onItemSelected);
     mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &CompanionWindow::onNameFilterChanged);

--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -48,6 +48,9 @@ CompanionWindow::CompanionWindow(DragAndDrop *dragAndDrop, MessageBoxManager* ma
     getWidget(mEncumbranceBar, "EncumbranceBar");
     getWidget(mFilterEdit, "FilterEdit");
     getWidget(mItemView, "ItemView");
+
+    mFilterEdit->setUserString("AcceptTab", "true");
+
     mItemView->eventBackgroundClicked += MyGUI::newDelegate(this, &CompanionWindow::onBackgroundSelected);
     mItemView->eventItemClicked += MyGUI::newDelegate(this, &CompanionWindow::onItemSelected);
     mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &CompanionWindow::onNameFilterChanged);
@@ -121,6 +124,7 @@ void CompanionWindow::setPtr(const MWWorld::Ptr& npc)
 
     mModel = new CompanionItemModel(npc);
     mSortModel = new SortFilterItemModel(mModel);
+    mFilterEdit->setCaption(std::string());
     mItemView->setModel(mSortModel);
     mItemView->resetScrollBars();
 

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -91,6 +91,8 @@ namespace MWGui
         getWidget(mArmorRating, "ArmorRating");
         getWidget(mFilterEdit, "FilterEdit");
 
+        mFilterEdit->setUserString("AcceptTab", "true");
+
         mAvatarImage->eventMouseButtonClick += MyGUI::newDelegate(this, &InventoryWindow::onAvatarClicked);
         mAvatarImage->setRenderItemTexture(mPreviewTexture.get());
         mAvatarImage->getSubWidgetMain()->_setUVSet(MyGUI::FloatRect(0.f, 0.f, 1.f, 1.f));
@@ -133,6 +135,8 @@ namespace MWGui
             mSortModel->setSourceModel(mTradeModel);
         else
             mSortModel = new SortFilterItemModel(mTradeModel);
+
+        mSortModel->setNameFilter(mFilterEdit->getCaption());
 
         mItemView->setModel(mSortModel);
 

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -91,8 +91,6 @@ namespace MWGui
         getWidget(mArmorRating, "ArmorRating");
         getWidget(mFilterEdit, "FilterEdit");
 
-        mFilterEdit->setUserString("AcceptTab", "true");
-
         mAvatarImage->eventMouseButtonClick += MyGUI::newDelegate(this, &InventoryWindow::onAvatarClicked);
         mAvatarImage->setRenderItemTexture(mPreviewTexture.get());
         mAvatarImage->getSubWidgetMain()->_setUVSet(MyGUI::FloatRect(0.f, 0.f, 1.f, 1.f));

--- a/apps/openmw/mwgui/keyboardnavigation.cpp
+++ b/apps/openmw/mwgui/keyboardnavigation.cpp
@@ -16,9 +16,6 @@ namespace MWGui
 
 bool shouldAcceptKeyFocus(MyGUI::Widget* w)
 {
-    if (w && w->getUserString("IgnoreTabKey") == "y")
-        return false;
-
     return w && !w->castType<MyGUI::Window>(false) && w->getInheritedEnabled() && w->getInheritedVisible() && w->getVisible() && w->getEnabled();
 }
 

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -45,7 +45,7 @@ namespace MWGui
         getWidget(mEffectBox, "EffectsBox");
         getWidget(mFilterEdit, "FilterEdit");
 
-        mFilterEdit->setUserString("IgnoreTabKey", "y");
+        mFilterEdit->setUserString("AcceptTab", "true");
 
         mSpellView->eventSpellClicked += MyGUI::newDelegate(this, &SpellWindow::onModelIndexSelected);
         mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &SpellWindow::onFilterChanged);

--- a/apps/openmw/mwgui/spellwindow.cpp
+++ b/apps/openmw/mwgui/spellwindow.cpp
@@ -45,8 +45,6 @@ namespace MWGui
         getWidget(mEffectBox, "EffectsBox");
         getWidget(mFilterEdit, "FilterEdit");
 
-        mFilterEdit->setUserString("AcceptTab", "true");
-
         mSpellView->eventSpellClicked += MyGUI::newDelegate(this, &SpellWindow::onModelIndexSelected);
         mFilterEdit->eventEditTextChange += MyGUI::newDelegate(this, &SpellWindow::onFilterChanged);
         deleteButton->eventMouseButtonClick += MyGUI::newDelegate(this, &SpellWindow::onDeleteClicked);

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -71,6 +71,8 @@ namespace MWGui
         getWidget(mBottomPane, "BottomPane");
         getWidget(mFilterEdit, "FilterEdit");
 
+        mFilterEdit->setUserString("AcceptTab", "true");
+
         getWidget(mItemView, "ItemView");
         mItemView->eventItemClicked += MyGUI::newDelegate(this, &TradeWindow::onItemSelected);
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -71,8 +71,6 @@ namespace MWGui
         getWidget(mBottomPane, "BottomPane");
         getWidget(mFilterEdit, "FilterEdit");
 
-        mFilterEdit->setUserString("AcceptTab", "true");
-
         getWidget(mItemView, "ItemView");
         mItemView->eventItemClicked += MyGUI::newDelegate(this, &TradeWindow::onItemSelected);
 

--- a/files/mygui/openmw_companion_window.layout
+++ b/files/mygui/openmw_companion_window.layout
@@ -8,6 +8,7 @@
         <Widget type="HBox"  position="5 5 575 23" align="Left Top HStretch" name="_Filter">
             <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 0 23" name="FilterEdit">
                 <UserString key="HStretch" value="true"/>
+                <UserString key="AcceptTab" value="true"/>
             </Widget>
         </Widget>
         <!-- Items -->

--- a/files/mygui/openmw_inventory_window.layout
+++ b/files/mygui/openmw_inventory_window.layout
@@ -52,7 +52,8 @@
                 </Widget>
                 <!-- Search box-->
                 <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 0 23" name="FilterEdit">
-                <UserString key="HStretch" value="true"/>
+                    <UserString key="HStretch" value="true"/>
+                    <UserString key="AcceptTab" value="true"/>
                 </Widget>
             </Widget>
 

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -24,6 +24,7 @@
 
         <!-- Search box-->
         <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="8 535 268 23" align="Left Bottom HStretch" name="FilterEdit">
+            <UserString key="AcceptTab" value="true"/>
         </Widget>
 
     </Widget>

--- a/files/mygui/openmw_trade_window.layout
+++ b/files/mygui/openmw_trade_window.layout
@@ -30,6 +30,7 @@
             <!-- Search box-->
             <Widget type="EditBox" skin="MW_TextBoxEditWithBorder" position="0 0 0 23" name="FilterEdit">
                 <UserString key="HStretch" value="true"/>
+                <UserString key="AcceptTab" value="true"/>
             </Widget>
         </Widget>
 


### PR DESCRIPTION
1) There were keyboard focus issues due to how the spell window search field and the inventory search field are supposed to ignore Tab to avoid breaking Tab shortcut used as an alternative to Right Click pause shortcut. The used approach in spell window is problematic as it's a bit nuclear and can break mouse focus for the fields that have the user string, I switched it to a different solution where AcceptTab user string is set to true that works a bit differently - once you switch focus to the fields, Tab doesn't switch focus to anything in favor of other actions Tab is assigned to - but it should still be acceptable and even convenient somewhat. It's added to all search fields for consistency. IgnoreTabKey user string handling was dropped because it went unused.
2) Inventory search filter behaved oddly when the sort item model was replaced when the inventory window was reinitialized (after you load a save for example)
3) Companion window search filter wasn't cleaned up properly either.

I could have missed something.