### PR TITLE
Do not write empty trade time

### DIFF
--- a/components/esm/creaturestats.cpp
+++ b/components/esm/creaturestats.cpp
@@ -144,7 +144,8 @@ void ESM::CreatureStats::save (ESMWriter &esm) const
     if (mGoldPool)
         esm.writeHNT ("GOLD", mGoldPool);
 
-    esm.writeHNT ("TIME", mTradeTime);
+    if (mTradeTime.mDay != 0 || mTradeTime.mHour != 0)
+        esm.writeHNT ("TIME", mTradeTime);
 
     if (mDead)
         esm.writeHNT ("DEAD", mDead);


### PR DESCRIPTION
There is no point to write trading timestamp just for every scrib - we set it only when player talks with actor, so the timestamp is empty for most of creatures.
So I just use the same approach as for `mTimeOfDeath`.
No savegame format change is required, since the "TIME" record in savegame is already optional.

The difference is not very noticable (maybe about 0.3-0.5% of save), but it is still a nice improvement.