### PR TITLE
Keep an AiWanderStorage when cloning an actor

### DIFF
--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -28,6 +28,10 @@ void AiSequence::copy (const AiSequence& sequence)
     for (std::list<AiPackage *>::const_iterator iter (sequence.mPackages.begin());
         iter!=sequence.mPackages.end(); ++iter)
         mPackages.push_back ((*iter)->clone());
+
+    // We need to keep an AiWander storage, if present - it has a state machine.
+    // Not sure about another temporary storages
+    sequence.mAiState.copy<AiWanderStorage>(mAiState);
 }
 
 AiSequence::AiSequence() : mDone (false), mRepeat(false), mLastAiPackage(-1) {}

--- a/apps/openmw/mwmechanics/aistate.hpp
+++ b/apps/openmw/mwmechanics/aistate.hpp
@@ -38,6 +38,14 @@ namespace MWMechanics
             //return a reference to the (new allocated) object 
             return *result;
         }
+
+        template< class Derived >
+        void copy(DerivedClassStorage& destination) const
+        {
+            Derived* result = dynamic_cast<Derived*>(mStorage);
+            if (result != nullptr)
+                destination.store<Derived>(*result);
+        }
         
         template< class Derived >
         void store( const Derived& payload )


### PR DESCRIPTION
Fixes [bug #5267](https://gitlab.com/OpenMW/openmw/-/issues/5267).
A cause of this issue - if an actor without content file crosses cell borders, we place a copy of actor to the new cell, and drop an actor from the old cell.
During cloning process we do not clone a temporary AI storage. It leads to issues with wandering actors, since AiWanderStorage contains a state machine, which we lose as well.

Suggested fix - when we copy an AiSequence, copy an AiWanderStorage as well, if it is present.
It allows to avoid a quite brütal AI reset, when wandering actor without content file crosses cell borders.

Note: we will keep storage after scripted teleportation as well. BTW, the only way to make actor to wander properly after telepotation in Morrowind is to assign a new AiWander package to him.