### PR TITLE
Clamp sound volume on settings update (fix #5507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
     Bug #5490: Hits to carried left slot aren't redistributed if there's no shield equipped
     Bug #5499: Faction advance is available when requirements not met
     Bug #5502: Dead zone for analogue stick movement is too small
+    Bug #5507: Sound volume is not clamped on ingame settings update
     Feature #390: 3rd person look "over the shoulder"
     Feature #2386: Distant Statics in the form of Object Paging
     Feature #5297: Add a search function to the "Datafiles" tab of the OpenMW launcher

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -57,7 +57,7 @@ add_openmw_dir (mwscript
 
 add_openmw_dir (mwsound
     soundmanagerimp openal_output ffmpeg_decoder sound sound_buffer sound_decoder sound_output
-    loudness movieaudiofactory alext efx efx-presets regionsoundselector watersoundupdater
+    loudness movieaudiofactory alext efx efx-presets regionsoundselector watersoundupdater volumesettings
     )
 
 add_openmw_dir (mwworld

--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -6,6 +6,7 @@
 #include <set>
 
 #include "../mwworld/ptr.hpp"
+#include "../mwsound/type.hpp"
 
 namespace MWWorld
 {
@@ -44,14 +45,7 @@ namespace MWSound
         LoopNoEnv = Loop | NoEnv,
         LoopRemoveAtDistance = Loop | RemoveAtDistance
     };
-    enum class Type {
-        Sfx   = 1<<4, /* Normal SFX sound */
-        Voice = 1<<5, /* Voice sound */
-        Foot  = 1<<6, /* Footstep sound */
-        Music = 1<<7, /* Music track */
-        Movie = 1<<8, /* Movie audio track */
-        Mask  = Sfx | Voice | Foot | Music | Movie
-    };
+
     // Used for creating a type mask for SoundManager::pauseSounds and resumeSounds
     inline int operator~(Type a) { return ~static_cast<int>(a); }
     inline int operator&(Type a, Type b) { return static_cast<int>(a) & static_cast<int>(b); }

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -53,11 +53,6 @@ namespace MWSound
     SoundManager::SoundManager(const VFS::Manager* vfs, bool useSound)
         : mVFS(vfs)
         , mOutput(new DEFAULT_OUTPUT(*this))
-        , mMasterVolume(1.0f)
-        , mSFXVolume(1.0f)
-        , mMusicVolume(1.0f)
-        , mVoiceVolume(1.0f)
-        , mFootstepsVolume(1.0f)
         , mWaterSoundUpdater(makeWaterSoundUpdaterSettings())
         , mSoundBuffers(new SoundBufferList::element_type())
         , mBufferCacheSize(0)
@@ -72,17 +67,6 @@ namespace MWSound
         , mNearWaterSound(nullptr)
         , mPlaybackPaused(false)
     {
-        mMasterVolume = Settings::Manager::getFloat("master volume", "Sound");
-        mMasterVolume = std::min(std::max(mMasterVolume, 0.0f), 1.0f);
-        mSFXVolume = Settings::Manager::getFloat("sfx volume", "Sound");
-        mSFXVolume = std::min(std::max(mSFXVolume, 0.0f), 1.0f);
-        mMusicVolume = Settings::Manager::getFloat("music volume", "Sound");
-        mMusicVolume = std::min(std::max(mMusicVolume, 0.0f), 1.0f);
-        mVoiceVolume = Settings::Manager::getFloat("voice volume", "Sound");
-        mVoiceVolume = std::min(std::max(mVoiceVolume, 0.0f), 1.0f);
-        mFootstepsVolume = Settings::Manager::getFloat("footsteps volume", "Sound");
-        mFootstepsVolume = std::min(std::max(mFootstepsVolume, 0.0f), 1.0f);
-
         mBufferCacheMin = std::max(Settings::Manager::getInt("buffer cache min", "Sound"), 1);
         mBufferCacheMax = std::max(Settings::Manager::getInt("buffer cache max", "Sound"), 1);
         mBufferCacheMax *= 1024*1024;
@@ -349,26 +333,7 @@ namespace MWSound
     // Gets the combined volume settings for the given sound type
     float SoundManager::volumeFromType(Type type) const
     {
-        float volume = mMasterVolume;
-        switch(type)
-        {
-            case Type::Sfx:
-                volume *= mSFXVolume;
-                break;
-            case Type::Voice:
-                volume *= mVoiceVolume;
-                break;
-            case Type::Foot:
-                volume *= mFootstepsVolume;
-                break;
-            case Type::Music:
-                volume *= mMusicVolume;
-                break;
-            case Type::Movie:
-            case Type::Mask:
-                break;
-        }
-        return volume;
+        return mVolumeSettings.getVolumeFromType(type);
     }
 
     void SoundManager::stopMusic()
@@ -1158,11 +1123,7 @@ namespace MWSound
 
     void SoundManager::processChangedSettings(const Settings::CategorySettingVector& settings)
     {
-        mMasterVolume = Settings::Manager::getFloat("master volume", "Sound");
-        mMusicVolume = Settings::Manager::getFloat("music volume", "Sound");
-        mSFXVolume = Settings::Manager::getFloat("sfx volume", "Sound");
-        mFootstepsVolume = Settings::Manager::getFloat("footsteps volume", "Sound");
-        mVoiceVolume = Settings::Manager::getFloat("voice volume", "Sound");
+        mVolumeSettings.update();
 
         if(!mOutput->isInitialized())
             return;

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -16,6 +16,8 @@
 
 #include "regionsoundselector.hpp"
 #include "watersoundupdater.hpp"
+#include "type.hpp"
+#include "volumesettings.hpp"
 
 namespace VFS
 {
@@ -56,11 +58,7 @@ namespace MWSound
         std::unordered_map<std::string, std::vector<int>> mMusicToPlay; // A list with music files not yet played
         std::string mLastPlayedMusic; // The music file that was last played
 
-        float mMasterVolume;
-        float mSFXVolume;
-        float mMusicVolume;
-        float mVoiceVolume;
-        float mFootstepsVolume;
+        VolumeSettings mVolumeSettings;
 
         WaterSoundUpdater mWaterSoundUpdater;
 

--- a/apps/openmw/mwsound/type.hpp
+++ b/apps/openmw/mwsound/type.hpp
@@ -1,0 +1,17 @@
+#ifndef GAME_SOUND_TYPE_H
+#define GAME_SOUND_TYPE_H
+
+namespace MWSound
+{
+    enum class Type
+    {
+        Sfx   = 1 << 4, /* Normal SFX sound */
+        Voice = 1 << 5, /* Voice sound */
+        Foot  = 1 << 6, /* Footstep sound */
+        Music = 1 << 7, /* Music track */
+        Movie = 1 << 8, /* Movie audio track */
+        Mask  = Sfx | Voice | Foot | Music | Movie
+    };
+}
+
+#endif

--- a/apps/openmw/mwsound/volumesettings.cpp
+++ b/apps/openmw/mwsound/volumesettings.cpp
@@ -1,0 +1,56 @@
+#include "volumesettings.hpp"
+
+#include <components/settings/settings.hpp>
+
+#include <algorithm>
+
+namespace MWSound
+{
+    namespace
+    {
+        float clamp(float value)
+        {
+            return std::max(0.0f, std::min(1.0f, value));
+        }
+    }
+
+    VolumeSettings::VolumeSettings()
+        : mMasterVolume(clamp(Settings::Manager::getFloat("master volume", "Sound"))),
+          mSFXVolume(clamp(Settings::Manager::getFloat("sfx volume", "Sound"))),
+          mMusicVolume(clamp(Settings::Manager::getFloat("music volume", "Sound"))),
+          mVoiceVolume(clamp(Settings::Manager::getFloat("voice volume", "Sound"))),
+          mFootstepsVolume(clamp(Settings::Manager::getFloat("footsteps volume", "Sound")))
+    {
+    }
+
+    float VolumeSettings::getVolumeFromType(Type type) const
+    {
+        float volume = mMasterVolume;
+
+        switch(type)
+        {
+            case Type::Sfx:
+                volume *= mSFXVolume;
+                break;
+            case Type::Voice:
+                volume *= mVoiceVolume;
+                break;
+            case Type::Foot:
+                volume *= mFootstepsVolume;
+                break;
+            case Type::Music:
+                volume *= mMusicVolume;
+                break;
+            case Type::Movie:
+            case Type::Mask:
+                break;
+        }
+
+        return volume;
+    }
+
+    void VolumeSettings::update()
+    {
+        *this = VolumeSettings();
+    }
+}

--- a/apps/openmw/mwsound/volumesettings.hpp
+++ b/apps/openmw/mwsound/volumesettings.hpp
@@ -1,0 +1,26 @@
+#ifndef GAME_SOUND_VOLUMESETTINGS_H
+#define GAME_SOUND_VOLUMESETTINGS_H
+
+#include "type.hpp"
+
+namespace MWSound
+{
+    class VolumeSettings
+    {
+        public:
+            VolumeSettings();
+
+            float getVolumeFromType(Type type) const;
+
+            void update();
+
+        private:
+            float mMasterVolume;
+            float mSFXVolume;
+            float mMusicVolume;
+            float mVoiceVolume;
+            float mFootstepsVolume;
+    };
+}
+
+#endif


### PR DESCRIPTION
https://gitlab.com/OpenMW/openmw/-/issues/5507

1. Put logic for volume clamping into a single place.
2. Move all volume settings related stuff into a separate class.