### PR TITLE
Fix warning

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -612,7 +612,7 @@ namespace NifOsg
                 bool hasVisController = false;
                 for (Nif::ControllerPtr ctrl = nifNode->controller; !ctrl.empty(); ctrl = ctrl->next)
                 {
-                    if (hasVisController |= (ctrl->recType == Nif::RC_NiVisController))
+                    if ((hasVisController |= (ctrl->recType == Nif::RC_NiVisController)))
                         break;
                 }
 


### PR DESCRIPTION
```
/home/travis/build/OpenMW/openmw/components/nifosg/nifloader.cpp:615:42: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                    if (hasVisController |= (ctrl->recType == Nif::RC_NiVisController))
                        ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/OpenMW/openmw/components/nifosg/nifloader.cpp:615:42: note: place parentheses around the assignment to silence this warning
                    if (hasVisController |= (ctrl->recType == Nif::RC_NiVisController))
                                         ^
                        (                                                             )
```