### PR TITLE
Some more minor NIF stuff

### DIFF
--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -225,7 +225,7 @@ void NiSkinData::read(NIFStream *nif)
     trafo.scale = nif->getFloat();
 
     int boneNum = nif->getInt();
-    if (nif->getVersion() >= NIFFile::NIFVersion::VER_MW && nif->getVersion() <= NIFFile::NIFVersion::VER_GAMEBRYO)
+    if (nif->getVersion() >= NIFFile::NIFVersion::VER_MW && nif->getVersion() <= NIFStream::generateVersion(10,1,0,0))
         nif->skip(4); // NiSkinPartition link
 
     bones.resize(boneNum);

--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -163,11 +163,8 @@ void NiPixelData::read(NIFStream *nif)
 {
     fmt = (Format)nif->getUInt();
 
-    rmask = nif->getUInt(); // usually 0xff
-    gmask = nif->getUInt(); // usually 0xff00
-    bmask = nif->getUInt(); // usually 0xff0000
-    amask = nif->getUInt(); // usually 0xff000000 or zero
-
+    for (unsigned int i = 0; i < 4; ++i)
+        colorMask[i] = nif->getUInt();
     bpp = nif->getUInt();
 
     // 8 bytes of "Old Fast Compare". Whatever that means.
@@ -190,10 +187,9 @@ void NiPixelData::read(NIFStream *nif)
     }
 
     // Read the data
-    unsigned int dataSize = nif->getUInt();
-    data.reserve(dataSize);
-    for (unsigned i=0; i<dataSize; ++i)
-        data.push_back((unsigned char)nif->getChar());
+    unsigned int numPixels = nif->getUInt();
+    if (numPixels)
+        nif->getUChars(data, numPixels);
 }
 
 void NiPixelData::post(NIFFile *nif)

--- a/components/nif/data.hpp
+++ b/components/nif/data.hpp
@@ -124,7 +124,8 @@ public:
     };
     Format fmt;
 
-    unsigned int rmask, gmask, bmask, amask, bpp;
+    unsigned int colorMask[4];
+    unsigned int bpp;
 
     NiPalettePtr palette;
     unsigned int numberOfMipmaps;

--- a/components/nif/niffile.cpp
+++ b/components/nif/niffile.cpp
@@ -144,7 +144,7 @@ void NIFFile::parse(Files::IStreamPtr stream)
     ver = nif.getUInt();
     // 4.0.0.0 is an older, practically identical version of the format.
     // It's not used by Morrowind assets but Morrowind supports it.
-    if(ver != nif.generateVersion(4,0,0,0) && ver != VER_MW)
+    if(ver != NIFStream::generateVersion(4,0,0,0) && ver != VER_MW)
         fail("Unsupported NIF version: " + printVersion(ver));
     // Number of records
     size_t recNum = nif.getInt();

--- a/components/nif/niffile.hpp
+++ b/components/nif/niffile.hpp
@@ -79,11 +79,7 @@ public:
     enum NIFVersion
     {
         VER_MW         = 0x04000002,    // 4.0.0.2. Main Morrowind NIF version.
-        VER_CI         = 0x04020200,    // 4.2.2.0. Main Culpa Innata NIF version, also used in Civ4.
-        VER_ZT2        = 0x0A000100,    // 10.0.1.0. Main Zoo Tycoon 2 NIF version, also used in Oblivion and Civ4.
         VER_OB_OLD     = 0x0A000102,    // 10.0.1.2. Main older Oblivion NIF version.
-        VER_GAMEBRYO   = 0x0A010000,    // 10.1.0.0. Lots of games use it. The first version that has Gamebryo File Format header.
-        VER_CIV4       = 0x14000004,    // 20.0.0.4. Main Civilization IV NIF version.
         VER_OB         = 0x14000005,    // 20.0.0.5. Main Oblivion NIF version.
         VER_BGS        = 0x14020007     // 20.2.0.7. Main Fallout 3/4/76/New Vegas and Skyrim/SkyrimSE NIF version.
     };

--- a/components/nif/nifstream.hpp
+++ b/components/nif/nifstream.hpp
@@ -200,6 +200,18 @@ public:
         return result;
     }
 
+    void getChars(std::vector<char> &vec, size_t size)
+    {
+        vec.resize(size);
+        readLittleEndianDynamicBufferOfType<char,char>(inp, vec.data(), size);
+    }
+
+    void getUChars(std::vector<unsigned char> &vec, size_t size)
+    {
+        vec.resize(size);
+        readLittleEndianDynamicBufferOfType<unsigned char,unsigned char>(inp, vec.data(), size);
+    }
+
     void getUShorts(std::vector<unsigned short> &vec, size_t size)
     {
         vec.resize(size);

--- a/components/nif/node.hpp
+++ b/components/nif/node.hpp
@@ -285,7 +285,7 @@ struct NiLODNode : public NiSwitchNode
     void read(NIFStream *nif)
     {
         NiSwitchNode::read(nif);
-        if (nif->getVersion() >= NIFFile::NIFVersion::VER_MW && nif->getVersion() <= NIFFile::NIFVersion::VER_ZT2)
+        if (nif->getVersion() >= NIFFile::NIFVersion::VER_MW && nif->getVersion() <= NIFStream::generateVersion(10,0,1,0))
             lodCenter = nif->getVector3();
         unsigned int numLodLevels = nif->getUInt();
         for (unsigned int i=0; i<numLodLevels; ++i)


### PR DESCRIPTION
1. Remove some more obscure enumerated versions. They are for games we're never reasonably or unreasonably going to properly support anyway, I find myself unable to recall what's the exact version number behind them anyway every single time I reach back to my nif branch, they're not terribly descriptive, there isn't going to be any difference during runtime since generateVersion is constexpr, it's more difficult to compare loader files against NifTools research when they are used, and there are myriads of other reasons why it was a bad idea to add them in the first place. I left versions related to BGS games in, they're easier to remember and are much more relevant.
2. Per request, don't rely on a NIFStream object to call generateVersion, it's unnecessary; use NIFStream::generateVersion() instead.
3. Adjust NiPixelData loading, should be a bit faster and easier to handle if we decide that we need to implement every single pixel format.