### PR TITLE
Don't play equip sound for reactivated quick key items (bug #5367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.47.0
 ------
 
+    Bug #5367: Selecting a spell on an enchanted item per hotkey always plays the equip sound
 
 0.46.0
 ------

--- a/apps/openmw/mwgui/quickkeysmenu.cpp
+++ b/apps/openmw/mwgui/quickkeysmenu.cpp
@@ -401,7 +401,8 @@ namespace MWGui
                     return;
                 }
 
-                MWBase::Environment::get().getWindowManager()->useItem(item);
+                if (!store.isEquipped(item))
+                    MWBase::Environment::get().getWindowManager()->useItem(item);
                 MWWorld::ConstContainerStoreIterator rightHand = store.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
                 // change draw state only if the item is in player's right hand
                 if (rightHand != store.end() && item == *rightHand)
@@ -411,8 +412,8 @@ namespace MWGui
             }
             else if (key->type == Type_MagicItem)
             {
-                // equip, if it can be equipped
-                if (!item.getClass().getEquipmentSlots(item).first.empty())
+                // equip, if it can be equipped and isn't yet equipped
+                if (!item.getClass().getEquipmentSlots(item).first.empty() && !store.isEquipped(item))
                 {
                     MWBase::Environment::get().getWindowManager()->useItem(item);
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5367)

Just add an "equipped" check before an item is activated redundantly.