### PR TITLE
Properly utilize creature levelled list's scale (bug #5369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.47.0
 ------
 
+    Bug #5369: Spawnpoint in the Grazelands doesn't produce oversized creatures
 
 0.46.0
 ------

--- a/apps/openmw/mwclass/creaturelevlist.cpp
+++ b/apps/openmw/mwclass/creaturelevlist.cpp
@@ -125,6 +125,7 @@ namespace MWClass
             const MWWorld::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
             MWWorld::ManualRef manualRef(store, id);
             manualRef.getPtr().getCellRef().setPosition(ptr.getCellRef().getPosition());
+            manualRef.getPtr().getCellRef().setScale(ptr.getCellRef().getScale());
             MWWorld::Ptr placed = MWBase::Environment::get().getWorld()->placeObject(manualRef.getPtr(), ptr.getCell() , ptr.getCellRef().getPosition());
             customData.mSpawnActorId = placed.getClass().getCreatureStats(placed).getActorId();
             customData.mSpawn = false;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5369)

Unlike levelled list position, which is obviously crucial, levelled list scale wasn't inherit by the creatures generated by the levelled list. This is fixed here, allowing Rodents of Unusual Size, Guars of Unusual Size, Golden Saints of Unusual Size spawn in that grazeland spot again.

To test this, one may need to artificially make that levelled list have zero chance not to spawn something or make more levelled lists non-1 scale to actually get a scaled creature to appear.