### PR TITLE
Check if the weapon is attached in GetWeaponDrawn (bug #4816)

### DIFF
--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -458,6 +458,7 @@ public:
     const osg::Node* getNode(const std::string& name) const;
 
     virtual bool useShieldAnimations() const { return false; }
+    virtual bool getWeaponsShown() const { return false; }
     virtual void showWeapons(bool showWeapon) {}
     virtual bool getCarriedLeftShown() const { return false; }
     virtual void showCarriedLeft(bool show) {}

--- a/apps/openmw/mwrender/creatureanimation.hpp
+++ b/apps/openmw/mwrender/creatureanimation.hpp
@@ -30,6 +30,7 @@ namespace MWRender
 
         virtual void equipmentChanged() { updateParts(); }
 
+        virtual bool getWeaponsShown() const { return mShowWeapons; }
         virtual void showWeapons(bool showWeapon);
 
         virtual bool getCarriedLeftShown() const { return mShowCarriedLeft; }

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -128,6 +128,7 @@ public:
     /// to indicate the facing orientation of the character.
     virtual void setPitchFactor(float factor) { mPitchFactor = factor; }
 
+    virtual bool getWeaponsShown() const { return mShowWeapons; }
     virtual void showWeapons(bool showWeapon);
 
     virtual bool getCarriedLeftShown() const { return mShowCarriedLeft; }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/4816)

Check if the equipped weapon is attached if there's one at all.
It seems to resolve the issue, but the behavior of the test case (the results the script returns) is heavily dependent on the frame rate and the chosen actor.