### PR TITLE
Fix mControlsDisabled flag usage

### DIFF
--- a/apps/openmw/mwbase/inputmanager.hpp
+++ b/apps/openmw/mwbase/inputmanager.hpp
@@ -76,6 +76,8 @@ namespace MWBase
             virtual void resetIdleTime() = 0;
 
             virtual void executeAction(int action) = 0;
+
+            virtual bool controlsDisabled() = 0;
     };
 }
 

--- a/apps/openmw/mwinput/controllermanager.cpp
+++ b/apps/openmw/mwinput/controllermanager.cpp
@@ -36,7 +36,6 @@ namespace MWInput
         , mSneakToggleShortcutTimer(0.f)
         , mGamepadZoom(0)
         , mGamepadGuiCursorEnabled(true)
-        , mControlsDisabled(false)
         , mJoystickLastUsed(false)
         , mSneakGamepadShortcut(false)
         , mGamepadPreviewMode(false)
@@ -83,9 +82,8 @@ namespace MWInput
         }
     }
 
-    bool ControllerManager::update(float dt, bool disableControls)
+    bool ControllerManager::update(float dt)
     {
-        mControlsDisabled = disableControls;
         mGamepadPreviewMode = mActionManager->getPreviewDelay() == 1.f;
 
         if (mGuiCursorEnabled && !(mJoystickLastUsed && !mGamepadGuiCursorEnabled))
@@ -232,7 +230,7 @@ namespace MWInput
         auto kc = sdlKeyToMyGUI(SDLK_ESCAPE);
         mBindingsManager->setPlayerControlsEnabled(!MyGUI::InputManager::getInstance().injectKeyPress(kc, 0));
 
-        if (!mControlsDisabled)
+        if (!MWBase::Environment::get().getInputManager()->controlsDisabled())
             mBindingsManager->controllerButtonPressed(deviceID, arg);
     }
 
@@ -244,7 +242,7 @@ namespace MWInput
             return;
         }
 
-        if (!mJoystickEnabled || mControlsDisabled)
+        if (!mJoystickEnabled || MWBase::Environment::get().getInputManager()->controlsDisabled())
             return;
 
         mJoystickLastUsed = true;
@@ -275,7 +273,7 @@ namespace MWInput
 
     void ControllerManager::axisMoved(int deviceID, const SDL_ControllerAxisEvent &arg)
     {
-        if (!mJoystickEnabled || mControlsDisabled)
+        if (!mJoystickEnabled || MWBase::Environment::get().getInputManager()->controlsDisabled())
             return;
 
         mJoystickLastUsed = true;

--- a/apps/openmw/mwinput/controllermanager.hpp
+++ b/apps/openmw/mwinput/controllermanager.hpp
@@ -23,7 +23,7 @@ namespace MWInput
 
         virtual ~ControllerManager() = default;
 
-        bool update(float dt, bool disableControls);
+        bool update(float dt);
 
         virtual void buttonPressed(int deviceID, const SDL_ControllerButtonEvent &arg);
         virtual void buttonReleased(int deviceID, const SDL_ControllerButtonEvent &arg);
@@ -56,7 +56,6 @@ namespace MWInput
         float mSneakToggleShortcutTimer;
         float mGamepadZoom;
         bool mGamepadGuiCursorEnabled;
-        bool mControlsDisabled;
         bool mJoystickLastUsed;
         bool mGuiCursorEnabled;
         bool mSneakGamepadShortcut;

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -31,6 +31,7 @@ namespace MWInput
             const std::string& userFile, bool userFileExists, const std::string& userControllerBindingsFile,
             const std::string& controllerBindingsFile, bool grab)
         : mGrabCursor(Settings::Manager::getBool("grab cursor", "Input"))
+        , mControlsDisabled(false)
     {
         mInputWrapper = new SDLUtil::InputWrapper(window, viewer, grab);
         mInputWrapper->setWindowEventCallback(MWBase::Environment::get().getWindowManager());
@@ -105,10 +106,11 @@ namespace MWInput
 
     void InputManager::update(float dt, bool disableControls, bool disableEvents)
     {
+        mControlsDisabled = disableControls;
+
         mInputWrapper->setMouseVisible(MWBase::Environment::get().getWindowManager()->getCursorVisible());
         mInputWrapper->capture(disableEvents);
 
-        mKeyboardManager->setControlsDisabled(disableControls);
         if (disableControls)
         {
             updateCursorMode();
@@ -119,8 +121,8 @@ namespace MWInput
 
         updateCursorMode();
 
-        bool controllerMove = mControllerManager->update(dt, disableControls);
-        mMouseManager->update(dt, disableControls);
+        bool controllerMove = mControllerManager->update(dt);
+        mMouseManager->update(dt);
         mSensorManager->update(dt);
         mActionManager->update(dt, controllerMove);
     }

--- a/apps/openmw/mwinput/inputmanagerimp.hpp
+++ b/apps/openmw/mwinput/inputmanagerimp.hpp
@@ -94,6 +94,8 @@ namespace MWInput
 
         virtual void executeAction(int action);
 
+        virtual bool controlsDisabled() { return mControlsDisabled; }
+
     private:
         void convertMousePosForMyGUI(int& x, int& y);
 
@@ -110,6 +112,7 @@ namespace MWInput
         SDLUtil::InputWrapper* mInputWrapper;
 
         bool mGrabCursor;
+        bool mControlsDisabled;
 
         ControlSwitch* mControlSwitch;
 

--- a/apps/openmw/mwinput/keyboardmanager.cpp
+++ b/apps/openmw/mwinput/keyboardmanager.cpp
@@ -18,7 +18,6 @@ namespace MWInput
 {
     KeyboardManager::KeyboardManager(BindingsManager* bindingsManager)
         : mBindingsManager(bindingsManager)
-        , mControlsDisabled(false)
     {
     }
 
@@ -53,10 +52,11 @@ namespace MWInput
         if (arg.repeat)
             return;
 
-        if (!mControlsDisabled && !consumed)
+        MWBase::InputManager* input = MWBase::Environment::get().getInputManager();
+        if (!input->controlsDisabled() && !consumed)
             mBindingsManager->keyPressed(arg);
 
-        MWBase::Environment::get().getInputManager()->setJoystickLastUsed(false);
+        input->setJoystickLastUsed(false);
     }
 
     void KeyboardManager::keyReleased(const SDL_KeyboardEvent &arg)

--- a/apps/openmw/mwinput/keyboardmanager.hpp
+++ b/apps/openmw/mwinput/keyboardmanager.hpp
@@ -19,12 +19,8 @@ namespace MWInput
         virtual void keyPressed(const SDL_KeyboardEvent &arg);
         virtual void keyReleased(const SDL_KeyboardEvent &arg);
 
-        void setControlsDisabled(bool disabled) { mControlsDisabled = disabled; }
-
     private:
         BindingsManager* mBindingsManager;
-
-        bool mControlsDisabled;
     };
 }
 #endif

--- a/apps/openmw/mwinput/mousemanager.cpp
+++ b/apps/openmw/mwinput/mousemanager.cpp
@@ -33,7 +33,6 @@ namespace MWInput
         , mGuiCursorY(0)
         , mMouseWheel(0)
         , mMouseLookEnabled(false)
-        , mControlsDisabled(false)
         , mGuiCursorEnabled(true)
     {
         float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
@@ -88,7 +87,7 @@ namespace MWInput
             MWBase::Environment::get().getWindowManager()->setCursorActive(true);
         }
 
-        if (mMouseLookEnabled && !mControlsDisabled)
+        if (mMouseLookEnabled && !input->controlsDisabled())
         {
             float x = arg.xrel * mCameraSensitivity * (mInvertX ? -1 : 1) / 256.f;
             float y = arg.yrel * mCameraSensitivity * (mInvertY ? -1 : 1) * mCameraYMultiplier / 256.f;
@@ -136,10 +135,11 @@ namespace MWInput
 
     void MouseManager::mouseWheelMoved(const SDL_MouseWheelEvent &arg)
     {
-        if (mBindingsManager->isDetectingBindingState() || !mControlsDisabled)
+        MWBase::InputManager* input = MWBase::Environment::get().getInputManager();
+        if (mBindingsManager->isDetectingBindingState() || !input->controlsDisabled())
             mBindingsManager->mouseWheelMoved(arg);
 
-        MWBase::Environment::get().getInputManager()->setJoystickLastUsed(false);
+        input->setJoystickLastUsed(false);
     }
 
     void MouseManager::mousePressed(const SDL_MouseButtonEvent &arg, Uint8 id)
@@ -169,10 +169,8 @@ namespace MWInput
             mBindingsManager->mousePressed(arg, id);
     }
 
-    void MouseManager::update(float dt, bool disableControls)
+    void MouseManager::update(float dt)
     {
-        mControlsDisabled = disableControls;
-
         if (!mMouseLookEnabled)
             return;
 

--- a/apps/openmw/mwinput/mousemanager.hpp
+++ b/apps/openmw/mwinput/mousemanager.hpp
@@ -20,7 +20,7 @@ namespace MWInput
 
         virtual ~MouseManager() = default;
 
-        void update(float dt, bool disableControls);
+        void update(float dt);
 
         virtual void mouseMoved(const SDLUtil::MouseMotionEvent &arg);
         virtual void mousePressed(const SDL_MouseButtonEvent &arg, Uint8 id);
@@ -51,7 +51,6 @@ namespace MWInput
         float mGuiCursorY;
         int mMouseWheel;
         bool mMouseLookEnabled;
-        bool mControlsDisabled;
         bool mGuiCursorEnabled;
     };
 }


### PR DESCRIPTION
Fixes a regression in #2783, where I did not update this flag properly, so OpenMW crashed if player used mouse wheel during logo video.

Also I suppose that it is simpler to store the flag just in one place.