### PR TITLE
Use sequenced texture units with .dae/collada

### DIFF
--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -360,6 +360,7 @@ namespace Resource
             // Note, for some formats (.obj/.mtl) that reference other (non-image) files a findFileCallback would be necessary.
             // but findFileCallback does not support virtual files, so we can't implement it.
             options->setReadFileCallback(new ImageReadCallback(imageManager));
+            if (ext == "dae") options->setOptionString("daeUseSequencedTextureUnits");
 
             osgDB::ReaderWriter::ReadResult result = reader->readNode(*file, options);
             if (!result.success())


### PR DESCRIPTION
This is a workaround to fix the diffuse texture in dae-format. With sequenced texture units, the diffuse is usually 0, which enables the auto-recognition of diffuse texture.

Default seems to be "predefined material sequencing", which isn't very useful in OpenMW.

A better implementation of texture recognition of dae-format would require that the OSG reads the texture names correctly, which isn't happening currently (possibly not implemented?).

https://gitlab.com/OpenMW/openmw/-/issues/5464