### PR TITLE
Improve color mode handling in shaders

### DIFF
--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -263,15 +263,21 @@ namespace Shader
                     case osg::Material::OFF:
                         colorMode = 0;
                         break;
-                    case GL_AMBIENT:
-                        colorMode = 3;
+                    case osg::Material::EMISSION:
+                        colorMode = 1;
                         break;
                     default:
-                    case GL_AMBIENT_AND_DIFFUSE:
+                    case osg::Material::AMBIENT_AND_DIFFUSE:
                         colorMode = 2;
                         break;
-                    case GL_EMISSION:
-                        colorMode = 1;
+                    case osg::Material::AMBIENT:
+                        colorMode = 3;
+                        break;
+                    case osg::Material::DIFFUSE:
+                        colorMode = 4;
+                        break;
+                    case osg::Material::SPECULAR:
+                        colorMode = 5;
                         break;
                     }
 

--- a/files/shaders/lighting.glsl
+++ b/files/shaders/lighting.glsl
@@ -2,6 +2,13 @@
 
 uniform int colorMode;
 
+const int ColorMode_None = 0;
+const int ColorMode_Emission = 1;
+const int ColorMode_AmbientAndDiffuse = 2;
+const int ColorMode_Ambient = 3;
+const int ColorMode_Diffuse = 4;
+const int ColorMode_Specular = 5;
+
 void perLight(out vec3 ambientOut, out vec3 diffuseOut, int lightIndex, vec3 viewPos, vec3 viewNormal, vec4 diffuse, vec3 ambient)
 {
     vec3 lightDir;
@@ -22,22 +29,25 @@ vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, float shadowing
 vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, out vec3 shadowDiffuse)
 #endif
 {
-    vec4 diffuse;
-    vec3 ambient;
-    if (colorMode == 3)
-    {
-        diffuse = gl_FrontMaterial.diffuse;
-        ambient = vertexColor.xyz;
-    }
-    else if (colorMode == 2)
+    vec4 diffuse = gl_FrontMaterial.diffuse;
+    vec3 ambient = gl_FrontMaterial.ambient.xyz;
+    vec3 emission = gl_FrontMaterial.emission.xyz;
+    if (colorMode == ColorMode_AmbientAndDiffuse)
     {
         diffuse = vertexColor;
         ambient = vertexColor.xyz;
     }
-    else
+    else if (colorMode == ColorMode_Ambient)
     {
-        diffuse = gl_FrontMaterial.diffuse;
-        ambient = gl_FrontMaterial.ambient.xyz;
+        ambient = vertexColor.xyz;
+    }
+    else if (colorMode == ColorMode_Diffuse)
+    {
+        diffuse = vertexColor;
+    }
+    else if (colorMode == ColorMode_Emission)
+    {
+        emission = vertexColor.xyz;
     }
     vec4 lightResult = vec4(0.0, 0.0, 0.0, diffuse.a);
 
@@ -55,12 +65,7 @@ vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, out vec3 shadow
         lightResult.xyz += ambientLight + diffuseLight;
     }
 
-    lightResult.xyz += gl_LightModel.ambient.xyz * ambient;
-
-    if (colorMode == 1)
-        lightResult.xyz += vertexColor.xyz;
-    else
-        lightResult.xyz += gl_FrontMaterial.emission.xyz;
+    lightResult.xyz += gl_LightModel.ambient.xyz * ambient + emission;
 
 #if @clamp
     lightResult = clamp(lightResult, vec4(0.0), vec4(1.0));

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -178,6 +178,8 @@ void main()
 #else
     float shininess = gl_FrontMaterial.shininess;
     vec3 matSpec = gl_FrontMaterial.specular.xyz;
+    if (colorMode == ColorMode_Specular)
+        matSpec = passColor.xyz;
 #endif
 
     gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -83,10 +83,12 @@ void main()
 
 #if @specularMap
     float shininess = 128.0; // TODO: make configurable
-    vec3 matSpec = vec3(diffuseTex.a, diffuseTex.a, diffuseTex.a);
+    vec3 matSpec = vec3(diffuseTex.a);
 #else
     float shininess = gl_FrontMaterial.shininess;
     vec3 matSpec = gl_FrontMaterial.specular.xyz;
+    if (colorMode == ColorMode_Specular)
+        matSpec = passColor.xyz;
 #endif
 
     gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos), shininess, matSpec) * shadowing;


### PR DESCRIPTION
Added two missing vertex color modes (specular and diffuse), tried to improve the readability of the relevant code both C++ side and shader-side. Diffuse color mode is used for some things, though rarely. This is mainly to make sure shaders behave the same as FFP if these modes are utilized.