### PR TITLE
Do not store object position, if it is the same as in CellRef

### DIFF
--- a/components/esm/defs.hpp
+++ b/components/esm/defs.hpp
@@ -57,6 +57,26 @@ struct Position
 };
 #pragma pack(pop)
 
+bool inline operator== (const Position& left, const Position& right) noexcept
+{
+    return left.pos[0] == right.pos[0] &&
+           left.pos[1] == right.pos[1] &&
+           left.pos[2] == right.pos[2] &&
+           left.rot[0] == right.rot[0] &&
+           left.rot[1] == right.rot[1] &&
+           left.rot[2] == right.rot[2];
+}
+
+bool inline operator!= (const Position& left, const Position& right) noexcept
+{
+    return left.pos[0] != right.pos[0] ||
+           left.pos[1] != right.pos[1] ||
+           left.pos[2] != right.pos[2] ||
+           left.rot[0] != right.rot[0] ||
+           left.rot[1] != right.rot[1] ||
+           left.rot[2] != right.rot[2];
+}
+
 template <int a, int b, int c, int d>
 struct FourCC
 {

--- a/components/esm/objectstate.cpp
+++ b/components/esm/objectstate.cpp
@@ -26,6 +26,7 @@ void ESM::ObjectState::load (ESMReader &esm)
     mCount = 1;
     esm.getHNOT (mCount, "COUN");
 
+    mPosition = mRef.mPos;
     esm.getHNOT (mPosition, "POS_", 24);
 
     if (esm.isNextSub("LROT"))
@@ -61,7 +62,7 @@ void ESM::ObjectState::save (ESMWriter &esm, bool inInventory) const
     if (mCount!=1)
         esm.writeHNT ("COUN", mCount);
 
-    if (!inInventory)
+    if (!inInventory && mPosition != mRef.mPos)
         esm.writeHNT ("POS_", mPosition, 24);
 
     if (mFlags != 0)

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -4,7 +4,7 @@
 #include "esmwriter.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 11;
+int ESM::SavedGame::sCurrentFormat = 12;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
We store object position in two places - in the ESM::CellRef (initially we read it from ESM/ESP file and treat as an initial object position) and in the ObjectState (a current position). In many cases (for containers and activators, for example) both coordinats sets are the same.

So the suggested approach - do not store the current position, if it is the same as an initial one (which we store in save as ESM::CellRef record). 
Such approach made my testing saves about 6% lesser without any noticable difference in the loading speed. But I suspect that for new games the difference will be smaller since we do not store data about not-looted-yet containers.