### PR TITLE
Reenable weapon animation lower body anim blending in first person view (#5441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     Bug #5416: Junk non-node records before the root node are not handled gracefully
     Bug #5424: Creatures do not headtrack player
     Bug #5427: GetDistance unknown ID error is misleading
+    Bug #5441: Enemies can't push a player character when in critical strike stance
     Feature #5362: Show the soul gems' trapped soul in count dialog
 
 0.46.0

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1260,10 +1260,9 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         }
     }
 
-    // Use blending only with 3d-person movement animations for bipedal actors
-    bool firstPersonPlayer = (mPtr == MWMechanics::getPlayer() && MWBase::Environment::get().getWorld()->isFirstPerson());
+    // For biped actors, blend weapon animations with lower body animations with higher priority
     MWRender::Animation::AnimPriority priorityWeapon(Priority_Weapon);
-    if (!firstPersonPlayer && mPtr.getClass().isBipedal(mPtr))
+    if (mPtr.getClass().isBipedal(mPtr))
         priorityWeapon[MWRender::Animation::BoneGroup_LowerBody] = Priority_WeaponLowerBody;
 
     bool forcestateupdate = false;


### PR DESCRIPTION
While it fixes things that are broken in vanilla, it also breaks things that aren't broken in vanilla, as evident from [the report](https://gitlab.com/OpenMW/openmw/-/issues/5441), so we should follow vanilla blending behavior to avoid further discrepancy-caused issues from cropping up.

This makes sure hit lower body animation can blend with the weapon animation so first person view behaves closer to third person view. Points 2 and 3 from bug 4575 rearise, but they're actually vanilla animation issues we should just faithfully carry over instead of trying to work around.