### PR TITLE
Make joysticks dead zone configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     Bug #5485: Intimidate doesn't increase disposition on marginal wins
     Bug #5490: Hits to carried left slot aren't redistributed if there's no shield equipped
     Bug #5499: Faction advance is available when requirements not met
+    Bug #5502: Dead zone for analogue stick movement is too small
     Feature #390: 3rd person look "over the shoulder"
     Feature #2386: Distant Statics in the form of Object Paging
     Feature #5297: Add a search function to the "Datafiles" tab of the OpenMW launcher

--- a/apps/openmw/mwinput/bindingsmanager.cpp
+++ b/apps/openmw/mwinput/bindingsmanager.cpp
@@ -226,6 +226,11 @@ namespace MWInput
         }
     }
 
+    void BindingsManager::setJoystickDeadZone(float deadZone)
+    {
+        mInputBinder->setJoystickDeadZone(deadZone);
+    }
+
     float BindingsManager::getActionValue (int id) const
     {
         return mInputBinder->getChannel(id)->getValue();

--- a/apps/openmw/mwinput/bindingsmanager.hpp
+++ b/apps/openmw/mwinput/bindingsmanager.hpp
@@ -36,6 +36,8 @@ namespace MWInput
 
         void setPlayerControlsEnabled(bool enabled);
 
+        void setJoystickDeadZone(float deadZone);
+
         bool isLeftOrRightButton(int action, bool joystick) const;
 
         bool actionIsActive(int id) const;

--- a/apps/openmw/mwinput/controllermanager.cpp
+++ b/apps/openmw/mwinput/controllermanager.cpp
@@ -72,6 +72,10 @@ namespace MWInput
         float uiScale = Settings::Manager::getFloat("scaling factor", "GUI");
         if (uiScale != 0.f)
             mInvUiScalingFactor = 1.f / uiScale;
+
+        float deadZoneRadius = Settings::Manager::getFloat("joystick dead zone", "Input");
+        deadZoneRadius = std::min(std::max(deadZoneRadius, 0.0f), 0.5f);
+        mBindingsManager->setJoystickDeadZone(deadZoneRadius);
     }
 
     void ControllerManager::processChangedSettings(const Settings::CategorySettingVector& changed)

--- a/docs/source/reference/modding/settings/input.rst
+++ b/docs/source/reference/modding/settings/input.rst
@@ -135,6 +135,18 @@ camera sensitivity setting.
 
 This setting can only be configured by editing the settings configuration file.
 
+joystick dead zone
+------------------
+
+:Type:		floating point
+:Range:		0.0 to 0.5
+:Default:	0.1
+
+This setting controls the radius of dead zone (where an input is discarded) for joystick axes.
+Note that third-party software can provide its own dead zones. In this case OpenmW-specific setting dead zone can be disabled (0.0).
+
+This setting can only be configured by editing the settings configuration file.
+
 enable gyroscope
 ----------------
 

--- a/extern/oics/ICSInputControlSystem.cpp
+++ b/extern/oics/ICSInputControlSystem.cpp
@@ -34,6 +34,7 @@ namespace ICS
 		, DetectingBindingListener* detectingBindingListener
 		, InputControlSystemLog* log, size_t channelCount)
 		: mFileName(file)
+		, mDeadZone(0.1f)
 		, mLog(log)
 		, mDetectingBindingListener(detectingBindingListener)
 		, mDetectingBindingControl(NULL)

--- a/extern/oics/ICSInputControlSystem.h
+++ b/extern/oics/ICSInputControlSystem.h
@@ -79,6 +79,8 @@ namespace ICS
 		void setDetectingBindingListener(DetectingBindingListener* detectingBindingListener){ mDetectingBindingListener = detectingBindingListener; };
 		DetectingBindingListener* getDetectingBindingListener(){ return mDetectingBindingListener; };
 
+		void setJoystickDeadZone(float deadZone){ mDeadZone = deadZone; };
+
 		// in seconds
 		void update(float timeSinceLastFrame);
 
@@ -179,6 +181,8 @@ namespace ICS
 		std::list<PendingActionItem> mPendingActions;
 
 		std::string mFileName;
+
+		float mDeadZone;
 
         typedef std::map<SDL_Scancode, ControlKeyBinderItem> ControlsKeyBinderMapType;	// <Scancode, [direction, control]>
 		typedef std::map<int, ControlAxisBinderItem> ControlsAxisBinderMapType;			// <axis, [direction, control]>

--- a/extern/oics/ICSInputControlSystem_joystick.cpp
+++ b/extern/oics/ICSInputControlSystem_joystick.cpp
@@ -28,7 +28,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #define SDL_JOY_AXIS_MIN -32768
 #define SDL_JOY_AXIS_MAX 32767
-#define DEADZONE 0.1f
 
 namespace ICS
 {
@@ -263,13 +262,13 @@ namespace ICS
 
                         float axisRange = SDL_JOY_AXIS_MAX - SDL_JOY_AXIS_MIN;
                         float valDisplaced = (float)(evt.value - SDL_JOY_AXIS_MIN);
-                        float percent = valDisplaced / axisRange * (1+DEADZONE*2) - DEADZONE; //Assures all values, 0 through 1, are seen
-                        if(percent > .5-DEADZONE && percent < .5+DEADZONE) //close enough to center
+                        float percent = valDisplaced / axisRange * (1+mDeadZone*2) - mDeadZone; //Assures all values, 0 through 1, are seen
+                        if(percent > .5-mDeadZone && percent < .5+mDeadZone) //close enough to center
                             percent = .5;
                         else if(percent > .5)
-                            percent -= DEADZONE;
+                            percent -= mDeadZone;
                         else
-                            percent += DEADZONE;
+                            percent += mDeadZone;
 
                         if(joystickBinderItem.direction == Control::INCREASE)
                         {

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -421,6 +421,9 @@ enable controller = true
 # Emulated gamepad cursor sensitivity.
 gamepad cursor speed = 1.0
 
+# Set dead zone for joysticks (gamepad or on-screen ones)
+joystick dead zone = 0.1
+
 # Enable gyroscope support.
 enable gyroscope = false
 


### PR DESCRIPTION
Should fix [bug #5502](https://gitlab.com/OpenMW/openmw/-/issues/5502) by making threshold configurable.

Note that 3d-party gamepad calibration software (or driver itself) can set its own dead zone. In this case SDL may not emit related events, and it is better to disable (0.0) OpenMW-side dead zone to avoid conflicts.