### PR TITLE
Don't "disable" player's collision shape in TCL (#5435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     Bug #5424: Creatures do not headtrack player
     Bug #5425: Poison effect only appears for one frame
     Bug #5427: GetDistance unknown ID error is misleading
+    Bug #5435: Enemies can't hurt the player when collision is off
     Bug #5441: Enemies can't push a player character when in critical strike stance
     Feature #5362: Show the soul gems' trapped soul in count dialog
 

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -648,7 +648,7 @@ namespace MWPhysics
             bool cmode = found->second->getCollisionMode();
             cmode = !cmode;
             found->second->enableCollisionMode(cmode);
-            found->second->enableCollisionBody(cmode);
+            // NB: Collision body isn't disabled for vanilla TCL compatibility
             return cmode;
         }
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5435)

This allows player character themselves to keep not colliding with anything when the character moves on their own, but anything that tries to collide with the player (actor, projectile or a door) will still collide with the player as if they have collisions enabled. This means fighting actors can hurt the player character.

Note that since unlike vanilla we don't disable collisions for literally every actor in TCL handling actors will try to avoid colliding with the player unless it isn't possible, and it may lead to oddities (e.g. actors may jump in place). Nothing game-breaking though.