### PR TITLE
Use QMultiMap instead of QMap

### DIFF
--- a/components/config/gamesettings.cpp
+++ b/components/config/gamesettings.cpp
@@ -2,11 +2,8 @@
 #include "launchersettings.hpp"
 
 #include <QTextCodec>
-#include <QTextStream>
 #include <QDir>
-#include <QString>
 #include <QRegExp>
-#include <QMap>
 
 #include <components/files/configurationmanager.hpp>
 
@@ -105,9 +102,9 @@ bool Config::GameSettings::readUserFile(QTextStream &stream)
     return readFile(stream, mUserSettings);
 }
 
-bool Config::GameSettings::readFile(QTextStream &stream, QMap<QString, QString> &settings)
+bool Config::GameSettings::readFile(QTextStream &stream, QMultiMap<QString, QString> &settings)
 {
-    QMap<QString, QString> cache;
+    QMultiMap<QString, QString> cache;
     QRegExp keyRe("^([^=]+)\\s*=\\s*(.+)$");
 
     while (!stream.atEnd()) {
@@ -151,7 +148,7 @@ bool Config::GameSettings::readFile(QTextStream &stream, QMap<QString, QString> 
             values.append(settings.values(key));
 
             if (!values.contains(value)) {
-                cache.insertMulti(key, value);
+                cache.insert(key, value);
             }
         }
     }
@@ -368,7 +365,7 @@ bool Config::GameSettings::writeFileWithComments(QFile &file)
             *iter = QString(); // assume no match
             QString key = settingRegex.cap(1);
             QString keyVal = settingRegex.cap(1)+"="+settingRegex.cap(2);
-            QMap<QString, QString>::const_iterator i = mUserSettings.find(key);
+            QMultiMap<QString, QString>::const_iterator i = mUserSettings.find(key);
             while (i != mUserSettings.end() && i.key() == key)
             {
                 QString settingLine = i.key() + "=" + i.value();

--- a/components/config/gamesettings.hpp
+++ b/components/config/gamesettings.hpp
@@ -5,7 +5,7 @@
 #include <QStringList>
 #include <QString>
 #include <QFile>
-#include <QMap>
+#include <QMultiMap>
 
 #include <boost/filesystem/path.hpp>
 
@@ -31,7 +31,9 @@ namespace Config
 
         inline void setValue(const QString &key, const QString &value)
         {
+            mSettings.remove(key);
             mSettings.insert(key, value);
+            mUserSettings.remove(key);
             mUserSettings.insert(key, value);
         }
 
@@ -39,11 +41,11 @@ namespace Config
         {
             QStringList values = mSettings.values(key);
             if (!values.contains(value))
-                mSettings.insertMulti(key, value);
+                mSettings.insert(key, value);
 
             values = mUserSettings.values(key);
             if (!values.contains(value))
-                mUserSettings.insertMulti(key, value);
+                mUserSettings.insert(key, value);
         }
 
         inline void remove(const QString &key)
@@ -63,7 +65,7 @@ namespace Config
         QStringList values(const QString &key, const QStringList &defaultValues = QStringList()) const;
 
         bool readFile(QTextStream &stream);
-        bool readFile(QTextStream &stream, QMap<QString, QString> &settings);
+        bool readFile(QTextStream &stream, QMultiMap<QString, QString> &settings);
         bool readUserFile(QTextStream &stream);
 
         bool writeFile(QTextStream &stream);
@@ -78,8 +80,8 @@ namespace Config
         Files::ConfigurationManager &mCfgMgr;
 
         void validatePaths();
-        QMap<QString, QString> mSettings;
-        QMap<QString, QString> mUserSettings;
+        QMultiMap<QString, QString> mSettings;
+        QMultiMap<QString, QString> mUserSettings;
 
         QStringList mDataDirs;
         QString mDataLocal;

--- a/components/config/launchersettings.cpp
+++ b/components/config/launchersettings.cpp
@@ -3,7 +3,7 @@
 #include <QTextStream>
 #include <QString>
 #include <QRegExp>
-#include <QMap>
+#include <QMultiMap>
 
 #include <QDebug>
 
@@ -22,7 +22,7 @@ Config::LauncherSettings::~LauncherSettings()
 
 QStringList Config::LauncherSettings::subKeys(const QString &key)
 {
-    QMap<QString, QString> settings = SettingsBase::getSettings();
+    QMultiMap<QString, QString> settings = SettingsBase::getSettings();
     QStringList keys = settings.uniqueKeys();
 
     QRegExp keyRe("(.+)/");
@@ -54,7 +54,7 @@ bool Config::LauncherSettings::writeFile(QTextStream &stream)
 {
     QString sectionPrefix;
     QRegExp sectionRe("([^/]+)/(.+)$");
-    QMap<QString, QString> settings = SettingsBase::getSettings();
+    QMultiMap<QString, QString> settings = SettingsBase::getSettings();
 
     QMapIterator<QString, QString> i(settings);
     i.toBack();

--- a/components/config/launchersettings.hpp
+++ b/components/config/launchersettings.hpp
@@ -6,7 +6,7 @@
 
 namespace Config
 {
-    class LauncherSettings : public SettingsBase<QMap<QString, QString> >
+    class LauncherSettings : public SettingsBase<QMultiMap<QString, QString> >
     {
     public:
         LauncherSettings();

--- a/components/config/settingsbase.hpp
+++ b/components/config/settingsbase.hpp
@@ -5,7 +5,7 @@
 #include <QStringList>
 #include <QString>
 #include <QRegExp>
-#include <QMap>
+#include <QMultiMap>
 
 namespace Config
 {
@@ -33,7 +33,7 @@ namespace Config
         {
             QStringList values = mSettings.values(key);
             if (!values.contains(value))
-                mSettings.insertMulti(key, value);
+                mSettings.insert(key, value);
         }
 
         inline void setMultiValueEnabled(bool enable)
@@ -83,8 +83,9 @@ namespace Config
 
                     if (!values.contains(value)) {
                         if (mMultiValue) {
-                            cache.insertMulti(key, value);
+                            cache.insert(key, value);
                         } else {
+                            cache.remove(key);
                             cache.insert(key, value);
                         }
                     }


### PR DESCRIPTION
[Task #5476](https://gitlab.com/OpenMW/openmw/-/issues/5476).

Qt devs are aimed to encapsulate all multimap-specific functions in the QMultiMap instead of QMap, so it would be nice to update our API.
The main change is that with this PR we use `QMultiMap::insert` instead of `QMap::insertMulti` and `QMultiMap::remove + QMultiMap::insert` instead of `QMap::insert`.

Requires testing (can be tested on the launcher) since I could miss something.