### PR TITLE
Fix some serious oversights caused by my fever

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1871,7 +1871,8 @@ namespace MWMechanics
 
                 // Reset dynamic stats, attributes and skills
                 calculateCreatureStatModifiers(iter->first, 0);
-                calculateNpcStatModifiers(iter->first, 0);
+                if (iter->first.getClass().isNpc())
+                    calculateNpcStatModifiers(iter->first, 0);
 
                 if( iter->first == getPlayer())
                 {

--- a/components/settings/parser.cpp
+++ b/components/settings/parser.cpp
@@ -103,17 +103,17 @@ void Settings::SettingsFileParser::saveSettingsFile(const std::string& file, con
         // The current character position in the line.
         size_t i = 0;
 
-        // Don't add additional newlines at the end of the file.
-        if (istream.eof()) continue;
-
         // An empty line was queued.
         if (emptyLineQueued)
         {
             emptyLineQueued = false;
             // We're still going through the current category, so we should copy it.
-            if (currentCategory.empty() || line[i] != '[')
+            if (currentCategory.empty() || istream.eof() || line[i] != '[')
                 ostream << std::endl;
         }
+
+        // Don't add additional newlines at the end of the file otherwise.
+        if (istream.eof()) continue;
 
         // Queue entirely blank lines to add them if desired.
         if (!skipWhiteSpace(i, line))


### PR DESCRIPTION
calculateNpcStatModifiers can't be called for non-NPCs and blank lines were "eaten" by the settings writer at the end of the file.