### PR TITLE
Improve GetDistance and object search warnings (bug #5427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     Bug #5415: Environment maps in ebony cuirass and HiRez Armors Indoril cuirass don't work
     Bug #5416: Junk non-node records before the root node are not handled gracefully
     Bug #5424: Creatures do not headtrack player
+    Bug #5427: GetDistance unknown ID error is misleading
     Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -741,7 +741,10 @@ namespace MWWorld
         Ptr ret = searchPtr(name, activeOnly);
         if (!ret.isEmpty())
             return ret;
-        throw std::runtime_error ("unknown ID: " + name);
+        std::string error = "failed to find an instance of object '" + name + "'";
+        if (activeOnly)
+            error += " in active cells";
+        throw std::runtime_error(error);
     }
 
     Ptr World::searchPtrViaActorId (int actorId)


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5427).

Basically combines the approaches 3 and 4 from the report. GetDistance now doesn't stop script execution if the calling object's container or the object that is given as an ID doesn't exist. It logs a warning instead and the script gets a value of ~~340282346638528859811704183484516925440.0~~ zero as the distance to the nonexistent object. This makes sense because the script handler doesn't "know" whether the objects don't exist at all (not even in the ESM), are simply absent  from the game world or did exist previously. The warning will get logged to both openmw.log and the context.

Meanwhile getPtr throws a slightly more wordy exception to its callers which should be less confusing. Since it's an exception, it'll be logged to both openmw.log and the context as well in cases getPtr is used in scripting.