### PR TITLE
Get rid of ECLD and dependencies

### DIFF
--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -156,9 +156,7 @@ namespace MWGui
 
         getWidget(mCrosshair, "Crosshair");
 
-        int mapSize = std::max(1, Settings::Manager::getInt("local map hud widget size", "Map"));
-        int cellDistance = std::max(1, Settings::Manager::getInt("local map cell distance", "Map"));
-        LocalMapBase::init(mMinimap, mCompass, mapSize, cellDistance);
+        LocalMapBase::init(mMinimap, mCompass);
 
         mMainWidget->eventMouseButtonClick += MyGUI::newDelegate(this, &HUD::onWorldClicked);
         mMainWidget->eventMouseMove += MyGUI::newDelegate(this, &HUD::onWorldMouseOver);

--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -183,13 +183,13 @@ namespace MWGui
         mCustomMarkers.eventMarkersChanged -= MyGUI::newDelegate(this, &LocalMapBase::updateCustomMarkers);
     }
 
-    void LocalMapBase::init(MyGUI::ScrollView* widget, MyGUI::ImageBox* compass, int mapWidgetSize, int cellDistance)
+    void LocalMapBase::init(MyGUI::ScrollView* widget, MyGUI::ImageBox* compass)
     {
         mLocalMap = widget;
         mCompass = compass;
-        mMapWidgetSize = mapWidgetSize;
-        mCellDistance = cellDistance;
-        mNumCells = cellDistance * 2 + 1;
+        mMapWidgetSize = std::max(1, Settings::Manager::getInt("local map widget size", "Map"));
+        mCellDistance = Constants::CellGridRadius;
+        mNumCells = mCellDistance * 2 + 1;
 
         mLocalMap->setCanvasSize(mMapWidgetSize*mNumCells, mMapWidgetSize*mNumCells);
 
@@ -697,9 +697,7 @@ namespace MWGui
         mEventBoxLocal->eventMouseButtonPressed += MyGUI::newDelegate(this, &MapWindow::onDragStart);
         mEventBoxLocal->eventMouseButtonDoubleClick += MyGUI::newDelegate(this, &MapWindow::onMapDoubleClicked);
 
-        int mapSize = std::max(1, Settings::Manager::getInt("local map widget size", "Map"));
-        int cellDistance = std::max(1, Settings::Manager::getInt("local map cell distance", "Map"));
-        LocalMapBase::init(mLocalMap, mPlayerArrowLocal, mapSize, cellDistance);
+        LocalMapBase::init(mLocalMap, mPlayerArrowLocal);
 
         mGlobalMap->setVisible(mGlobal);
         mLocalMap->setVisible(!mGlobal);

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -72,7 +72,7 @@ namespace MWGui
     public:
         LocalMapBase(CustomMarkerCollection& markers, MWRender::LocalMap* localMapRender, bool fogOfWarEnabled = true);
         virtual ~LocalMapBase();
-        void init(MyGUI::ScrollView* widget, MyGUI::ImageBox* compass, int mapWidgetSize, int cellDistance);
+        void init(MyGUI::ScrollView* widget, MyGUI::ImageBox* compass);
 
         void setCellPrefix(const std::string& prefix);
         void setActiveCell(const int x, const int y, bool interior=false);

--- a/apps/openmw/mwmechanics/aipackage.cpp
+++ b/apps/openmw/mwmechanics/aipackage.cpp
@@ -344,7 +344,6 @@ bool MWMechanics::AiPackage::isNearInactiveCell(osg::Vec3f position)
         Misc::CoordinateConverter(playerCell).toLocal(position);
 
         // currently assumes 3 x 3 grid for exterior cells, with player at center cell.
-        // ToDo: (Maybe) use "exterior cell load distance" setting to get count of actual active cells
         // AI shuts down actors before they reach edges of 3 x 3 grid.
         const float distanceFromEdge = 200.0;
         float minThreshold = (-1.0f * ESM::Land::REAL_SIZE) + distanceFromEdge;

--- a/apps/openmw/mwrender/localmap.cpp
+++ b/apps/openmw/mwrender/localmap.cpp
@@ -74,7 +74,7 @@ LocalMap::LocalMap(osg::Group* root)
     : mRoot(root)
     , mMapResolution(Settings::Manager::getInt("local map resolution", "Map"))
     , mMapWorldSize(Constants::CellSizeInUnits)
-    , mCellDistance(Settings::Manager::getInt("local map cell distance", "Map"))
+    , mCellDistance(Constants::CellGridRadius)
     , mAngle(0.f)
     , mInterior(false)
 {

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -757,7 +757,6 @@ namespace MWWorld
     Scene::Scene (MWRender::RenderingManager& rendering, MWPhysics::PhysicsSystem *physics,
                   DetourNavigator::Navigator& navigator)
     : mCurrentCell (0), mCellChanged (false), mPhysics(physics), mRendering(rendering), mNavigator(navigator)
-    , mHalfGridSize(Settings::Manager::getInt("exterior cell load distance", "Cells"))
     , mCellLoadingThreshold(1024.f)
     , mPreloadDistance(Settings::Manager::getInt("preload distance", "Cells"))
     , mPreloadEnabled(Settings::Manager::getBool("preload enabled", "Cells"))

--- a/apps/openmw/mwworld/scene.hpp
+++ b/apps/openmw/mwworld/scene.hpp
@@ -11,6 +11,8 @@
 #include <memory>
 #include <unordered_map>
 
+#include <components/misc/constants.hpp>
+
 namespace osg
 {
     class Vec3f;
@@ -75,7 +77,6 @@ namespace MWWorld
             MWRender::RenderingManager& mRendering;
             DetourNavigator::Navigator& mNavigator;
             std::unique_ptr<CellPreloader> mPreloader;
-            int mHalfGridSize;
             float mCellLoadingThreshold;
             float mPreloadDistance;
             bool mPreloadEnabled;
@@ -84,6 +85,8 @@ namespace MWWorld
             bool mPreloadDoors;
             bool mPreloadFastTravel;
             float mPredictionTime;
+
+            static const int mHalfGridSize = Constants::CellGridRadius;
 
             osg::Vec3f mLastPlayerPos;
 

--- a/components/misc/constants.hpp
+++ b/components/misc/constants.hpp
@@ -24,6 +24,9 @@ const float GravityConst = 8.96f;
 // Size of one exterior cell in game units
 const int CellSizeInUnits = 8192;
 
+// Size of active cell grid in cells (it is a square with the (2 * CellGridRadius + 1) cells side)
+const int CellGridRadius = 1;
+
 // A label to mark night/day visual switches
 const std::string NightDayLabel = "NightDaySwitch";
 

--- a/docs/source/reference/modding/settings/camera.rst
+++ b/docs/source/reference/modding/settings/camera.rst
@@ -51,21 +51,20 @@ viewing distance
 This value controls the maximum visible distance (also called the far clipping plane).
 Larger values significantly improve rendering in exterior spaces,
 but also increase the amount of rendered geometry and significantly reduce the frame rate.
-This value interacts with the exterior cell load distance setting
-in that it's probably undesired for this value to provide visibility into cells that have not yet been loaded.
-When cells are visible before loading, the geometry will "pop-in" suddenly, creating a jarring visual effect.
-To prevent this effect, this value must be less than::
+Note that when cells are visible before loading (when not using a Distant Land), the geometry will "pop-in" suddenly,
+creating a jarring visual effect. To prevent this effect, this value must be less than::
 
-	(8192 * exterior cell load distance - 1024) * 0.93
+	(CellSizeInUnits * CellGridRadius - 1024) * 0.93
 
-The constant 8192 is the size of a cell, and 1024 is the threshold distance for loading a new cell.
+The CellSizeInUnits is the size of a game cell in units (8192 by default), CellGridRadius determines how many
+neighboring cells to current one to load (1 by default - 3x3 grid), and 1024 is the threshold distance for loading a new cell.
 Additionally, the field of view setting also interacts with this setting because the view frustum end is a plane,
 so you can see further at the edges of the screen than you should be able to.
 This can be observed in game by looking at distant objects
 and rotating the camera so the objects are near the edge of the screen.
 As a result, this setting should further be reduced by a factor that depends on the field of view setting.
 In the default configuration this reduction is 7%, hence the factor of 0.93 above.
-Using this factor, approximate values recommended for other exterior cell load distance settings are:
+Using this factor, approximate values recommended for other CellGridRadius values are:
 
 ======= ========
 Cells	Viewing
@@ -82,10 +81,6 @@ and long viewing distances near the edges of the screen.
 Such situations are unusual and probably not worth the performance penalty introduced
 by loading geometry obscured by fog in the center of the screen.
 See RenderingManager::configureFog for the relevant source code.
-
-Enabling the distant terrain setting is an alternative to increasing exterior cell load distance.
-Note that the distant land setting does not include rendering of distant static objects,
-so the resulting visual effect is not the same.
 
 This setting can be adjusted in game from the ridiculously low value of 2048.0 to a maximum of 81920.0
 using the View Distance slider in the Detail tab of the Video panel of the Options menu.

--- a/docs/source/reference/modding/settings/cells.rst
+++ b/docs/source/reference/modding/settings/cells.rst
@@ -1,30 +1,6 @@
 Cells Settings
 ##############
 
-exterior cell load distance
----------------------------
-
-:Type:		integer
-:Range:		>= 1
-:Default:	1
-
-This setting determines the number of exterior cells adjacent to the character that will be loaded for rendering.
-
-.. Warning::
-	Values greater than 1 will significantly affect the frame rate and loading times. 
-	This setting is mainly intended for making screenshots of scenic vistas and not for real-time gameplay. 
-	Loading more cells can break certain scripts or quests in the game that expect cells to not be loaded until the player is there. 
-	These limitations will be addressed in a future version with a separate technique for rendering distant cells.
-
-This setting interacts with viewing distance and field of view settings.
-
-It is generally very wasteful for this value to load geometry than will almost never be visible
-due to viewing distance and fog. For low frame rate screen shots of scenic vistas,
-this setting should be set high, and viewing distances adjusted accordingly.
-
-This setting can only be configured by editing the settings configuration file.
-
-
 preload enabled
 ---------------
 
@@ -60,7 +36,7 @@ consider increasing the number of preloading threads to 2 or 3 for a boost in pr
 Faster preloading will reduce the chance that a cell could not be completely loaded before the player moves into it,
 and hence reduce the chance of seeing loading screens or frame drops.
 This may be especially relevant when the player moves at high speed
-and/or a large number of cells are loaded in via 'exterior cell load distance'.
+and/or a large number of objects are preloaded due to large viewing distance.
 
 A value of 4 or higher is not recommended.
 With 4 or more threads, improvements will start to diminish due to file reading and synchronization bottlenecks.

--- a/docs/source/reference/modding/settings/map.rst
+++ b/docs/source/reference/modding/settings/map.rst
@@ -103,14 +103,3 @@ and typically require more panning to see all available portions of the map.
 This larger size also enables an overall greater level of detail if the local map resolution setting is also increased.
 
 This setting can not be configured except by editing the settings configuration file.
-
-local map cell distance
------------------------
-
-:Type:		integer
-:Range:		>= 1
-:Default:	1
-
-Similar to "exterior cell load distance" in the Cells section, controls how many cells are rendered on the local map. 
-Please note that only loaded cells can be rendered,
-so this setting must be lower or equal to "exterior cell load distance" to work properly.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -35,10 +35,6 @@ first person field of view = 60.0
 
 [Cells]
 
-# Adjacent exterior cells loaded (>0). Caution: this setting can
-# dramatically affect performance, see documentation for details.
-exterior cell load distance = 1
-
 # Preload cells in a background thread. All settings starting with 'preload' have no effect unless this is enabled.
 preload enabled = true
 
@@ -165,11 +161,6 @@ local map resolution = 256
 
 # Size of local map in GUI window in pixels.  (e.g. 256 to 1024).
 local map widget size = 512
-
-# Similar to "[Cells] exterior cell load distance", controls
-# how many cells are rendered on the local map. Values higher than the default
-# may result in longer loading times.
-local map cell distance = 1
 
 # If true, map in world mode, otherwise in local mode
 global = false


### PR DESCRIPTION
The "exterior cell load distance" setting is obsolete now and is not needed since it was used as a stopgap for Distant Land.
The same thing for "local map cell distance" - Distant Land does not load distant cells fully, so these cells can not be rendered on the local map anyway.

So I removed these settings and replaced them by compile-time constant (as cell size) - maybe it is not worth to fully remove an ability to load additional cells, we just do not want this thing to be abused by end users. 