### PR TITLE
Use the new option to treat TGA files as TGA 1.0

### DIFF
--- a/components/resource/imagemanager.cpp
+++ b/components/resource/imagemanager.cpp
@@ -47,7 +47,7 @@ namespace Resource
     ImageManager::ImageManager(const VFS::Manager *vfs)
         : ResourceManager(vfs)
         , mWarningImage(createWarningImage())
-        , mOptions(new osgDB::Options("dds_flip dds_dxt1_detect_rgba"))
+        , mOptions(new osgDB::Options("dds_flip dds_dxt1_detect_rgba ignoreTga2Fields"))
     {
     }
 


### PR DESCRIPTION
Now that Robert merged AnyOldName3's TGA changes to upstream 3.6.x, I went ahead and cherry-picked it to OSGoS. This is the openmw counterpart of the "regression fix".

In OSG builds that have the option and AnyOldName3's other TGA improvements (3.6.6 (?) revisions, OSGoS 3.4.2) it will make sure the malformed TGAs in Graphic Herbalism mods look as expected (transparent). I tested it with OSGoS 3.4.2.

In OSG builds that have AnyOldName3's other TGA improvements but lack the new option (3.6.4, 3.6.5) they still won't look as expected (they'll be opaque).

In OSG builds that don't have either of these things (official 3.4.x, 3.6.3 and earlier) the malformed TGAs will look like expected, but some TGA formats in obscure mods won't load at all.