### PR TITLE
Extend OSG stats

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -203,12 +203,14 @@ bool OMW::Engine::frame(float frametime)
 
         if (stats->collectStats("resource"))
         {
+            stats->setAttribute(frameNumber, "FrameNumber", frameNumber);
+
             mResourceSystem->reportStats(frameNumber, stats);
 
             stats->setAttribute(frameNumber, "WorkQueue", mWorkQueue->getNumItems());
             stats->setAttribute(frameNumber, "WorkThread", mWorkQueue->getNumActiveThreads());
 
-            mEnvironment.getWorld()->getNavigator()->reportStats(frameNumber, *stats);
+            mEnvironment.reportStats(frameNumber, *stats);
         }
 
     }

--- a/apps/openmw/mwbase/environment.cpp
+++ b/apps/openmw/mwbase/environment.cpp
@@ -198,3 +198,9 @@ const MWBase::Environment& MWBase::Environment::get()
     assert (sThis);
     return *sThis;
 }
+
+void MWBase::Environment::reportStats(unsigned int frameNumber, osg::Stats& stats) const
+{
+    mMechanicsManager->reportStats(frameNumber, stats);
+    mWorld->reportStats(frameNumber, stats);
+}

--- a/apps/openmw/mwbase/environment.hpp
+++ b/apps/openmw/mwbase/environment.hpp
@@ -1,6 +1,11 @@
 #ifndef GAME_BASE_ENVIRONMENT_H
 #define GAME_BASE_ENVIRONMENT_H
 
+namespace osg
+{
+    class Stats;
+}
+
 namespace MWBase
 {
     class World;
@@ -97,6 +102,8 @@ namespace MWBase
 
             static const Environment& get();
             ///< Return instance of this class.
+
+            void reportStats(unsigned int frameNumber, osg::Stats& stats) const;
     };
 }
 

--- a/apps/openmw/mwbase/mechanicsmanager.hpp
+++ b/apps/openmw/mwbase/mechanicsmanager.hpp
@@ -11,6 +11,7 @@
 
 namespace osg
 {
+    class Stats;
     class Vec3f;
 }
 
@@ -269,6 +270,8 @@ namespace MWBase
             virtual bool isAttackPreparing(const MWWorld::Ptr& ptr) = 0;
             virtual bool isRunning(const MWWorld::Ptr& ptr) = 0;
             virtual bool isSneaking(const MWWorld::Ptr& ptr) = 0;
+
+            virtual void reportStats(unsigned int frameNumber, osg::Stats& stats) const = 0;
     };
 }
 

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -21,6 +21,7 @@ namespace osg
     class Matrixf;
     class Quat;
     class Image;
+    class Stats;
 }
 
 namespace Loading
@@ -629,6 +630,8 @@ namespace MWBase
             virtual bool hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const = 0;
 
             virtual bool isAreaOccupiedByOtherActor(const osg::Vec3f& position, const float radius, const MWWorld::ConstPtr& ignore) const = 0;
+
+            virtual void reportStats(unsigned int frameNumber, osg::Stats& stats) const = 0;
     };
 }
 

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -70,6 +70,7 @@ namespace MWMechanics
 
             PtrActorMap::const_iterator begin() { return mActors.begin(); }
             PtrActorMap::const_iterator end() { return mActors.end(); }
+            std::size_t size() const { return mActors.size(); }
 
             void notifyDied(const MWWorld::Ptr &actor);
 

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -1,5 +1,7 @@
 #include "mechanicsmanagerimp.hpp"
 
+#include <osg/Stats>
+
 #include <components/misc/rng.hpp>
 
 #include <components/esm/esmwriter.hpp>
@@ -1944,4 +1946,9 @@ namespace MWMechanics
         mActors.cleanupSummonedCreature(caster.getClass().getCreatureStats(caster), creatureActorId);
     }
 
+    void MechanicsManager::reportStats(unsigned int frameNumber, osg::Stats& stats) const
+    {
+        stats.setAttribute(frameNumber, "Mechanics Actors", mActors.size());
+        stats.setAttribute(frameNumber, "Mechanics Objects", mObjects.size());
+    }
 }

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.hpp
@@ -240,6 +240,8 @@ namespace MWMechanics
             virtual bool isRunning(const MWWorld::Ptr& ptr) override;
             virtual bool isSneaking(const MWWorld::Ptr& ptr) override;
 
+            virtual void reportStats(unsigned int frameNumber, osg::Stats& stats) const override;
+
         private:
             bool canCommitCrimeAgainst(const MWWorld::Ptr& victim, const MWWorld::Ptr& attacker);
             bool canReportCrime(const MWWorld::Ptr &actor, const MWWorld::Ptr &victim, std::set<MWWorld::Ptr> &playerFollowers);

--- a/apps/openmw/mwmechanics/objects.hpp
+++ b/apps/openmw/mwmechanics/objects.hpp
@@ -52,6 +52,11 @@ namespace MWMechanics
         void persistAnimationStates();
 
         void getObjectsInRange (const osg::Vec3f& position, float radius, std::vector<MWWorld::Ptr>& out);
+
+        std::size_t size() const
+        {
+            return mObjects.size();
+        }
     };
 }
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -1,6 +1,7 @@
 #include "physicssystem.hpp"
 
 #include <osg/Group>
+#include <osg/Stats>
 
 #include <BulletCollision/CollisionShapes/btConeShape.h>
 #include <BulletCollision/CollisionShapes/btSphereShape.h>
@@ -882,5 +883,12 @@ namespace MWPhysics
         HasSphereCollisionCallback callback(bulletPosition, radius, object, mask, group);
         mCollisionWorld->getBroadphase()->aabbTest(aabbMin, aabbMax, callback);
         return callback.getResult();
+    }
+
+    void PhysicsSystem::reportStats(unsigned int frameNumber, osg::Stats& stats) const
+    {
+        stats.setAttribute(frameNumber, "Physics Actors", mActors.size());
+        stats.setAttribute(frameNumber, "Physics Objects", mObjects.size());
+        stats.setAttribute(frameNumber, "Physics HeightFields", mHeightFields.size());
     }
 }

--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -17,6 +17,7 @@ namespace osg
 {
     class Group;
     class Object;
+    class Stats;
 }
 
 namespace MWRender
@@ -185,6 +186,8 @@ namespace MWPhysics
             }
 
             bool isAreaOccupiedByOtherActor(const osg::Vec3f& position, const float radius, const MWWorld::ConstPtr& ignore) const;
+
+            void reportStats(unsigned int frameNumber, osg::Stats& stats) const;
 
         private:
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3947,4 +3947,10 @@ namespace MWWorld
     {
         return mPhysics->isAreaOccupiedByOtherActor(position, radius, ignore);
     }
+
+    void World::reportStats(unsigned int frameNumber, osg::Stats& stats) const
+    {
+        mNavigator->reportStats(frameNumber, stats);
+        mPhysics->reportStats(frameNumber, stats);
+    }
 }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -20,6 +20,7 @@
 namespace osg
 {
     class Group;
+    class Stats;
 }
 
 namespace osgViewer
@@ -732,6 +733,8 @@ namespace MWWorld
             bool hasCollisionWithDoor(const MWWorld::ConstPtr& door, const osg::Vec3f& position, const osg::Vec3f& destination) const override;
 
             bool isAreaOccupiedByOtherActor(const osg::Vec3f& position, const float radius, const MWWorld::ConstPtr& ignore) const override;
+
+            void reportStats(unsigned int frameNumber, osg::Stats& stats) const override;
     };
 }
 

--- a/components/resource/stats.cpp
+++ b/components/resource/stats.cpp
@@ -262,7 +262,6 @@ void StatsHandler::setUpScene(osgViewer::ViewerBase *viewer)
     stateset->setAttribute(new osg::PolygonMode(), osg::StateAttribute::PROTECTED);
 #endif
 
-    osg::Vec3 pos(_statsWidth-420.f, _statsHeight-500.0f,0.0f);
     osg::Vec4 backgroundColor(0.0, 0.0, 0.0f, 0.3);
     osg::Vec4 staticTextColor(1.0, 1.0, 0.0f, 1.0);
     osg::Vec4 dynamicTextColor(1.0, 1.0, 1.0f, 1.0);
@@ -277,6 +276,8 @@ void StatsHandler::setUpScene(osgViewer::ViewerBase *viewer)
         _switch->addChild(group, false);
 
         static const std::vector<std::string> statNames({
+            "FrameNumber",
+            "",
             "Compiling",
             "WorkQueue",
             "WorkThread",
@@ -302,16 +303,25 @@ void StatsHandler::setUpScene(osgViewer::ViewerBase *viewer)
             "NavMesh CacheSize",
             "NavMesh UsedTiles",
             "NavMesh CachedTiles",
+            "",
+            "Mechanics Actors",
+            "Mechanics Objects",
+            "",
+            "Physics Actors",
+            "Physics Objects",
+            "Physics HeightFields",
         });
 
         static const auto longest = std::max_element(statNames.begin(), statNames.end(),
             [] (const std::string& lhs, const std::string& rhs) { return lhs.size() < rhs.size(); });
-        const int numLines = statNames.size();
         const float statNamesWidth = 13 * _characterSize + 2 * backgroundMargin;
+        const float statTextWidth = 7 * _characterSize + 2 * backgroundMargin;
+        const float statHeight = statNames.size() * _characterSize + 2 * backgroundMargin;
+        osg::Vec3 pos(_statsWidth - statNamesWidth - backgroundSpacing - statTextWidth, statHeight, 0.0f);
 
         group->addChild(createBackgroundRectangle(pos + osg::Vec3(-backgroundMargin, _characterSize + backgroundMargin, 0),
                                                         statNamesWidth,
-                                                        numLines * _characterSize + 2 * backgroundMargin,
+                                                        statHeight,
                                                         backgroundColor));
 
         osg::ref_ptr<osgText::Text> staticText = new osgText::Text;
@@ -335,8 +345,8 @@ void StatsHandler::setUpScene(osgViewer::ViewerBase *viewer)
         pos.x() += statNamesWidth + backgroundSpacing;
 
         group->addChild(createBackgroundRectangle(pos + osg::Vec3(-backgroundMargin, _characterSize + backgroundMargin, 0),
-                                                        7 * _characterSize + 2 * backgroundMargin,
-                                                        numLines * _characterSize + 2 * backgroundMargin,
+                                                        statTextWidth,
+                                                        statHeight,
                                                         backgroundColor));
 
         osg::ref_ptr<osgText::Text> statsText = new osgText::Text;


### PR DESCRIPTION
Add report for:
* Current frame number (it's not showed by default, probably there is other way how to do this properly).
* Number of mechanics actors
* Number of mechanics objects
* Number of physics actors
* Number of physics objects
* Number of physics heigh fields

Allows to see and analyze dependency between a number of entities and frame time.