### PR TITLE
Always pass the vertex color to the fragment shader

### DIFF
--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -59,9 +59,8 @@ varying float linearDepth;
 #if !PER_PIXEL_LIGHTING
 centroid varying vec4 lighting;
 centroid varying vec3 shadowDiffuseLighting;
-#else
-centroid varying vec4 passColor;
 #endif
+centroid varying vec4 passColor;
 varying vec3 passViewPos;
 varying vec3 passNormal;
 

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -45,9 +45,8 @@ varying float linearDepth;
 #if !PER_PIXEL_LIGHTING
 centroid varying vec4 lighting;
 centroid varying vec3 shadowDiffuseLighting;
-#else
-centroid varying vec4 passColor;
 #endif
+centroid varying vec4 passColor;
 varying vec3 passViewPos;
 varying vec3 passNormal;
 
@@ -108,9 +107,8 @@ void main(void)
 
 #if !PER_PIXEL_LIGHTING
     lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting);
-#else
-    passColor = gl_Color;
 #endif
+    passColor = gl_Color;
     passViewPos = viewPos.xyz;
     passNormal = gl_Normal.xyz;
 

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -20,9 +20,8 @@ varying float linearDepth;
 #if !PER_PIXEL_LIGHTING
 centroid varying vec4 lighting;
 centroid varying vec3 shadowDiffuseLighting;
-#else
-centroid varying vec4 passColor;
 #endif
+centroid varying vec4 passColor;
 varying vec3 passViewPos;
 varying vec3 passNormal;
 

--- a/files/shaders/terrain_vertex.glsl
+++ b/files/shaders/terrain_vertex.glsl
@@ -9,9 +9,8 @@ varying float linearDepth;
 #if !PER_PIXEL_LIGHTING
 centroid varying vec4 lighting;
 centroid varying vec3 shadowDiffuseLighting;
-#else
-centroid varying vec4 passColor;
 #endif
+centroid varying vec4 passColor;
 varying vec3 passViewPos;
 varying vec3 passNormal;
 
@@ -32,9 +31,8 @@ void main(void)
 
 #if !PER_PIXEL_LIGHTING
     lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting);
-#else
-    passColor = gl_Color;
 #endif
+    passColor = gl_Color;
     passNormal = gl_Normal.xyz;
     passViewPos = viewPos.xyz;
 


### PR DESCRIPTION
Even when per-pixel lighting is off. Fixes per-vertex lighting being broken atm.
In general it's pretty useful to keep it around for some things. Specular color mode is one of these things, but there's also the decal texture blending thing that would benefit from it.