### PR TITLE
Show the soulgem soul in count dialog (feature #5362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.47.0
 ------
 
+    Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0
 ------

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -141,8 +141,6 @@ namespace MWClass
 
         MWGui::ToolTipInfo info;
 
-        const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
-
         bool gold = isGold(ptr);
         if (gold)
             count *= getValue(ptr);
@@ -153,17 +151,8 @@ namespace MWClass
         else // gold displays its count also if it's 1.
             countString = " (" + std::to_string(count) + ")";
 
-        info.caption = MyGUI::TextIterator::toTagsString(getName(ptr)) + countString;
+        info.caption = MyGUI::TextIterator::toTagsString(getName(ptr)) + countString + MWGui::ToolTips::getSoulString(ptr.getCellRef());
         info.icon = ref->mBase->mIcon;
-
-        if (ref->mRef.getSoul() != "")
-        {
-            const ESM::Creature *creature = store.get<ESM::Creature>().search(ref->mRef.getSoul());
-            if (creature && !creature->mName.empty())
-                info.caption += " (" + creature->mName + ")";
-            else if (creature)
-                info.caption += " (" + creature->mId + ")";
-        }
 
         std::string text;
 

--- a/apps/openmw/mwgui/companionwindow.cpp
+++ b/apps/openmw/mwgui/companionwindow.cpp
@@ -16,6 +16,7 @@
 #include "draganddrop.hpp"
 #include "countdialog.hpp"
 #include "widgets.hpp"
+#include "tooltips.hpp"
 
 namespace
 {
@@ -86,7 +87,8 @@ void CompanionWindow::onItemSelected(int index)
     if (count > 1 && !shift)
     {
         CountDialog* dialog = MWBase::Environment::get().getWindowManager()->getCountDialog();
-        dialog->openCountDialog(object.getClass().getName(object), "#{sTake}", count);
+        std::string name = object.getClass().getName(object) + MWGui::ToolTips::getSoulString(object.getCellRef());
+        dialog->openCountDialog(name, "#{sTake}", count);
         dialog->eventOkClicked.clear();
         dialog->eventOkClicked += MyGUI::newDelegate(this, &CompanionWindow::dragItem);
     }

--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -25,6 +25,7 @@
 #include "sortfilteritemmodel.hpp"
 #include "pickpocketitemmodel.hpp"
 #include "draganddrop.hpp"
+#include "tooltips.hpp"
 
 namespace MWGui
 {
@@ -79,7 +80,8 @@ namespace MWGui
         if (count > 1 && !shift)
         {
             CountDialog* dialog = MWBase::Environment::get().getWindowManager()->getCountDialog();
-            dialog->openCountDialog(object.getClass().getName(object), "#{sTake}", count);
+            std::string name = object.getClass().getName(object) + MWGui::ToolTips::getSoulString(object.getCellRef());
+            dialog->openCountDialog(name, "#{sTake}", count);
             dialog->eventOkClicked.clear();
             dialog->eventOkClicked += MyGUI::newDelegate(this, &ContainerWindow::dragItem);
         }

--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -38,6 +38,7 @@
 #include "tradewindow.hpp"
 #include "draganddrop.hpp"
 #include "widgets.hpp"
+#include "tooltips.hpp"
 
 namespace
 {
@@ -298,7 +299,8 @@ namespace MWGui
         {
             CountDialog* dialog = MWBase::Environment::get().getWindowManager()->getCountDialog();
             std::string message = mTrading ? "#{sQuanityMenuMessage01}" : "#{sTake}";
-            dialog->openCountDialog(object.getClass().getName(object), message, count);
+            std::string name = object.getClass().getName(object) + MWGui::ToolTips::getSoulString(object.getCellRef());
+            dialog->openCountDialog(name, message, count);
             dialog->eventOkClicked.clear();
             if (mTrading)
                 dialog->eventOkClicked += MyGUI::newDelegate(this, &InventoryWindow::sellItem);

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -647,6 +647,20 @@ namespace MWGui
             return " (" + MyGUI::utility::toString(value) + ")";
     }
 
+    std::string ToolTips::getSoulString(const MWWorld::CellRef& cellref)
+    {
+        std::string soul = cellref.getSoul();
+        if (soul.empty())
+            return std::string();
+        const MWWorld::ESMStore &store = MWBase::Environment::get().getWorld()->getStore();
+        const ESM::Creature *creature = store.get<ESM::Creature>().search(soul);
+        if (!creature)
+            return std::string();
+        if (creature->mName.empty())
+            return " (" + creature->mId + ")";
+        return " (" + creature->mName + ")";
+    }
+
     std::string ToolTips::getCellRefString(const MWWorld::CellRef& cellref)
     {
         std::string ret;

--- a/apps/openmw/mwgui/tooltips.hpp
+++ b/apps/openmw/mwgui/tooltips.hpp
@@ -81,6 +81,9 @@ namespace MWGui
         static std::string getCountString(const int value);
         ///< @return blank string if count is 1, or else " (value)"
 
+        static std::string getSoulString(const MWWorld::CellRef& cellref);
+        ///< Returns a string containing the name of the creature that the ID in the cellref's soul field belongs to.
+
         static std::string getCellRefString(const MWWorld::CellRef& cellref);
         ///< Returns a string containing debug tooltip information about the given cellref.
 

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -27,6 +27,7 @@
 #include "tradeitemmodel.hpp"
 #include "countdialog.hpp"
 #include "controllers.hpp"
+#include "tooltips.hpp"
 
 namespace
 {
@@ -201,7 +202,8 @@ namespace MWGui
         {
             CountDialog* dialog = MWBase::Environment::get().getWindowManager()->getCountDialog();
             std::string message = "#{sQuanityMenuMessage02}";
-            dialog->openCountDialog(object.getClass().getName(object), message, count);
+            std::string name = object.getClass().getName(object) + MWGui::ToolTips::getSoulString(object.getCellRef());
+            dialog->openCountDialog(name, message, count);
             dialog->eventOkClicked.clear();
             dialog->eventOkClicked += MyGUI::newDelegate(this, &TradeWindow::sellItem);
             mItemToSell = mSortModel->mapToSource(index);


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/-/issues/5362).

Add the creature name to its name field in a way similar to how it's added to the Misc items' tooltips.