### PR TITLE
Make sure it's a crime to unlock owned doors

### DIFF
--- a/apps/openmw/mwmechanics/security.cpp
+++ b/apps/openmw/mwmechanics/security.cpp
@@ -43,6 +43,8 @@ namespace MWMechanics
         x *= pickQuality * mFatigueTerm;
         x += fPickLockMult * lockStrength;
 
+        MWBase::Environment::get().getMechanicsManager()->unlockAttempted(mActor, lock);
+
         resultSound = "Open Lock Fail";
         if (x <= 0)
             resultMessage = "#{sLockImpossible}";
@@ -59,7 +61,6 @@ namespace MWMechanics
                 resultMessage = "#{sLockFail}";
         }
 
-        MWBase::Environment::get().getMechanicsManager()->unlockAttempted(mActor, lock);
         int uses = lockpick.getClass().getItemHealth(lockpick);
         --uses;
         lockpick.getCellRef().setCharge(uses);
@@ -84,6 +85,8 @@ namespace MWMechanics
         x += fTrapCostMult * trapSpellPoints;
         x *= probeQuality * mFatigueTerm;
 
+        MWBase::Environment::get().getMechanicsManager()->unlockAttempted(mActor, trap);
+
         resultSound = "Disarm Trap Fail";
         if (x <= 0)
             resultMessage = "#{sTrapImpossible}";
@@ -101,7 +104,6 @@ namespace MWMechanics
                 resultMessage = "#{sTrapFail}";
         }
 
-        MWBase::Environment::get().getMechanicsManager()->unlockAttempted(mActor, trap);
         int uses = probe.getClass().getItemHealth(probe);
         --uses;
         probe.getCellRef().setCharge(uses);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -709,6 +709,11 @@ namespace MWMechanics
             }
             else if (effectId == ESM::MagicEffect::Open)
             {
+                if (!caster.isEmpty())
+                {
+                    MWBase::Environment::get().getMechanicsManager()->unlockAttempted(getPlayer(), target);
+                    // Use the player instead of the caster for vanilla crime compatibility
+                }
                 const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
                 const ESM::MagicEffect *magiceffect = store.get<ESM::MagicEffect>().find(effectId);
                 MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(target);
@@ -726,11 +731,10 @@ namespace MWMechanics
                     target.getCellRef().unlock();
                 }
                 else
+                {
                     MWBase::Environment::get().getSoundManager()->playSound3D(target, "Open Lock Fail", 1.f, 1.f);
+                }
 
-                if (!caster.isEmpty())
-                    MWBase::Environment::get().getMechanicsManager()->unlockAttempted(getPlayer(), target);
-                    // Use the player instead of the caster for vanilla crime compatibility
                 return true;
             }
         }


### PR DESCRIPTION
unlockAttempted must be called before the doors are actually unlocked because it's not a crime to unlock unlocked doors. Somehow in testing whether it was a crime to fail to unlock a door I overlooked checking the main situation where an attempt to unlock a door is successful. Ouch.

Should go into 0.46.0 branch as well.