### PR TITLE
Avoid a hack to initialize mIndex in the editor

### DIFF
--- a/apps/opencs/model/world/refcollection.cpp
+++ b/apps/opencs/model/world/refcollection.cpp
@@ -18,10 +18,10 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
     CellRef ref;
     ref.mNew = false;
     ESM::MovedCellRef mref;
+    mref.mRefNum.mIndex = 0;
     bool isDeleted = false;
 
-    // hack to initialise mindex
-    while (!(mref.mRefNum.mIndex = 0) && ESM::Cell::getNextRef(reader, ref, isDeleted, true, &mref))
+    while (ESM::Cell::getNextRef(reader, ref, isDeleted, true, &mref))
     {
         // Keep mOriginalCell empty when in modified (as an indicator that the
         // original cell will always be equal the current cell).
@@ -59,6 +59,8 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
         }
         else
             ref.mCell = cell2.mId;
+
+        mref.mRefNum.mIndex = 0;
 
         // ignore content file number
         std::map<ESM::RefNum, std::string>::iterator iter = cache.begin();


### PR DESCRIPTION
The `!(mref.mRefNum.mIndex = 0)` is a hack which is supposed to set mIndex to 0 before `getNextRef()` call. I suppose that we can just:
1. Make sure that the `mIndex` is 0 during `mref` initialization.
2. Set it to 0 when the value from `getNextRef()` is not used anymore, so it is 0 when the next iteration starts.

From what I can tell, the step 2 may be not really needed - `getNextRef()` here did not touch the `mIndex` value for some reason in my testing.