### PR TITLE
Don't reset dead non-werewolf vampires' vampire NPC type (regression #5327)

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -269,6 +269,9 @@ void HeadAnimationTime::setBlinkStop(float value)
 NpcAnimation::NpcType NpcAnimation::getNpcType()
 {
     const MWWorld::Class &cls = mPtr.getClass();
+    // Dead vampires should typically stay vampires.
+    if (mNpcType == Type_Vampire && cls.getNpcStats(mPtr).isDead() && !cls.getNpcStats(mPtr).isWerewolf())
+        return mNpcType;
     NpcAnimation::NpcType curType = Type_Normal;
     if (cls.getCreatureStats(mPtr).getMagicEffects().get(ESM::MagicEffect::Vampirism).getMagnitude() > 0)
         curType = Type_Vampire;


### PR DESCRIPTION
[Issue page](https://gitlab.com/OpenMW/openmw/-/issues/5327)

Typically it shouldn't be reset (see vampirism code in the character controller), but it was reset in the case equipment was changed and probably other cases because we recalculate it in updateParts. It allows to avoid an extraneous animation reset when the vampires turn back human (or mer) technically and unexpectedly (since they don't have any active magic effects anymore, including vampirism).