### PR TITLE
Update spell effects during death animation (#5403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     Bug #5370: Opening an unlocked but trapped door uses the key
     Bug #5397: NPC greeting does not reset if you leave + reenter area
     Bug #5400: Editor: Verifier checks race of non-skin bodyparts
+    Bug #5403: Enchantment effect doesn't show on an enemy during death animation
     Bug #5415: Environment maps in ebony cuirass and HiRez Armors Indoril cuirass don't work
     Bug #5416: Junk non-node records before the root node are not handled gracefully
     Bug #5424: Creatures do not headtrack player

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1623,9 +1623,14 @@ namespace MWMechanics
 
                 iter->first.getClass().getCreatureStats(iter->first).getActiveSpells().update(duration);
 
-                // For dead actors we need to remove looping spell particles
+                // For dead actors we need to update looping spell particles
                 if (iter->first.getClass().getCreatureStats(iter->first).isDead())
+                {
+                    // They can be added during the death animation
+                    if (!iter->first.getClass().getCreatureStats(iter->first).isDeathAnimationFinished())
+                        adjustMagicEffects(iter->first);
                     ctrl->updateContinuousVfx();
+                }
                 else
                 {
                     bool cellChanged = world->hasCellChanged();

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -572,7 +572,8 @@ void MWWorld::InventoryStore::updateMagicEffects(const Ptr& actor)
 
     mMagicEffects = MWMechanics::MagicEffects();
 
-    if (actor.getClass().getCreatureStats(actor).isDead())
+    const auto& stats = actor.getClass().getCreatureStats(actor);
+    if (stats.isDead() && stats.isDeathAnimationFinished())
         return;
 
     for (TSlots::const_iterator iter (mSlots.begin()); iter!=mSlots.end(); ++iter)


### PR DESCRIPTION
Should resolve [this](https://gitlab.com/OpenMW/openmw/-/issues/5403).

Effects will now be updated while the actor hasn't yet departed this world completely and can still be inflicted with a spell or an enchantment while the character is falling down like in Morrowind. This allows visual effects to properly play out. Of course you can't hit a character with an on-strike enchantment because of how physical combat is handled.
Health bar won't be shown if the player casts a harmful spell on a dying actor to prevent oddities.
Effects caused by constant effect items will be updated on dying actors too.

May horribly break something, there were troubles with fixes for a similar issue earlier. :man_shrugging: 