### PR TITLE
Fix crash in the stateset updater

### DIFF
--- a/components/sceneutil/statesetupdater.cpp
+++ b/components/sceneutil/statesetupdater.cpp
@@ -22,7 +22,7 @@ namespace SceneUtil
             }
         }
 
-        osg::StateSet* stateset = mStateSets[nv->getTraversalNumber()%2];
+        osg::ref_ptr<osg::StateSet> stateset = mStateSets[nv->getTraversalNumber()%2];
         apply(stateset, nv);
 
         if (!isCullVisitor)


### PR DESCRIPTION
Fixes [regression #5478](https://gitlab.com/OpenMW/openmw/-/issues/5478).
The main idea is to do not use raw pointer to prevent it from become dangling when we reset statesets.