### PR TITLE
Trace down dead persistent actors underwater

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1424,7 +1424,9 @@ namespace MWWorld
 
         pos.z() += 20; // place slightly above. will snap down to ground with code below
 
-        if (force || !ptr.getClass().isActor() || (!isFlying(ptr) && !isSwimming(ptr) && isActorCollisionEnabled(ptr)))
+        // We still should trace down dead persistent actors - they do not use the "swimdeath" animation.
+        bool swims = ptr.getClass().isActor() && isSwimming(ptr) && !(ptr.getClass().isPersistent(ptr) && ptr.getClass().getCreatureStats(ptr).isDeathAnimationFinished());
+        if (force || !ptr.getClass().isActor() || (!isFlying(ptr) && !swims && isActorCollisionEnabled(ptr)))
         {
             osg::Vec3f traced = mPhysics->traceDown(ptr, pos, Constants::CellSizeInUnits);
             if (traced.z() < pos.z())


### PR DESCRIPTION
Fixes [regression #5317](https://gitlab.com/OpenMW/openmw/-/issues/5317).

Persistent dead actors do not use "swim death" animations and do not float up, so we still should trace them down underwater. I do not know if the Mororwind behaves *exactly* in the same way, though.

As for non-persistent initially dead actors, a behaviour is buggy in Morrowind - dead actor starts to use a common swim animation underwater, as he is still alive. In OpenMW such actors use use "swim death" animations and float up instead.