### PR TITLE
Mutate base records when editing AI settings (#2798)

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -35,6 +35,7 @@ namespace ESM
     struct Position;
     struct Cell;
     struct Class;
+    struct Creature;
     struct Potion;
     struct Spell;
     struct NPC;
@@ -374,6 +375,14 @@ namespace MWBase
             /// \return pointer to created record
 
             virtual const ESM::ItemLevList *createOverrideRecord (const ESM::ItemLevList& record) = 0;
+            ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
+            /// \return pointer to created record
+
+            virtual const ESM::Creature *createOverrideRecord (const ESM::Creature& record) = 0;
+            ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
+            /// \return pointer to created record
+
+            virtual const ESM::NPC *createOverrideRecord (const ESM::NPC& record) = 0;
             ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
             /// \return pointer to created record
 

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -878,4 +878,9 @@ namespace MWClass
         const MWWorld::LiveCellRef<ESM::Creature> *ref = ptr.get<ESM::Creature>();
         scale *= ref->mBase->mScale;
     }
+
+    void Creature::setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value) const
+    {
+        MWMechanics::setBaseAISetting<ESM::Creature>(id, setting, value);
+    }
 }

--- a/apps/openmw/mwclass/creature.hpp
+++ b/apps/openmw/mwclass/creature.hpp
@@ -129,6 +129,8 @@ namespace MWClass
 
             virtual void adjustScale(const MWWorld::ConstPtr& ptr, osg::Vec3f& scale, bool rendering) const;
             /// @param rendering Indicates if the scale to adjust is for the rendering mesh, or for the collision mesh
+
+            virtual void setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value) const;
     };
 }
 

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -1437,4 +1437,9 @@ namespace MWClass
         const MWWorld::LiveCellRef<ESM::NPC> *ref = ptr.get<ESM::NPC>();
         return ref->mBase->getFactionRank();
     }
+
+    void Npc::setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value) const
+    {
+        MWMechanics::setBaseAISetting<ESM::NPC>(id, setting, value);
+    }
 }

--- a/apps/openmw/mwclass/npc.hpp
+++ b/apps/openmw/mwclass/npc.hpp
@@ -164,6 +164,8 @@ namespace MWClass
 
             virtual std::string getPrimaryFaction(const MWWorld::ConstPtr &ptr) const;
             virtual int getPrimaryFactionRank(const MWWorld::ConstPtr &ptr) const;
+
+            virtual void setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value) const;
     };
 }
 

--- a/apps/openmw/mwmechanics/actorutil.hpp
+++ b/apps/openmw/mwmechanics/actorutil.hpp
@@ -1,6 +1,16 @@
 #ifndef OPENMW_MWMECHANICS_ACTORUTIL_H
 #define OPENMW_MWMECHANICS_ACTORUTIL_H
 
+#include <components/esm/loadcrea.hpp>
+#include <components/esm/loadnpc.hpp>
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
+
+#include "../mwworld/esmstore.hpp"
+
+#include "./creaturestats.hpp"
+
 namespace MWWorld
 {
     class Ptr;
@@ -11,6 +21,33 @@ namespace MWMechanics
     MWWorld::Ptr getPlayer();
     bool isPlayerInCombat();
     bool canActorMoveByZAxis(const MWWorld::Ptr& actor);
+
+    template<class T>
+    void setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value)
+    {
+        T copy = *MWBase::Environment::get().getWorld()->getStore().get<T>().find(id);
+        switch(setting)
+        {
+            case MWMechanics::CreatureStats::AiSetting::AI_Hello:
+                copy.mAiData.mHello = value;
+                break;
+            case MWMechanics::CreatureStats::AiSetting::AI_Fight:
+                copy.mAiData.mFight = value;
+                break;
+            case MWMechanics::CreatureStats::AiSetting::AI_Flee:
+                copy.mAiData.mFlee = value;
+                break;
+            case MWMechanics::CreatureStats::AiSetting::AI_Alarm:
+                copy.mAiData.mAlarm = value;
+                break;
+            default:
+                assert(0);
+        }
+        MWBase::Environment::get().getWorld()->createOverrideRecord(copy);
+    }
+
+    template void setBaseAISetting<ESM::Creature>(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value);
+    template void setBaseAISetting<ESM::NPC>(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value);
 }
 
 #endif

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -257,8 +257,10 @@ namespace MWScript
                     Interpreter::Type_Integer value = runtime[0].mInteger;
                     runtime.pop();
 
-                    ptr.getClass().getCreatureStats (ptr).setAiSetting (mIndex,
-                        ptr.getClass().getCreatureStats (ptr).getAiSetting (mIndex).getBase() + value);
+                    int modified = ptr.getClass().getCreatureStats (ptr).getAiSetting (mIndex).getBase() + value;
+
+                    ptr.getClass().getCreatureStats (ptr).setAiSetting (mIndex, modified);
+                    ptr.getClass().setBaseAISetting(ptr.getCellRef().getRefId(), mIndex, modified);
                 }
         };
         template<class R>
@@ -277,6 +279,7 @@ namespace MWScript
                     MWMechanics::Stat<int> stat = ptr.getClass().getCreatureStats(ptr).getAiSetting(mIndex);
                     stat.setModified(value, 0);
                     ptr.getClass().getCreatureStats(ptr).setAiSetting(mIndex, stat);
+                    ptr.getClass().setBaseAISetting(ptr.getCellRef().getRefId(), mIndex, value);
                 }
         };
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -460,6 +460,7 @@ void MWState::StateManager::loadGame (const Character *character, const std::str
                 case ESM::REC_ENAB:
                 case ESM::REC_LEVC:
                 case ESM::REC_LEVI:
+                case ESM::REC_CREA:
                     MWBase::Environment::get().getWorld()->readRecord(reader, n.intval, contentFileMap);
                     break;
 

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -516,4 +516,9 @@ namespace MWWorld
         result.z() = magicEffect->mData.mBlue / 255.f;
         return result;
     }
+
+    void Class::setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value) const
+    {
+        throw std::runtime_error ("class does not have creature stats");
+    }
 }

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -10,6 +10,7 @@
 
 #include "ptr.hpp"
 #include "doorstate.hpp"
+#include "../mwmechanics/creaturestats.hpp"
 
 namespace ESM
 {
@@ -28,7 +29,6 @@ namespace MWPhysics
 
 namespace MWMechanics
 {
-    class CreatureStats;
     class NpcStats;
     struct Movement;
 }
@@ -360,6 +360,8 @@ namespace MWWorld
             virtual float getEffectiveArmorRating(const MWWorld::ConstPtr& armor, const MWWorld::Ptr& actor) const;
 
             virtual osg::Vec4f getEnchantmentColor(const MWWorld::ConstPtr& item) const;
+
+            virtual void setBaseAISetting(const std::string& id, MWMechanics::CreatureStats::AiSetting setting, int value) const;
     };
 }
 

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -273,7 +273,8 @@ void ESMStore::validate()
             +mSpells.getDynamicSize()
             +mWeapons.getDynamicSize()
             +mCreatureLists.getDynamicSize()
-            +mItemLists.getDynamicSize();
+            +mItemLists.getDynamicSize()
+            +mCreatures.getDynamicSize();
     }
 
     void ESMStore::write (ESM::ESMWriter& writer, Loading::Listener& progress) const
@@ -295,6 +296,7 @@ void ESMStore::validate()
         mNpcs.write (writer, progress);
         mItemLists.write (writer, progress);
         mCreatureLists.write (writer, progress);
+        mCreatures.write (writer, progress);
     }
 
     bool ESMStore::readRecord (ESM::ESMReader& reader, uint32_t type)
@@ -312,24 +314,8 @@ void ESMStore::validate()
             case ESM::REC_NPC_:
             case ESM::REC_LEVI:
             case ESM::REC_LEVC:
-
-                {
-                    mStores[type]->read (reader);
-                }
-
-                if (type==ESM::REC_NPC_)
-                {
-                    // NPC record will always be last and we know that there can be only one
-                    // dynamic NPC record (player) -> We are done here with dynamic record loading
-                    setUp();
-
-                    const ESM::NPC *player = mNpcs.find ("player");
-
-                    if (!mRaces.find (player->mRace) ||
-                        !mClasses.find (player->mClass))
-                        throw std::runtime_error ("Invalid player record (race or class unavailable");
-                }
-
+            case ESM::REC_CREA:
+                mStores[type]->read (reader);
                 return true;
 
             case ESM::REC_DYNA:
@@ -341,6 +327,17 @@ void ESMStore::validate()
 
                 return false;
         }
+    }
+
+    void ESMStore::checkPlayer()
+    {
+        setUp();
+
+        const ESM::NPC *player = mNpcs.find ("player");
+
+        if (!mRaces.find (player->mRace) ||
+            !mClasses.find (player->mClass))
+            throw std::runtime_error ("Invalid player record (race or class unavailable");
     }
 
 } // end namespace

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -239,6 +239,9 @@ namespace MWWorld
 
         bool readRecord (ESM::ESMReader& reader, uint32_t type);
         ///< \return Known type?
+
+        // To be called when we are done with dynamic record loading
+        void checkPlayer();
     };
 
     template <>

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -403,6 +403,7 @@ namespace MWWorld
                 reader.getHNT(mLevitationEnabled, "LEVT");
                 return;
             case ESM::REC_PLAY:
+                mStore.checkPlayer();
                 mPlayer->readRecord(reader, type);
                 if (getPlayerPtr().isInCell())
                 {
@@ -1811,6 +1812,16 @@ namespace MWWorld
     }
 
     const ESM::ItemLevList *World::createOverrideRecord(const ESM::ItemLevList &record)
+    {
+        return mStore.overrideRecord(record);
+    }
+
+    const ESM::Creature *World::createOverrideRecord(const ESM::Creature &record)
+    {
+        return mStore.overrideRecord(record);
+    }
+
+    const ESM::NPC *World::createOverrideRecord(const ESM::NPC &record)
     {
         return mStore.overrideRecord(record);
     }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -490,6 +490,14 @@ namespace MWWorld
             ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
             /// \return pointer to created record
 
+            const ESM::Creature *createOverrideRecord (const ESM::Creature& record) override;
+            ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
+            /// \return pointer to created record
+
+            const ESM::NPC *createOverrideRecord (const ESM::NPC& record) override;
+            ///< Write this record to the ESM store, allowing it to override a pre-existing record with the same ID.
+            /// \return pointer to created record
+
             void update (float duration, bool paused) override;
             void updatePhysics (float duration, bool paused) override;
 


### PR DESCRIPTION
Split from #2870. Following akortunov's advice a bit earlier than I initially expected.

I had assumed Add and RemoveSpell would require a similar change to AI settings, this is so far from true it's not even funny. So no reason to keep this change waiting.