### PR TITLE
Fix usage of uninitialized weapon type in equipmentChanged()

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -1127,7 +1127,7 @@ void NpcAnimation::equipmentChanged()
     static const bool shieldSheathing = Settings::Manager::getBool("shield sheathing", "Game");
     if (shieldSheathing)
     {
-        int weaptype;
+        int weaptype = ESM::Weapon::None;
         MWMechanics::getActiveWeapon(mPtr, &weaptype);
         showCarriedLeft(updateCarriedLeftVisible(weaptype));
     }


### PR DESCRIPTION
Unlike other users of getActiveWeapon(), equipmentChanged() assumes it will always set the weapon type to a valid value, but getActiveWeapon() doesn't change the weapon type if there's no active weapon. Now it does the same thing as all the other callers of getActiveWeapon(): uses None weapon type.

Previously weapon type in this scope could be anything since it was uninitialized, so updateCarriedLeftVisible got an invalid value fed to it.

This fixes invisible torches of NPCs that have them out of combat while shield sheathing is enabled.

And yeah, it's a 0.46.0 regression, get this into 0.46.0 branch.