### PR TITLE
Ignore unterminated empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
     Bug #5300: NPCs don't switch from torch to shield when starting combat
     Bug #5308: World map copying makes save loading much slower
     Bug #5313: Node properties of identical type are not applied in the correct order
+    Bug #5345: Dopey Necromancy does not work due to a missing quote
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/components/compiler/scanner.cpp
+++ b/components/compiler/scanner.cpp
@@ -282,6 +282,8 @@ namespace Compiler
 
         if (!scanName (name))
             return false;
+        else if(name.empty())
+            return true;
 
         TokenLoc loc (mLoc);
         mLoc.mLiteral.clear();
@@ -366,6 +368,13 @@ namespace Compiler
                 {
                     if (mIgnoreNewline)
                         mErrorHandler.warning ("string contains newline character, make sure that it is intended", mLoc);
+                    else if (name.size() == 1 || name.size() == 2 && name[1] == '\r')
+                    {
+                        name.clear();
+                        mLoc.mLiteral.clear();
+                        mErrorHandler.warning ("unterminated empty string", mLoc);
+                        break;
+                    }
                     else
                     {
                         error = true;

--- a/components/compiler/scanner.cpp
+++ b/components/compiler/scanner.cpp
@@ -368,15 +368,28 @@ namespace Compiler
                 {
                     if (mIgnoreNewline)
                         mErrorHandler.warning ("string contains newline character, make sure that it is intended", mLoc);
-                    else if (name.size() == 1 || (name.size() == 2 && name[1] == '\r'))
-                    {
-                        name.clear();
-                        mLoc.mLiteral.clear();
-                        mErrorHandler.warning ("unterminated empty string", mLoc);
-                        break;
-                    }
                     else
                     {
+                        bool allWhitespace = true;
+                        for (size_t i = 1; i < name.size(); i++)
+                        {
+                            //ignore comments
+                            if (name[i] == ';')
+                                break;
+                            else if (name[i] != '\t' && name[i] != ' ' && name[i] != '\r')
+                            {
+                                allWhitespace = false;
+                                break;
+                            }
+                        }
+                        if (allWhitespace)
+                        {
+                            name.clear();
+                            mLoc.mLiteral.clear();
+                            mErrorHandler.warning ("unterminated empty string", mLoc);
+                            return true;
+                        }
+
                         error = true;
                         mErrorHandler.error ("incomplete string or name", mLoc);
                         break;

--- a/components/compiler/scanner.cpp
+++ b/components/compiler/scanner.cpp
@@ -368,7 +368,7 @@ namespace Compiler
                 {
                     if (mIgnoreNewline)
                         mErrorHandler.warning ("string contains newline character, make sure that it is intended", mLoc);
-                    else if (name.size() == 1 || name.size() == 2 && name[1] == '\r')
+                    else if (name.size() == 1 || (name.size() == 2 && name[1] == '\r'))
                     {
                         name.clear();
                         mLoc.mLiteral.clear();


### PR DESCRIPTION
Makes the script(s) in [this thread](https://forum.openmw.org/viewtopic.php?f=40&t=6781) compile.

This still fails in at least two **hypothetical** cases:
1. StartScript DN_MinionDrain_s" <- final whitespace
2. StartScript DN_MinionDrain_s" ;comment

Does anyone feel those are worth fixing as well?