### PR TITLE
Refactor list of variables in the WorldManager

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -164,10 +164,11 @@ namespace MWWorld
         const std::string& startCell, const std::string& startupScript,
         const std::string& resourcePath, const std::string& userDataPath)
     : mResourceSystem(resourceSystem), mLocalScripts (mStore),
-      mSky (true), mCells (mStore, mEsm),
-      mGodMode(false), mScriptsEnabled(true), mContentFiles (contentFiles), mUserDataPath(userDataPath),
+      mCells (mStore, mEsm), mSky (true),
+      mGodMode(false), mScriptsEnabled(true), mContentFiles (contentFiles),
+      mUserDataPath(userDataPath), mShouldUpdateNavigator(false),
       mActivationDistanceOverride (activationDistanceOverride),
-      mStartCell (startCell), mDistanceToFacedObject(-1), mTeleportEnabled(true),
+      mStartCell(startCell), mDistanceToFacedObject(-1.f), mTeleportEnabled(true),
       mLevitationEnabled(true), mGoToJail(false), mDaysInPrison(0),
       mPlayerTraveling(false), mPlayerInJail(false), mSpellPreloadTimer(0.f)
     {

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -77,13 +77,13 @@ namespace MWWorld
 
     class World final: public MWBase::World
     {
+        private:
             Resource::ResourceSystem* mResourceSystem;
 
             std::vector<ESM::ESMReader> mEsm;
             MWWorld::ESMStore mStore;
             LocalScripts mLocalScripts;
             MWWorld::Globals mGlobalVariables;
-            bool mSky;
 
             ESM::Variant* mGameHour;
             ESM::Variant* mDaysPassed;
@@ -104,6 +104,7 @@ namespace MWWorld
             std::unique_ptr<MWWorld::WeatherManager> mWeatherManager;
             std::shared_ptr<ProjectileManager> mProjectileManager;
 
+            bool mSky;
             bool mGodMode;
             bool mScriptsEnabled;
             std::vector<std::string> mContentFiles;
@@ -111,18 +112,31 @@ namespace MWWorld
             std::string mUserDataPath;
 
             osg::Vec3f mDefaultHalfExtents;
-            bool mShouldUpdateNavigator = false;
-
-            // not implemented
-            World (const World&);
-            World& operator= (const World&);
+            bool mShouldUpdateNavigator;
 
             int mActivationDistanceOverride;
+
+            std::string mStartCell;
+
+            float mSwimHeightScale;
+
+            float mDistanceToFacedObject;
+
+            bool mTeleportEnabled;
+            bool mLevitationEnabled;
+            bool mGoToJail;
+            int mDaysInPrison;
+            bool mPlayerTraveling;
+            bool mPlayerInJail;
+
+            float mSpellPreloadTimer;
 
             std::map<MWWorld::Ptr, MWWorld::DoorState> mDoorStates;
             ///< only holds doors that are currently moving. 1 = opening, 2 = closing
 
-            std::string mStartCell;
+            // not implemented
+            World (const World&);
+            World& operator= (const World&);
 
             void updateWeather(float duration, bool paused = false);
             int getDaysPerMonth (int month) const;
@@ -141,10 +155,6 @@ namespace MWWorld
 
             MWWorld::Ptr getFacedObject(float maxDistance, bool ignorePlayer=true);
 
-    public: // FIXME
-            void addContainerScripts(const Ptr& reference, CellStore* cell) override;
-            void removeContainerScripts(const Ptr& reference) override;
-    private:
             void PCDropped (const Ptr& item);
 
             bool rotateDoor(const Ptr door, DoorState state, float duration);
@@ -172,19 +182,6 @@ namespace MWWorld
             void loadContentFiles(const Files::Collections& fileCollections,
                 const std::vector<std::string>& content, ContentLoader& contentLoader);
 
-            float mSwimHeightScale;
-
-            float mDistanceToFacedObject;
-
-            bool mTeleportEnabled;
-            bool mLevitationEnabled;
-            bool mGoToJail;
-            int mDaysInPrison;
-            bool mPlayerTraveling;
-            bool mPlayerInJail;
-
-            float mSpellPreloadTimer;
-
             float feetToGameUnits(float feet);
             float getActivationDistancePlusTelekinesis();
 
@@ -192,6 +189,9 @@ namespace MWWorld
             MWWorld::ConstPtr getClosestMarkerFromExteriorPosition( const osg::Vec3f& worldPos, const std::string &id );
 
         public:
+            // FIXME
+            void addContainerScripts(const Ptr& reference, CellStore* cell) override;
+            void removeContainerScripts(const Ptr& reference) override;
 
             World (
                 osgViewer::Viewer* viewer,


### PR DESCRIPTION
Summary of changes:
1. Move fields declarations to the single block, as we do in other places, rather than mix them with methods declarations in a random way.
2. Unify the way to init WorldManager fields.