### PR TITLE
Make adding non-existent global script more forgiving (bug #5364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.47.0
 ------
 
+    Bug #5364: Script fails/stops if trying to startscript an unknown script
 
 0.46.0
 ------

--- a/apps/openmw/mwscript/globalscripts.cpp
+++ b/apps/openmw/mwscript/globalscripts.cpp
@@ -28,7 +28,7 @@ namespace MWScript
 
         if (iter==mScripts.end())
         {
-            if (const ESM::Script *script = mStore.get<ESM::Script>().find (name))
+            if (const ESM::Script *script = mStore.get<ESM::Script>().search(name))
             {
                 GlobalScriptDesc desc;
                 desc.mRunning = true;
@@ -36,6 +36,10 @@ namespace MWScript
                 desc.mId = targetId;
 
                 mScripts.insert (std::make_pair (name, desc));
+            }
+            else
+            {
+                Log(Debug::Error) << "Failed to add global script " << name << ": script record not found";
             }
         }
         else if (!iter->second.mRunning)


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5364)

If the script record isn't found, an error is still logged (though not in the console context as it's not an exception the compiler can catch) but it's no longer fatal for script execution.