### PR TITLE
Editor: Implement dropping objects with keypress in instancemode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,7 @@
     Feature #5193: Weapon sheathing
     Feature #5219: Impelement TestCells console command
     Feature #5224: Handle NiKeyframeController for NiTriShape
+    Feature #5274: Editor: Keyboard shortcut to drop objects to ground/obstacle in scene view
     Feature #5304: Morrowind-style bump-mapping
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption

--- a/CHANGELOG_PR.md
+++ b/CHANGELOG_PR.md
@@ -43,6 +43,7 @@ New Editor Features:
 - Changes to height editing can be cancelled without changes to data (press esc to cancel) (#4840)
 - Land heightmap/shape editing and vertex selection (#5170)
 - Deleting instances with a keypress (#5172)
+- Dropping objects with keyboard shortcuts (#5274)
 
 Bug Fixes:
 - The Mouse Wheel can now be used for key bindings (#2679)

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -356,8 +356,10 @@ void CSMPrefs::State::declare()
         QKeySequence(Qt::ControlModifier | (int)Qt::MiddleButton));
     declareModifier ("scene-speed-modifier", "Speed Modifier", Qt::Key_Shift);
     declareShortcut ("scene-delete", "Delete Instance", QKeySequence(Qt::Key_Delete));
-    declareShortcut ("scene-instance-groundlevel", "Instance to Ground Level", QKeySequence(Qt::Key_G));
-    declareShortcut ("scene-instance-drop", "Drop Instance", QKeySequence(Qt::Key_H));
+    declareShortcut ("scene-instance-drop-terrain", "Drop to terrain level", QKeySequence(Qt::Key_G));
+    declareShortcut ("scene-instance-drop-collision", "Drop to collision", QKeySequence(Qt::Key_H));
+    declareShortcut ("scene-instance-drop-terrain-separately", "Drop to terrain level separately", QKeySequence());
+    declareShortcut ("scene-instance-drop-collision-separately", "Drop to collision separately", QKeySequence());
     declareShortcut ("scene-load-cam-cell", "Load Camera Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_5));
     declareShortcut ("scene-load-cam-eastcell", "Load East Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_6));
     declareShortcut ("scene-load-cam-northcell", "Load North Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_8));

--- a/apps/opencs/model/prefs/state.cpp
+++ b/apps/opencs/model/prefs/state.cpp
@@ -356,6 +356,8 @@ void CSMPrefs::State::declare()
         QKeySequence(Qt::ControlModifier | (int)Qt::MiddleButton));
     declareModifier ("scene-speed-modifier", "Speed Modifier", Qt::Key_Shift);
     declareShortcut ("scene-delete", "Delete Instance", QKeySequence(Qt::Key_Delete));
+    declareShortcut ("scene-instance-groundlevel", "Instance to Ground Level", QKeySequence(Qt::Key_G));
+    declareShortcut ("scene-instance-drop", "Drop Instance", QKeySequence(Qt::Key_H));
     declareShortcut ("scene-load-cam-cell", "Load Camera Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_5));
     declareShortcut ("scene-load-cam-eastcell", "Load East Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_6));
     declareShortcut ("scene-load-cam-northcell", "Load North Cell", QKeySequence(Qt::KeypadModifier | Qt::Key_8));

--- a/apps/opencs/view/render/instancemode.cpp
+++ b/apps/opencs/view/render/instancemode.cpp
@@ -21,7 +21,6 @@
 #include "../widget/scenetoolbar.hpp"
 #include "../widget/scenetoolmode.hpp"
 
-#include <components/debug/debuglog.hpp>
 #include <components/sceneutil/vismask.hpp>
 
 #include "object.hpp"

--- a/apps/opencs/view/render/instancemode.cpp
+++ b/apps/opencs/view/render/instancemode.cpp
@@ -700,7 +700,7 @@ void CSVRender::InstanceMode::deleteSelectedInstances(bool active)
 
 void CSVRender::InstanceMode::dropInstance(DropMode dropMode, CSVRender::Object* object, float objectHeight)
 {
-    const osg::Vec3d& point = object->getPosition().asVec3();
+    osg::Vec3d point = object->getPosition().asVec3();
 
     osg::Vec3d start = point;
     start.z() += objectHeight;
@@ -712,8 +712,10 @@ void CSVRender::InstanceMode::dropInstance(DropMode dropMode, CSVRender::Object*
     intersector->setIntersectionLimit(osgUtil::LineSegmentIntersector::NO_LIMIT);
     osgUtil::IntersectionVisitor visitor(intersector);
 
-    if (dropMode == Terrain_sep) visitor.setTraversalMask(SceneUtil::Mask_Terrain);
-    if (dropMode == Collision_sep) visitor.setTraversalMask(SceneUtil::Mask_Terrain | SceneUtil::Mask_EditorReference);
+    if (dropMode == TerrainSep)
+        visitor.setTraversalMask(SceneUtil::Mask_Terrain);
+    if (dropMode == CollisionSep)
+        visitor.setTraversalMask(SceneUtil::Mask_Terrain | SceneUtil::Mask_EditorReference);
 
     mParentNode->accept(visitor);
 
@@ -732,7 +734,7 @@ void CSVRender::InstanceMode::dropInstance(DropMode dropMode, CSVRender::Object*
 
 float CSVRender::InstanceMode::getDropHeight(DropMode dropMode, CSVRender::Object* object, float objectHeight)
 {
-    const osg::Vec3d& point = object->getPosition().asVec3();
+    osg::Vec3d point = object->getPosition().asVec3();
 
     osg::Vec3d start = point;
     start.z() += objectHeight;
@@ -744,8 +746,10 @@ float CSVRender::InstanceMode::getDropHeight(DropMode dropMode, CSVRender::Objec
     intersector->setIntersectionLimit(osgUtil::LineSegmentIntersector::NO_LIMIT);
     osgUtil::IntersectionVisitor visitor(intersector);
 
-    if (dropMode == Terrain) visitor.setTraversalMask(SceneUtil::Mask_Terrain);
-    if (dropMode == Collision) visitor.setTraversalMask(SceneUtil::Mask_Terrain | SceneUtil::Mask_EditorReference);
+    if (dropMode == Terrain)
+        visitor.setTraversalMask(SceneUtil::Mask_Terrain);
+    if (dropMode == Collision)
+        visitor.setTraversalMask(SceneUtil::Mask_Terrain | SceneUtil::Mask_EditorReference);
 
     mParentNode->accept(visitor);
 
@@ -772,18 +776,19 @@ void CSVRender::InstanceMode::dropSelectedInstancesToTerrain()
 
 void CSVRender::InstanceMode::dropSelectedInstancesToCollisionSeparately()
 {
-    handleDropMethod(Terrain_sep, "Drop instances to next collision level separately");
+    handleDropMethod(TerrainSep, "Drop instances to next collision level separately");
 }
 
 void CSVRender::InstanceMode::dropSelectedInstancesToTerrainSeparately()
 {
-    handleDropMethod(Collision_sep, "Drop instances to terrain level separately");
+    handleDropMethod(CollisionSep, "Drop instances to terrain level separately");
 }
 
 void CSVRender::InstanceMode::handleDropMethod(DropMode dropMode, QString commandMsg)
 {
     std::vector<osg::ref_ptr<TagBase> > selection = getWorldspaceWidget().getSelection (SceneUtil::Mask_EditorReference);
-    if (selection.empty()) return;
+    if (selection.empty())
+        return;
 
     CSMDoc::Document& document = getWorldspaceWidget().getDocument();
     QUndoStack& undoStack = document.getUndoStack();
@@ -803,7 +808,8 @@ void CSVRender::InstanceMode::handleDropMethod(DropMode dropMode, QString comman
                     if (CSVRender::ObjectTag *objectTag = dynamic_cast<CSVRender::ObjectTag *> (tag.get()))
                     {
                         float thisDrop = getDropHeight(dropMode, objectTag->mObject, dropObjectDataHandler.mObjectHeights[counter]);
-                        if (thisDrop < smallestDropHeight) smallestDropHeight = thisDrop;
+                        if (thisDrop < smallestDropHeight)
+                            smallestDropHeight = thisDrop;
                         counter++;
                     }
                 for(osg::ref_ptr<TagBase> tag: selection)
@@ -818,8 +824,8 @@ void CSVRender::InstanceMode::handleDropMethod(DropMode dropMode, QString comman
         }
             break;
 
-        case Terrain_sep:
-        case Collision_sep:
+        case TerrainSep:
+        case CollisionSep:
         {
             int counter = 0;
             for(osg::ref_ptr<TagBase> tag: selection)
@@ -830,9 +836,6 @@ void CSVRender::InstanceMode::handleDropMethod(DropMode dropMode, QString comman
                     counter++;
                 }
         }
-            break;
-
-        default:
             break;
     }
 }
@@ -853,7 +856,8 @@ CSVRender::DropObjectDataHandler::DropObjectDataHandler(WorldspaceWidget* worlds
             objectNodeWithoutGUI->accept(computeBounds);
             osg::BoundingBox bounds = computeBounds.getBoundingBox();
             float boundingBoxOffset = 0.0f;
-            if (bounds.valid()) boundingBoxOffset = bounds.zMin();
+            if (bounds.valid())
+                boundingBoxOffset = bounds.zMin();
 
             mObjectHeights.emplace_back(boundingBoxOffset);
             mOldMasks.emplace_back(objectNodeWithGUI->getNodeMask());

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -114,6 +114,19 @@ namespace CSVRender
             void dropSelectedInstancesToTerrainSeparately();
             void handleDropMethod(DropMode dropMode, QString commandMsg);
     };
+
+    /// \brief Helper class to handle object mask data in safe way
+    class DropObjectDataHandler
+    {
+        public:
+            DropObjectDataHandler(WorldspaceWidget* worldspacewidget);
+            ~DropObjectDataHandler();
+            std::vector<float> mObjectHeights;
+
+        private:
+            WorldspaceWidget* mWorldspaceWidget;
+            std::vector<osg::Node::NodeMask> mOldMasks;
+    };
 }
 
 #endif

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -38,7 +38,7 @@ namespace CSVRender
                 Collision,
                 Terrain,
                 CollisionSep,
-                Terrainsep
+                TerrainSep
             };
 
             CSVWidget::SceneToolMode *mSubMode;

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -1,6 +1,8 @@
 #ifndef CSV_RENDER_INSTANCEMODE_H
 #define CSV_RENDER_INSTANCEMODE_H
 
+#include <QString>
+
 #include <osg/ref_ptr>
 #include <osg/Group>
 #include <osg/Quat>
@@ -33,8 +35,10 @@ namespace CSVRender
 
             enum DropMode
             {
-                Coillision_Below,
-                Ground_level
+                Collision,
+                Terrain,
+                Collision_sep,
+                Terrain_sep
             };
 
             CSVWidget::SceneToolMode *mSubMode;
@@ -54,6 +58,7 @@ namespace CSVRender
             osg::Vec3f getSelectionCenter(const std::vector<osg::ref_ptr<TagBase> >& selection) const;
             osg::Vec3f getScreenCoords(const osg::Vec3f& pos);
             void dropInstance(DropMode dropMode, CSVRender::Object* object);
+            float getDropHeight(DropMode dropMode, CSVRender::Object* object);
 
         public:
 
@@ -103,8 +108,11 @@ namespace CSVRender
 
             void subModeChanged (const std::string& id);
             void deleteSelectedInstances(bool active);
-            void dropSelectedInstances(bool active);
-            void groundlevelSelectedInstances(bool active);
+            void dropSelectedInstancesToCollision(bool active);
+            void dropSelectedInstancesToTerrain(bool active);
+            void dropSelectedInstancesToCollisionSeparately(bool active);
+            void dropSelectedInstancesToTerrainSeparately(bool active);
+            void handleDropMethod(DropMode dropMode, QString commandMsg);
     };
 }
 

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -57,7 +57,7 @@ namespace CSVRender
 
             osg::Vec3f getSelectionCenter(const std::vector<osg::ref_ptr<TagBase> >& selection) const;
             osg::Vec3f getScreenCoords(const osg::Vec3f& pos);
-            void dropInstance(DropMode dropMode, CSVRender::Object* object);
+            void dropInstance(DropMode dropMode, CSVRender::Object* object, float objectHeight);
             float getDropHeight(DropMode dropMode, CSVRender::Object* object, float objectHeight);
 
         public:
@@ -108,10 +108,10 @@ namespace CSVRender
 
             void subModeChanged (const std::string& id);
             void deleteSelectedInstances(bool active);
-            void dropSelectedInstancesToCollision(bool active);
-            void dropSelectedInstancesToTerrain(bool active);
-            void dropSelectedInstancesToCollisionSeparately(bool active);
-            void dropSelectedInstancesToTerrainSeparately(bool active);
+            void dropSelectedInstancesToCollision();
+            void dropSelectedInstancesToTerrain();
+            void dropSelectedInstancesToCollisionSeparately();
+            void dropSelectedInstancesToTerrainSeparately();
             void handleDropMethod(DropMode dropMode, QString commandMsg);
     };
 }

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -37,8 +37,8 @@ namespace CSVRender
             {
                 Collision,
                 Terrain,
-                Collision_sep,
-                Terrain_sep
+                CollisionSep,
+                Terrainsep
             };
 
             CSVWidget::SceneToolMode *mSubMode;

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -58,7 +58,7 @@ namespace CSVRender
             osg::Vec3f getSelectionCenter(const std::vector<osg::ref_ptr<TagBase> >& selection) const;
             osg::Vec3f getScreenCoords(const osg::Vec3f& pos);
             void dropInstance(DropMode dropMode, CSVRender::Object* object);
-            float getDropHeight(DropMode dropMode, CSVRender::Object* object);
+            float getDropHeight(DropMode dropMode, CSVRender::Object* object, float objectHeight);
 
         public:
 

--- a/apps/opencs/view/render/instancemode.hpp
+++ b/apps/opencs/view/render/instancemode.hpp
@@ -2,6 +2,7 @@
 #define CSV_RENDER_INSTANCEMODE_H
 
 #include <osg/ref_ptr>
+#include <osg/Group>
 #include <osg/Quat>
 #include <osg/Vec3f>
 
@@ -16,6 +17,7 @@ namespace CSVRender
 {
     class TagBase;
     class InstanceSelectionMode;
+    class Object;
 
     class InstanceMode : public EditMode
     {
@@ -29,6 +31,12 @@ namespace CSVRender
                 DragMode_Scale
             };
 
+            enum DropMode
+            {
+                Coillision_Below,
+                Ground_level
+            };
+
             CSVWidget::SceneToolMode *mSubMode;
             std::string mSubModeId;
             InstanceSelectionMode *mSelectionMode;
@@ -36,6 +44,7 @@ namespace CSVRender
             int mDragAxis;
             bool mLocked;
             float mUnitScaleDist;
+            osg::ref_ptr<osg::Group> mParentNode;
 
             int getSubModeFromId (const std::string& id) const;
 
@@ -44,10 +53,11 @@ namespace CSVRender
 
             osg::Vec3f getSelectionCenter(const std::vector<osg::ref_ptr<TagBase> >& selection) const;
             osg::Vec3f getScreenCoords(const osg::Vec3f& pos);
+            void dropInstance(DropMode dropMode, CSVRender::Object* object);
 
         public:
 
-            InstanceMode (WorldspaceWidget *worldspaceWidget, QWidget *parent = 0);
+            InstanceMode (WorldspaceWidget *worldspaceWidget, osg::ref_ptr<osg::Group> parentNode, QWidget *parent = 0);
 
             virtual void activate (CSVWidget::SceneToolbar *toolbar);
 
@@ -93,6 +103,8 @@ namespace CSVRender
 
             void subModeChanged (const std::string& id);
             void deleteSelectedInstances(bool active);
+            void dropSelectedInstances(bool active);
+            void groundlevelSelectedInstances(bool active);
     };
 }
 

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -482,6 +482,11 @@ osg::ref_ptr<osg::Group> CSVRender::Object::getRootNode()
     return mRootNode;
 }
 
+osg::ref_ptr<osg::Group> CSVRender::Object::getBaseNode()
+{
+    return mBaseNode;
+}
+
 bool CSVRender::Object::referenceableDataChanged (const QModelIndex& topLeft,
     const QModelIndex& bottomRight)
 {

--- a/apps/opencs/view/render/object.cpp
+++ b/apps/opencs/view/render/object.cpp
@@ -477,6 +477,11 @@ bool CSVRender::Object::getSelected() const
     return mSelected;
 }
 
+osg::ref_ptr<osg::Group> CSVRender::Object::getRootNode()
+{
+    return mRootNode;
+}
+
 bool CSVRender::Object::referenceableDataChanged (const QModelIndex& topLeft,
     const QModelIndex& bottomRight)
 {

--- a/apps/opencs/view/render/object.hpp
+++ b/apps/opencs/view/render/object.hpp
@@ -146,6 +146,9 @@ namespace CSVRender
 
             bool getSelected() const;
 
+            /// For direct altering of object rendering
+            osg::ref_ptr<osg::Group> getRootNode();
+
             /// \return Did this call result in a modification of the visual representation of
             /// this object?
             bool referenceableDataChanged (const QModelIndex& topLeft,

--- a/apps/opencs/view/render/object.hpp
+++ b/apps/opencs/view/render/object.hpp
@@ -146,8 +146,11 @@ namespace CSVRender
 
             bool getSelected() const;
 
-            /// For direct altering of object rendering
+            /// Get object node with GUI graphics
             osg::ref_ptr<osg::Group> getRootNode();
+
+            /// Get object node without GUI graphics
+            osg::ref_ptr<osg::Group> getBaseNode();
 
             /// \return Did this call result in a modification of the visual representation of
             /// this object?

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -370,7 +370,7 @@ void CSVRender::WorldspaceWidget::addVisibilitySelectorButtons (
 void CSVRender::WorldspaceWidget::addEditModeSelectorButtons (CSVWidget::SceneToolMode *tool)
 {
     /// \todo replace EditMode with suitable subclasses
-    tool->addButton (new InstanceMode (this, tool), "object");
+    tool->addButton (new InstanceMode (this, mRootNode, tool), "object");
     tool->addButton (new PathgridMode (this, tool), "pathgrid");
 }
 


### PR DESCRIPTION
G to drop objects to ground level, H to drop objects to next collision (e.g. on top of object below). If multiple objects are selected, their relative positions remain unchanged. Additionally implements two drop functions with different behavior that breaks the relative positions, dropping each item individually, these have no default assigned keyboard shortcut.

Notes:
- Implements osg::ref_ptr<osg::Group> CSVRender::Object::getRootNode() that is used to temporarily move object to SceneUtil::Mask_Disabled so that intersector doesn't collide with the dropped object itself.
- Implements also osg::ref_ptr<osg::Group> CSVRender::Object::getBaseNode() to calculate bounding boxes
- LineSegmentIntersector code is modified from similar code at CSVRender::WorldspaceWidget::mousePick
- The `LineSegmentIntersector` shoots straight down from the middle point of object, and often the lowest point is somewhere other than directly below the root node. This can result in a drop that looks wrong, but this should be good enough collision detection for OpenMW-CS.

Implemented:
- Bounding Box implementation
- Outdoor and indoor