### PR TITLE
Fix AiWander crash

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -292,7 +292,8 @@ namespace MWMechanics
             completeManualWalking(actor, storage);
         }
 
-        if (storage.mState == AiWanderStorage::Wander_Walking
+        if (storage.mIsWanderingManually
+            && storage.mState == AiWanderStorage::Wander_Walking
             && (mPathFinder.getPathSize() == 0
                 || isDestinationHidden(actor, mPathFinder.getPath().back())
                 || isAreaOccupiedByOtherActor(actor, mPathFinder.getPath().back())))

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -293,7 +293,8 @@ namespace MWMechanics
         }
 
         if (storage.mState == AiWanderStorage::Wander_Walking
-            && (isDestinationHidden(actor, mPathFinder.getPath().back())
+            && (mPathFinder.getPathSize() == 0
+                || isDestinationHidden(actor, mPathFinder.getPath().back())
                 || isAreaOccupiedByOtherActor(actor, mPathFinder.getPath().back())))
             completeManualWalking(actor, storage);
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -276,8 +276,7 @@ namespace MWMechanics
             completeManualWalking(actor, storage);
         }
 
-        AiWanderStorage::WanderState& wanderState = storage.mState;
-        if ((wanderState == AiWanderStorage::Wander_MoveNow) && storage.mCanWanderAlongPathGrid)
+        if (storage.mState == AiWanderStorage::Wander_MoveNow && storage.mCanWanderAlongPathGrid)
         {
             // Construct a new path if there isn't one
             if(!mPathFinder.isPathConstructed())
@@ -293,7 +292,7 @@ namespace MWMechanics
             completeManualWalking(actor, storage);
         }
 
-        if (wanderState == AiWanderStorage::Wander_Walking
+        if (storage.mState == AiWanderStorage::Wander_Walking
             && (isDestinationHidden(actor, mPathFinder.getPath().back())
                 || isAreaOccupiedByOtherActor(actor, mPathFinder.getPath().back())))
             completeManualWalking(actor, storage);


### PR DESCRIPTION
Based on report from [discord](https://discordapp.com/channels/260439894298460160/260443579908882434/711120918075670589):
> CMAugustToday at 9:40 AM
Ouch, just had a crash while playing in the bzzt branch
![crash](https://cdn.discordapp.com/attachments/260443579908882434/711120912916807750/openmw_bzzt_crash5.png)
Just exited a door from one vivec hlaalu interior to another and it conked out

Still unclear when this happens. I wasn't able to reproduce the situation when path is empty but storage.mState is Wander_Walking. Looking at the code this is possible only due to package reset. And reset for AiWander happens only when package duration is ended. For now just considering empty path for walking state as condition to stop walking.

Also disabled check for target in LOS for actors wandering over pathgrid. This is quite noticable, actors almost stopped wander at interior cells.