### PR TITLE
Do not disable a mouse cursor until it moved when you exit a GUI mode

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1162,11 +1162,7 @@ namespace MWGui
 
     void WindowManager::setCursorVisible(bool visible)
     {
-        if (visible == mCursorVisible)
-            return;
         mCursorVisible = visible;
-        if (!visible)
-            mCursorActive = false;
     }
 
     void WindowManager::setCursorActive(bool active)


### PR DESCRIPTION
Scrawl [introduced](https://github.com/OpenMW/openmw/commit/fce9a14986e352af26270d814add9085c609c01c) a quite questionable feature, when he implemented a keyboard navigation.

When OpenMW hides a game cursor (e.g. when you exited a GUI mode), it "disables" cursor. It means then even if you enter a GUI mode again, the cursor does not appear until you move mouse or use its button.

As for me, it is a bit frustrating (and it is a derivation from vanilla engine).

So the main idea - just disable this feature for now. A "gamepad look" feature still uses this API, so it should work (but I can not test it by myself).