### PR TITLE
Always create NiGeometry nodes as MatrixTransform

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -461,8 +461,6 @@ namespace NifOsg
                 break;
             }
             case Nif::RC_NiSwitchNode:
-            case Nif::RC_NiTriShape:
-            case Nif::RC_NiTriStrips:
             case Nif::RC_NiAutoNormalParticles:
             case Nif::RC_NiRotatingParticles:
                 // Leaf nodes in the NIF hierarchy, so won't be able to dynamically attach children.


### PR DESCRIPTION
This allows NiKeyframeControllers to work on NiTriShape/NiTriStrips properly even when these nodes have no transformations and not cause a crash (due to being unable to find a valid MatrixTransform). Unfortunately we can't optimize out their ability to be transformed anyhow because there may still be a keyframe controller in the kf file that would have affected the NiTriShape. It doesn't cause any crashes in vanilla according to Greatness7 and mods can and will rely on the fact that vanilla doesn't do the same kind of optimization.