### PR TITLE
Cleanup

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1111,7 +1111,7 @@ namespace NifOsg
 
             std::vector<const Nif::Property*> drawableProps;
             collectDrawableProperties(nifNode, drawableProps);
-            applyDrawableProperties(parentNode, drawableProps, composite, true, animflags, true);
+            applyDrawableProperties(parentNode, drawableProps, composite, true, animflags);
 
             // particle system updater (after the emitters and affectors in the scene graph)
             // I think for correct culling needs to be *before* the ParticleSystem, though osg examples do it the other way
@@ -1203,7 +1203,7 @@ namespace NifOsg
             //   above the actual renderable would be tedious.
             std::vector<const Nif::Property*> drawableProps;
             collectDrawableProperties(nifNode, drawableProps);
-            applyDrawableProperties(parentNode, drawableProps, composite, vertexColorsPresent, animflags, false);
+            applyDrawableProperties(parentNode, drawableProps, composite, vertexColorsPresent, animflags);
         }
 
         void handleTriShape(const Nif::Node* nifNode, osg::Group* parentNode, SceneUtil::CompositeStateSetUpdater* composite, const std::vector<unsigned int>& boundTextures, int animflags)
@@ -1755,7 +1755,7 @@ namespace NifOsg
         }
 
         void applyDrawableProperties(osg::Node* node, const std::vector<const Nif::Property*>& properties, SceneUtil::CompositeStateSetUpdater* composite,
-                                             bool hasVertexColors, int animflags, bool particleMaterial)
+                                             bool hasVertexColors, int animflags)
         {
             osg::StateSet* stateset = node->getOrCreateStateSet();
 

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -323,6 +323,7 @@ void updateWaterCullingView(HeightCullCallback* callback, ViewData* vd, osgUtil:
         return;
     }
     cv->pushCurrentMask();
+    static bool debug = getenv("OPENMW_WATER_CULLING_DEBUG") != nullptr;
     for (unsigned int i=0; i<vd->getNumEntries(); ++i)
     {
         ViewData::Entry& entry = vd->getEntry(i);
@@ -337,7 +338,6 @@ void updateWaterCullingView(HeightCullCallback* callback, ViewData* vd, osgUtil:
             continue;
         lowZ = bb._min.z();
 
-        static bool debug = getenv("OPENMW_WATER_CULLING_DEBUG") != nullptr;
         if (!debug)
             break;
         osg::Box* b = new osg::Box;

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -40,36 +40,46 @@ namespace Terrain
     class ChunkManager;
     class CompositeMapRenderer;
 
-class HeightCullCallback : public osg::NodeCallback
-{
-public:
-    HeightCullCallback() : mLowZ(-std::numeric_limits<float>::max()), mHighZ(std::numeric_limits<float>::max()), mMask(~0) {}
-
-    void setLowZ(float z)
+    class HeightCullCallback : public osg::NodeCallback
     {
-        mLowZ = z;
-    }
-    float getLowZ() const { return mLowZ; }
+    public:
+        void setLowZ(float z)
+        {
+            mLowZ = z;
+        }
+        float getLowZ() const
+        {
+            return mLowZ;
+        }
 
-    void setHighZ(float highZ)
-    {
-        mHighZ = highZ;
-    }
-    float getHighZ() const { return mHighZ; }
+        void setHighZ(float highZ)
+        {
+            mHighZ = highZ;
+        }
+        float getHighZ() const
+        {
+            return mHighZ;
+        }
 
-    void setCullMask(unsigned int mask) { mMask = mask; }
-    unsigned int getCullMask() const { return mMask; }
+        void setCullMask(unsigned int mask)
+        {
+            mMask = mask;
+        }
+        unsigned int getCullMask() const
+        {
+            return mMask;
+        }
 
-    virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
-    {
-        if (mLowZ <= mHighZ)
-            traverse(node, nv);
-    }
-private:
-    float mLowZ;
-    float mHighZ;
-    unsigned int mMask;
-};
+        virtual void operator()(osg::Node* node, osg::NodeVisitor* nv)
+        {
+            if (mLowZ <= mHighZ)
+                traverse(node, nv);
+        }
+    private:
+        float mLowZ{-std::numeric_limits<float>::max()};
+        float mHighZ{std::numeric_limits<float>::max()};
+        unsigned int mMask{~0u};
+    };
 
     /**
      * @brief A View is a collection of rendering objects that are visible from a given camera/intersection.


### PR DESCRIPTION
Addresses akortunov's concerns about water culling merge request: static variable declaration is moved out of the loop, which shouldn't change the behavior (which is probably ok) but should look slightly less odd to the reader, (subjectively) improved HeightCullCallback class formatting.

applyDrawableProperties() no longer accepts a particle material argument that went unused after mp3butcher's particle lighting fixes.

TerrainDrawable constructor and destructor are left alone, seems that they're put into the implementation file for a good reason.