### PR TITLE
[WIP] Editor: Update osgQt in extern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ if (USE_QT)
         find_package(Qt5Core REQUIRED)
         find_package(Qt5Network REQUIRED)
         find_package(Qt5OpenGL REQUIRED)
+        find_package(Qt5Gui REQUIRED)
     # Instruct CMake to run moc automatically when needed.
     #set(CMAKE_AUTOMOC ON)
     endif()

--- a/extern/osgQt/CMakeLists.txt
+++ b/extern/osgQt/CMakeLists.txt
@@ -1,9 +1,26 @@
 set(OSGQT_LIBRARY "osgQt")
 
+
+SET(SOURCE_H
+    osgQOpenGLWidget
+    osgQOpenGLWindow
+    OSGRenderer
+)
+
+qt5_wrap_cpp(SOURCES_H_MOC ${SOURCE_H} #[[OPTIONS ${MOC_OPTIONS}]])
+
 # Sources
 
 set(OSGQT_SOURCE_FILES
     GraphicsWindowQt.cpp
+    CullVisitorEx.cpp
+    GraphicsWindowEx.cpp
+    osgQOpenGLWidget.cpp
+    osgQOpenGLWindow.cpp
+    OSGRenderer.cpp
+    RenderStageEx.cpp
+    StateEx.cpp
+    ${SOURCES_H_MOC}
 )
 
 add_library(${OSGQT_LIBRARY} STATIC ${OSGQT_SOURCE_FILES})
@@ -12,7 +29,7 @@ if (DESIRED_QT_VERSION MATCHES 4)
     include(${QT_USE_FILE})
     target_link_libraries(${OSGQT_LIBRARY} ${QT_QTCORE_LIBRARY} ${QT_QTOPENGL_LIBRARY})
 else()
-    target_link_libraries(${OSGQT_LIBRARY} Qt5::Core Qt5::OpenGL)
+    target_link_libraries(${OSGQT_LIBRARY} Qt5::Core Qt5::Gui Qt5::OpenGL)
 endif()
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/extern/osgQt/CullVisitorEx
+++ b/extern/osgQt/CullVisitorEx
@@ -1,0 +1,24 @@
+#ifndef CULLVISITOREX_H
+#define CULLVISITOREX_H
+
+#include <osgUtil/CullVisitor>
+
+/// Needed for mixing osg rendering with Qt 2D drawing using QPainter...
+/// See http://forum.openscenegraph.org/viewtopic.php?t=15627&view=previous
+
+class CullVisitorEx : public osgUtil::CullVisitor
+{
+public:
+    META_NodeVisitor(Ex, CullVisitorEx)
+
+    CullVisitorEx() {}
+    CullVisitorEx(const CullVisitorEx& cv) : osgUtil::CullVisitor(cv) { }
+    CullVisitorEx* clone() const
+    {
+        return new CullVisitorEx(*this);
+    }
+
+    virtual void apply(osg::Camera& camera);
+};
+
+#endif // CULLVISITOREX_H

--- a/extern/osgQt/CullVisitorEx.cpp
+++ b/extern/osgQt/CullVisitorEx.cpp
@@ -1,0 +1,377 @@
+#include "CullVisitorEx"
+#include "RenderStageEx"
+
+/// Needed for mixing osg rendering with Qt 2D drawing using QPainter...
+/// See http://forum.openscenegraph.org/viewtopic.php?t=15627&view=previous
+
+class RenderStageCacheEx : public osg::Object, public osg::Observer
+{
+public:
+
+    typedef std::map<osgUtil::CullVisitor*, osg::ref_ptr<osgUtil::RenderStage> >
+    RenderStageMap;
+
+    RenderStageCacheEx() {}
+    RenderStageCacheEx(const RenderStageCacheEx&, const osg::CopyOp&) {}
+    virtual ~RenderStageCacheEx()
+    {
+        for(RenderStageMap::iterator itr = _renderStageMap.begin();
+            itr != _renderStageMap.end();
+            ++itr)
+        {
+            itr->first->removeObserver(this);
+        }
+    }
+
+    META_Object(Ex, RenderStageCacheEx)
+
+    virtual void objectDeleted(void* object)
+    {
+        osg::Referenced* ref = reinterpret_cast<osg::Referenced*>(object);
+        osgUtil::CullVisitor* cv = dynamic_cast<osgUtil::CullVisitor*>(ref);
+
+        OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
+
+        RenderStageMap::iterator itr = _renderStageMap.find(cv);
+
+        if(itr != _renderStageMap.end())
+        {
+            _renderStageMap.erase(itr);
+        }
+    }
+
+    void setRenderStage(osgUtil::CullVisitor* cv, osgUtil::RenderStage* rs)
+    {
+        OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
+        RenderStageMap::iterator itr = _renderStageMap.find(cv);
+
+        if(itr == _renderStageMap.end())
+        {
+            _renderStageMap[cv] = rs;
+            cv->addObserver(this);
+        }
+        else
+        {
+            itr->second = rs;
+        }
+
+    }
+
+    osgUtil::RenderStage* getRenderStage(osgUtil::CullVisitor* cv)
+    {
+        OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
+        RenderStageMap::iterator itr = _renderStageMap.find(cv);
+
+        if(itr != _renderStageMap.end())
+        {
+            return itr->second.get();
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+    /** Resize any per context GLObject buffers to specified size. */
+    virtual void resizeGLObjectBuffers(unsigned int maxSize)
+    {
+        for(RenderStageMap::const_iterator itr = _renderStageMap.begin();
+            itr != _renderStageMap.end();
+            ++itr)
+        {
+            itr->second->resizeGLObjectBuffers(maxSize);
+        }
+    }
+
+    /** If State is non-zero, this function releases any associated OpenGL objects for
+         the specified graphics context. Otherwise, releases OpenGL objexts
+         for all graphics contexts. */
+    virtual void releaseGLObjects(osg::State* state = 0) const
+    {
+        for(RenderStageMap::const_iterator itr = _renderStageMap.begin();
+            itr != _renderStageMap.end();
+            ++itr)
+        {
+            itr->second->releaseGLObjects(state);
+        }
+    }
+
+    OpenThreads::Mutex  _mutex;
+    RenderStageMap      _renderStageMap;
+};
+
+void CullVisitorEx::apply(osg::Camera& camera)
+{
+
+    // **************************************************************
+    // Code from RenderStage class
+
+    // push the node's state.
+    osg::StateSet* node_state = camera.getStateSet();
+
+    if(node_state) pushStateSet(node_state);
+
+    //#define DEBUG_CULLSETTINGS
+
+#ifdef DEBUG_CULLSETTINGS
+
+    if(osg::isNotifyEnabled(osg::NOTICE))
+    {
+        OSG_NOTICE << std::endl << std::endl << "CullVisitor, before : ";
+        write(osg::notify(osg::NOTICE));
+    }
+
+#endif
+
+    // Save current cull settings
+    CullSettings saved_cull_settings(*this);
+
+#ifdef DEBUG_CULLSETTINGS
+
+    if(osg::isNotifyEnabled(osg::NOTICE))
+    {
+        OSG_NOTICE << "CullVisitor, saved_cull_settings : ";
+        saved_cull_settings.write(osg::notify(osg::NOTICE));
+    }
+
+#endif
+
+#if 1
+    // set cull settings from this Camera
+    setCullSettings(camera);
+
+#ifdef DEBUG_CULLSETTINGS
+    OSG_NOTICE << "CullVisitor, after setCullSettings(camera) : ";
+    write(osg::notify(osg::NOTICE));
+#endif
+    // inherit the settings from above
+    inheritCullSettings(saved_cull_settings, camera.getInheritanceMask());
+
+#ifdef DEBUG_CULLSETTINGS
+    OSG_NOTICE << "CullVisitor, after inheritCullSettings(saved_cull_settings," <<
+               camera.getInheritanceMask() << ") : ";
+    write(osg::notify(osg::NOTICE));
+#endif
+
+#else
+    // activate all active cull settings from this Camera
+    inheritCullSettings(camera);
+#endif
+
+    // set the cull mask.
+    unsigned int savedTraversalMask = getTraversalMask();
+    bool mustSetCullMask = (camera.getInheritanceMask() &
+                            osg::CullSettings::CULL_MASK) == 0;
+
+    if(mustSetCullMask) setTraversalMask(camera.getCullMask());
+
+    osg::RefMatrix& originalModelView = *getModelViewMatrix();
+
+    osg::RefMatrix* projection = 0;
+    osg::RefMatrix* modelview = 0;
+
+    if(camera.getReferenceFrame() == osg::Transform::RELATIVE_RF)
+    {
+        if(camera.getTransformOrder() == osg::Camera::POST_MULTIPLY)
+        {
+            projection = createOrReuseMatrix(*getProjectionMatrix() *
+                                             camera.getProjectionMatrix());
+            modelview = createOrReuseMatrix(*getModelViewMatrix() * camera.getViewMatrix());
+        }
+        else // pre multiply
+        {
+            projection = createOrReuseMatrix(camera.getProjectionMatrix() *
+                                             (*getProjectionMatrix()));
+            modelview = createOrReuseMatrix(camera.getViewMatrix() *
+                                            (*getModelViewMatrix()));
+        }
+    }
+    else
+    {
+        // an absolute reference frame
+        projection = createOrReuseMatrix(camera.getProjectionMatrix());
+        modelview = createOrReuseMatrix(camera.getViewMatrix());
+    }
+
+
+    if(camera.getViewport()) pushViewport(camera.getViewport());
+
+    // record previous near and far values.
+    value_type previous_znear = _computed_znear;
+    value_type previous_zfar = _computed_zfar;
+
+    // take a copy of the current near plane candidates
+    DistanceMatrixDrawableMap  previousNearPlaneCandidateMap;
+    previousNearPlaneCandidateMap.swap(_nearPlaneCandidateMap);
+
+    DistanceMatrixDrawableMap  previousFarPlaneCandidateMap;
+    previousFarPlaneCandidateMap.swap(_farPlaneCandidateMap);
+
+    _computed_znear = FLT_MAX;
+    _computed_zfar = -FLT_MAX;
+
+    pushProjectionMatrix(projection);
+    pushModelViewMatrix(modelview, camera.getReferenceFrame());
+
+    // **************************************************************
+    // New code
+
+    if(camera.getRenderOrder() == osg::Camera::NESTED_RENDER)
+    {
+        handle_cull_callbacks_and_traverse(camera);
+    }
+    else
+    {
+        osgUtil::RenderStage* prevRenderStage = getCurrentRenderBin()->getStage();
+        osg::ref_ptr<RenderStageCacheEx> rsCache = dynamic_cast<RenderStageCacheEx*>
+                                                   (camera.getRenderingCache());
+
+        if(!rsCache)
+        {
+            rsCache = new RenderStageCacheEx();
+            camera.setRenderingCache(rsCache);
+        }
+
+        osg::ref_ptr<osgUtil::RenderStage> rtts = rsCache->getRenderStage(this);
+
+        if(!rtts)
+        {
+            OpenThreads::ScopedLock<OpenThreads::Mutex> lock(*
+                                                             (camera.getDataChangeMutex()));
+
+            rtts = new RenderStageEx();
+            rsCache->setRenderStage(this, rtts.get());
+
+            rtts->setCamera(&camera);
+
+            if(camera.getInheritanceMask() & DRAW_BUFFER)
+            {
+                // inherit draw buffer from above.
+                rtts->setDrawBuffer(prevRenderStage->getDrawBuffer(),
+                                    prevRenderStage->getDrawBufferApplyMask());
+            }
+            else
+            {
+                rtts->setDrawBuffer(camera.getDrawBuffer());
+            }
+
+            if(camera.getInheritanceMask() & READ_BUFFER)
+            {
+                // inherit read buffer from above.
+                rtts->setReadBuffer(prevRenderStage->getReadBuffer(),
+                                    prevRenderStage->getReadBufferApplyMask());
+            }
+            else
+            {
+                rtts->setReadBuffer(camera.getReadBuffer());
+            }
+        }
+        else
+        {
+            // reusing render to texture stage, so need to reset it to empty it from previous frames contents.
+            rtts->reset();
+        }
+
+        // **************************************************************
+        // Code from RenderStage class
+
+        // set up clear masks/values
+        rtts->setClearDepth(camera.getClearDepth());
+        rtts->setClearAccum(camera.getClearAccum());
+        rtts->setClearStencil(camera.getClearStencil());
+        rtts->setClearMask((camera.getInheritanceMask() & CLEAR_MASK) ?
+                           prevRenderStage->getClearMask() : camera.getClearMask());
+        rtts->setClearColor((camera.getInheritanceMask() & CLEAR_COLOR) ?
+                            prevRenderStage->getClearColor() : camera.getClearColor());
+
+        // set the color mask.
+        osg::ColorMask* colorMask = camera.getColorMask() != 0 ? camera.getColorMask() :
+                                    prevRenderStage->getColorMask();
+        rtts->setColorMask(colorMask);
+
+        // set up the viewport.
+        osg::Viewport* viewport = camera.getViewport() != 0 ? camera.getViewport() :
+                                  prevRenderStage->getViewport();
+        rtts->setViewport(viewport);
+
+        // set initial view matrix
+        rtts->setInitialViewMatrix(modelview);
+
+        // set up to charge the same PositionalStateContainer is the parent previous stage.
+        osg::Matrix inheritedMVtolocalMV;
+        inheritedMVtolocalMV.invert(originalModelView);
+        inheritedMVtolocalMV.postMult(*getModelViewMatrix());
+        rtts->setInheritedPositionalStateContainerMatrix(inheritedMVtolocalMV);
+        rtts->setInheritedPositionalStateContainer(
+            prevRenderStage->getPositionalStateContainer());
+
+        // record the render bin, to be restored after creation
+        // of the render to text
+        osgUtil::RenderBin* previousRenderBin = getCurrentRenderBin();
+
+        // set the current renderbin to be the newly created stage.
+        setCurrentRenderBin(rtts.get());
+
+        // traverse the subgraph
+        {
+            handle_cull_callbacks_and_traverse(camera);
+        }
+
+        // restore the previous renderbin.
+        setCurrentRenderBin(previousRenderBin);
+
+
+        if(rtts->getStateGraphList().size() == 0
+           && rtts->getRenderBinList().size() == 0)
+        {
+            // getting to this point means that all the subgraph has been
+            // culled by small feature culling or is beyond LOD ranges.
+        }
+
+
+        // and the render to texture stage to the current stages
+        // dependency list.
+        switch(camera.getRenderOrder())
+        {
+        case osg::Camera::PRE_RENDER:
+            getCurrentRenderBin()->getStage()->addPreRenderStage(rtts.get(),
+                                                                 camera.getRenderOrderNum());
+            break;
+
+        default:
+            getCurrentRenderBin()->getStage()->addPostRenderStage(rtts.get(),
+                                                                  camera.getRenderOrderNum());
+            break;
+        }
+    }
+
+    // **************************************************************
+    // Code from RenderStage class
+    // restore the previous model view matrix.
+    popModelViewMatrix();
+
+    // restore the previous model view matrix.
+    popProjectionMatrix();
+
+
+    // restore the original near and far values
+    _computed_znear = previous_znear;
+    _computed_zfar = previous_zfar;
+
+    // swap back the near plane candidates
+    previousNearPlaneCandidateMap.swap(_nearPlaneCandidateMap);
+    previousFarPlaneCandidateMap.swap(_farPlaneCandidateMap);
+
+
+    if(camera.getViewport()) popViewport();
+
+    // restore the previous traversal mask settings
+    if(mustSetCullMask) setTraversalMask(savedTraversalMask);
+
+    // restore the previous cull settings
+    setCullSettings(saved_cull_settings);
+
+    // pop the node's state off the render graph stack.
+    if(node_state) popStateSet();
+}

--- a/extern/osgQt/GraphicsWindowEx
+++ b/extern/osgQt/GraphicsWindowEx
@@ -1,0 +1,60 @@
+#ifndef GRAPHICSWINDOWEX_H
+#define GRAPHICSWINDOWEX_H
+
+#include <osg/Export>
+
+#include <osgViewer/GraphicsWindow>
+
+/// Needed for mixing osg rendering with Qt 2D drawing using QPainter...
+/// See http://forum.openscenegraph.org/viewtopic.php?t=15627&view=previous
+
+class GraphicsWindowEx : public osgViewer::GraphicsWindow
+{
+public:
+    GraphicsWindowEx(osg::GraphicsContext::Traits* traits);
+    GraphicsWindowEx(int x, int y, int width, int height);
+
+    void init();
+
+    virtual bool isSameKindAs(const osg::Object* object) const
+    {
+        return dynamic_cast<const GraphicsWindowEx*>(object) != 0;
+    }
+    virtual const char* libraryName() const
+    {
+        return "";
+    }
+    virtual const char* className() const
+    {
+        return "GraphicsWindowEx";
+    }
+
+    // dummy implementations, assume that graphics context is *always* current and valid.
+    virtual bool valid() const
+    {
+        return true;
+    }
+    virtual bool realizeImplementation()
+    {
+        return true;
+    }
+    virtual bool isRealizedImplementation() const
+    {
+        return true;
+    }
+    virtual void closeImplementation() {}
+    virtual bool makeCurrentImplementation()
+    {
+        return true;
+    }
+    virtual bool releaseContextImplementation()
+    {
+        return true;
+    }
+    virtual void swapBuffersImplementation() {}
+    virtual void grabFocus() {}
+    virtual void grabFocusIfPointerInWindow() {}
+    virtual void raiseWindow() {}
+};
+
+#endif // GRAPHICSWINDOWEX_H

--- a/extern/osgQt/GraphicsWindowEx.cpp
+++ b/extern/osgQt/GraphicsWindowEx.cpp
@@ -1,0 +1,40 @@
+#include "GraphicsWindowEx"
+#include "StateEx"
+
+GraphicsWindowEx::GraphicsWindowEx(osg::GraphicsContext::Traits* traits)
+{
+    _traits = traits;
+
+    init();
+}
+
+GraphicsWindowEx::GraphicsWindowEx(int x, int y, int width, int height)
+{
+    _traits = new osg::GraphicsContext::Traits();
+    _traits->x = x;
+    _traits->x = y;
+    _traits->width = width;
+    _traits->height = height;
+
+    init();
+}
+
+void GraphicsWindowEx::init()
+{
+    if(valid())
+    {
+        // inject our "extended" state
+        setState(new StateEx());
+        getState()->setGraphicsContext(this);
+
+        if(_traits.valid() && _traits->sharedContext.valid())
+        {
+            getState()->setContextID(_traits->sharedContext->getState()->getContextID());
+            incrementContextIDUsageCount(getState()->getContextID());
+        }
+        else
+        {
+            getState()->setContextID(osg::GraphicsContext::createNewContextID());
+        }
+    }
+}

--- a/extern/osgQt/OSGRenderer
+++ b/extern/osgQt/OSGRenderer
@@ -1,0 +1,104 @@
+// Copyright (C) 2017 Mike Krus
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#ifndef OSGRENDERER_H
+#define OSGRENDERER_H
+
+#include <osg/Export>
+
+#include <QObject>
+
+#include <osgViewer/Viewer>
+
+class QInputEvent;
+class QKeyEvent;
+class QMouseEvent;
+class QWheelEvent;
+namespace eveBIM
+{
+    class ViewerWidget;
+}
+
+
+namespace osgQt
+{
+
+class OSGRenderer : public QObject, public osgViewer::Viewer
+{
+    bool                                       m_osgInitialized {false};
+    osg::ref_ptr<osgViewer::GraphicsWindow>    m_osgWinEmb;
+    float                                      m_windowScale {1.0f};
+    bool                                       m_continuousUpdate {true};
+
+    int                                        _timerId{0};
+    osg::Timer                                 _lastFrameStartTime;
+    bool                                       _applicationAboutToQuit {false};
+    bool                                       _osgWantsToRenderFrame{true};
+
+    Q_OBJECT
+
+    friend class eveBIM::ViewerWidget;
+
+public:
+
+    explicit OSGRenderer(QObject* parent = nullptr);
+    explicit OSGRenderer(osg::ArgumentParser* arguments, QObject* parent = nullptr);
+
+    ~OSGRenderer() override;
+
+    bool continuousUpdate() const
+    {
+        return m_continuousUpdate;
+    }
+    void setContinuousUpdate(bool continuousUpdate)
+    {
+        m_continuousUpdate = continuousUpdate;
+    }
+
+    virtual void keyPressEvent(QKeyEvent* event);
+    virtual void keyReleaseEvent(QKeyEvent* event);
+    virtual void mousePressEvent(QMouseEvent* event);
+    virtual void mouseReleaseEvent(QMouseEvent* event);
+    virtual void mouseDoubleClickEvent(QMouseEvent* event);
+    virtual void mouseMoveEvent(QMouseEvent* event);
+    virtual void wheelEvent(QWheelEvent* event);
+
+    virtual void resize(int windowWidth, int windowHeight, float windowScale);
+
+    void setupOSG(int windowWidth, int windowHeight, float windowScale);
+
+    // overrided from osgViewer::Viewer
+    virtual bool checkNeedToDoFrame() override;
+
+    // overrided from osgViewer::ViewerBase
+    void frame(double simulationTime = USE_REFERENCE_TIME) override;
+
+    // overrided from osgViewer::Viewer
+    void requestRedraw() override;
+    // overrided from osgViewer::Viewer
+    bool checkEvents() override;
+    void update();
+
+protected:
+    void timerEvent(QTimerEvent* event) override;
+
+    void setKeyboardModifiers(QInputEvent* event);
+
+};
+
+}
+
+#endif // OSGRENDERER_H

--- a/extern/osgQt/OSGRenderer.cpp
+++ b/extern/osgQt/OSGRenderer.cpp
@@ -1,0 +1,515 @@
+// Copyright (C) 2017 Mike Krus
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#include "OSGRenderer"
+
+#include "osgQOpenGLWindow"
+#include "osgQOpenGLWidget"
+
+//#include <osgQOpenGL/CullVisitorEx>
+//#include <osgQOpenGL/GraphicsWindowEx>
+
+#include <QApplication>
+#include <QScreen>
+#include <QOpenGLContext>
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLVertexArrayObject>
+
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QWheelEvent>
+
+#include <QThread>
+
+namespace
+{
+
+    class QtKeyboardMap
+    {
+    public:
+        QtKeyboardMap()
+        {
+            mKeyMap[Qt::Key_Escape     ] = osgGA::GUIEventAdapter::KEY_Escape;
+            mKeyMap[Qt::Key_Delete     ] = osgGA::GUIEventAdapter::KEY_Delete;
+            mKeyMap[Qt::Key_Home       ] = osgGA::GUIEventAdapter::KEY_Home;
+            mKeyMap[Qt::Key_Enter      ] = osgGA::GUIEventAdapter::KEY_KP_Enter;
+            mKeyMap[Qt::Key_End        ] = osgGA::GUIEventAdapter::KEY_End;
+            mKeyMap[Qt::Key_Return     ] = osgGA::GUIEventAdapter::KEY_Return;
+            mKeyMap[Qt::Key_PageUp     ] = osgGA::GUIEventAdapter::KEY_Page_Up;
+            mKeyMap[Qt::Key_PageDown   ] = osgGA::GUIEventAdapter::KEY_Page_Down;
+            mKeyMap[Qt::Key_Left       ] = osgGA::GUIEventAdapter::KEY_Left;
+            mKeyMap[Qt::Key_Right      ] = osgGA::GUIEventAdapter::KEY_Right;
+            mKeyMap[Qt::Key_Up         ] = osgGA::GUIEventAdapter::KEY_Up;
+            mKeyMap[Qt::Key_Down       ] = osgGA::GUIEventAdapter::KEY_Down;
+            mKeyMap[Qt::Key_Backspace  ] = osgGA::GUIEventAdapter::KEY_BackSpace;
+            mKeyMap[Qt::Key_Tab        ] = osgGA::GUIEventAdapter::KEY_Tab;
+            mKeyMap[Qt::Key_Space      ] = osgGA::GUIEventAdapter::KEY_Space;
+            mKeyMap[Qt::Key_Delete     ] = osgGA::GUIEventAdapter::KEY_Delete;
+            mKeyMap[Qt::Key_Alt        ] = osgGA::GUIEventAdapter::KEY_Alt_L;
+            mKeyMap[Qt::Key_Shift      ] = osgGA::GUIEventAdapter::KEY_Shift_L;
+            mKeyMap[Qt::Key_Control    ] = osgGA::GUIEventAdapter::KEY_Control_L;
+            mKeyMap[Qt::Key_Meta       ] = osgGA::GUIEventAdapter::KEY_Meta_L;
+            mKeyMap[Qt::Key_F1             ] = osgGA::GUIEventAdapter::KEY_F1;
+            mKeyMap[Qt::Key_F2             ] = osgGA::GUIEventAdapter::KEY_F2;
+            mKeyMap[Qt::Key_F3             ] = osgGA::GUIEventAdapter::KEY_F3;
+            mKeyMap[Qt::Key_F4             ] = osgGA::GUIEventAdapter::KEY_F4;
+            mKeyMap[Qt::Key_F5             ] = osgGA::GUIEventAdapter::KEY_F5;
+            mKeyMap[Qt::Key_F6             ] = osgGA::GUIEventAdapter::KEY_F6;
+            mKeyMap[Qt::Key_F7             ] = osgGA::GUIEventAdapter::KEY_F7;
+            mKeyMap[Qt::Key_F8             ] = osgGA::GUIEventAdapter::KEY_F8;
+            mKeyMap[Qt::Key_F9             ] = osgGA::GUIEventAdapter::KEY_F9;
+            mKeyMap[Qt::Key_F10            ] = osgGA::GUIEventAdapter::KEY_F10;
+            mKeyMap[Qt::Key_F11            ] = osgGA::GUIEventAdapter::KEY_F11;
+            mKeyMap[Qt::Key_F12            ] = osgGA::GUIEventAdapter::KEY_F12;
+            mKeyMap[Qt::Key_F13            ] = osgGA::GUIEventAdapter::KEY_F13;
+            mKeyMap[Qt::Key_F14            ] = osgGA::GUIEventAdapter::KEY_F14;
+            mKeyMap[Qt::Key_F15            ] = osgGA::GUIEventAdapter::KEY_F15;
+            mKeyMap[Qt::Key_F16            ] = osgGA::GUIEventAdapter::KEY_F16;
+            mKeyMap[Qt::Key_F17            ] = osgGA::GUIEventAdapter::KEY_F17;
+            mKeyMap[Qt::Key_F18            ] = osgGA::GUIEventAdapter::KEY_F18;
+            mKeyMap[Qt::Key_F19            ] = osgGA::GUIEventAdapter::KEY_F19;
+            mKeyMap[Qt::Key_F20            ] = osgGA::GUIEventAdapter::KEY_F20;
+            mKeyMap[Qt::Key_hyphen         ] = '-';
+            mKeyMap[Qt::Key_Equal         ] = '=';
+            mKeyMap[Qt::Key_division      ] = osgGA::GUIEventAdapter::KEY_KP_Divide;
+            mKeyMap[Qt::Key_multiply      ] = osgGA::GUIEventAdapter::KEY_KP_Multiply;
+            mKeyMap[Qt::Key_Minus         ] = '-';
+            mKeyMap[Qt::Key_Plus          ] = '+';
+            mKeyMap[Qt::Key_Insert        ] = osgGA::GUIEventAdapter::KEY_KP_Insert;
+        }
+
+        ~QtKeyboardMap()
+        {
+        }
+
+        int remapKey(QKeyEvent* event)
+        {
+            KeyMap::iterator itr = mKeyMap.find(event->key());
+
+            if(itr == mKeyMap.end())
+            {
+                return int(*(event->text().toLatin1().data()));
+            }
+            else
+                return itr->second;
+        }
+
+    private:
+        typedef std::map<unsigned int, int> KeyMap;
+        KeyMap mKeyMap;
+    };
+
+    static QtKeyboardMap s_QtKeyboardMap;
+} // namespace
+
+using namespace osgQt;
+
+OSGRenderer::OSGRenderer(QObject* parent)
+    : QObject(parent), osgViewer::Viewer()
+{
+    //    QObject::connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit,
+    //                     [this]()
+    //    {
+    //        _applicationAboutToQuit = true;
+    //        killTimer(_timerId);
+    //        _timerId = 0;
+    //    });
+}
+
+OSGRenderer::OSGRenderer(osg::ArgumentParser* arguments, QObject* parent)
+    : QObject(parent), osgViewer::Viewer(*arguments)
+{
+    //    QObject::connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit,
+    //                     [this]()
+    //    {
+    //        _applicationAboutToQuit = true;
+    //        killTimer(_timerId);
+    //        _timerId = 0;
+    //    });
+}
+
+OSGRenderer::~OSGRenderer()
+{
+}
+
+void OSGRenderer::update()
+{
+    osgQOpenGLWindow* osgWidgetRendered = dynamic_cast<osgQOpenGLWindow*>(parent());
+
+    if(osgWidgetRendered != nullptr)
+    {
+        osgWidgetRendered->_osgWantsToRenderFrame = true;
+        osgWidgetRendered->update();
+    }
+
+    else
+    {
+        osgQOpenGLWidget* osgWidget = dynamic_cast<osgQOpenGLWidget*>(parent());
+        osgWidget->_osgWantsToRenderFrame = true;
+        osgWidget->update();
+    }
+}
+
+void OSGRenderer::resize(int windowWidth, int windowHeight, float windowScale)
+{
+    if(!m_osgInitialized)
+        return;
+
+    m_windowScale = windowScale;
+
+    /*  _camera->setViewport(new osg::Viewport(0, 0, windowWidth * windowScale,
+                                           windowHeight * windowScale));*/
+
+    m_osgWinEmb->resized(0, 0,
+                         windowWidth * windowScale,
+                         windowHeight * windowScale);
+    m_osgWinEmb->getEventQueue()->windowResize(0, 0,
+                                               windowWidth * windowScale,
+                                               windowHeight * windowScale);
+
+    update();
+}
+
+
+void OSGRenderer::setupOSG(int windowWidth, int windowHeight, float windowScale)
+{
+    m_osgInitialized = true;
+    m_windowScale = windowScale;
+    m_osgWinEmb = new osgViewer::GraphicsWindowEmbedded(0, 0,
+                                                        windowWidth * windowScale, windowHeight * windowScale);
+    //m_osgWinEmb = new osgViewer::GraphicsWindowEmbedded(0, 0, windowWidth * windowScale, windowHeight * windowScale);
+    // make sure the event queue has the correct window rectangle size and input range
+    m_osgWinEmb->getEventQueue()->syncWindowRectangleWithGraphicsContext();
+    _camera->setViewport(new osg::Viewport(0, 0, windowWidth * windowScale,
+                                           windowHeight * windowScale));
+    _camera->setGraphicsContext(m_osgWinEmb.get());
+    // disable key event (default is Escape key) that the viewer checks on each
+    // frame to see
+    // if the viewer's done flag should be set to signal end of viewers main
+    // loop.
+    setKeyEventSetsDone(0);
+    setReleaseContextAtEndOfFrameHint(false);
+    setThreadingModel(osgViewer::Viewer::SingleThreaded);
+
+    osgViewer::Viewer::Windows windows;
+    getWindows(windows);
+
+    _timerId = startTimer(10, Qt::PreciseTimer);
+    _lastFrameStartTime.setStartTick(0);
+}
+
+void OSGRenderer::setKeyboardModifiers(QInputEvent* event)
+{
+    unsigned int modkey = event->modifiers() & (Qt::ShiftModifier |
+                                                Qt::ControlModifier |
+                                                Qt::AltModifier);
+    unsigned int mask = 0;
+
+    if(modkey & Qt::ShiftModifier) mask |= osgGA::GUIEventAdapter::MODKEY_SHIFT;
+
+    if(modkey & Qt::ControlModifier) mask |= osgGA::GUIEventAdapter::MODKEY_CTRL;
+
+    if(modkey & Qt::AltModifier) mask |= osgGA::GUIEventAdapter::MODKEY_ALT;
+
+    m_osgWinEmb->getEventQueue()->getCurrentEventState()->setModKeyMask(mask);
+}
+
+void OSGRenderer::keyPressEvent(QKeyEvent* event)
+{
+    setKeyboardModifiers(event);
+    int value = s_QtKeyboardMap.remapKey(event);
+    m_osgWinEmb->getEventQueue()->keyPress(value);
+}
+
+void OSGRenderer::keyReleaseEvent(QKeyEvent* event)
+{
+    if(event->isAutoRepeat())
+    {
+        event->ignore();
+    }
+    else
+    {
+        setKeyboardModifiers(event);
+        int value = s_QtKeyboardMap.remapKey(event);
+        m_osgWinEmb->getEventQueue()->keyRelease(value);
+    }
+}
+
+void OSGRenderer::mousePressEvent(QMouseEvent* event)
+{
+    int button = 0;
+
+    switch(event->button())
+    {
+    case Qt::LeftButton:
+        button = 1;
+        break;
+
+    case Qt::MidButton:
+        button = 2;
+        break;
+
+    case Qt::RightButton:
+        button = 3;
+        break;
+
+    case Qt::NoButton:
+        button = 0;
+        break;
+
+    default:
+        button = 0;
+        break;
+    }
+
+    setKeyboardModifiers(event);
+    m_osgWinEmb->getEventQueue()->mouseButtonPress(event->x() * m_windowScale,
+                                                   event->y() * m_windowScale, button);
+}
+
+void OSGRenderer::mouseReleaseEvent(QMouseEvent* event)
+{
+    int button = 0;
+
+    switch(event->button())
+    {
+    case Qt::LeftButton:
+        button = 1;
+        break;
+
+    case Qt::MidButton:
+        button = 2;
+        break;
+
+    case Qt::RightButton:
+        button = 3;
+        break;
+
+    case Qt::NoButton:
+        button = 0;
+        break;
+
+    default:
+        button = 0;
+        break;
+    }
+
+    setKeyboardModifiers(event);
+    m_osgWinEmb->getEventQueue()->mouseButtonRelease(event->x() * m_windowScale,
+                                                     event->y() * m_windowScale, button);
+}
+
+void OSGRenderer::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    int button = 0;
+
+    switch(event->button())
+    {
+    case Qt::LeftButton:
+        button = 1;
+        break;
+
+    case Qt::MidButton:
+        button = 2;
+        break;
+
+    case Qt::RightButton:
+        button = 3;
+        break;
+
+    case Qt::NoButton:
+        button = 0;
+        break;
+
+    default:
+        button = 0;
+        break;
+    }
+
+    setKeyboardModifiers(event);
+    m_osgWinEmb->getEventQueue()->mouseDoubleButtonPress(event->x() * m_windowScale,
+                                                         event->y() * m_windowScale, button);
+}
+
+void OSGRenderer::mouseMoveEvent(QMouseEvent* event)
+{
+    setKeyboardModifiers(event);
+    m_osgWinEmb->getEventQueue()->mouseMotion(event->x() * m_windowScale,
+                                              event->y() * m_windowScale);
+}
+
+void OSGRenderer::wheelEvent(QWheelEvent* event)
+{
+    setKeyboardModifiers(event);
+    m_osgWinEmb->getEventQueue()->mouseMotion(event->x() * m_windowScale,
+                                              event->y() * m_windowScale);
+    m_osgWinEmb->getEventQueue()->mouseScroll(
+        event->orientation() == Qt::Vertical ?
+        (event->delta() > 0 ? osgGA::GUIEventAdapter::SCROLL_UP :
+         osgGA::GUIEventAdapter::SCROLL_DOWN) :
+        (event->delta() > 0 ? osgGA::GUIEventAdapter::SCROLL_LEFT :
+         osgGA::GUIEventAdapter::SCROLL_RIGHT));
+}
+
+bool OSGRenderer::checkEvents()
+{
+    // check events from any attached sources
+    for(Devices::iterator eitr = _eventSources.begin();
+        eitr != _eventSources.end();
+        ++eitr)
+    {
+        osgGA::Device* es = eitr->get();
+
+        if(es->getCapabilities() & osgGA::Device::RECEIVE_EVENTS)
+        {
+            if(es->checkEvents())
+                return true;
+        }
+
+    }
+
+    // get events from all windows attached to Viewer.
+    Windows windows;
+    getWindows(windows);
+
+    for(Windows::iterator witr = windows.begin();
+        witr != windows.end();
+        ++witr)
+    {
+        if((*witr)->checkEvents())
+            return true;
+    }
+
+    return false;
+}
+
+bool OSGRenderer::checkNeedToDoFrame()
+{
+    // check if any event handler has prompted a redraw
+    if(_requestRedraw)
+        return true;
+
+    if(_requestContinousUpdate)
+        return true;
+
+    // check if the view needs to update the scene graph
+    // this check if camera has update callback and if scene requires to update scene graph
+    if(requiresUpdateSceneGraph())
+        return true;
+
+    // check if the database pager needs to update the scene
+    if(getDatabasePager()->requiresUpdateSceneGraph())
+        return true;
+
+    // check if the image pager needs to update the scene
+    if(getImagePager()->requiresUpdateSceneGraph())
+        return true;
+
+
+    // check if the scene needs to be redrawn
+    if(requiresRedraw())
+        return true;
+
+    // check if events are available and need processing
+    if(checkEvents())
+        return true;
+
+    // and check again if any event handler has prompted a redraw
+    if(_requestRedraw)
+        return true;
+
+    if(_requestContinousUpdate)
+        return true;
+
+    return false;
+}
+
+// called from ViewerWidget paintGL() method
+void OSGRenderer::frame(double simulationTime)
+{
+    // limit the frame rate
+    if(getRunMaxFrameRate() > 0.0)
+    {
+        double dt = _lastFrameStartTime.time_s();
+        double minFrameTime = 1.0 / getRunMaxFrameRate();
+
+        if(dt < minFrameTime)
+            QThread::usleep(static_cast<unsigned int>(1000000.0 * (minFrameTime - dt)));
+    }
+
+    // avoid excessive CPU loading when no frame is required in ON_DEMAND mode
+    if(getRunFrameScheme() == osgViewer::ViewerBase::ON_DEMAND)
+    {
+        double dt = _lastFrameStartTime.time_s();
+
+        if(dt < 0.01)
+            OpenThreads::Thread::microSleep(static_cast<unsigned int>(1000000.0 *
+                                                                      (0.01 - dt)));
+    }
+
+    // record start frame time
+    _lastFrameStartTime.setStartTick();
+    // make frame
+
+#if 1
+    osgViewer::Viewer::frame(simulationTime);
+#else
+
+    if(_done) return;
+
+    // OSG_NOTICE<<std::endl<<"CompositeViewer::frame()"<<std::endl<<std::endl;
+
+    if(_firstFrame)
+    {
+        viewerInit();
+
+        if(!isRealized())
+        {
+            realize();
+        }
+
+        _firstFrame = false;
+    }
+
+    advance(simulationTime);
+
+    eventTraversal();
+    updateTraversal();
+    //    renderingTraversals();
+#endif
+}
+
+void OSGRenderer::requestRedraw()
+{
+    osgViewer::Viewer::requestRedraw();
+}
+
+void OSGRenderer::timerEvent(QTimerEvent* /*event*/)
+{
+    // application is about to quit, just return
+    if(_applicationAboutToQuit)
+    {
+        return;
+    }
+
+    // ask ViewerWidget to update 3D view
+    if(getRunFrameScheme() != osgViewer::ViewerBase::ON_DEMAND ||
+       checkNeedToDoFrame())
+    {
+        update();
+    }
+}

--- a/extern/osgQt/RenderStageEx
+++ b/extern/osgQt/RenderStageEx
@@ -1,0 +1,18 @@
+#ifndef RENDERSTAGEEX_H
+#define RENDERSTAGEEX_H
+
+#include <osg/Export>
+
+#include <osgUtil/RenderStage>
+
+/// Needed for mixing osg rendering with Qt 2D drawing using QPainter...
+/// See http://forum.openscenegraph.org/viewtopic.php?t=15627&view=previous
+
+class RenderStageEx : public osgUtil::RenderStage
+{
+public:
+    virtual void drawInner(osg::RenderInfo& renderInfo,
+                           osgUtil::RenderLeaf*& previous, bool& doCopyTexture);
+};
+
+#endif // RENDERSTAGEEX_H

--- a/extern/osgQt/RenderStageEx.cpp
+++ b/extern/osgQt/RenderStageEx.cpp
@@ -1,0 +1,278 @@
+#include "RenderStageEx"
+#include "StateEx"
+
+void RenderStageEx::drawInner(osg::RenderInfo& renderInfo,
+                              osgUtil::RenderLeaf*& previous, bool& doCopyTexture)
+{
+#if 0
+    // **************************************************************
+    // Code from RenderStage class
+    struct SubFunc
+    {
+        static void applyReadFBO(bool& apply_read_fbo,
+                                 const osg::FrameBufferObject* read_fbo, osg::State& state)
+        {
+            if(read_fbo->isMultisample())
+            {
+                OSG_WARN << "Attempting to read from a"
+                         " multisampled framebuffer object. Set a resolve"
+                         " framebuffer on the RenderStage to fix this." << std::endl;
+            }
+
+            if(apply_read_fbo)
+            {
+                // Bind the monosampled FBO to read from
+                read_fbo->apply(state, osg::FrameBufferObject::READ_FRAMEBUFFER);
+                apply_read_fbo = false;
+            }
+        }
+    };
+    // **************************************************************
+    // New code
+    osg::State& state = *renderInfo.getState();
+    //osg::FBOExtensions* fbo_ext = osg::FBOExtensions::instance(state.getContextID(), true);
+    osg::GLExtensions* fbo_ext = state.get<osg::GLExtensions>();
+    bool using_multiple_render_targets = false;
+
+    if(fbo_ext)
+    {
+        if(_fbo.valid())
+        {
+            using_multiple_render_targets = _fbo->hasMultipleRenderingTargets();
+
+            if(!using_multiple_render_targets)
+            {
+#if !defined(OSG_GLES1_AVAILABLE) && !defined(OSG_GLES2_AVAILABLE)
+
+                if(getDrawBufferApplyMask())
+                    glDrawBuffer(_drawBuffer);
+
+                if(getReadBufferApplyMask())
+                    glReadBuffer(_readBuffer);
+
+#endif
+            }
+        }
+        else
+            fbo_ext->glBindFramebuffer(osg::FrameBufferObject::READ_DRAW_FRAMEBUFFER,
+                                       static_cast<StateEx*>(&state)->getDefaultFbo());
+    }
+
+    RenderBin::draw(renderInfo, previous);
+
+    // **************************************************************
+    // Code from RenderStage class
+
+    if(state.getCheckForGLErrors() != osg::State::NEVER_CHECK_GL_ERRORS)
+    {
+        if(state.checkGLErrors("after RenderBin::draw(..)"))
+        {
+            if(fbo_ext)
+            {
+                GLenum fbstatus = fbo_ext->glCheckFramebufferStatus(GL_FRAMEBUFFER_EXT);
+
+                if(fbstatus != GL_FRAMEBUFFER_COMPLETE_EXT)
+                {
+                    OSG_NOTICE << "RenderStage::drawInner(,) FBO status = 0x" << std::hex <<
+                               fbstatus << std::dec << std::endl;
+                }
+            }
+        }
+    }
+
+    const osg::FrameBufferObject* read_fbo = fbo_ext ? _fbo.get() : 0;
+    bool apply_read_fbo = false;
+
+    if(fbo_ext && _resolveFbo.valid() && fbo_ext->glBlitFramebuffer)
+    {
+        GLbitfield blitMask = 0;
+        bool needToBlitColorBuffers = false;
+
+        //find which buffer types should be copied
+        for(osg::FrameBufferObject::AttachmentMap::const_iterator
+            it = _resolveFbo->getAttachmentMap().begin(),
+            end = _resolveFbo->getAttachmentMap().end(); it != end; ++it)
+        {
+            switch(it->first)
+            {
+            case osg::Camera::DEPTH_BUFFER:
+                blitMask |= GL_DEPTH_BUFFER_BIT;
+                break;
+
+            case osg::Camera::STENCIL_BUFFER:
+                blitMask |= GL_STENCIL_BUFFER_BIT;
+                break;
+
+            case osg::Camera::PACKED_DEPTH_STENCIL_BUFFER:
+                blitMask |= GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
+                break;
+
+            case osg::Camera::COLOR_BUFFER:
+                blitMask |= GL_COLOR_BUFFER_BIT;
+                break;
+
+            default:
+                needToBlitColorBuffers = true;
+                break;
+            }
+        }
+
+        // Bind the resolve framebuffer to blit into.
+        _fbo->apply(state, osg::FrameBufferObject::READ_FRAMEBUFFER);
+        _resolveFbo->apply(state, osg::FrameBufferObject::DRAW_FRAMEBUFFER);
+
+        if(blitMask)
+        {
+            // Blit to the resolve framebuffer.
+            // Note that (with nvidia 175.16 windows drivers at least) if the read
+            // framebuffer is multisampled then the dimension arguments are ignored
+            // and the whole framebuffer is always copied.
+            fbo_ext->glBlitFramebuffer(
+                static_cast<GLint>(_viewport->x()), static_cast<GLint>(_viewport->y()),
+                static_cast<GLint>(_viewport->x() + _viewport->width()),
+                static_cast<GLint>(_viewport->y() + _viewport->height()),
+                static_cast<GLint>(_viewport->x()), static_cast<GLint>(_viewport->y()),
+                static_cast<GLint>(_viewport->x() + _viewport->width()),
+                static_cast<GLint>(_viewport->y() + _viewport->height()),
+                blitMask, GL_NEAREST);
+        }
+
+#if !defined(OSG_GLES1_AVAILABLE) && !defined(OSG_GLES2_AVAILABLE)
+
+        if(needToBlitColorBuffers)
+        {
+            for(osg::FrameBufferObject::AttachmentMap::const_iterator
+                it = _resolveFbo->getAttachmentMap().begin(),
+                end = _resolveFbo->getAttachmentMap().end(); it != end; ++it)
+            {
+                osg::Camera::BufferComponent attachment = it->first;
+
+                if(attachment >= osg::Camera::COLOR_BUFFER0)
+                {
+                    glReadBuffer(GL_COLOR_ATTACHMENT0_EXT + (attachment -
+                                                             osg::Camera::COLOR_BUFFER0));
+                    glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT + (attachment -
+                                                             osg::Camera::COLOR_BUFFER0));
+                    fbo_ext->glBlitFramebuffer(
+                        static_cast<GLint>(_viewport->x()), static_cast<GLint>(_viewport->y()),
+                        static_cast<GLint>(_viewport->x() + _viewport->width()),
+                        static_cast<GLint>(_viewport->y() + _viewport->height()),
+                        static_cast<GLint>(_viewport->x()), static_cast<GLint>(_viewport->y()),
+                        static_cast<GLint>(_viewport->x() + _viewport->width()),
+                        static_cast<GLint>(_viewport->y() + _viewport->height()),
+                        GL_COLOR_BUFFER_BIT, GL_NEAREST);
+                }
+            }
+
+            // reset the read and draw buffers?  will comment out for now with the assumption that
+            // the buffers will be set explicitly when needed elsewhere.
+            // glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
+            // glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+        }
+
+#endif
+        apply_read_fbo = true;
+        read_fbo = _resolveFbo.get();
+        using_multiple_render_targets = read_fbo->hasMultipleRenderingTargets();
+    }
+
+    // now copy the rendered image to attached texture.
+    if(doCopyTexture)
+    {
+        if(read_fbo) SubFunc::applyReadFBO(apply_read_fbo, read_fbo, state);
+
+        copyTexture(renderInfo);
+    }
+
+    std::map< osg::Camera::BufferComponent, Attachment>::const_iterator itr;
+
+    for(itr = _bufferAttachmentMap.begin();
+        itr != _bufferAttachmentMap.end();
+        ++itr)
+    {
+        if(itr->second._image.valid())
+        {
+            if(read_fbo) SubFunc::applyReadFBO(apply_read_fbo, read_fbo, state);
+
+#if !defined(OSG_GLES1_AVAILABLE) && !defined(OSG_GLES2_AVAILABLE)
+
+            if(using_multiple_render_targets)
+            {
+                int attachment = itr->first;
+
+                if(attachment == osg::Camera::DEPTH_BUFFER
+                   || attachment == osg::Camera::STENCIL_BUFFER)
+                {
+                    // assume first buffer rendered to is the one we want
+                    glReadBuffer(read_fbo->getMultipleRenderingTargets()[0]);
+                }
+                else
+                {
+                    glReadBuffer(GL_COLOR_ATTACHMENT0_EXT + (attachment -
+                                                             osg::Camera::COLOR_BUFFER0));
+                }
+            }
+            else
+            {
+                if(_readBuffer != GL_NONE)
+                {
+                    glReadBuffer(_readBuffer);
+                }
+            }
+
+#endif
+            GLenum pixelFormat = itr->second._image->getPixelFormat();
+
+            if(pixelFormat == 0) pixelFormat = _imageReadPixelFormat;
+
+            if(pixelFormat == 0) pixelFormat = GL_RGB;
+
+            GLenum dataType = itr->second._image->getDataType();
+
+            if(dataType == 0) dataType = _imageReadPixelDataType;
+
+            if(dataType == 0) dataType = GL_UNSIGNED_BYTE;
+
+            itr->second._image->readPixels(static_cast<int>(_viewport->x()),
+                                           static_cast<int>(_viewport->y()),
+                                           static_cast<int>(_viewport->width()),
+                                           static_cast<int>(_viewport->height()),
+                                           pixelFormat, dataType);
+        }
+    }
+
+    if(fbo_ext)
+    {
+        if(getDisableFboAfterRender())
+        {
+            // switch off the frame buffer object
+            GLuint fboId = state.getGraphicsContext() ?
+                           state.getGraphicsContext()->getDefaultFboId() : 0;
+            fbo_ext->glBindFramebuffer(GL_FRAMEBUFFER_EXT, fboId);
+        }
+
+        doCopyTexture = true;
+    }
+
+    if(fbo_ext && _camera.valid())
+    {
+        // now generate mipmaps if they are required.
+        const osg::Camera::BufferAttachmentMap& bufferAttachments =
+            _camera->getBufferAttachmentMap();
+
+        for(osg::Camera::BufferAttachmentMap::const_iterator itr =
+                bufferAttachments.begin();
+            itr != bufferAttachments.end();
+            ++itr)
+        {
+            if(itr->second._texture.valid() && itr->second._mipMapGeneration)
+            {
+                state.setActiveTextureUnit(0);
+                state.applyTextureAttribute(0, itr->second._texture.get());
+                fbo_ext->glGenerateMipmap(itr->second._texture->getTextureTarget());
+            }
+        }
+    }
+
+#endif
+}

--- a/extern/osgQt/StateEx
+++ b/extern/osgQt/StateEx
@@ -1,0 +1,28 @@
+#ifndef STATEEX_H
+#define STATEEX_H
+
+#include <osg/Export>
+
+#include <osg/State>
+
+/// Needed for mixing osg rendering with Qt 2D drawing using QPainter...
+/// See http://forum.openscenegraph.org/viewtopic.php?t=15627&view=previous
+
+class StateEx : public osg::State
+{
+public:
+    StateEx() : defaultFbo(0) {}
+    inline void setDefaultFbo(GLuint fbo)
+    {
+        defaultFbo = fbo;
+    }
+    inline GLuint getDefaultFbo() const
+    {
+        return defaultFbo;
+    }
+
+protected:
+    GLuint defaultFbo;
+};
+
+#endif // STATEEX_H

--- a/extern/osgQt/StateEx.cpp
+++ b/extern/osgQt/StateEx.cpp
@@ -1,0 +1,1 @@
+#include "StateEx"

--- a/extern/osgQt/osgQOpenGLWidget
+++ b/extern/osgQt/osgQOpenGLWidget
@@ -1,0 +1,91 @@
+#ifndef OSGQOPENGLWIDGET_H
+#define OSGQOPENGLWIDGET_H
+
+#ifdef __APPLE__
+#   define __glext_h_
+#   include <QtGui/qopengl.h>
+#   undef __glext_h_
+#   include <QtGui/qopenglext.h>
+#endif
+
+#include <osg/Export>
+#include <OpenThreads/ReadWriteMutex>
+
+#ifdef WIN32
+//#define __gl_h_
+#include <osg/GL>
+#endif
+
+#include <osg/ArgumentParser>
+
+#include <QOpenGLWidget>
+#include <QOpenGLFunctions>
+#include <QReadWriteLock>
+
+namespace osgViewer
+{
+    class Viewer;
+}
+
+namespace osgQt
+{
+
+class OSGRenderer;
+
+class osgQOpenGLWidget : public QOpenGLWidget,
+    protected QOpenGLFunctions
+{
+    Q_OBJECT
+
+protected:
+    OSGRenderer* m_renderer {nullptr};
+    bool _osgWantsToRenderFrame{true};
+    OpenThreads::ReadWriteMutex _osgMutex;
+    osg::ArgumentParser* _arguments {nullptr};
+	bool _isFirstFrame {true};
+
+    friend class OSGRenderer;
+
+public:
+    osgQOpenGLWidget(QWidget* parent = nullptr);
+    osgQOpenGLWidget(osg::ArgumentParser* arguments, QWidget* parent = nullptr);
+    virtual ~osgQOpenGLWidget();
+
+    /** Get osgViewer View */
+    virtual osgViewer::Viewer* getOsgViewer();
+
+    //! get mutex
+    virtual OpenThreads::ReadWriteMutex* mutex();
+
+signals:
+    void initialized();
+
+protected:
+
+    //! call createRender. If overloaded, this method must send initialized signal at end
+    void initializeGL() override;
+
+    void resizeGL(int w, int h) override;
+
+    //! lock scene graph and call osgViewer::frame()
+    void paintGL() override;
+
+    //! called before creating renderer
+    virtual void setDefaultDisplaySettings();
+
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+
+    void createRenderer();
+
+private:
+};
+
+}
+
+#endif // OSGQOPENGLWIDGET_H

--- a/extern/osgQt/osgQOpenGLWidget.cpp
+++ b/extern/osgQt/osgQOpenGLWidget.cpp
@@ -1,0 +1,223 @@
+#include "osgQOpenGLWidget"
+#include "OSGRenderer"
+
+#include <osgViewer/Viewer>
+#include <osg/GL>
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QInputDialog>
+#include <QLayout>
+#include <QMainWindow>
+#include <QScreen>
+#include <QWindow>
+
+using namespace osgQt;
+
+osgQOpenGLWidget::osgQOpenGLWidget(QWidget* parent)
+    : QOpenGLWidget(parent)
+{
+}
+
+osgQOpenGLWidget::osgQOpenGLWidget(osg::ArgumentParser* arguments,
+                                   QWidget* parent) :
+    QOpenGLWidget(parent),
+    _arguments(arguments)
+{
+
+}
+
+osgQOpenGLWidget::~osgQOpenGLWidget()
+{
+}
+
+osgViewer::Viewer* osgQOpenGLWidget::getOsgViewer()
+{
+    return m_renderer;
+}
+
+OpenThreads::ReadWriteMutex* osgQOpenGLWidget::mutex()
+{
+    return &_osgMutex;
+}
+
+
+void osgQOpenGLWidget::initializeGL()
+{
+    // Initializes OpenGL function resolution for the current context.
+    initializeOpenGLFunctions();
+    createRenderer();
+    emit initialized();
+}
+
+void osgQOpenGLWidget::resizeGL(int w, int h)
+{
+    Q_ASSERT(m_renderer);
+    QScreen* screen = windowHandle()
+                      && windowHandle()->screen() ? windowHandle()->screen() :
+                      qApp->screens().front();
+    m_renderer->resize(w, h, screen->devicePixelRatio());
+}
+
+void osgQOpenGLWidget::paintGL()
+{
+    OpenThreads::ScopedReadLock locker(_osgMutex);
+	if (_isFirstFrame) {
+		_isFirstFrame = false;
+		m_renderer->getCamera()->getGraphicsContext()->setDefaultFboId(defaultFramebufferObject());
+	}
+	m_renderer->frame();
+}
+
+void osgQOpenGLWidget::keyPressEvent(QKeyEvent* event)
+{
+    Q_ASSERT(m_renderer);
+
+    if(event->key() == Qt::Key_F)
+    {
+        static QSize g;
+        static QMargins sMargins;
+
+        if(parent() && parent()->isWidgetType())
+        {
+            QMainWindow* _mainwindow = dynamic_cast<QMainWindow*>(parent());
+
+            if(_mainwindow)
+            {
+                g = size();
+
+                if(layout())
+                    sMargins = layout()->contentsMargins();
+
+                bool ok = true;
+
+                // select screen
+                if(qApp->screens().size() > 1)
+                {
+                    QMap<QString, QScreen*> screens;
+                    int screenNumber = 0;
+
+                    for(QScreen* screen : qApp->screens())
+                    {
+                        QString name = screen->name();
+
+                        if(name.isEmpty())
+                        {
+                            name = tr("Screen %1").arg(screenNumber);
+                        }
+
+                        name += " (" + QString::number(screen->size().width()) + "x" + QString::number(
+                                    screen->size().height()) + ")";
+                        screens[name] = screen;
+                        ++screenNumber;
+                    }
+
+                    QString selected = QInputDialog::getItem(this,
+                                                             tr("Choose fullscreen target screen"), tr("Screen"), screens.keys(), 0, false,
+                                                             &ok);
+
+                    if(ok && !selected.isEmpty())
+                    {
+                        context()->setScreen(screens[selected]);
+                        move(screens[selected]->geometry().x(), screens[selected]->geometry().y());
+                        resize(screens[selected]->geometry().width(),
+                               screens[selected]->geometry().height());
+                    }
+                }
+
+                if(ok)
+                {
+                    // in fullscreen mode, a thiner (1px) border around
+                    // viewer widget
+                    if(layout())
+                        layout()->setContentsMargins(1, 1, 1, 1);
+
+                    setParent(0);
+                    showFullScreen();
+                }
+            }
+        }
+        else
+        {
+            showNormal();
+            setMinimumSize(g);
+            QMainWindow* _mainwindow = dynamic_cast<QMainWindow*>(parent());
+            _mainwindow->setCentralWidget(this);
+
+            if(layout())
+                layout()->setContentsMargins(sMargins);
+
+            qApp->processEvents();
+            setMinimumSize(QSize(1, 1));
+        }
+    }
+    else // not 'F' key
+    {
+        // forward event to renderer
+        m_renderer->keyPressEvent(event);
+    }
+}
+
+void osgQOpenGLWidget::keyReleaseEvent(QKeyEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->keyReleaseEvent(event);
+}
+
+void osgQOpenGLWidget::mousePressEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mousePressEvent(event);
+}
+
+void osgQOpenGLWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mouseReleaseEvent(event);
+}
+
+void osgQOpenGLWidget::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mouseDoubleClickEvent(event);
+}
+
+void osgQOpenGLWidget::mouseMoveEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mouseMoveEvent(event);
+}
+
+void osgQOpenGLWidget::wheelEvent(QWheelEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->wheelEvent(event);
+}
+
+void osgQOpenGLWidget::setDefaultDisplaySettings()
+{
+    osg::DisplaySettings* ds = osg::DisplaySettings::instance().get();
+    ds->setNvOptimusEnablement(1);
+    ds->setStereo(false);
+}
+
+void osgQOpenGLWidget::createRenderer()
+{
+    // call this before creating a View...
+    setDefaultDisplaySettings();
+	if (!_arguments) {
+		m_renderer = new OSGRenderer(this);
+	} else {
+		m_renderer = new OSGRenderer(_arguments, this);
+	}
+	QScreen* screen = windowHandle()
+                      && windowHandle()->screen() ? windowHandle()->screen() :
+                      qApp->screens().front();
+    m_renderer->setupOSG(width(), height(), screen->devicePixelRatio());
+}

--- a/extern/osgQt/osgQOpenGLWindow
+++ b/extern/osgQt/osgQOpenGLWindow
@@ -1,0 +1,92 @@
+#ifndef OSGQOPENGLWINDOW_H
+#define OSGQOPENGLWINDOW_H
+
+#ifdef __APPLE__
+#   define __glext_h_
+#   include <QtGui/qopengl.h>
+#   undef __glext_h_
+#   include <QtGui/qopenglext.h>
+#endif
+
+#include <OpenThreads/ReadWriteMutex>
+
+#ifdef WIN32
+//#define __gl_h_
+#include <osg/GL>
+#endif
+
+#include <QOpenGLWindow>
+#include <QOpenGLFunctions>
+#include <QReadWriteLock>
+
+class QWidget;
+
+namespace osgViewer
+{
+    class Viewer;
+}
+
+namespace osgQt
+{
+
+class OSGRenderer;
+
+class osgQOpenGLWindow : public QOpenGLWindow,
+    protected QOpenGLFunctions
+{
+    Q_OBJECT
+
+protected:
+    OSGRenderer* m_renderer {nullptr};
+    bool _osgWantsToRenderFrame{true};
+    OpenThreads::ReadWriteMutex _osgMutex;
+	bool _isFirstFrame {true};
+    friend class OSGRenderer;
+
+    QWidget* _widget = nullptr;
+
+public:
+    osgQOpenGLWindow(QWidget* parent = nullptr);
+    virtual ~osgQOpenGLWindow();
+
+    /** Get osgViewer View */
+    virtual osgViewer::Viewer* getOsgViewer();
+
+    //! get mutex
+    virtual OpenThreads::ReadWriteMutex* mutex();
+
+    QWidget* asWidget()
+    {
+        return _widget;
+    }
+
+signals:
+    void initialized();
+
+protected:
+
+    //! call createRender. If overloaded, this method must send initialized signal at end
+    void initializeGL() override;
+
+    void resizeGL(int w, int h) override;
+
+    //! lock scene graph and call osgViewer::frame()
+    void paintGL() override;
+
+    //! called before creating renderer
+    virtual void setDefaultDisplaySettings();
+
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+
+    void createRenderer();
+};
+
+}
+
+#endif // OSGQOPENGLWINDOW_H

--- a/extern/osgQt/osgQOpenGLWindow.cpp
+++ b/extern/osgQt/osgQOpenGLWindow.cpp
@@ -1,0 +1,127 @@
+#include "osgQOpenGLWindow"
+#include "OSGRenderer"
+
+#include <osgViewer/Viewer>
+#include <osg/GL>
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QInputDialog>
+#include <QLayout>
+#include <QMainWindow>
+#include <QScreen>
+#include <QWindow>
+
+using namespace osgQt;
+
+osgQOpenGLWindow::osgQOpenGLWindow(QWidget* parent)
+    : QOpenGLWindow(QOpenGLWindow::NoPartialUpdate, nullptr)
+{
+    _widget = QWidget::createWindowContainer(this);
+}
+
+osgQOpenGLWindow::~osgQOpenGLWindow()
+{
+}
+
+osgViewer::Viewer* osgQOpenGLWindow::getOsgViewer()
+{
+    return m_renderer;
+}
+
+OpenThreads::ReadWriteMutex* osgQOpenGLWindow::mutex()
+{
+    return &_osgMutex;
+}
+
+
+void osgQOpenGLWindow::initializeGL()
+{
+    // Initializes OpenGL function resolution for the current context.
+    initializeOpenGLFunctions();
+    createRenderer();
+    emit initialized();
+}
+
+void osgQOpenGLWindow::resizeGL(int w, int h)
+{
+    Q_ASSERT(m_renderer);
+    double pixelRatio = screen()->devicePixelRatio();
+    m_renderer->resize(w, h, pixelRatio);
+}
+
+void osgQOpenGLWindow::paintGL()
+{
+    OpenThreads::ScopedReadLock locker(_osgMutex);
+	if (_isFirstFrame) {
+		_isFirstFrame = false;
+		m_renderer->getCamera()->getGraphicsContext()->setDefaultFboId(defaultFramebufferObject());
+	}
+    m_renderer->frame();
+}
+
+void osgQOpenGLWindow::keyPressEvent(QKeyEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->keyPressEvent(event);
+}
+
+void osgQOpenGLWindow::keyReleaseEvent(QKeyEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->keyReleaseEvent(event);
+}
+
+void osgQOpenGLWindow::mousePressEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mousePressEvent(event);
+}
+
+void osgQOpenGLWindow::mouseReleaseEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mouseReleaseEvent(event);
+}
+
+void osgQOpenGLWindow::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mouseDoubleClickEvent(event);
+}
+
+void osgQOpenGLWindow::mouseMoveEvent(QMouseEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->mouseMoveEvent(event);
+}
+
+void osgQOpenGLWindow::wheelEvent(QWheelEvent* event)
+{
+    Q_ASSERT(m_renderer);
+    // forward event to renderer
+    m_renderer->wheelEvent(event);
+}
+
+void osgQOpenGLWindow::setDefaultDisplaySettings()
+{
+    osg::DisplaySettings* ds = osg::DisplaySettings::instance().get();
+    ds->setNvOptimusEnablement(1);
+    ds->setStereo(false);
+}
+
+void osgQOpenGLWindow::createRenderer()
+{
+    // call this before creating a View...
+    setDefaultDisplaySettings();
+
+    m_renderer = new OSGRenderer(this);
+    double pixelRatio = screen()->devicePixelRatio();
+    m_renderer->setupOSG(width(), height(), pixelRatio);
+}


### PR DESCRIPTION
Very heavily WIP, but a PR for commenting and pointing out stuff early. Idea is to update osgQt in extern. It's used by the OpenMW-CS scene view. I understood it generated some errors, and it's probably a reason for a crash when exiting OpenMW-CS compiled with Qt5.

The PR is currently broken (probably should use osgQOpenGLWidget instead of Window), but it does compile. There might be additional unused clutter here too. I haven't really worked with CMakeLists or Qt MOC before.

What's done:
- scenewidget uses osgQOpenGLWindow by default instead of GraphicsWindowQt
- Added Qt5Gui to CMakeLists, because QOpenGLFunctions is part of it and osgQOpenGLWindow is derived from it.
- Added all cpp and header files from osgQt to extern
- Added namespace osgQt to osgQOpenGLWindow, osgQOpenGLWidget and OSGRenderer.
- Removed export macros from osgQt function declarations just to make stuff more clear for me, but maybe those are needed for some win compilers, I don't know (please help).
E.g. removed "OSGQOPENGL_EXPORT" present in https://github.com/openscenegraph/osgQt/blob/cf47af8c7608b1b2e0f6a70ba8b730db8a8cdff8/include/osgQOpenGL/osgQOpenGLWindow#L31 , but not in https://github.com/unelsson/openmw/blob/da16836ba3de1c5744b7b2e15437dd100386b612/extern/osgQt/osgQOpenGLWindow#L34