### PR TITLE
Update Windows CI script to Google Test 1.10.0

### DIFF
--- a/CI/before_script.msvc.sh
+++ b/CI/before_script.msvc.sh
@@ -504,11 +504,11 @@ if [ -z $SKIP_DOWNLOAD ]; then
 
 	# Google test and mock
 	if [ ! -z $TEST_FRAMEWORK ]; then
-		echo "Google test 1.8.1..."
+		echo "Google test 1.10.0..."
 		if [ -d googletest ]; then
 			printf "  Google test exists, skipping."
 		else
-			git clone -b release-1.8.1 https://github.com/google/googletest.git
+			git clone -b release-1.10.0 https://github.com/google/googletest.git
 		fi
 	fi
 fi
@@ -820,7 +820,7 @@ cd $DEPS
 echo
 # Google Test and Google Mock
 if [ ! -z $TEST_FRAMEWORK ]; then
-	printf "Google test 1.8.1 ..."
+	printf "Google test 1.10.0 ..."
 
 	cd googletest
 	if [ ! -d build ]; then


### PR DESCRIPTION
This is the same version used in build_googletest.sh. 1.8.1 doesn't actually work anymore.