### PR TITLE
Make extra sure groups with special behavior aren't optimized out

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -457,7 +457,7 @@ namespace NifOsg
             {
                 const Nif::NiLODNode* niLodNode = static_cast<const Nif::NiLODNode*>(nifNode);
                 node = handleLodNode(niLodNode);
-                dataVariance = osg::Object::STATIC;
+                dataVariance = osg::Object::DYNAMIC;
                 break;
             }
             case Nif::RC_NiSwitchNode:
@@ -476,8 +476,8 @@ namespace NifOsg
             {
                 bool enabled = nifNode->flags & Nif::NiNode::Flag_ActiveCollision;
                 node = new CollisionSwitch(nifNode->trafo.toMatrix(), enabled);
-                dataVariance = osg::Object::STATIC;
-
+                // This matrix transform must not be combined with another matrix transform.
+                dataVariance = osg::Object::DYNAMIC;
                 break;
             }
             default:


### PR DESCRIPTION
Since there are more static transforms now (for example, controller-less NiTriShapes), they could be merged with NiCollisionSwitches and make them lose their special node mask, which caused issues with GitD interior god rays. Setting data variance to dynamic makes sure NiCollisionSwitches aren't considered eligible for such a thing.

osg::LOD groups have their data variance set to dynamic too so as to prevent similar optimizer issues from appearing (e.g. if someone figures out how to handle transformations but forgets to change the data variance, or if RemoveRedundantNodesVisitor decides osg::LOD node should be purged when it really shouldn't).

Switch nodes are handled slightly differently, I didn't touch them.

This should go into 0.46.0 branch.