### PR TITLE
Log some more things

### DIFF
--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -144,6 +144,7 @@ void MWState::StateManager::newGame (bool bypass)
 
     try
     {
+        Log(Debug::Info) << "Starting a new game";
         MWBase::Environment::get().getScriptManager()->getGlobalScripts().addStartup();
 
         MWBase::Environment::get().getWorld()->startNewGame (bypass);
@@ -220,6 +221,7 @@ void MWState::StateManager::saveGame (const std::string& description, const Slot
         profile.mTimePlayed = mTimePlayed;
         profile.mDescription = description;
 
+        Log(Debug::Info) << "Making a screenshot for saved game '" << description << "'";;
         writeScreenshot(profile.mScreenshot);
 
         if (!slot)
@@ -229,6 +231,8 @@ void MWState::StateManager::saveGame (const std::string& description, const Slot
 
         // Make sure the animation state held by references is up to date before saving the game.
         MWBase::Environment::get().getMechanicsManager()->persistAnimationStates();
+
+        Log(Debug::Info) << "Writing saved game '" << description << "' for character " << profile.mPlayerName;
 
         // Write to a memory stream first. If there is an exception during the save process, we don't want to trash the
         // existing save file we are overwriting.
@@ -380,6 +384,8 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
     {
         cleanup();
 
+        Log(Debug::Info) << "Reading saved game " << filepath;
+
         ESM::ESMReader reader;
         reader.open (filepath);
 
@@ -418,6 +424,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
                             return;
                         }
                         mTimePlayed = profile.mTimePlayed;
+                        Log(Debug::Info) << "Loading saved game '" << profile.mDescription << "' for character " << profile.mPlayerName;
                     }
                     break;
 
@@ -526,6 +533,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
         else
         {
             // Cell no longer exists (i.e. changed game files), choose a default cell
+            Log(Debug::Warning) << "Warning: Player character's cell no longer exists, changing to the default cell";
             MWWorld::CellStore* cell = MWBase::Environment::get().getWorld()->getExterior(0,0);
             float x,y;
             MWBase::Environment::get().getWorld()->indexToPosition(0,0,x,y,false);
@@ -628,7 +636,7 @@ bool MWState::StateManager::verifyProfile(const ESM::SavedGame& profile) const
         if (std::find(selectedContentFiles.begin(), selectedContentFiles.end(), *it)
                 == selectedContentFiles.end())
         {
-            Log(Debug::Warning) << "Warning: Savegame dependency " << *it << " is missing.";
+            Log(Debug::Warning) << "Warning: Saved game dependency " << *it << " is missing.";
             notFound = true;
         }
     }

--- a/components/esm/loadcell.cpp
+++ b/components/esm/loadcell.cpp
@@ -210,13 +210,15 @@ namespace ESM
     std::string Cell::getDescription() const
     {
         if (mData.mFlags & Interior)
-        {
             return mName;
-        }
-        else
-        {
-            return std::to_string(mData.mX) + ", " + std::to_string(mData.mY);
-        }
+
+        std::string cellGrid = "(" + std::to_string(mData.mX) + ", " + std::to_string(mData.mY) + ")";
+        if (!mName.empty())
+            return mName + ' ' + cellGrid;
+        // FIXME: should use sDefaultCellname GMST instead, but it's not available in this scope
+        std::string region = !mRegion.empty() ? mRegion : "Wilderness";
+
+        return region + ' ' + cellGrid;
     }
 
     bool Cell::getNextRef(ESMReader &esm, CellRef &ref, bool &isDeleted, bool ignoreMoves, MovedCellRef *mref)


### PR DESCRIPTION
Sometimes it's difficult to guess the user's actions from openmw.log. I've added a bunch of extra log messages that should be helpful for debug.

- Message when a new game is started
- Message before a screenshot is made for a saved game
- Message when the actual saved game writing begins
- Message when saved game reading is started
- Message when saved game loading is started
- Message when the player character is teleported to the default cell because their current cell is unavailable

Exterior cell descriptions used in messages like "Loading cell", "Unloading cell" etc. now include the name if it's present or the region name if it's present or just "Wilderness" otherwise (localized GMST for the default cell name isn't available).