### PR TITLE
Lookup sound when need to stop

### DIFF
--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -163,9 +163,6 @@ namespace MWBase
             virtual void stopSound(const MWWorld::CellStore *cell) = 0;
             ///< Stop all sounds for the given cell.
 
-            virtual void stopSound(const std::string& soundId) = 0;
-            ///< Stop a non-3d looping sound
-
             virtual void fadeOutSound3D(const MWWorld::ConstPtr &reference, const std::string& soundId, float duration) = 0;
             ///< Fade out given sound (that is already playing) of given object
             ///< @param reference Reference to object, whose sound is faded out

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -772,7 +772,7 @@ namespace MWSound
         if(!mOutput->isInitialized())
             return;
 
-        Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
+        Sound_Buffer *sfx = lookupSound(Misc::StringUtils::lowerCase(soundId));
         if (!sfx) return;
 
         stopSound(sfx, MWWorld::ConstPtr());
@@ -783,7 +783,7 @@ namespace MWSound
         if(!mOutput->isInitialized())
             return;
 
-        Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
+        Sound_Buffer *sfx = lookupSound(Misc::StringUtils::lowerCase(soundId));
         if (!sfx) return;
 
         stopSound(sfx, ptr);

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -767,17 +767,6 @@ namespace MWSound
         }
     }
 
-    void SoundManager::stopSound(const std::string& soundId)
-    {
-        if(!mOutput->isInitialized())
-            return;
-
-        Sound_Buffer *sfx = lookupSound(Misc::StringUtils::lowerCase(soundId));
-        if (!sfx) return;
-
-        stopSound(sfx, MWWorld::ConstPtr());
-    }
-
     void SoundManager::stopSound3D(const MWWorld::ConstPtr &ptr, const std::string& soundId)
     {
         if(!mOutput->isInitialized())

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -233,9 +233,6 @@ namespace MWSound
         virtual void stopSound(const MWWorld::CellStore *cell);
         ///< Stop all sounds for the given cell.
 
-        virtual void stopSound(const std::string& soundId);
-        ///< Stop a non-3d looping sound
-
         virtual void fadeOutSound3D(const MWWorld::ConstPtr &reference, const std::string& soundId, float duration);
         ///< Fade out given sound (that is already playing) of given object
         ///< @param reference Reference to object, whose sound is faded out


### PR DESCRIPTION
When sounds are loaded synchronously it's not a problem to call loadSound, because we know it's already in the buffer. But still this looks strange unless I'm missing something. Also remove unused stopSound overload.