### PR TITLE
Remove 63 UV set limit

### DIFF
--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -47,10 +47,9 @@ void ShapeData::read(NIFStream *nif)
     if(nif->getInt())
         nif->getVector4s(colors, verts);
 
-    // Only the first 6 bits are used as a count. I think the rest are
-    // flags of some sort.
+    // In Morrowind this field only corresponds to the number of UV sets.
+    // NifTools research is inaccurate.
     int uvs = nif->getUShort();
-    uvs &= 0x3f;
 
     if(nif->getInt())
     {


### PR DESCRIPTION
MWSE guys reverse-engineered NiGeometryData serialization in Morrowind and found out Morrowind doesn't do masking here and instead acts as if the entire short corresponds to the number of UV sets.
So NifTools information isn't entirely correct. It may be different for later NIF versions but the circumstances of that are unclear.
This archive includes a mesh that has 16k UV sets which should load fine in Morrowind but will break current master.
[16k UV sets.zip](https://github.com/OpenMW/openmw/files/4777126/16k.UV.sets.zip)

Although it's unlikely any mod will ever include that many UV sets.