### PR TITLE
Check distance to object before load sound

### DIFF
--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -620,13 +620,13 @@ namespace MWSound
         if(!mOutput->isInitialized())
             return nullptr;
 
+        const osg::Vec3f objpos(ptr.getRefData().getPosition().asVec3());
+        if ((mode & PlayMode::RemoveAtDistance) && (mListenerPos - objpos).length2() > 2000 * 2000)
+            return nullptr;
+
         // Look up the sound in the ESM data
         Sound_Buffer *sfx = loadSound(Misc::StringUtils::lowerCase(soundId));
         if(!sfx) return nullptr;
-
-        const osg::Vec3f objpos(ptr.getRefData().getPosition().asVec3());
-        if((mode&PlayMode::RemoveAtDistance) && (mListenerPos-objpos).length2() > 2000*2000)
-            return nullptr;
 
         // Only one copy of given sound can be played at time on ptr, so stop previous copy
         stopSound(sfx, ptr);


### PR DESCRIPTION
`loadSound` can lead to I/O that can take much more time than a distance check.