### PR TITLE
Improve blank line handling in settings writer (bug #5326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
     Bug #5300: NPCs don't switch from torch to shield when starting combat
     Bug #5308: World map copying makes save loading much slower
     Bug #5313: Node properties of identical type are not applied in the correct order
+    Bug #5326: Formatting issues in the settings.cfg
     Bug #5328: Skills aren't properly reset for dead actors
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5326)

Some adjustments that should resolve Andrei's concerns.

Empty lines are not copied immediately, rather they will be queued for adding - and as long as the next line is not something that starts a new category or there's no current category at all they will be copied to the file. Trailing whitespace isn't preserved. Once all settings (possibly none) are written into a category, a blank line is added to separate individual settings.cfg sections.

Additionally, when the writer gets to the opening bracket of the first category in the file, it won't unnecessarily check if there are any unwritten settings that belong to a category that lacks a name, which should make settings.cfg saving slightly faster.