### PR TITLE
Revert an invalid attempt to autoequip shields instead of torches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,6 @@
     Bug #5264: "Damage Fatigue" Magic Effect Can Bring Fatigue below 0
     Bug #5269: Editor: Cell lighting in resaved cleaned content files is corrupted
     Bug #5278: Console command Show doesn't fall back to global variable after local var not found
-    Bug #5300: NPCs don't switch from torch to shield when starting combat
     Bug #5308: World map copying makes save loading much slower
     Bug #5313: Node properties of identical type are not applied in the correct order
     Bug #5326: Formatting issues in the settings.cfg

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1235,11 +1235,6 @@ namespace MWMechanics
                         if (heldIter != inventoryStore.end() && heldIter->getTypeName() != typeid(ESM::Light).name())
                             inventoryStore.unequipItem(*heldIter, ptr);
                     }
-                    else if (heldIter == inventoryStore.end() || heldIter->getTypeName() == typeid(ESM::Light).name())
-                    {
-                        // For hostile NPCs, see if they have anything better to equip first
-                        inventoryStore.autoEquip(ptr);
-                    }
 
                     heldIter = inventoryStore.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
 


### PR DESCRIPTION
On a second thought, that idea was awful.

Fixes [this](https://gitlab.com/OpenMW/openmw/-/issues/5388). I've reopened 5300.

The reason for the issue is that weapons are autoequipped too based on the actor's skills even though combat package tries to properly rate the weapon and autoequip the better weapon instead. And it's not especially efficient to autoequip stuff every single time a light is attempted to be equipped while in combat.