### PR TITLE
Calculate viewNormal only when needed

### DIFF
--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -83,7 +83,9 @@ void main()
     mat3 tbnTranspose = mat3(normalizedTangent, binormal, normalizedNormal);
 
     vec3 viewNormal = gl_NormalMatrix * normalize(tbnTranspose * (normalTex.xyz * 2.0 - 1.0));
-#else
+#endif
+
+#if (!@normalMap && (@parallax || @forcePPL))
     vec3 viewNormal = gl_NormalMatrix * normalize(passNormal);
 #endif
 
@@ -184,7 +186,12 @@ void main()
 #endif
 
     if (matSpec != vec3(0.0))
+    {
+#if (!normalMap && !@parallax && !forcePPL)
+        vec3 viewNormal = gl_NormalMatrix * normalize(passNormal);
+#endif
         gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos.xyz), shininess, matSpec) * shadowing;
+    }
 #if @radialFog
     float depth;
     // For the less detailed mesh of simple water we need to recalculate depth on per-pixel basis

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -63,7 +63,9 @@ void main(void)
     euclideanDepth = length(viewPos.xyz);
     linearDepth = gl_Position.z;
 
+#if (@envMap || !PER_PIXEL_LIGHTING || @shadows_enabled)
     vec3 viewNormal = normalize((gl_NormalMatrix * gl_Normal).xyz);
+#endif
 
 #if @envMap
     vec3 viewVec = normalize(viewPos.xyz);
@@ -112,5 +114,7 @@ void main(void)
     passViewPos = viewPos.xyz;
     passNormal = gl_Normal.xyz;
 
+#if (@shadows_enabled)
     setupShadowCoords(viewPos, viewNormal);
+#endif
 }

--- a/files/shaders/terrain_fragment.glsl
+++ b/files/shaders/terrain_fragment.glsl
@@ -43,8 +43,10 @@ void main()
     mat3 tbnTranspose = mat3(tangent, binormal, normalizedNormal);
 
     vec3 viewNormal = normalize(gl_NormalMatrix * (tbnTranspose * (normalTex.xyz * 2.0 - 1.0)));
-#else
-    vec3 viewNormal = normalize(gl_NormalMatrix * passNormal);
+#endif
+
+#if (!@normalMap && (@parallax || @forcePPL))
+    vec3 viewNormal = gl_NormalMatrix * normalize(passNormal);
 #endif
 
 #if @parallax
@@ -93,7 +95,12 @@ void main()
 #endif
 
     if (matSpec != vec3(0.0))
+    {
+#if (!normalMap && !@parallax && !forcePPL)
+        vec3 viewNormal = gl_NormalMatrix * normalize(passNormal);
+#endif
         gl_FragData[0].xyz += getSpecular(normalize(viewNormal), normalize(passViewPos), shininess, matSpec) * shadowing;
+    }
 
 #if @radialFog
     float fogValue = clamp((euclideanDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);

--- a/files/shaders/terrain_vertex.glsl
+++ b/files/shaders/terrain_vertex.glsl
@@ -26,8 +26,10 @@ void main(void)
     gl_ClipVertex = viewPos;
     euclideanDepth = length(viewPos.xyz);
     linearDepth = gl_Position.z;
-    
+
+#if (!PER_PIXEL_LIGHTING || @shadows_enabled)
     vec3 viewNormal = normalize((gl_NormalMatrix * gl_Normal).xyz);
+#endif
 
 #if !PER_PIXEL_LIGHTING
     lighting = doLighting(viewPos.xyz, viewNormal, gl_Color, shadowDiffuseLighting);
@@ -38,5 +40,7 @@ void main(void)
 
     uv = gl_MultiTexCoord0.xy;
 
+#if (@shadows_enabled)
     setupShadowCoords(viewPos, viewNormal);
+#endif
 }


### PR DESCRIPTION
It is used only in per-pixel lighting, also in normal, parallax and specular maps, but we always calculate it anyway, and optimizer may fail to remove that redundant calculations.

On my hardware (GTX 1050) it allows to increase FPS a bit when there are a lot of particles in scene (from 64 to 72 FPS in "Valenvaryon, Propylon Chamber").