### PR TITLE
Add bump-mapping support (feature #5304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,7 @@
     Feature #5193: Weapon sheathing
     Feature #5219: Impelement TestCells console command
     Feature #5224: Handle NiKeyframeController for NiTriShape
+    Feature #5304: Morrowind-style bump-mapping
     Task #4686: Upgrade media decoder to a more current FFmpeg API
     Task #4695: Optimize Distant Terrain memory consumption
     Task #4789: Optimize cell transitions

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -81,6 +81,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     Shader::ShaderManager::DefineMap shadowDefines = SceneUtil::ShadowManager::getShadowsDisabledDefines();
     defines["forcePPL"] = "0";
     defines["clamp"] = "1";
+    defines["preLightEnv"] = "0";
     for (const auto& define : shadowDefines)
         defines[define.first] = define.second;
     mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(defines);

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -79,9 +79,9 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
 
     Shader::ShaderManager::DefineMap defines = mResourceSystem->getSceneManager()->getShaderManager().getGlobalDefines();
     Shader::ShaderManager::DefineMap shadowDefines = SceneUtil::ShadowManager::getShadowsDisabledDefines();
-    defines["forcePPL"] = "0";
-    defines["clamp"] = "1";
-    defines["preLightEnv"] = "0";
+    defines["forcePPL"] = "0"; // Don't force per-pixel lighting
+    defines["clamp"] = "1"; // Clamp lighting
+    defines["preLightEnv"] = "0"; // Apply environment maps after lighting like Morrowind
     for (const auto& define : shadowDefines)
         defines[define.first] = define.second;
     mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(defines);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -253,6 +253,7 @@ namespace MWRender
 
         globalDefines["forcePPL"] = Settings::Manager::getBool("force per pixel lighting", "Shaders") ? "1" : "0";
         globalDefines["clamp"] = Settings::Manager::getBool("clamp lighting", "Shaders") ? "1" : "0";
+        globalDefines["preLightEnv"] = Settings::Manager::getBool("apply lighting to environment maps", "Shaders") ? "1" : "0";
 
         // It is unnecessary to stop/start the viewer as no frames are being rendered yet.
         mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(globalDefines);

--- a/components/nif/property.cpp
+++ b/components/nif/property.cpp
@@ -46,12 +46,10 @@ void NiTexturingProperty::read(NIFStream *nif)
     for (unsigned int i = 0; i < numTextures; i++)
     {
         textures[i].read(nif);
-        // Ignore these at the moment
         if (i == 5 && textures[5].inUse) // Bump map settings
         {
-            /*float lumaScale =*/ nif->getFloat();
-            /*float lumaOffset =*/ nif->getFloat();
-            /*const Vector4 *lumaMatrix =*/ nif->getVector4();
+            envMapLumaBias = nif->getVector2();
+            bumpMapMatrix = nif->getVector4();
         }
     }
 }

--- a/components/nif/property.hpp
+++ b/components/nif/property.hpp
@@ -93,6 +93,9 @@ public:
 
     std::vector<Texture> textures;
 
+    osg::Vec2f envMapLumaBias;
+    osg::Vec4f bumpMapMatrix;
+
     void read(NIFStream *nif);
     void post(NIFFile *nif);
 };

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -41,7 +41,6 @@
 #include <components/sceneutil/skeleton.hpp>
 #include <components/sceneutil/riggeometry.hpp>
 #include <components/sceneutil/morphgeometry.hpp>
-#include <components/settings/settings.hpp>
 
 #include "particle.hpp"
 #include "userdata.hpp"
@@ -428,29 +427,12 @@ namespace NifOsg
             texture2d->setWrap(osg::Texture::WRAP_S, wrapS ? osg::Texture::REPEAT : osg::Texture::CLAMP_TO_EDGE);
             texture2d->setWrap(osg::Texture::WRAP_T, wrapT ? osg::Texture::REPEAT : osg::Texture::CLAMP_TO_EDGE);
 
-            static const bool preLightEnv = Settings::Manager::getBool("apply lighting to environment maps", "Shaders");
             osg::ref_ptr<osg::TexEnvCombine> texEnv = new osg::TexEnvCombine;
-            if (!preLightEnv)
-            {
-                texEnv->setCombine_Alpha(osg::TexEnvCombine::REPLACE);
-                texEnv->setSource0_Alpha(osg::TexEnvCombine::PREVIOUS);
-                texEnv->setCombine_RGB(osg::TexEnvCombine::ADD);
-                texEnv->setSource0_RGB(osg::TexEnvCombine::PREVIOUS);
-                texEnv->setSource1_RGB(osg::TexEnvCombine::TEXTURE);
-            }
-            else
-            {
-                texEnv->setCombine_RGB(osg::TexEnvCombine::INTERPOLATE);
-                texEnv->setSource0_RGB(osg::TexEnvCombine::TEXTURE);
-                texEnv->setOperand0_RGB(osg::TexEnvCombine::SRC_COLOR);
-                texEnv->setSource1_RGB(osg::TexEnvCombine::PREVIOUS);
-                texEnv->setOperand1_RGB(osg::TexEnvCombine::SRC_COLOR);
-                texEnv->setSource2_RGB(osg::TexEnvCombine::TEXTURE);
-                texEnv->setOperand2_RGB(osg::TexEnvCombine::SRC_ALPHA);
-                texEnv->setCombine_Alpha(osg::TexEnvCombine::REPLACE);
-                texEnv->setSource0_Alpha(osg::TexEnvCombine::PREVIOUS);
-                texEnv->setOperand0_Alpha(osg::TexEnvCombine::SRC_ALPHA);
-            }
+            texEnv->setCombine_Alpha(osg::TexEnvCombine::REPLACE);
+            texEnv->setSource0_Alpha(osg::TexEnvCombine::PREVIOUS);
+            texEnv->setCombine_RGB(osg::TexEnvCombine::ADD);
+            texEnv->setSource0_RGB(osg::TexEnvCombine::PREVIOUS);
+            texEnv->setSource1_RGB(osg::TexEnvCombine::TEXTURE);
 
             int texUnit = 3; // FIXME
 

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1536,6 +1536,10 @@ namespace NifOsg
                     {
                         // Set this texture to Off by default since we can't render it with the fixed-function pipeline
                         stateset->setTextureMode(texUnit, GL_TEXTURE_2D, osg::StateAttribute::OFF);
+                        osg::Matrix2 bumpMapMatrix(texprop->bumpMapMatrix.x(), texprop->bumpMapMatrix.y(),
+                                                   texprop->bumpMapMatrix.z(), texprop->bumpMapMatrix.w());
+                        stateset->addUniform(new osg::Uniform("bumpMapMatrix", bumpMapMatrix));
+                        stateset->addUniform(new osg::Uniform("envMapLumaBias", texprop->envMapLumaBias));
                     }
                     else if (i == Nif::NiTexturingProperty::DecalTexture)
                     {
@@ -1559,7 +1563,7 @@ namespace NifOsg
                         texture2d->setName("diffuseMap");
                         break;
                     case Nif::NiTexturingProperty::BumpTexture:
-                        texture2d->setName("normalMap");
+                        texture2d->setName("bumpMap");
                         break;
                     case Nif::NiTexturingProperty::GlowTexture:
                         texture2d->setName("emissiveMap");

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -75,7 +75,7 @@ namespace Shader
         return newStateSet.get();
     }
 
-    const char* defaultTextures[] = { "diffuseMap", "normalMap", "emissiveMap", "darkMap", "detailMap", "envMap", "specularMap", "decalMap" };
+    const char* defaultTextures[] = { "diffuseMap", "normalMap", "emissiveMap", "darkMap", "detailMap", "envMap", "specularMap", "decalMap", "bumpMap" };
     bool isTextureNameRecognized(const std::string& name)
     {
         for (unsigned int i=0; i<sizeof(defaultTextures)/sizeof(defaultTextures[0]); ++i)
@@ -130,6 +130,14 @@ namespace Shader
                                 diffuseMap = texture;
                             else if (texName == "specularMap")
                                 specularMap = texture;
+                            else if (texName == "bumpMap")
+                            {
+                                mRequirements.back().mShaderRequired = true;
+                                if (!writableStateSet)
+                                    writableStateSet = getWritableStateSet(node);
+                                // Bump maps are off by default as well
+                                writableStateSet->setTextureMode(unit, GL_TEXTURE_2D, osg::StateAttribute::ON);
+                            }
                         }
                         else
                             Log(Debug::Error) << "ShaderVisitor encountered unknown texture " << texture;

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -96,6 +96,7 @@ namespace Shader
             const osg::Texture* diffuseMap = nullptr;
             const osg::Texture* normalMap = nullptr;
             const osg::Texture* specularMap = nullptr;
+            const osg::Texture* bumpMap = nullptr;
             for(unsigned int unit=0;unit<texAttributes.size();++unit)
             {
                 const osg::StateAttribute *attr = stateset->getTextureAttribute(unit, osg::StateAttribute::TEXTURE);
@@ -133,6 +134,7 @@ namespace Shader
                                 specularMap = texture;
                             else if (texName == "bumpMap")
                             {
+                                bumpMap = texture;
                                 mRequirements.back().mShaderRequired = true;
                                 if (!writableStateSet)
                                     writableStateSet = getWritableStateSet(node);
@@ -173,8 +175,11 @@ namespace Shader
                         image = mImageManager.getImage(normalMapFileName);
                     }
                 }
+                // Avoid using the auto-detected normal map if it's already being used as a bump map.
+                // It's probably not an actual normal map.
+                bool hasNamesakeBumpMap = image && bumpMap && bumpMap->getImage(0) && image->getFileName() == bumpMap->getImage(0)->getFileName();
 
-                if (image)
+                if (!hasNamesakeBumpMap && image)
                 {
                     osg::ref_ptr<osg::Texture2D> normalMapTex (new osg::Texture2D(image));
                     normalMapTex->setTextureSize(image->s(), image->t());

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -12,6 +12,7 @@
 #include <components/vfs/manager.hpp>
 #include <components/sceneutil/riggeometry.hpp>
 #include <components/sceneutil/morphgeometry.hpp>
+#include <components/settings/settings.hpp>
 
 #include "shadermanager.hpp"
 
@@ -137,6 +138,12 @@ namespace Shader
                                     writableStateSet = getWritableStateSet(node);
                                 // Bump maps are off by default as well
                                 writableStateSet->setTextureMode(unit, GL_TEXTURE_2D, osg::StateAttribute::ON);
+                            }
+                            else if (texName == "envMap")
+                            {
+                                static const bool preLightEnv = Settings::Manager::getBool("apply lighting to environment maps", "Shaders");
+                                if (preLightEnv)
+                                    mRequirements.back().mShaderRequired = true;
                             }
                         }
                         else

--- a/docs/source/reference/modding/settings/shaders.rst
+++ b/docs/source/reference/modding/settings/shaders.rst
@@ -124,3 +124,14 @@ terrain specular map pattern
 :Default:	_diffusespec
 
 The filename pattern to probe for when detecting terrain specular maps (see 'auto use terrain specular maps')
+
+apply lighting to environment maps
+----------------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+Normally environment map reflections aren't affected by lighting, which makes environment-mapped (and thus bump-mapped objects) glow in the dark.
+Morrowind Code Patch includes an option to remedy that by doing environment-mapping before applying lighting, this is the equivalent of that option.
+This also affects fixed function pipeline rendering.

--- a/docs/source/reference/modding/settings/shaders.rst
+++ b/docs/source/reference/modding/settings/shaders.rst
@@ -134,4 +134,4 @@ apply lighting to environment maps
 
 Normally environment map reflections aren't affected by lighting, which makes environment-mapped (and thus bump-mapped objects) glow in the dark.
 Morrowind Code Patch includes an option to remedy that by doing environment-mapping before applying lighting, this is the equivalent of that option.
-Has no effect in fixed function pipeline.
+Affected objects will use shaders.

--- a/docs/source/reference/modding/settings/shaders.rst
+++ b/docs/source/reference/modding/settings/shaders.rst
@@ -134,4 +134,4 @@ apply lighting to environment maps
 
 Normally environment map reflections aren't affected by lighting, which makes environment-mapped (and thus bump-mapped objects) glow in the dark.
 Morrowind Code Patch includes an option to remedy that by doing environment-mapping before applying lighting, this is the equivalent of that option.
-This also affects fixed function pipeline rendering.
+Has no effect in fixed function pipeline.

--- a/docs/source/reference/modding/texture-modding/convert-bump-mapped-mods.rst
+++ b/docs/source/reference/modding/texture-modding/convert-bump-mapped-mods.rst
@@ -75,13 +75,18 @@ Morrowind bump-mapping
 **Conversion difficulty:**
 *Varies. Sometimes quick and easy, sometimes time-consuming and hard.*
 
-You might have bumped (pun intended) on a few bump-mapped texture packs for Morrowind that require the
-Morrowind Code Patch (MCP). OpenMW does support the legacy bump-maps,
-but bump-mapped models may look brighter than intended if they were designed with Morrowind Code Patch in mind
-because MCP can optionally apply lighting after environment maps are processed which makes bump-mapped models look a bit better,
-and can make use of the gloss map channel in the bump map. It also makes skinned mesh bump-mapping possible.
-We chose not to replicate the difference in environment map handling, but gloss map channel as well as skinned mesh bump-mapping are supported.
+You might have bumped (pun intended) on a few bump-mapped texture packs for Morrowind that require
+Morrowind Code Patch (MCP). OpenMW supports them, and like MCP can optionally apply lighting after environment maps
+are processed which makes bump-mapped models look a bit better,
+can make use of the gloss map channel in the bump map and can apply bump-mapping to skinned models.
+Add this to settings.cfg_-file:
 
+::
+
+    [Shaders]
+    apply lighting to environment maps = true
+
+But sometimes you may want them to look a bit better than in vanilla.
 Technically you aren't supposed to convert bump maps because they shouldn't be normal maps that are supported by OpenMW as well,
 but artists may use actual normal maps as bump maps either because they look better in vanilla... or because they're lazy.
 In this case you can benefit from OpenMW's normal-mapping support by using these bump maps the way normal maps are used.
@@ -203,7 +208,7 @@ Since we want the glory of normal-mapping in our OpenMW setup, we will go with t
 
 #. Start by downloading Apel's `Various Things - Sacks`_ from Nexus.
 #. Once downloaded, install it the way you'd normally install your mods (**Pro tip**: Install using OpenMW's `Multiple data folders`_ function!).
-#. Now, if you ran the mod right away, your sacks may look... wetter than expected. This is because the mod assumes you have the MCP feature which makes the sacks less shiny enabled. Which you can't have enabled.
+#. Now, if you ran the mod right away, your sacks may look... wetter than expected. This is because the mod assumes you have the MCP feature which makes the sacks less shiny enabled. You can have its equivalent enabled to make the sacks look like in Morrowind with MCP, or you may proceed on the tutorial.
 #. We need to fix this by removing some tags in the model files. You need to download NifSkope_ for this, which, again, only have binaries available for Windows.
 #. Go the place where you installed the mod and go to ``./Meshes/o/`` to find the model files.
     - If you installed the mod like I suggested, finding the files will be easy as a pie, but if you installed it by dropping everything into your main Morrowind Data Files folder, then you'll have to scroll a lot to find them. Check the mod's zip file for the file names of the models if this is the case. The same thing applies to when fixing the textures.

--- a/docs/source/reference/modding/texture-modding/convert-bump-mapped-mods.rst
+++ b/docs/source/reference/modding/texture-modding/convert-bump-mapped-mods.rst
@@ -3,59 +3,59 @@ Normal maps from Morrowind to OpenMW
 ====================================
 
 - `General introduction to normal map conversion`_
-    - `Normal Mapping in OpenMW`_
-    - `Activating normal mapping shaders in OpenMW`_
-    - `Normal mapping in Morrowind with Morrowind Code Patch`_
-    - `Normal mapping in Morrowind with MGE XE`_
+    - `OpenMW normal-mapping`_
+    - `Activating normal-mapping shaders in OpenMW`_
+    - `Morrowind bump-mapping`_
+    - `MGE XE normal-mapping`_
 - `Converting PeterBitt's Scamp Replacer`_ (Mod made for the MGE XE PBR prototype)
     - `Tutorial - MGE`_
-- `Converting Lougian's Hlaalu Bump mapped`_ (MCP's fake bump map function, part 1: *without* custom models)
-    - `Tutorial - MCP, Part 1`_
-- `Converting Apel's Various Things - Sacks`_ (MCP's fake bump map function, part 2: *with* custom models)
-    - `Tutorial - MCP, Part 2`_
+- `Converting Lougian's Hlaalu Bump mapped`_ (Morrowind's bump-mapping, part 1: *without* custom models)
+    - `Tutorial - Morrowind, Part 1`_
+- `Converting Apel's Various Things - Sacks`_ (Morrowind's bump-mapping, part 2: *with* custom models)
+    - `Tutorial - Morrowind, Part 2`_
 
 General introduction to normal map conversion
 ------------------------------------------------
 
-:Authors: Joakim (Lysol) Berg
-:Updated: 2016-11-11
+:Authors: Joakim (Lysol) Berg, Alexei (Capo) Dobrohotov
+:Updated: 2020-03-03
 
-This page has general information and tutorials on how normal mapping works in OpenMW and how you can make mods using 
-the old fake normal mapping technique (such as `Netch Bump mapped`_ and `Hlaalu Bump mapped`_, and maybe the most 
-(in)famous one to give shiny rocks in OpenMW, the mod `On the Rocks`_!, featured in MGSO and Morrowind Rebirth) work in OpenMW.
+This page has general information and tutorials on how normal-mapping works in OpenMW and how you can make mods using
+the old environment-mapped bump-mapping technique (such as `Netch Bump mapped`_ and `Hlaalu Bump mapped`_, and maybe the most
+(in)famous one to previously give shiny rocks in OpenMW, the mod `On the Rocks`_!, featured in MGSO and Morrowind Rebirth) work better in OpenMW.
 
 *Note:* The conversion made in the `Converting Apel's Various Things - Sacks`_-part of this tutorial require the use of the application NifSkope_.
 
-*Another note:* I will use the terms bump mapping and normal mapping simultaneously. 
-Normal mapping is one form of bump mapping. In other words, normal mapping is bump mapping, 
-but bump mapping isn't necessarily normal mapping. 
-There are several techniques for bump mapping, and normal mapping is the most common one today.
+*Another note:* I will use the terms bump-mapping and normal-mapping simultaneously.
+Normal-mapping is one form of bump-mapping. In other words, normal-mapping is bump-mapping,
+but bump-mapping isn't necessarily normal-mapping.
+There are several techniques for bump-mapping, and normal-mapping is the most common one today.
 
 So let's get on with it.
 
-Normal Mapping in OpenMW
+OpenMW normal-mapping
 ************************
 
-Normal mapping in OpenMW works in a very simple way: The engine just looks for a texture with a *_n.dds* suffix, 
+Normal-mapping in OpenMW works in a very simple way: The engine just looks for a texture with a *_n.dds* suffix,
 and you're done.
 
-So to expand on this a bit, let's take a look at how a model seeks for textures.
+So to expand on this a bit, let's take a look at how a model looks up textures.
 
-Let us assume we have the model *example.nif*. In this model file, 
-there should be a tag (NiSourceTexture) that states what texture it should use and where to find it. Typically, 
-it will point to something like *exampletexture_01.dds*. This texture is supposed to be located directly in the 
-Textures folder since it does not state anything else. If the model is a custom made one, modders tend to group 
-their textures in separate folders, just to easily keep track of them. 
-It might be something like *./Textures/moddername/exampletexture_02.dds*.
+Let us assume we have the model *example.nif*. In this model file,
+there should be a tag (NiTexturingProperty) that states what textures it should use and where to find them. Typically,
+the model's base (diffuse) texture reference will point to something named like *exampletexture_01.dds*. This texture is supposed to be located directly in the
+Textures folder since it does not state anything else.
+Modders tend to group textures for custom-made models in dedicated folders to keep track of them easily,
+so it might be something like *./Textures/moddername/exampletexture_02.dds*.
 
-When OpenMW finally adds normal mapping, it simply takes the NiSourceTexture file path, e.g., 
-*exampletexture_01.dds*, and looks for a *exampletexture_01_n.dds*. If it can't find this file, no normal mapping is added. 
-If it *does* find this file, the model will use this texture as a normal map. Simple.
+OpenMW will pick the diffuse map file path from the mesh, e.g.
+*exampletexture_01.dds*, and look up a texture named *exampletexture_01_n.dds*.
+That file will be the normal map if it's present. Simple.
 
-Activating normal mapping shaders in OpenMW
+Activating normal-mapping shaders in OpenMW
 *******************************************
 
-Before normal (and specular and parallax) maps will show up in OpenMW, you'll need to activate them in the 
+Before normal (and specular and parallax) maps can show up in OpenMW, their auto-detection needs to be turned on in
 settings.cfg_-file. Add these rows where it would make sense:
 
 ::
@@ -64,66 +64,46 @@ settings.cfg_-file. Add these rows where it would make sense:
     auto use object normal maps = true
     auto use terrain normal maps = true
 
-And while we're at it, why not activate specular maps too just for the sake of it?
-
-::
-
     auto use object specular maps = true
     auto use terrain specular maps = true
 
-Lastly, if you want really nice lights in OpenMW, add these rows:
+See OpenMW's wiki page about `texture modding`_ to read more about it.
 
-::
-
-    force shaders = true
-    clamp lighting = false
-
-See OpenMW's wiki page about `texture modding`_ to read further about this.
-
-Normal mapping in Morrowind with Morrowind Code Patch
+Morrowind bump-mapping
 *****************************************************
 
 **Conversion difficulty:**
 *Varies. Sometimes quick and easy, sometimes time-consuming and hard.*
 
-You might have bumped (pun intended) on a few bump-mapped texture packs for Morrowind that require the 
-Morrowind Code Patch (MCP). You might even be thinking: Why doesn't OpenMW just support these instead of reinventing 
-the wheel? I know it sounds strange, but it will make sense. Here's how MCP handles normal maps:
+You might have bumped (pun intended) on a few bump-mapped texture packs for Morrowind that require the
+Morrowind Code Patch (MCP). OpenMW does support the legacy bump-maps,
+but bump-mapped models may look brighter than intended if they were designed with Morrowind Code Patch in mind
+because MCP can optionally apply lighting after environment maps are processed which makes bump-mapped models look a bit better,
+and can make use of the gloss map channel in the bump map. It also makes skinned mesh bump-mapping possible.
+We chose not to replicate the difference in environment map handling, but gloss map channel as well as skinned mesh bump-mapping are supported.
 
-Morrowind does not recognize normal maps (they weren't really a "thing" yet in 2002), so even if you have a normal map,
-Morrowind will not load and display it. MCP has a clever way to solve this issue, by using something Morrowind *does* support, 
-namely environment maps. You could add a tag for an environment map and then add a normal map as the environment map, 
-but you'd end up with a shiny ugly model in the game. MCP solves this by turning down the brightness of the environment maps, 
-making the model look *kind of* as if it had a normal map applied to it. 
-I say kind of because it does not really look as good as normal mapping usually does. It was a hacky way to do it, 
-but it was the only way at the time, and therefore the best way.
+Technically you aren't supposed to convert bump maps because they shouldn't be normal maps that are supported by OpenMW as well,
+but artists may use actual normal maps as bump maps either because they look better in vanilla... or because they're lazy.
+In this case you can benefit from OpenMW's normal-mapping support by using these bump maps the way normal maps are used.
+This means that you will have to drop the bump-mapping references from the model and sometimes rename the texture.
 
-The biggest problem with this is not that it doesn't look as good as it could – no, 
-the biggest problem in my opinion is that it requires you to state the file paths for your normal map textures *in the models*!
-For buildings, which often use several textures for one single model file, it could take *ages* to do this, 
-and you had to do it for dozens of model files too. You also had to ship your texture pack with model files, 
-making your mod bigger in file size.
-
-These are basically the reasons why OpenMW does not support fake bump maps like MCP does. 
-It is just a really bad way to enhance your models, all the more when you have the possibility to do it in a better way.
-
-Normal mapping in Morrowind with MGE XE
+MGE XE normal-mapping
 ***************************************
 
 **Conversion difficulty:**
 *Easy*
 
-The most recent feature on this topic is that the Morrowind Graphics Extender (MGE) finally started to support real 
-normal mapping in an experimental version available here: `MGE XE`_ (you can't use MGE with OpenMW!). 
-Not only this but it also adds full support for physically based rendering (PBR), 
-making it one step ahead of OpenMW in terms of texturing techniques. However, 
-OpenMW will probably have this feature in the future too – and let's hope that OpenMW and MGE will handle PBR in a 
+The most recent feature on this topic is that the Morrowind Graphics Extender (MGE) finally started to support real
+normal-mapping in an experimental version available here: `MGE XE`_ (you can't use MGE with OpenMW!).
+Not only this but it also adds full support for physically based rendering (PBR),
+making it one step ahead of OpenMW in terms of texturing techniques. However,
+OpenMW will probably have this feature in the future too – and let's hope that OpenMW and MGE will handle PBR in a
 similar fashion in the future so that mods can be used for both MGE and OpenMW without any hassle.
 
-I haven't researched that much on the MGE variant yet but it does support real implementation of normal mapping, 
-making it really easy to convert mods made for MGE into OpenMW (I'm only talking about the normal map textures though). 
-There's some kind of text file if I understood it correctly that MGE uses to find the normal map. 
-OpenMW does not need this, you just have to make sure the normal map has the same name as the diffuse texture but with 
+I haven't researched that much on the MGE variant yet but it does support real implementation of normal-mapping,
+making it really easy to convert mods made for MGE into OpenMW (I'm only talking about the normal map textures though).
+There's some kind of text file if I understood it correctly that MGE uses to find the normal map.
+OpenMW does not need this, you just have to make sure the normal map has the same name as the diffuse texture but with
 the correct suffix after.
 
 Now, on to the tutorials.
@@ -135,20 +115,20 @@ Converting PeterBitt's Scamp Replacer
 :Authors: Joakim (Lysol) Berg
 :Updated: 2016-11-11
 
-So, let's say you've found out that PeterBitt_ makes awesome models and textures featuring physically based rendering 
-(PBR) and normal maps. Let's say that you tried to run his `PBR Scamp Replacer`_ in OpenMW and that you were greatly 
-disappointed when the normal map didn't seem to work. Lastly, let's say you came here, looking for some answers. 
+So, let's say you've found out that PeterBitt_ makes awesome models and textures featuring physically based rendering
+(PBR) and normal maps. Let's say that you tried to run his `PBR Scamp Replacer`_ in OpenMW and that you were greatly
+disappointed when the normal map didn't seem to work. Lastly, let's say you came here, looking for some answers.
 Am I right? Great. Because you've come to the right place!
 
-*A quick note before we begin*: Please note that you can only use the normal map texture and not the rest of the materials, 
-since PBR isn't implemented in OpenMW yet. Sometimes PBR textures can look dull without all of the texture files, 
+*A quick note before we begin*: Please note that you can only use the normal map texture and not the rest of the materials,
+since PBR isn't implemented in OpenMW yet. Sometimes PBR textures can look dull without all of the texture files,
 so have that in mind.
 
 Tutorial - MGE
 **************
 
-In this tutorial, I will use PeterBitt's `PBR Scamp Replacer`_ as an example, 
-but any mod featuring PBR that requires the PBR version of MGE will do, 
+In this tutorial, I will use PeterBitt's `PBR Scamp Replacer`_ as an example,
+but any mod featuring PBR that requires the PBR version of MGE will do,
 provided it also includes a normal map (which it probably does).
 
 So, follow these steps:
@@ -163,67 +143,67 @@ So, follow these steps:
 #. Rename your newly extracted file (``tx_Scamp_normals.dds``) to ``tx_Scamp_n.dds`` (which is exactly the same name as the diffuse texture file, except for the added *_n* suffix before the filename extention).
 #. You're actually done!
 
-So as you might notice, converting these mods is very simple and takes just a couple of minutes. 
+So as you might notice, converting these mods is very simple and takes just a couple of minutes.
 It's more or less just a matter of renaming and moving a few files.
 
-I totally recommend you to also try this on PeterBitt's Nix Hound replacer and Flash3113's various replacers. 
+I totally recommend you to also try this on PeterBitt's Nix Hound replacer and Flash3113's various replacers.
 It should be the same principle to get those to work.
 
-And let's hope that some one implements PBR shaders to OpenMW too, 
+And let's hope that some one implements PBR shaders to OpenMW too,
 so that we can use all the material files of these mods in the future.
 
 Converting Lougian's Hlaalu Bump mapped
 ---------------------------------------
-**Mod made for MCP's fake bump function, without custom models**
+**Mod made for Morrowind's bump-mapping, without custom models**
 
-:Authors: Joakim (Lysol) Berg
-:Updated: 2016-11-11
+:Authors: Joakim (Lysol) Berg, Alexei (Capo) Dobrohotov
+:Updated: 2020-03-03
 
-Converting textures made for the Morrowind Code Patch (MCP) fake bump mapping can be really easy or a real pain, 
-depending on a few circumstances. In this tutorial, we will look at a very easy, 
+Converting normal maps made for the Morrowind's bump-mapping can be really easy or a real pain,
+depending on a few circumstances. In this tutorial, we will look at a very easy,
 although in some cases a bit time-consuming, example.
 
-Tutorial - MCP, Part 1
+Tutorial - Morrowind, Part 1
 **********************
 
 We will be converting a quite popular texture replacer of the Hlaalu architecture, namely Lougian's `Hlaalu Bump mapped`_.
-Since this is just a texture pack and not a model replacer, 
-we can convert the mod in a few minutes by just renaming a few dozen files and by *not* extracting the included model 
+Since this is just a texture pack and not a model replacer,
+we can convert the mod in a few minutes by just renaming a few dozen files and by *not* extracting the included model
 (``.nif``) files when installing the mod.
 
 #. Download Lougian's `Hlaalu Bump mapped`_.
 #. Install the mod by extracting the ``./Textures`` folder to a data folder the way you usually install mods (**Pro tip**: Install using OpenMW's `Multiple data folders`_ function!).
-    - Again, yes, *only* the ``./Textures`` folder. Do *not* extract the Meshes folder. They are only there to make the MCP hack work, which is not of any interest to us.
+    - Again, yes, *only* the ``./Textures`` folder. Do not extract the Meshes folder. They are there to make Morrowind bump-mapping work.
 #. Go to your new texture folder. If you installed the mod like I recommended, you won't have any trouble finding the files. If you instead placed all your files in Morrowinds main Data Files folder (sigh), you need to check with the mod's .rar file to see what files you should look for. Because you'll be scrolling through a lot of files.
 #. Find all the textures related to the texture pack in the Textures folder and take note of all the ones that ends with a *_nm.dds*.
 #. The *_nm.dds* files are normal map files. OpenMW's standard format is to have the normal maps with a *_n.dds* instead. Rename all the normal map textures to only have a *_n.dds* instead of the *_nm.dds*.
     - As a nice bonus to this tutorial, this pack actually included one specularity texture too. We should use it of course. It's the one called "``tx_glass_amber_02_reflection.dds``". For OpenMW to recognize this file and use it as a specular map, you need to change the *_reflection.dds* part to *_spec.dds*, resulting in the name ``tx_glass_amber_01_spec.dds``.
 #. That should be it. Really simple, but I do know that it takes a few minutes to rename all those files.
 
-Now – if the mod you want to change includes custom made models it gets a bit more complicated I'm afraid. 
+Now – if the mod you want to change includes custom made models it gets a bit more complicated I'm afraid.
 But that is for the next tutorial.
 
 Converting Apel's Various Things - Sacks
 ----------------------------------------
-**Mod made for MCP's fake bump function, with custom models**
+**Mod made for Morrowind bump-mapping, with custom models**
 
-:Authors: Joakim (Lysol) Berg
-:Updated: 2016-11-09
+:Authors: Joakim (Lysol) Berg, Alexei (Capostrophic) Dobrohotov
+:Updated: 2020-03-03
 
-In part one of this tutorial, we converted a mod that only included modified Morrowind model (``.nif``) 
-files so that the normal maps could be loaded in Morrowind with MCP. 
-We ignored those model files since they are not needed with OpenMW. In this tutorial however, 
-we will convert a mod that includes new, custom made models. In other words, we cannot just ignore those files this time.
+In part one of this tutorial, we converted a mod that only included modified Morrowind model (``.nif``)
+files so that the bump maps could be loaded as normal maps.
+We ignored those model files since they are not needed with OpenMW. In this tutorial however,
+we will convert a mod that includes new, custom-made models. In other words, we cannot just ignore those files this time.
 
-Tutorial - MCP, Part 2
+Tutorial - Morrowind, Part 2
 **********************
 
-The sacks included in Apel's `Various Things - Sacks`_ come in two versions – Without bump mapping, and with bump mapping. 
-Since we want the glory of normal mapping in our OpenMW setup, we will go with the bump-mapped version.
+The sacks included in Apel's `Various Things - Sacks`_ come in two versions – without bump-mapping, and with bump-mapping.
+Since we want the glory of normal-mapping in our OpenMW setup, we will go with the bump-mapped version.
 
 #. Start by downloading Apel's `Various Things - Sacks`_ from Nexus.
 #. Once downloaded, install it the way you'd normally install your mods (**Pro tip**: Install using OpenMW's `Multiple data folders`_ function!).
-#. Now, if you ran the mod right away, your sacks will be made out of lead_. This is because the normal map is loaded as an environment map which MCP fixes so that it looks less shiny. We don't use MCP, so therefore, it looks kind of like the shack was made out of lead.
+#. Now, if you ran the mod right away, your sacks may look... wetter than expected. This is because the mod assumes you have the MCP feature which makes the sacks less shiny enabled. Which you can't have enabled.
 #. We need to fix this by removing some tags in the model files. You need to download NifSkope_ for this, which, again, only have binaries available for Windows.
 #. Go the place where you installed the mod and go to ``./Meshes/o/`` to find the model files.
     - If you installed the mod like I suggested, finding the files will be easy as a pie, but if you installed it by dropping everything into your main Morrowind Data Files folder, then you'll have to scroll a lot to find them. Check the mod's zip file for the file names of the models if this is the case. The same thing applies to when fixing the textures.
@@ -232,14 +212,14 @@ Since we want the glory of normal mapping in our OpenMW setup, we will go with t
     - NiSourceTexture with the value that appears to be a normal map file, in this mod, they have the suffix *_nm.dds*.
 #. Remove all these tags by selecting them one at a time and press right click>Block>Remove Branch. (Ctrl-Del)
 #. Repeat this on all the affected models.
-#. If you launch OpenMW now, you'll `no longer have shiny models`_. But one thing is missing. Can you see it? It's actually hard to spot on still pictures, but we have no normal maps here.
+#. If you launch OpenMW now, you'll `no longer have wet models`_. But one thing is missing. Can you see it? It's actually hard to spot on still pictures, but we have no normal maps here.
 #. Now, go back to the root of where you installed the mod. Now go to ``./Textures/`` and you'll find the texture files in question.
 #. OpenMW detects normal maps if they have the same name as the base diffuse texture, but with a *_n.dds* suffix. In this mod, the normal maps has a suffix of *_nm.dds*. Change all the files that ends with *_nm.dds* to instead end with *_n.dds*.
 #. Finally, `we are done`_!
 
-Since these models have one or two textures applied to them, the fix was not that time-consuming. The process continues to work for more complex models that use more textures, but looking through each category for texture effects and normal mapped textures rapidly becomes tedious. Luckily, NifSkope provides a feature to do the same automatically. 
+Since these models have one or two textures applied to them, the fix was not that time-consuming. The process continues to work for more complex models that use more textures, but looking through each category for texture effects and normal mapped textures rapidly becomes tedious. Luckily, NifSkope provides a feature to do the same automatically.
 
-Rightclick in NifSkope to access the *Spells* dropdown menu, also available via the top bar, hover over the *Blocks* section, and `choose the action to Remove by ID`_. You can then input the RegEx expression ``^NiTextureEffect`` (directing it to remove any block whose name starts with "NiTextureEffect") to automatically remove all texture effect blocks within the NIF. This also has the helpful side effect of listing `all the blocks within the NIF in the bottom section`_, allowing you to additionally root out any blocks referencing *_nm.dds* textures without having to painstakingly open each category.  
+Right-click in NifSkope to access the *Spells* dropdown menu, also available via the top bar, hover over the *Blocks* section, and `choose the action to Remove by ID`_. You can then input the RegEx expression ``^NiTextureEffect`` (directing it to remove any block whose name starts with "NiTextureEffect") to automatically remove all texture effect blocks within the NIF. This also has the helpful side effect of listing `all the blocks within the NIF in the bottom section`_, allowing you to additionally root out any blocks referencing *_nm.dds* textures without having to painstakingly open each category.
 
 .. _`Netch Bump mapped`: https://www.nexusmods.com/morrowind/mods/42851/?
 .. _`Hlaalu Bump mapped`: https://www.nexusmods.com/morrowind/mods/42396/?
@@ -251,10 +231,9 @@ Rightclick in NifSkope to access the *Spells* dropdown menu, also available via 
 .. _settings.cfg: https://wiki.openmw.org/index.php?title=Settings
 .. _`Multiple data folders`: https://wiki.openmw.org/index.php?title=Mod_installation
 .. _`Various Things - Sacks`: https://www.nexusmods.com/morrowind/mods/42558/?
-.. _Lead: https://imgur.com/bwpcYlc
 .. _NifSkope: https://wiki.openmw.org/index.php?title=Tools#NifSkope
 .. _Blocks: https://imgur.com/VmQC0WG
-.. _`no longer have shiny models`: https://imgur.com/vu1k7n1
+.. _`no longer have wet models`: https://imgur.com/vu1k7n1
 .. _`we are done`: https://imgur.com/yyZxlTw
 .. _`choose the action to Remove by ID`: https://imgur.com/a/qs2t0tC
 .. _`all the blocks within the NIF in the bottom section`: https://imgur.com/a/UFFNyWt

--- a/docs/source/reference/modding/texture-modding/texture-basics.rst
+++ b/docs/source/reference/modding/texture-modding/texture-basics.rst
@@ -23,18 +23,6 @@ To plug in a normal map, you name the normal map as the diffuse texture but with
 OpenMW will then recognise the file and load it as a normal map, provided you have set up your settings file correctly. 
 See the section `Automatic use`_ further down below for detailed information.
 
-.. note::
-	While the original Morrowind engine does support the loading of a BumpTexture slot in the NIF, 
-	it will not display it as a normal map. Morrowind Code Patch (MCP) 
-	added a way to hack normal maps into the engine by first enabling the engine to load the BumpTexture slot as an 
-	environment map and then turn down the brightness of the environment map. 
-	This will imitate how a real normal map shader would display a normal map, but it will not look exactly the same.
-	OpenMW uses standard normal mapping, which achieves much better results.
-	Unfortunately, this difference can result in incompatibilities.
-	Some mods
-	(e.g. `Redoran Bump Mapped <http://www.nexusmods.com/morrowind/mods/42406/?>`_)
-	look much darker compared to the vanilla engine and will have to be recalibrated.
-
 Specular Mapping
 ################
 
@@ -43,14 +31,12 @@ The alpha channel specifies shininess in range [0, 255].
 If a specular map is used, it will override the shininess and specular color
 set in the NiMaterialProperty / osg::Material.
 
-NIF files do not support specular maps.
+Morrowind format NIF files do not support normal maps or specular maps.
 In order to use them anyway, see the next section.
 
 Automatic Use
 #############
 
-In addition to editing mesh files,
-there is another way of plugging in these texture maps.
 Simply create the textures with appropriate naming convention
 (e.g. when the base texture is called foo.dds,
 the normal map would have to be called foo_n.dds).

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -347,7 +347,7 @@ specular map pattern = _spec
 terrain specular map pattern = _diffusespec
 
 # Apply lighting to environment map reflections on the rendered objects like in Morrowind Code Patch.
-# Also affects fixed function pipeline.
+# Requires shaders to work.
 apply lighting to environment maps = false
 
 [Input]

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -346,8 +346,8 @@ specular map pattern = _spec
 # The filename pattern to probe for when detecting terrain specular maps (see 'auto use terrain specular maps')
 terrain specular map pattern = _diffusespec
 
-# Apply lighting to environment map reflections on the rendered objects like in Morrowind Code Patch.
-# Requires shaders to work.
+# Apply lighting to reflections on the environment-mapped objects like in Morrowind Code Patch.
+# Affected objects use shaders.
 apply lighting to environment maps = false
 
 [Input]

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -346,6 +346,10 @@ specular map pattern = _spec
 # The filename pattern to probe for when detecting terrain specular maps (see 'auto use terrain specular maps')
 terrain specular map pattern = _diffusespec
 
+# Apply lighting to environment map reflections on the rendered objects like in Morrowind Code Patch.
+# Also affects fixed function pipeline.
+apply lighting to environment maps = false
+
 [Input]
 
 # Capture control of the cursor prevent movement outside the window.

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -121,6 +121,31 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, decalTex.xyz, decalTex.a);
 #endif
 
+#if @envMap
+
+    vec2 envTexCoordGen = envMapUV;
+    float envLuma = 1.0;
+
+#if @normalMap
+    // if using normal map + env map, take advantage of per-pixel normals for envTexCoordGen
+    vec3 viewVec = normalize(passViewPos.xyz);
+    vec3 r = reflect( viewVec, viewNormal );
+    float m = 2.0 * sqrt( r.x*r.x + r.y*r.y + (r.z+1.0)*(r.z+1.0) );
+    envTexCoordGen = vec2(r.x/m + 0.5, r.y/m + 0.5);
+#endif
+
+#if @bumpMap
+    vec4 bumpTex = texture2D(bumpMap, bumpMapUV);
+    envTexCoordGen += bumpTex.rg * bumpMapMatrix;
+    envLuma = clamp(bumpTex.b * envMapLumaBias.x + envMapLumaBias.y, 0.0, 1.0);
+#endif
+
+#if @preLightEnv
+    gl_FragData[0].xyz += texture2D(envMap, envTexCoordGen).xyz * envMapColor.xyz * envLuma;
+#endif
+
+#endif
+
     float shadowing = unshadowedLightRatio(depth);
 
 #if !PER_PIXEL_LIGHTING
@@ -135,28 +160,12 @@ void main()
     gl_FragData[0] *= doLighting(passViewPos, normalize(viewNormal), passColor, shadowing);
 #endif
 
+#if @envMap && !@preLightEnv
+    gl_FragData[0].xyz += texture2D(envMap, envTexCoordGen).xyz * envMapColor.xyz * envLuma;
+#endif
+
 #if @emissiveMap
     gl_FragData[0].xyz += texture2D(emissiveMap, emissiveMapUV).xyz;
-#endif
-
-#if @envMap
-    vec2 texCoordGen = envMapUV;
-    float envLuma = 1.0;
-
-#if @normalMap
-    // if using normal map + env map, take advantage of per-pixel normals for texCoordGen
-    vec3 viewVec = normalize(passViewPos.xyz);
-    vec3 r = reflect( viewVec, viewNormal );
-    float m = 2.0 * sqrt( r.x*r.x + r.y*r.y + (r.z+1.0)*(r.z+1.0) );
-    texCoordGen = vec2(r.x/m + 0.5, r.y/m + 0.5);
-#endif
-
-#if @bumpMap
-    vec4 bumpTex = texture2D(bumpMap, bumpMapUV);
-    texCoordGen += bumpTex.rg * bumpMapMatrix;
-    envLuma = clamp(bumpTex.b * envMapLumaBias.x + envMapLumaBias.y, 0.0, 1.0);
-#endif
-    gl_FragData[0].xyz += texture2D(envMap, texCoordGen).xyz * envMapColor.xyz * envLuma;
 #endif
 
 #if @specularMap

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -42,6 +42,13 @@ uniform sampler2D specularMap;
 varying vec2 specularMapUV;
 #endif
 
+#if @bumpMap
+uniform sampler2D bumpMap;
+varying vec2 bumpMapUV;
+uniform vec2 envMapLumaBias;
+uniform mat2 bumpMapMatrix;
+#endif
+
 varying float depth;
 
 #define PER_PIXEL_LIGHTING (@normalMap || @forcePPL)
@@ -132,20 +139,24 @@ void main()
     gl_FragData[0].xyz += texture2D(emissiveMap, emissiveMapUV).xyz;
 #endif
 
-
 #if @envMap
+    vec2 texCoordGen = envMapUV;
+    float envLuma = 1.0;
 
 #if @normalMap
     // if using normal map + env map, take advantage of per-pixel normals for texCoordGen
     vec3 viewVec = normalize(passViewPos.xyz);
     vec3 r = reflect( viewVec, viewNormal );
     float m = 2.0 * sqrt( r.x*r.x + r.y*r.y + (r.z+1.0)*(r.z+1.0) );
-    vec2 texCoordGen = vec2(r.x/m + 0.5, r.y/m + 0.5);
-    gl_FragData[0].xyz += texture2D(envMap, texCoordGen).xyz * envMapColor.xyz;
-#else
-    gl_FragData[0].xyz += texture2D(envMap, envMapUV).xyz * envMapColor.xyz;
+    texCoordGen = vec2(r.x/m + 0.5, r.y/m + 0.5);
 #endif
 
+#if @bumpMap
+    vec4 bumpTex = texture2D(bumpMap, bumpMapUV);
+    texCoordGen += bumpTex.rg * bumpMapMatrix;
+    envLuma = clamp(bumpTex.b * envMapLumaBias.x + envMapLumaBias.y, 0.0, 1.0);
+#endif
+    gl_FragData[0].xyz += texture2D(envMap, texCoordGen).xyz * envMapColor.xyz * envLuma;
 #endif
 
 #if @specularMap

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -29,6 +29,10 @@ varying vec4 passTangent;
 varying vec2 envMapUV;
 #endif
 
+#if @bumpMap
+varying vec2 bumpMapUV;
+#endif
+
 #if @specularMap
 varying vec2 specularMapUV;
 #endif
@@ -89,6 +93,10 @@ void main(void)
 #if @normalMap
     normalMapUV = (gl_TextureMatrix[@normalMapUV] * gl_MultiTexCoord@normalMapUV).xy;
     passTangent = gl_MultiTexCoord7.xyzw;
+#endif
+
+#if @bumpMap
+    bumpMapUV = (gl_TextureMatrix[@bumpMapUV] * gl_MultiTexCoord@bumpMapUV).xy;
 #endif
 
 #if @specularMap


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/issues/5304)

tl;dr: SHINY ROCKS BEGONE.

Add bump-mapping support using MGE XE fixed function pipeline emulation as a reference.
Bump-mapped objects always use shaders.

Morrowind Code Patch option where the lighting is applied to environment map reflections is added as well. Affected objects are rendered with shaders.

Notes:
1. Theoretically bump map references can be added to OSG format files. Bad things may happen since there's no NIF-specific information there. They shouldn't be used in them anyway since normal maps are better. I didn't update the relevant documentation part about texture types supported in OSG files due to this.
2. Spherical environment maps look somewhat different to Morrowind (I'm not sure how), and various texture generation types Morrowind and our fixed function pipeline has aren't replicated in shaders.
3. Normal maps can now only be picked up by autodetection, but some of the relevant code hasn't been removed as more recent NIF files include normal map information.
4. (Auto-detected) normal maps and bump maps can be used simultaneously as long as it's not literally the same file, as they're fundamentally different from the rendering viewpoint. If there's a conflict, only the bump map will be used.

I've updated the documentation, removing and replacing a lot of inaccurate and/or outdated information. It's still helpful in case the user wants to convert bump maps that are actually normal maps to be handled as normal maps.

Example (old version of Lougian's Hlaalu retexture + On The Rocks):
0.45.0/master:
![screenshot199](https://user-images.githubusercontent.com/21265616/75804604-4b1c2c00-5d91-11ea-803d-b74e741b4032.png)
With the option toggled off (vanilla-like)
![screenshot205](https://user-images.githubusercontent.com/21265616/75804645-638c4680-5d91-11ea-9a41-4042b14490cc.png)
With the option toggled on (MCP-like)
![screenshot202](https://user-images.githubusercontent.com/21265616/75804621-55d6c100-5d91-11ea-92f7-48f15a4ace05.png)

It's difficult to show it on pictures.