### PR TITLE
Move font loading to the FontLoader

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -411,8 +411,6 @@ namespace MWGui
     MWWorld::Ptr mSelectedEnchantItem;
     MWWorld::Ptr mSelectedWeapon;
 
-    void loadFontDelegate(MyGUI::xml::ElementPtr _node, const std::string& _file, MyGUI::Version _version);
-
     std::vector<WindowModal*> mCurrentModals;
 
     // Markers placed manually by the player. Must be shared between both map views (the HUD map and the map window).
@@ -516,8 +514,6 @@ namespace MWGui
     int mShowOwned;
 
     ToUTF8::FromType mEncoding;
-
-    int mFontHeight;
 
     std::string mVersionDescription;
 

--- a/components/fontloader/fontloader.hpp
+++ b/components/fontloader/fontloader.hpp
@@ -3,6 +3,9 @@
 
 #include "boost/filesystem/operations.hpp"
 
+#include <MyGUI_XmlDocument.h>
+#include <MyGUI_Version.h>
+
 #include <components/myguiplatform/myguidatamanager.hpp>
 #include <components/to_utf8/to_utf8.hpp>
 
@@ -19,8 +22,6 @@ namespace MyGUI
 
 namespace Gui
 {
-
-
     /// @brief loads Morrowind's .fnt/.tex fonts for use with MyGUI and OSG
     /// @note The FontLoader needs to remain in scope as long as you want to use the loaded fonts.
     class FontLoader
@@ -33,16 +34,21 @@ namespace Gui
         void loadBitmapFonts (bool exportToFile);
         void loadTrueTypeFonts ();
 
+        void loadFontFromXml(MyGUI::xml::ElementPtr _node, const std::string& _file, MyGUI::Version _version);
+
+        int getFontHeight();
+
     private:
         ToUTF8::FromType mEncoding;
         const VFS::Manager* mVFS;
         std::string mUserDataPath;
+        int mFontHeight;
 
         std::vector<MyGUI::ITexture*> mTextures;
         std::vector<MyGUI::ResourceManualFont*> mFonts;
 
         /// @param exportToFile export the converted font (Image and XML with glyph metrics) to files?
-        void loadFont (const std::string& fileName, bool exportToFile);
+        void loadBitmapFont (const std::string& fileName, bool exportToFile);
 
         FontLoader(const FontLoader&);
         void operator=(const FontLoader&);

--- a/components/widgets/fontwrapper.hpp
+++ b/components/widgets/fontwrapper.hpp
@@ -38,7 +38,7 @@ namespace Gui
 
         std::string getFontSize()
         {
-            // Note: we can not use the WindowManager here, so there is a code duplication a bit.
+            // Note: we can not use the FontLoader here, so there is a code duplication a bit.
             static const std::string fontSize = std::to_string(clamp(Settings::Manager::getInt("font size", "GUI"), 12, 20));
             return fontSize;
         }


### PR DESCRIPTION
We already have a FontLoader class, which handles fonts loading itself (including XML parsing for bitmap fonts). So I suppose than XML parsing for TrueType fonts really should be here instead of WindowManager itself.