### PR TITLE
Remove custom data for disposed actors

### DIFF
--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -813,6 +813,12 @@ namespace MWClass
             return;
         }
 
+        if (ptr.getRefData().getCount() <= 0)
+        {
+            state.mHasCustomState = false;
+            return;
+        }
+
         const CreatureCustomData& customData = ptr.getRefData().getCustomData()->asCreatureCustomData();
 
         customData.mContainerStore->writeState (state2.mInventory);

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1331,6 +1331,12 @@ namespace MWClass
             return;
         }
 
+        if (ptr.getRefData().getCount() <= 0)
+        {
+            state.mHasCustomState = false;
+            return;
+        }
+
         const NpcCustomData& customData = ptr.getRefData().getCustomData()->asNpcCustomData();
 
         customData.mInventoryStore.writeState (state2.mInventory);

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1197,7 +1197,7 @@ namespace MWMechanics
 
         if (!Misc::StringUtils::ciEqual(item.getCellRef().getRefId(), MWWorld::ContainerStore::sGoldId))
         {
-            if (victim.isEmpty() || (victim.getClass().isActor() && !victim.getClass().getCreatureStats(victim).isDead()))
+            if (victim.isEmpty() || (victim.getClass().isActor() && victim.getRefData().getCount() > 0 && !victim.getClass().getCreatureStats(victim).isDead()))
                 mStolenItems[Misc::StringUtils::lowerCase(item.getCellRef().getRefId())][owner] += count;
         }
         if (alarm)


### PR DESCRIPTION
Based on [task #5194](https://gitlab.com/OpenMW/openmw/issues/5194).

Summary of changes:
1. Do not write a custom data (inventory, current stats values, etc) to the savegame, if an actor is deleted (count = 0).
2. Adjust "check if item's owner is dead" logic to take in account the fact that we can not use CreatureStats for disposed actors.

According to my testing, my endgame save has about 400 records for dead actors (many records are for dead horkers from the Bloodmoon quest line).
A cleanup makes my endgame save about 550 KB smaller (about 2%), and it loads about 2-3% faster.

Notes:
1. This patch does not require a savegame format change, but older 0.47 builds rely on fact that we store data forever, so they can not handle the "check if item's owner is dead" logic well for cleaned saves.
2. If there is an additional obscure logic, which handles disposed actors (basically, accesses CreatureStats or ContainerStore), it should be updated as well.
As for script commands which check target's stats or inventory, they should not work for disposed actors as well (in the Morrowind they return default values, as if target was resurrected).