### PR TITLE
Fix faction requirement calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
     Bug #5479: NPCs who should be walking around town are standing around without walking
     Bug #5484: Zero value items shouldn't be able to be bought or sold for 1 gold
     Bug #5490: Hits to carried left slot aren't redistributed if there's no shield equipped
+    Bug #5499: Faction advance is available when requirements not met
     Feature #390: 3rd person look "over the shoulder"
     Feature #2386: Distant Statics in the form of Object Paging
     Feature #5297: Add a search function to the "Datafiles" tab of the OpenMW launcher

--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -740,9 +740,9 @@ void Record<ESM::Faction>::print()
             std::cout << "    Attribute2 Requirement: "
                       << mData.mData.mRankData[i].mAttribute2 << std::endl;
             std::cout << "    One Skill at Level: "
-                      << mData.mData.mRankData[i].mSkill1 << std::endl;
+                      << mData.mData.mRankData[i].mPrimarySkill << std::endl;
             std::cout << "    Two Skills at Level: "
-                      << mData.mData.mRankData[i].mSkill2 << std::endl;
+                      << mData.mData.mRankData[i].mFavouredSkill << std::endl;
             std::cout << "    Faction Reaction: "
                       << mData.mData.mRankData[i].mFactReaction << std::endl;
         }

--- a/apps/opencs/model/world/nestedcoladapterimp.cpp
+++ b/apps/opencs/model/world/nestedcoladapterimp.cpp
@@ -1143,8 +1143,8 @@ namespace CSMWorld
             case 0: return QString(faction.mRanks[subRowIndex].c_str());
             case 1: return rankData.mAttribute1;
             case 2: return rankData.mAttribute2;
-            case 3: return rankData.mSkill1;
-            case 4: return rankData.mSkill2;
+            case 3: return rankData.mPrimarySkill;
+            case 4: return rankData.mFavouredSkill;
             case 5: return rankData.mFactReaction;
             default: throw std::runtime_error("Rank subcolumn index out of range");
         }
@@ -1165,8 +1165,8 @@ namespace CSMWorld
             case 0: faction.mRanks[subRowIndex] = value.toString().toUtf8().constData(); break;
             case 1: rankData.mAttribute1 = value.toInt(); break;
             case 2: rankData.mAttribute2 = value.toInt(); break;
-            case 3: rankData.mSkill1 = value.toInt(); break;
-            case 4: rankData.mSkill2 = value.toInt(); break;
+            case 3: rankData.mPrimarySkill = value.toInt(); break;
+            case 4: rankData.mFavouredSkill = value.toInt(); break;
             case 5: rankData.mFactReaction = value.toInt(); break;
             default: throw std::runtime_error("Rank index out of range");
         }

--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -620,10 +620,10 @@ namespace MWGui
 
                         text += "\n";
 
-                        if (rankData.mSkill1 > 0)
-                            text += "\n#{sNeedOneSkill} " + MyGUI::utility::toString(rankData.mSkill1);
-                        if (rankData.mSkill2 > 0)
-                            text += " #{sand} #{sNeedTwoSkills} " + MyGUI::utility::toString(rankData.mSkill2);
+                        if (rankData.mPrimarySkill > 0)
+                            text += "\n#{sNeedOneSkill} " + MyGUI::utility::toString(rankData.mPrimarySkill);
+                        if (rankData.mFavouredSkill > 0)
+                            text += " #{sand} #{sNeedTwoSkills} " + MyGUI::utility::toString(rankData.mFavouredSkill);
                     }
                 }
 

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -409,21 +409,21 @@ bool MWMechanics::NpcStats::hasSkillsForRank (const std::string& factionId, int 
 
     const ESM::RankData& rankData = faction.mData.mRankData[rank];
 
-    if (*iter<rankData.mSkill1)
+    if (*iter<rankData.mPrimarySkill)
         return false;
 
     if (skills.size() < 2)
         return true;
 
     iter++;
-    if (*iter<rankData.mSkill2)
+    if (*iter<rankData.mFavouredSkill)
         return false;
 
     if (skills.size() < 3)
         return true;
 
     iter++;
-    if (*iter<rankData.mSkill2)
+    if (*iter<rankData.mFavouredSkill)
         return false;
 
     return true;

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -415,7 +415,18 @@ bool MWMechanics::NpcStats::hasSkillsForRank (const std::string& factionId, int 
     if (skills.size() < 2)
         return true;
 
-    return *++iter>=rankData.mSkill2;
+    iter++;
+    if (*iter<rankData.mSkill2)
+        return false;
+
+    if (skills.size() < 3)
+        return true;
+
+    iter++;
+    if (*iter<rankData.mSkill2)
+        return false;
+
+    return true;
 }
 
 bool MWMechanics::NpcStats::isWerewolf() const

--- a/components/esm/loadfact.cpp
+++ b/components/esm/loadfact.cpp
@@ -122,7 +122,7 @@ namespace ESM
         for (int i=0; i<10; ++i)
         {
             mData.mRankData[i].mAttribute1 = mData.mRankData[i].mAttribute2 = 0;
-            mData.mRankData[i].mSkill1 = mData.mRankData[i].mSkill2 = 0;
+            mData.mRankData[i].mPrimarySkill = mData.mRankData[i].mFavouredSkill = 0;
             mData.mRankData[i].mFactReaction = 0;
 
             mRanks[i].clear();

--- a/components/esm/loadfact.hpp
+++ b/components/esm/loadfact.hpp
@@ -19,10 +19,11 @@ struct RankData
 {
     int mAttribute1, mAttribute2; // Attribute level
 
-    int mSkill1, mSkill2; // Skill level (faction skills given in
+    // Skill level (faction skills given in
     // skillID below.) You need one skill at
-    // level 'skill1' and two skills at level
-    // 'skill2' to advance to this rank.
+    // level 'mPrimarySkill' and two skills at level
+    // 'mFavouredSkill' to advance to this rank.
+    int mPrimarySkill, mFavouredSkill;
 
     int mFactReaction; // Reaction from faction members
 };


### PR DESCRIPTION
Fixes [bug #5499](https://gitlab.com/OpenMW/openmw/-/issues/5499).
Actually we should check `mSkill2` twice instead of once.
Also I added meaningful names, as in TES CS, instead of `mSkill1` and `mSkill2`.