### PR TITLE
Update active spells during rest

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -2051,6 +2051,8 @@ namespace MWMechanics
 
         for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
         {
+            iter->first.getClass().getCreatureStats(iter->first).getActiveSpells().update(duration);
+
             if (iter->first.getClass().getCreatureStats(iter->first).isDead())
                 continue;
 


### PR DESCRIPTION
Fixes a recent regression - since we do not use timestamps to update spells, we should update them during rest.

Note that there is also an undefined behaviour for actors in inactive cells - Morrowind seems to remove active spells when actor is removed from scene for some reason (e.g. when player moves to an another cell or actor is disabled via `disable` console command). But it is outside of scope of this PR.