### PR TITLE
Cleanup ownership for items in containers

### DIFF
--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -290,7 +290,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr
     item.getCellRef().setOwner("");
     item.getCellRef().resetGlobalVariable();
     item.getCellRef().setFaction("");
-    item.getCellRef().setFactionRank(-1);
+    item.getCellRef().setFactionRank(-2);
 
     // must reset the RefNum on the copied item, so that the RefNum on the original item stays unique
     // maybe we should do this in the copy constructor instead?

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -153,13 +153,19 @@ void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory, bool
         esm.writeHNT("XSCL", scale);
     }
 
-    esm.writeHNOCString("ANAM", mOwner);
+    if (!inInventory)
+        esm.writeHNOCString("ANAM", mOwner);
+
     esm.writeHNOCString("BNAM", mGlobalVariable);
     esm.writeHNOCString("XSOL", mSoul);
 
-    esm.writeHNOCString("CNAM", mFaction);
-    if (mFactionRank != -2) {
-        esm.writeHNT("INDX", mFactionRank);
+    if (!inInventory)
+    {
+        esm.writeHNOCString("CNAM", mFaction);
+        if (mFactionRank != -2)
+        {
+            esm.writeHNT("INDX", mFactionRank);
+        }
     }
 
     if (mEnchantmentCharge != -1)


### PR DESCRIPTION
For faction ownership we have two special states:
1. -2, which means that there is no faction ownership for given item.
2. -1, which means that there is a faction ownership, but no rank requirements.
When we add an item to container, we are supposed to reset ownership, including factions one.
Scrawl erroneously reset faction rank to -1, not to -2, so we store that -1 for EVERY item in EVERY container in EVERY visited cell in savegame. Yes, magic numbers are obscure and lead to bugs.

So the summary of changes:
1. Reset rank requirements to -2 instead of -1, when we add an item to container.
2. During saving check if an item is in container. If yes, there is no need to store ownership data at all. Allows to cleanup old saves.

As a result, my testing savegame has size 28MB instead of 29.5MB (a 5% lesser size), and loads about 3-5% faster.

There should be no need to increase a savegame version, but older OpenMW will write -1 for items in new cells.