### PR TITLE
Correct drawable property apply order (bug #5313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@
     Bug #5278: Console command Show doesn't fall back to global variable after local var not found
     Bug #5300: NPCs don't switch from torch to shield when starting combat
     Bug #5308: World map copying makes save loading much slower
+    Bug #5313: Node properties of identical type are not applied in the correct order
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -63,6 +63,8 @@ namespace
     // Collect all properties affecting the given drawable that should be handled on drawable basis rather than on the node hierarchy above it.
     void collectDrawableProperties(const Nif::Node* nifNode, std::vector<const Nif::Property*>& out)
     {
+        if (nifNode->parent)
+            collectDrawableProperties(nifNode->parent, out);
         const Nif::PropertyList& props = nifNode->props;
         for (size_t i = 0; i <props.length();++i)
         {
@@ -81,8 +83,6 @@ namespace
                 }
             }
         }
-        if (nifNode->parent)
-            collectDrawableProperties(nifNode->parent, out);
     }
 
     // NodeCallback used to have a node always oriented towards the camera. The node can have translation and scale
@@ -1719,9 +1719,8 @@ namespace NifOsg
 
             int lightmode = 1;
 
-            for (std::vector<const Nif::Property*>::const_reverse_iterator it = properties.rbegin(); it != properties.rend(); ++it)
+            for (const Nif::Property* property : properties)
             {
-                const Nif::Property* property = *it;
                 switch (property->recType)
                 {
                 case Nif::RC_NiSpecularProperty:


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5313).

In the current setup, the properties are collected in this order (or a similar order):
1. Current node's property 1
2. Current node's property 2
3. Current node's property 3
4. Parent node's property 1
5. Parent node's property 2
6. Parent node's property 3
7. Parent node's parent node's property 1
8. Parent node's parent node's property 2
9. Parent node's parent node's property 3

And they're applied in this order:
1. Parent node's parent node's property 3
2. Parent node's parent node's property 2
3. Parent node's parent node's property 1
4. Parent node's property 3
5. Parent node's property 2
6. Parent node's property 1
7. Current node's property 3
8. Current node's property 2
9. Current node's property 1.

So the first property of a node has the highest priority, which isn't very meaningful, inconsistent with NetImmerse's/Gamebryo's observed behavior in other situations and evidently breaks mods.

The proposed collection order (and also the applying order) is:
1. Parent node's parent node's property 1
2. Parent node's parent node's property 2
3. Parent node's parent node's property 3
4. Parent node's property 1
5. Parent node's property 2
6. Parent node's property 3
7. Current node's property 1
8. Current node's property 2
9. Current node's property 3

That should make the order meaningful and correct the mod's behavior (which it does in my testing).