### PR TITLE
Fix changelog particle lighting entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 0.47.0
 ------
 
+    Bug #1952: Incorrect particle lighting
     Bug #3676: NiParticleColorModifier isn't applied properly
-    Bug #4949: Incorrect particle lighting when force shaders = true
     Bug #5358: ForceGreeting always resets the dialogue window completely
     Bug #5363: Enchantment autocalc not always 0/1
     Bug #5364: Script fails/stops if trying to startscript an unknown script


### PR DESCRIPTION
[1952](https://gitlab.com/OpenMW/openmw/-/issues/1952) along with its many, many duplicates is resolved now that particles support diffuse lighting properly but [4949](https://gitlab.com/OpenMW/openmw/issues/4949) isn't.