### PR TITLE
Add basic NiPathController support (movement only)

### DIFF
--- a/components/nif/controller.cpp
+++ b/components/nif/controller.cpp
@@ -123,12 +123,10 @@ namespace Nif
     {
         Controller::read(nif);
 
-        /*
-           int = 1
-           2xfloat
-           short = 0 or 1
-        */
-        nif->skip(14);
+        bankDir = nif->getInt();
+        maxBankAngle = nif->getFloat();
+        smoothing = nif->getFloat();
+        followAxis = nif->getShort();
         posData.read(nif);
         floatData.read(nif);
     }

--- a/components/nif/controller.hpp
+++ b/components/nif/controller.hpp
@@ -96,6 +96,20 @@ public:
     NiPosDataPtr posData;
     NiFloatDataPtr floatData;
 
+    enum Flags
+    {
+        Flag_OpenCurve      = 0x020,
+        Flag_AllowFlip      = 0x040,
+        Flag_Bank           = 0x080,
+        Flag_ConstVelocity  = 0x100,
+        Flag_Follow         = 0x200,
+        Flag_FlipFollowAxis = 0x400
+    };
+
+    int bankDir;
+    float maxBankAngle, smoothing;
+    short followAxis;
+
     void read(NIFStream *nif);
     void post(NIFFile *nif);
 };

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -342,6 +342,25 @@ namespace NifOsg
         float mEmitStop;
     };
 
+    class PathController : public osg::NodeCallback, public SceneUtil::Controller
+    {
+    public:
+        PathController(const Nif::NiPathController* ctrl);
+        PathController() = default;
+        PathController(const PathController& copy, const osg::CopyOp& copyop);
+
+        META_Object(NifOsg, PathController)
+
+        virtual void operator() (osg::Node*, osg::NodeVisitor*);
+
+    private:
+        Vec3Interpolator mPath;
+        FloatInterpolator mPercent;
+        int mFlags{0};
+
+        float getPercent(float time) const;
+    };
+
 }
 
 #endif

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -752,6 +752,17 @@ namespace NifOsg
                         node->addUpdateCallback(callback);
                     }
                 }
+                else if (ctrl->recType == Nif::RC_NiPathController)
+                {
+                    const Nif::NiPathController *path = static_cast<const Nif::NiPathController*>(ctrl.getPtr());
+                    if (!path->posData.empty() && !path->floatData.empty())
+                    {
+                        osg::ref_ptr<PathController> callback(new PathController(path));
+
+                        setupController(path, callback, animflags);
+                        node->addUpdateCallback(callback);
+                    }
+                }
                 else if (ctrl->recType == Nif::RC_NiVisController)
                 {
                     handleVisController(static_cast<const Nif::NiVisController*>(ctrl.getPtr()), node, animflags);
@@ -777,6 +788,17 @@ namespace NifOsg
                         osg::ref_ptr<KeyframeController> callback(new KeyframeController(key->data.getPtr()));
 
                         setupController(key, callback, animflags);
+                        transformNode->addUpdateCallback(callback);
+                    }
+                }
+                else if (ctrl->recType == Nif::RC_NiPathController)
+                {
+                    const Nif::NiPathController *path = static_cast<const Nif::NiPathController*>(ctrl.getPtr());
+                    if (!path->posData.empty() && !path->floatData.empty())
+                    {
+                        osg::ref_ptr<PathController> callback(new PathController(path));
+
+                        setupController(path, callback, animflags);
                         transformNode->addUpdateCallback(callback);
                     }
                 }


### PR DESCRIPTION
A "placeholder" that doesn't quite implement the feature, but seems to be better than nothing. Allows insects from BCSounds, Nocturnal Moths and other models based on the same controller setup to move as intended, doesn't include advanced features of the controller.

Flags and other values in the record are unused but their values should be accurate.

Both geometry-type nodes and group-type nodes should support this controller.