### PR TITLE
Added setting to change the directory screenshots are stored in

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -686,7 +686,7 @@ void OMW::Engine::go()
 #endif
 
     mScreenCaptureOperation = new WriteScreenshotToFileOperation(
-        mCfgMgr.getScreenshotPath(Settings::Manager::getString("screenshot path", "General")).string(),
+        mCfgMgr.getScreenshotPath().string(),
         Settings::Manager::getString("screenshot format", "General"));
 
     mScreenCaptureHandler = new osgViewer::ScreenCaptureHandler(mScreenCaptureOperation);

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -657,7 +657,6 @@ private:
 };
 
 // Initialise and enter main loop.
-
 void OMW::Engine::go()
 {
     assert (!mContentFiles.empty());
@@ -686,7 +685,8 @@ void OMW::Engine::go()
     mViewer->setUseConfigureAffinity(false);
 #endif
 
-    mScreenCaptureOperation = new WriteScreenshotToFileOperation(mCfgMgr.getUserDataPath().string(),
+    mScreenCaptureOperation = new WriteScreenshotToFileOperation(
+        mCfgMgr.getScreenshotPath(Settings::Manager::getString("screenshot path", "General")).string(),
         Settings::Manager::getString("screenshot format", "General"));
 
     mScreenCaptureHandler = new osgViewer::ScreenCaptureHandler(mScreenCaptureOperation);

--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -196,4 +196,17 @@ const boost::filesystem::path& ConfigurationManager::getLogPath() const
     return mLogPath;
 }
 
+const boost::filesystem::path ConfigurationManager::getScreenshotPath(std::string const& screenshotSettings) const
+{
+    boost::filesystem::path ssPath = screenshotSettings;
+    if (ssPath.is_relative()) {
+        ssPath = mFixedPath.getUserDataPath() / ssPath;
+    }
+    boost::system::error_code dirErr;
+    if (!boost::filesystem::create_directories(ssPath, dirErr) && !boost::filesystem::is_directory(ssPath)) {
+        ssPath = mFixedPath.getUserDataPath();
+    }
+    return ssPath;
+}
+
 } /* namespace Cfg */

--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -32,6 +32,14 @@ ConfigurationManager::ConfigurationManager(bool silent)
     boost::filesystem::create_directories(mFixedPath.getUserDataPath());
 
     mLogPath = mFixedPath.getUserConfigPath();
+
+    mScreenshotPath = mFixedPath.getUserDataPath() / "screenshots";
+
+    // probably not necessary but validate the creation of the screenshots directory and fallback to the original behavior if it fails
+    boost::system::error_code dirErr;
+    if (!boost::filesystem::create_directories(mScreenshotPath, dirErr) && !boost::filesystem::is_directory(mScreenshotPath)) {
+        mScreenshotPath = mFixedPath.getUserDataPath();
+    }
 }
 
 ConfigurationManager::~ConfigurationManager()
@@ -196,17 +204,9 @@ const boost::filesystem::path& ConfigurationManager::getLogPath() const
     return mLogPath;
 }
 
-const boost::filesystem::path ConfigurationManager::getScreenshotPath(std::string const& screenshotSettings) const
+const boost::filesystem::path& ConfigurationManager::getScreenshotPath() const
 {
-    boost::filesystem::path ssPath = screenshotSettings;
-    if (ssPath.is_relative()) {
-        ssPath = mFixedPath.getUserDataPath() / ssPath;
-    }
-    boost::system::error_code dirErr;
-    if (!boost::filesystem::create_directories(ssPath, dirErr) && !boost::filesystem::is_directory(ssPath)) {
-        ssPath = mFixedPath.getUserDataPath();
-    }
-    return ssPath;
+    return mScreenshotPath;
 }
 
 } /* namespace Cfg */

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -41,7 +41,7 @@ struct ConfigurationManager
     const boost::filesystem::path& getCachePath() const;
 
     const boost::filesystem::path& getLogPath() const;
-    const boost::filesystem::path  getScreenshotPath(std::string const& screenshotSetting) const;
+    const boost::filesystem::path& getScreenshotPath() const;
 
     private:
         typedef Files::FixedPath<> FixedPathType;
@@ -58,6 +58,7 @@ struct ConfigurationManager
         FixedPathType mFixedPath;
 
         boost::filesystem::path mLogPath;
+        boost::filesystem::path mScreenshotPath;
 
         TokensMappingContainer mTokensMapping;
 

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -41,6 +41,7 @@ struct ConfigurationManager
     const boost::filesystem::path& getCachePath() const;
 
     const boost::filesystem::path& getLogPath() const;
+    const boost::filesystem::path  getScreenshotPath(std::string const& screenshotSetting) const;
 
     private:
         typedef Files::FixedPath<> FixedPathType;

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -284,9 +284,6 @@ anisotropy = 4
 # File format for screenshots.  (jpg, png, tga, and possibly more).
 screenshot format = png
 
-# Directory to store screenshots in. Supports relative and absolute paths. Relative paths will be to the user data folder.
-screenshot path =./
-
 # Texture magnification filter type.  (nearest or linear).
 texture mag filter = linear
 

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -284,6 +284,9 @@ anisotropy = 4
 # File format for screenshots.  (jpg, png, tga, and possibly more).
 screenshot format = png
 
+# Directory to store screenshots in. Supports relative and absolute paths. Relative paths will be to the user data folder.
+screenshot path =./
+
 # Texture magnification filter type.  (nearest or linear).
 texture mag filter = linear
 


### PR DESCRIPTION
Was annoyed that all my screnshots were clogging up my user data path so whipped this up.  

Uses boost filesystem for creating directories so should be cross platform and falls back to the user data directory if making the folder fails.  I was torn on putting this in the ConfigurationManager because although it thematically fits, it needs the settings string passed into it and returns by-value.  This seemed consistent enough with the behavior the configurationmanager already does in the constructor.  Let me know if you dont like it there, I'm completely new to this codebase (and also deeply prefer c-style structure)

Tested relative and absolute paths on windows only.