### PR TITLE
Reset dialogue history when the window can't track what closed it

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -355,7 +355,6 @@ namespace MWGui
     {
         if (exit())
         {
-            resetHistory();
             MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Dialogue);
         }
     }
@@ -476,8 +475,9 @@ namespace MWGui
         mDeleteLater.clear();
     }
 
-    void DialogueWindow::resetHistory()
+    void DialogueWindow::onClose()
     {
+        // Reset history
         for (DialogueText* text : mHistoryContents)
             delete text;
         mHistoryContents.clear();
@@ -663,7 +663,6 @@ namespace MWGui
 
     void DialogueWindow::onGoodbyeActivated()
     {
-        resetHistory();
         MWBase::Environment::get().getDialogueManager()->goodbyeSelected();
         MWBase::Environment::get().getWindowManager()->removeGuiMode(MWGui::GM_Dialogue);
         resetReference();
@@ -718,7 +717,6 @@ namespace MWGui
 
     void DialogueWindow::onReferenceUnavailable()
     {
-        resetHistory();
         MWBase::Environment::get().getWindowManager()->removeGuiMode(GM_Dialogue);
     }
 

--- a/apps/openmw/mwgui/dialogue.hpp
+++ b/apps/openmw/mwgui/dialogue.hpp
@@ -133,6 +133,8 @@ namespace MWGui
 
         void updateTopics();
 
+        void onClose();
+
     protected:
         void updateTopicsPane();
         bool isCompanion(const MWWorld::Ptr& actor);
@@ -156,7 +158,6 @@ namespace MWGui
         void updateDisposition();
         void restock();
         void deleteLater();
-        void resetHistory();
 
         bool mIsCompanion;
         std::list<std::string> mKeywords;


### PR DESCRIPTION
A slightly different more universal approach. Seems to still work when it comes to solving the original issue.