### PR TITLE
Decrease game time limit per frame to 1/24 (bug #5431)

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -754,7 +754,7 @@ void OMW::Engine::go()
     {
         double dt = frameTimer.time_s();
         frameTimer.setStartTick();
-        dt = std::min(dt, 0.2);
+        dt = std::min(dt, 1.0 / 24.0);
 
         mViewer->advance(simulationTime);
 


### PR DESCRIPTION
See detailed report in https://gitlab.com/OpenMW/openmw/-/issues/5431 . Not sure about exact value but for now 1/24 is working good enough.