### PR TITLE
Fix UB in NpcAnimation::mNpcType initialization

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -266,16 +266,22 @@ void HeadAnimationTime::setBlinkStop(float value)
 
 // ----------------------------------------------------
 
-NpcAnimation::NpcType NpcAnimation::getNpcType()
+NpcAnimation::NpcType NpcAnimation::getNpcType() const
 {
     const MWWorld::Class &cls = mPtr.getClass();
     // Dead vampires should typically stay vampires.
     if (mNpcType == Type_Vampire && cls.getNpcStats(mPtr).isDead() && !cls.getNpcStats(mPtr).isWerewolf())
         return mNpcType;
+    return getNpcType(mPtr);
+}
+
+NpcAnimation::NpcType NpcAnimation::getNpcType(const MWWorld::Ptr& ptr)
+{
+    const MWWorld::Class &cls = ptr.getClass();
     NpcAnimation::NpcType curType = Type_Normal;
-    if (cls.getCreatureStats(mPtr).getMagicEffects().get(ESM::MagicEffect::Vampirism).getMagnitude() > 0)
+    if (cls.getCreatureStats(ptr).getMagicEffects().get(ESM::MagicEffect::Vampirism).getMagnitude() > 0)
         curType = Type_Vampire;
-    if (cls.getNpcStats(mPtr).isWerewolf())
+    if (cls.getNpcStats(ptr).isWerewolf())
         curType = Type_Werewolf;
 
     return curType;
@@ -326,7 +332,7 @@ NpcAnimation::NpcAnimation(const MWWorld::Ptr& ptr, osg::ref_ptr<osg::Group> par
     mViewMode(viewMode),
     mShowWeapons(false),
     mShowCarriedLeft(true),
-    mNpcType(getNpcType()),
+    mNpcType(getNpcType(ptr)),
     mFirstPersonFieldOfView(firstPersonFieldOfView),
     mSoundsDisabled(disableSounds),
     mAccurateAiming(false),

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -74,7 +74,7 @@ private:
 
     void updateNpcBase();
 
-    NpcType getNpcType();
+    NpcType getNpcType() const;
 
     PartHolderPtr insertBoundedPart(const std::string &model, const std::string &bonename,
                                         const std::string &bonefilter, bool enchantedGlow, osg::Vec4f* glowColor=nullptr);
@@ -94,6 +94,7 @@ private:
 
     static bool isFirstPersonPart(const ESM::BodyPart* bodypart);
     static bool isFemalePart(const ESM::BodyPart* bodypart);
+    static NpcType getNpcType(const MWWorld::Ptr& ptr);
 
 protected:
     virtual void addControllers();


### PR DESCRIPTION
Detected by ubsan:
```
/home/elsid/dev/openmw/apps/openmw/mwrender/npcanimation.cpp:273:9: runtime error: load of value 169995480, which is not a valid value for type 'MWRender::NpcAnimation::NpcType'
    #0 0x559f50405df9 in MWRender::NpcAnimation::getNpcType() /home/elsid/dev/openmw/apps/openmw/mwrender/npcanimation.cpp:273:9
    #1 0x559f5040795f in MWRender::NpcAnimation::NpcAnimation(MWWorld::Ptr const&, osg::ref_ptr<osg::Group>, Resource::ResourceSystem*, bool, MWRender::NpcAnimation::ViewMode, float) /home/elsid/dev/openmw/apps/openmw/mwrender/npcanimation.cpp:329:14
    #2 0x559f502fcbe5 in MWRender::RenderingManager::renderPlayer(MWWorld::Ptr const&) /home/elsid/dev/openmw/apps/openmw/mwrender/renderingmanager.cpp:1223:32
    #3 0x559f50bdd1ff in MWWorld::World::renderPlayer() /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:2494:21
    #4 0x559f5133b9a7 in MWState::StateManager::loadGame(MWState::Character const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/elsid/dev/openmw/apps/openmw/mwstate/statemanagerimp.cpp:510:48
    #5 0x559f5133a3d1 in MWState::StateManager::loadGame(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/elsid/dev/openmw/apps/openmw/mwstate/statemanagerimp.cpp
    #6 0x559f51395d72 in OMW::Engine::go() /home/elsid/dev/openmw/apps/openmw/engine.cpp:721:41
    #7 0x559f5135403c in runApplication(int, char**) /home/elsid/dev/openmw/apps/openmw/main.cpp:259:17
    #8 0x559f517de503 in wrapApplication(int (*)(int, char**), int, char**, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/elsid/dev/openmw/components/debug/debugging.cpp:138:15
    #9 0x559f5135417d in main /home/elsid/dev/openmw/apps/openmw/main.cpp:271:12
    #10 0x7f5b37d76022 in __libc_start_main (/usr/lib/libc.so.6+0x27022)
    #11 0x559f502a159d in _start (/home/elsid/dev/openmw/build/clang/ubsan/openmw+0x29e259d)
```