### PR TITLE
Fix msvc dir for Qt

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -740,7 +740,7 @@ fi
 	fi
 	if [ -z $APPVEYOR ]; then
 		cd $DEPS_INSTALL
-		QT_SDK="$(real_pwd)/Qt/5.15.0/msvc${MSVC_YEAR}${SUFFIX}"
+		QT_SDK="$(real_pwd)/Qt/5.15.0/msvc${MSVC_REAL_YEAR}${SUFFIX}"
 
 		if [ -d 'Qt/5.15.0' ]; then
 			printf "Exists. "


### PR DESCRIPTION
Otherwise it fails with:
```
Qt 5.15.0... Exists. CI/before_script.msvc.sh: line 781: cd: MSVC2019_64_Ninja/deps/Qt/5.15.0/msvc2015_64: No such file or directory
```