### PR TITLE
Reset skills of dead actors (bug #5328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
     Bug #5300: NPCs don't switch from torch to shield when starting combat
     Bug #5308: World map copying makes save loading much slower
     Bug #5313: Node properties of identical type are not applied in the correct order
+    Bug #5328: Skills aren't properly reset for dead actors
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1850,6 +1850,8 @@ namespace MWMechanics
                     stats.getActiveSpells().visitEffectSources(soulTrap);
                 }
 
+                // Magic effects will be reset later, and the magic effect that could kill the actor
+                // needs to be determined now
                 calculateCreatureStatModifiers(iter->first, 0);
 
                 if (cls.isEssential(iter->first))
@@ -1867,7 +1869,9 @@ namespace MWMechanics
                 // Make sure spell effects are removed
                 purgeSpellEffects(stats.getActorId());
 
+                // Reset dynamic stats, attributes and skills
                 calculateCreatureStatModifiers(iter->first, 0);
+                calculateNpcStatModifiers(iter->first, 0);
 
                 if( iter->first == getPlayer())
                 {


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5328)

Creature stats like health, fatigue and attributes were reset, but skills that can be fortified or damaged aren't creature stats, they're NPC stats, so unarmored skill wasn't recalculated after the last frame of the death animation and it led to the issue with vampires' abilities seemingly staying present, which seems to be fixed now in my testing.