### PR TITLE
Fix issues, reported by CoverityScan

### DIFF
--- a/apps/openmw/mwinput/controllermanager.cpp
+++ b/apps/openmw/mwinput/controllermanager.cpp
@@ -36,6 +36,7 @@ namespace MWInput
         , mSneakToggleShortcutTimer(0.f)
         , mGamepadZoom(0)
         , mGamepadGuiCursorEnabled(true)
+        , mGuiCursorEnabled(true)
         , mJoystickLastUsed(false)
         , mSneakGamepadShortcut(false)
         , mGamepadPreviewMode(false)

--- a/apps/openmw/mwrender/objectpaging.hpp
+++ b/apps/openmw/mwrender/objectpaging.hpp
@@ -80,7 +80,7 @@ namespace MWRender
     class RefnumMarker : public osg::Object
     {
     public:
-        RefnumMarker() : mNumVertices(0) {}
+        RefnumMarker() : mNumVertices(0) { mRefnum.unset(); }
         RefnumMarker(const RefnumMarker &copy, osg::CopyOp co) : mRefnum(copy.mRefnum), mNumVertices(copy.mNumVertices) {}
         META_Object(MWRender, RefnumMarker)
 

--- a/apps/openmw/mwscript/globalscripts.cpp
+++ b/apps/openmw/mwscript/globalscripts.cpp
@@ -24,6 +24,7 @@ namespace
         {
             ESM::GlobalScript script;
             script.mTargetRef.unset();
+            script.mRunning = false;
             if (!ptr.isEmpty())
             {
                 if (ptr.getCellRef().hasContentFile())
@@ -42,6 +43,7 @@ namespace
             ESM::GlobalScript script;
             script.mTargetId = pair.second;
             script.mTargetRef = pair.first;
+            script.mRunning = false;
             return script;
         }
     };

--- a/components/fontloader/fontloader.cpp
+++ b/components/fontloader/fontloader.cpp
@@ -165,7 +165,14 @@ namespace Gui
 
     FontLoader::~FontLoader()
     {
-        MyGUI::ResourceManager::getInstance().unregisterLoadXmlDelegate("Resource");
+        try
+        {
+            MyGUI::ResourceManager::getInstance().unregisterLoadXmlDelegate("Resource");
+        }
+        catch(const MyGUI::Exception& e)
+        {
+            Log(Debug::Error) << "Error in the FontLoader destructor: " << e.what();
+        }
 
         for (std::vector<MyGUI::ITexture*>::iterator it = mTextures.begin(); it != mTextures.end(); ++it)
             delete *it;

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -28,6 +28,7 @@ ChunkManager::ChunkManager(Storage *storage, Resource::SceneManager *sceneMgr, T
     , mSceneManager(sceneMgr)
     , mTextureManager(textureManager)
     , mCompositeMapRenderer(renderer)
+    , mNodeMask(0)
     , mCompositeMapSize(512)
     , mCompositeMapLevel(1.f)
     , mMaxCompGeometrySize(1.f)


### PR DESCRIPTION
Mostly complaints about non-initialized variables.

Note that 304711 appears to be a yet-another false-positive in `atan2` function.

