### PR TITLE
Fix Qt download link for Windows

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -421,7 +421,7 @@ if [ -z $SKIP_DOWNLOAD ]; then
 		fi
 
 		download "Qt 5.7.0" \
-			"https://download.qt.io/archive/qt/5.7/5.7.0/qt-opensource-windows-x86-msvc${MSVC_YEAR}${QT_SUFFIX}-5.7.0.exe" \
+			"https://download.qt.io/new_archive/qt/5.7/5.7.0/qt-opensource-windows-x86-msvc${MSVC_YEAR}${QT_SUFFIX}-5.7.0.exe" \
 			"qt-5.7.0-msvc${MSVC_YEAR}-win${BITS}.exe" \
 			"https://www.lysator.liu.se/~ace/OpenMW/deps/qt-5-install.qs" \
 			"qt-5-install.qs"


### PR DESCRIPTION
A 5.7 distro was removed from the "archive" folder, but it is still available in the "new_archive" folder.