### PR TITLE
Fix tab focus for pinned windows

### DIFF
--- a/apps/openmw/mwgui/keyboardnavigation.cpp
+++ b/apps/openmw/mwgui/keyboardnavigation.cpp
@@ -116,6 +116,13 @@ void KeyboardNavigation::onFrame()
     if (!mEnabled)
         return;
 
+    MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
+    if (mode == GM_None)
+    {
+        MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nullptr);
+        return;
+    }
+
     MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
 
     if (focus == mCurrentFocus)
@@ -215,6 +222,10 @@ bool KeyboardNavigation::injectKeyPress(MyGUI::KeyCode key, unsigned int text, b
 
 bool KeyboardNavigation::switchFocus(int direction, bool wrap)
 {
+    MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
+    if (mode == GM_None)
+        return false;
+
     MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();
 
     bool isCycle = (direction == D_Prev || direction == D_Next);

--- a/apps/openmw/mwgui/keyboardnavigation.cpp
+++ b/apps/openmw/mwgui/keyboardnavigation.cpp
@@ -116,8 +116,7 @@ void KeyboardNavigation::onFrame()
     if (!mEnabled)
         return;
 
-    MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
-    if (mode == GM_None)
+    if (!MWBase::Environment::get().getWindowManager()->isGuiMode())
     {
         MWBase::Environment::get().getWindowManager()->setKeyFocusWidget(nullptr);
         return;
@@ -222,8 +221,7 @@ bool KeyboardNavigation::injectKeyPress(MyGUI::KeyCode key, unsigned int text, b
 
 bool KeyboardNavigation::switchFocus(int direction, bool wrap)
 {
-    MWGui::GuiMode mode = MWBase::Environment::get().getWindowManager()->getMode();
-    if (mode == GM_None)
+    if (!MWBase::Environment::get().getWindowManager()->isGuiMode())
         return false;
 
     MyGUI::Widget* focus = MyGUI::InputManager::getInstance().getKeyFocusWidget();


### PR DESCRIPTION
There are two problems upon pinning the window with tab focus and text input. 

1. If you already have focus and you pin the window, you cannot exit the focus. This makes keyboard navigation impossible. The only way to regain control of your character is to re-pin the window. 

2. If you press Tab while a window is pinned, then the same issue occurs as above. This is especially cumbersome when you have Tab bound to another action. 

Having a window pinned that has a text input field is probably extremely rare ( I don't know of anybody who has their spells or inventory pinned) but I still think it's an issue. 

I doubt this is the solution, but I just did it this very quickly to make sure I wasn't going crazy and to verify the current behavior doesn't make much sense. After testing it with both, I think ignoring Tab focus when you are not in any game modes makes sense. 