### PR TITLE
Load audio asychronously (fix #4880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     Bug #4764: Data race in osg ParticleSystem
     Bug #4765: Data race in ChunkManager -> Array::setBinding
     Bug #4774: Guards are ignorant of an invisible player that tries to attack them
+    Bug #4880: Single frames are slowed down by audio loading
     Bug #5101: Hostile followers travel with the player
     Bug #5108: Savegame bloating due to inefficient fog textures format
     Bug #5165: Active spells should use real time intead of timestamps

--- a/apps/openmw/mwsound/ffmpeg_decoder.cpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.cpp
@@ -429,7 +429,7 @@ size_t FFmpeg_Decoder::getSampleOffset()
 }
 
 FFmpeg_Decoder::FFmpeg_Decoder(const VFS::Manager* vfs)
-  : Sound_Decoder(vfs)
+  : mResourceMgr(vfs)
   , mFormatCtx(nullptr)
   , mCodecCtx(nullptr)
   , mStream(nullptr)

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -69,11 +69,10 @@ namespace MWSound
         FFmpeg_Decoder& operator=(const FFmpeg_Decoder &rhs);
         FFmpeg_Decoder(const FFmpeg_Decoder &rhs);
 
-        FFmpeg_Decoder(const VFS::Manager* vfs);
     public:
-        virtual ~FFmpeg_Decoder();
+        explicit FFmpeg_Decoder(const VFS::Manager* vfs);
 
-        friend class SoundManager;
+        virtual ~FFmpeg_Decoder();
     };
 #ifndef DEFAULT_DECODER
 #define DEFAULT_DECODER (::MWSound::FFmpeg_Decoder)

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -26,6 +26,8 @@ namespace MWSound
 {
     class FFmpeg_Decoder final : public Sound_Decoder
     {
+        const VFS::Manager *mResourceMgr;
+
         AVFormatContext *mFormatCtx;
         AVCodecContext *mCodecCtx;
         AVStream **mStream;

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -74,9 +74,6 @@ namespace MWSound
 
         virtual ~FFmpeg_Decoder();
     };
-#ifndef DEFAULT_DECODER
-#define DEFAULT_DECODER (::MWSound::FFmpeg_Decoder)
-#endif
 }
 
 #endif

--- a/apps/openmw/mwsound/movieaudiofactory.cpp
+++ b/apps/openmw/mwsound/movieaudiofactory.cpp
@@ -17,8 +17,7 @@ namespace MWSound
     {
     public:
         MWSoundDecoderBridge(MWSound::MovieAudioDecoder* decoder)
-            : Sound_Decoder(nullptr)
-            , mDecoder(decoder)
+            : mDecoder(decoder)
         {
         }
 

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -18,7 +18,6 @@
 #include "openal_output.hpp"
 #include "sound_decoder.hpp"
 #include "sound.hpp"
-#include "soundmanagerimp.hpp"
 #include "loudness.hpp"
 
 #include "efx-presets.h"
@@ -953,7 +952,7 @@ std::pair<Sound_Handle,size_t> OpenAL_Output::loadSound(const std::string &fname
 
     try
     {
-        DecoderPtr decoder = mManager.getDecoder();
+        DecoderPtr decoder = mDecoderProvider->getDecoder();
         // Workaround: Bethesda at some point converted some of the files to mp3, but the references were kept as .wav.
         if(decoder->mResourceMgr->exists(fname))
             decoder->open(fname);
@@ -1511,8 +1510,8 @@ void OpenAL_Output::resumeSounds(int types)
 }
 
 
-OpenAL_Output::OpenAL_Output(SoundManager &mgr)
-  : Sound_Output(mgr)
+OpenAL_Output::OpenAL_Output(const DecoderProvider& decoderBuilder)
+  : mDecoderProvider(&decoderBuilder)
   , mDevice(nullptr), mContext(nullptr)
   , mListenerPos(0.0f, 0.0f, 0.0f), mListenerEnv(Env_Normal)
   , mWaterFilter(0), mWaterEffect(0), mDefaultEffect(0), mEffectSlot(0)

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -954,7 +954,7 @@ std::pair<Sound_Handle,size_t> OpenAL_Output::loadSound(const std::string &fname
     {
         DecoderPtr decoder = mDecoderProvider->getDecoder();
         // Workaround: Bethesda at some point converted some of the files to mp3, but the references were kept as .wav.
-        if(decoder->mResourceMgr->exists(fname))
+        if (mVFS->exists(fname))
             decoder->open(fname);
         else
         {
@@ -1510,8 +1510,9 @@ void OpenAL_Output::resumeSounds(int types)
 }
 
 
-OpenAL_Output::OpenAL_Output(const DecoderProvider& decoderBuilder)
+OpenAL_Output::OpenAL_Output(const DecoderProvider& decoderBuilder, const VFS::Manager& vfs)
   : mDecoderProvider(&decoderBuilder)
+  , mVFS(&vfs)
   , mDevice(nullptr), mContext(nullptr)
   , mListenerPos(0.0f, 0.0f, 0.0f), mListenerEnv(Env_Normal)
   , mWaterFilter(0), mWaterEffect(0), mDefaultEffect(0), mEffectSlot(0)

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -14,12 +14,13 @@
 
 namespace MWSound
 {
-    class SoundManager;
     class Sound;
     class Stream;
 
     class OpenAL_Output : public Sound_Output
     {
+        const DecoderProvider* mDecoderProvider;
+
         ALCdevice *mDevice;
         ALCcontext *mContext;
 
@@ -95,7 +96,7 @@ namespace MWSound
         void pauseActiveDevice() override;
         void resumeActiveDevice() override;
 
-        OpenAL_Output(SoundManager &mgr);
+        OpenAL_Output(const DecoderProvider& decoderBuilder);
         virtual ~OpenAL_Output();
     };
 #ifndef DEFAULT_OUTPUT

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -99,9 +99,6 @@ namespace MWSound
         OpenAL_Output(const DecoderProvider& decoderBuilder);
         virtual ~OpenAL_Output();
     };
-#ifndef DEFAULT_OUTPUT
-#define DEFAULT_OUTPUT(x) ::MWSound::OpenAL_Output((x))
-#endif
 }
 
 #endif

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -12,6 +12,11 @@
 
 #include "sound_output.hpp"
 
+namespace VFS
+{
+    class Manager;
+}
+
 namespace MWSound
 {
     class Sound;
@@ -20,6 +25,7 @@ namespace MWSound
     class OpenAL_Output : public Sound_Output
     {
         const DecoderProvider* mDecoderProvider;
+        const VFS::Manager* mVFS;
 
         ALCdevice *mDevice;
         ALCcontext *mContext;
@@ -96,7 +102,7 @@ namespace MWSound
         void pauseActiveDevice() override;
         void resumeActiveDevice() override;
 
-        OpenAL_Output(const DecoderProvider& decoderBuilder);
+        OpenAL_Output(const DecoderProvider& decoderBuilder, const VFS::Manager& vfs);
         virtual ~OpenAL_Output();
     };
 }

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -21,7 +21,8 @@ namespace MWSound
     struct SoundParams
     {
         osg::Vec3f mPos;
-        float mVolume = 1;
+        float mVolumeFactor = 1;
+        float mSfxVolume = 1;
         float mBaseVolume = 1;
         float mPitch = 1;
         float mMinDistance = 1;
@@ -44,7 +45,8 @@ namespace MWSound
 
     public:
         void setPosition(const osg::Vec3f &pos) { mParams.mPos = pos; }
-        void setVolume(float volume) { mParams.mVolume = volume; }
+        void setVolumeFactor(float volume) { mParams.mVolumeFactor = volume; }
+        void setSfxVolume(float volume) { mParams.mSfxVolume = volume; }
         void setBaseVolume(float volume) { mParams.mBaseVolume = volume; }
         void setFadeout(float duration) { mParams.mFadeOutTime = duration; }
         void updateFade(float duration)
@@ -52,13 +54,13 @@ namespace MWSound
             if (mParams.mFadeOutTime > 0.0f)
             {
                 float soundDuration = std::min(duration, mParams.mFadeOutTime);
-                mParams.mVolume *= (mParams.mFadeOutTime - soundDuration) / mParams.mFadeOutTime;
+                mParams.mVolumeFactor *= (mParams.mFadeOutTime - soundDuration) / mParams.mFadeOutTime;
                 mParams.mFadeOutTime -= soundDuration;
             }
         }
 
         const osg::Vec3f &getPosition() const { return mParams.mPos; }
-        float getRealVolume() const { return mParams.mVolume * mParams.mBaseVolume; }
+        float getRealVolume() const { return mParams.mVolumeFactor * mParams.mSfxVolume * mParams.mBaseVolume; }
         float getPitch() const { return mParams.mPitch; }
         float getMinDistance() const { return mParams.mMinDistance; }
         float getMaxDistance() const { return mParams.mMaxDistance; }

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -57,6 +57,8 @@ namespace MWSound
         void setVolumeFactor(float volume) { mParams.mVolumeFactor = volume; }
         void setSfxVolume(float volume) { mParams.mSfxVolume = volume; }
         void setBaseVolume(float volume) { mParams.mBaseVolume = volume; }
+        void setMinDistance(float value) { mParams.mMinDistance = value; }
+        void setMaxDistance(float value) { mParams.mMaxDistance = value; }
         void setFadeout(float duration) { mParams.mFadeOutTime = duration; }
         void updateFade(float duration)
         {
@@ -82,6 +84,8 @@ namespace MWSound
         bool getIsLooping() const { return mParams.mFlags & MWSound::PlayMode::Loop; }
         bool getDistanceCull() const { return mParams.mFlags & MWSound::PlayMode::RemoveAtDistance; }
         bool getIs3D() const { return mParams.mFlags & Play_3D; }
+        bool isPlaying() const { return mState == State::Playing; }
+        bool isLoadCancelled() const { return mState == State::LoadCancelled; }
 
         void init(const SoundParams& params)
         {

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -38,6 +38,15 @@ namespace MWSound
 
         SoundParams mParams;
 
+        enum class State
+        {
+            Loading,
+            Playing,
+            LoadCancelled,
+        };
+
+        State mState = State::Loading;
+
     protected:
         Sound_Instance mHandle = nullptr;
 
@@ -58,6 +67,8 @@ namespace MWSound
                 mParams.mFadeOutTime -= soundDuration;
             }
         }
+        void setPlaying() { mState = State::Playing; }
+        void cancelLoading() { mState = State::LoadCancelled; }
 
         const osg::Vec3f &getPosition() const { return mParams.mPos; }
         float getRealVolume() const { return mParams.mVolumeFactor * mParams.mSfxVolume * mParams.mBaseVolume; }
@@ -75,6 +86,7 @@ namespace MWSound
         void init(const SoundParams& params)
         {
             mParams = params;
+            mState = State::Loading;
             mHandle = nullptr;
         }
 

--- a/apps/openmw/mwsound/sound_decoder.hpp
+++ b/apps/openmw/mwsound/sound_decoder.hpp
@@ -32,8 +32,6 @@ namespace MWSound
 
     struct Sound_Decoder
     {
-        const VFS::Manager* mResourceMgr;
-
         virtual void open(const std::string &fname) = 0;
         virtual void close() = 0;
 
@@ -44,8 +42,8 @@ namespace MWSound
         virtual void readAll(std::vector<char> &output);
         virtual size_t getSampleOffset() = 0;
 
-        Sound_Decoder(const VFS::Manager* resourceMgr) : mResourceMgr(resourceMgr)
-        { }
+        Sound_Decoder() = default;
+
         virtual ~Sound_Decoder() { }
 
     private:

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -9,8 +9,6 @@
 
 namespace MWSound
 {
-    class SoundManager;
-    struct Sound_Decoder;
     class Sound;
     class Stream;
 
@@ -31,10 +29,13 @@ namespace MWSound
         Env_Underwater
     };
 
+    struct DecoderProvider
+    {
+        virtual DecoderPtr getDecoder() const = 0;
+    };
+
     class Sound_Output
     {
-        SoundManager &mManager;
-
         virtual std::vector<std::string> enumerate() = 0;
         virtual bool init(const std::string &devname, const std::string &hrtfname, HrtfMode hrtfmode) = 0;
         virtual void deinit() = 0;
@@ -75,11 +76,10 @@ namespace MWSound
         Sound_Output(const Sound_Output &rhs);
 
     protected:
-        bool mInitialized;
+        bool mInitialized = false;
 
-        Sound_Output(SoundManager &mgr)
-          : mManager(mgr), mInitialized(false)
-        { }
+        Sound_Output() = default;
+
     public:
         virtual ~Sound_Output() { }
 

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -115,7 +115,7 @@ namespace MWSound
     }
 
     // Return a new decoder instance, used as needed by the output implementations
-    DecoderPtr SoundManager::getDecoder()
+    DecoderPtr SoundManager::getDecoder() const
     {
         return DecoderPtr(new DEFAULT_DECODER (mVFS));
     }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -109,7 +109,7 @@ namespace MWSound
 
     SoundManager::~SoundManager()
     {
-        clear();
+        SoundManager::clear();
         mSoundBuffers.clear();
         mOutput.reset();
     }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -54,7 +54,7 @@ namespace MWSound
 
     SoundManager::SoundManager(const VFS::Manager* vfs, bool useSound)
         : mVFS(vfs)
-        , mOutput(new DEFAULT_OUTPUT(*this))
+        , mOutput(new OpenAL_Output(*this))
         , mWaterSoundUpdater(makeWaterSoundUpdaterSettings())
         , mSoundBuffers(*vfs, *mOutput)
         , mListenerUnderwater(false)

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -504,7 +504,8 @@ namespace MWSound
         SoundPtr sound = getSoundRef();
         sound->init([&] {
             SoundParams params;
-            params.mVolume = volume * sfx->getVolume();
+            params.mVolumeFactor = volume;
+            params.mSfxVolume = sfx->getVolume();
             params.mBaseVolume = volumeFromType(type);
             params.mPitch = pitch;
             params.mFlags = mode | type | Play_2D;
@@ -543,7 +544,8 @@ namespace MWSound
         {
             sound->init([&] {
                 SoundParams params;
-                params.mVolume = volume * sfx->getVolume();
+                params.mVolumeFactor = volume;
+                params.mSfxVolume = sfx->getVolume();
                 params.mBaseVolume = volumeFromType(type);
                 params.mPitch = pitch;
                 params.mFlags = mode | type | Play_2D;
@@ -556,7 +558,8 @@ namespace MWSound
             sound->init([&] {
                 SoundParams params;
                 params.mPos = objpos;
-                params.mVolume = volume * sfx->getVolume();
+                params.mVolumeFactor = volume;
+                params.mSfxVolume = sfx->getVolume();
                 params.mBaseVolume = volumeFromType(type);
                 params.mPitch = pitch;
                 params.mMinDistance = sfx->getMinDist();
@@ -590,7 +593,8 @@ namespace MWSound
         sound->init([&] {
             SoundParams params;
             params.mPos = initialPos;
-            params.mVolume = volume * sfx->getVolume();
+            params.mVolumeFactor = volume;
+            params.mSfxVolume = sfx->getVolume();
             params.mBaseVolume = volumeFromType(type);
             params.mPitch = pitch;
             params.mMinDistance = sfx->getMinDist();
@@ -786,7 +790,8 @@ namespace MWSound
             case WaterSoundAction::DoNothing:
                 break;
             case WaterSoundAction::SetVolume:
-                mNearWaterSound->setVolume(update.mVolume * sfx->getVolume());
+                mNearWaterSound->setVolumeFactor(update.mVolume);
+                mNearWaterSound->setSfxVolume(sfx->getVolume());
                 break;
             case WaterSoundAction::FinishSound:
                 mOutput->finishSound(mNearWaterSound);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -117,7 +117,7 @@ namespace MWSound
     // Return a new decoder instance, used as needed by the output implementations
     DecoderPtr SoundManager::getDecoder() const
     {
-        return DecoderPtr(new DEFAULT_DECODER (mVFS));
+        return std::make_shared<FFmpeg_Decoder>(mVFS);
     }
 
     DecoderPtr SoundManager::loadVoice(const std::string &voicefile)

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -54,7 +54,7 @@ namespace MWSound
 
     SoundManager::SoundManager(const VFS::Manager* vfs, bool useSound)
         : mVFS(vfs)
-        , mOutput(new OpenAL_Output(*this))
+        , mOutput(new OpenAL_Output(*this, *vfs))
         , mWaterSoundUpdater(makeWaterSoundUpdaterSettings())
         , mSoundBuffers(*vfs, *mOutput)
         , mListenerUnderwater(false)

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -58,7 +58,7 @@ namespace MWSound
 
         WaterSoundUpdater mWaterSoundUpdater;
 
-        SoundBufferPool mSoundBuffers;
+        Misc::ScopeGuarded<SoundBufferPool> mSoundBuffers;
 
         Misc::ObjectPool<Sound> mSounds;
 
@@ -125,6 +125,19 @@ namespace MWSound
         std::vector<Music> mWaitingMusic;
         Misc::ScopeGuarded<std::map<std::string, DecoderPtr>> mMusicDecoders;
 
+        struct LoadingSound
+        {
+            MWWorld::ConstPtr mPtr;
+            std::string mSoundId;
+            float mOffset;
+            SoundPtr mSound;
+            osg::ref_ptr<SceneUtil::WorkItem> mWorkItem;
+            std::chrono::steady_clock::time_point mDeadline;
+        };
+
+        std::vector<LoadingSound> mLoadingSounds;
+        Misc::ScopeGuarded<std::map<std::string, Sound_Buffer*>> mLoadedSoundBuffers;
+
         Sound_Buffer *insertSound(const std::string &soundId, const ESM::Sound *sound);
 
         // returns a decoder to start streaming, or nullptr if the sound was not found
@@ -166,6 +179,16 @@ namespace MWSound
         void createMusicDecoder(const std::string& fileName);
 
         void playMusicFromCreatedDecoder();
+
+        void loadSound(const std::string &soundId);
+
+        Sound_Buffer* lookupSound(const std::string &soundId) const;
+
+        void loadSoundAsync(const MWWorld::ConstPtr& ptr, std::string soundId, float offset, SoundPtr&& sound);
+
+        void playLoadedSounds();
+
+        void playLoadedSound(Sound_Buffer& sfx, const MWWorld::ConstPtr& ptr, float offset, SoundPtr&& sound);
 
         SoundManager(const SoundManager &rhs);
         SoundManager& operator=(const SoundManager &rhs);

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -40,7 +40,7 @@ namespace MWSound
     using SoundPtr = Misc::ObjectPtr<Sound>;
     using StreamPtr = Misc::ObjectPtr<Stream>;
 
-    class SoundManager : public MWBase::SoundManager
+    class SoundManager : public MWBase::SoundManager, DecoderProvider
     {
         const VFS::Manager* mVFS;
 
@@ -133,7 +133,7 @@ namespace MWSound
         SoundManager& operator=(const SoundManager &rhs);
 
     protected:
-        DecoderPtr getDecoder();
+        DecoderPtr getDecoder() const final;
         friend class OpenAL_Output;
 
         void stopSound(Sound_Buffer *sfx, const MWWorld::ConstPtr &ptr);

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -816,7 +816,7 @@ void WeatherManager::update(float duration, bool paused, const TimeStamp& time, 
         mPlayingSoundID = mResult.mAmbientLoopSoundID;
     }
     else if (mAmbientSound)
-        mAmbientSound->setVolume(mResult.mAmbientSoundVolume);
+        mAmbientSound->setVolumeFactor(mResult.mAmbientSoundVolume);
 }
 
 void WeatherManager::stopSounds()

--- a/components/misc/guarded.hpp
+++ b/components/misc/guarded.hpp
@@ -75,20 +75,20 @@ namespace Misc
                 return Locked<T>(mMutex, mValue);
             }
 
-            Locked<const T> lockConst()
+            Locked<const T> lockConst() const
             {
                 return Locked<const T>(mMutex, mValue);
             }
 
             template <class Predicate>
-            void wait(std::condition_variable& cv, Predicate&& predicate)
+            void wait(std::condition_variable& cv, Predicate&& predicate) const
             {
                 std::unique_lock<std::mutex> lock(mMutex);
                 cv.wait(lock, [&] { return predicate(mValue); });
             }
 
         private:
-            std::mutex mMutex;
+            mutable std::mutex mMutex;
             T mValue;
     };
 }


### PR DESCRIPTION
The idea is to use background thread to open voice files. The problem first was discovered in https://gitlab.com/OpenMW/openmw/-/issues/4880 . My research shows this as the only thing that may have significant impact on a single frame time in mechanics manager. This graph shows frame time for each frame before this change:
![before_osg_stats](https://user-images.githubusercontent.com/764107/85619315-640f5c80-b662-11ea-859c-2dafc889b27a.png)

There are multiple one frame duration spikes. This happens on SSD. Digging into the problem shows the same reason as bug [4880](https://gitlab.com/OpenMW/openmw/-/issues/4880).

After the change for the same test graph doesn't have this kind of spikes:
![after_osg_stats](https://user-images.githubusercontent.com/764107/85621285-50192a00-b665-11ea-8cdf-d0218eacbdee.png)

