### PR TITLE
AiPackage refactoring

### DIFF
--- a/apps/openmw/mwmechanics/aiactivate.cpp
+++ b/apps/openmw/mwmechanics/aiactivate.cpp
@@ -44,11 +44,6 @@ namespace MWMechanics
         return false;
     }
 
-    int AiActivate::getTypeId() const
-    {
-        return TypeIdActivate;
-    }
-
     void AiActivate::writeState(ESM::AiSequence::AiSequence &sequence) const
     {
         std::unique_ptr<ESM::AiSequence::AiActivate> activate(new ESM::AiSequence::AiActivate());

--- a/apps/openmw/mwmechanics/aiactivate.hpp
+++ b/apps/openmw/mwmechanics/aiactivate.hpp
@@ -29,7 +29,8 @@ namespace MWMechanics
             AiActivate(const ESM::AiSequence::AiActivate* activate);
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
-            int getTypeId() const final;
+
+            static constexpr TypeId getTypeId() { return TypeIdActivate; }
 
             void writeState(ESM::AiSequence::AiSequence& sequence) const final;
 

--- a/apps/openmw/mwmechanics/aiavoiddoor.cpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.cpp
@@ -72,16 +72,6 @@ bool MWMechanics::AiAvoidDoor::execute (const MWWorld::Ptr& actor, CharacterCont
     return false;
 }
 
-int MWMechanics::AiAvoidDoor::getTypeId() const
-{
-    return TypeIdAvoidDoor;
-}
-
-unsigned int MWMechanics::AiAvoidDoor::getPriority() const
-{
- return 2;
-}
-
 bool MWMechanics::AiAvoidDoor::isStuck(const osg::Vec3f& actorPos) const
 {
     return (actorPos - mLastPos).length2() < 10 * 10;

--- a/apps/openmw/mwmechanics/aiavoiddoor.hpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.hpp
@@ -24,12 +24,13 @@ namespace MWMechanics
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdAvoidDoor; }
 
-            unsigned int getPriority() const final;
+            static constexpr unsigned int defaultPriority() { return 2; }
 
-            bool canCancel() const final { return false; }
-            bool shouldCancelPreviousAi() const final { return false; }
+            static constexpr bool defaultCanCancel() { return false; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return false; }
 
         private:
             float mDuration;

--- a/apps/openmw/mwmechanics/aibreathe.cpp
+++ b/apps/openmw/mwmechanics/aibreathe.cpp
@@ -31,13 +31,3 @@ bool MWMechanics::AiBreathe::execute (const MWWorld::Ptr& actor, CharacterContro
 
     return true;
 }
-
-int MWMechanics::AiBreathe::getTypeId() const
-{
-    return TypeIdBreathe;
-}
-
-unsigned int MWMechanics::AiBreathe::getPriority() const
-{
-    return 2;
-}

--- a/apps/openmw/mwmechanics/aibreathe.hpp
+++ b/apps/openmw/mwmechanics/aibreathe.hpp
@@ -12,13 +12,13 @@ namespace MWMechanics
         public:
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdBreathe; }
 
-            unsigned int getPriority() const final;
+            static constexpr unsigned int defaultPriority() { return 2; }
 
-            bool canCancel() const final { return false; }
-            bool shouldCancelPreviousAi() const final { return false; }
+            static constexpr bool defaultCanCancel() { return false; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return false; }
     };
 }
 #endif
-

--- a/apps/openmw/mwmechanics/aicast.cpp
+++ b/apps/openmw/mwmechanics/aicast.cpp
@@ -79,13 +79,3 @@ MWWorld::Ptr MWMechanics::AiCast::getTarget() const
 
     return target;
 }
-
-int MWMechanics::AiCast::getTypeId() const
-{
-    return AiPackage::TypeIdCast;
-}
-
-unsigned int MWMechanics::AiCast::getPriority() const
-{
-    return 3;
-}

--- a/apps/openmw/mwmechanics/aicast.hpp
+++ b/apps/openmw/mwmechanics/aicast.hpp
@@ -17,14 +17,15 @@ namespace MWMechanics
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdCast; }
 
             MWWorld::Ptr getTarget() const final;
 
-            unsigned int getPriority() const final;
+            static constexpr unsigned int defaultPriority() { return 3; }
 
-            bool canCancel() const final { return false; }
-            bool shouldCancelPreviousAi() const final { return false; }
+            static constexpr bool defaultCanCancel() { return false; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return false; }
 
         private:
             std::string mTargetId;

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -406,16 +406,6 @@ namespace MWMechanics
         }
     }
 
-    int AiCombat::getTypeId() const
-    {
-        return TypeIdCombat;
-    }
-
-    unsigned int AiCombat::getPriority() const
-    {
-        return 1;
-    }
-
     MWWorld::Ptr AiCombat::getTarget() const
     {
         return MWBase::Environment::get().getWorld()->searchPtrViaActorId(mTargetActorId);

--- a/apps/openmw/mwmechanics/aicombat.hpp
+++ b/apps/openmw/mwmechanics/aicombat.hpp
@@ -104,17 +104,18 @@ namespace MWMechanics
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdCombat; }
 
-            unsigned int getPriority() const final;
+            static constexpr unsigned int defaultPriority() { return 1; }
 
             ///Returns target ID
             MWWorld::Ptr getTarget() const final;
 
             void writeState(ESM::AiSequence::AiSequence &sequence) const final;
 
-            bool canCancel() const final { return false; }
-            bool shouldCancelPreviousAi() const final { return false; }
+            static constexpr bool defaultCanCancel() { return false; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return false; }
 
         private:
             /// Returns true if combat should end

--- a/apps/openmw/mwmechanics/aiescort.cpp
+++ b/apps/openmw/mwmechanics/aiescort.cpp
@@ -100,11 +100,6 @@ namespace MWMechanics
         return false;
     }
 
-    int AiEscort::getTypeId() const
-    {
-        return TypeIdEscort;
-    }
-
     void AiEscort::writeState(ESM::AiSequence::AiSequence &sequence) const
     {
         std::unique_ptr<ESM::AiSequence::AiEscort> escort(new ESM::AiSequence::AiEscort());

--- a/apps/openmw/mwmechanics/aiescort.hpp
+++ b/apps/openmw/mwmechanics/aiescort.hpp
@@ -32,11 +32,11 @@ namespace MWMechanics
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdEscort; }
 
-            bool useVariableSpeed() const final { return true; }
+            static constexpr bool defaultUseVariableSpeed() { return true; }
 
-            bool sideWithTarget() const final { return true; }
+            static constexpr bool defaultSideWithTarget() { return true; }
 
             void writeState(ESM::AiSequence::AiSequence &sequence) const final;
 

--- a/apps/openmw/mwmechanics/aiface.cpp
+++ b/apps/openmw/mwmechanics/aiface.cpp
@@ -14,13 +14,3 @@ bool MWMechanics::AiFace::execute(const MWWorld::Ptr& actor, MWMechanics::Charac
     osg::Vec3f dir = osg::Vec3f(mTargetX, mTargetY, 0) - actor.getRefData().getPosition().asVec3();
     return zTurn(actor, std::atan2(dir.x(), dir.y()), osg::DegreesToRadians(3.f));
 }
-
-int MWMechanics::AiFace::getTypeId() const
-{
-    return AiPackage::TypeIdFace;
-}
-
-unsigned int MWMechanics::AiFace::getPriority() const
-{
-    return 2;
-}

--- a/apps/openmw/mwmechanics/aiface.hpp
+++ b/apps/openmw/mwmechanics/aiface.hpp
@@ -12,12 +12,13 @@ namespace MWMechanics
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdFace; }
 
-            unsigned int getPriority() const final;
+            static constexpr unsigned int defaultPriority() { return 2; }
 
-            bool canCancel() const final { return false; }
-            bool shouldCancelPreviousAi() const final { return false; }
+            static constexpr bool defaultCanCancel() { return false; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return false; }
 
         private:
             float mTargetX, mTargetY;

--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -16,25 +16,24 @@
 
 namespace MWMechanics
 {
-
 int AiFollow::mFollowIndexCounter = 0;
 
 AiFollow::AiFollow(const std::string &actorId, float duration, float x, float y, float z)
-: mAlwaysFollow(false), mCommanded(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
+: mAlwaysFollow(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
 , mCellId(""), mActive(false), mFollowIndex(mFollowIndexCounter++)
 {
     mTargetActorRefId = actorId;
 }
 
 AiFollow::AiFollow(const std::string &actorId, const std::string &cellId, float duration, float x, float y, float z)
-: mAlwaysFollow(false), mCommanded(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
+: mAlwaysFollow(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
 , mCellId(cellId), mActive(false), mFollowIndex(mFollowIndexCounter++)
 {
     mTargetActorRefId = actorId;
 }
 
 AiFollow::AiFollow(const MWWorld::Ptr& actor, float duration, float x, float y, float z)
-: mAlwaysFollow(false), mCommanded(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
+: mAlwaysFollow(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
 , mCellId(""), mActive(false), mFollowIndex(mFollowIndexCounter++)
 {
     mTargetActorRefId = actor.getCellRef().getRefId();
@@ -42,7 +41,7 @@ AiFollow::AiFollow(const MWWorld::Ptr& actor, float duration, float x, float y, 
 }
 
 AiFollow::AiFollow(const MWWorld::Ptr& actor, const std::string &cellId, float duration, float x, float y, float z)
-: mAlwaysFollow(false), mCommanded(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
+: mAlwaysFollow(false), mDuration(duration), mRemainingDuration(duration), mX(x), mY(y), mZ(z)
 , mCellId(cellId), mActive(false), mFollowIndex(mFollowIndexCounter++)
 {
     mTargetActorRefId = actor.getCellRef().getRefId();
@@ -50,18 +49,20 @@ AiFollow::AiFollow(const MWWorld::Ptr& actor, const std::string &cellId, float d
 }
 
 AiFollow::AiFollow(const MWWorld::Ptr& actor, bool commanded)
-: mAlwaysFollow(true), mCommanded(commanded), mDuration(0), mRemainingDuration(0), mX(0), mY(0), mZ(0)
+: mAlwaysFollow(true), mDuration(0), mRemainingDuration(0), mX(0), mY(0), mZ(0)
 , mCellId(""), mActive(false), mFollowIndex(mFollowIndexCounter++)
 {
+    mOptions.mShouldCancelPreviousAi = !commanded;
     mTargetActorRefId = actor.getCellRef().getRefId();
     mTargetActorId = actor.getClass().getCreatureStats(actor).getActorId();
 }
 
 AiFollow::AiFollow(const ESM::AiSequence::AiFollow *follow)
-    : mAlwaysFollow(follow->mAlwaysFollow), mCommanded(follow->mCommanded), mRemainingDuration(follow->mRemainingDuration)
+    : mAlwaysFollow(follow->mAlwaysFollow), mRemainingDuration(follow->mRemainingDuration)
     , mX(follow->mData.mX), mY(follow->mData.mY), mZ(follow->mData.mZ)
     , mCellId(follow->mCellId), mActive(follow->mActive), mFollowIndex(mFollowIndexCounter++)
 {
+    mOptions.mShouldCancelPreviousAi = !follow->mCommanded;
     mTargetActorRefId = follow->mTargetId;
     mTargetActorId = follow->mTargetActorId;
     // mDuration isn't saved in the save file, so just giving it "1" for now if the package had a duration.
@@ -201,14 +202,9 @@ std::string AiFollow::getFollowedActor()
     return mTargetActorRefId;
 }
 
-int AiFollow::getTypeId() const
-{
-    return TypeIdFollow;
-}
-
 bool AiFollow::isCommanded() const
 {
-    return mCommanded;
+    return !mOptions.mShouldCancelPreviousAi;
 }
 
 void AiFollow::writeState(ESM::AiSequence::AiSequence &sequence) const
@@ -222,7 +218,7 @@ void AiFollow::writeState(ESM::AiSequence::AiSequence &sequence) const
     follow->mRemainingDuration = mRemainingDuration;
     follow->mCellId = mCellId;
     follow->mAlwaysFollow = mAlwaysFollow;
-    follow->mCommanded = mCommanded;
+    follow->mCommanded = isCommanded();
     follow->mActive = mActive;
 
     ESM::AiSequence::AiPackageContainer package;

--- a/apps/openmw/mwmechanics/aifollow.hpp
+++ b/apps/openmw/mwmechanics/aifollow.hpp
@@ -53,15 +53,15 @@ namespace MWMechanics
 
             AiFollow(const ESM::AiSequence::AiFollow* follow);
 
-            bool sideWithTarget() const final { return true; }
-            bool followTargetThroughDoors() const final { return true; }
-            bool shouldCancelPreviousAi() const final { return !mCommanded; }
+            static constexpr bool defaultSideWithTarget() { return true; }
+
+            static constexpr bool defaultFollowTargetThroughDoors() { return true; }
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdFollow; }
 
-            bool useVariableSpeed() const final { return true; }
+            static constexpr bool defaultUseVariableSpeed() { return true; }
 
             /// Returns the actor being followed
             std::string getFollowedActor();
@@ -87,7 +87,6 @@ namespace MWMechanics
             /// This will make the actor always follow.
             /** Thus ignoring mDuration and mX,mY,mZ (used for summoned creatures). **/
             bool mAlwaysFollow;
-            bool mCommanded;
             float mDuration; // Hours
             float mRemainingDuration; // Hours
             float mX;

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -24,7 +24,9 @@
 
 #include <osg/Quat>
 
-MWMechanics::AiPackage::AiPackage() :
+MWMechanics::AiPackage::AiPackage(TypeId typeId, const Options& options) :
+    mTypeId(typeId),
+    mOptions(options),
     mTimer(AI_REACTION_TIME + 1.0f), // to force initial pathbuild
     mTargetActorRefId(""),
     mTargetActorId(-1),
@@ -56,31 +58,6 @@ MWWorld::Ptr MWMechanics::AiPackage::getTarget() const
         return MWBase::Environment::get().getWorld()->searchPtrViaActorId(mTargetActorId);
     else
         return MWWorld::Ptr();
-}
-
-bool MWMechanics::AiPackage::sideWithTarget() const
-{
-    return false;
-}
-
-bool MWMechanics::AiPackage::followTargetThroughDoors() const
-{
-    return false;
-}
-
-bool MWMechanics::AiPackage::canCancel() const
-{
-    return true;
-}
-
-bool MWMechanics::AiPackage::shouldCancelPreviousAi() const
-{
-    return true;
-}
-
-bool MWMechanics::AiPackage::getRepeat() const
-{
-    return false;
 }
 
 void MWMechanics::AiPackage::reset()

--- a/apps/openmw/mwmechanics/aipackage.hpp
+++ b/apps/openmw/mwmechanics/aipackage.hpp
@@ -55,10 +55,37 @@ namespace MWMechanics
                 TypeIdCast = 11
             };
 
-            ///Default constructor
-            AiPackage();
+            struct Options
+            {
+                unsigned int mPriority;
+                bool mUseVariableSpeed;
+                bool mSideWithTarget;
+                bool mFollowTargetThroughDoors;
+                bool mShouldCancelPreviousAi;
+                bool mCanCancel;
+                bool mRepeat;
+                bool mAlwaysActive;
+            };
+
+            AiPackage(TypeId typeId, const Options& options);
 
             virtual ~AiPackage() = default;
+
+            static constexpr unsigned int defaultPriority() { return 0; }
+
+            static constexpr bool defaultUseVariableSpeed() { return false; }
+
+            static constexpr bool defaultSideWithTarget() { return false; }
+
+            static constexpr bool defaultFollowTargetThroughDoors() { return false; }
+
+            static constexpr bool defaultCanCancel() { return true; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return true; }
+
+            static constexpr bool defaultRepeat() { return false; }
+
+            static constexpr bool defaultAlwaysActive() { return false; }
 
             ///Clones the package
             virtual std::unique_ptr<AiPackage> clone() const = 0;
@@ -69,13 +96,13 @@ namespace MWMechanics
 
             /// Returns the TypeID of the AiPackage
             /// \see enum TypeId
-            virtual int getTypeId() const = 0;
+            TypeId getTypeId() const { return mTypeId; }
 
             /// Higher number is higher priority (0 being the lowest)
-            virtual unsigned int getPriority() const {return 0;}
+            unsigned int getPriority() const { return mOptions.mPriority; }
 
             /// Check if package use movement with variable speed
-            virtual bool useVariableSpeed() const { return false;}
+            bool useVariableSpeed() const { return mOptions.mUseVariableSpeed; }
 
             virtual void writeState (ESM::AiSequence::AiSequence& sequence) const {}
 
@@ -89,24 +116,24 @@ namespace MWMechanics
             virtual osg::Vec3f getDestination(const MWWorld::Ptr& actor) const { return osg::Vec3f(0, 0, 0); };
 
             /// Return true if having this AiPackage makes the actor side with the target in fights (default false)
-            virtual bool sideWithTarget() const;
+            bool sideWithTarget() const { return mOptions.mSideWithTarget; }
 
             /// Return true if the actor should follow the target through teleport doors (default false)
-            virtual bool followTargetThroughDoors() const;
+            bool followTargetThroughDoors() const { return mOptions.mFollowTargetThroughDoors; }
 
             /// Can this Ai package be canceled? (default true)
-            virtual bool canCancel() const;
+            bool canCancel() const { return mOptions.mCanCancel; }
 
             /// Upon adding this Ai package, should the Ai Sequence attempt to cancel previous Ai packages (default true)?
-            virtual bool shouldCancelPreviousAi() const;
+            bool shouldCancelPreviousAi() const { return mOptions.mShouldCancelPreviousAi; }
 
             /// Return true if this package should repeat. Currently only used for Wander packages.
-            virtual bool getRepeat() const;
+            bool getRepeat() const { return mOptions.mRepeat; }
 
             virtual osg::Vec3f getDestination() const { return osg::Vec3f(0, 0, 0); }
 
-            // Return true if any loaded actor with this AI package must be active.
-            virtual bool alwaysActive() const { return false; }
+            /// Return true if any loaded actor with this AI package must be active.
+            bool alwaysActive() const { return mOptions.mAlwaysActive; }
 
             /// Reset pathfinding state
             void reset();
@@ -138,6 +165,9 @@ namespace MWMechanics
             const PathgridGraph& getPathGridGraph(const MWWorld::CellStore* cell);
 
             DetourNavigator::Flags getNavigatorFlags(const MWWorld::Ptr& actor) const;
+
+            const TypeId mTypeId = TypeIdNone;
+            Options mOptions;
 
             // TODO: all this does not belong here, move into temporary storage
             PathFinder mPathFinder;

--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -66,11 +66,6 @@ bool AiPursue::execute (const MWWorld::Ptr& actor, CharacterController& characte
     return false;
 }
 
-int AiPursue::getTypeId() const
-{
-    return TypeIdPursue;
-}
-
 MWWorld::Ptr AiPursue::getTarget() const
 {
     return MWBase::Environment::get().getWorld()->searchPtrViaActorId(mTargetActorId);

--- a/apps/openmw/mwmechanics/aipursue.hpp
+++ b/apps/openmw/mwmechanics/aipursue.hpp
@@ -27,14 +27,16 @@ namespace MWMechanics
             AiPursue(const ESM::AiSequence::AiPursue* pursue);
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
-            int getTypeId() const final;
+
+            static constexpr TypeId getTypeId() { return TypeIdPursue; }
 
             MWWorld::Ptr getTarget() const final;
 
             void writeState (ESM::AiSequence::AiSequence& sequence) const final;
 
-            bool canCancel() const final { return false; }
-            bool shouldCancelPreviousAi() const final { return false; }
+            static constexpr bool defaultCanCancel() { return false; }
+
+            static constexpr bool defaultShouldCancelPreviousAi() { return false; }
     };
 }
 #endif

--- a/apps/openmw/mwmechanics/aisequence.cpp
+++ b/apps/openmw/mwmechanics/aisequence.cpp
@@ -338,7 +338,7 @@ void AiSequence::stack (const AiPackage& package, const MWWorld::Ptr& actor, boo
             dest = actor.getRefData().getPosition().asVec3();
         }
 
-        MWMechanics::AiTravel travelPackage(dest.x(), dest.y(), dest.z(), true);
+        MWMechanics::AiInternalTravel travelPackage(dest.x(), dest.y(), dest.z());
         stack(travelPackage, actor, false);
     }
 
@@ -478,7 +478,11 @@ void AiSequence::readState(const ESM::AiSequence::AiSequence &sequence)
         }
         case ESM::AiSequence::Ai_Travel:
         {
-            package.reset(new AiTravel(static_cast<ESM::AiSequence::AiTravel*>(it->mPackage)));
+            const auto source = static_cast<const ESM::AiSequence::AiTravel*>(it->mPackage);
+            if (source->mHidden)
+                package.reset(new AiInternalTravel(source));
+            else
+                package.reset(new AiTravel(source));
             break;
         }
         case ESM::AiSequence::Ai_Escort:

--- a/apps/openmw/mwmechanics/aitravel.cpp
+++ b/apps/openmw/mwmechanics/aitravel.cpp
@@ -27,14 +27,25 @@ bool isWithinMaxRange(const osg::Vec3f& pos1, const osg::Vec3f& pos2)
 
 namespace MWMechanics
 {
-    AiTravel::AiTravel(float x, float y, float z, bool hidden)
-    : mX(x),mY(y),mZ(z),mHidden(hidden)
+    AiTravel::AiTravel(float x, float y, float z, AiTravel*)
+        : mX(x), mY(y), mZ(z), mHidden(false)
+    {
+    }
+
+    AiTravel::AiTravel(float x, float y, float z, AiInternalTravel* derived)
+        : TypedAiPackage<AiTravel>(derived), mX(x), mY(y), mZ(z), mHidden(true)
+    {
+    }
+
+    AiTravel::AiTravel(float x, float y, float z)
+        : AiTravel(x, y, z, this)
     {
     }
 
     AiTravel::AiTravel(const ESM::AiSequence::AiTravel *travel)
-        : mX(travel->mData.mX), mY(travel->mData.mY), mZ(travel->mData.mZ), mHidden(travel->mHidden)
+        : mX(travel->mData.mX), mY(travel->mData.mY), mZ(travel->mData.mZ), mHidden(false)
     {
+        assert(!travel->mHidden);
     }
 
     bool AiTravel::execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration)
@@ -78,11 +89,6 @@ namespace MWMechanics
         return false;
     }
 
-    int AiTravel::getTypeId() const
-    {
-        return mHidden ? TypeIdInternalTravel : TypeIdTravel;
-    }
-
     void AiTravel::fastForward(const MWWorld::Ptr& actor, AiState& state)
     {
         if (!isWithinMaxRange(osg::Vec3f(mX, mY, mZ), actor.getRefData().getPosition().asVec3()))
@@ -106,6 +112,21 @@ namespace MWMechanics
         package.mType = ESM::AiSequence::Ai_Travel;
         package.mPackage = travel.release();
         sequence.mPackages.push_back(package);
+    }
+
+    AiInternalTravel::AiInternalTravel(float x, float y, float z)
+        : AiTravel(x, y, z, this)
+    {
+    }
+
+    AiInternalTravel::AiInternalTravel(const ESM::AiSequence::AiTravel* travel)
+        : AiTravel(travel->mData.mX, travel->mData.mY, travel->mData.mZ, this)
+    {
+    }
+
+    std::unique_ptr<AiPackage> AiInternalTravel::clone() const
+    {
+        return std::make_unique<AiInternalTravel>(*this);
     }
 }
 

--- a/apps/openmw/mwmechanics/aitravel.hpp
+++ b/apps/openmw/mwmechanics/aitravel.hpp
@@ -13,12 +13,18 @@ namespace AiSequence
 
 namespace MWMechanics
 {
+    struct AiInternalTravel;
+
     /// \brief Causes the AI to travel to the specified point
-    class AiTravel final : public TypedAiPackage<AiTravel>
+    class AiTravel : public TypedAiPackage<AiTravel>
     {
         public:
-            /// Default constructor
-            AiTravel(float x, float y, float z, bool hidden = false);
+            AiTravel(float x, float y, float z, AiTravel* derived);
+
+            AiTravel(float x, float y, float z, AiInternalTravel* derived);
+
+            AiTravel(float x, float y, float z);
+
             AiTravel(const ESM::AiSequence::AiTravel* travel);
 
             /// Simulates the passing of time
@@ -28,11 +34,11 @@ namespace MWMechanics
 
             bool execute (const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdTravel; }
 
-            bool useVariableSpeed() const final { return true; }
+            static constexpr bool defaultUseVariableSpeed() { return true; }
 
-            bool alwaysActive() const final { return true; }
+            static constexpr bool defaultAlwaysActive() { return true; }
 
             osg::Vec3f getDestination() const final { return osg::Vec3f(mX, mY, mZ); }
 
@@ -42,6 +48,17 @@ namespace MWMechanics
             float mZ;
 
             bool mHidden;
+    };
+
+    struct AiInternalTravel final : public AiTravel
+    {
+        AiInternalTravel(float x, float y, float z);
+
+        explicit AiInternalTravel(const ESM::AiSequence::AiTravel* travel);
+
+        static constexpr TypeId getTypeId() { return TypeIdInternalTravel; }
+
+        std::unique_ptr<AiPackage> clone() const final;
     };
 }
 

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -98,9 +98,10 @@ namespace MWMechanics
 
     AiWander::AiWander(int distance, int duration, int timeOfDay, const std::vector<unsigned char>& idle, bool repeat):
         mDistance(distance), mDuration(duration), mRemainingDuration(duration), mTimeOfDay(timeOfDay), mIdle(idle),
-        mRepeat(repeat), mStoredInitialActorPosition(false), mInitialActorPosition(osg::Vec3f(0, 0, 0)),
+        mStoredInitialActorPosition(false), mInitialActorPosition(osg::Vec3f(0, 0, 0)),
         mHasDestination(false), mDestination(osg::Vec3f(0, 0, 0)), mUsePathgrid(false)
     {
+        mOptions.mRepeat = repeat;
         mIdle.resize(8, 0);
         init();
     }
@@ -301,11 +302,6 @@ namespace MWMechanics
             completeManualWalking(actor, storage);
 
         return false; // AiWander package not yet completed
-    }
-
-    bool AiWander::getRepeat() const
-    {
-        return mRepeat;
     }
 
     osg::Vec3f AiWander::getDestination(const MWWorld::Ptr& actor) const
@@ -593,11 +589,6 @@ namespace MWMechanics
         }
     }
 
-    int AiWander::getTypeId() const
-    {
-        return TypeIdWander;
-    }
-
     void AiWander::stopWalking(const MWWorld::Ptr& actor)
     {
         mPathFinder.clearPath();
@@ -867,7 +858,7 @@ namespace MWMechanics
         assert (mIdle.size() == 8);
         for (int i=0; i<8; ++i)
             wander->mData.mIdle[i] = mIdle[i];
-        wander->mData.mShouldRepeat = mRepeat;
+        wander->mData.mShouldRepeat = mOptions.mRepeat;
         wander->mStoredInitialActorPosition = mStoredInitialActorPosition;
         if (mStoredInitialActorPosition)
             wander->mInitialActorPosition = mInitialActorPosition;
@@ -883,12 +874,12 @@ namespace MWMechanics
         , mDuration(wander->mData.mDuration)
         , mRemainingDuration(wander->mDurationData.mRemainingDuration)
         , mTimeOfDay(wander->mData.mTimeOfDay)
-        , mRepeat(wander->mData.mShouldRepeat != 0)
         , mStoredInitialActorPosition(wander->mStoredInitialActorPosition)
         , mHasDestination(false)
         , mDestination(osg::Vec3f(0, 0, 0))
         , mUsePathgrid(false)
     {
+        mOptions.mRepeat = wander->mData.mShouldRepeat != 0;
         if (mStoredInitialActorPosition)
             mInitialActorPosition = wander->mInitialActorPosition;
         for (int i=0; i<8; ++i)

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -93,15 +93,15 @@ namespace MWMechanics
 
             bool execute(const MWWorld::Ptr& actor, CharacterController& characterController, AiState& state, float duration) final;
 
-            int getTypeId() const final;
+            static constexpr TypeId getTypeId() { return TypeIdWander; }
 
-            bool useVariableSpeed() const final { return true; }
+            static constexpr bool defaultUseVariableSpeed() { return true; }
 
             void writeState(ESM::AiSequence::AiSequence &sequence) const final;
 
             void fastForward(const MWWorld::Ptr& actor, AiState& state) final;
 
-            bool getRepeat() const final;
+            static constexpr bool defaultRepeat() { return false; }
 
             osg::Vec3f getDestination(const MWWorld::Ptr& actor) const final;
 
@@ -141,7 +141,6 @@ namespace MWMechanics
             float mRemainingDuration;
             int mTimeOfDay;
             std::vector<unsigned char> mIdle;
-            bool mRepeat;
 
             bool mStoredInitialActorPosition;
             osg::Vec3f mInitialActorPosition; // Note: an original engine does not reset coordinates even when actor changes a cell

--- a/apps/openmw/mwmechanics/typedaipackage.hpp
+++ b/apps/openmw/mwmechanics/typedaipackage.hpp
@@ -6,8 +6,30 @@
 namespace MWMechanics
 {
     template <class T>
+    constexpr AiPackage::Options makeAiPackageOptions()
+    {
+        AiPackage::Options options;
+        options.mPriority = T::defaultPriority();
+        options.mUseVariableSpeed = T::defaultUseVariableSpeed();
+        options.mSideWithTarget = T::defaultSideWithTarget();
+        options.mFollowTargetThroughDoors = T::defaultFollowTargetThroughDoors();
+        options.mCanCancel = T::defaultCanCancel();
+        options.mShouldCancelPreviousAi = T::defaultShouldCancelPreviousAi();
+        options.mRepeat = T::defaultRepeat();
+        options.mAlwaysActive = T::defaultAlwaysActive();
+        return options;
+    };
+
+    template <class T>
     struct TypedAiPackage : public AiPackage
     {
+        TypedAiPackage() :
+            AiPackage(T::getTypeId(), makeAiPackageOptions<T>()) {}
+
+        template <class Derived>
+        TypedAiPackage(Derived*) :
+            AiPackage(Derived::getTypeId(), makeAiPackageOptions<Derived>()) {}
+
         virtual std::unique_ptr<AiPackage> clone() const override
         {
             return std::make_unique<T>(*static_cast<const T*>(this));


### PR DESCRIPTION
Store options as values in AiPackage class but initialize from values defined in derived classes. It's still possible to change them during runtime but overhead for virtual calls is removed.
