### PR TITLE
Verifier: Don't check race of non-skin body parts (bug #5400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     Bug #5367: Selecting a spell on an enchanted item per hotkey always plays the equip sound
     Bug #5369: Spawnpoint in the Grazelands doesn't produce oversized creatures
     Bug #5370: Opening an unlocked but trapped door uses the key
+    Bug #5400: Editor: Verifier checks race of non-skin bodyparts
     Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0

--- a/apps/opencs/model/tools/bodypartcheck.cpp
+++ b/apps/opencs/model/tools/bodypartcheck.cpp
@@ -33,13 +33,10 @@ void CSMTools::BodyPartCheckStage::perform (int stage, CSMDoc::Messages &message
     CSMWorld::UniversalId id( CSMWorld::UniversalId::Type_BodyPart, bodyPart.mId );
 
     // Check BYDT
-    if (bodyPart.mData.mPart > 14 )
+    if (bodyPart.mData.mPart >= ESM::BodyPart::MP_Count )
         messages.add(id, "Invalid part", "", CSMDoc::Message::Severity_Error);
 
-    if (bodyPart.mData.mFlags > 3 )
-        messages.add(id, "Invalid flags", "", CSMDoc::Message::Severity_Error);
-
-    if (bodyPart.mData.mType > 2 )
+    if (bodyPart.mData.mType > ESM::BodyPart::MT_Armor )
         messages.add(id, "Invalid type", "", CSMDoc::Message::Severity_Error);
 
     // Check MODL
@@ -48,9 +45,12 @@ void CSMTools::BodyPartCheckStage::perform (int stage, CSMDoc::Messages &message
     else if ( mMeshes.searchId( bodyPart.mModel ) == -1 )
         messages.add(id, "Model '" + bodyPart.mModel + "' does not exist", "", CSMDoc::Message::Severity_Error);
 
-    // Check FNAM
-    if ( bodyPart.mRace.empty() )
-        messages.add(id, "Race is missing", "", CSMDoc::Message::Severity_Error);
-    else if ( mRaces.searchId( bodyPart.mRace ) == -1 )
-        messages.add(id, "Race '" + bodyPart.mRace + "' does not exist", "", CSMDoc::Message::Severity_Error);
+    // Check FNAM for skin body parts (for non-skin body parts it's meaningless)
+    if ( bodyPart.mData.mType == ESM::BodyPart::MT_Skin )
+    {
+        if ( bodyPart.mRace.empty() )
+            messages.add(id, "Race is missing", "", CSMDoc::Message::Severity_Error);
+        else if ( mRaces.searchId( bodyPart.mRace ) == -1 )
+            messages.add(id, "Race '" + bodyPart.mRace + "' does not exist", "", CSMDoc::Message::Severity_Error);
+    }
 }


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5400)

This check doesn't fail for vanilla armor/clothing body parts because they have a dummy race assigned (sometimes it's Argonian, sometimes it's Breton). This is an odd discrepancy of vanilla which may need investigation if clothing body part records saved in OpenMW-CS end up being incompatible with the original ESM reader.
Either way, it's meaningless to do it for equipment body parts.

I removed the flags check too. The user can't actually fix the flags and it seems too strict (not to mention not that useful).
And cleaned up magic values.

We probably should get a MT_Count value, but editing base record structs triggers half of the engine to be rebuilt, I'd rather not do that for this fix.