### PR TITLE
Don't deliberately do redundant assignments in shaders

### DIFF
--- a/files/shaders/lighting.glsl
+++ b/files/shaders/lighting.glsl
@@ -29,25 +29,27 @@ vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, float shadowing
 vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, out vec3 shadowDiffuse)
 #endif
 {
-    vec4 diffuse = gl_FrontMaterial.diffuse;
-    vec3 ambient = gl_FrontMaterial.ambient.xyz;
-    vec3 emission = gl_FrontMaterial.emission.xyz;
+    vec4 diffuse;
+    vec3 ambient;
     if (colorMode == ColorMode_AmbientAndDiffuse)
     {
         diffuse = vertexColor;
         ambient = vertexColor.xyz;
     }
-    else if (colorMode == ColorMode_Ambient)
-    {
-        ambient = vertexColor.xyz;
-    }
     else if (colorMode == ColorMode_Diffuse)
     {
         diffuse = vertexColor;
+        ambient = gl_FrontMaterial.ambient.xyz;
     }
-    else if (colorMode == ColorMode_Emission)
+    else if (colorMode == ColorMode_Ambient)
     {
-        emission = vertexColor.xyz;
+        diffuse = gl_FrontMaterial.diffuse;
+        ambient = vertexColor.xyz;
+    }
+    else
+    {
+        diffuse = gl_FrontMaterial.diffuse;
+        ambient = gl_FrontMaterial.ambient.xyz;
     }
     vec4 lightResult = vec4(0.0, 0.0, 0.0, diffuse.a);
 
@@ -65,7 +67,12 @@ vec4 doLighting(vec3 viewPos, vec3 viewNormal, vec4 vertexColor, out vec3 shadow
         lightResult.xyz += ambientLight + diffuseLight;
     }
 
-    lightResult.xyz += gl_LightModel.ambient.xyz * ambient + emission;
+    lightResult.xyz += gl_LightModel.ambient.xyz * ambient;
+
+    if (colorMode == ColorMode_Emission)
+        lightResult.xyz += vertexColor.xyz;
+    else
+        lightResult.xyz += gl_FrontMaterial.emission.xyz;
 
 #if @clamp
     lightResult = clamp(lightResult, vec4(0.0), vec4(1.0));

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -176,18 +176,22 @@ void main()
     vec3 matSpec = specTex.xyz;
 #else
     float shininess = gl_FrontMaterial.shininess;
-    vec3 matSpec = gl_FrontMaterial.specular.xyz;
+    vec3 matSpec;
     if (colorMode == ColorMode_Specular)
         matSpec = passColor.xyz;
+    else
+        matSpec = gl_FrontMaterial.specular.xyz;
 #endif
 
     if (matSpec != vec3(0.0))
         gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;
 #if @radialFog
-    float depth = euclideanDepth;
+    float depth;
     // For the less detailed mesh of simple water we need to recalculate depth on per-pixel basis
     if (simpleWater)
         depth = length(passViewPos);
+    else
+        depth = euclideanDepth;
     float fogValue = clamp((depth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
 #else
     float fogValue = clamp((linearDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -85,9 +85,11 @@ void main()
     vec3 matSpec = vec3(diffuseTex.a);
 #else
     float shininess = gl_FrontMaterial.shininess;
-    vec3 matSpec = gl_FrontMaterial.specular.xyz;
+    vec3 matSpec;
     if (colorMode == ColorMode_Specular)
         matSpec = passColor.xyz;
+    else
+        matSpec = gl_FrontMaterial.specular.xyz;
 #endif
 
     if (matSpec != vec3(0.0))


### PR DESCRIPTION
Apparently these aren't getting optimized out and may lower performance (they do in akortunov's testing), so nevermind, let's go back to what 0.46.0 was doing with some fancy constants and Specular/Diffuse vertex color modes left in.