### PR TITLE
Use template specialization for writeHNT to write raw arrays

### DIFF
--- a/apps/opencs/model/doc/savingstages.cpp
+++ b/apps/opencs/model/doc/savingstages.cpp
@@ -356,7 +356,7 @@ void CSMDoc::WriteCellCollectionStage::perform (int stage, Messages& messages)
                         istream >> ignore >> moved.mTarget[0] >> moved.mTarget[1];
 
                         refRecord.mRefNum.save (writer, false, "MVRF");
-                        writer.writeHNT ("CNDT", moved.mTarget, 8);
+                        writer.writeHNT ("CNDT", moved.mTarget);
                     }
 
                     refRecord.save (writer, false, false, ref.mState == CSMWorld::RecordBase::State_Deleted);

--- a/components/esm/esmwriter.hpp
+++ b/components/esm/esmwriter.hpp
@@ -82,17 +82,23 @@ class ESMWriter
             endRecord(name);
         }
 
-private:
+        template<typename T, std::size_t size>
+        void writeHNT(const std::string& name, const T (&data)[size])
+        {
+            startSubRecord(name);
+            writeT(data);
+            endRecord(name);
+        }
+
         // Prevent using writeHNT with strings. This already happened by accident and results in
         // state being discarded without any error on writing or reading it. :(
         // writeHNString and friends must be used instead.
-        void writeHNT(const std::string& name, const std::string& data)
-        {
-        }
-        void writeT(const std::string& data)
-        {
-        }
-public:
+        void writeHNT(const std::string& name, const std::string& data) = delete;
+
+        void writeT(const std::string& data) = delete;
+
+        template<typename T, std::size_t size>
+        void writeHNT(const std::string& name, const T (&data)[size], int) = delete;
 
         template<typename T>
         void writeHNT(const std::string& name, const T& data, int size)
@@ -106,6 +112,12 @@ public:
         void writeT(const T& data)
         {
             write((char*)&data, sizeof(T));
+        }
+
+        template<typename T, std::size_t size>
+        void writeT(const T (&data)[size])
+        {
+            write(reinterpret_cast<const char*>(data), size * sizeof(T));
         }
 
         template<typename T>

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -127,7 +127,7 @@ namespace ESM
         if (mLandData)
         {
             if (mDataTypes & Land::DATA_VNML) {
-                esm.writeHNT("VNML", mLandData->mNormals, sizeof(mLandData->mNormals));
+                esm.writeHNT("VNML", mLandData->mNormals);
             }
             if (mDataTypes & Land::DATA_VHGT) {
                 VHGT offsets;
@@ -175,18 +175,18 @@ namespace ESM
                     wnam[row * LAND_GLOBAL_MAP_LOD_SIZE_SQRT + col] = static_cast<signed char>(height);
                 }
             }
-            esm.writeHNT("WNAM", wnam, 81);
+            esm.writeHNT("WNAM", wnam);
         }
 
         if (mLandData)
         {
             if (mDataTypes & Land::DATA_VCLR) {
-                esm.writeHNT("VCLR", mLandData->mColours, 3*LAND_NUM_VERTS);
+                esm.writeHNT("VCLR", mLandData->mColours);
             }
             if (mDataTypes & Land::DATA_VTEX) {
                 uint16_t vtex[LAND_NUM_TEXTURES];
                 transposeTextureData(mLandData->mTextures, vtex);
-                esm.writeHNT("VTEX", vtex, sizeof(vtex));
+                esm.writeHNT("VTEX", vtex);
             }
         }
 

--- a/components/esm/player.cpp
+++ b/components/esm/player.cpp
@@ -58,7 +58,7 @@ void ESM::Player::save (ESMWriter &esm) const
 
     mCellId.save (esm);
 
-    esm.writeHNT ("LKEP", mLastKnownExteriorPosition, 12);
+    esm.writeHNT ("LKEP", mLastKnownExteriorPosition);
 
     if (mHasMark)
     {


### PR DESCRIPTION
To avoid passing explicit size argument where it's possible.