### PR TITLE
Handle enchantment autocalc flag as a flag (bug #5363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.47.0
 ------
 
+    Bug #5363: Enchantment autocalc not always 0/1
 
 0.46.0
 ------

--- a/apps/esmtool/labels.cpp
+++ b/apps/esmtool/labels.cpp
@@ -4,6 +4,7 @@
 #include <components/esm/loadcell.hpp>
 #include <components/esm/loadcont.hpp>
 #include <components/esm/loadcrea.hpp>
+#include <components/esm/loadench.hpp>
 #include <components/esm/loadlevlist.hpp>
 #include <components/esm/loadligh.hpp>
 #include <components/esm/loadmgef.hpp>
@@ -723,6 +724,16 @@ std::string creatureFlags(int flags)
                    ESM::Creature::Essential));
     if (flags & unused) properties += "Invalid ";
     properties += Misc::StringUtils::format("(0x%02X)", flags);
+    return properties;
+}
+
+std::string enchantmentFlags(int flags)
+{
+    std::string properties;
+    if (flags == 0) properties += "[None] ";
+    if (flags & ESM::Enchantment::Autocalc) properties += "Autocalc ";
+    if (flags & (0xFFFFFFFF ^ ESM::Enchantment::Autocalc)) properties += "Invalid ";
+    properties += Misc::StringUtils::format("(0x%08X)", flags);
     return properties;
 }
 

--- a/apps/esmtool/labels.hpp
+++ b/apps/esmtool/labels.hpp
@@ -49,6 +49,7 @@ std::string bodyPartFlags(int flags);
 std::string cellFlags(int flags);
 std::string containerFlags(int flags);
 std::string creatureFlags(int flags);
+std::string enchantmentFlags(int flags);
 std::string landFlags(int flags);
 std::string creatureListFlags(int flags);
 std::string itemListFlags(int flags);

--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -714,7 +714,7 @@ void Record<ESM::Enchantment>::print()
               << " (" << mData.mData.mType << ")" << std::endl;
     std::cout << "  Cost: " << mData.mData.mCost << std::endl;
     std::cout << "  Charge: " << mData.mData.mCharge << std::endl;
-    std::cout << "  AutoCalc: " << mData.mData.mAutocalc << std::endl;
+    std::cout << "  Flags: " << enchantmentFlags(mData.mData.mFlags) << std::endl;
     printEffectList(mData.mEffects);
     std::cout << "  Deleted: " << mIsDeleted << std::endl;
 }

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -373,7 +373,7 @@ CSMWorld::Data::Data (ToUTF8::FromType encoding, bool fsStrict, const Files::Pat
     mEnchantments.addColumn (new EnchantmentTypeColumn<ESM::Enchantment>);
     mEnchantments.addColumn (new CostColumn<ESM::Enchantment>);
     mEnchantments.addColumn (new ChargesColumn2<ESM::Enchantment>);
-    mEnchantments.addColumn (new AutoCalcColumn<ESM::Enchantment>);
+    mEnchantments.addColumn (new FlagColumn<ESM::Enchantment> (Columns::ColumnId_AutoCalc, ESM::Enchantment::Autocalc));
     // Enchantment effects
     mEnchantments.addColumn (new NestedParentColumn<ESM::Enchantment> (Columns::ColumnId_EffectList));
     index = mEnchantments.getColumns()-1;

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -63,7 +63,7 @@ namespace MWMechanics
         const MWWorld::Ptr& player = getPlayer();
         MWWorld::ContainerStore& store = player.getClass().getContainerStore(player);
         ESM::Enchantment enchantment;
-        enchantment.mData.mAutocalc = 0;
+        enchantment.mData.mFlags = 0;
         enchantment.mData.mType = mCastStyle;
         enchantment.mData.mCost = getBaseCastCost();
 
@@ -219,7 +219,7 @@ namespace MWMechanics
             if (iter->mEffects.mList.size() != toFind.mEffects.mList.size())
                 continue;
 
-            if (iter->mData.mAutocalc != toFind.mData.mAutocalc
+            if (iter->mData.mFlags != toFind.mData.mFlags
                     || iter->mData.mType != toFind.mData.mType
                     || iter->mData.mCost != toFind.mData.mCost
                     || iter->mData.mCharge != toFind.mData.mCharge)

--- a/components/esm/loadench.cpp
+++ b/components/esm/loadench.cpp
@@ -66,7 +66,7 @@ namespace ESM
         mData.mType = 0;
         mData.mCost = 0;
         mData.mCharge = 0;
-        mData.mAutocalc = 0;
+        mData.mFlags = 0;
 
         mEffects.mList.clear();
     }

--- a/components/esm/loadench.hpp
+++ b/components/esm/loadench.hpp
@@ -29,13 +29,17 @@ struct Enchantment
         ConstantEffect = 3
     };
 
+    enum Flags
+    {
+        Autocalc = 0x01
+    };
+
     struct ENDTstruct
     {
         int mType;
         int mCost;
         int mCharge;
-        int mAutocalc; // Guessing this is 1 if we are supposed to auto
-        // calculate
+        int mFlags;
     };
 
     std::string mId;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5363).

Seems to be the most sensible option. esmtool and OpenMW-CS are the only real users of this flag and have been adjusted.