### PR TITLE
Only disarm traps with keys when the door/container is locked (bug #5370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     Bug #5364: Script fails/stops if trying to startscript an unknown script
     Bug #5367: Selecting a spell on an enchanted item per hotkey always plays the equip sound
     Bug #5369: Spawnpoint in the Grazelands doesn't produce oversized creatures
+    Bug #5370: Opening an unlocked but trapped door uses the key
     Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -177,11 +177,10 @@ namespace MWClass
             }
         }
 
-        if ((isLocked || isTrapped) && hasKey)
+        if (isLocked && hasKey)
         {
             MWBase::Environment::get().getWindowManager ()->messageBox (keyName + " #{sKeyUsed}");
-            if(isLocked)
-                ptr.getCellRef().unlock();
+            ptr.getCellRef().unlock();
             // using a key disarms the trap
             if(isTrapped)
             {

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -158,12 +158,11 @@ namespace MWClass
             }
         }
 
-        if ((isLocked || isTrapped) && hasKey)
+        if (isLocked && hasKey)
         {
             if(actor == MWMechanics::getPlayer())
                 MWBase::Environment::get().getWindowManager()->messageBox(keyName + " #{sKeyUsed}");
-            if(isLocked)
-                ptr.getCellRef().unlock(); //Call the function here. because that makes sense.
+            ptr.getCellRef().unlock(); //Call the function here. because that makes sense.
             // using a key disarms the trap
             if(isTrapped)
             {

--- a/components/esm/cellref.cpp
+++ b/components/esm/cellref.cpp
@@ -130,7 +130,10 @@ void ESM::CellRef::loadData(ESMReader &esm, bool &isDeleted)
     }
 
     if (mLockLevel == 0 && !mKey.empty())
+    {
         mLockLevel = UnbreakableLock;
+        mTrap.clear();
+    }
 }
 
 void ESM::CellRef::save (ESMWriter &esm, bool wideRefNum, bool inInventory, bool isDeleted) const


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5370).

Removes the undesirable "disarm unlocked doors" behavior for keys.
Containers and doors behave the same way here in Morrowind in my testing.

The behavior was added in PR #995, but somehow it doesn't seem like it's present in the vanilla game (neither in my testing nor geist's). Maybe Allofich meant something different when he said "lock level 0" like locks that were locked with `Lock 0`?..