### PR TITLE
Accept an extra numerical argument in GetItemCount

### DIFF
--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -116,7 +116,7 @@ namespace Compiler
         void registerExtensions (Extensions& extensions)
         {
             extensions.registerInstruction ("additem", "clX", opcodeAddItem, opcodeAddItemExplicit);
-            extensions.registerFunction ("getitemcount", 'l', "c", opcodeGetItemCount,
+            extensions.registerFunction ("getitemcount", 'l', "cX", opcodeGetItemCount,
                 opcodeGetItemCountExplicit);
             extensions.registerInstruction ("removeitem", "clX", opcodeRemoveItem,
                 opcodeRemoveItemExplicit);


### PR DESCRIPTION
It'll be ignored and a warning will be emitted. Fixes the execution of a buggy script in [this](https://www.nexusmods.com/morrowind/mods/46877) mod, doesn't seem to break any other scripts.