### PR TITLE
Choose next action for water sound in a separate function

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -885,7 +885,7 @@ namespace MWSound
             playSound(*next, 1.0f, 1.0f);
     }
 
-    void SoundManager::updateWaterSound(float /*duration*/)
+    void SoundManager::updateWaterSound()
     {
         MWBase::World* world = MWBase::Environment::get().getWorld();
         const MWWorld::ConstPtr player = world->getPlayerPtr();
@@ -1115,7 +1115,7 @@ namespace MWSound
             MWBase::StateManager::State_NoGame)
         {
             updateRegionSound(duration);
-            updateWaterSound(duration);
+            updateWaterSound();
         }
     }
 

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -143,6 +143,17 @@ namespace MWSound
 
         float volumeFromType(Type type) const;
 
+        enum class WaterSoundAction
+        {
+            DoNothing,
+            SetVolume,
+            FinishSound,
+            PlaySound,
+        };
+
+        std::pair<WaterSoundAction, Sound_Buffer*> getWaterSoundAction(const WaterSoundUpdate& update,
+                                                                       const ESM::Cell* cell) const;
+
         SoundManager(const SoundManager &rhs);
         SoundManager& operator=(const SoundManager &rhs);
 

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -138,7 +138,7 @@ namespace MWSound
 
         void updateSounds(float duration);
         void updateRegionSound(float duration);
-        void updateWaterSound(float duration);
+        void updateWaterSound();
         void updateMusic(float duration);
 
         float volumeFromType(Type type) const;


### PR DESCRIPTION
In general this allows to use playSound only once. But this became not very straight and more like experimental because this function has to return pointer to Sound_Buffer in one case. So I used boost::variant+visitor based on custom implementation of [overloaded](https://en.cppreference.com/w/cpp/utility/variant/visit) adjusted for C++14. If this is too much, I can do this without variant.