### PR TITLE
Increase water-camera Z axis fudge factor (bug #5351)

### DIFF
--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -188,7 +188,7 @@ public:
     {
         osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(nv);
 
-        const float fudge = 0.2;
+        const float fudge = 5;
         if (std::abs(cv->getEyeLocal().z()) < fudge)
         {
             float diff = fudge - cv->getEyeLocal().z();


### PR DESCRIPTION
On ATI/AMD hardware, the current fudge factor is way too small, which results in serious artefacting when the camera gets too close to the water surface.

The value of 5 way chosen because smaller values, like 1 or 2, still produce visible artifacting at higher resolutions.

---

[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5351).

Be warned that I only tested this patch on Polaris (RX 550) on Linux, it's untested on any other GPU+OS combination.