### PR TITLE
[WIP] Mutable ESM records (#2798)

### DIFF
--- a/apps/openmw/mwscript/globalscripts.cpp
+++ b/apps/openmw/mwscript/globalscripts.cpp
@@ -299,6 +299,15 @@ namespace MWScript
         return iter->second->mLocals;
     }
 
+    const Locals* GlobalScripts::getLocalsIfPresent (const std::string& name) const
+    {
+        std::string name2 = ::Misc::StringUtils::lowerCase (name);
+        auto iter = mScripts.find (name2);
+        if (iter==mScripts.end())
+            return nullptr;
+        return &iter->second->mLocals;
+    }
+
     void GlobalScripts::updatePtrs(const MWWorld::Ptr& base, const MWWorld::Ptr& updated)
     {
         MatchPtrVisitor visitor(base);

--- a/apps/openmw/mwscript/globalscripts.hpp
+++ b/apps/openmw/mwscript/globalscripts.hpp
@@ -82,6 +82,8 @@ namespace MWScript
             ///< If the script \a name has not been added as a global script yet, it is added
             /// automatically, but is not set to running state.
 
+            const Locals* getLocalsIfPresent (const std::string& name) const;
+
             void updatePtrs(const MWWorld::Ptr& base, const MWWorld::Ptr& updated);
             ///< Update the Ptrs stored in mTarget. Should be called after the reference has been moved to a new cell.
     };

--- a/apps/openmw/mwscript/locals.cpp
+++ b/apps/openmw/mwscript/locals.cpp
@@ -1,4 +1,5 @@
 #include "locals.hpp"
+#include "globalscripts.hpp"
 
 #include <components/esm/loadscpt.hpp>
 #include <components/esm/variant.hpp>
@@ -33,15 +34,25 @@ namespace MWScript
         if (mInitialised)
             return false;
 
-        const Compiler::Locals& locals =
-            MWBase::Environment::get().getScriptManager()->getLocals (script.mId);
+        const Locals* global = MWBase::Environment::get().getScriptManager()->getGlobalScripts().getLocalsIfPresent(script.mId);
+        if(global)
+        {
+            mShorts = global->mShorts;
+            mLongs = global->mLongs;
+            mFloats = global->mFloats;
+        }
+        else
+        {
+            const Compiler::Locals& locals =
+                MWBase::Environment::get().getScriptManager()->getLocals (script.mId);
 
-        mShorts.clear();
-        mShorts.resize (locals.get ('s').size(), 0);
-        mLongs.clear();
-        mLongs.resize (locals.get ('l').size(), 0);
-        mFloats.clear();
-        mFloats.resize (locals.get ('f').size(), 0);
+            mShorts.clear();
+            mShorts.resize (locals.get ('s').size(), 0);
+            mLongs.clear();
+            mLongs.resize (locals.get ('l').size(), 0);
+            mFloats.clear();
+            mFloats.resize (locals.get ('f').size(), 0);
+        }
 
         mInitialised = true;
         return true;


### PR DESCRIPTION
Since rot provided a nice list, I'll just copy the things that I'm sure need doing.
- [x] actor record, when using AI parameter functions like SetFight
- [x] actor records, when using AddSpell, RemoveSpell
- [x] script records, when editing local variables with "scriptID".localvar
- [ ] AddItem for containers
- [x] AddItem for non-unique actors

Levelled lists have been in for years and I haven't checked how faction reactions and weather are handled... but I think those also work? ~~Leaving `script records, when editing local variables with "scriptID".localvar`. I know that syntax works, but does it work like it's supposed to?~~