### PR TITLE
Cleanup WindowManager

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -45,7 +45,7 @@ add_openmw_dir (mwgui
     itemmodel containeritemmodel inventoryitemmodel sortfilteritemmodel itemview
     tradeitemmodel companionitemmodel pickpocketitemmodel controllers savegamedialog
     recharge mode videowidget backgroundimage itemwidget screenfader debugwindow spellmodel spellview
-    draganddrop timeadvancer jailscreen itemchargeview keyboardnavigation
+    draganddrop timeadvancer jailscreen itemchargeview keyboardnavigation textcolours
     )
 
 add_openmw_dir (mwdialogue

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -181,7 +181,7 @@ bool OMW::Engine::frame(float frametime)
         osg::Timer_t afterWorldTick = osg::Timer::instance()->tick();
 
         // update GUI
-        mEnvironment.getWindowManager()->onFrame(frametime);
+        mEnvironment.getWindowManager()->update(frametime);
 
         unsigned int frameNumber = mViewer->getFrameStamp()->getFrameNumber();
         osg::Stats* stats = mViewer->getViewerStats();

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -253,12 +253,6 @@ namespace MWBase
 
             virtual void onFrame (float frameDuration) = 0;
 
-            /// \todo get rid of this stuff. Move it to the respective UI element classes, if needed.
-            virtual std::map<int, MWMechanics::SkillValue > getPlayerSkillValues() = 0;
-            virtual std::map<int, MWMechanics::AttributeValue > getPlayerAttributeValues() = 0;
-            virtual SkillList getPlayerMinorSkills() = 0;
-            virtual SkillList getPlayerMajorSkills() = 0;
-
             /**
              * Fetches a GMST string from the store, if there is no setting with the given
              * ID or it is not a string the default string is returned.

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -251,7 +251,7 @@ namespace MWBase
             /// returns the index of the pressed button or -1 if no button was pressed (->MessageBoxmanager->InteractiveMessageBox)
             virtual int readPressedButton() = 0;
 
-            virtual void onFrame (float frameDuration) = 0;
+            virtual void update (float duration) = 0;
 
             /**
              * Fetches a GMST string from the store, if there is no setting with the given

--- a/apps/openmw/mwgui/charactercreation.hpp
+++ b/apps/openmw/mwgui/charactercreation.hpp
@@ -4,6 +4,7 @@
 #include <components/esm/loadskil.hpp>
 #include <components/esm/loadclas.hpp>
 
+#include <map>
 #include <vector>
 
 #include "../mwmechanics/stat.hpp"
@@ -55,6 +56,10 @@ namespace MWGui
     private:
     osg::Group* mParent;
     Resource::ResourceSystem* mResourceSystem;
+
+    SkillList mPlayerMajorSkills, mPlayerMinorSkills;
+    std::map<int, MWMechanics::AttributeValue> mPlayerAttributes;
+    std::map<int, MWMechanics::SkillValue> mPlayerSkillValues;
 
     //Dialogs
     TextInputDialog* mNameDialog;

--- a/apps/openmw/mwgui/textcolours.cpp
+++ b/apps/openmw/mwgui/textcolours.cpp
@@ -1,0 +1,36 @@
+#include "textcolours.hpp"
+
+#include <MyGUI_LanguageManager.h>
+
+#include <string>
+
+namespace MWGui
+{
+    MyGUI::Colour getTextColour(const std::string& type)
+    {
+        return MyGUI::Colour::parse(MyGUI::LanguageManager::getInstance().replaceTags("#{fontcolour=" + type + "}"));
+    }
+
+    void TextColours::loadColours()
+    {
+        header = getTextColour("header");
+        normal = getTextColour("normal");
+        notify = getTextColour("notify");
+
+        link = getTextColour("link");
+        linkOver = getTextColour("link_over");
+        linkPressed = getTextColour("link_pressed");
+
+        answer = getTextColour("answer");
+        answerOver = getTextColour("answer_over");
+        answerPressed = getTextColour("answer_pressed");
+
+        journalLink = getTextColour("journal_link");
+        journalLinkOver = getTextColour("journal_link_over");
+        journalLinkPressed = getTextColour("journal_link_pressed");
+
+        journalTopic = getTextColour("journal_topic");
+        journalTopicOver = getTextColour("journal_topic_over");
+        journalTopicPressed = getTextColour("journal_topic_pressed");
+    }
+}

--- a/apps/openmw/mwgui/textcolours.hpp
+++ b/apps/openmw/mwgui/textcolours.hpp
@@ -5,13 +5,11 @@
 
 namespace MWGui
 {
-
     struct TextColours
     {
         MyGUI::Colour header;
         MyGUI::Colour normal;
         MyGUI::Colour notify;
-
 
         MyGUI::Colour link;
         MyGUI::Colour linkOver;
@@ -28,6 +26,9 @@ namespace MWGui
         MyGUI::Colour journalTopic;
         MyGUI::Colour journalTopicOver;
         MyGUI::Colour journalTopicPressed;
+
+    public:
+        void loadColours();
     };
 
 }

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -117,19 +117,8 @@
 #include "keyboardnavigation.hpp"
 #include "resourceskin.hpp"
 
-namespace
-{
-
-    MyGUI::Colour getTextColour(const std::string& type)
-    {
-        return MyGUI::Colour::parse(MyGUI::LanguageManager::getInstance().replaceTags("#{fontcolour=" + type + "}"));
-    }
-
-}
-
 namespace MWGui
 {
-
     WindowManager::WindowManager(
             SDL_Window* window, osgViewer::Viewer* viewer, osg::Group* guiRoot, Resource::ResourceSystem* resourceSystem, SceneUtil::WorkQueue* workQueue,
             const std::string& logpath, const std::string& resourcePath, bool consoleOnlyScripts, Translation::Storage& translationDataStorage,
@@ -392,26 +381,7 @@ namespace MWGui
         int w = MyGUI::RenderManager::getInstance().getViewSize().width;
         int h = MyGUI::RenderManager::getInstance().getViewSize().height;
 
-        mTextColours.header = getTextColour("header");
-        mTextColours.normal = getTextColour("normal");
-        mTextColours.notify = getTextColour("notify");
-
-        mTextColours.link = getTextColour("link");
-        mTextColours.linkOver = getTextColour("link_over");
-        mTextColours.linkPressed = getTextColour("link_pressed");
-
-        mTextColours.answer = getTextColour("answer");
-        mTextColours.answerOver = getTextColour("answer_over");
-        mTextColours.answerPressed = getTextColour("answer_pressed");
-
-        mTextColours.journalLink = getTextColour("journal_link");
-        mTextColours.journalLinkOver = getTextColour("journal_link_over");
-        mTextColours.journalLinkPressed = getTextColour("journal_link_pressed");
-
-        mTextColours.journalTopic = getTextColour("journal_topic");
-        mTextColours.journalTopicOver = getTextColour("journal_topic_over");
-        mTextColours.journalTopicPressed = getTextColour("journal_topic_pressed");
-
+        mTextColours.loadColours();
 
         mDragAndDrop = new DragAndDrop();
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -182,12 +182,6 @@ namespace MWGui
       , mCursorVisible(true)
       , mCursorActive(false)
       , mPlayerBounty(-1)
-      , mPlayerName()
-      , mPlayerRaceId()
-      , mPlayerAttributes()
-      , mPlayerMajorSkills()
-      , mPlayerMinorSkills()
-      , mPlayerSkillValues()
       , mGui(nullptr)
       , mGuiModes()
       , mCursorManager(nullptr)
@@ -594,17 +588,6 @@ namespace MWGui
 
         mCharGen = new CharacterCreation(mViewer->getSceneData()->asGroup(), mResourceSystem);
 
-        // Setup player stats
-        for (int i = 0; i < ESM::Attribute::Length; ++i)
-        {
-            mPlayerAttributes.insert(std::make_pair(ESM::Attribute::sAttributeIds[i], MWMechanics::AttributeValue()));
-        }
-
-        for (int i = 0; i < ESM::Skill::Length; ++i)
-        {
-            mPlayerSkillValues.insert(std::make_pair(ESM::Skill::sSkillIds[i], MWMechanics::SkillValue()));
-        }
-
         updatePinnedWindows();
 
         // Set up visibility
@@ -797,32 +780,7 @@ namespace MWGui
     {
         mStatsWindow->setValue (id, value);
         mCharGen->setValue(id, value);
-
-        static const char *ids[] =
-        {
-            "AttribVal1", "AttribVal2", "AttribVal3", "AttribVal4", "AttribVal5",
-            "AttribVal6", "AttribVal7", "AttribVal8"
-        };
-        static ESM::Attribute::AttributeID attributes[] =
-        {
-            ESM::Attribute::Strength,
-            ESM::Attribute::Intelligence,
-            ESM::Attribute::Willpower,
-            ESM::Attribute::Agility,
-            ESM::Attribute::Speed,
-            ESM::Attribute::Endurance,
-            ESM::Attribute::Personality,
-            ESM::Attribute::Luck
-        };
-        for (size_t i = 0; i < sizeof(ids)/sizeof(ids[0]); ++i)
-        {
-            if (id != ids[i])
-                continue;
-            mPlayerAttributes[attributes[i]] = value;
-            break;
-        }
     }
-
 
     void WindowManager::setValue (int parSkill, const MWMechanics::SkillValue& value)
     {
@@ -830,7 +788,6 @@ namespace MWGui
         /// allow custom skills.
         mStatsWindow->setValue(static_cast<ESM::Skill::SkillEnum> (parSkill), value);
         mCharGen->setValue(static_cast<ESM::Skill::SkillEnum> (parSkill), value);
-        mPlayerSkillValues[parSkill] = value;
     }
 
     void WindowManager::setValue (const std::string& id, const MWMechanics::DynamicStat<float>& value)
@@ -843,10 +800,6 @@ namespace MWGui
     void WindowManager::setValue (const std::string& id, const std::string& value)
     {
         mStatsWindow->setValue (id, value);
-        if (id=="name")
-            mPlayerName = value;
-        else if (id=="race")
-            mPlayerRaceId = value;
     }
 
     void WindowManager::setValue (const std::string& id, int value)
@@ -868,8 +821,6 @@ namespace MWGui
     {
         mStatsWindow->configureSkills (major, minor);
         mCharGen->configureSkills(major, minor);
-        mPlayerMajorSkills = major;
-        mPlayerMinorSkills = minor;
     }
 
     void WindowManager::updateSkillArea()
@@ -1637,26 +1588,6 @@ namespace MWGui
         if (mGuiModes.empty())
             return GM_None;
         return mGuiModes.back();
-    }
-
-    std::map<int, MWMechanics::SkillValue > WindowManager::getPlayerSkillValues()
-    {
-        return mPlayerSkillValues;
-    }
-
-    std::map<int, MWMechanics::AttributeValue > WindowManager::getPlayerAttributeValues()
-    {
-        return mPlayerAttributes;
-    }
-
-    WindowManager::SkillList WindowManager::getPlayerMinorSkills()
-    {
-        return mPlayerMinorSkills;
-    }
-
-    WindowManager::SkillList WindowManager::getPlayerMajorSkills()
-    {
-        return mPlayerMajorSkills;
     }
 
     void WindowManager::disallowMouse()

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -956,7 +956,7 @@ namespace MWGui
         mHud->setPlayerPos(x, y, u, v);
     }
 
-    void WindowManager::onFrame (float frameDuration)
+    void WindowManager::update (float frameDuration)
     {
         bool gameRunning = MWBase::Environment::get().getStateManager()->getState()!=
             MWBase::StateManager::State_NoGame;

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -282,12 +282,6 @@ namespace MWGui
 
     virtual void onFrame (float frameDuration);
 
-    /// \todo get rid of this stuff. Move it to the respective UI element classes, if needed.
-    virtual std::map<int, MWMechanics::SkillValue > getPlayerSkillValues();
-    virtual std::map<int, MWMechanics::AttributeValue > getPlayerAttributeValues();
-    virtual SkillList getPlayerMinorSkills();
-    virtual SkillList getPlayerMajorSkills();
-
     /**
      * Fetches a GMST string from the store, if there is no setting with the given
      * ID or it is not a string the default string is returned.
@@ -473,14 +467,6 @@ namespace MWGui
     int mPlayerBounty;
 
     void setCursorVisible(bool visible);
-
-    /// \todo get rid of this stuff. Move it to the respective UI element classes, if needed.
-    // Various stats about player as needed by window manager
-    std::string mPlayerName;
-    std::string mPlayerRaceId;
-    std::map<int, MWMechanics::AttributeValue > mPlayerAttributes;
-    SkillList mPlayerMajorSkills, mPlayerMinorSkills;
-    std::map<int, MWMechanics::SkillValue > mPlayerSkillValues;
 
     MyGUI::Gui *mGui; // Gui
 

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -280,7 +280,7 @@ namespace MWGui
 
     virtual int readPressedButton (); ///< returns the index of the pressed button or -1 if no button was pressed (->MessageBoxmanager->InteractiveMessageBox)
 
-    virtual void onFrame (float frameDuration);
+    virtual void update (float duration);
 
     /**
      * Fetches a GMST string from the store, if there is no setting with the given


### PR DESCRIPTION
Summary of changes:
1. Fix a TODO - do not store player-related data in the WindowManager itself, since these fields are used only to pass them to the CharacterCreation. 
I moved them to the CharacterCreation, what allowed to simplify API (there is no need to move maps now) and reduce code duplication. Interesting that mPlayerName and mPlayerRaceId were not used at all.
2. Rename WindowManager::onFrame() to the WindowManager::update() to make it consistent with other managers.
3. Move TextColours initialization to the separate TexColours::loadColours() method.