### PR TITLE
Do not try to launch magic bolt when direction to target is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@
     Bug #5326: Formatting issues in the settings.cfg
     Bug #5328: Skills aren't properly reset for dead actors
     Bug #5345: Dopey Necromancy does not work due to a missing quote
+    Bug #5350: An attempt to launch magic bolt causes "AL error invalid value" error
     Bug #5352: Light source items' duration is decremented while they aren't visible
     Feature #1774: Handle AvoidNode
     Feature #2229: Improve pathfinding AI

--- a/apps/openmw/mwworld/projectilemanager.cpp
+++ b/apps/openmw/mwworld/projectilemanager.cpp
@@ -291,6 +291,12 @@ namespace MWWorld
         if (state.mEffects.mList.empty())
             return;
 
+        if (!caster.getClass().isActor() && fallbackDirection.length2() <= 0)
+        {
+            Log(Debug::Warning) << "Unable to launch magic bolt (direction to target is empty)";
+            return;
+        }
+
         MWWorld::ManualRef ref(MWBase::Environment::get().getWorld()->getStore(), state.mIdMagic.at(0));
         MWWorld::Ptr ptr = ref.getPtr();
 


### PR DESCRIPTION
Fixes [bug #5350](https://gitlab.com/OpenMW/openmw/-/issues/5350).

When direction to target is empty, orientation quaternion becomes malformed, and it is impossible to launch magic bolt properly - it causes errors on OSG and OpenAL-Soft side.
It happens when you use the `explodespell` console command for non-actor object (so it is supposed to cast a spell to itself), when the spell has effects with OnTargetRange.

In Morrowind this case is buggy as well - it does not launch a bolt, but plays magic bolt sound untill you rest. So we can not treat such case as valid.

So a suggested approach - print a warning when direction is empty and do not launch magic bolt.
