### PR TITLE
Fix Bullet flags usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(BUILD_NIFTEST            "Build nif file tester" ON)
 option(BUILD_DOCS               "Build documentation." OFF )
 option(BUILD_WITH_CODE_COVERAGE "Enable code coverage with gconv" OFF)
 option(BUILD_UNITTESTS          "Enable Unittests with Google C++ Unittest" OFF)
+option(BULLET_USE_DOUBLES       "Use double precision for Bullet" OFF)
 
 if (NOT BUILD_LAUNCHER AND NOT BUILD_OPENCS AND NOT BUILD_WIZARD)
    set(USE_QT FALSE)
@@ -904,4 +905,3 @@ if (DOXYGEN_FOUND)
         WORKING_DIRECTORY ${OpenMW_BINARY_DIR}
         COMMENT "Generating documentation for the github-pages at ${DOXYGEN_PAGES_OUTPUT_DIR}" VERBATIM)
 endif ()
-

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -15,6 +15,10 @@ set(GAME_HEADER
     engine.hpp
 )
 
+if (BULLET_USE_DOUBLES)
+    add_definitions(-DBT_USE_DOUBLE_PRECISION)
+endif()
+
 source_group(game FILES ${GAME} ${GAME_HEADER})
 
 add_openmw_dir (mwrender

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -15,6 +15,9 @@
 #include <MyGUI_ClipboardManager.h>
 #include <MyGUI_WidgetManager.h>
 
+// For BT_NO_PROFILE
+#include <LinearMath/btQuickprof.h>
+
 #include <SDL_keyboard.h>
 #include <SDL_clipboard.h>
 
@@ -2202,7 +2205,9 @@ namespace MWGui
 
     void WindowManager::toggleDebugWindow()
     {
+#ifndef BT_NO_PROFILE
         mDebugWindow->setVisible(!mDebugWindow->isVisible());
+#endif
     }
 
     void WindowManager::cycleSpell(bool next)

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -285,3 +285,7 @@ endif()
 
 # Make the variable accessible for other subdirectories
 set(COMPONENT_FILES ${COMPONENT_FILES} PARENT_SCOPE)
+
+if (BULLET_USE_DOUBLES)
+    add_definitions(-DBT_USE_DOUBLE_PRECISION)
+endif()


### PR DESCRIPTION
Summary of changes:
1. Disable physics profiler window (F10), if Bullet was compiled with BT_NO_PROFILE. This window is just empty and does not get any input anyway, when the BT_NO_PROFILE is defined.
2. Add a BULLET_USE_DOUBLES option for CMake to define BT_USE_DOUBLE_PRECISION compile flag. When this flag is present, compiler thinks that the `btScalar` is a `double`, otherwise it thinks that the `btScalar` is a `float`. Allows to fix linking issues.