### PR TITLE
Fix spell school calculation

### DIFF
--- a/apps/openmw/mwmechanics/spellutil.cpp
+++ b/apps/openmw/mwmechanics/spellutil.cpp
@@ -101,6 +101,9 @@ namespace MWMechanics
 
     float getSpellSuccessChance (const ESM::Spell* spell, const MWWorld::Ptr& actor, int* effectiveSchool, bool cap, bool checkMagicka)
     {
+        // NB: Base chance is calculated here because the effective school pointer must be filled
+        float baseChance = calcSpellBaseSuccessChance(spell, actor, effectiveSchool);
+
         bool godmode = actor == getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState();
 
         CreatureStats& stats = actor.getClass().getCreatureStats(actor);
@@ -124,7 +127,7 @@ namespace MWMechanics
             return 100;
 
         float castBonus = -stats.getMagicEffects().get(ESM::MagicEffect::Sound).getMagnitude();
-        float castChance = calcSpellBaseSuccessChance(spell, actor, effectiveSchool) + castBonus;
+        float castChance = baseChance + castBonus;
         castChance *= stats.getFatigueTerm();
 
         return std::max(0.f, cap ? std::min(100.f, castChance) : castChance);


### PR DESCRIPTION
An overlooked part of spellcasting refactoring. Moved the combined base chance and spell school calculation back where it belongs and added a comment that clarifies it must be there. Fixes the calculation of spell school for spells that don't use the calculated chance (e.g. spells that can't be casted due to the lack of mana, like in the [report](https://forum.openmw.org/viewtopic.php?f=8&p=67631#p67622)).