### PR TITLE
Avoid more deprecated Qt stuff

### DIFF
--- a/apps/opencs/model/world/idtree.cpp
+++ b/apps/opencs/model/world/idtree.cpp
@@ -116,7 +116,7 @@ bool CSMWorld::IdTree::setData (const QModelIndex &index, const QVariant &value,
 Qt::ItemFlags CSMWorld::IdTree::flags (const QModelIndex & index) const
 {
     if (!index.isValid())
-        return 0;
+        return Qt::ItemFlags();
 
     if (index.internalId() != 0)
     {

--- a/apps/wizard/inisettings.cpp
+++ b/apps/wizard/inisettings.cpp
@@ -127,25 +127,24 @@ bool Wizard::IniSettings::writeFile(const QString &path, QTextStream &stream)
         QString key(fullKey.at(1));
 
         int index = buffer.lastIndexOf(section);
-        if (index != -1) {
-            // Look for the next section
-            index = buffer.indexOf(QLatin1Char('['), index + 1);
-
-            if (index == -1 ) {
-                // We are at the last section, append it to the bottom of the file
-                buffer.append(QString("\n%1=%2").arg(key, i.value().toString()));
-                mSettings.remove(i.key());
-                continue;
-            } else {
-                // Not at last section, add the key at the index
-                buffer.insert(index - 1, QString("\n%1=%2").arg(key, i.value().toString()));
-                mSettings.remove(i.key());
-            }
-
-        } else {
+        if (index == -1) {
             // Add the section to the end of the file, because it's not found
             buffer.append(QString("\n%1\n").arg(section));
-            i.previous();
+            index = buffer.lastIndexOf(section);
+        }
+
+        // Look for the next section
+        index = buffer.indexOf(QLatin1Char('['), index + 1);
+
+        if (index == -1 ) {
+            // We are at the last section, append it to the bottom of the file
+            buffer.append(QString("\n%1=%2").arg(key, i.value().toString()));
+            mSettings.remove(i.key());
+            continue;
+        } else {
+            // Not at last section, add the key at the index
+            buffer.insert(index - 1, QString("\n%1=%2").arg(key, i.value().toString()));
+            mSettings.remove(i.key());
         }
     }
 


### PR DESCRIPTION
1. Use a default constructor instead of 0 in yet another place.
2. Avoid reverse iteration in QHash - Qt devs are aimed to make it forward-only.
We use it in one place (to write values to the Morrowind.ini when we extract addons via Unshield), and it is not really needed here.