### PR TITLE
[WIP] An attempt to fix context loss on Android

### DIFF
--- a/apps/openmw/android_main.cpp
+++ b/apps/openmw/android_main.cpp
@@ -4,6 +4,9 @@ int stderr = 0; // Hack: fix linker error
 #include <SDL_gamecontroller.h>
 #include <SDL_mouse.h>
 #include <SDL_events.h>
+#include <SDL_hints.h>
+
+#include "mwbase/inputmanager.hpp"
 
 /*******************************************************************************
  Functions called by JNI
@@ -17,13 +20,11 @@ extern int argcData;
 extern const char **argvData;
 void releaseArgv();
 
-
 extern "C" int Java_org_libsdl_app_SDLActivity_getMouseX(JNIEnv *env, jclass cls, jobject obj) {
     int ret = 0;
     SDL_GetMouseState(&ret, nullptr);
     return ret;
 }
-
 
 extern "C" int Java_org_libsdl_app_SDLActivity_getMouseY(JNIEnv *env, jclass cls, jobject obj) {
     int ret = 0;
@@ -52,5 +53,19 @@ extern "C" int Java_org_libsdl_app_SDLActivity_nativeInit(JNIEnv* env, jclass cl
     // On Android, we use a virtual controller with guid="Virtual"
     SDL_GameControllerAddMapping("5669727475616c000000000000000000,Virtual,a:b0,b:b1,back:b15,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b16,leftshoulder:b6,leftstick:b13,lefttrigger:a5,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a4,rightx:a2,righty:a3,start:b11,x:b3,y:b4");
 
+    SDL_SetHint(SDL_HINT_ANDROID_BLOCK_ON_PAUSE, "0");
+
     return 0;
+}
+
+extern "C" void Java_org_libsdl_app_SDLActivity_omwSurfaceDestroyed(JNIEnv *env, jclass cls, jobject obj) {
+    MWBase::InputManager* inp = MWBase::Environment::get().getInputManager();
+    if (inp)
+        inp->windowVisibilityChange(false, true);
+}
+
+extern "C" void Java_org_libsdl_app_SDLActivity_omwSurfaceRecreated(JNIEnv *env, jclass cls, jobject obj) {
+    MWBase::InputManager* inp = MWBase::Environment::get().getInputManager();
+    if (inp)
+        inp->windowVisibilityChange(true, true);
 }

--- a/apps/openmw/mwbase/inputmanager.hpp
+++ b/apps/openmw/mwbase/inputmanager.hpp
@@ -66,6 +66,8 @@ namespace MWBase
             virtual void resetToDefaultKeyBindings() = 0;
             virtual void resetToDefaultControllerBindings() = 0;
 
+            virtual void windowVisibilityChange(bool visible, bool updateContext = false) = 0;
+
             /// Returns if the last used input device was a joystick or a keyboard
             /// @return true if joystick, false otherwise
             virtual bool joystickLastUsed() = 0;

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -129,7 +129,7 @@ namespace MWInput
         virtual void controllerAdded(int deviceID, const SDL_ControllerDeviceEvent &arg);
         virtual void controllerRemoved(const SDL_ControllerDeviceEvent &arg);
 
-        virtual void windowVisibilityChange( bool visible );
+        virtual void windowVisibilityChange(bool visible, bool updateContext = false);
         virtual void windowFocusChange( bool have_focus );
         virtual void windowResized (int x, int y);
         virtual void windowClosed ();


### PR DESCRIPTION
I try to use a slightly better approach than [global variable](https://github.com/xyzz/openmw-android/blob/master/buildscripts/patches/openmw/0010-android-fix-context-being-lost-on-app-minimize.patch).

Note: If we do not want to maintain android_main file for some reason, probably it would be better to drop it (Android port already fully replaces it).