### PR TITLE
Allow particle emitters to be attached to an arbitrary node

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1056,6 +1056,8 @@ namespace NifOsg
                 emitter->setReferenceFrame(osgParticle::ParticleProcessor::RELATIVE_RF);
 
                 // The emitter node may not actually be handled yet, so let's delay attaching the emitter to a later moment.
+                // If the emitter node is placed later than the particle node, it'll have a single frame delay in particle processing.
+                // But that shouldn't be a game-breaking issue.
                 mEmitterQueue.emplace_back(partctrl->emitter->recIndex, emitter);
 
                 osg::ref_ptr<ParticleSystemController> callback(new ParticleSystemController(partctrl));
@@ -1073,7 +1075,7 @@ namespace NifOsg
                 partsys->update(0.0, nv);
             }
 
-            // affectors must be attached *after* the emitter in the scene graph for correct update order
+            // affectors should be attached *after* the emitter in the scene graph for correct update order
             // attach to same node as the ParticleSystem, we need osgParticle Operators to get the correct
             // localToWorldMatrix for transforming to particle space
             handleParticlePrograms(partctrl->affectors, partctrl->colliders, parentNode, partsys.get(), rf);

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -219,6 +219,9 @@ namespace NifOsg
         size_t mFirstRootTextureIndex = -1;
         bool mFoundFirstRootTexturingProperty = false;
 
+        // This is used to queue emitters that weren't attached to their node yet.
+        std::vector<std::pair<size_t, osg::ref_ptr<Emitter>>> mEmitterQueue;
+
         static void loadKf(Nif::NIFFilePtr nif, KeyframeHolder& target)
         {
             if(nif->numRoots() < 1)
@@ -289,6 +292,9 @@ namespace NifOsg
             osg::ref_ptr<TextKeyMapHolder> textkeys (new TextKeyMapHolder);
 
             osg::ref_ptr<osg::Node> created = handleNode(nifNode, nullptr, imageManager, std::vector<unsigned int>(), 0, false, false, false, &textkeys->mTextKeys);
+
+            // Attach particle emitters to their nodes which should all be loaded by now.
+            handleQueuedParticleEmitters(created, nif);
 
             if (nif->getUseSkinning())
             {
@@ -979,6 +985,27 @@ namespace NifOsg
             return emitter;
         }
 
+        void handleQueuedParticleEmitters(osg::Node* rootNode, Nif::NIFFilePtr nif)
+        {
+            for (const auto& emitterPair : mEmitterQueue)
+            {
+                size_t recIndex = emitterPair.first;
+                FindGroupByRecIndex findEmitterNode(recIndex);
+                rootNode->accept(findEmitterNode);
+                osg::Group* emitterNode = findEmitterNode.mFound;
+                if (!emitterNode)
+                {
+                    nif->warn("Failed to find particle emitter emitter node (node record index " + std::to_string(recIndex) + ")");
+                    continue;
+                }
+
+                // Emitter attached to the emitter node. Note one side effect of the emitter using the CullVisitor is that hiding its node
+                // actually causes the emitter to stop firing. Convenient, because MW behaves this way too!
+                emitterNode->addChild(emitterPair.second);
+            }
+            mEmitterQueue.clear();
+        }
+
         void handleParticleSystem(const Nif::Node *nifNode, osg::Group *parentNode, SceneUtil::CompositeStateSetUpdater* composite, int animflags, osg::Node* rootNode)
         {
             osg::ref_ptr<ParticleSystem> partsys (new ParticleSystem);
@@ -1028,22 +1055,8 @@ namespace NifOsg
                 emitter->setParticleSystem(partsys);
                 emitter->setReferenceFrame(osgParticle::ParticleProcessor::RELATIVE_RF);
 
-                // Note: we assume that the Emitter node is placed *before* the Particle node in the scene graph.
-                // This seems to be true for all NIF files in the game that I've checked, suggesting that NIFs work similar to OSG with regards to update order.
-                // If something ever violates this assumption, the worst that could happen is the culling being one frame late, which wouldn't be a disaster.
-
-                FindGroupByRecIndex find (partctrl->emitter->recIndex);
-                rootNode->accept(find);
-                if (!find.mFound)
-                {
-                    Log(Debug::Info) << "can't find emitter node, wrong node order? in " << mFilename;
-                    return;
-                }
-                osg::Group* emitterNode = find.mFound;
-
-                // Emitter attached to the emitter node. Note one side effect of the emitter using the CullVisitor is that hiding its node
-                // actually causes the emitter to stop firing. Convenient, because MW behaves this way too!
-                emitterNode->addChild(emitter);
+                // The emitter node may not actually be handled yet, so let's delay attaching the emitter to a later moment.
+                mEmitterQueue.emplace_back(partctrl->emitter->recIndex, emitter);
 
                 osg::ref_ptr<ParticleSystemController> callback(new ParticleSystemController(partctrl));
                 setupController(partctrl, callback, animflags);

--- a/components/sceneutil/clone.cpp
+++ b/components/sceneutil/clone.cpp
@@ -69,6 +69,15 @@ namespace SceneUtil
     osgParticle::ParticleProcessor* CopyOp::operator() (const osgParticle::ParticleProcessor* processor) const
     {
         osgParticle::ParticleProcessor* cloned = osg::clone(processor, osg::CopyOp::DEEP_COPY_CALLBACKS);
+        for (std::map<const osgParticle::ParticleSystem*, osgParticle::ParticleSystem*>::const_iterator it = mMap3.begin(); it != mMap3.end(); ++it)
+        {
+            if (processor->getParticleSystem() == it->first)
+            {
+                cloned->setParticleSystem(it->second);
+                return cloned;
+            }
+        }
+
         mMap[cloned] = processor->getParticleSystem();
         return cloned;
     }
@@ -93,6 +102,9 @@ namespace SceneUtil
                 updater->addParticleSystem(cloned);
             }
         }
+        // In rare situations a particle processor may be placed after the particle system in the scene graph.
+        mMap3[partsys] = cloned;
+
         return cloned;
     }
 

--- a/components/sceneutil/clone.hpp
+++ b/components/sceneutil/clone.hpp
@@ -35,10 +35,11 @@ namespace SceneUtil
         virtual osg::Object* operator ()(const osg::Object* node) const;
 
     private:
-        // maps new ParticleProcessor to their old ParticleSystem pointer
+        // maps new pointers to their old pointers
         // a little messy, but I think this should be the most efficient way
         mutable std::map<osgParticle::ParticleProcessor*, const osgParticle::ParticleSystem*> mMap;
         mutable std::map<osgParticle::ParticleSystemUpdater*, const osgParticle::ParticleSystem*> mMap2;
+        mutable std::map<const osgParticle::ParticleSystem*, osgParticle::ParticleSystem*> mMap3;
     };
 
 }

--- a/components/sceneutil/clone.hpp
+++ b/components/sceneutil/clone.hpp
@@ -37,9 +37,9 @@ namespace SceneUtil
     private:
         // maps new pointers to their old pointers
         // a little messy, but I think this should be the most efficient way
-        mutable std::map<osgParticle::ParticleProcessor*, const osgParticle::ParticleSystem*> mMap;
-        mutable std::map<osgParticle::ParticleSystemUpdater*, const osgParticle::ParticleSystem*> mMap2;
-        mutable std::map<const osgParticle::ParticleSystem*, osgParticle::ParticleSystem*> mMap3;
+        mutable std::map<osgParticle::ParticleProcessor*, const osgParticle::ParticleSystem*> mProcessorToOldPs;
+        mutable std::map<osgParticle::ParticleSystemUpdater*, const osgParticle::ParticleSystem*> mUpdaterToOldPs;
+        mutable std::map<const osgParticle::ParticleSystem*, osgParticle::ParticleSystem*> mOldPsToNewPs;
     };
 
 }


### PR DESCRIPTION
Should fix [this](https://gitlab.com/OpenMW/openmw/-/issues/5332) issue in Morrowind Optimization Patch.

Since we use osgParticle and Morrowind modellers themselves didn't seem to put the emitter node later than the particle node in the scene graph, there was an assumption in place that the particle emitter is always placed before the particle system in the scene graph. That's what osgParticle normally expects, since particle processors operate on particles that have already been emitted, but apparently it's not guaranteed for every model.

This allows NIF loader to attach the emitter to any emitter node in the NIF hierarchy and fixes cloning operations to make sure that particle processors like an emitter that is attached later than the particle system still get its particle system pointer updated. I didn't remove the assumption that the particle system updater must be placed before the particle system as that doesn't seem to be necessary in the current setup (and probably will never be) and violating osgParticle's assumptions further isn't very nice.

Hopefully this should be everything necessary.

Looks like it's not actually that intimidating of a workaround, so we probably want to get this into 0.46.0. 0.46.0 has a lot of other MOP compatibility fixes, so I didn't add a changelog entry.