### PR TITLE
Redistribute hits to carried left slot when possible (#5490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     Bug #5441: Enemies can't push a player character when in critical strike stance
     Bug #5451: Magic projectiles don't disappear with the caster
     Bug #5452: Autowalk is being included in savegames
+    Bug #5490: Hits to carried left slot aren't redistributed if there's no shield equipped
     Feature #390: 3rd person look "over the shoulder"
     Feature #2386: Distant Statics in the form of Object Paging
     Feature #5297: Add a search function to the "Datafiles" tab of the OpenMW launcher

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -784,7 +784,22 @@ namespace MWClass
                 MWWorld::InventoryStore &inv = getInventoryStore(ptr);
                 MWWorld::ContainerStoreIterator armorslot = inv.getSlot(hitslot);
                 MWWorld::Ptr armor = ((armorslot != inv.end()) ? *armorslot : MWWorld::Ptr());
-                if(!armor.isEmpty() && armor.getTypeName() == typeid(ESM::Armor).name())
+                bool hasArmor = !armor.isEmpty() && armor.getTypeName() == typeid(ESM::Armor).name();
+                // If there's no item in the carried left slot or if it is not a shield redistribute the hit.
+                if (!hasArmor && hitslot == MWWorld::InventoryStore::Slot_CarriedLeft)
+                {
+                    if (Misc::Rng::rollDice(2) == 0)
+                        hitslot = MWWorld::InventoryStore::Slot_Cuirass;
+                    else
+                        hitslot = MWWorld::InventoryStore::Slot_LeftPauldron;
+                    armorslot = inv.getSlot(hitslot);
+                    if (armorslot != inv.end())
+                    {
+                        armor = *armorslot;
+                        hasArmor = !armor.isEmpty() && armor.getTypeName() == typeid(ESM::Armor).name();
+                    }
+                }
+                if (hasArmor)
                 {
                     if (!object.isEmpty() || attacker.isEmpty() || attacker.getClass().isNpc()) // Unarmed creature attacks don't affect armor condition
                     {


### PR DESCRIPTION
[Tracked issue](https://gitlab.com/OpenMW/openmw/-/issues/5490)

Implement as described. I made an assumption that a torch doesn't count as a shield. Hopefully it's everything that should be necessary.