### PR TITLE
Mutate base records when adding/removing spells

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -82,7 +82,7 @@ add_openmw_dir (mwclass
     )
 
 add_openmw_dir (mwmechanics
-    mechanicsmanagerimp stat creaturestats magiceffects movement actorutil
+    mechanicsmanagerimp stat creaturestats magiceffects movement actorutil spelllist
     drawstate spells activespells npcstats aipackage aisequence aipursue alchemy aiwander aitravel aifollow aiavoiddoor aibreathe
     aicast aiescort aiface aiactivate aicombat recharge repair enchanting pathfinding pathgrid security spellcasting spellresistance
     disease pickpocket levelledlist combat steering obstacle autocalcspell difficultyscaling aicombataction actor summoning

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -141,14 +141,9 @@ namespace MWClass
                 data->mCreatureStats.setDeathAnimationFinished(isPersistent(ptr));
 
             // spells
-            for (std::vector<std::string>::const_iterator iter (ref->mBase->mSpells.mList.begin());
-                iter!=ref->mBase->mSpells.mList.end(); ++iter)
-            {
-                if (const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(*iter))
-                    data->mCreatureStats.getSpells().add (spell);
-                else /// \todo add option to make this a fatal error message pop-up, but default to warning for vanilla compatibility
-                    Log(Debug::Warning) << "Warning: ignoring nonexistent spell '" << *iter << "' on creature '" << ref->mBase->mId << "'";
-            }
+            bool spellsInitialised = data->mCreatureStats.getSpells().setSpells(ref->mBase->mId);
+            if (!spellsInitialised)
+                data->mCreatureStats.getSpells().addAllToInstance(ref->mBase->mSpells.mList);
 
             // inventory
             bool hasInventory = hasInventoryStore(ptr);
@@ -781,6 +776,9 @@ namespace MWClass
         CreatureCustomData& customData = ptr.getRefData().getCustomData()->asCreatureCustomData();
         const ESM::CreatureState& creatureState = state.asCreatureState();
         customData.mContainerStore->readState (creatureState.mInventory);
+        bool spellsInitialised = customData.mCreatureStats.getSpells().setSpells(ptr.get<ESM::Creature>()->mBase->mId);
+        if(spellsInitialised)
+            customData.mCreatureStats.getSpells().clear();
         customData.mCreatureStats.readState (creatureState.mCreatureStats);
     }
 

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -1973,10 +1973,6 @@ namespace MWMechanics
                 // One case where we need this is to make sure bound items are removed upon death
                 stats.modifyMagicEffects(MWMechanics::MagicEffects());
                 stats.getActiveSpells().clear();
-
-                if (!isPlayer)
-                    stats.getSpells().clear();
-
                 // Make sure spell effects are removed
                 purgeSpellEffects(stats.getActorId());
 

--- a/apps/openmw/mwmechanics/disease.hpp
+++ b/apps/openmw/mwmechanics/disease.hpp
@@ -40,7 +40,7 @@ namespace MWMechanics
                 continue;
 
             float resist = 0.f;
-            if (spells.hasCorprusEffect(spell))
+            if (Spells::hasCorprusEffect(spell))
                 resist = 1.f - 0.01f * (actorEffects.get(ESM::MagicEffect::ResistCorprusDisease).getMagnitude()
                                         - actorEffects.get(ESM::MagicEffect::WeaknessToCorprusDisease).getMagnitude());
             else if (spell->mData.mType == ESM::Spell::ST_Disease)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -83,7 +83,7 @@ namespace MWMechanics
 
         // reset
         creatureStats.setLevel(player->mNpdt.mLevel);
-        creatureStats.getSpells().clear();
+        creatureStats.getSpells().clear(true);
         creatureStats.modifyMagicEffects(MagicEffects());
 
         for (int i=0; i<27; ++i)

--- a/apps/openmw/mwmechanics/spelllist.cpp
+++ b/apps/openmw/mwmechanics/spelllist.cpp
@@ -1,0 +1,175 @@
+#include "spelllist.hpp"
+
+#include <algorithm>
+
+#include <components/esm/loadspel.hpp>
+#include <components/misc/rng.hpp>
+
+#include "spells.hpp"
+
+#include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
+
+#include "../mwworld/esmstore.hpp"
+
+namespace
+{
+    template<class T>
+    const std::vector<std::string> getSpellList(const std::string& id)
+    {
+        return MWBase::Environment::get().getWorld()->getStore().get<T>().find(id)->mSpells.mList;
+    }
+
+    template<class T>
+    bool withBaseRecord(const std::string& id, const std::function<bool(std::vector<std::string>&)>& function)
+    {
+        T copy = *MWBase::Environment::get().getWorld()->getStore().get<T>().find(id);
+        bool changed = function(copy.mSpells.mList);
+        if(changed)
+            MWBase::Environment::get().getWorld()->createOverrideRecord(copy);
+        return changed;
+    }
+}
+
+namespace MWMechanics
+{
+    SpellList::SpellList(const std::string& id, int type) : mId(id), mType(type) {}
+
+    bool SpellList::withBaseRecord(const std::function<bool(std::vector<std::string>&)>& function)
+    {
+        switch(mType)
+        {
+            case ESM::REC_CREA:
+                return ::withBaseRecord<ESM::Creature>(mId, function);
+            case ESM::REC_NPC_:
+                return ::withBaseRecord<ESM::NPC>(mId, function);
+            default:
+                throw std::logic_error("failed to update base record for " + mId);
+        }
+    }
+
+    const std::vector<std::string> SpellList::getSpells() const
+    {
+        switch(mType)
+        {
+            case ESM::REC_CREA:
+                return getSpellList<ESM::Creature>(mId);
+            case ESM::REC_NPC_:
+                return getSpellList<ESM::NPC>(mId);
+            default:
+                throw std::logic_error("failed to get spell list for " + mId);
+        }
+    }
+
+    const ESM::Spell* SpellList::getSpell(const std::string& id)
+    {
+        return MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(id);
+    }
+
+    void SpellList::add (const ESM::Spell* spell)
+    {
+        auto& id = spell->mId;
+        bool changed = withBaseRecord([&] (auto& spells)
+        {
+            for(auto it : spells)
+            {
+                if(Misc::StringUtils::ciEqual(id, it))
+                    return false;
+            }
+            spells.push_back(id);
+            return true;
+        });
+        if(changed)
+        {
+            for(auto listener : mListeners)
+                listener->addSpell(spell);
+        }
+    }
+
+    void SpellList::remove (const ESM::Spell* spell)
+    {
+        auto& id = spell->mId;
+        bool changed = withBaseRecord([&] (auto& spells)
+        {
+            for(auto it = spells.begin(); it != spells.end(); it++)
+            {
+                if(Misc::StringUtils::ciEqual(id, *it))
+                {
+                    spells.erase(it);
+                    return true;
+                }
+            }
+            return false;
+        });
+        if(changed)
+        {
+            for(auto listener : mListeners)
+                listener->removeSpell(spell);
+        }
+    }
+
+    void SpellList::removeAll (const std::vector<std::string>& ids)
+    {
+        bool changed = withBaseRecord([&] (auto& spells)
+        {
+            const auto it = std::remove_if(spells.begin(), spells.end(), [&] (const auto& spell)
+            {
+                const auto isSpell = [&] (const auto& id) { return Misc::StringUtils::ciEqual(spell, id); };
+                return ids.end() != std::find_if(ids.begin(), ids.end(), isSpell);
+            });
+            if (it == spells.end())
+                return false;
+            spells.erase(it, spells.end());
+            return true;
+        });
+        if(changed)
+        {
+            for(auto listener : mListeners)
+            {
+                for(auto& id : ids)
+                {
+                    const auto spell = getSpell(id);
+                    listener->removeSpell(spell);
+                }
+            }
+        }
+    }
+
+    void SpellList::clear()
+    {
+        bool changed = withBaseRecord([] (auto& spells)
+        {
+            if(spells.empty())
+                return false;
+            spells.clear();
+            return true;
+        });
+        if(changed)
+        {
+            for(auto listener : mListeners)
+                listener->removeAllSpells();
+        }
+    }
+
+    void SpellList::addListener(Spells* spells)
+    {
+        for(const auto ptr : mListeners)
+        {
+            if(ptr == spells)
+                return;
+        }
+        mListeners.push_back(spells);
+    }
+
+    void SpellList::removeListener(Spells* spells)
+    {
+        for(auto it = mListeners.begin(); it != mListeners.end(); it++)
+        {
+            if(*it == spells)
+            {
+                mListeners.erase(it);
+                break;
+            }
+        }
+    }
+}

--- a/apps/openmw/mwmechanics/spelllist.hpp
+++ b/apps/openmw/mwmechanics/spelllist.hpp
@@ -1,0 +1,60 @@
+#ifndef GAME_MWMECHANICS_SPELLLIST_H
+#define GAME_MWMECHANICS_SPELLLIST_H
+
+#include <functional>
+#include <map>
+#include <string>
+#include <set>
+#include <vector>
+
+#include <components/esm/loadspel.hpp>
+
+#include "magiceffects.hpp"
+
+namespace ESM
+{
+    struct SpellState;
+}
+
+namespace MWMechanics
+{
+    struct SpellParams
+    {
+        std::map<int, float> mEffectRands; // <effect index, normalised random magnitude>
+        std::set<int> mPurgedEffects; // indices of purged effects
+    };
+
+    class Spells;
+
+    class SpellList
+    {
+            const std::string mId;
+            const int mType;
+            std::vector<Spells*> mListeners;
+
+            bool withBaseRecord(const std::function<bool(std::vector<std::string>&)>& function);
+        public:
+            SpellList(const std::string& id, int type);
+
+            /// Get spell from ID, throws exception if not found
+            static const ESM::Spell* getSpell(const std::string& id);
+
+            void add (const ESM::Spell* spell);
+            ///< Adding a spell that is already listed in *this is a no-op.
+
+            void remove (const ESM::Spell* spell);
+
+            void removeAll(const std::vector<std::string>& spells);
+
+            void clear();
+            ///< Remove all spells of all types.
+
+            void addListener(Spells* spells);
+
+            void removeListener(Spells* spells);
+
+            const std::vector<std::string> getSpells() const;
+    };
+}
+
+#endif

--- a/apps/openmw/mwmechanics/spells.cpp
+++ b/apps/openmw/mwmechanics/spells.cpp
@@ -1,8 +1,10 @@
 #include "spells.hpp"
 
+#include <components/debug/debuglog.hpp>
 #include <components/esm/loadspel.hpp>
 #include <components/esm/spellstate.hpp>
 #include <components/misc/rng.hpp>
+#include <components/misc/stringops.hpp>
 
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
@@ -22,19 +24,14 @@ namespace MWMechanics
     {
     }
 
-    Spells::TIterator Spells::begin() const
+    std::map<const ESM::Spell*, SpellParams>::const_iterator Spells::begin() const
     {
         return mSpells.begin();
     }
 
-    Spells::TIterator Spells::end() const
+    std::map<const ESM::Spell*, SpellParams>::const_iterator Spells::end() const
     {
         return mSpells.end();
-    }
-
-    const ESM::Spell* Spells::getSpell(const std::string& id) const
-    {
-        return MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(id);
     }
 
     void Spells::rebuildEffects() const
@@ -42,26 +39,26 @@ namespace MWMechanics
         mEffects = MagicEffects();
         mSourcedEffects.clear();
 
-        for (TIterator iter = mSpells.begin(); iter!=mSpells.end(); ++iter)
+        for (const auto& iter : mSpells)
         {
-            const ESM::Spell *spell = iter->first;
+            const ESM::Spell *spell = iter.first;
 
             if (spell->mData.mType==ESM::Spell::ST_Ability || spell->mData.mType==ESM::Spell::ST_Blight ||
                 spell->mData.mType==ESM::Spell::ST_Disease || spell->mData.mType==ESM::Spell::ST_Curse)
             {
                 int i=0;
-                for (std::vector<ESM::ENAMstruct>::const_iterator it = spell->mEffects.mList.begin(); it != spell->mEffects.mList.end(); ++it)
+                for (const auto& effect : spell->mEffects.mList)
                 {
-                    if (iter->second.mPurgedEffects.find(i) != iter->second.mPurgedEffects.end())
+                    if (iter.second.mPurgedEffects.find(i) != iter.second.mPurgedEffects.end())
                         continue; // effect was purged
 
                     float random = 1.f;
-                    if (iter->second.mEffectRands.find(i) != iter->second.mEffectRands.end())
-                        random = iter->second.mEffectRands.at(i);
+                    if (iter.second.mEffectRands.find(i) != iter.second.mEffectRands.end())
+                        random = iter.second.mEffectRands.at(i);
 
-                    float magnitude = it->mMagnMin + (it->mMagnMax - it->mMagnMin) * random;
-                    mEffects.add (*it, magnitude);
-                    mSourcedEffects[spell].add(MWMechanics::EffectKey(*it), magnitude);
+                    float magnitude = effect.mMagnMin + (effect.mMagnMax - effect.mMagnMin) * random;
+                    mEffects.add (effect, magnitude);
+                    mSourcedEffects[spell].add(MWMechanics::EffectKey(effect), magnitude);
 
                     ++i;
                 }
@@ -71,7 +68,7 @@ namespace MWMechanics
 
     bool Spells::hasSpell(const std::string &spell) const
     {
-        return hasSpell(getSpell(spell));
+        return hasSpell(SpellList::getSpell(spell));
     }
 
     bool Spells::hasSpell(const ESM::Spell *spell) const
@@ -80,6 +77,16 @@ namespace MWMechanics
     }
 
     void Spells::add (const ESM::Spell* spell)
+    {
+        mSpellList->add(spell);
+    }
+
+    void Spells::add (const std::string& spellId)
+    {
+        add(SpellList::getSpell(spellId));
+    }
+
+    void Spells::addSpell(const ESM::Spell* spell)
     {
         if (mSpells.find (spell)==mSpells.end())
         {
@@ -106,24 +113,24 @@ namespace MWMechanics
         }
     }
 
-    void Spells::add (const std::string& spellId)
-    {
-        add(getSpell(spellId));
-    }
-
     void Spells::remove (const std::string& spellId)
     {
-        const ESM::Spell* spell = getSpell(spellId);
-        TContainer::iterator iter = mSpells.find (spell);
-
-        if (iter!=mSpells.end())
-        {
-            mSpells.erase (iter);
-            mSpellsChanged = true;
-        }
+        const auto spell = SpellList::getSpell(spellId);
+        removeSpell(spell);
+        mSpellList->remove(spell);
 
         if (spellId==mSelectedSpell)
             mSelectedSpell.clear();
+    }
+
+    void Spells::removeSpell(const ESM::Spell* spell)
+    {
+        const auto it = mSpells.find(spell);
+        if(it != mSpells.end())
+        {
+            mSpells.erase(it);
+            mSpellsChanged = true;
+        }
     }
 
     MagicEffects Spells::getMagicEffects() const
@@ -135,10 +142,17 @@ namespace MWMechanics
         return mEffects;
     }
 
-    void Spells::clear()
+    void Spells::removeAllSpells()
     {
         mSpells.clear();
         mSpellsChanged = true;
+    }
+
+    void Spells::clear(bool modifyBase)
+    {
+        removeAllSpells();
+        if(modifyBase)
+            mSpellList->clear();
     }
 
     void Spells::setSelectedSpell (const std::string& spellId)
@@ -166,101 +180,78 @@ namespace MWMechanics
         return false;
     }
 
-    bool Spells::hasCommonDisease() const
+    bool Spells::hasDisease(const ESM::Spell::SpellType type) const
     {
-        for (TIterator iter = mSpells.begin(); iter!=mSpells.end(); ++iter)
+        for (const auto& iter : mSpells)
         {
-            const ESM::Spell *spell = iter->first;
-            if (spell->mData.mType == ESM::Spell::ST_Disease)
+            const ESM::Spell *spell = iter.first;
+            if (spell->mData.mType == type)
                 return true;
         }
 
         return false;
+    }
+
+    bool Spells::hasCommonDisease() const
+    {
+        return hasDisease(ESM::Spell::ST_Disease);
     }
 
     bool Spells::hasBlightDisease() const
     {
-        for (TIterator iter = mSpells.begin(); iter!=mSpells.end(); ++iter)
+        return hasDisease(ESM::Spell::ST_Blight);
+    }
+
+    void Spells::purge(const SpellFilter& filter)
+    {
+        std::vector<std::string> purged;
+        for (auto iter = mSpells.begin(); iter!=mSpells.end();)
         {
             const ESM::Spell *spell = iter->first;
-            if (spell->mData.mType == ESM::Spell::ST_Blight)
-                return true;
+            if (filter(spell))
+            {
+                mSpells.erase(iter++);
+                purged.push_back(spell->mId);
+                mSpellsChanged = true;
+            }
+            else
+                ++iter;
         }
-
-        return false;
+        if(!purged.empty())
+            mSpellList->removeAll(purged);
     }
 
     void Spells::purgeCommonDisease()
     {
-        for (TContainer::iterator iter = mSpells.begin(); iter!=mSpells.end();)
-        {
-            const ESM::Spell *spell = iter->first;
-            if (spell->mData.mType == ESM::Spell::ST_Disease)
-            {
-                mSpells.erase(iter++);
-                mSpellsChanged = true;
-            }
-            else
-                ++iter;
-        }
+        purge([](auto spell) { return spell->mData.mType == ESM::Spell::ST_Disease; });
     }
 
     void Spells::purgeBlightDisease()
     {
-        for (TContainer::iterator iter = mSpells.begin(); iter!=mSpells.end();)
-        {
-            const ESM::Spell *spell = iter->first;
-            if (spell->mData.mType == ESM::Spell::ST_Blight && !hasCorprusEffect(spell))
-            {
-                mSpells.erase(iter++);
-                mSpellsChanged = true;
-            }
-            else
-                ++iter;
-        }
+        purge([](auto spell) { return spell->mData.mType == ESM::Spell::ST_Blight && !hasCorprusEffect(spell); });
     }
 
     void Spells::purgeCorprusDisease()
     {
-        for (TContainer::iterator iter = mSpells.begin(); iter!=mSpells.end();)
-        {
-            const ESM::Spell *spell = iter->first;
-            if (hasCorprusEffect(spell))
-            {
-                mSpells.erase(iter++);
-                mSpellsChanged = true;
-            }
-            else
-                ++iter;
-        }
+        purge(&hasCorprusEffect);
     }
 
     void Spells::purgeCurses()
     {
-        for (TContainer::iterator iter = mSpells.begin(); iter!=mSpells.end();)
-        {
-            const ESM::Spell *spell = iter->first;
-            if (spell->mData.mType == ESM::Spell::ST_Curse)
-            {
-                mSpells.erase(iter++);
-                mSpellsChanged = true;
-            }
-            else
-                ++iter;
-        }
+        purge([](auto spell) { return spell->mData.mType == ESM::Spell::ST_Curse; });
     }
 
     void Spells::removeEffects(const std::string &id)
     {
         if (isSpellActive(id))
         {
-            for (TContainer::iterator spell = mSpells.begin(); spell != mSpells.end(); ++spell)
+            for (auto& spell : mSpells)
             {
-                if (spell->first == getSpell(id))
+                if (spell.first == SpellList::getSpell(id))
                 {
-                    for (long unsigned int i = 0; i != spell->first->mEffects.mList.size(); i++)
+                    for (long unsigned int i = 0; i != spell.first->mEffects.mList.size(); i++)
                     {
-                        spell->second.mPurgedEffects.insert(i);
+                        spell.second.mPurgedEffects.insert(i);
                     }
                 }
             }
@@ -276,23 +267,21 @@ namespace MWMechanics
             mSpellsChanged = false;
         }
 
-        for (std::map<SpellKey, MagicEffects>::const_iterator it = mSourcedEffects.begin();
-             it != mSourcedEffects.end(); ++it)
+        for (const auto& it : mSourcedEffects)
         {
-            const ESM::Spell * spell = it->first;
-            for (MagicEffects::Collection::const_iterator effectIt = it->second.begin();
-                 effectIt != it->second.end(); ++effectIt)
+            const ESM::Spell * spell = it.first;
+            for (const auto& effectIt : it.second)
             {
-                visitor.visit(effectIt->first, spell->mName, spell->mId, -1, effectIt->second.getMagnitude());
+                visitor.visit(effectIt.first, spell->mName, spell->mId, -1, effectIt.second.getMagnitude());
             }
         }
     }
 
     bool Spells::hasCorprusEffect(const ESM::Spell *spell)
     {
-        for (std::vector<ESM::ENAMstruct>::const_iterator effectIt = spell->mEffects.mList.begin(); effectIt != spell->mEffects.mList.end(); ++effectIt)
+        for (const auto& effectIt : spell->mEffects.mList)
         {
-            if (effectIt->mEffectID == ESM::MagicEffect::Corprus)
+            if (effectIt.mEffectID == ESM::MagicEffect::Corprus)
             {
                 return true;
             }
@@ -302,14 +291,14 @@ namespace MWMechanics
 
     void Spells::purgeEffect(int effectId)
     {
-        for (TContainer::iterator spellIt = mSpells.begin(); spellIt != mSpells.end(); ++spellIt)
+        for (auto& spellIt : mSpells)
         {
             int i = 0;
-            for (std::vector<ESM::ENAMstruct>::const_iterator effectIt = spellIt->first->mEffects.mList.begin(); effectIt != spellIt->first->mEffects.mList.end(); ++effectIt)
+            for (auto& effectIt : spellIt.first->mEffects.mList)
             {
-                if (effectIt->mEffectID == effectId)
+                if (effectIt.mEffectID == effectId)
                 {
-                    spellIt->second.mPurgedEffects.insert(i);
+                    spellIt.second.mPurgedEffects.insert(i);
                     mSpellsChanged = true;
                 }
                 ++i;
@@ -319,15 +308,15 @@ namespace MWMechanics
 
     void Spells::purgeEffect(int effectId, const std::string & sourceId)
     {
-        const ESM::Spell * spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().find(sourceId);
-        TContainer::iterator spellIt = mSpells.find(spell);
+        const ESM::Spell * spell = SpellList::getSpell(sourceId);
+        auto spellIt = mSpells.find(spell);
         if (spellIt == mSpells.end())
             return;
 
         int i = 0;
-        for (std::vector<ESM::ENAMstruct>::const_iterator effectIt = spellIt->first->mEffects.mList.begin(); effectIt != spellIt->first->mEffects.mList.end(); ++effectIt)
+        for (auto& effectIt : spellIt->first->mEffects.mList)
         {
-            if (effectIt->mEffectID == effectId)
+            if (effectIt.mEffectID == effectId)
             {
                 spellIt->second.mPurgedEffects.insert(i);
                 mSpellsChanged = true;
@@ -338,11 +327,8 @@ namespace MWMechanics
 
     bool Spells::canUsePower(const ESM::Spell* spell) const
     {
-        std::map<SpellKey, MWWorld::TimeStamp>::const_iterator it = mUsedPowers.find(spell);
-        if (it == mUsedPowers.end() || it->second + 24 <= MWBase::Environment::get().getWorld()->getTimeStamp())
-            return true;
-        else
-            return false;
+        const auto it = mUsedPowers.find(spell);
+        return it == mUsedPowers.end() || it->second + 24 <= MWBase::Environment::get().getWorld()->getTimeStamp();
     }
 
     void Spells::usePower(const ESM::Spell* spell)
@@ -352,6 +338,8 @@ namespace MWMechanics
 
     void Spells::readState(const ESM::SpellState &state, CreatureStats* creatureStats)
     {
+        const auto& baseSpells = mSpellList->getSpells();
+
         for (ESM::SpellState::TContainer::const_iterator it = state.mSpells.begin(); it != state.mSpells.end(); ++it)
         {
             // Discard spells that are no longer available due to changed content files
@@ -364,6 +352,13 @@ namespace MWMechanics
                 if (it->first == state.mSelectedSpell)
                     mSelectedSpell = it->first;
             }
+        }
+        // Add spells from the base record
+        for(const std::string& id : baseSpells)
+        {
+            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(id);
+            if(spell)
+                addSpell(spell);
         }
 
         for (std::map<std::string, ESM::TimeStamp>::const_iterator it = state.mUsedPowers.begin(); it != state.mUsedPowers.end(); ++it)
@@ -436,17 +431,50 @@ namespace MWMechanics
 
     void Spells::writeState(ESM::SpellState &state) const
     {
-        for (TContainer::const_iterator it = mSpells.begin(); it != mSpells.end(); ++it)
+        const auto& baseSpells = mSpellList->getSpells();
+        for (const auto& it : mSpells)
         {
-            ESM::SpellState::SpellParams params;
-            params.mEffectRands = it->second.mEffectRands;
-            params.mPurgedEffects = it->second.mPurgedEffects;
-            state.mSpells.insert(std::make_pair(it->first->mId, params));
+            //Don't save spells stored in the base record
+            if(std::find(baseSpells.begin(), baseSpells.end(), it.first->mId) == baseSpells.end())
+            {
+                ESM::SpellState::SpellParams params;
+                params.mEffectRands = it.second.mEffectRands;
+                params.mPurgedEffects = it.second.mPurgedEffects;
+                state.mSpells.insert(std::make_pair(it.first->mId, params));
+            }
         }
 
         state.mSelectedSpell = mSelectedSpell;
 
-        for (std::map<SpellKey, MWWorld::TimeStamp>::const_iterator it = mUsedPowers.begin(); it != mUsedPowers.end(); ++it)
-            state.mUsedPowers[it->first->mId] = it->second.toEsm();
+        for (const auto& it : mUsedPowers)
+            state.mUsedPowers[it.first->mId] = it.second.toEsm();
+    }
+
+    bool Spells::setSpells(const std::string& actorId)
+    {
+        bool result;
+        std::tie(mSpellList, result) = MWBase::Environment::get().getWorld()->getStore().getSpellList(actorId);
+        mSpellList->addListener(this);
+        for(const auto& id : mSpellList->getSpells())
+            addSpell(SpellList::getSpell(id));
+        return result;
+    }
+
+    void Spells::addAllToInstance(const std::vector<std::string>& spells)
+    {
+        for(const std::string& id : spells)
+        {
+            const ESM::Spell* spell = MWBase::Environment::get().getWorld()->getStore().get<ESM::Spell>().search(id);
+            if(spell)
+                addSpell(spell);
+            else
+                Log(Debug::Warning) << "Warning: ignoring nonexistent spell '" << id << "'";
+        }
+    }
+
+    Spells::~Spells()
+    {
+        if(mSpellList)
+            mSpellList->removeListener(this);
     }
 }

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -1,6 +1,7 @@
 #ifndef OPENMW_MWWORLD_ESMSTORE_H
 #define OPENMW_MWWORLD_ESMSTORE_H
 
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 
@@ -10,6 +11,11 @@
 namespace Loading
 {
     class Listener;
+}
+
+namespace MWMechanics
+{
+    class SpellList;
 }
 
 namespace MWWorld
@@ -77,6 +83,8 @@ namespace MWWorld
         ESM::NPC mPlayerTemplate;
 
         unsigned int mDynamicCount;
+
+        mutable std::map<std::string, std::weak_ptr<MWMechanics::SpellList> > mSpellListCache;
 
         /// Validate entries in store after setup
         void validate();
@@ -257,6 +265,8 @@ namespace MWWorld
         void checkPlayer();
 
         int getRefCount(const std::string& id) const;
+
+        std::pair<std::shared_ptr<MWMechanics::SpellList>, bool> getSpellList(const std::string& id) const;
     };
 
     template <>

--- a/apps/openmw_test_suite/mwworld/test_store.cpp
+++ b/apps/openmw_test_suite/mwworld/test_store.cpp
@@ -8,6 +8,12 @@
 #include <components/loadinglistener/loadinglistener.hpp>
 
 #include "apps/openmw/mwworld/esmstore.hpp"
+#include "apps/openmw/mwmechanics/spelllist.hpp"
+
+namespace MWMechanics
+{
+    SpellList::SpellList(const std::string& id, int type) : mId(id), mType(type) {}
+}
 
 static Loading::Listener dummyListener;
 

--- a/components/esm/savedgame.cpp
+++ b/components/esm/savedgame.cpp
@@ -4,7 +4,7 @@
 #include "esmwriter.hpp"
 
 unsigned int ESM::SavedGame::sRecordId = ESM::REC_SAVE;
-int ESM::SavedGame::sCurrentFormat = 12;
+int ESM::SavedGame::sCurrentFormat = 13;
 
 void ESM::SavedGame::load (ESMReader &esm)
 {


### PR DESCRIPTION
Split from #2870. This doesn't so much implement vanilla behaviour as vanilla-adjacent behaviour. It should get a good bit of testing.

Instances of the same actor in vanilla share a single in-memory spell list drawn from the base record. GetSpell appears to interact with this list with the interesting side effect that it cannot detect racial abilities. Adding spells to one actor adds them to all instances instantly. (Though visual effects don't get updated until the cell is reloaded.) Basically it's weird all around.

Calling AddSpell on an NPC adds the spell to the base record, provided the NPC doesn't have autocalculated stats. This PR adds it to the base record regardless. (Saving and reloading would also clear any added spells for autocalculated actors.)

The Cure Disease effect can conditionally remove spells (diseases) from the base record. Example:

[instance A]->AddSpell collywobbles
[instance A]->GetCommonDisease == 1
[instance B]->GetCommonDisease == 1
Cast "cure common disease other" on [instance B]
[instance A]->GetCommonDisease == 0
[instance B]->GetCommonDisease == 0
Save and reload
[instance A]->GetCommonDisease == 1
[instance B]->GetCommonDisease == 1
Cast "cure common disease other" on [instance A]
Save and reload
[instance A]->GetCommonDisease == 0
[instance B]->GetCommonDisease == 0

This PR makes both instances affect the base record equally.