### PR TITLE
Make book layer have lower priority than the layer for other GUI windows

### DIFF
--- a/files/mygui/openmw_layers.xml
+++ b/files/mygui/openmw_layers.xml
@@ -6,10 +6,10 @@
     <Layer name="AdditiveOverlay" type="AdditiveLayer" pick="false"/>
     <Layer name="HUD" overlapped="false" pick="true"/>
     <Layer name="Menu" overlapped="false" pick="true"/>
-    <Layer name="Windows" overlapped="true" pick="true"/>
     <Layer name="JournalBooks" type="ScalingLayer" pick="true">
         <Property key="Size" value="600 520"/>
     </Layer>
+    <Layer name="Windows" overlapped="true" pick="true"/>
     <Layer name="Debug" overlapped="true" pick="true"/>
     <Layer name="Notification" overlapped="false" pick="false"/>
     <Layer name="Popup" overlapped="true" pick="true"/>


### PR DESCRIPTION
Should in theory solve [this](https://gitlab.com/OpenMW/openmw/-/issues/5349) painlessly. Books must have their own layer for scaling reasons, but there isn't a good reason to let them overlap all and any GUI window, and since books/scrolls/journal view is an exclusive GUI mode, it shouldn't be able to conflict with another GUI window. Except the free-floating console.

Apparently letting the console have its own layer with higher priority than both books and GUI windows still has its caveats, while this set up should avoid issues with it.

If it's merged it should go into 0.46 branch.