### PR TITLE
Fix some issues, found by CoverityScan

### DIFF
--- a/apps/opencs/view/render/instancemode.cpp
+++ b/apps/opencs/view/render/instancemode.cpp
@@ -719,16 +719,14 @@ void CSVRender::InstanceMode::dropInstance(DropMode dropMode, CSVRender::Object*
 
     mParentNode->accept(visitor);
 
-    for (osgUtil::LineSegmentIntersector::Intersections::iterator it = intersector->getIntersections().begin();
-         it != intersector->getIntersections().end(); ++it)
+    osgUtil::LineSegmentIntersector::Intersections::iterator it = intersector->getIntersections().begin();
+    if (it != intersector->getIntersections().end())
     {
         osgUtil::LineSegmentIntersector::Intersection intersection = *it;
         ESM::Position position = object->getPosition();
         object->setEdited (Object::Override_Position);
         position.pos[2] = intersection.getWorldIntersectPoint().z() + objectHeight;
         object->setPosition(position.pos);
-
-        return;
     }
 }
 
@@ -753,8 +751,8 @@ float CSVRender::InstanceMode::getDropHeight(DropMode dropMode, CSVRender::Objec
 
     mParentNode->accept(visitor);
 
-    for (osgUtil::LineSegmentIntersector::Intersections::iterator it = intersector->getIntersections().begin();
-         it != intersector->getIntersections().end(); ++it)
+    osgUtil::LineSegmentIntersector::Intersections::iterator it = intersector->getIntersections().begin();
+    if (it != intersector->getIntersections().end())
     {
         osgUtil::LineSegmentIntersector::Intersection intersection = *it;
         float collisionLevel = intersection.getWorldIntersectPoint().z();

--- a/apps/openmw/mwgui/alchemywindow.cpp
+++ b/apps/openmw/mwgui/alchemywindow.cpp
@@ -31,6 +31,7 @@ namespace MWGui
 {
     AlchemyWindow::AlchemyWindow()
         : WindowBase("openmw_alchemy_window.layout")
+        , mCurrentFilter(FilterType::ByName)
         , mModel(nullptr)
         , mSortModel(nullptr)
         , mAlchemy(new MWMechanics::Alchemy())
@@ -192,16 +193,16 @@ namespace MWGui
         std::set<std::string> itemNames, itemEffects;
         for (size_t i = 0; i < mModel->getItemCount(); ++i)
         {
-            auto const& base = mModel->getItem(i).mBase;
-            if (base.getTypeName() != typeid(ESM::Ingredient).name())
+            MWWorld::Ptr item = mModel->getItem(i).mBase;
+            if (item.getTypeName() != typeid(ESM::Ingredient).name())
                 continue;
 
-            itemNames.insert(base.getClass().getName(base));
+            itemNames.insert(item.getClass().getName(item));
 
             MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayerPtr();
             auto const alchemySkill = player.getClass().getSkill(player, ESM::Skill::Alchemy);
 
-            auto const effects = MWMechanics::Alchemy::effectsDescription(base, alchemySkill);
+            auto const effects = MWMechanics::Alchemy::effectsDescription(item, alchemySkill);
             itemEffects.insert(effects.begin(), effects.end());
         }
 

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -1146,8 +1146,6 @@ namespace MWInput
             default:
                 return 0.f;
         }
-
-        return 0.f;
     }
 
     void InputManager::displayOrientationChanged()

--- a/components/esm/loadscpt.cpp
+++ b/components/esm/loadscpt.cpp
@@ -30,9 +30,11 @@ namespace ESM
         // The tmp buffer is a null-byte separated string list, we
         // just have to pick out one string at a time.
         char* str = tmp.data();
-        if (!str && mVarNames.size() > 0)
+        if (!str)
         {
-            Log(Debug::Warning) << "SCVR with no variable names";
+            if (mVarNames.size() > 0)
+                Log(Debug::Warning) << "SCVR with no variable names";
+
             return;
         }
 

--- a/components/terrain/cellborder.hpp
+++ b/components/terrain/cellborder.hpp
@@ -31,7 +31,6 @@ namespace Terrain
         osg::Group *mRoot;
 
         CellGrid mCellBorderNodes;
-        int mBorderMask;
     };
 }
 


### PR DESCRIPTION
Should fix 7 of 8 of issues, detected by last scan.
Basically, a cleanup for some dead code and fixed an undefined behaviour in a couple of cases.

As about null dereference in the `Land::save()`, @Capostrophic volunteered to fix it (#2757).

Note: I assume that @unelsson uses a hackish way to get a first intersection in the editor code, so this PR just makes the code a bit more readable, without changing its behaviour.