### PR TITLE
Reset errorhandler context

### DIFF
--- a/apps/openmw/mwscript/scriptmanagerimp.cpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.cpp
@@ -171,7 +171,7 @@ namespace MWScript
         {
             Compiler::Locals locals;
 
-            Compiler::ContextRestore restore = mErrorHandler.setContext(name2 + "[local variables]", true);
+            const Compiler::ContextRestore&& restore = mErrorHandler.setContext(name2 + "[local variables]", true);
 
             std::istringstream stream (script->mScriptText);
             Compiler::QuickFileParser parser (mErrorHandler, mCompilerContext, locals);

--- a/apps/openmw/mwscript/scriptmanagerimp.cpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.cpp
@@ -171,7 +171,7 @@ namespace MWScript
         {
             Compiler::Locals locals;
 
-            const Compiler::ContextRestore&& restore = mErrorHandler.setContext(name2 + "[local variables]", true);
+            const Compiler::ContextOverride override(mErrorHandler, name2 + "[local variables]");
 
             std::istringstream stream (script->mScriptText);
             Compiler::QuickFileParser parser (mErrorHandler, mCompilerContext, locals);

--- a/apps/openmw/mwscript/scriptmanagerimp.cpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.cpp
@@ -171,7 +171,7 @@ namespace MWScript
         {
             Compiler::Locals locals;
 
-            mErrorHandler.setContext(name2 + "[local variables]");
+            Compiler::ContextRestore restore = mErrorHandler.setContext(name2 + "[local variables]", true);
 
             std::istringstream stream (script->mScriptText);
             Compiler::QuickFileParser parser (mErrorHandler, mCompilerContext, locals);

--- a/components/compiler/streamerrorhandler.cpp
+++ b/components/compiler/streamerrorhandler.cpp
@@ -72,6 +72,11 @@ namespace Compiler
 
     ContextRestore::ContextRestore(StreamErrorHandler* handler, const std::string& context) : mHandler(handler), mContext(context) {}
 
+    ContextRestore::ContextRestore(ContextRestore&& other) : mHandler(other.mHandler), mContext(other.mContext)
+    {
+        other.mHandler = nullptr;
+    }
+
     ContextRestore::~ContextRestore()
     {
         if(mHandler)

--- a/components/compiler/streamerrorhandler.cpp
+++ b/components/compiler/streamerrorhandler.cpp
@@ -56,10 +56,25 @@ namespace Compiler
         Log(logLevel) << text.str();
     }
 
-    void StreamErrorHandler::setContext(const std::string &context)
+    ContextRestore StreamErrorHandler::setContext(const std::string &context, bool restore)
     {
+        if (!restore)
+        {
+            mContext = context;
+            return {nullptr, {}};
+        }
+        ContextRestore restorer(this, mContext);
         mContext = context;
+        return restorer;
     }
 
     StreamErrorHandler::StreamErrorHandler()  {}
+
+    ContextRestore::ContextRestore(StreamErrorHandler* handler, const std::string& context) : mHandler(handler), mContext(context) {}
+
+    ContextRestore::~ContextRestore()
+    {
+        if(mHandler)
+            mHandler->setContext(mContext);
+    }
 }

--- a/components/compiler/streamerrorhandler.cpp
+++ b/components/compiler/streamerrorhandler.cpp
@@ -56,30 +56,20 @@ namespace Compiler
         Log(logLevel) << text.str();
     }
 
-    ContextRestore StreamErrorHandler::setContext(const std::string &context, bool restore)
+    void StreamErrorHandler::setContext(const std::string &context)
     {
-        if (!restore)
-        {
-            mContext = context;
-            return {nullptr, {}};
-        }
-        ContextRestore restorer(this, mContext);
         mContext = context;
-        return restorer;
     }
 
     StreamErrorHandler::StreamErrorHandler()  {}
 
-    ContextRestore::ContextRestore(StreamErrorHandler* handler, const std::string& context) : mHandler(handler), mContext(context) {}
-
-    ContextRestore::ContextRestore(ContextRestore&& other) : mHandler(other.mHandler), mContext(other.mContext)
+    ContextOverride::ContextOverride(StreamErrorHandler& handler, const std::string& context) : mHandler(handler), mContext(handler.mContext)
     {
-        other.mHandler = nullptr;
+        mHandler.setContext(context);
     }
 
-    ContextRestore::~ContextRestore()
+    ContextOverride::~ContextOverride()
     {
-        if(mHandler)
-            mHandler->setContext(mContext);
+        mHandler.setContext(mContext);
     }
 }

--- a/components/compiler/streamerrorhandler.hpp
+++ b/components/compiler/streamerrorhandler.hpp
@@ -7,13 +7,14 @@
 
 namespace Compiler
 {
-    class ContextRestore;
+    class ContextOverride;
     /// \brief Error handler implementation: Write errors into logging stream
 
     class StreamErrorHandler : public ErrorHandler
     {
             std::string mContext;
 
+            friend class ContextOverride;
         // not implemented
 
             StreamErrorHandler (const StreamErrorHandler&);
@@ -27,7 +28,7 @@ namespace Compiler
 
         public:
 
-            ContextRestore setContext(const std::string& context, bool restore = false);
+            void setContext(const std::string& context);
 
         // constructors
 
@@ -35,16 +36,17 @@ namespace Compiler
             ///< constructor
     };
 
-    class ContextRestore
+    class ContextOverride
     {
-            StreamErrorHandler* mHandler;
+            StreamErrorHandler& mHandler;
             const std::string mContext;
         public:
-            ContextRestore (StreamErrorHandler* handler, const std::string& context);
+            ContextOverride (StreamErrorHandler& handler, const std::string& context);
 
-            ContextRestore (ContextRestore&& other);
+            ContextOverride (const ContextOverride&) = delete;
+            ContextOverride& operator= (const ContextOverride&) = delete;
 
-            ~ContextRestore();
+            ~ContextOverride();
     };
 }
 

--- a/components/compiler/streamerrorhandler.hpp
+++ b/components/compiler/streamerrorhandler.hpp
@@ -42,6 +42,8 @@ namespace Compiler
         public:
             ContextRestore (StreamErrorHandler* handler, const std::string& context);
 
+            ContextRestore (ContextRestore&& other);
+
             ~ContextRestore();
     };
 }

--- a/components/compiler/streamerrorhandler.hpp
+++ b/components/compiler/streamerrorhandler.hpp
@@ -7,6 +7,7 @@
 
 namespace Compiler
 {
+    class ContextRestore;
     /// \brief Error handler implementation: Write errors into logging stream
 
     class StreamErrorHandler : public ErrorHandler
@@ -26,12 +27,22 @@ namespace Compiler
 
         public:
 
-            void setContext(const std::string& context);
+            ContextRestore setContext(const std::string& context, bool restore = false);
 
         // constructors
 
             StreamErrorHandler ();
             ///< constructor
+    };
+
+    class ContextRestore
+    {
+            StreamErrorHandler* mHandler;
+            const std::string mContext;
+        public:
+            ContextRestore (StreamErrorHandler* handler, const std::string& context);
+
+            ~ContextRestore();
     };
 }
 


### PR DESCRIPTION
Compiling scripts can result in errors/warnings being logged with the wrong script name, leading to cases where the log says "Warning: script_a[local variables]..." while the actual error is in script_b.