### PR TITLE
Put logic for the next region sound selection into a separate class

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -57,7 +57,7 @@ add_openmw_dir (mwscript
 
 add_openmw_dir (mwsound
     soundmanagerimp openal_output ffmpeg_decoder sound sound_buffer sound_decoder sound_output
-    loudness movieaudiofactory alext efx efx-presets
+    loudness movieaudiofactory alext efx efx-presets regionsoundselector
     )
 
 add_openmw_dir (mwworld

--- a/apps/openmw/mwsound/regionsoundselector.cpp
+++ b/apps/openmw/mwsound/regionsoundselector.cpp
@@ -1,0 +1,71 @@
+#include "regionsoundselector.hpp"
+
+#include <components/misc/rng.hpp>
+
+#include <algorithm>
+#include <numeric>
+
+#include "../mwbase/world.hpp"
+#include "../mwworld/esmstore.hpp"
+
+namespace MWSound
+{
+    namespace
+    {
+        int addChance(int result, const ESM::Region::SoundRef &v)
+        {
+            return result + v.mChance;
+        }
+    }
+
+    boost::optional<std::string> RegionSoundSelector::getNextRandom(float duration, const std::string& regionName,
+                                                                    const MWBase::World& world)
+    {
+        mTimePassed += duration;
+
+        if (mTimePassed < mTimeToNextEnvSound)
+            return {};
+
+        const float a = Misc::Rng::rollClosedProbability();
+        // NOTE: We should use the "Minimum Time Between Environmental Sounds" and
+        // "Maximum Time Between Environmental Sounds" fallback settings here.
+        mTimeToNextEnvSound = 5.0f * a + 15.0f * (1.0f - a);
+        mTimePassed = 0;
+
+        if (mLastRegionName != regionName)
+        {
+            mLastRegionName = regionName;
+            mSumChance = 0;
+        }
+
+        const ESM::Region* const region = world.getStore().get<ESM::Region>().search(mLastRegionName);
+
+        if (region == nullptr)
+            return {};
+
+        if (mSumChance == 0)
+        {
+            mSumChance = std::accumulate(region->mSoundList.begin(), region->mSoundList.end(), 0, addChance);
+            if (mSumChance == 0)
+                return {};
+        }
+
+        const int r = Misc::Rng::rollDice(mSumChance);
+        int pos = 0;
+
+        const auto isSelected = [&] (const ESM::Region::SoundRef& sound)
+        {
+            if (r - pos < sound.mChance)
+                return true;
+            pos += sound.mChance;
+            return false;
+        };
+
+        const auto it = std::find_if(region->mSoundList.begin(), region->mSoundList.end(), isSelected);
+
+        if (it == region->mSoundList.end())
+            return {};
+
+        return it->mSound;
+    }
+}

--- a/apps/openmw/mwsound/regionsoundselector.hpp
+++ b/apps/openmw/mwsound/regionsoundselector.hpp
@@ -1,0 +1,29 @@
+#ifndef GAME_SOUND_REGIONSOUNDSELECTOR_H
+#define GAME_SOUND_REGIONSOUNDSELECTOR_H
+
+#include <boost/optional.hpp>
+
+#include <string>
+
+namespace MWBase
+{
+    class World;
+}
+
+namespace MWSound
+{
+    class RegionSoundSelector
+    {
+        public:
+            boost::optional<std::string> getNextRandom(float duration, const std::string& regionName,
+                                                       const MWBase::World& world);
+
+        private:
+            float mTimeToNextEnvSound = 0.0f;
+            int mSumChance = 0;
+            std::string mLastRegionName;
+            float mTimePassed = 0.0;
+    };
+}
+
+#endif

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -14,6 +14,8 @@
 
 #include "../mwbase/soundmanager.hpp"
 
+#include "regionsoundselector.hpp"
+
 namespace VFS
 {
     class Manager;
@@ -114,6 +116,8 @@ namespace MWSound
 
         std::string mNextMusic;
         bool mPlaybackPaused;
+
+        RegionSoundSelector mRegionSoundSelector;
 
         Sound_Buffer *insertSound(const std::string &soundId, const ESM::Sound *sound);
 


### PR DESCRIPTION
This is a refactoring part of https://github.com/OpenMW/openmw/pull/2928. I will split this kind of changes into separate prs to reduce the size of that pr.

Also move local static variables from `SoundManager::updateRegionSound` into the state of a new class.
