### PR TITLE
Cap movement animation playback speed

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2289,8 +2289,12 @@ void CharacterController::update(float duration, bool animationOnly)
         }
         else if (mMovementState != CharState_None && mAdjustMovementAnimSpeed)
         {
-            float speedmult = speed / mMovementAnimSpeed;
-            mAnimation->adjustSpeedMult(mCurrentMovement, speedmult);
+            // Vanilla caps the played animation speed.
+            const float maxSpeedMult = 10.f;
+            const float speedMult = speed / mMovementAnimSpeed;
+            mAnimation->adjustSpeedMult(mCurrentMovement, std::min(maxSpeedMult, speedMult));
+            // Make sure the actual speed is the "expected" speed even though the animation is slower
+            scale *= std::max(1.f, speedMult / maxSpeedMult);
         }
 
         if (!mSkipAnim)


### PR DESCRIPTION
Requested by Greatness7. Vanilla [does](https://wiki.openmw.org/index.php?title=Research:Movement#Animation_system) this. It makes the footstep sound and the character behave less ridiculous when the character is rolling around at the speed of sound. Unlike vanilla, actual character velocity should stay the same so that you can still make sure the engine loads ~69420 cells at once when you speed around the island testing object paging or something.