### PR TITLE
Make slider control in the wait window to be a more intuitive

### DIFF
--- a/apps/openmw/mwgui/waitdialog.cpp
+++ b/apps/openmw/mwgui/waitdialog.cpp
@@ -227,9 +227,9 @@ namespace MWGui
 
     void WaitDialog::onKeyButtonPressed(MyGUI::Widget *sender, MyGUI::KeyCode key, MyGUI::Char character)
     {
-        if (key == MyGUI::KeyCode::ArrowDown)
+        if (key == MyGUI::KeyCode::ArrowUp)
             mHourSlider->setScrollPosition(std::min(mHourSlider->getScrollPosition()+1, mHourSlider->getScrollRange()-1));
-        else if (key == MyGUI::KeyCode::ArrowUp)
+        else if (key == MyGUI::KeyCode::ArrowDown)
             mHourSlider->setScrollPosition(std::max(static_cast<int>(mHourSlider->getScrollPosition())-1, 0));
         else
             return;


### PR DESCRIPTION
In a generic UI design, when you control a parameter's value in slider via arrow keys, ArrowUp key increases the value, ArrowDown key decreases it (a more/lesser semantics). A wait dialogue in OpenMW uses a reverse order for some reason (a scroll to begin/end semantics, as for document navigation), what is a quite frustrating.

This PR makes directions to be more intuitive.
