### PR TITLE
Fixes of my mistakes

### DIFF
--- a/apps/openmw_test_suite/nifloader/testbulletnifloader.cpp
+++ b/apps/openmw_test_suite/nifloader/testbulletnifloader.cpp
@@ -266,7 +266,7 @@ namespace
         MOCK_CONST_METHOD0(numRecords, std::size_t ());
         MOCK_CONST_METHOD1(getRoot, Nif::Record* (std::size_t));
         MOCK_CONST_METHOD0(numRoots, std::size_t ());
-        MOCK_CONST_METHOD1(getString, std::string (std::size_t));
+        MOCK_CONST_METHOD1(getString, std::string (uint32_t));
         MOCK_METHOD1(setUseSkinning, void (bool));
         MOCK_CONST_METHOD0(getUseSkinning, bool ());
         MOCK_CONST_METHOD0(getFilename, std::string ());

--- a/components/bsa/compressedbsafile.cpp
+++ b/components/bsa/compressedbsafile.cpp
@@ -422,7 +422,8 @@ void CompressedBSAFile::convertCompressedSizesToUncompressed()
 std::uint64_t CompressedBSAFile::generateHash(std::string stem, std::string extension) const
 {
     size_t len = stem.length();
-    if (len == 0) return 0;
+    if (len == 0)
+        return 0;
     std::uint64_t hash = 0;
     unsigned int hash2 = 0;
     Misc::StringUtils::lowerCaseInPlace(stem);
@@ -434,12 +435,19 @@ std::uint64_t CompressedBSAFile::generateHash(std::string stem, std::string exte
         for (const char &c : extension)
             hash = hash * 0x1003f + c;
     }
-    for (size_t i = 1; i < len-2 && len > 3; i++)
-        hash2 = hash2 * 0x1003f + stem[i];
+    if (len >= 4)
+    {
+        for (size_t i = 1; i < len-2; i++)
+            hash2 = hash2 * 0x1003f + stem[i];
+    }
     hash = (hash + hash2) << 32;
     hash2 = (stem[0] << 24) | (len << 16);
-    if (len >= 3) hash2 |= stem[len-2] << 8;
-    if (len >= 2) hash2 |= stem[len-1];
+    if (len >= 2)
+    {
+        if (len >= 3)
+            hash2 |= stem[len-2] << 8;
+        hash2 |= stem[len-1];
+    }
     if (!extension.empty())
     {
         if (extension == ".kf")       hash2 |= 0x80;

--- a/components/nif/niffile.hpp
+++ b/components/nif/niffile.hpp
@@ -26,7 +26,7 @@ struct File
 
     virtual size_t numRoots() const = 0;
 
-    virtual std::string getString(size_t index) const = 0;
+    virtual std::string getString(uint32_t index) const = 0;
 
     virtual void setUseSkinning(bool skinning) = 0;
 
@@ -129,8 +129,10 @@ public:
     size_t numRoots() const override { return roots.size(); }
 
     /// Get a given string from the file's string table
-    std::string getString(size_t index) const override
+    std::string getString(uint32_t index) const override
     {
+        if (index == std::numeric_limits<uint32_t>::max())
+            return std::string();
         return strings.at(index);
     }
 


### PR DESCRIPTION
Fixes two oversights of mine that bothered me for a while.

1. Fix empty string handling in string tables.
String table support is unused, but had it been used, this would have allowed it to work properly in much more cases. Also string table indexing is now properly constrained by NIF format limitations.

2. Don't save space in compressed BSA hash calculation
It leads to a bit more asm being generated and slightly worse readability for no good reason. There seemed to be 2 more CPU operations per cycle (and what instructions are present were more expensive) in the file stem loop because the constant length was compared with a constant number every time. One redundant length check is removed for stem length >= 2 case (the majority of the cases).
