### PR TITLE
Store fog of war as a PNG image instead of TGA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@
     Bug #5104: Black Dart's enchantment doesn't trigger at low Enchant levels
     Bug #5105: NPCs start combat with werewolves from any distance
     Bug #5106: Still can jump even when encumbered
+    Bug #5108: Savegame bloating due to inefficient fog textures format
     Bug #5110: ModRegion with a redundant numerical argument breaks script execution
     Bug #5112: Insufficient magicka for current spell not reflected on HUD icon
     Bug #5113: Unknown alchemy question mark not centered

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -209,6 +209,7 @@ namespace MWGui
                     MyGUI::IntCoord(mx*mMapWidgetSize, my*mMapWidgetSize, mMapWidgetSize, mMapWidgetSize),
                     MyGUI::Align::Top | MyGUI::Align::Left);
                 fog->setDepth(Local_FogLayer);
+                fog->setColour(MyGUI::Colour(0, 0, 0));
 
                 map->setNeedMouseFocus(false);
                 fog->setNeedMouseFocus(false);

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -692,12 +692,10 @@ void LocalMap::MapSegment::loadFogOfWar(const ESM::FogTexture &esm)
         return;
     }
 
-    // TODO: deprecate tga and use raw data instead
-
-    osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
+    osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension("png");
     if (!readerwriter)
     {
-        Log(Debug::Error) << "Error: Unable to load fog, can't find a tga ReaderWriter" ;
+        Log(Debug::Error) << "Error: Unable to load fog, can't find a png ReaderWriter" ;
         return;
     }
 
@@ -726,10 +724,10 @@ void LocalMap::MapSegment::saveFogOfWar(ESM::FogTexture &fog) const
 
     std::ostringstream ostream;
 
-    osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
+    osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension("png");
     if (!readerwriter)
     {
-        Log(Debug::Error) << "Error: Unable to write fog, can't find a tga ReaderWriter";
+        Log(Debug::Error) << "Error: Unable to write fog, can't find a png ReaderWriter";
         return;
     }
 

--- a/components/esm/fogstate.cpp
+++ b/components/esm/fogstate.cpp
@@ -3,10 +3,60 @@
 #include "esmreader.hpp"
 #include "esmwriter.hpp"
 
+#include <osgDB/ReadFile>
+
+#include <components/debug/debuglog.hpp>
+#include <components/files/memorystream.hpp>
+
+#include "savedgame.hpp"
+
+void convertFogOfWar(std::vector<char>& imageData)
+{
+    if (imageData.empty())
+    {
+        return;
+    }
+
+    osgDB::ReaderWriter* tgaReader = osgDB::Registry::instance()->getReaderWriterForExtension("tga");
+    if (!tgaReader)
+    {
+        Log(Debug::Error) << "Error: Unable to load fog, can't find a tga ReaderWriter";
+        return;
+    }
+
+    Files::IMemStream in(&imageData[0], imageData.size());
+
+    osgDB::ReaderWriter::ReadResult result = tgaReader->readImage(in);
+    if (!result.success())
+    {
+        Log(Debug::Error) << "Error: Failed to read fog: " << result.message() << " code " << result.status();
+        return;
+    }
+
+    osgDB::ReaderWriter* pngWriter = osgDB::Registry::instance()->getReaderWriterForExtension("png");
+    if (!pngWriter)
+    {
+        Log(Debug::Error) << "Error: Unable to write fog, can't find a png ReaderWriter";
+        return;
+    }
+
+    std::ostringstream ostream;
+    osgDB::ReaderWriter::WriteResult png = pngWriter->writeImage(*result.getImage(), ostream);
+    if (!png.success())
+    {
+        Log(Debug::Error) << "Error: Unable to write fog: " << png.message() << " code " << png.status();
+        return;
+    }
+
+    std::string str = ostream.str();
+    imageData = std::vector<char>(str.begin(), str.end());
+}
+
 void ESM::FogState::load (ESMReader &esm)
 {
     esm.getHNOT(mBounds, "BOUN");
     esm.getHNOT(mNorthMarkerAngle, "ANGL");
+    int dataFormat = esm.getFormat();
     while (esm.isNextSub("FTEX"))
     {
         esm.getSubHeader();
@@ -18,6 +68,10 @@ void ESM::FogState::load (ESMReader &esm)
         size_t imageSize = esm.getSubSize()-sizeof(int)*2;
         tex.mImageData.resize(imageSize);
         esm.getExact(&tex.mImageData[0], imageSize);
+
+        if (dataFormat < 6)
+            convertFogOfWar(tex.mImageData);
+
         mFogTextures.push_back(tex);
     }
 }

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -5,7 +5,7 @@
 #include "defs.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 5;
+int ESM::SavedGame::sCurrentFormat = 6;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
An alternative for #2580.

Just store fog of war as a PNG image (with its palette and compression) instead of TGA, which uses 4 bytes per pixel.
As a result, fog of war occupies about 1.5% of savegame instead of 20% without noticable performance difference (my testing save shrinked from 29.3MB to 23.9MB with this PR, and to 24.7MB with the raw data storage). 

We do not need any additional 3d-party dependencies since we already store world map in savegames as a PNG image.

Basically, we will need to decide which data format would be better for us.