### PR TITLE
Mark some methds as overrides to avoid warnings

### DIFF
--- a/apps/openmw/mwgui/hud.hpp
+++ b/apps/openmw/mwgui/hud.hpp
@@ -47,7 +47,7 @@ namespace MWGui
         void setCrosshairVisible(bool visible);
         void setCrosshairOwned(bool owned);
 
-        void onFrame(float dt);
+        void onFrame(float dt) override;
 
         void setCellName(const std::string& cellName);
 
@@ -58,7 +58,7 @@ namespace MWGui
         void setEnemy(const MWWorld::Ptr& enemy);
         void resetEnemy();
 
-        void clear();
+        void clear() override;
 
     private:
         MyGUI::ProgressBar *mHealth, *mMagicka, *mStamina, *mEnemyHealth, *mDrowning;
@@ -112,8 +112,8 @@ namespace MWGui
         void onMapClicked(MyGUI::Widget* _sender);
 
         // LocalMapBase
-        virtual void customMarkerCreated(MyGUI::Widget* marker);
-        virtual void doorMarkerCreated(MyGUI::Widget* marker);
+        virtual void customMarkerCreated(MyGUI::Widget* marker) override;
+        virtual void doorMarkerCreated(MyGUI::Widget* marker) override;
 
         void updateEnemyHealthBar();
 

--- a/apps/openmw/mwgui/statswindow.hpp
+++ b/apps/openmw/mwgui/statswindow.hpp
@@ -18,7 +18,7 @@ namespace MWGui
             StatsWindow(DragAndDrop* drag);
 
             /// automatically updates all the data in the stats window, but only if it has changed.
-            void onFrame(float dt);
+            void onFrame(float dt) override;
 
             void setBar(const std::string& name, const std::string& tname, int val, int max);
             void setPlayerName(const std::string& playerName);
@@ -35,7 +35,7 @@ namespace MWGui
             void setBounty (int bounty) { if (bounty != mBounty) mChanged = true; this->mBounty = bounty; }
             void updateSkillArea();
 
-            virtual void onOpen() { onWindowResize(mMainWidget->castType<MyGUI::Window>()); }
+            virtual void onOpen() override { onWindowResize(mMainWidget->castType<MyGUI::Window>()); }
 
         private:
             void addSkills(const SkillList &skills, const std::string &titleId, const std::string &titleDefault, MyGUI::IntCoord &coord1, MyGUI::IntCoord &coord2);
@@ -70,8 +70,8 @@ namespace MWGui
             const int mMinFullWidth;
 
         protected:
-            virtual void onPinToggled();
-            virtual void onTitleDoubleClicked();
+            virtual void onPinToggled() override;
+            virtual void onTitleDoubleClicked() override;
     };
 }
 #endif


### PR DESCRIPTION
I suppose warnings are caused by multiple inheritance, when several base classes have methods with the same signature.