### PR TITLE
Re-enable non-biped creature headtracking (bug #5424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     Bug #5400: Editor: Verifier checks race of non-skin bodyparts
     Bug #5415: Environment maps in ebony cuirass and HiRez Armors Indoril cuirass don't work
     Bug #5416: Junk non-node records before the root node are not handled gracefully
+    Bug #5424: Creatures do not headtrack player
     Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1815,33 +1815,30 @@ namespace MWRender
     {
         mHeadController = nullptr;
 
-        if (mPtr.getClass().isBipedal(mPtr))
+        NodeMap::const_iterator found = getNodeMap().find("bip01 head");
+        if (found == getNodeMap().end())
+            return;
+
+        osg::MatrixTransform* node = found->second;
+
+        bool foundKeyframeCtrl = false;
+        osg::Callback* cb = node->getUpdateCallback();
+        while (cb)
         {
-            NodeMap::const_iterator found = getNodeMap().find("bip01 head");
-            if (found != getNodeMap().end())
+            if (dynamic_cast<NifOsg::KeyframeController*>(cb))
             {
-                osg::MatrixTransform* node = found->second;
-
-                bool foundKeyframeCtrl = false;
-                osg::Callback* cb = node->getUpdateCallback();
-                while (cb)
-                {
-                    if (dynamic_cast<NifOsg::KeyframeController*>(cb))
-                    {
-                        foundKeyframeCtrl = true;
-                        break;
-                    }
-                    cb = cb->getNestedCallback();
-                }
-
-                if (foundKeyframeCtrl)
-                {
-                    mHeadController = new RotateController(mObjectRoot.get());
-                    node->addUpdateCallback(mHeadController);
-                    mActiveControllers.emplace_back(node, mHeadController);
-                }
+                foundKeyframeCtrl = true;
+                break;
             }
+            cb = cb->getNestedCallback();
         }
+
+        if (!foundKeyframeCtrl)
+            return;
+
+        mHeadController = new RotateController(mObjectRoot.get());
+        node->addUpdateCallback(mHeadController);
+        mActiveControllers.emplace_back(node, mHeadController);
     }
 
     void Animation::setHeadPitch(float pitchRadians)


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5424)
Add head controller for eligible non-biped creatures as well.
So far it didn't seem to cause the adverse effects that were there 5 years ago, but it may need more testing.