### PR TITLE
Avoid to use some deprecated Qt API

### DIFF
--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -116,7 +116,7 @@ bool CSMWorld::IdTable::setData (const QModelIndex &index, const QVariant &value
 Qt::ItemFlags CSMWorld::IdTable::flags (const QModelIndex & index) const
 {
     if (!index.isValid())
-        return 0;
+        return Qt::ItemFlags();
 
     Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
 

--- a/apps/opencs/view/prefs/contextmenulist.hpp
+++ b/apps/opencs/view/prefs/contextmenulist.hpp
@@ -14,7 +14,7 @@ namespace CSVPrefs
     
         public:
     
-            ContextMenuList(QWidget* parent = 0);
+            ContextMenuList(QWidget* parent = nullptr);
     
         protected:
     

--- a/apps/opencs/view/render/orbitcameramode.hpp
+++ b/apps/opencs/view/render/orbitcameramode.hpp
@@ -21,7 +21,7 @@ namespace CSVRender
         public:
 
             OrbitCameraMode(WorldspaceWidget* worldspaceWidget, const QIcon& icon, const QString& tooltip = "",
-                QWidget* parent = 0);
+                QWidget* parent = nullptr);
             ~OrbitCameraMode();
 
             virtual void activate(CSVWidget::SceneToolbar* toolbar);

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -332,7 +332,7 @@ void SceneWidget::mouseMoveEvent (QMouseEvent *event)
 
 void SceneWidget::wheelEvent(QWheelEvent *event)
 {
-    mCurrentCamControl->handleMouseScrollEvent(event->delta());
+    mCurrentCamControl->handleMouseScrollEvent(event->angleDelta().y());
 }
 
 void SceneWidget::update(double dt)

--- a/apps/opencs/view/render/scenewidget.hpp
+++ b/apps/opencs/view/render/scenewidget.hpp
@@ -49,7 +49,7 @@ namespace CSVRender
             Q_OBJECT
 
         public:
-            RenderWidget(QWidget* parent = 0, Qt::WindowFlags f = 0);
+            RenderWidget(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
             virtual ~RenderWidget();
 
             /// Initiates a request to redraw the view
@@ -78,8 +78,8 @@ namespace CSVRender
     {
             Q_OBJECT
         public:
-            SceneWidget(std::shared_ptr<Resource::ResourceSystem> resourceSystem, QWidget* parent = 0,
-                    Qt::WindowFlags f = 0, bool retrieveInput = true);
+            SceneWidget(std::shared_ptr<Resource::ResourceSystem> resourceSystem, QWidget* parent = nullptr,
+                        Qt::WindowFlags f = Qt::WindowFlags(), bool retrieveInput = true);
             virtual ~SceneWidget();
 
             CSVWidget::SceneToolMode *makeLightingSelector (CSVWidget::SceneToolbar *parent);

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -33,7 +33,7 @@
 #include "cameracontroller.hpp"
 
 CSVRender::WorldspaceWidget::WorldspaceWidget (CSMDoc::Document& document, QWidget* parent)
-    : SceneWidget (document.getData().getResourceSystem(), parent, 0, false)
+    : SceneWidget (document.getData().getResourceSystem(), parent, Qt::WindowFlags(), false)
     , mSceneElements(0)
     , mRun(0)
     , mDocument(document)

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -677,8 +677,7 @@ void CSVRender::WorldspaceWidget::wheelEvent (QWheelEvent *event)
             factor *= mDragShiftFactor;
 
         EditMode& editMode = dynamic_cast<CSVRender::EditMode&> (*mEditMode->getCurrent());
-
-        editMode.dragWheel (event->delta(), factor);
+        editMode.dragWheel (event->angleDelta().y(), factor);
     }
     else
         SceneWidget::wheelEvent(event);

--- a/apps/opencs/view/tools/reporttable.cpp
+++ b/apps/opencs/view/tools/reporttable.cpp
@@ -273,7 +273,7 @@ void CSVTools::ReportTable::settingChanged (const CSMPrefs::Setting *setting)
         if (key.startsWith (base))
         {
             QString modifierString = key.mid (base.size());
-            Qt::KeyboardModifiers modifiers = 0;
+            Qt::KeyboardModifiers modifiers;
 
             if (modifierString=="-s")
                 modifiers = Qt::ShiftModifier;

--- a/apps/opencs/view/world/table.cpp
+++ b/apps/opencs/view/world/table.cpp
@@ -671,7 +671,7 @@ void CSVWorld::Table::settingChanged (const CSMPrefs::Setting *setting)
     {
         std::string modifierString = setting->getKey().substr (6);
 
-        Qt::KeyboardModifiers modifiers = 0;
+        Qt::KeyboardModifiers modifiers;
 
         if (modifierString=="-s")
             modifiers = Qt::ShiftModifier;

--- a/apps/wizard/mainwizard.cpp
+++ b/apps/wizard/mainwizard.cpp
@@ -120,9 +120,10 @@ void Wizard::MainWizard::addLogText(const QString &text)
     QTextStream out(&file);
 
     if (!text.isEmpty())
-        out << text << endl;
-
-//    file.close();
+    {
+        out << text << "\n";
+        out.flush();
+    }
 }
 
 void Wizard::MainWizard::setupGameSettings()

--- a/extern/osgQt/GraphicsWindowQt
+++ b/extern/osgQt/GraphicsWindowQt
@@ -41,9 +41,9 @@ class GLWidget : public QGLWidget
 
 public:
 
-    GLWidget( QWidget* parent = NULL, const QGLWidget* shareWidget = NULL, Qt::WindowFlags f = 0);
-    GLWidget( QGLContext* context, QWidget* parent = NULL, const QGLWidget* shareWidget = NULL, Qt::WindowFlags f = 0);
-    GLWidget( const QGLFormat& format, QWidget* parent = NULL, const QGLWidget* shareWidget = NULL, Qt::WindowFlags f = 0);
+    GLWidget( QWidget* parent = nullptr, const QGLWidget* shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    GLWidget( QGLContext* context, QWidget* parent = nullptr, const QGLWidget* shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    GLWidget( const QGLFormat& format, QWidget* parent = nullptr, const QGLWidget* shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     virtual ~GLWidget();
 
     inline void setGraphicsWindow( GraphicsWindowQt* gw ) { _gw = gw; }
@@ -93,7 +93,7 @@ protected:
 class GraphicsWindowQt : public osgViewer::GraphicsWindow
 {
 public:
-    GraphicsWindowQt( osg::GraphicsContext::Traits* traits, QWidget* parent = NULL, const QGLWidget* shareWidget = NULL, Qt::WindowFlags f = 0 );
+    GraphicsWindowQt( osg::GraphicsContext::Traits* traits, QWidget* parent = nullptr, const QGLWidget* shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
     GraphicsWindowQt( GLWidget* widget );
     virtual ~GraphicsWindowQt();
 
@@ -107,7 +107,7 @@ public:
 
     struct WindowData : public osg::Referenced
     {
-        WindowData( GLWidget* widget = NULL, QWidget* parent = NULL ): _widget(widget), _parent(parent) {}
+        WindowData( GLWidget* widget = nullptr, QWidget* parent = nullptr ): _widget(widget), _parent(parent) {}
         GLWidget* _widget;
         QWidget* _parent;
     };

--- a/extern/osgQt/GraphicsWindowQt.cpp
+++ b/extern/osgQt/GraphicsWindowQt.cpp
@@ -24,19 +24,19 @@ using namespace osgQt;
 #define GETDEVICEPIXELRATIO() devicePixelRatio()
 
 GLWidget::GLWidget( QWidget* parent, const QGLWidget* shareWidget, Qt::WindowFlags f)
-: QGLWidget(parent, shareWidget, f), _gw( NULL )
+: QGLWidget(parent, shareWidget, f), _gw( nullptr )
 {
     _devicePixelRatio = GETDEVICEPIXELRATIO();
 }
 
 GLWidget::GLWidget( QGLContext* context, QWidget* parent, const QGLWidget* shareWidget, Qt::WindowFlags f)
-: QGLWidget(context, parent, shareWidget, f), _gw( NULL )
+: QGLWidget(context, parent, shareWidget, f), _gw( nullptr )
 {
     _devicePixelRatio = GETDEVICEPIXELRATIO();
 }
 
 GLWidget::GLWidget( const QGLFormat& format, QWidget* parent, const QGLWidget* shareWidget, Qt::WindowFlags f)
-: QGLWidget(format, parent, shareWidget, f), _gw( NULL )
+: QGLWidget(format, parent, shareWidget, f), _gw( nullptr )
 {
     _devicePixelRatio = GETDEVICEPIXELRATIO();
 }
@@ -47,8 +47,8 @@ GLWidget::~GLWidget()
     if( _gw )
     {
         _gw->close();
-        _gw->_widget = NULL;
-        _gw = NULL;
+        _gw->_widget = nullptr;
+        _gw = nullptr;
     }
 }
 
@@ -155,7 +155,7 @@ GraphicsWindowQt::GraphicsWindowQt( osg::GraphicsContext::Traits* traits, QWidge
 :   _realized(false)
 {
 
-    _widget = NULL;
+    _widget = nullptr;
     _traits = traits;
     init( parent, shareWidget, f );
 }
@@ -165,7 +165,7 @@ GraphicsWindowQt::GraphicsWindowQt( GLWidget* widget )
 {
     _widget = widget;
     _traits = _widget ? createTraits( _widget ) : new osg::GraphicsContext::Traits;
-    init( NULL, NULL, 0 );
+    init( nullptr, nullptr, Qt::WindowFlags() );
 }
 
 GraphicsWindowQt::~GraphicsWindowQt()
@@ -174,20 +174,20 @@ GraphicsWindowQt::~GraphicsWindowQt()
 
     // remove reference from GLWidget
     if ( _widget )
-        _widget->_gw = NULL;
+        _widget->_gw = nullptr;
 }
 
 bool GraphicsWindowQt::init( QWidget* parent, const QGLWidget* shareWidget, Qt::WindowFlags f )
 {
     // update _widget and parent by WindowData
-    WindowData* windowData = _traits.get() ? dynamic_cast<WindowData*>(_traits->inheritedWindowData.get()) : 0;
+    WindowData* windowData = _traits.get() ? dynamic_cast<WindowData*>(_traits->inheritedWindowData.get()) : nullptr;
     if ( !_widget )
-        _widget = windowData ? windowData->_widget : NULL;
+        _widget = windowData ? windowData->_widget : nullptr;
     if ( !parent )
-        parent = windowData ? windowData->_parent : NULL;
+        parent = windowData ? windowData->_parent : nullptr;
 
     // create widget if it does not exist
-    _ownsWidget = _widget == NULL;
+    _ownsWidget = _widget == nullptr;
     if ( !_widget )
     {
         // shareWidget
@@ -310,7 +310,7 @@ osg::GraphicsContext::Traits* GraphicsWindowQt::createTraits( const QGLWidget* w
 
 bool GraphicsWindowQt::setWindowRectangleImplementation( int x, int y, int width, int height )
 {
-    if ( _widget == NULL )
+    if ( _widget == nullptr )
         return false;
 
     _widget->setGeometry( x, y, width, height );
@@ -596,13 +596,13 @@ public:
         if (traits->pbuffer)
         {
             OSG_WARN << "osgQt: createGraphicsContext - pbuffer not implemented yet." << std::endl;
-            return NULL;
+            return nullptr;
         }
         else
         {
             osg::ref_ptr< GraphicsWindowQt > window = new GraphicsWindowQt( traits );
             if (window->valid()) return window.release();
-            else return NULL;
+            else return nullptr;
         }
     }
 


### PR DESCRIPTION
Summary of changes:
1. Use default constructors for flags and nullptr's instead of 0 ([task #5477](https://gitlab.com/OpenMW/openmw/-/issues/5477)).
2. Do not use deprecated `endl` from Qt streams
3. Update mouse wheel event handling - now Qt returns movement angle for both axes and we need only a vertical movement so far.