### PR TITLE
Fix simple water with radial fog enabled

### DIFF
--- a/components/sceneutil/waterutil.cpp
+++ b/components/sceneutil/waterutil.cpp
@@ -74,6 +74,9 @@ namespace SceneUtil
 
         stateset->setRenderBinDetails(renderBin, "RenderBin");
 
+        // Let the shader know we're dealing with simple water here.
+        stateset->addUniform(new osg::Uniform("simpleWater", true));
+
         return stateset;
     }
 }

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -49,6 +49,8 @@ uniform vec2 envMapLumaBias;
 uniform mat2 bumpMapMatrix;
 #endif
 
+uniform bool simpleWater = false;
+
 varying float euclideanDepth;
 varying float linearDepth;
 
@@ -180,7 +182,11 @@ void main()
 
     gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;
 #if @radialFog
-    float fogValue = clamp((euclideanDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
+    float depth = euclideanDepth;
+    // For the less detailed mesh of simple water we need to recalculate depth on per-pixel basis
+    if (simpleWater)
+        depth = length(passViewPos);
+    float fogValue = clamp((depth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
 #else
     float fogValue = clamp((linearDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
 #endif


### PR DESCRIPTION
Apparently recalculating euclidean depth on per-fragment basis works for simple water.

Things to note:
1) The way this is done means on older GPUs the length of the view position vector will be calculated once for every vertex and once per every fragment, while on modern GPUs the second calculation will be optimized out for tiles which lack simple water. I've considered doing it only once (once per fragment) for every object but that isn't ideal: while per-fragment calculation isn't really going to be avoidable, the per-vertex calculation cost should be extremely minor for water tiles, while on modern GPUs per-fragment calculation is clearly avoidable.

2) Initializers for uniforms are legal in GLSL 1.20 though I don't know if they work on Android.

3) Should go into 0.46.0 branch too.