### PR TITLE
Remove "extra argument" warning from AiTravel

### DIFF
--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -33,7 +33,7 @@ namespace Compiler
         {
             extensions.registerInstruction ("aiactivate", "c/l", opcodeAIActivate,
                 opcodeAIActivateExplicit);
-            extensions.registerInstruction ("aitravel", "fff/zx", opcodeAiTravel,
+            extensions.registerInstruction ("aitravel", "fff/lx", opcodeAiTravel,
                 opcodeAiTravelExplicit);
             extensions.registerInstruction ("aiescort", "cffff/l", opcodeAiEscort,
                 opcodeAiEscortExplicit);


### PR DESCRIPTION
AiTravel takes a reset flag per https://gitlab.com/OpenMW/openmw/-/issues/1465 and https://www.tamriel-rebuilt.org/content/tutorial-morrowind-scripting-dummies but OpenMW currently emits a warning when a script contains said flag.