### PR TITLE
Ignore bogus string arguments for Disable/Enable again

### DIFF
--- a/components/compiler/extensions0.cpp
+++ b/components/compiler/extensions0.cpp
@@ -247,8 +247,8 @@ namespace Compiler
             extensions.registerInstruction ("startscript", "c", opcodeStartScript, opcodeStartScriptExplicit);
             extensions.registerInstruction ("stopscript", "c", opcodeStopScript);
             extensions.registerFunction ("getsecondspassed", 'f', "", opcodeGetSecondsPassed);
-            extensions.registerInstruction ("enable", "", opcodeEnable, opcodeEnableExplicit);
-            extensions.registerInstruction ("disable", "", opcodeDisable, opcodeDisableExplicit);
+            extensions.registerInstruction ("enable", "x", opcodeEnable, opcodeEnableExplicit);
+            extensions.registerInstruction ("disable", "x", opcodeDisable, opcodeDisableExplicit);
             extensions.registerFunction ("getdisabled", 'l', "x", opcodeGetDisabled, opcodeGetDisabledExplicit);
             extensions.registerFunction ("xbox", 'l', "", opcodeXBox);
             extensions.registerFunction ("onactivate", 'l', "", opcodeOnActivate, opcodeOnActivateExplicit);

--- a/components/compiler/lineparser.cpp
+++ b/components/compiler/lineparser.cpp
@@ -86,13 +86,6 @@ namespace Compiler
     bool LineParser::parseName (const std::string& name, const TokenLoc& loc,
         Scanner& scanner)
     {
-        if (mState==PotentialEndState)
-        {
-            getErrorHandler().warning ("Stray string argument", loc);
-            mState = EndState;
-            return true;
-        }
-
         if (mState==SetState)
         {
             std::string name2 = Misc::StringUtils::lowerCase (name);
@@ -445,8 +438,7 @@ namespace Compiler
             return true;
         }
 
-        if (code==Scanner::S_newline &&
-            (mState==EndState || mState==BeginState || mState==PotentialEndState))
+        if (code==Scanner::S_newline && (mState==EndState || mState==BeginState))
             return false;
 
         if (code==Scanner::S_comma && mState==MessageState)

--- a/components/compiler/lineparser.hpp
+++ b/components/compiler/lineparser.hpp
@@ -25,8 +25,7 @@ namespace Compiler
                 SetState, SetLocalVarState, SetGlobalVarState, SetPotentialMemberVarState,
                 SetMemberVarState, SetMemberVarState2,
                 MessageState, MessageCommaState, MessageButtonState, MessageButtonCommaState,
-                EndState, PotentialEndState /* may have a stray string argument */,
-                PotentialExplicitState, ExplicitState, MemberState
+                EndState, PotentialExplicitState, ExplicitState, MemberState
             };
 
             Locals& mLocals;


### PR DESCRIPTION
They were ignored before Disable/Enable were moved to custom extensions thanks to PotentialEndState state, but when they were moved there wasn't any special state anymore and their arguments weren't set up right. So at least 2 vanilla scripts couldn't be compiled anymore.

PotentialEndState state was only used for Disable/Enable (no longer used anywhere) and seems to be kind of hacky. I removed it.