### PR TITLE
Revert the changes for "bug" #4551

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -147,10 +147,11 @@ namespace MWSound
         volume = static_cast<float>(pow(10.0, (sound->mData.mVolume / 255.0*3348.0 - 3348.0) / 2000.0));
         min = sound->mData.mMinRange;
         max = sound->mData.mMaxRange;
-        if (min == 0)
+        if (min == 0 && max == 0)
+        {
             min = fAudioDefaultMinDistance;
-        if (max == 0)
             max = fAudioDefaultMaxDistance;
+        }
 
         min *= fAudioMinDistanceMult;
         max *= fAudioMaxDistanceMult;


### PR DESCRIPTION
I made zero sound ranges be reset separately in August 2018 for 0.45.0. Morrowind doesn't actually do this so it may have caused differences in how sounds are played. The original concern - the lack of sound attenuation for sounds that have a zero assigned as a distance - isn't actually a thing because it's 1 unit that is the minimum distance assigned to the sound, not 0 units.

The way this was done before August 2018 had been consistent with Hrnchamd's research.