### PR TITLE
Use more C++11 in tools code

### DIFF
--- a/apps/bsatool/bsatool.cpp
+++ b/apps/bsatool/bsatool.cpp
@@ -183,19 +183,19 @@ int list(Bsa::BSAFile& bsa, Arguments& info)
 {
     // List all files
     const Bsa::BSAFile::FileList &files = bsa.getList();
-    for(unsigned int i=0; i<files.size(); i++)
+    for (const auto& file : files)
     {
         if(info.longformat)
         {
             // Long format
             std::ios::fmtflags f(std::cout.flags());
-            std::cout << std::setw(50) << std::left << files[i].name;
-            std::cout << std::setw(8) << std::left << std::dec << files[i].fileSize;
-            std::cout << "@ 0x" << std::hex << files[i].offset << std::endl;
+            std::cout << std::setw(50) << std::left << file.name;
+            std::cout << std::setw(8) << std::left << std::dec << file.fileSize;
+            std::cout << "@ 0x" << std::hex << file.offset << std::endl;
             std::cout.flags(f);
         }
         else
-            std::cout << files[i].name << std::endl;
+            std::cout << file.name << std::endl;
     }
 
     return 0;
@@ -252,14 +252,9 @@ int extract(Bsa::BSAFile& bsa, Arguments& info)
 
 int extractAll(Bsa::BSAFile& bsa, Arguments& info)
 {
-    // Get the list of files present in the archive
-    Bsa::BSAFile::FileList list = bsa.getList();
-
-    // Iter on the list
-    for(Bsa::BSAFile::FileList::iterator it = list.begin(); it != list.end(); ++it) {
-        const char* archivePath = it->name;
-
-        std::string extractPath (archivePath);
+    for (const auto &file : bsa.getList())
+    {
+        std::string extractPath(file.name);
         replaceAll(extractPath, "\\", "/");
 
         // Get the target path (the path the file will be extracted to)
@@ -278,7 +273,7 @@ int extractAll(Bsa::BSAFile& bsa, Arguments& info)
 
         // Get a stream for the file to extract
         // (inefficient because getFile iter on the list again)
-        Files::IStreamPtr data = bsa.getFile(archivePath);
+        Files::IStreamPtr data = bsa.getFile(file.name);
         bfs::ofstream out(target, std::ios::binary);
 
         // Write the file to disk

--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -352,12 +352,12 @@ int load(Arguments& info)
             std::cout << "Author: " << esm.getAuthor() << std::endl
                  << "Description: " << esm.getDesc() << std::endl
                  << "File format version: " << esm.getFVer() << std::endl;
-            std::vector<ESM::Header::MasterData> m = esm.getGameFiles();
-            if (!m.empty())
+            std::vector<ESM::Header::MasterData> masterData = esm.getGameFiles();
+            if (!masterData.empty())
             {
                 std::cout << "Masters:" << std::endl;
-                for(unsigned int i=0;i<m.size();i++)
-                    std::cout << "  " << m[i].name << ", " << m[i].size << " bytes" << std::endl;
+                for(const auto& master : masterData)
+                    std::cout << "  " << master.name << ", " << master.size << " bytes" << std::endl;
             }
         }
 
@@ -369,7 +369,7 @@ int load(Arguments& info)
             esm.getRecHeader(flags);
 
             EsmTool::RecordBase *record = EsmTool::RecordBase::create(n);
-            if (record == 0)
+            if (record == nullptr)
             {
                 if (std::find(skipped.begin(), skipped.end(), n.intval) == skipped.end())
                 {
@@ -538,8 +538,8 @@ int comp(Arguments& info)
     Arguments fileOne;
     Arguments fileTwo;
 
-    fileOne.raw_given = 0;
-    fileTwo.raw_given = 0;
+    fileOne.raw_given = false;
+    fileTwo.raw_given = false;
 
     fileOne.mode = "clone";
     fileTwo.mode = "clone";

--- a/apps/esmtool/labels.cpp
+++ b/apps/esmtool/labels.cpp
@@ -779,7 +779,7 @@ std::string creatureListFlags(int flags)
 
 std::string lightFlags(int flags)
 {
-    std::string properties = "";
+    std::string properties;
     if (flags == 0) properties += "[None] ";
     if (flags & ESM::Light::Dynamic) properties += "Dynamic ";
     if (flags & ESM::Light::Fire) properties += "Fire ";

--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -9,7 +9,7 @@
 namespace
 {
 
-void printAIPackage(ESM::AIPackage p)
+void printAIPackage(const ESM::AIPackage& p)
 {
     std::cout << "  AI Type: " << aiTypeLabel(p.mType)
               << " (" << Misc::StringUtils::format("0x%08X", p.mType) << ")" << std::endl;
@@ -53,7 +53,7 @@ void printAIPackage(ESM::AIPackage p)
         std::cout << "    Cell Name: " << p.mCellName << std::endl;
 }
 
-std::string ruleString(ESM::DialInfo::SelectStruct ss)
+std::string ruleString(const ESM::DialInfo::SelectStruct& ss)
 {
     std::string rule = ss.mSelectRule;
 
@@ -126,7 +126,7 @@ std::string ruleString(ESM::DialInfo::SelectStruct ss)
     return result;
 }
 
-void printEffectList(ESM::EffectList effects)
+void printEffectList(const ESM::EffectList& effects)
 {
     int i = 0;
     for (const ESM::ENAMstruct& effect : effects.mList)
@@ -174,7 +174,7 @@ namespace EsmTool {
 RecordBase *
 RecordBase::create(ESM::NAME type)
 {
-    RecordBase *record = 0;
+    RecordBase *record = nullptr;
 
     switch (type.intval) {
     case ESM::REC_ACTI:
@@ -388,7 +388,7 @@ RecordBase::create(ESM::NAME type)
         break;
     }
     default:
-        record = 0;
+        record = nullptr;
     }
     if (record) {
         record->mType = type;
@@ -728,10 +728,9 @@ void Record<ESM::Faction>::print()
               << " (" << mData.mData.mAttribute[0] << ")" << std::endl;
     std::cout << "  Attribute2: " << attributeLabel(mData.mData.mAttribute[1])
               << " (" << mData.mData.mAttribute[1] << ")" << std::endl;
-    for (int i = 0; i < 7; i++)
-        if (mData.mData.mSkills[i] != -1)
-            std::cout << "  Skill: " << skillLabel(mData.mData.mSkills[i])
-                      << " (" << mData.mData.mSkills[i] << ")" << std::endl;
+    for (int skill : mData.mData.mSkills)
+        if (skill != -1)
+            std::cout << "  Skill: " << skillLabel(skill) << " (" << skill << ")" << std::endl;
     for (int i = 0; i != 10; i++)
         if (!mData.mRanks[i].empty())
         {

--- a/apps/essimporter/converter.cpp
+++ b/apps/essimporter/converter.cpp
@@ -52,9 +52,7 @@ namespace
                           // a dynamically created record e.g. player-enchanted weapon
 
         std::string index = indexedRefId.substr(indexedRefId.size()-8);
-        if(index.find_first_not_of("0123456789ABCDEF") == std::string::npos )
-            return true;
-        return false;
+        return index.find_first_not_of("0123456789ABCDEF") == std::string::npos;
     }
 
     void splitIndexedRefId(const std::string& indexedRefId, int& refIndex, std::string& refId)
@@ -139,12 +137,12 @@ namespace ESSImport
         image2->allocateImage(width, height, 1, GL_RGBA, GL_UNSIGNED_BYTE);
         memcpy(image2->data(), &data[0], data.size());
 
-        for (std::set<std::pair<int, int> >::const_iterator it = mContext->mExploredCells.begin(); it != mContext->mExploredCells.end(); ++it)
+        for (const auto & exploredCell : mContext->mExploredCells)
         {
-            if (it->first > mContext->mGlobalMapState.mBounds.mMaxX
-                    || it->first < mContext->mGlobalMapState.mBounds.mMinX
-                    || it->second > mContext->mGlobalMapState.mBounds.mMaxY
-                    || it->second < mContext->mGlobalMapState.mBounds.mMinY)
+            if (exploredCell.first > mContext->mGlobalMapState.mBounds.mMaxX
+                    || exploredCell.first < mContext->mGlobalMapState.mBounds.mMinX
+                    || exploredCell.second > mContext->mGlobalMapState.mBounds.mMaxY
+                    || exploredCell.second < mContext->mGlobalMapState.mBounds.mMinY)
             {
                 // out of bounds, I think this could happen, since the original engine had a fixed-size map
                 continue;
@@ -152,12 +150,12 @@ namespace ESSImport
 
             int imageLeftSrc = mGlobalMapImage->s()/2;
             int imageTopSrc = mGlobalMapImage->t()/2;
-            imageLeftSrc += it->first * cellSize;
-            imageTopSrc -= it->second * cellSize;
+            imageLeftSrc += exploredCell.first * cellSize;
+            imageTopSrc -= exploredCell.second * cellSize;
             int imageLeftDst = width/2;
             int imageTopDst = height/2;
-            imageLeftDst += it->first * cellSize;
-            imageTopDst -= it->second * cellSize;
+            imageLeftDst += exploredCell.first * cellSize;
+            imageTopDst -= exploredCell.second * cellSize;
             for (int x=0; x<cellSize; ++x)
                 for (int y=0; y<cellSize; ++y)
                 {
@@ -329,9 +327,8 @@ namespace ESSImport
         csta.mWaterLevel = esmcell.mWater;
         csta.save(esm);
 
-        for (std::vector<CellRef>::const_iterator refIt = cell.mRefs.begin(); refIt != cell.mRefs.end(); ++refIt)
+        for (const auto & cellref : cell.mRefs)
         {
-            const CellRef& cellref = *refIt;
             ESM::CellRef out (cellref);
 
             // TODO: use mContext->mCreatures/mNpcs
@@ -437,16 +434,16 @@ namespace ESSImport
 
     void ConvertCell::write(ESM::ESMWriter &esm)
     {
-        for (std::map<std::string, Cell>::const_iterator it = mIntCells.begin(); it != mIntCells.end(); ++it)
-            writeCell(it->second, esm);
+        for (const auto & cell : mIntCells)
+            writeCell(cell.second, esm);
 
-        for (std::map<std::pair<int, int>, Cell>::const_iterator it = mExtCells.begin(); it != mExtCells.end(); ++it)
-            writeCell(it->second, esm);
+        for (const auto & cell : mExtCells)
+            writeCell(cell.second, esm);
 
-        for (std::vector<ESM::CustomMarker>::const_iterator it = mMarkers.begin(); it != mMarkers.end(); ++it)
+        for (const auto & marker : mMarkers)
         {
             esm.startRecord(ESM::REC_MARK);
-            it->save(esm);
+            marker.save(esm);
             esm.endRecord(ESM::REC_MARK);
         }
     }

--- a/apps/essimporter/converter.hpp
+++ b/apps/essimporter/converter.hpp
@@ -127,8 +127,8 @@ public:
             ESM::SpellState::SpellParams empty;
             // FIXME: player start spells and birthsign spells aren't listed here,
             // need to fix openmw to account for this
-            for (std::vector<std::string>::const_iterator it = npc.mSpells.mList.begin(); it != npc.mSpells.mList.end(); ++it)
-                mContext->mPlayer.mObject.mCreatureStats.mSpells.mSpells[*it] = empty;
+            for (const auto & spell : npc.mSpells.mList)
+                mContext->mPlayer.mObject.mCreatureStats.mSpells.mSpells[spell] = empty;
 
             // Clear the list now that we've written it, this prevents issues cropping up with
             // ensureCustomData() in OpenMW tripping over no longer existing spells, where an error would be fatal.
@@ -434,9 +434,9 @@ public:
         for (std::map<std::string, std::set<Owner> >::const_iterator it = mStolenItems.begin(); it != mStolenItems.end(); ++it)
         {
             std::map<std::pair<std::string, bool>, int> owners;
-            for (std::set<Owner>::const_iterator ownerIt = it->second.begin(); ownerIt != it->second.end(); ++ownerIt)
+            for (const auto & ownerIt : it->second)
             {
-                owners.insert(std::make_pair(std::make_pair(ownerIt->first, ownerIt->second)
+                owners.insert(std::make_pair(std::make_pair(ownerIt.first, ownerIt.second)
                                              // Since OpenMW doesn't suffer from the owner contamination bug,
                                              // it needs a count argument. But for legacy savegames, we don't know
                                              // this count, so must assume all items of that ID are stolen,
@@ -588,10 +588,10 @@ public:
     }
     virtual void write(ESM::ESMWriter &esm)
     {
-        for (std::vector<ESM::GlobalScript>::const_iterator it = mScripts.begin(); it != mScripts.end(); ++it)
+        for (const auto & script : mScripts)
         {
             esm.startRecord(ESM::REC_GSCR);
-            it->save(esm);
+            script.save(esm);
             esm.endRecord(ESM::REC_GSCR);
         }
     }

--- a/apps/essimporter/convertinventory.cpp
+++ b/apps/essimporter/convertinventory.cpp
@@ -9,21 +9,20 @@ namespace ESSImport
     void convertInventory(const Inventory &inventory, ESM::InventoryState &state)
     {
         int index = 0;
-        for (std::vector<Inventory::InventoryItem>::const_iterator it = inventory.mItems.begin();
-             it != inventory.mItems.end(); ++it)
+        for (const auto & item : inventory.mItems)
         {
             ESM::ObjectState objstate;
             objstate.blank();
-            objstate.mRef = *it;
-            objstate.mRef.mRefID = Misc::StringUtils::lowerCase(it->mId);
-            objstate.mCount = std::abs(it->mCount); // restocking items have negative count in the savefile
+            objstate.mRef = item;
+            objstate.mRef.mRefID = Misc::StringUtils::lowerCase(item.mId);
+            objstate.mCount = std::abs(item.mCount); // restocking items have negative count in the savefile
                                                     // openmw handles them differently, so no need to set any flags
             state.mItems.push_back(objstate);
-            if (it->mRelativeEquipmentSlot != -1)
+            if (item.mRelativeEquipmentSlot != -1)
                 // Note we should really write the absolute slot here, which we do not know about
                 // Not a big deal, OpenMW will auto-correct to a valid slot, the only problem is when
                 // an item could be equipped in two different slots (e.g. equipped two rings)
-                state.mEquipmentSlots[index] = it->mRelativeEquipmentSlot;
+                state.mEquipmentSlots[index] = item.mRelativeEquipmentSlot;
             ++index;
         }
     }

--- a/apps/essimporter/convertplayer.cpp
+++ b/apps/essimporter/convertplayer.cpp
@@ -10,13 +10,13 @@ namespace ESSImport
     {
         out.mBirthsign = pcdt.mBirthsign;
         out.mObject.mNpcStats.mBounty = pcdt.mBounty;
-        for (std::vector<PCDT::FNAM>::const_iterator it = pcdt.mFactions.begin(); it != pcdt.mFactions.end(); ++it)
+        for (const auto & essFaction : pcdt.mFactions)
         {
             ESM::NpcStats::Faction faction;
-            faction.mExpelled = (it->mFlags & 0x2) != 0;
-            faction.mRank = it->mRank;
-            faction.mReputation = it->mReputation;
-            out.mObject.mNpcStats.mFactions[Misc::StringUtils::lowerCase(it->mFactionName.toString())] = faction;
+            faction.mExpelled = (essFaction.mFlags & 0x2) != 0;
+            faction.mRank = essFaction.mRank;
+            faction.mReputation = essFaction.mReputation;
+            out.mObject.mNpcStats.mFactions[Misc::StringUtils::lowerCase(essFaction.mFactionName.toString())] = faction;
         }
         for (int i=0; i<3; ++i)
             out.mObject.mNpcStats.mSpecIncreases[i] = pcdt.mPNAM.mSpecIncreases[i];
@@ -35,10 +35,9 @@ namespace ESSImport
         teleportingEnabled = !(pcdt.mPNAM.mPlayerFlags & PCDT::PlayerFlags_TeleportingDisabled);
         levitationEnabled = !(pcdt.mPNAM.mPlayerFlags & PCDT::PlayerFlags_LevitationDisabled);
 
-        for (std::vector<std::string>::const_iterator it = pcdt.mKnownDialogueTopics.begin();
-             it != pcdt.mKnownDialogueTopics.end(); ++it)
+        for (const auto & knownDialogueTopic : pcdt.mKnownDialogueTopics)
         {
-            outDialogueTopics.push_back(Misc::StringUtils::lowerCase(*it));
+            outDialogueTopics.push_back(Misc::StringUtils::lowerCase(knownDialogueTopic));
         }
 
         controls.mViewSwitchDisabled = pcdt.mPNAM.mPlayerFlags & PCDT::PlayerFlags_ViewSwitchDisabled;

--- a/apps/essimporter/convertscri.cpp
+++ b/apps/essimporter/convertscri.cpp
@@ -1,18 +1,16 @@
 #include "convertscri.hpp"
 
-#include <iostream>
-
 namespace
 {
 
     template <typename T, ESM::VarType VariantType>
     void storeVariables(const std::vector<T>& variables, ESM::Locals& locals, const std::string& scriptname)
     {
-        for (typename std::vector<T>::const_iterator it = variables.begin(); it != variables.end(); ++it)
+        for (const auto& variable : variables)
         {
-            ESM::Variant val(*it);
+            ESM::Variant val(variable);
             val.setType(VariantType);
-            locals.mVariables.push_back(std::make_pair(std::string(), val));
+            locals.mVariables.emplace_back(std::string(), val);
         }
     }
 

--- a/apps/essimporter/importer.cpp
+++ b/apps/essimporter/importer.cpp
@@ -16,15 +16,12 @@
 #include <components/esm/player.hpp>
 
 #include <components/esm/loadalch.hpp>
-#include <components/esm/loadclas.hpp>
 #include <components/esm/loadspel.hpp>
 #include <components/esm/loadarmo.hpp>
 #include <components/esm/loadweap.hpp>
 #include <components/esm/loadclot.hpp>
 #include <components/esm/loadench.hpp>
-#include <components/esm/loadweap.hpp>
 #include <components/esm/loadlevlist.hpp>
-#include <components/esm/loadglob.hpp>
 
 #include <components/misc/constants.hpp>
 
@@ -49,7 +46,7 @@ namespace
         image->allocateImage(128, 128, 1, GL_RGB, GL_UNSIGNED_BYTE);
 
         // need to convert pixel format from BGRA to RGB as the jpg readerwriter doesn't support it otherwise
-        std::vector<unsigned char>::const_iterator it = fileHeader.mSCRS.begin();
+        auto it = fileHeader.mSCRS.begin();
         for (int y=0; y<128; ++y)
         {
             for (int x=0; x<128; ++x)
@@ -317,10 +314,9 @@ namespace ESSImport
 
         std::set<unsigned int> unknownRecords;
 
-        for (std::map<unsigned int, std::shared_ptr<Converter> >::const_iterator it = converters.begin();
-             it != converters.end(); ++it)
+        for (const auto & converter : converters)
         {
-            it->second->setContext(context);
+            converter.second->setContext(context);
         }
 
         while (esm.hasMoreRecs())
@@ -328,7 +324,7 @@ namespace ESSImport
             ESM::NAME n = esm.getRecName();
             esm.getRecHeader();
 
-            std::map<unsigned int, std::shared_ptr<Converter> >::iterator it = converters.find(n.intval);
+            auto it = converters.find(n.intval);
             if (it != converters.end())
             {
                 it->second->read(esm);
@@ -358,17 +354,15 @@ namespace ESSImport
         writer.setDescription("");
         writer.setRecordCount (0);
 
-        for (std::vector<ESM::Header::MasterData>::const_iterator it = header.mMaster.begin();
-             it != header.mMaster.end(); ++it)
-            writer.addMaster (it->name, 0); // not using the size information anyway -> use value of 0
+        for (const auto & master : header.mMaster)
+            writer.addMaster(master.name, 0); // not using the size information anyway -> use value of 0
 
         writer.save (stream);
 
         ESM::SavedGame profile;
-        for (std::vector<ESM::Header::MasterData>::const_iterator it = header.mMaster.begin();
-             it != header.mMaster.end(); ++it)
+        for (const auto & master : header.mMaster)
         {
-            profile.mContentFiles.push_back(it->name);
+            profile.mContentFiles.push_back(master.name);
         }
         profile.mDescription = esm.getDesc();
         profile.mInGameTime.mDay = context.mDay;

--- a/apps/essimporter/importinventory.cpp
+++ b/apps/essimporter/importinventory.cpp
@@ -4,8 +4,6 @@
 
 #include <components/esm/esmreader.hpp>
 
-#include <components/esm/loadcont.hpp>
-
 namespace ESSImport
 {
 


### PR DESCRIPTION
Mostly loops style changes and variables initialization (use `nullptr` instead of 0 for references, for example).

Based on #2738 (with some concers addressed), but without formatting changes (which are mostly whitespace moving).