### PR TITLE
Use vector for MWRender::Animation::mActiveControllers

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1064,7 +1064,7 @@ namespace MWRender
     void Animation::resetActiveGroups()
     {
         // remove all previous external controllers from the scene graph
-        for (ControllerMap::iterator it = mActiveControllers.begin(); it != mActiveControllers.end(); ++it)
+        for (auto it = mActiveControllers.begin(); it != mActiveControllers.end(); ++it)
         {
             osg::Node* node = it->first;
             node->removeUpdateCallback(it->second);
@@ -1103,7 +1103,7 @@ namespace MWRender
                     osg::ref_ptr<osg::Node> node = getNodeMap().at(it->first); // this should not throw, we already checked for the node existing in addAnimSource
 
                     node->addUpdateCallback(it->second);
-                    mActiveControllers.insert(std::make_pair(node, it->second));
+                    mActiveControllers.emplace_back(node, it->second);
 
                     if (blendMask == 0 && node == mAccumRoot)
                     {
@@ -1116,7 +1116,7 @@ namespace MWRender
                             mResetAccumRootCallback->setAccumulate(mAccumulate);
                         }
                         mAccumRoot->addUpdateCallback(mResetAccumRootCallback);
-                        mActiveControllers.insert(std::make_pair(mAccumRoot, mResetAccumRootCallback));
+                        mActiveControllers.emplace_back(mAccumRoot, mResetAccumRootCallback);
                     }
                 }
             }
@@ -1850,7 +1850,7 @@ namespace MWRender
                 {
                     mHeadController = new RotateController(mObjectRoot.get());
                     node->addUpdateCallback(mHeadController);
-                    mActiveControllers.insert(std::make_pair(node, mHeadController));
+                    mActiveControllers.emplace_back(node, mHeadController);
                 }
             }
         }

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -6,6 +6,8 @@
 #include <components/sceneutil/controller.hpp>
 #include <components/sceneutil/util.hpp>
 
+#include <vector>
+
 namespace ESM
 {
     struct Light;
@@ -246,8 +248,7 @@ protected:
 
     // Keep track of controllers that we added to our scene graph.
     // We may need to rebuild these controllers when the active animation groups / sources change.
-    typedef std::multimap<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback> > ControllerMap;
-    ControllerMap mActiveControllers;
+    std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback>>> mActiveControllers;
 
     std::shared_ptr<AnimationTime> mAnimationTimePtr[sNumBlendMasks];
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -956,7 +956,7 @@ void NpcAnimation::addControllers()
             osg::MatrixTransform* node = found->second.get();
             mFirstPersonNeckController = new NeckController(mObjectRoot.get());
             node->addUpdateCallback(mFirstPersonNeckController);
-            mActiveControllers.emplace(node, mFirstPersonNeckController);
+            mActiveControllers.emplace_back(node, mFirstPersonNeckController);
         }
     }
     else if (mViewMode == VM_Normal)

--- a/apps/openmw/mwrender/weaponanimation.cpp
+++ b/apps/openmw/mwrender/weaponanimation.cpp
@@ -168,7 +168,7 @@ void WeaponAnimation::releaseArrow(MWWorld::Ptr actor, float attackStrength)
 }
 
 void WeaponAnimation::addControllers(const std::map<std::string, osg::ref_ptr<osg::MatrixTransform> >& nodes,
-                                     std::multimap<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback> > &map, osg::Node* objectRoot)
+    std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback>>> &map, osg::Node* objectRoot)
 {
     for (int i=0; i<2; ++i)
     {
@@ -180,7 +180,7 @@ void WeaponAnimation::addControllers(const std::map<std::string, osg::ref_ptr<os
             osg::Node* node = found->second;
             mSpineControllers[i] = new RotateController(objectRoot);
             node->addUpdateCallback(mSpineControllers[i]);
-            map.insert(std::make_pair(node, mSpineControllers[i]));
+            map.emplace_back(node, mSpineControllers[i]);
         }
     }
 }

--- a/apps/openmw/mwrender/weaponanimation.hpp
+++ b/apps/openmw/mwrender/weaponanimation.hpp
@@ -41,7 +41,7 @@ namespace MWRender
 
         /// Add WeaponAnimation-related controllers to \a nodes and store the added controllers in \a map.
         void addControllers(const std::map<std::string, osg::ref_ptr<osg::MatrixTransform> >& nodes,
-                std::multimap<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback> >& map, osg::Node* objectRoot);
+                std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback>>>& map, osg::Node* objectRoot);
 
         void deleteControllers();
 


### PR DESCRIPTION
Container is only used to add elements, iterate over all of them and clear. Multimap adds overhead for all of these operations without any benefits. Reduce Animation::resetActiveGroups CPU time usage by 50% for a scene with ~100 actors.