### PR TITLE
Make sure non-carriable light sources can't be picked up

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -732,7 +732,8 @@ namespace MWGui
             && (type != typeid(ESM::Potion).name()))
             return;
 
-        if (object.getClass().getName(object) == "") // objects without name presented to user can never be picked up
+        // An object that can be picked up must have a tooltip.
+        if (!object.getClass().hasToolTip(object))
             return;
 
         int count = object.getRefData().getCount();


### PR DESCRIPTION
Name check would never have worked as intended in many cases either way, and now that objects without a name get an ID as that name, it's much better to check for the presence of a tooltip. This is consistent with how we early-out before activating objects directly.

Should be cherry-picked into 0.46 branch.