### PR TITLE
Particle System shading and lighting (fixing bug#3676 and #4949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 0.47.0
 ------
 
+    Bug #3676: NiParticleColorModifier isn't applied properly
+    Bug #4949: Incorrect particle lighting when force shaders = true
     Bug #5358: ForceGreeting always resets the dialogue window completely
     Bug #5363: Enchantment autocalc not always 0/1
     Bug #5364: Script fails/stops if trying to startscript an unknown script

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1809,14 +1809,6 @@ namespace NifOsg
             if (specFlags == 0)
                 mat->setSpecular(osg::Material::FRONT_AND_BACK, osg::Vec4f(0.f,0.f,0.f,0.f));
 
-            // Particles don't have normals, so can't be diffuse lit.
-            if (particleMaterial)
-            {
-                // NB ignoring diffuse.a()
-                mat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(0,0,0,1));
-                mat->setColorMode(osg::Material::AMBIENT);
-            }
-
             if (lightmode == 0)
             {
                 osg::Vec4f diffuse = mat->getDiffuse(osg::Material::FRONT_AND_BACK);

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1078,6 +1078,8 @@ namespace NifOsg
                 trans->addChild(toAttach);
                 parentNode->addChild(trans);
             }
+            // create partsys stateset in order to pass in ShaderVisitor like all other Drawables
+            partsys->getOrCreateStateSet();
         }
 
         void triCommonToGeometry(osg::Geometry *geometry, const std::vector<osg::Vec3f>& vertices, const std::vector<osg::Vec3f>& normals, const std::vector<std::vector<osg::Vec2f>>& uvlist, const std::vector<osg::Vec4f>& colors, const std::vector<unsigned int>& boundTextures, const std::string& name)

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -159,8 +159,11 @@ void ParticleColorAffector::operate(osgParticle::Particle* particle, double /* d
 {
     float time = static_cast<float>(particle->getAge()/particle->getLifeTime());
     osg::Vec4f color = mData.interpKey(time);
+    float alpha = color.a();
+    color.a() = 1.0f;
 
     particle->setColorRange(osgParticle::rangev4(color, color));
+    particle->setAlphaRange(osgParticle::rangef(alpha, alpha));
 }
 
 GravityAffector::GravityAffector(const Nif::NiGravity *gravity)

--- a/components/nifosg/particle.cpp
+++ b/components/nifosg/particle.cpp
@@ -2,6 +2,7 @@
 
 #include <limits>
 
+#include <osg/Version>
 #include <osg/MatrixTransform>
 #include <osg/Geometry>
 
@@ -19,12 +20,19 @@ ParticleSystem::ParticleSystem()
     : osgParticle::ParticleSystem()
     , mQuota(std::numeric_limits<int>::max())
 {
+    mNormalArray = new osg::Vec3Array(1);
+    mNormalArray->setBinding(osg::Array::BIND_OVERALL);
+    (*mNormalArray.get())[0] = osg::Vec3(0.3, 0.3, 0.3);
 }
 
 ParticleSystem::ParticleSystem(const ParticleSystem &copy, const osg::CopyOp &copyop)
     : osgParticle::ParticleSystem(copy, copyop)
     , mQuota(copy.mQuota)
 {
+    mNormalArray = new osg::Vec3Array(1);
+    mNormalArray->setBinding(osg::Array::BIND_OVERALL);
+    (*mNormalArray.get())[0] = osg::Vec3(0.3, 0.3, 0.3);
+
     // For some reason the osgParticle constructor doesn't copy the particles
     for (int i=0;i<copy.numParticles()-copy.numDeadParticles();++i)
         ParticleSystem::createParticle(copy.getParticle(i));
@@ -40,6 +48,25 @@ osgParticle::Particle* ParticleSystem::createParticle(const osgParticle::Particl
     if (numParticles()-numDeadParticles() < mQuota)
         return osgParticle::ParticleSystem::createParticle(ptemplate);
     return nullptr;
+}
+
+void ParticleSystem::drawImplementation(osg::RenderInfo& renderInfo) const
+{
+    osg::State & state = *renderInfo.getState();
+#if OSG_MIN_VERSION_REQUIRED(3, 5, 6)
+    if(state.useVertexArrayObject(getUseVertexArrayObject()))
+    {
+        state.getCurrentVertexArrayState()->assignNormalArrayDispatcher();
+        state.getCurrentVertexArrayState()->setNormalArray(state, mNormalArray);
+    }
+    else
+    {
+        state.getAttributeDispatchers().activateNormalArray(mNormalArray);
+    }
+#else
+     state.Normal(0.3, 0.3, 0.3);
+#endif
+     osgParticle::ParticleSystem::drawImplementation(renderInfo);
 }
 
 void InverseWorldMatrix::operator()(osg::Node *node, osg::NodeVisitor *nv)

--- a/components/nifosg/particle.hpp
+++ b/components/nifosg/particle.hpp
@@ -36,8 +36,11 @@ namespace NifOsg
 
         void setQuota(int quota);
 
+        virtual void drawImplementation(osg::RenderInfo& renderInfo) const;
+
     private:
         int mQuota;
+        osg::ref_ptr<osg::Vec3Array> mNormalArray;
     };
 
     // HACK: Particle doesn't allow setting the initial age, but we need this for loading the particle system state


### PR DESCRIPTION


This pr enables lighting of particle systems
it also fixes the alpha issue (https://gitlab.com/OpenMW/openmw/issues/3676) and https://gitlab.com/OpenMW/openmw/issues/4949

NB: 
- I would have let Ambient material on partsys but spec say alpha come from diffuse product.
https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glLightModel.xml

>             The alpha component of the resulting lighted color is set to the alpha value
>             of the material diffuse reflectance.

I only force particles normal to (0.3,0.3,0.3) following aon3 DX trace...

![fountain](https://user-images.githubusercontent.com/4062709/79695683-91ade300-8278-11ea-8be3-9d90ac8ed9b2.jpg)
![lighsmok](https://user-images.githubusercontent.com/4062709/79695705-a9856700-8278-11ea-90d7-ebca8026c34b.jpg)