### PR TITLE
Track magic effect index for summoning

### DIFF
--- a/apps/openmw/mwgui/container.cpp
+++ b/apps/openmw/mwgui/container.cpp
@@ -252,7 +252,7 @@ namespace MWGui
                     }
 
                     // Clean up summoned creatures as well
-                    std::map<MWMechanics::CreatureStats::SummonKey, int>& creatureMap = creatureStats.getSummonedCreatureMap();
+                    std::map<ESM::SummonKey, int>& creatureMap = creatureStats.getSummonedCreatureMap();
                     for (const auto& creature : creatureMap)
                         MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(mPtr, creature.second);
                     creatureMap.clear();

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -25,8 +25,8 @@
 namespace MWGui
 {
 
-    void EffectSourceVisitor::visit (MWMechanics::EffectKey key,
-                                           const std::string& sourceName, const std::string& sourceId, int casterActorId,
+    void EffectSourceVisitor::visit (MWMechanics::EffectKey key, int effectIndex,
+                                     const std::string& sourceName, const std::string& sourceId, int casterActorId,
                                      float magnitude, float remainingTime, float totalTime)
     {
         MagicEffectInfo newEffectSource;

--- a/apps/openmw/mwgui/spellicons.hpp
+++ b/apps/openmw/mwgui/spellicons.hpp
@@ -46,8 +46,8 @@ namespace MWGui
 
         virtual ~EffectSourceVisitor() {}
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                 const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1);
     };
 

--- a/apps/openmw/mwmechanics/activespells.cpp
+++ b/apps/openmw/mwmechanics/activespells.cpp
@@ -210,9 +210,8 @@ namespace MWMechanics
                 std::string name = it->second.mDisplayName;
 
                 float magnitude = effectIt->mMagnitude;
-
                 if (magnitude)
-                    visitor.visit(MWMechanics::EffectKey(effectIt->mEffectId, effectIt->mArg), name, it->first, it->second.mCasterActorId, magnitude, effectIt->mTimeLeft, effectIt->mDuration);
+                    visitor.visit(MWMechanics::EffectKey(effectIt->mEffectId, effectIt->mArg), effectIt->mEffectIndex, name, it->first, it->second.mCasterActorId, magnitude, effectIt->mTimeLeft, effectIt->mDuration);
             }
         }
     }
@@ -258,14 +257,14 @@ namespace MWMechanics
         mSpellsChanged = true;
     }
 
-    void ActiveSpells::purgeEffect(short effectId, const std::string& sourceId)
+    void ActiveSpells::purgeEffect(short effectId, const std::string& sourceId, int effectIndex)
     {
         for (TContainer::iterator it = mSpells.begin(); it != mSpells.end(); ++it)
         {
             for (std::vector<ActiveEffect>::iterator effectIt = it->second.mEffects.begin();
                  effectIt != it->second.mEffects.end();)
             {
-                if (effectIt->mEffectId == effectId && it->first == sourceId)
+                if (effectIt->mEffectId == effectId && it->first == sourceId && (effectIndex < 0 || effectIndex == effectIt->mEffectIndex))
                     effectIt = it->second.mEffects.erase(effectIt);
                 else
                     ++effectIt;

--- a/apps/openmw/mwmechanics/activespells.hpp
+++ b/apps/openmw/mwmechanics/activespells.hpp
@@ -85,7 +85,7 @@ namespace MWMechanics
             void purgeEffect (short effectId);
 
             /// Remove all active effects with this effect id and source id
-            void purgeEffect (short effectId, const std::string& sourceId);
+            void purgeEffect (short effectId, const std::string& sourceId, int effectIndex=-1);
 
             /// Remove all active effects, if roll succeeds (for each effect)
             void purgeAll(float chance, bool spellOnly = false);

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -2016,7 +2016,7 @@ namespace MWMechanics
 
             // Remove the summoned creature's summoned creatures as well
             MWMechanics::CreatureStats& stats = ptr.getClass().getCreatureStats(ptr);
-            std::map<CreatureStats::SummonKey, int>& creatureMap = stats.getSummonedCreatureMap();
+            std::map<ESM::SummonKey, int>& creatureMap = stats.getSummonedCreatureMap();
             for (const auto& creature : creatureMap)
                 cleanupSummonedCreature(stats, creature.second);
             creatureMap.clear();

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -88,12 +88,13 @@ class CheckActorCommanded : public MWMechanics::EffectSourceVisitor
     MWWorld::Ptr mActor;
 public:
     bool mCommanded;
+
     CheckActorCommanded(const MWWorld::Ptr& actor)
         : mActor(actor)
-    , mCommanded(false){}
+        , mCommanded(false){}
 
-    virtual void visit (MWMechanics::EffectKey key,
-                             const std::string& sourceName, const std::string& sourceId, int casterActorId,
+    virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                        const std::string& sourceName, const std::string& sourceId, int casterActorId,
                         float magnitude, float remainingTime = -1, float totalTime = -1)
     {
         if (((key.mId == ESM::MagicEffect::CommandHumanoid && mActor.getClass().isNpc())
@@ -156,8 +157,8 @@ namespace MWMechanics
         GetStuntedMagickaDuration(const MWWorld::Ptr& actor)
             : mRemainingTime(0.f){}
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1)
         {
             if (mRemainingTime == -1) return;
@@ -186,8 +187,8 @@ namespace MWMechanics
         {
         }
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                 const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1)
         {
             if (magnitude <= 0)
@@ -206,8 +207,8 @@ namespace MWMechanics
     {
 
     public:
-        virtual void visit (MWMechanics::EffectKey key,
-                                 const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1)
         {
             if (key.mId != ESM::MagicEffect::Corprus)
@@ -231,8 +232,8 @@ namespace MWMechanics
         {
         }
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                 const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1)
         {
             if (mTrapped)
@@ -894,7 +895,7 @@ namespace MWMechanics
             {
             }
 
-            virtual void visit (MWMechanics::EffectKey key,
+            virtual void visit (MWMechanics::EffectKey key, int /*effectIndex*/,
                                 const std::string& /*sourceName*/, const std::string& /*sourceId*/, int /*casterActorId*/,
                                 float magnitude, float remainingTime = -1, float /*totalTime*/ = -1)
             {
@@ -1196,6 +1197,7 @@ namespace MWMechanics
         {
             UpdateSummonedCreatures updateSummonedCreatures(ptr);
             creatureStats.getActiveSpells().visitEffectSources(updateSummonedCreatures);
+            creatureStats.getSpells().visitEffectSources(updateSummonedCreatures);
             if (ptr.getClass().hasInventoryStore(ptr))
                 ptr.getClass().getInventoryStore(ptr).visitEffectSources(updateSummonedCreatures);
             updateSummonedCreatures.process(mTimerDisposeSummonsCorpses == 0.f);

--- a/apps/openmw/mwmechanics/creaturestats.cpp
+++ b/apps/openmw/mwmechanics/creaturestats.cpp
@@ -683,7 +683,7 @@ namespace MWMechanics
         return mTimeOfDeath;
     }
 
-    std::map<CreatureStats::SummonKey, int>& CreatureStats::getSummonedCreatureMap()
+    std::map<ESM::SummonKey, int>& CreatureStats::getSummonedCreatureMap()
     {
         return mSummonedCreatures;
     }

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -84,7 +84,7 @@ namespace MWMechanics
         float mSideMovementAngle;
 
     public:
-        typedef std::pair<int, std::string> SummonKey; // <ESM::MagicEffect index, spell ID>
+        typedef std::tuple<int, std::string, int> SummonKey; // <ESM::MagicEffect index, source ID, effect index>
     private:
         std::map<SummonKey, int> mSummonedCreatures; // <SummonKey, ActorId>
 

--- a/apps/openmw/mwmechanics/creaturestats.hpp
+++ b/apps/openmw/mwmechanics/creaturestats.hpp
@@ -13,6 +13,7 @@
 #include "drawstate.hpp"
 
 #include <components/esm/attr.hpp>
+#include <components/esm/magiceffects.hpp>
 
 namespace ESM
 {
@@ -83,10 +84,8 @@ namespace MWMechanics
         // The difference between view direction and lower body direction.
         float mSideMovementAngle;
 
-    public:
-        typedef std::tuple<int, std::string, int> SummonKey; // <ESM::MagicEffect index, source ID, effect index>
     private:
-        std::map<SummonKey, int> mSummonedCreatures; // <SummonKey, ActorId>
+        std::map<ESM::SummonKey, int> mSummonedCreatures; // <SummonKey, ActorId>
 
         // Contains ActorIds of summoned creatures with an expired lifetime that have not been deleted yet.
         // This may be necessary when the creature is in an inactive cell.
@@ -235,7 +234,7 @@ namespace MWMechanics
         void setBlock(bool value);
         bool getBlock() const;
 
-        std::map<SummonKey, int>& getSummonedCreatureMap(); // <SummonKey, ActorId of summoned creature>
+        std::map<ESM::SummonKey, int>& getSummonedCreatureMap(); // <SummonKey, ActorId of summoned creature>
         std::vector<int>& getSummonedCreatureGraveyard(); // ActorIds
 
         enum Flag

--- a/apps/openmw/mwmechanics/linkedeffects.cpp
+++ b/apps/openmw/mwmechanics/linkedeffects.cpp
@@ -58,6 +58,7 @@ namespace MWMechanics
         std::vector<ActiveSpells::ActiveEffect> absorbEffects;
         ActiveSpells::ActiveEffect absorbEffect = appliedEffect;
         absorbEffect.mMagnitude *= -1;
+        absorbEffect.mEffectIndex = appliedEffect.mEffectIndex;
         absorbEffects.emplace_back(absorbEffect);
 
         // Morrowind negates reflected Absorb spells so the original caster won't be harmed.

--- a/apps/openmw/mwmechanics/magiceffects.hpp
+++ b/apps/openmw/mwmechanics/magiceffects.hpp
@@ -74,8 +74,8 @@ namespace MWMechanics
     {
         virtual ~EffectSourceVisitor() { }
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                 const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1) = 0;
     };
 

--- a/apps/openmw/mwmechanics/spellabsorption.cpp
+++ b/apps/openmw/mwmechanics/spellabsorption.cpp
@@ -23,8 +23,8 @@ namespace MWMechanics
 
         GetAbsorptionProbability() = default;
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                const std::string& /*sourceName*/, const std::string& /*sourceId*/, int /*casterActorId*/,
+        virtual void visit (MWMechanics::EffectKey key, int /*effectIndex*/,
+                            const std::string& /*sourceName*/, const std::string& /*sourceId*/, int /*casterActorId*/,
                             float magnitude, float /*remainingTime*/, float /*totalTime*/)
         {
             if (key.mId == ESM::MagicEffect::SpellAbsorption)

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -270,7 +270,8 @@ namespace MWMechanics
                 if (isSummoningEffect(effectIt->mEffectID) && !target.isEmpty() && target.getClass().isActor())
                 {
                     CreatureStats& targetStats = target.getClass().getCreatureStats(target);
-                    std::map<CreatureStats::SummonKey, int>::iterator findCreature = targetStats.getSummonedCreatureMap().find(std::make_tuple(effectIt->mEffectID, mId, currentEffectIndex));
+                    ESM::SummonKey key(effectIt->mEffectID, mId, currentEffectIndex);
+                    auto findCreature = targetStats.getSummonedCreatureMap().find(key);
                     if (findCreature != targetStats.getSummonedCreatureMap().end())
                     {
                         MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(target, findCreature->second);

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -121,8 +121,9 @@ namespace MWMechanics
         // Try absorbing the spell. Some handling must still happen for absorbed effects.
         bool absorbed = absorbSpell(spell, caster, target);
 
+        int currentEffectIndex = 0;
         for (std::vector<ESM::ENAMstruct>::const_iterator effectIt (effects.mList.begin());
-             !target.isEmpty() && effectIt != effects.mList.end(); ++effectIt)
+             !target.isEmpty() && effectIt != effects.mList.end(); ++effectIt, ++currentEffectIndex)
         {
             if (effectIt->mRange != range)
                 continue;
@@ -189,6 +190,7 @@ namespace MWMechanics
                     effect.mArg = MWMechanics::EffectKey(*effectIt).mArg;
                     effect.mMagnitude = magnitude;
                     effect.mTimeLeft = 0.f;
+                    effect.mEffectIndex = currentEffectIndex;
 
                     // Avoid applying absorb effects if the caster is the target
                     // We still need the spell to be added
@@ -268,7 +270,7 @@ namespace MWMechanics
                 if (isSummoningEffect(effectIt->mEffectID) && !target.isEmpty() && target.getClass().isActor())
                 {
                     CreatureStats& targetStats = target.getClass().getCreatureStats(target);
-                    std::map<CreatureStats::SummonKey, int>::iterator findCreature = targetStats.getSummonedCreatureMap().find(std::make_pair(effectIt->mEffectID, mId));
+                    std::map<CreatureStats::SummonKey, int>::iterator findCreature = targetStats.getSummonedCreatureMap().find(std::make_tuple(effectIt->mEffectID, mId, currentEffectIndex));
                     if (findCreature != targetStats.getSummonedCreatureMap().end())
                     {
                         MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(target, findCreature->second);

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -50,7 +50,10 @@ namespace MWMechanics
                 for (const auto& effect : spell->mEffects.mList)
                 {
                     if (iter.second.mPurgedEffects.find(i) != iter.second.mPurgedEffects.end())
+                    {
+                        ++i;
                         continue; // effect was purged
+                    }
 
                     float random = 1.f;
                     if (iter.second.mEffectRands.find(i) != iter.second.mEffectRands.end())
@@ -108,7 +111,7 @@ namespace MWMechanics
 
             SpellParams params;
             params.mEffectRands = random;
-            mSpells.insert (std::make_pair (spell, params));
+            mSpells.emplace(spell, params);
             mSpellsChanged = true;
         }
     }
@@ -272,7 +275,8 @@ namespace MWMechanics
             const ESM::Spell * spell = it.first;
             for (const auto& effectIt : it.second)
             {
-                visitor.visit(effectIt.first, spell->mName, spell->mId, -1, effectIt.second.getMagnitude());
+                // FIXME: since Spells merges effects with the same ID, there is no sense to use multiple effects with same ID here
+                visitor.visit(effectIt.first, -1, spell->mName, spell->mId, -1, effectIt.second.getMagnitude());
             }
         }
     }
@@ -308,20 +312,24 @@ namespace MWMechanics
 
     void Spells::purgeEffect(int effectId, const std::string & sourceId)
     {
-        const ESM::Spell * spell = SpellList::getSpell(sourceId);
+        // Effect source may be not a spell
+        const ESM::Spell * spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(sourceId);
+        if (spell == nullptr)
+            return;
+
         auto spellIt = mSpells.find(spell);
         if (spellIt == mSpells.end())
             return;
 
-        int i = 0;
+        int index = 0;
         for (auto& effectIt : spellIt->first->mEffects.mList)
         {
             if (effectIt.mEffectID == effectId)
             {
-                spellIt->second.mPurgedEffects.insert(i);
+                spellIt->second.mPurgedEffects.insert(index);
                 mSpellsChanged = true;
             }
-            ++i;
+            ++index;
         }
     }
 
@@ -441,7 +449,7 @@ namespace MWMechanics
                 ESM::SpellState::SpellParams params;
                 params.mEffectRands = it.second.mEffectRands;
                 params.mPurgedEffects = it.second.mPurgedEffects;
-                state.mSpells.insert(std::make_pair(it.first->mId, params));
+                state.mSpells.emplace(it.first->mId, params);
             }
         }
 

--- a/apps/openmw/mwmechanics/summoning.cpp
+++ b/apps/openmw/mwmechanics/summoning.cpp
@@ -65,11 +65,11 @@ namespace MWMechanics
     {
     }
 
-    void UpdateSummonedCreatures::visit(EffectKey key, const std::string &sourceName, const std::string &sourceId, int casterActorId, float magnitude, float remainingTime, float totalTime)
+    void UpdateSummonedCreatures::visit(EffectKey key, int effectIndex, const std::string &sourceName, const std::string &sourceId, int casterActorId, float magnitude, float remainingTime, float totalTime)
     {
         if (isSummoningEffect(key.mId) && magnitude > 0)
         {
-            mActiveEffects.insert(std::make_pair(key.mId, sourceId));
+            mActiveEffects.insert(std::make_tuple(key.mId, sourceId, effectIndex));
         }
     }
 
@@ -78,12 +78,12 @@ namespace MWMechanics
         MWMechanics::CreatureStats& creatureStats = mActor.getClass().getCreatureStats(mActor);
         std::map<CreatureStats::SummonKey, int>& creatureMap = creatureStats.getSummonedCreatureMap();
 
-        for (std::set<std::pair<int, std::string> >::iterator it = mActiveEffects.begin(); it != mActiveEffects.end(); ++it)
+        for (std::set<CreatureStats::SummonKey>::iterator it = mActiveEffects.begin(); it != mActiveEffects.end(); ++it)
         {
-            bool found = creatureMap.find(std::make_pair(it->first, it->second)) != creatureMap.end();
+            bool found = creatureMap.find(*it) != creatureMap.end();
             if (!found)
             {
-                std::string creatureID = getSummonedCreature(it->first);
+                std::string creatureID = getSummonedCreature(std::get<0>(*it));
                 if (!creatureID.empty())
                 {
                     int creatureActorId = -1;
@@ -115,7 +115,7 @@ namespace MWMechanics
                         // still insert into creatureMap so we don't try to spawn again every frame, that would spam the warning log
                     }
 
-                    creatureMap.insert(std::make_pair(*it, creatureActorId));
+                    creatureMap.emplace(*it, creatureActorId);
                 }
             }
         }
@@ -149,9 +149,10 @@ namespace MWMechanics
             if (ptr.isEmpty() || (ptr.getClass().getCreatureStats(ptr).isDead() && ptr.getClass().getCreatureStats(ptr).isDeathAnimationFinished()))
             {
                 // Purge the magic effect so a new creature can be summoned if desired
-                creatureStats.getActiveSpells().purgeEffect(it->first.first, it->first.second);
+                creatureStats.getActiveSpells().purgeEffect(std::get<0>(it->first), std::get<1>(it->first), std::get<2>(it->first));
+                creatureStats.getSpells().purgeEffect(std::get<0>(it->first), std::get<1>(it->first));
                 if (mActor.getClass().hasInventoryStore(mActor))
-                    mActor.getClass().getInventoryStore(mActor).purgeEffect(it->first.first, it->first.second);
+                    mActor.getClass().getInventoryStore(mActor).purgeEffect(std::get<0>(it->first), std::get<1>(it->first), false, std::get<2>(it->first));
 
                 MWBase::Environment::get().getMechanicsManager()->cleanupSummonedCreature(mActor, it->second);
                 creatureMap.erase(it++);

--- a/apps/openmw/mwmechanics/summoning.hpp
+++ b/apps/openmw/mwmechanics/summoning.hpp
@@ -20,8 +20,8 @@ namespace MWMechanics
         UpdateSummonedCreatures(const MWWorld::Ptr& actor);
         virtual ~UpdateSummonedCreatures() = default;
 
-        virtual void visit (MWMechanics::EffectKey key,
-                                 const std::string& sourceName, const std::string& sourceId, int casterActorId,
+        virtual void visit (MWMechanics::EffectKey key, int effectIndex,
+                            const std::string& sourceName, const std::string& sourceId, int casterActorId,
                             float magnitude, float remainingTime = -1, float totalTime = -1);
 
         /// To call after all effect sources have been visited
@@ -30,7 +30,7 @@ namespace MWMechanics
     private:
         MWWorld::Ptr mActor;
 
-        std::set<std::pair<int, std::string> > mActiveEffects;
+        std::set<std::tuple<int, std::string, int>> mActiveEffects;
     };
 
 }

--- a/apps/openmw/mwmechanics/summoning.hpp
+++ b/apps/openmw/mwmechanics/summoning.hpp
@@ -5,6 +5,8 @@
 
 #include "../mwworld/ptr.hpp"
 
+#include <components/esm/magiceffects.hpp>
+
 #include "magiceffects.hpp"
 
 namespace MWMechanics
@@ -30,7 +32,7 @@ namespace MWMechanics
     private:
         MWWorld::Ptr mActor;
 
-        std::set<std::tuple<int, std::string, int>> mActiveEffects;
+        std::set<ESM::SummonKey> mActiveEffects;
     };
 
 }

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -917,7 +917,7 @@ void MWWorld::InventoryStore::visitEffectSources(MWMechanics::EffectSourceVisito
             float magnitude = effect.mMagnMin + (effect.mMagnMax - effect.mMagnMin) * params.mRandom;
             magnitude *= params.mMultiplier;
             if (magnitude > 0)
-                visitor.visit(MWMechanics::EffectKey(effect), (**iter).getClass().getName(**iter), (**iter).getCellRef().getRefId(), -1, magnitude);
+                visitor.visit(MWMechanics::EffectKey(effect), i-1, (**iter).getClass().getName(**iter), (**iter).getCellRef().getRefId(), -1, magnitude);
         }
     }
 }
@@ -931,7 +931,7 @@ void MWWorld::InventoryStore::purgeEffect(short effectId, bool wholeSpell)
     }
 }
 
-void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sourceId, bool wholeSpell)
+void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sourceId, bool wholeSpell, int effectIndex)
 {
     TEffectMagnitudes::iterator effectMagnitudeIt = mPermanentMagicEffectMagnitudes.find(sourceId);
     if (effectMagnitudeIt == mPermanentMagicEffectMagnitudes.end())
@@ -962,6 +962,9 @@ void MWWorld::InventoryStore::purgeEffect(short effectId, const std::string &sou
                 effectIt!=enchantment.mEffects.mList.end(); ++effectIt, ++i)
             {
                 if (effectIt->mEffectID != effectId)
+                    continue;
+
+                if (effectIndex >= 0 && effectIndex != i)
                     continue;
 
                 if (wholeSpell)

--- a/apps/openmw/mwworld/inventorystore.hpp
+++ b/apps/openmw/mwworld/inventorystore.hpp
@@ -206,7 +206,7 @@ namespace MWWorld
             void purgeEffect (short effectId, bool wholeSpell = false);
             ///< Remove a magic effect
 
-            void purgeEffect (short effectId, const std::string& sourceId, bool wholeSpell = false);
+            void purgeEffect (short effectId, const std::string& sourceId, bool wholeSpell = false, int effectIndex=-1);
             ///< Remove a magic effect
 
             virtual void clear();

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3119,7 +3119,7 @@ namespace MWWorld
         {
         }
 
-        virtual void visit (MWMechanics::EffectKey key,
+        virtual void visit (MWMechanics::EffectKey key, int /*effectIndex*/,
                             const std::string& /*sourceName*/, const std::string& /*sourceId*/, int /*casterActorId*/,
                             float /*magnitude*/, float /*remainingTime*/ = -1, float /*totalTime*/ = -1)
         {

--- a/components/esm/activespells.cpp
+++ b/components/esm/activespells.cpp
@@ -24,6 +24,7 @@ namespace ESM
                     esm.writeHNT ("ARG_", effectIt->mArg);
                 esm.writeHNT ("MAGN", effectIt->mMagnitude);
                 esm.writeHNT ("DURA", effectIt->mDuration);
+                esm.writeHNT ("EIND", effectIt->mEffectIndex);
                 esm.writeHNT ("LEFT", effectIt->mTimeLeft);
             }
         }
@@ -53,6 +54,8 @@ namespace ESM
                 esm.getHNOT(effect.mArg, "ARG_");
                 esm.getHNT (effect.mMagnitude, "MAGN");
                 esm.getHNT (effect.mDuration, "DURA");
+                effect.mEffectIndex = -1;
+                esm.getHNOT (effect.mEffectIndex, "EIND");
                 if (format < 9)
                     effect.mTimeLeft = effect.mDuration;
                 else

--- a/components/esm/activespells.hpp
+++ b/components/esm/activespells.hpp
@@ -22,6 +22,7 @@ namespace ESM
         int mArg; // skill or attribute
         float mDuration;
         float mTimeLeft;
+        int mEffectIndex;
     };
 
     // format 0, saved games only

--- a/components/esm/creaturestats.cpp
+++ b/components/esm/creaturestats.cpp
@@ -115,9 +115,11 @@ void ESM::CreatureStats::load (ESMReader &esm)
         int magicEffect;
         esm.getHT(magicEffect);
         std::string source = esm.getHNOString("SOUR");
+        int effectIndex = -1;
+        esm.getHNOT (effectIndex, "EIND");
         int actorId;
         esm.getHNT (actorId, "ACID");
-        mSummonedCreatureMap[std::make_pair(magicEffect, source)] = actorId;
+        mSummonedCreatureMap[std::make_tuple(magicEffect, source, effectIndex)] = actorId;
     }
 
     while (esm.isNextSub("GRAV"))
@@ -212,10 +214,13 @@ void ESM::CreatureStats::save (ESMWriter &esm) const
     mAiSequence.save(esm);
     mMagicEffects.save(esm);
 
-    for (std::map<std::pair<int, std::string>, int>::const_iterator it = mSummonedCreatureMap.begin(); it != mSummonedCreatureMap.end(); ++it)
+    for (std::map<std::tuple<int, std::string, int>, int>::const_iterator it = mSummonedCreatureMap.begin(); it != mSummonedCreatureMap.end(); ++it)
     {
-        esm.writeHNT ("SUMM", it->first.first);
-        esm.writeHNString ("SOUR", it->first.second);
+        esm.writeHNT ("SUMM", std::get<0>(it->first));
+        esm.writeHNString ("SOUR", std::get<1>(it->first));
+        int effectIndex = std::get<2>(it->first);
+        if (effectIndex != -1)
+            esm.writeHNT ("EIND", effectIndex);
         esm.writeHNT ("ACID", it->second);
     }
 

--- a/components/esm/creaturestats.cpp
+++ b/components/esm/creaturestats.cpp
@@ -119,7 +119,7 @@ void ESM::CreatureStats::load (ESMReader &esm)
         esm.getHNOT (effectIndex, "EIND");
         int actorId;
         esm.getHNT (actorId, "ACID");
-        mSummonedCreatureMap[std::make_tuple(magicEffect, source, effectIndex)] = actorId;
+        mSummonedCreatureMap[SummonKey(magicEffect, source, effectIndex)] = actorId;
     }
 
     while (esm.isNextSub("GRAV"))
@@ -214,19 +214,19 @@ void ESM::CreatureStats::save (ESMWriter &esm) const
     mAiSequence.save(esm);
     mMagicEffects.save(esm);
 
-    for (std::map<std::tuple<int, std::string, int>, int>::const_iterator it = mSummonedCreatureMap.begin(); it != mSummonedCreatureMap.end(); ++it)
+    for (const auto& summon : mSummonedCreatureMap)
     {
-        esm.writeHNT ("SUMM", std::get<0>(it->first));
-        esm.writeHNString ("SOUR", std::get<1>(it->first));
-        int effectIndex = std::get<2>(it->first);
+        esm.writeHNT ("SUMM", summon.first.mEffectId);
+        esm.writeHNString ("SOUR", summon.first.mSourceId);
+        int effectIndex = summon.first.mEffectIndex;
         if (effectIndex != -1)
             esm.writeHNT ("EIND", effectIndex);
-        esm.writeHNT ("ACID", it->second);
+        esm.writeHNT ("ACID", summon.second);
     }
 
-    for (std::vector<int>::const_iterator it = mSummonGraveyard.begin(); it != mSummonGraveyard.end(); ++it)
+    for (int key : mSummonGraveyard)
     {
-        esm.writeHNT ("GRAV", *it);
+        esm.writeHNT ("GRAV", key);
     }
 
     esm.writeHNT("AISE", mHasAiSettings);
@@ -236,11 +236,11 @@ void ESM::CreatureStats::save (ESMWriter &esm) const
             mAiSettings[i].save(esm);
     }
 
-    for (std::map<std::string, CorprusStats>::const_iterator it = mCorprusSpells.begin(); it != mCorprusSpells.end(); ++it)
+    for (const auto& corprusSpell : mCorprusSpells)
     {
-        esm.writeHNString("CORP", it->first);
+        esm.writeHNString("CORP", corprusSpell.first);
 
-        const CorprusStats & stats = it->second;
+        const CorprusStats & stats = corprusSpell.second;
         esm.writeHNT("WORS", stats.mWorsenings);
         esm.writeHNT("TIME", stats.mNextWorsening);
     }

--- a/components/esm/creaturestats.hpp
+++ b/components/esm/creaturestats.hpp
@@ -39,7 +39,7 @@ namespace ESM
         bool mHasAiSettings;
         StatState<int> mAiSettings[4];
 
-        std::map<std::pair<int, std::string>, int> mSummonedCreatureMap;
+        std::map<std::tuple<int, std::string, int>, int> mSummonedCreatureMap;
         std::vector<int> mSummonGraveyard;
 
         ESM::TimeStamp mTradeTime;

--- a/components/esm/creaturestats.hpp
+++ b/components/esm/creaturestats.hpp
@@ -39,7 +39,7 @@ namespace ESM
         bool mHasAiSettings;
         StatState<int> mAiSettings[4];
 
-        std::map<std::tuple<int, std::string, int>, int> mSummonedCreatureMap;
+        std::map<SummonKey, int> mSummonedCreatureMap;
         std::vector<int> mSummonGraveyard;
 
         ESM::TimeStamp mTradeTime;

--- a/components/esm/magiceffects.hpp
+++ b/components/esm/magiceffects.hpp
@@ -2,6 +2,7 @@
 #define COMPONENTS_ESM_MAGICEFFECTS_H
 
 #include <map>
+#include <string>
 
 namespace ESM
 {
@@ -18,6 +19,37 @@ namespace ESM
         void save (ESMWriter &esm) const;
     };
 
+    struct SummonKey
+    {
+        SummonKey(int effectId, const std::string& sourceId, int index)
+        {
+            mEffectId = effectId;
+            mSourceId = sourceId;
+            mEffectIndex = index;
+        }
+
+        bool operator==(const SummonKey &other) const
+        {
+            return mEffectId == other.mEffectId &&
+                    mSourceId == other.mSourceId &&
+                    mEffectIndex == other.mEffectIndex;
+        }
+
+        bool operator<(const SummonKey &other) const
+        {
+            if (mEffectId < other.mEffectId)
+                return true;
+
+            if (mSourceId < other.mSourceId)
+                return true;
+
+            return mEffectIndex < other.mEffectIndex;
+        }
+
+        int mEffectId;
+        std::string mSourceId;
+        int mEffectIndex;
+    };
 }
 
 #endif

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -4,7 +4,7 @@
 #include "esmwriter.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 13;
+int ESM::SavedGame::sCurrentFormat = 14;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
Related to [bug #5207](https://gitlab.com/OpenMW/openmw/-/issues/5207).
Despite it is possible to add a given magic effect only once to spell or enchantment, it is possible to add it many times via editor, and Morrowind supports it just well.

Unfortunately, the whole OpenMW's magic system was designed that there is a magic effect can be added only once.

This PR is supposed to change it. So far I managed to track (and save) effect index in active spells, so it it possible, for example, summon several skeletons with the single spell.
But it is unclear how to handle permanent spells so far.
"Spells" collection merges constant effects with the same ID internally, so multiple summons with the same ID are out of question for constant spells so far.