### PR TITLE
CollisionSwitch and Switch/LOD node fixes

### DIFF
--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -735,20 +735,6 @@ bool Optimizer::CombineStaticTransformsVisitor::removeTransforms(osg::Node* node
 // RemoveEmptyNodes.
 ////////////////////////////////////////////////////////////////////////////
 
-void Optimizer::RemoveEmptyNodesVisitor::apply(osg::Switch& switchNode)
-{
-    // We should keep all switch child nodes since they reflect different switch states.
-    for (unsigned int i=0; i<switchNode.getNumChildren(); ++i)
-        traverse(*switchNode.getChild(i));
-}
-
-void Optimizer::RemoveEmptyNodesVisitor::apply(osg::LOD& lod)
-{
-    // don't remove any direct children of the LOD because they are used to define each LOD level.
-    for (unsigned int i=0; i<lod.getNumChildren(); ++i)
-        traverse(*lod.getChild(i));
-}
-
 void Optimizer::RemoveEmptyNodesVisitor::apply(osg::Group& group)
 {
     if (group.getNumParents()>0)
@@ -787,8 +773,11 @@ void Optimizer::RemoveEmptyNodesVisitor::removeEmptyNodes()
                 ++pitr)
             {
                 osg::Group* parent = *pitr;
-                parent->removeChild(nodeToRemove.get());
-                if (parent->getNumChildren()==0 && isOperationPermissibleForObject(parent)) newEmptyGroups.insert(parent);
+                if (!parent->asSwitch() && !dynamic_cast<osg::LOD*>(parent))
+                {
+                    parent->removeChild(nodeToRemove.get());
+                    if (parent->getNumChildren()==0 && isOperationPermissibleForObject(parent)) newEmptyGroups.insert(parent);
+                }
             }
         }
 

--- a/components/sceneutil/optimizer.hpp
+++ b/components/sceneutil/optimizer.hpp
@@ -321,8 +321,6 @@ class Optimizer
                     BaseOptimizerVisitor(optimizer, REMOVE_REDUNDANT_NODES) {}
 
                 virtual void apply(osg::Group& group);
-                virtual void apply(osg::LOD& lod);
-                virtual void apply(osg::Switch& switchNode);
 
                 void removeEmptyNodes();
 

--- a/components/sceneutil/serialize.cpp
+++ b/components/sceneutil/serialize.cpp
@@ -131,6 +131,7 @@ void registerSerializers()
             "NifOsg::StaticBoundingBoxCallback",
             "NifOsg::GeomMorpherController",
             "NifOsg::UpdateMorphGeometry",
+            "NifOsg::CollisionSwitch",
             "osgMyGUI::Drawable",
             "osg::DrawCallback",
             "osgOQ::ClearQueriesCallback",


### PR DESCRIPTION
Fixes up some remaining limitations of NiSwitchNode/NiLODNode usage in 0.46.0.

1) They can both properly handle their transformations and controllers. NiLODNode had previously supported them in 0.45.0. NiSwitchNode isn't supposed to be a leaf node in the hierarchy and will properly support NiKeyframeControllers without causing crashes.
2) They can both be used as the root node of the model. E.g. a plant with NiSwitchNode as the root node will support herbalism, and while NiLODNode can support it its capability to be transformed was previously removed to do that and now it's restored (note that root nodes' transformations are ignored). Windows users may want to test it (check Morrowind Optimization Patch old 6.0 version using the information from [this](https://gitlab.com/OpenMW/openmw/-/issues/4837) report and also check the attachment). 
3) The way their children are not optimized out is much closer to how upstream OSG does it and is shorter.

The problem with scrawl's original approach that akortunov tried to workaround was that handleNode() tried to return the osg::LOD node instead of the actual root transform node it was attached to to handleNode() caller. This caused issues or crashes. akortunov just removed the transform wrapper for LOD nodes and then restored it for Switch nodes. Now both types of record are wrapped into a transform node and this transform node is returned as the root node instead of the node with special behavior, but NiSwitchNode/NiLODNode children are still attached to the wrapped node.

akortunov tried to reimplement what was there present in upstream optimizer but was removed by scrawl accidentally (osg::Switch handling was purged from the initial optimizer fork).

Additionally, CollisionSwitch group (the equivalent of NiCollisionSwitch) is now properly added to the scene graph instead of being just a matrix transform due to the absence of CopyOp and other vital things so something that might be added later that works with the scene graph should be able to toggle its state properly. Serializer used for ShowSceneGraph instruction will not show it.

This archive contains a modified heather model from Graphic Herbalism and its harvested texture which has a NiSwitchNode as its root node.
[heather.zip](https://github.com/OpenMW/openmw/files/4558285/heather.zip)

Once this is merged, it should go to 0.46.0 branch as well, as is the tradition.