### PR TITLE
Only reset dialogue history of dialogue GUI mode is gone

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -477,6 +477,8 @@ namespace MWGui
 
     void DialogueWindow::onClose()
     {
+        if (MWBase::Environment::get().getWindowManager()->containsMode(GM_Dialogue))
+            return;
         // Reset history
         for (DialogueText* text : mHistoryContents)
             delete text;


### PR DESCRIPTION
[Regression report](https://gitlab.com/OpenMW/openmw/-/issues/5395)

0.47.0 regression. This additional check seems to fix it without causing the previous regression or the issue itself to rearise.