### PR TITLE
Only clear dialogue history if the dialogue window is closed (bug #5358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.47.0
 ------
 
+    Bug #5358: ForceGreeting always resets the dialogue window completely
 
 0.46.0
 ------

--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -354,7 +354,10 @@ namespace MWGui
     void DialogueWindow::onByeClicked(MyGUI::Widget* _sender)
     {
         if (exit())
+        {
+            resetHistory();
             MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Dialogue);
+        }
     }
 
     void DialogueWindow::onSelectListItem(const std::string& topic, int id)
@@ -418,9 +421,7 @@ namespace MWGui
         bool sameActor = (mPtr == actor);
         if (!sameActor)
         {
-            for (DialogueText* text : mHistoryContents)
-                delete text;
-            mHistoryContents.clear();
+            // The history is not reset here
             mKeywords.clear();
             mTopicsList->clear();
             for (Link* link : mLinks)
@@ -473,6 +474,13 @@ namespace MWGui
         for (Link* link : mDeleteLater)
             delete link;
         mDeleteLater.clear();
+    }
+
+    void DialogueWindow::resetHistory()
+    {
+        for (DialogueText* text : mHistoryContents)
+            delete text;
+        mHistoryContents.clear();
     }
 
     void DialogueWindow::setKeywords(std::list<std::string> keyWords)
@@ -655,6 +663,7 @@ namespace MWGui
 
     void DialogueWindow::onGoodbyeActivated()
     {
+        resetHistory();
         MWBase::Environment::get().getDialogueManager()->goodbyeSelected();
         MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Dialogue);
         resetReference();
@@ -709,6 +718,7 @@ namespace MWGui
 
     void DialogueWindow::onReferenceUnavailable()
     {
+        resetHistory();
         MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Dialogue);
     }
 

--- a/apps/openmw/mwgui/dialogue.hpp
+++ b/apps/openmw/mwgui/dialogue.hpp
@@ -156,6 +156,7 @@ namespace MWGui
         void updateDisposition();
         void restock();
         void deleteLater();
+        void resetHistory();
 
         bool mIsCompanion;
         std::list<std::string> mKeywords;


### PR DESCRIPTION
The history is reset in a handful of ways the window is closed but it's not reset if the window's actor is changed without closing the window, which seems to resolve [the issue](https://gitlab.com/OpenMW/openmw/-/issues/5358).