### PR TITLE
Reset selected slot when closing savegame dialogue

### DIFF
--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -132,6 +132,13 @@ namespace MWGui
         MWBase::Environment::get().getWindowManager()->injectKeyRelease(MyGUI::KeyCode::None);
     }
 
+    void SaveGameDialog::onClose()
+    {
+        mSaveList->setIndexSelected(MyGUI::ITEM_NONE);
+
+        WindowModal::onClose();
+    }
+
     void SaveGameDialog::onOpen()
     {
         WindowModal::onOpen();

--- a/apps/openmw/mwgui/savegamedialog.hpp
+++ b/apps/openmw/mwgui/savegamedialog.hpp
@@ -20,6 +20,7 @@ namespace MWGui
         SaveGameDialog();
 
         virtual void onOpen();
+        virtual void onClose();
 
         void setLoadOrSave(bool load);
 


### PR DESCRIPTION
Otherwise it is possible to get an accidental saving/loading when using console while savegame dialogue is hidden.

Sometimes I encounter such behaviour when using `coc` console command after savegame loading.