### PR TITLE
Don't use up light duration if the held light is hidden (bug #5352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@
     Bug #5326: Formatting issues in the settings.cfg
     Bug #5328: Skills aren't properly reset for dead actors
     Bug #5345: Dopey Necromancy does not work due to a missing quote
+    Bug #5352: Light source items' duration is decremented while they aren't visible
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI
     Feature #3025: Analogue gamepad movement controls

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1268,19 +1268,23 @@ namespace MWMechanics
             // Use time from the player's light
             if(isPlayer)
             {
-                float timeRemaining = heldIter->getClass().getRemainingUsageTime(*heldIter);
-
-                // -1 is infinite light source. Other negative values are treated as 0.
-                if(timeRemaining != -1.0f)
+                // But avoid using it up if the light source is hidden
+                MWRender::Animation *anim = MWBase::Environment::get().getWorld()->getAnimation(ptr);
+                if (anim && anim->getCarriedLeftShown())
                 {
-                    timeRemaining -= duration;
+                    float timeRemaining = heldIter->getClass().getRemainingUsageTime(*heldIter);
 
-                    if(timeRemaining > 0.0f)
-                        heldIter->getClass().setRemainingUsageTime(*heldIter, timeRemaining);
-                    else
+                    // -1 is infinite light source. Other negative values are treated as 0.
+                    if (timeRemaining != -1.0f)
                     {
-                        inventoryStore.remove(*heldIter, 1, ptr); // remove it
-                        return;
+                        timeRemaining -= duration;
+                        if (timeRemaining <= 0.f)
+                        {
+                            inventoryStore.remove(*heldIter, 1, ptr); // remove it
+                            return;
+                        }
+
+                        heldIter->getClass().setRemainingUsageTime(*heldIter, timeRemaining);
                     }
                 }
             }

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -459,6 +459,7 @@ public:
 
     virtual bool useShieldAnimations() const { return false; }
     virtual void showWeapons(bool showWeapon) {}
+    virtual bool getCarriedLeftShown() const { return false; }
     virtual void showCarriedLeft(bool show) {}
     virtual void setWeaponGroup(const std::string& group, bool relativeDuration) {}
     virtual void setVampire(bool vampire) {}

--- a/apps/openmw/mwrender/creatureanimation.hpp
+++ b/apps/openmw/mwrender/creatureanimation.hpp
@@ -31,6 +31,8 @@ namespace MWRender
         virtual void equipmentChanged() { updateParts(); }
 
         virtual void showWeapons(bool showWeapon);
+
+        virtual bool getCarriedLeftShown() const { return mShowCarriedLeft; }
         virtual void showCarriedLeft(bool show);
 
         void updateParts();

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -129,6 +129,8 @@ public:
     virtual void setPitchFactor(float factor) { mPitchFactor = factor; }
 
     virtual void showWeapons(bool showWeapon);
+
+    virtual bool getCarriedLeftShown() const { return mShowCarriedLeft; }
     virtual void showCarriedLeft(bool show);
 
     virtual void attachArrow();


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5352)

Use mShowCarriedLeft value from the player's animation object. This allows the duration not to decrease if the character is currently in a "two-handed" attack ready state (e.g. hand-to-hand attack stance, two-handed weapon attack stance, spellcasting stance).