### PR TITLE
Minor shader fixes

### DIFF
--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -49,7 +49,7 @@ uniform vec2 envMapLumaBias;
 uniform mat2 bumpMapMatrix;
 #endif
 
-uniform bool simpleWater = false;
+uniform bool simpleWater;
 
 varying float euclideanDepth;
 varying float linearDepth;
@@ -181,7 +181,8 @@ void main()
         matSpec = passColor.xyz;
 #endif
 
-    gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;
+    if (matSpec != vec3(0.0))
+        gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;
 #if @radialFog
     float depth = euclideanDepth;
     // For the less detailed mesh of simple water we need to recalculate depth on per-pixel basis

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -90,7 +90,8 @@ void main()
         matSpec = passColor.xyz;
 #endif
 
-    gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos), shininess, matSpec) * shadowing;
+    if (matSpec != vec3(0.0))
+        gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos), shininess, matSpec) * shadowing;
 
 #if @radialFog
     float fogValue = clamp((euclideanDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);


### PR DESCRIPTION
- simpleWater bool is not set to false by default anymore. Uniforms are initialized to zero by default which corresponds to false, so this shouldn't be necessary, and GL4ES doesn't support initializers for uniforms right now and currently has to manually do the same thing done here.
- Most objects in the game only have a diffuse map and don't have specularity, but while handling the diffuse map is obviously necessary, the per-fragment specularity calculations in the shaders used for all objects should be avoided whenever possible. Per suggestion of akortunov, getSpecular call isn't done for objects that have a black specular color in their material as well as terrain. This seems to result in a ~10% higher framerate on a GeForce GTX 1050 when shaders are used (of course it depends on whether shadows and water shader are used), while on older video cards it may not lead to discernible benefit but certainly shouldn't lead to a discernible loss either. Should probably resolve [5428](https://gitlab.com/OpenMW/openmw/-/issues/5428), as there isn't much that can be done otherwise; I thought about making specular lighting per-vertex when the entire lighting is per-vertex, but given that there are at least four situations that should be taken care of  — per-vertex material specularity, per-vertex specular map specularity (shouldn't be a thing), per-pixel material specularity, per-pixel specular map specularity — it has proven to complicate shaders much more than what I'm comfortable with. Maybe later.