### PR TITLE
Clean up magic bolts casted by actors that are gone (bug #5451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     Bug #5427: GetDistance unknown ID error is misleading
     Bug #5435: Enemies can't hurt the player when collision is off
     Bug #5441: Enemies can't push a player character when in critical strike stance
+    Bug #5451: Magic projectiles don't disappear with the caster
     Feature #5362: Show the soul gems' trapped soul in count dialog
     Feature #5445: Handle NiLines
 


### PR DESCRIPTION
[Bug report](https://gitlab.com/OpenMW/openmw/-/issues/5451)

Magic bolts update now cleans up magic bolts casted by absent and dead actors almost immediately. This seems to replicate the original behavior in the cases I've tested. Hopefully this is everything necessary to avoid the discrepancy.
Should be compatible with akortunov's corpse disposal and projectile collision PRs.