### PR TITLE
Give new opcodes to old functions made custom

### DIFF
--- a/apps/openmw/mwscript/docs/vmformat.txt
+++ b/apps/openmw/mwscript/docs/vmformat.txt
@@ -464,5 +464,20 @@ op 0x200030d: RepairedOnMe, explicit
 op 0x200030e: TestCells
 op 0x200030f: TestInteriorCells
 op 0x2000310: ToggleRecastMesh
+op 0x2000311: MenuMode
+op 0x2000312: Random
+op 0x2000313: ScriptRunning
+op 0x2000314: StartScript
+op 0x2000315: StopScript
+op 0x2000316: GetSecondsPassed
+op 0x2000317: Enable
+op 0x2000318: Disable
+op 0x2000319: GetDisabled
+op 0x200031a: Enable, explicit
+op 0x200031b: Disable, explicit
+op 0x200031c: GetDisabled, explicit
+op 0x200031d: StartScript, explicit
+op 0x200031e: GetDistance
+op 0x200031f: GetDistance, explicit
 
-opcodes 0x2000311-0x3ffffff unused
+opcodes 0x2000320-0x3ffffff unused

--- a/components/compiler/opcodes.hpp
+++ b/components/compiler/opcodes.hpp
@@ -201,19 +201,6 @@ namespace Compiler
 
     namespace Misc
     {
-        const int opcodeMenuMode = 38;
-        const int opcodeRandom = 45;
-        const int opcodeScriptRunning = 46;
-        const int opcodeStartScript = 47;
-        const int opcodeStopScript = 48;
-        const int opcodeGetSecondsPassed = 50;
-        const int opcodeEnable = 51;
-        const int opcodeDisable = 52;
-        const int opcodeGetDisabled = 53;
-        const int opcodeEnableExplicit = 54;
-        const int opcodeDisableExplicit = 55;
-        const int opcodeGetDisabledExplicit = 56;
-        const int opcodeStartScriptExplicit = 71;
         const int opcodeXBox = 0x200000c;
         const int opcodeOnActivate = 0x200000d;
         const int opcodeOnActivateExplicit = 0x2000306;
@@ -318,6 +305,19 @@ namespace Compiler
         const int opcodeRepairedOnMe = 0x200030c;
         const int opcodeRepairedOnMeExplicit = 0x200030d;
         const int opcodeToggleRecastMesh = 0x2000310;
+        const int opcodeMenuMode = 0x2000311;
+        const int opcodeRandom = 0x2000312;
+        const int opcodeScriptRunning = 0x2000313;
+        const int opcodeStartScript = 0x2000314;
+        const int opcodeStopScript = 0x2000315;
+        const int opcodeGetSecondsPassed = 0x2000316;
+        const int opcodeEnable = 0x2000317;
+        const int opcodeDisable = 0x2000318;
+        const int opcodeGetDisabled = 0x2000319;
+        const int opcodeEnableExplicit = 0x200031a;
+        const int opcodeDisableExplicit = 0x200031b;
+        const int opcodeGetDisabledExplicit = 0x200031c;
+        const int opcodeStartScriptExplicit = 0x200031d;
     }
 
     namespace Sky
@@ -486,8 +486,6 @@ namespace Compiler
 
     namespace Transformation
     {
-        const int opcodeGetDistance = 49;
-        const int opcodeGetDistanceExplicit = 57;
         const int opcodeSetScale = 0x2000164;
         const int opcodeSetScaleExplicit = 0x2000165;
         const int opcodeSetAngle = 0x2000166;
@@ -528,6 +526,8 @@ namespace Compiler
         const int opcodeMoveWorldExplicit = 0x2000209;
         const int opcodeResetActors = 0x20002f4;
         const int opcodeFixme = 0x2000302;
+        const int opcodeGetDistance = 0x200031e;
+        const int opcodeGetDistanceExplicit = 0x200031f;
     }
 
     namespace User

--- a/components/interpreter/docs/vmformat.txt
+++ b/components/interpreter/docs/vmformat.txt
@@ -96,27 +96,14 @@ op  34: compare (float) stack[1] with stack[0]; pop twice; push 1 if lesser than
 op  35: compare (float) stack[1] with stack[0]; pop twice; push 1 if lesser or equal, 0 else
 op  36: compare (float) stack[1] with stack[0]; pop twice; push 1 if greater than, 0 else
 op  37: compare (float) stack[1] with stack[0]; pop twice; push 1 if greater or equal, 0 else
-op  38: push 1 if game is in menu mode, 0 else
+opcode 38 unused
 op  39: store stack[0] in global short stack[1] and pop twice
 op  40: store stack[0] in global long stack[1] and pop twice
 op  41: store stack[0] in global float stack[1] and pop twice
 op  42: replace stack[0] with global short stack[0]
 op  43: replace stack[0] with global long stack[0]
 op  44: replace stack[0] with global float stack[0]
-op  45: replace stack[0] with a random integer value in the range [0, stack[0]-1]
-op  46: replace stack[0] with 1, if global script stack[0] is running, 0 else
-op  47: start script stack[0] and pop
-op  48: stop script stack[0] and pop
-op  49: replace stack[0] with distance between implicit reference and a reference of ID stack[0]
-op  50: push frame duration (float)
-op  51: enable implicit reference
-op  52: disable implicit reference
-op  53: push 1, if implicit reference is disabled, 0 else
-op  54: explicit reference = stack[0]; pop; enable explicit reference
-op  55: explicit reference = stack[0]; pop; disable explicit reference
-op  56: explicit reference = stack[0]; pop; push 1, if explicit reference is disabled, 0 else
-op  57: explicit reference = stack[0]; pop;
-        replace stack[0] with distance between explicit reference and a reference of ID stack[0]
+opcodes 45-57 unused
 op  58: report string literal index in stack[0];
          additional arguments (if any) in stack[n]..stack[1];
          n is determined according to the message string
@@ -133,6 +120,5 @@ op 67: store stack[0] in member float stack[2] of global script with ID stack[1]
 op 68: replace stack[0] with member short stack[1] of global script with ID stack[0]
 op 69: replace stack[0] with member short stack[1] of global script with ID stack[0]
 op 70: replace stack[0] with member short stack[1] of global script with ID stack[0]
-op 71: explicit reference (target) = stack[0]; pop; start script stack[0] and pop
-opcodes 72-33554431 unused
+opcodes 71-33554431 unused
 opcodes 33554432-67108863 reserved for extensions


### PR DESCRIPTION
Makes them use not yet utilized opcodes in segment 5 instead of the old opcodes that segment 5 functions aren't supposed to use. Should fix the assert elsid pointed at [here](https://github.com/OpenMW/openmw/pull/2841#issuecomment-632749667).

Also updated the documentation.