### PR TITLE
Consider the first person movement sneaking if it's actually sneaking

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -615,7 +615,9 @@ void CharacterController::refreshMovementAnims(const std::string& weapShortGroup
                     // The first person anims don't have any velocity to calculate a speed multiplier from.
                     // We use the third person velocities instead.
                     // FIXME: should be pulled from the actual animation, but it is not presently loaded.
-                    mMovementAnimSpeed = (isSneaking() ? 33.5452f : (isRunning() ? 222.857f : 154.064f));
+                    bool sneaking = mMovementState == CharState_SneakForward || mMovementState == CharState_SneakBack
+                                 || mMovementState == CharState_SneakLeft    || mMovementState == CharState_SneakRight;
+                    mMovementAnimSpeed = (sneaking ? 33.5452f : (isRunning() ? 222.857f : 154.064f));
                     mMovementAnimationControlled = false;
                 }
             }


### PR DESCRIPTION
There seem to still be idle reset troubles: sneaking idle state somehow doesn't get reset when you get back from sneaking state while you have an idle fallback turned on. But I don't want to experiment with idle reset fixes anymore (especially when the symptom is in something completely unrelated to idles) and this is just something that will work with movement. Especially considering that the touched code is already a hack.

Should go into 0.46 branch.