### PR TITLE
Disable specular lighting for 4.0.0.2 and earlier files

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1705,7 +1705,8 @@ namespace NifOsg
         {
             osg::StateSet* stateset = node->getOrCreateStateSet();
 
-            int specFlags = 0; // Specular is disabled by default, even if there's a specular color in the NiMaterialProperty
+            // Specular lighting is enabled by default, but there's a quirk...
+            int specFlags = 1;
             osg::ref_ptr<osg::Material> mat (new osg::Material);
             mat->setColorMode(hasVertexColors ? osg::Material::AMBIENT_AND_DIFFUSE : osg::Material::OFF);
 
@@ -1723,6 +1724,7 @@ namespace NifOsg
                 {
                 case Nif::RC_NiSpecularProperty:
                 {
+                    // Specular property can turn specular lighting off.
                     specFlags = property->flags;
                     break;
                 }
@@ -1806,7 +1808,8 @@ namespace NifOsg
                 }
             }
 
-            if (specFlags == 0)
+            // While NetImmerse and Gamebryo support specular lighting, Morrowind has its support disabled.
+            if (mVersion <= Nif::NIFFile::NIFVersion::VER_MW || specFlags == 0)
                 mat->setSpecular(osg::Material::FRONT_AND_BACK, osg::Vec4f(0.f,0.f,0.f,0.f));
 
             // Particles don't have normals, so can't be diffuse lit.


### PR DESCRIPTION
Morrowind doesn't actually support specular lighting, while scrawl made it purposefully enabled if there's a NiSpecularProperty with non-zero flag in the model. This sometimes makes the models made for Morrowind not look as intended. Since we strive for legacy compatibility when it comes to NIFs, specular lighting should be disabled in cases Morrowind has it disabled. However, NetImmerse and Gamebryo do support it, and seem to be designed to have it on by default unless NiSpecularProperty is added with its flags set to 0. So with this only 4.0.0.2 and earlier files — which Morrowind can read — will have specular lighting disabled as long as there isn't a specular map autodetected. 

This should improve compatibility with such mods as Better Meshes (don't know which one) or Westly's head replacer.

To underline: specular maps will be A-OK, it's the material specularity that will be murdered.