### PR TITLE
Fix collision switch node mask (again)

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -376,6 +376,7 @@ namespace MWRender
 
         mViewer->getCamera()->setCullMask(~(Mask_UpdateVisitor|Mask_SimpleWater));
         NifOsg::Loader::setHiddenNodeMask(Mask_UpdateVisitor);
+        NifOsg::Loader::setIntersectionDisabledNodeMask(Mask_Effect);
 
         mNearClip = Settings::Manager::getFloat("near clip", "Camera");
         mViewDistance = Settings::Manager::getFloat("viewing distance", "Camera");

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -177,7 +177,7 @@ namespace NifOsg
 
         void setEnabled(bool enabled)
         {
-            setNodeMask(enabled ? ~0 : 0);
+            setNodeMask(enabled ? ~0 : Loader::getIntersectionDisabledNodeMask());
         }
     };
 
@@ -202,6 +202,18 @@ namespace NifOsg
     unsigned int Loader::getHiddenNodeMask()
     {
         return sHiddenNodeMask;
+    }
+
+    unsigned int Loader::sIntersectionDisabledNodeMask = ~0;
+
+    void Loader::setIntersectionDisabledNodeMask(unsigned int mask)
+    {
+        sIntersectionDisabledNodeMask = mask;
+    }
+
+    unsigned int Loader::getIntersectionDisabledNodeMask()
+    {
+        return sIntersectionDisabledNodeMask;
     }
 
     class LoaderImpl

--- a/components/nifosg/nifloader.hpp
+++ b/components/nifosg/nifloader.hpp
@@ -79,8 +79,14 @@ namespace NifOsg
         static void setHiddenNodeMask(unsigned int mask);
         static unsigned int getHiddenNodeMask();
 
+        // Set the mask to use for nodes that ignore the crosshair intersection. The default is the default node mask.
+        // This is used for NiCollisionSwitch nodes with NiCollisionSwitch state set to disabled.
+        static void setIntersectionDisabledNodeMask(unsigned int mask);
+        static unsigned int getIntersectionDisabledNodeMask();
+
     private:
         static unsigned int sHiddenNodeMask;
+        static unsigned int sIntersectionDisabledNodeMask;
         static bool sShowMarkers;
     };
 


### PR DESCRIPTION
psi29a accidentally set it to 0 (disabled) instead of what it is supposed to be, Mask_Effect. However, that mask is specific to openmw application, so thanks to the same approach being used as the one for hidden nodes the editor will use the default node mask for such nodes.

This is a 0.47.0 regression.