### PR TITLE
CopyRigVisitor fixes (bug #5415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     Bug #5369: Spawnpoint in the Grazelands doesn't produce oversized creatures
     Bug #5370: Opening an unlocked but trapped door uses the key
     Bug #5400: Editor: Verifier checks race of non-skin bodyparts
+    Bug #5415: Environment maps in ebony cuirass and HiRez Armors Indoril cuirass don't work
     Bug #5416: Junk non-node records before the root node are not handled gracefully
     Feature #5362: Show the soul gems' trapped soul in count dialog
 

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -45,23 +45,26 @@ namespace SceneUtil
 
         virtual void apply(osg::Drawable& drawable)
         {
-            std::string lowerName = Misc::StringUtils::lowerCase(drawable.getName());
-            if ((lowerName.size() >= mFilter.size() && lowerName.compare(0, mFilter.size(), mFilter) == 0)
-                    || (lowerName.size() >= mFilter2.size() && lowerName.compare(0, mFilter2.size(), mFilter2) == 0))
+            if (!filterMatches(drawable.getName()))
+                return;
+
+            osg::Node* node = &drawable;
+            if (!node)
+                return;
+            while (node->getNumParents())
             {
-                osg::Node* node = &drawable;
-                while (node && node->getNumParents() && !node->getStateSet())
-                    node = node->getParent(0);
-                if (node)
-                    mToCopy.push_back(node);
+                osg::Group* parent = node->getParent(0);
+                if (!parent || !filterMatches(parent->getName()))
+                    break;
+                node = parent;
             }
+            mToCopy.emplace(node);
         }
 
         void doCopy()
         {
-            for (std::vector<osg::ref_ptr<osg::Node> >::iterator it = mToCopy.begin(); it != mToCopy.end(); ++it)
+            for (const osg::ref_ptr<osg::Node>& node : mToCopy)
             {
-                osg::ref_ptr<osg::Node> node = *it;
                 if (node->getNumParents() > 1)
                     Log(Debug::Error) << "Error CopyRigVisitor: node has multiple parents";
                 while (node->getNumParents())
@@ -73,8 +76,16 @@ namespace SceneUtil
         }
 
     private:
-        typedef std::vector<osg::ref_ptr<osg::Node> > NodeVector;
-        NodeVector mToCopy;
+
+        bool filterMatches(const std::string& name) const
+        {
+            std::string lowerName = Misc::StringUtils::lowerCase(name);
+            return (lowerName.size() >= mFilter.size() && lowerName.compare(0, mFilter.size(), mFilter) == 0)
+                || (lowerName.size() >= mFilter2.size() && lowerName.compare(0, mFilter2.size(), mFilter2) == 0);
+        }
+
+        using NodeSet = std::set<osg::ref_ptr<osg::Node>>;
+        NodeSet mToCopy;
 
         osg::ref_ptr<osg::Group> mParent;
         std::string mFilter;

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -49,8 +49,6 @@ namespace SceneUtil
                 return;
 
             osg::Node* node = &drawable;
-            if (!node)
-                return;
             while (node->getNumParents())
             {
                 osg::Group* parent = node->getParent(0);


### PR DESCRIPTION
If you check the cuirasses mentioned in the title of [the report](https://gitlab.com/OpenMW/openmw/-/issues/5415) you'll notice that if they are placed in the world as body parts they'll still have their environment map; the issue is triggered later on when they are attached to the actor.

The environment map effect is assigned to a node that didn't get copied by CopyRigVisitor (in these cuirasses it's Chest node). It's named appropriately but NiTriShapes under that node have their own stateset so CopyRigVisitor ignored it. Apparently vanilla seems to make all appropriately named nodes a part of the body part (you can check it if you rename the Chest node into something else, that'll kill the environment map) that gets attached, so the effect affects the chest geometry as well. These changes should make sure CopyRigVisitor does something similar.

There's a flaw that isn't going to be solved by this, however: optimizer may optimize out nodes it deems redundant between the geometry node and the node with the effect stateset, so the body part geometry may be affected by the environment map erroneously or somehow have incorrect transformations. Try to put an empty node between Tri Chest N nodes and the Chest node in a cuirass; the environment map will disappear in vanilla and in OpenMW without optimizations applied but it won't disappear in OpenMW with optimizations. No good solution for this atm.

Also copied nodes are cached into a set and not a vector so they won't be copied multiple times if multiple geometry nodes in the body part have it as a parent.

Yes, this brings back the infamous environment map used for ebony cuirass, which is also visible when MCP is installed in the original engine. The fact that environment maps are supported for skinned geometry is still a desirable behavior since HiRez Armors mod's indoril cuirass mesh relies on it.