### PR TITLE
Remove redundant variables from the RenderingManager

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -213,10 +213,8 @@ namespace MWRender
         , mUnderwaterIndoorFog(Fallback::Map::getFloat("Water_UnderwaterIndoorFog"))
         , mNightEyeFactor(0.f)
         , mDistantFog(false)
-        , mDistantTerrain(false)
         , mFieldOfViewOverridden(false)
         , mFieldOfViewOverride(0.f)
-        , mBorders(false)
     {
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
         resourceSystem->getSceneManager()->setShaderPath(resourcePath + "/shaders");
@@ -290,9 +288,7 @@ namespace MWRender
         DLUnderwaterFogEnd = Settings::Manager::getFloat("distant underwater fog end", "Fog");
         DLInteriorFogStart = Settings::Manager::getFloat("distant interior fog start", "Fog");
         DLInteriorFogEnd = Settings::Manager::getFloat("distant interior fog end", "Fog");
-
         mDistantFog = Settings::Manager::getBool("use distant fog", "Fog");
-        mDistantTerrain = Settings::Manager::getBool("distant terrain", "Terrain");
 
         const std::string normalMapPattern = Settings::Manager::getString("normal map pattern", "Shaders");
         const std::string heightMapPattern = Settings::Manager::getString("normal height map pattern", "Shaders");
@@ -302,7 +298,7 @@ namespace MWRender
 
         mTerrainStorage = new TerrainStorage(mResourceSystem, normalMapPattern, heightMapPattern, useTerrainNormalMaps, specularMapPattern, useTerrainSpecularMaps);
 
-        if (mDistantTerrain)
+        if (Settings::Manager::getBool("distant terrain", "Terrain"))
         {
             const int compMapResolution = Settings::Manager::getInt("composite map resolution", "Terrain");
             int compMapPower = Settings::Manager::getInt("composite map level", "Terrain");
@@ -558,9 +554,9 @@ namespace MWRender
 
     bool RenderingManager::toggleBorders()
     {
-        mBorders = !mBorders;
-        mTerrain->setBordersVisible(mBorders);
-        return mBorders;
+        bool borders = !mTerrain->getBordersVisible();
+        mTerrain->setBordersVisible(borders);
+        return borders;
     }
 
     bool RenderingManager::toggleRenderMode(RenderMode mode)

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -299,12 +299,10 @@ namespace MWRender
         float mNearClip;
         float mViewDistance;
         bool mDistantFog : 1;
-        bool mDistantTerrain : 1;
         bool mFieldOfViewOverridden : 1;
         float mFieldOfViewOverride;
         float mFieldOfView;
         float mFirstPersonFieldOfView;
-        bool mBorders;
 
         void operator = (const RenderingManager&);
         RenderingManager(const RenderingManager&);

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -139,6 +139,7 @@ namespace Terrain
         virtual void enable(bool enabled) {}
 
         virtual void setBordersVisible(bool visible);
+        virtual bool getBordersVisible() { return mBorderVisible; }
 
         /// Create a View to use with preload feature. The caller is responsible for deleting the view.
         /// @note Thread safe.


### PR DESCRIPTION
Summary of changes:
1. Terrain system itself already tracks if it renders cells borders or if it is not. There is no point to track it in the RenderingManager too.
2. mDistantLand field is not used outside the constructor, so there is no need to keep it.