### PR TITLE
Allow guards to pursue an invisible player (bug #4774)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
     Bug #1952: Incorrect particle lighting
     Bug #3676: NiParticleColorModifier isn't applied properly
+    Bug #4774: Guards are ignorant of an invisible player that tries to attack them
     Bug #5358: ForceGreeting always resets the dialogue window completely
     Bug #5363: Enchantment autocalc not always 0/1
     Bug #5364: Script fails/stops if trying to startscript an unknown script

--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -3,6 +3,7 @@
 #include <components/esm/aisequence.hpp>
 
 #include "../mwbase/environment.hpp"
+#include "../mwbase/mechanicsmanager.hpp"
 #include "../mwbase/windowmanager.hpp"
 #include "../mwbase/world.hpp"
 
@@ -42,8 +43,9 @@ bool AiPursue::execute (const MWWorld::Ptr& actor, CharacterController& characte
     if (target == MWWorld::Ptr() || !target.getRefData().getCount() || !target.getRefData().isEnabled())
         return true;
 
-    if (isTargetMagicallyHidden(target))
-        return true;
+    if (!MWBase::Environment::get().getWorld()->getLOS(target, actor)
+     || !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(target, actor))
+        return false;
 
     if (target.getClass().getCreatureStats(target).isDead())
         return true;


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/4774)

Just use akortunov's 1st idea listed (i.e. Morrowind-like approach). Seems to resolve the issue. Guards move (with some serious twitching) to the player and flee if the player tries to resist arrest.