### PR TITLE
Remove redundant virtual qualifier

### DIFF
--- a/apps/openmw/mwgui/statswatcher.hpp
+++ b/apps/openmw/mwgui/statswatcher.hpp
@@ -62,7 +62,7 @@ namespace MWGui
         void removeListener(StatsListener* listener);
 
         void watchActor(const MWWorld::Ptr& ptr);
-        virtual MWWorld::Ptr getWatchedActor() const { return mWatched; }
+        MWWorld::Ptr getWatchedActor() const { return mWatched; }
     };
 }
 


### PR DESCRIPTION
The `getWatchedActor` method does not really need to be virtual.
Should also silence MSVC warnings about missing virtual destructor.