### PR TITLE
Increase disposition on marginal Intimidate wins (#5485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
     Bug #5451: Magic projectiles don't disappear with the caster
     Bug #5452: Autowalk is being included in savegames
     Bug #5484: Zero value items shouldn't be able to be bought or sold for 1 gold
+    Bug #5485: Intimidate doesn't increase disposition on marginal wins
     Bug #5490: Hits to carried left slot aren't redistributed if there's no shield equipped
     Feature #390: 3rd person look "over the shoulder"
     Feature #2386: Distant Statics in the form of Object Paging

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -786,8 +786,11 @@ namespace MWMechanics
             {
                 if (std::abs(c) < iPerMinChange)
                 {
-                    x = 0;
-                    y = -iPerMinChange;
+                    // Deviating from Morrowind here: it doesn't increase disposition on marginal wins,
+                    // which seems to be a bug (MCP fixes it too).
+                    // Original logic: x = 0, y = -iPerMinChange
+                    x = -iPerMinChange;
+                    y = x; // This goes unused.
                 }
                 else
                 {


### PR DESCRIPTION
[Tracked issue](https://gitlab.com/OpenMW/openmw/-/issues/5485)

Implement as described, though the description is a bit vague. Oddly enough the disposition change will be divided by fPerTempMult later unlike the other cases but MCP seems to do this exactly and fPerTempMult is equal to 1 by default anyway.