### PR TITLE
Handle non-node roots more gracefully (bug #5416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     Bug #5369: Spawnpoint in the Grazelands doesn't produce oversized creatures
     Bug #5370: Opening an unlocked but trapped door uses the key
     Bug #5400: Editor: Verifier checks race of non-skin bodyparts
+    Bug #5416: Junk non-node records before the root node are not handled gracefully
     Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0

--- a/apps/openmw_test_suite/nifloader/testbulletnifloader.cpp
+++ b/apps/openmw_test_suite/nifloader/testbulletnifloader.cpp
@@ -349,19 +349,6 @@ namespace
         EXPECT_EQ(*result, expected);
     }
 
-    TEST_F(TestBulletNifLoader, for_root_not_nif_node_should_return_default)
-    {
-        StrictMock<RecordMock> record;
-
-        EXPECT_CALL(mNifFile, numRoots()).WillOnce(Return(1));
-        EXPECT_CALL(mNifFile, getRoot(0)).WillOnce(Return(&record));
-        const auto result = mLoader.load(mNifFile);
-
-        Resource::BulletShape expected;
-
-        EXPECT_EQ(*result, expected);
-    }
-
     TEST_F(TestBulletNifLoader, for_default_root_nif_node_should_return_default)
     {
         EXPECT_CALL(mNifFile, numRoots()).WillOnce(Return(1));

--- a/components/nifbullet/bulletnifloader.cpp
+++ b/components/nifbullet/bulletnifloader.cpp
@@ -132,20 +132,17 @@ osg::ref_ptr<Resource::BulletShape> BulletNifLoader::load(const Nif::File& nif)
     mStaticMesh.reset();
     mAvoidStaticMesh.reset();
 
-    if (nif.numRoots() < 1)
+    Nif::Node* node;
+    for (size_t i = 0; i < nif.numRoots(); ++i)
+    {
+        Nif::Record* r = nif.getRoot(i);
+        assert(r != nullptr);
+        if ((node = dynamic_cast<Nif::Node*>(r)))
+            break;
+    }
+    if (!node)
     {
         warn("Found no root nodes in NIF.");
-        return mShape;
-    }
-
-    Nif::Record *r = nif.getRoot(0);
-    assert(r != nullptr);
-
-    Nif::Node *node = dynamic_cast<Nif::Node*>(r);
-    if (node == nullptr)
-    {
-        warn("First root in file was not a node, but a " +
-             r->recName + ". Skipping file.");
         return mShape;
     }
 

--- a/components/nifbullet/bulletnifloader.cpp
+++ b/components/nifbullet/bulletnifloader.cpp
@@ -132,8 +132,9 @@ osg::ref_ptr<Resource::BulletShape> BulletNifLoader::load(const Nif::File& nif)
     mStaticMesh.reset();
     mAvoidStaticMesh.reset();
 
-    Nif::Node* node;
-    for (size_t i = 0; i < nif.numRoots(); ++i)
+    Nif::Node* node = nullptr;
+    const size_t numRoots = nif.numRoots();
+    for (size_t i = 0; i < numRoots; ++i)
     {
         Nif::Record* r = nif.getRoot(i);
         assert(r != nullptr);

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -247,8 +247,9 @@ namespace NifOsg
 
         static void loadKf(Nif::NIFFilePtr nif, KeyframeHolder& target)
         {
-            const Nif::NiSequenceStreamHelper *seq;
-            for (size_t i = 0; i < nif->numRoots(); ++i)
+            const Nif::NiSequenceStreamHelper *seq = nullptr;
+            const size_t numRoots = nif->numRoots();
+            for (size_t i = 0; i < numRoots; ++i)
             {
                 const Nif::Record *r = nif->getRoot(i);
                 assert(r != nullptr);
@@ -304,8 +305,9 @@ namespace NifOsg
 
         osg::ref_ptr<osg::Node> load(Nif::NIFFilePtr nif, Resource::ImageManager* imageManager)
         {
-            const Nif::Node* nifNode;
-            for (size_t i = 0; i < nif->numRoots(); ++i)
+            const Nif::Node* nifNode = nullptr;
+            const size_t numRoots = nif->numRoots();
+            for (size_t i = 0; i < numRoots; ++i)
             {
                 const Nif::Record* r = nif->getRoot(i);
                 if ((nifNode = dynamic_cast<const Nif::Node*>(r)))


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5416)

NIF loaders will at least try to find a valid root node before declaring that the NIF file is completely unusable. This fixes the gauntlet model in my testing.