### PR TITLE
Introduce NiGeometry abstraction

### DIFF
--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -31,7 +31,7 @@ void NiSkinInstance::post(NIFFile *nif)
     }
 }
 
-void ShapeData::read(NIFStream *nif)
+void NiGeometryData::read(NIFStream *nif)
 {
     int verts = nif->getUShort();
 
@@ -69,7 +69,7 @@ void ShapeData::read(NIFStream *nif)
 
 void NiTriShapeData::read(NIFStream *nif)
 {
-    ShapeData::read(nif);
+    NiGeometryData::read(nif);
 
     /*int tris =*/ nif->getUShort();
 
@@ -92,7 +92,7 @@ void NiTriShapeData::read(NIFStream *nif)
 
 void NiTriStripsData::read(NIFStream *nif)
 {
-    ShapeData::read(nif);
+    NiGeometryData::read(nif);
 
     // Every strip with n points defines n-2 triangles, so this should be unnecessary.
     /*int tris =*/ nif->getUShort();
@@ -112,7 +112,7 @@ void NiTriStripsData::read(NIFStream *nif)
 
 void NiAutoNormalParticlesData::read(NIFStream *nif)
 {
-    ShapeData::read(nif);
+    NiGeometryData::read(nif);
 
     // Should always match the number of vertices
     numParticles = nif->getUShort();

--- a/components/nif/data.hpp
+++ b/components/nif/data.hpp
@@ -32,7 +32,7 @@ namespace Nif
 {
 
 // Common ancestor for several data classes
-class ShapeData : public Record
+class NiGeometryData : public Record
 {
 public:
     std::vector<osg::Vec3f> vertices, normals;
@@ -44,7 +44,7 @@ public:
     void read(NIFStream *nif);
 };
 
-class NiTriShapeData : public ShapeData
+class NiTriShapeData : public NiGeometryData
 {
 public:
     // Triangles, three vertex indices per triangle
@@ -53,7 +53,7 @@ public:
     void read(NIFStream *nif);
 };
 
-class NiTriStripsData : public ShapeData
+class NiTriStripsData : public NiGeometryData
 {
 public:
     // Triangle strips, series of vertex indices.
@@ -62,7 +62,7 @@ public:
     void read(NIFStream *nif);
 };
 
-class NiAutoNormalParticlesData : public ShapeData
+class NiAutoNormalParticlesData : public NiGeometryData
 {
 public:
     int numParticles;

--- a/components/nif/node.hpp
+++ b/components/nif/node.hpp
@@ -128,7 +128,12 @@ struct NiNode : Node
     }
 };
 
-struct NiTriShape : Node
+struct NiGeometry : Node
+{
+    NiSkinInstancePtr skin;
+};
+
+struct NiTriShape : NiGeometry
 {
     /* Possible flags:
         0x40 - mesh has no vertex normals ?
@@ -138,7 +143,6 @@ struct NiTriShape : Node
     */
 
     NiTriShapeDataPtr data;
-    NiSkinInstancePtr skin;
 
     void read(NIFStream *nif)
     {
@@ -157,10 +161,9 @@ struct NiTriShape : Node
     }
 };
 
-struct NiTriStrips : Node
+struct NiTriStrips : NiGeometry
 {
     NiTriStripsDataPtr data;
-    NiSkinInstancePtr skin;
 
     void read(NIFStream *nif)
     {

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -649,11 +649,7 @@ namespace NifOsg
                 const bool isMarker = hasMarkers && !nodeName.compare(0, markerName.size(), markerName);
                 if (!isMarker && nodeName.compare(0, shadowName.size(), shadowName) && nodeName.compare(0, shadowName2.size(), shadowName2))
                 {
-                    Nif::NiSkinInstancePtr skin;
-                    if (nifNode->recType == Nif::RC_NiTriShape)
-                        skin = static_cast<const Nif::NiTriShape*>(nifNode)->skin;
-                    else // if (nifNode->recType == Nif::RC_NiTriStrips)
-                        skin = static_cast<const Nif::NiTriStrips*>(nifNode)->skin;
+                    Nif::NiSkinInstancePtr skin = static_cast<const Nif::NiGeometry*>(nifNode)->skin;
 
                     if (skin.empty())
                         handleTriShape(nifNode, node, composite, boundTextures, animflags);
@@ -1294,12 +1290,7 @@ namespace NifOsg
             // Assign bone weights
             osg::ref_ptr<SceneUtil::RigGeometry::InfluenceMap> map (new SceneUtil::RigGeometry::InfluenceMap);
 
-            Nif::NiSkinInstancePtr skinPtr;
-            if (nifNode->recType == Nif::RC_NiTriShape)
-                skinPtr = static_cast<const Nif::NiTriShape*>(nifNode)->skin;
-            else
-                skinPtr = static_cast<const Nif::NiTriStrips*>(nifNode)->skin;
-            const Nif::NiSkinInstance *skin = skinPtr.getPtr();
+            const Nif::NiSkinInstance *skin = static_cast<const Nif::NiGeometry*>(nifNode)->skin.getPtr();
             const Nif::NiSkinData *data = skin->data.getPtr();
             const Nif::NodeList &bones = skin->bones;
             for(size_t i = 0;i < bones.length();i++)


### PR DESCRIPTION
This is kind of how NifSkope does it and it allows to handle skinned geometry in a more generic way.

ShapeData has been renamed into NiGeometryData.

Data record pointer can't be moved as it is, so it stays in the individual geometry classes. So skin pointer reading should also happen on per-record type basis.