### PR TITLE
Don't save to or read automove state from saved games (#5452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     Bug #5427: GetDistance unknown ID error is misleading
     Bug #5435: Enemies can't hurt the player when collision is off
     Bug #5441: Enemies can't push a player character when in critical strike stance
+    Bug #5452: Autowalk is being included in savegames
     Feature #5362: Show the soul gems' trapped soul in count dialog
     Feature #5445: Handle NiLines
 

--- a/apps/essimporter/importercontext.hpp
+++ b/apps/essimporter/importercontext.hpp
@@ -63,7 +63,6 @@ namespace ESSImport
             , mHour(0.f)
             , mNextActorId(0)
         {
-            mPlayer.mAutoMove = 0;
             ESM::CellId playerCellId;
             playerCellId.mPaged = true;
             playerCellId.mIndex.mX = playerCellId.mIndex.mY = 0;

--- a/apps/openmw/mwworld/player.cpp
+++ b/apps/openmw/mwworld/player.cpp
@@ -356,8 +356,6 @@ namespace MWWorld
         else
             player.mHasMark = false;
 
-        player.mAutoMove = mAutoMove ? 1 : 0;
-
         for (int i=0; i<ESM::Attribute::Length; ++i)
             mSaveAttributes[i].writeState(player.mSaveAttributes[i]);
         for (int i=0; i<ESM::Skill::Length; ++i)
@@ -451,8 +449,6 @@ namespace MWWorld
             {
                 mMarkedCell = 0;
             }
-
-            mAutoMove = player.mAutoMove!=0;
 
             mForwardBackward = 0;
             mTeleported = false;

--- a/components/esm/player.cpp
+++ b/components/esm/player.cpp
@@ -21,8 +21,9 @@ void ESM::Player::load (ESMReader &esm)
     else
         mHasMark = false;
 
-    mAutoMove = 0;
-    esm.getHNOT (mAutoMove, "AMOV");
+    // Automove, no longer used.
+    if (esm.isNextSub("AMOV"))
+        esm.skipHSub();
 
     mBirthsign = esm.getHNString ("SIGN");
 
@@ -65,9 +66,6 @@ void ESM::Player::save (ESMWriter &esm) const
         esm.writeHNT ("MARK", mMarkedPosition, 24);
         mMarkedCell.save (esm);
     }
-
-    if (mAutoMove)
-        esm.writeHNT ("AMOV", mAutoMove);
 
     esm.writeHNString ("SIGN", mBirthsign);
 

--- a/components/esm/player.hpp
+++ b/components/esm/player.hpp
@@ -25,9 +25,8 @@ namespace ESM
         unsigned char mHasMark;
         ESM::Position mMarkedPosition;
         CellId mMarkedCell;
-        unsigned char mAutoMove;
         std::string mBirthsign;
-        
+
         int mCurrentCrimeId;
         int mPaidCrimeId;
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5452)

Don't write AMOV subrecord nor use its value in older saves. It's not necessary to update the saved game format because the subrecord was already optional (only saved when autorun was on and only loaded if it was present).

Automove state is already properly reset during a session when a new game is started or a saved game is loaded.