### PR TITLE
[WIP] In-game menu to tweak shadows

### DIFF
--- a/apps/openmw/mwgui/settingswindow.hpp
+++ b/apps/openmw/mwgui/settingswindow.hpp
@@ -34,6 +34,7 @@ namespace MWGui
 
             MyGUI::ComboBox* mWaterTextureSize;
             MyGUI::ComboBox* mWaterReflectionDetail;
+            MyGUI::ComboBox* mShadowTextureSize;
 
             // controls
             MyGUI::ScrollView* mControlsBox;
@@ -54,6 +55,8 @@ namespace MWGui
 
             void onWaterTextureSizeChanged(MyGUI::ComboBox* _sender, size_t pos);
             void onWaterReflectionDetailChanged(MyGUI::ComboBox* _sender, size_t pos);
+
+            void onShadowTextureSizeChanged(MyGUI::ComboBox* _sender, size_t pos);
 
             void onRebindAction(MyGUI::Widget* _sender);
             void onInputTabMouseWheel(MyGUI::Widget* _sender, int _rel);

--- a/components/sceneutil/mwshadowtechnique.cpp
+++ b/components/sceneutil/mwshadowtechnique.cpp
@@ -864,14 +864,14 @@ void SceneUtil::MWShadowTechnique::disableFrontFaceCulling()
         _shadowCastingStateSet->setMode(GL_CULL_FACE, osg::StateAttribute::OFF | osg::StateAttribute::OVERRIDE);
 }
 
-void SceneUtil::MWShadowTechnique::setupCastingShader(Shader::ShaderManager & shaderManager)
+void SceneUtil::MWShadowTechnique::setupCastingShader(Shader::ShaderManager* shaderManager)
 {
     // This can't be part of the constructor as OSG mandates that there be a trivial constructor available
     
     _castingProgram = new osg::Program();
 
-    _castingProgram->addShader(shaderManager.getShader("shadowcasting_vertex.glsl", Shader::ShaderManager::DefineMap(), osg::Shader::VERTEX));
-    _castingProgram->addShader(shaderManager.getShader("shadowcasting_fragment.glsl", Shader::ShaderManager::DefineMap(), osg::Shader::FRAGMENT));
+    _castingProgram->addShader(shaderManager->getShader("shadowcasting_vertex.glsl", Shader::ShaderManager::DefineMap(), osg::Shader::VERTEX));
+    _castingProgram->addShader(shaderManager->getShader("shadowcasting_fragment.glsl", Shader::ShaderManager::DefineMap(), osg::Shader::FRAGMENT));
 }
 
 MWShadowTechnique::ViewDependentData* MWShadowTechnique::createViewDependentData(osgUtil::CullVisitor* /*cv*/)
@@ -1564,7 +1564,7 @@ void MWShadowTechnique::createShaders()
     }
 
     if (!_castingProgram)
-        OSG_NOTICE << "Shadow casting shader has not been set up. Remember to call setupCastingShader(Shader::ShaderManager &)" << std::endl;
+        OSG_NOTICE << "Shadow casting shader has not been set up. Remember to call setupCastingShader(Shader::ShaderManager *)" << std::endl;
 
     _shadowCastingStateSet->setAttributeAndModes(_castingProgram, osg::StateAttribute::ON | osg::StateAttribute::OVERRIDE);
     // The casting program uses a sampler, so to avoid undefined behaviour, we must bind a dummy texture in case no other is supplied

--- a/components/sceneutil/mwshadowtechnique.hpp
+++ b/components/sceneutil/mwshadowtechnique.hpp
@@ -82,7 +82,7 @@ namespace SceneUtil {
 
         virtual void disableFrontFaceCulling();
 
-        virtual void setupCastingShader(Shader::ShaderManager &shaderManager);
+        virtual void setupCastingShader(Shader::ShaderManager* shaderManager);
 
         class ComputeLightSpaceBounds : public osg::NodeVisitor, public osg::CullStack
         {

--- a/components/sceneutil/shadow.hpp
+++ b/components/sceneutil/shadow.hpp
@@ -5,6 +5,7 @@
 #include <osgShadow/ShadowedScene>
 
 #include <components/shader/shadermanager.hpp>
+#include <components/settings/settings.hpp>
 
 #include "mwshadowtechnique.hpp"
 
@@ -17,11 +18,13 @@ namespace SceneUtil
 
         static Shader::ShaderManager::DefineMap getShadowsDisabledDefines();
 
-        ShadowManager(osg::ref_ptr<osg::Group> sceneRoot, osg::ref_ptr<osg::Group> rootNode, unsigned int outdoorShadowCastingMask, unsigned int indoorShadowCastingMask, Shader::ShaderManager &shaderManager);
+        ShadowManager(osg::ref_ptr<osg::Group> sceneRoot, osg::ref_ptr<osg::Group> rootNode, Shader::ShaderManager* shaderManager);
 
         void setupShadowSettings();
 
         Shader::ShaderManager::DefineMap getShadowDefines();
+
+        void processChangedSettings(const Settings::CategorySettingVector &changed, osgViewer::Viewer* viewer, bool isIndoor);
 
         void enableIndoorMode();
 
@@ -32,6 +35,7 @@ namespace SceneUtil
         osg::ref_ptr<osgShadow::ShadowedScene> mShadowedScene;
         osg::ref_ptr<osgShadow::ShadowSettings> mShadowSettings;
         osg::ref_ptr<MWShadowTechnique> mShadowTechnique;
+        Shader::ShaderManager* mShaderManager;
 
         unsigned int mOutdoorShadowCastingMask;
         unsigned int mIndoorShadowCastingMask;

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -265,7 +265,7 @@
             </Widget>
             <Widget type="TabItem" skin="" position="4 32 360 308">
                 <Property key="Caption" value="  #{sVideo}  "/>
-                <Widget type="TabControl" skin="TabControlInner" position="4 4 352 390" align="Stretch">
+                <Widget type="TabControl" skin="TabControlInner" position="4 4 352 390" align="Stretch" name="VideoTabs">
                     <Property key="ButtonAutoWidth" value="true"/>
                     <Widget type="TabItem" skin="" position="0 28 352 268" align="Stretch">
                         <Property key="Caption" value="  Video  "/>
@@ -455,88 +455,83 @@
                                 </Widget>
                             </Widget>
                         </Widget>
-
                     </Widget>
-                    <!--
-                    <Widget type="TabItem" skin="" position="0 28 352 268">
-                    <Widget type="Widget" skin="" position="0 28 352 268">
-                        <Property key="Visible" value="false"/>
+                    <Widget type="TabItem" skin="" position="0 28 380 268">
                         <Property key="Caption" value="  Shadows  "/>
                         <Widget type="HBox" skin="" position="4 4 350 24">
                             <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ShadowsEnabledButton">
                                 <UserString key="SettingCategory" value="Shadows"/>
-                                <UserString key="SettingName" value="enabled"/>
+                                <UserString key="SettingName" value="enable shadows"/>
                                 <UserString key="SettingType" value="CheckButton"/>
                             </Widget>
                             <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 65 16" align="Left Top">
                                 <Property key="Caption" value="Shadows"/>
                             </Widget>
                         </Widget>
-                        <Widget type="Widget" skin="" position="24 32 300 230">
+                        <Widget type="Widget" skin="" position="24 32 350 300">
                             <Widget type="HBox" skin="" position="4 0 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ShadowsLargeDistance">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="PlayerShadows">
                                     <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="split"/>
-                                    <UserString key="SettingType" value="CheckButton"/>
-                                </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 182 16" align="Left Top">
-                                    <Property key="Caption" value="Large distance (PSSM3)"/>
-                                </Widget>
-                            </Widget>
-                            <Widget type="HBox" skin="" position="4 28 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="TerrainShadows">
-                                    <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="terrain shadows"/>
+                                    <UserString key="SettingName" value="player shadows"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
                                 <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 122 16" align="Left Top">
-                                    <Property key="Caption" value="Terrain shadows"/>
+                                    <Property key="Caption" value="Player shadows"/>
                                 </Widget>
                             </Widget>
-                            <Widget type="HBox" skin="" position="4 56 350 24">
+                            <Widget type="HBox" skin="" position="4 28 350 24">
                                 <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ActorShadows">
                                     <UserString key="SettingCategory" value="Shadows"/>
                                     <UserString key="SettingName" value="actor shadows"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 122 16" align="Left Top">
+                                    <Property key="Caption" value="Actor shadow"/>
+                                </Widget>
+                            </Widget>
+                            <Widget type="HBox" skin="" position="4 56 350 24">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ObjectShadows">
+                                    <UserString key="SettingCategory" value="Shadows"/>
+                                    <UserString key="SettingName" value="object shadows"/>
+                                    <UserString key="SettingType" value="CheckButton"/>
+                                </Widget>
                                 <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 108 16" align="Left Top">
-                                    <Property key="Caption" value="Actor shadows"/>
+                                    <Property key="Caption" value="Object shadows"/>
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 84 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="StaticsShadows">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="TerrainShadows">
                                     <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="statics shadows"/>
+                                    <UserString key="SettingName" value="terrain shadows"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 111 16" align="Left Top">
-                                    <Property key="Caption" value="World shadows"/>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 108 16" align="Left Top">
+                                    <Property key="Caption" value="Terrain shadows"/>
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 112 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="MiscShadows">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="IndoorShadows">
                                     <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="misc shadows"/>
+                                    <UserString key="SettingName" value="enable indoor shadows"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 102 16" align="Left Top">
-                                    <Property key="Caption" value="Misc shadows"/>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 108 16" align="Left Top">
+                                    <Property key="Caption" value="Indoor shadows"/>
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 140 350 24">
-                                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 60 24" align="Left Top" name="ShadowsTextureSize">
+                                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 70 24" align="Left Top" name="ShadowsTextureSize">
                                     <Property key="AddItem" value="512"/>
                                     <Property key="AddItem" value="1024"/>
                                     <Property key="AddItem" value="2048"/>
                                     <Property key="AddItem" value="4096"/>
                                 </Widget>
                                 <Widget type="AutoSizedTextBox" skin="SandText" position="64 4 90 16" align="Left Top">
-                                    <Property key="Caption" value="Texture size"/>
+                                    <Property key="Caption" value="Shadow map resolution"/>
                                 </Widget>
                             </Widget>
                         </Widget>
                     </Widget>
-                    -->
                 </Widget>
             </Widget>
         </Widget>


### PR DESCRIPTION
Mostly replicates menu from launcher. 

Known issues:
1. Shadows do not work on Android, so I have to disable shadows menu on that platform.
2. Attempts to disable shadows in interiors lead to graphics artifacts (because of `mShadowTechnique->disableShadows();` call).
3. Other settings require horrible hacks to tweak them in the runtime. Unfortunately, our shadowing system does not provide an API for runtime tweaks.