### PR TITLE
Fix hidden node with NiVisController optimization

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -591,7 +591,13 @@ namespace NifOsg
             {
                 bool hasVisController = false;
                 for (Nif::ControllerPtr ctrl = nifNode->controller; !ctrl.empty(); ctrl = ctrl->next)
-                    hasVisController = (ctrl->recType == Nif::RC_NiVisController);
+                {
+                    if (ctrl->recType == Nif::RC_NiVisController)
+                    {
+                        hasVisController = true;
+                        break;
+                    }
+                }
 
                 if (!hasVisController)
                     skipMeshes = true; // skip child meshes, but still create the child node hierarchy for animating collision shapes

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -592,11 +592,8 @@ namespace NifOsg
                 bool hasVisController = false;
                 for (Nif::ControllerPtr ctrl = nifNode->controller; !ctrl.empty(); ctrl = ctrl->next)
                 {
-                    if (ctrl->recType == Nif::RC_NiVisController)
-                    {
-                        hasVisController = true;
+                    if (hasVisController |= (ctrl->recType == Nif::RC_NiVisController))
                         break;
-                    }
                 }
 
                 if (!hasVisController)


### PR DESCRIPTION
Geometry that such a node could have could be erroneously optimized out because the check for whether the node has a NiVisController controlling it assumes the node will have the NiVisController as its last controller.

This optimization will have to be redesigned anyway in the future because controllers can control any parent node, but for now it should just not be broken.