### PR TITLE
Fix C5204 warnings by adding default virtual destructors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -716,6 +716,7 @@ if (WIN32)
         # caused by boost
         4191 # 'type cast' : unsafe conversion (1.56, thread_primitives.hpp, normally off)
         4643 # Forward declaring 'X' in namespace std is not permitted by the C++ Standard. (in *_std_fwd.h files)
+        5204 # Class has virtual functions, but its trivial destructor is not virtual
 
         # caused by MyGUI
         4275 # non dll-interface class 'std::exception' used as base for dll-interface class 'MyGUI::Exception'

--- a/apps/openmw/mwgui/bookpage.hpp
+++ b/apps/openmw/mwgui/bookpage.hpp
@@ -34,6 +34,8 @@ namespace MWGui
         /// right edge. The second integer is the height of all
         /// text combined prior to pagination.
         virtual std::pair <unsigned int, unsigned int> getSize () const = 0;
+
+        virtual ~TypesetBook() = default;
     };
 
     struct GlyphInfo
@@ -87,8 +89,7 @@ namespace MWGui
         typedef uint8_t const * Utf8Point;
         typedef std::pair <Utf8Point, Utf8Point> Utf8Span;
 
-
-
+        virtual ~BookTypesetter() = default;
 
         enum Alignment {
             AlignLeft   = -1,

--- a/apps/openmw/mwgui/journalviewmodel.hpp
+++ b/apps/openmw/mwgui/journalviewmodel.hpp
@@ -39,6 +39,8 @@ namespace MWGui
             /// and end of the span relative to the body, and a valid topic ID if
             /// the span represents a keyword, or zero if not.
             virtual void visitSpans (std::function <void (TopicId, size_t, size_t)> visitor) const = 0;
+
+            virtual ~Entry() = default;
         };
 
         /// An interface to topic data.
@@ -47,6 +49,8 @@ namespace MWGui
             /// Returns a pre-formatted span of UTF8 encoded text representing
             /// the name of the NPC this portion of dialog was heard from.
             virtual Utf8Span source () const = 0;
+
+            virtual ~TopicEntry() = default;
         };
 
         /// An interface to journal data.
@@ -55,8 +59,9 @@ namespace MWGui
             /// Returns a pre-formatted span of UTF8 encoded text representing
             /// the in-game date this entry was added to the journal.
             virtual Utf8Span timestamp () const = 0;
-        };
 
+            virtual ~JournalEntry() = default;
+        };
 
         /// called prior to journal opening
         virtual void load () = 0;
@@ -85,6 +90,8 @@ namespace MWGui
 
         // create an instance of the default journal view model implementation
         static Ptr create ();
+
+        virtual ~JournalViewModel() = default;
     };
 }
 

--- a/apps/openmw/mwgui/windowbase.hpp
+++ b/apps/openmw/mwgui/windowbase.hpp
@@ -81,6 +81,7 @@ namespace MWGui
 
         void onFrame(float dt);
         virtual void setAlpha(float alpha);
+        virtual ~NoDrop() = default;
 
     private:
         MyGUI::Widget* mWidget;

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -149,6 +149,8 @@ public:
     public:
         virtual void handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key,
                            const std::multimap<float, std::string>& map) = 0;
+
+        virtual ~TextKeyListener() = default;
     };
 
     void setTextKeyListener(TextKeyListener* listener);

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -40,6 +40,8 @@ namespace MWWorld
             return true;
         }
 
+        virtual ~ListModelsVisitor() = default;
+
         std::vector<std::string>& mOut;
     };
 

--- a/apps/openmw/mwworld/cellstore.hpp
+++ b/apps/openmw/mwworld/cellstore.hpp
@@ -382,6 +382,7 @@ namespace MWWorld
             public:
                 ///@note must return nullptr if the cell is not found
                 virtual CellStore* getCellStore(const ESM::CellId& cellId) = 0;
+                virtual ~GetCellStoreCallback() = default;
             };
 
             /// @param callback to use for retrieving of additional CellStore objects by ID (required for resolving moved references)

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -43,6 +43,7 @@ namespace MWWorld
         public:
             virtual void itemAdded(const ConstPtr& item, int count) {}
             virtual void itemRemoved(const ConstPtr& item, int count) {}
+            virtual ~ContainerStoreListener() = default;
     };
 
     class ContainerStore

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -34,6 +34,7 @@ namespace MWWorld
          */
         virtual void permanentEffectAdded (const ESM::MagicEffect *magicEffect, bool isNew) {}
 
+        virtual ~InventoryStoreListener() = default;
     };
 
     ///< \brief Variant of the ContainerStore for NPCs

--- a/components/debug/debugging.hpp
+++ b/components/debug/debugging.hpp
@@ -38,6 +38,8 @@ namespace Debug
 
         virtual std::streamsize write(const char *str, std::streamsize size);
 
+        virtual ~DebugOutputBase() = default;
+
     protected:
         static Level getLevelMarker(const char *str);
 

--- a/components/detournavigator/navmeshtilescache.hpp
+++ b/components/detournavigator/navmeshtilescache.hpp
@@ -118,6 +118,8 @@ namespace DetourNavigator
         public:
             KeyView() = default;
 
+            virtual ~KeyView() = default;
+
             KeyView(const std::string& value)
                 : mValue(&value) {}
 
@@ -160,6 +162,8 @@ namespace DetourNavigator
             {
                 return compare(other.getValue()) < 0;
             }
+
+            virtual ~RecastMeshKeyView() = default;
 
         private:
             std::reference_wrapper<const RecastMesh> mRecastMesh;

--- a/components/loadinglistener/loadinglistener.hpp
+++ b/components/loadinglistener/loadinglistener.hpp
@@ -29,6 +29,8 @@ namespace Loading
         virtual void setProgress (size_t value) {}
         /// Increase current progress, default by 1.
         virtual void increaseProgress (size_t increase = 1) {}
+
+        virtual ~Listener() = default;
     };
 
     /// @brief Used for stopping a loading sequence when the object goes out of scope

--- a/components/widgets/box.hpp
+++ b/components/widgets/box.hpp
@@ -33,6 +33,8 @@ namespace Gui
 
         virtual MyGUI::IntSize getRequestedSize() = 0;
 
+        virtual ~AutoSizedWidget() = default;
+
     protected:
         void notifySizeChange(MyGUI::Widget* w);
 
@@ -93,6 +95,8 @@ namespace Gui
     {
     public:
         Box();
+
+        virtual ~Box() = default;
 
         void notifyChildrenSizeChanged();
 

--- a/extern/oics/ICSChannelListener.h
+++ b/extern/oics/ICSChannelListener.h
@@ -38,6 +38,8 @@ namespace ICS
     {
     public:
         virtual void channelChanged(Channel* channel, float currentValue, float previousValue) = 0;
+
+        virtual ~ChannelListener() = default;
     };
 
 }

--- a/extern/oics/ICSControlListener.h
+++ b/extern/oics/ICSControlListener.h
@@ -38,6 +38,8 @@ namespace ICS
     {
     public:
         virtual void controlChanged(Control* control, float currentValue, float previousValue) = 0;
+
+        virtual ~ControlListener() = default;
     };
 
 }

--- a/extern/oics/ICSInputControlSystem.h
+++ b/extern/oics/ICSInputControlSystem.h
@@ -45,6 +45,8 @@ namespace ICS
 	{
 	public:
 		virtual void logMessage(const char* text) = 0;
+
+		virtual ~InputControlSystemLog() = default;
 	};
 
     class DllExport InputControlSystem
@@ -261,6 +263,8 @@ namespace ICS
 		virtual void mouseWheelBindingDetected(InputControlSystem* ICS, Control* control,
 		                                       InputControlSystem::MouseWheelClick click,
 		                                       Control::ControlChangingDirection direction);
+
+        virtual ~DetectingBindingListener() = default;
 
 		/* OPENMW CODE ENDS HERE
 		 * ------------------------------------------------------------------------------------- */


### PR DESCRIPTION
Fix spam about missing virtual destructors in OpenMW.
Add such destructors to OpenMW itself, silence the rest of warnings (which come from boost and MSVC headers).