### PR TITLE
Optimize MWRender::Animation::hasAnimation

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -942,7 +942,7 @@ void split(const std::string &s, char delim, std::vector<std::string> &elems) {
     }
 }
 
-void CharacterController::handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key, const std::multimap<float, std::string> &map)
+void CharacterController::handleTextKey(const std::string &groupname, NifOsg::TextKeyMap::ConstIterator key, const NifOsg::TextKeyMap& map)
 {
     const std::string &evt = key->second;
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -238,8 +238,7 @@ public:
     CharacterController(const MWWorld::Ptr &ptr, MWRender::Animation *anim);
     virtual ~CharacterController();
 
-    virtual void handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key,
-                       const std::multimap<float, std::string>& map);
+    virtual void handleTextKey(const std::string &groupname, NifOsg::TextKeyMap::ConstIterator key, const NifOsg::TextKeyMap& map);
 
     // Be careful when to call this, see comment in Actors
     void updateContinuousVfx();

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -5,6 +5,7 @@
 
 #include <components/sceneutil/controller.hpp>
 #include <components/sceneutil/util.hpp>
+#include <components/nifosg/textkeymap.hpp>
 
 namespace ESM
 {
@@ -147,8 +148,8 @@ public:
     class TextKeyListener
     {
     public:
-        virtual void handleTextKey(const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key,
-                           const std::multimap<float, std::string>& map) = 0;
+        virtual void handleTextKey(const std::string &groupname, NifOsg::TextKeyMap::ConstIterator key,
+                                   const NifOsg::TextKeyMap& map) = 0;
 
         virtual ~TextKeyListener() = default;
     };
@@ -296,12 +297,12 @@ protected:
      * the marker is not found, or if the markers are the same, it returns
      * false.
      */
-    bool reset(AnimState &state, const std::multimap<float, std::string> &keys,
+    bool reset(AnimState &state, const NifOsg::TextKeyMap &keys,
                const std::string &groupname, const std::string &start, const std::string &stop,
                float startpoint, bool loopfallback);
 
-    void handleTextKey(AnimState &state, const std::string &groupname, const std::multimap<float, std::string>::const_iterator &key,
-                       const std::multimap<float, std::string>& map);
+    void handleTextKey(AnimState &state, const std::string &groupname, NifOsg::TextKeyMap::ConstIterator key,
+                       const NifOsg::TextKeyMap& map);
 
     /** Sets the root model of the object.
      *

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -157,7 +157,8 @@ namespace
                     nextpos = std::distance(str.begin(), ++last);
                 }
                 std::string result = str.substr(pos, nextpos-pos);
-                textkeys.insert(std::make_pair(tk->list[i].time, Misc::StringUtils::lowerCase(result)));
+                Misc::StringUtils::lowerCaseInPlace(result);
+                textkeys.emplace(tk->list[i].time, std::move(result));
 
                 pos = nextpos;
             }

--- a/components/nifosg/nifloader.hpp
+++ b/components/nifosg/nifloader.hpp
@@ -7,6 +7,7 @@
 #include <osg/Referenced>
 
 #include "controller.hpp"
+#include "textkeymap.hpp"
 
 namespace osg
 {
@@ -20,8 +21,6 @@ namespace Resource
 
 namespace NifOsg
 {
-    typedef std::multimap<float,std::string> TextKeyMap;
-
     struct TextKeyMapHolder : public osg::Object
     {
     public:

--- a/components/nifosg/textkeymap.hpp
+++ b/components/nifosg/textkeymap.hpp
@@ -1,0 +1,87 @@
+#ifndef OPENMW_COMPONENTS_NIFOSG_TEXTKEYMAP
+#define OPENMW_COMPONENTS_NIFOSG_TEXTKEYMAP
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+
+namespace NifOsg
+{
+    class TextKeyMap
+    {
+    public:
+        using ConstIterator = std::multimap<float, std::string>::const_iterator;
+
+        auto begin() const noexcept
+        {
+            return mTextKeyByTime.begin();
+        }
+
+        auto end() const noexcept
+        {
+            return mTextKeyByTime.end();
+        }
+
+        auto rbegin() const noexcept
+        {
+            return mTextKeyByTime.rbegin();
+        }
+
+        auto rend() const noexcept
+        {
+            return mTextKeyByTime.rend();
+        }
+
+        auto lowerBound(float time) const
+        {
+            return mTextKeyByTime.lower_bound(time);
+        }
+
+        auto upperBound(float time) const
+        {
+            return mTextKeyByTime.upper_bound(time);
+        }
+
+        void emplace(float time, std::string&& textKey)
+        {
+            const auto separator = textKey.find(": ");
+            if (separator != std::string::npos)
+                mGroups.emplace(textKey.substr(0, separator));
+
+            mTextKeyByTime.emplace(time, std::move(textKey));
+        }
+
+        bool empty() const noexcept
+        {
+            return mTextKeyByTime.empty();
+        }
+
+        auto findGroupStart(const std::string &groupName) const
+        {
+            return std::find_if(mTextKeyByTime.begin(), mTextKeyByTime.end(), IsGroupStart{groupName});
+        }
+
+        bool hasGroupStart(const std::string &groupName) const
+        {
+            return mGroups.count(groupName) > 0;
+        }
+
+    private:
+        struct IsGroupStart
+        {
+            const std::string &mGroupName;
+
+            bool operator ()(const std::multimap<float, std::string>::value_type& value) const
+            {
+                return value.second.compare(0, mGroupName.size(), mGroupName) == 0 &&
+                        value.second.compare(mGroupName.size(), 2, ": ") == 0;
+            }
+        };
+
+        std::set<std::string> mGroups;
+        std::multimap<float, std::string> mTextKeyByTime;
+    };
+}
+
+#endif


### PR DESCRIPTION
Use a set to check for group start existence. Reduce time taken from 2.6% to 0.08% and MWMechanics::MechanicsManager::update from 7% to 5% in relative CPU time usage for a scene with ~100 actors.