### PR TITLE
Use clone() instead of subimage copying for global map texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@
     Bug #5269: Editor: Cell lighting in resaved cleaned content files is corrupted
     Bug #5278: Console command Show doesn't fall back to global variable after local var not found
     Bug #5300: NPCs don't switch from torch to shield when starting combat
+    Bug #5308: World map copying makes save loading much slower
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwrender/globalmap.cpp
+++ b/apps/openmw/mwrender/globalmap.cpp
@@ -457,7 +457,7 @@ namespace MWRender
         if (map.mImageData.empty())
             return;
 
-        Files::IMemStream istream(&map.mImageData[0], map.mImageData.size());
+        Files::IMemStream istream(map.mImageData.data(), map.mImageData.size());
 
         osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension("png");
         if (!readerwriter)
@@ -522,7 +522,7 @@ namespace MWRender
 
         if (srcBox == destBox && imageWidth == mWidth && imageHeight == mHeight)
         {
-            mOverlayImage->copySubImage(0, 0, 0, image);
+            mOverlayImage = image;
 
             requestOverlayTextureUpdate(0, 0, mWidth, mHeight, texture, true, false);
         }


### PR DESCRIPTION
Should fix [bug #5308](https://gitlab.com/OpenMW/openmw/issues/5308).

We handle global map in the master branch in this way:
1. We create map texture during game start, when we init UI.
2. We use this texture for new game, and bake it to the savegame in the PNG format.
3. During savegame loading we check if world dimensions and map resolution from the savegame are the same as for existing one. If they are, we **copy the whole overlay image data from texture, which we read from savegame, to the existing overlay image**.

EDIT: it should be enough just to use an assignment here.
