### PR TITLE
Corrections for StatsWatcher

### DIFF
--- a/apps/openmw/mwgui/statswatcher.cpp
+++ b/apps/openmw/mwgui/statswatcher.cpp
@@ -136,27 +136,6 @@ namespace MWGui
         }
 
         mWatchedStatsEmpty = false;
-
-        // Update the equipped weapon icon
-        MWWorld::InventoryStore& inv = mWatched.getClass().getInventoryStore(mWatched);
-        MWWorld::ContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
-        if (weapon == inv.end())
-            winMgr->unsetSelectedWeapon();
-        else
-            winMgr->setSelectedWeapon(*weapon);
-
-        // Update the selected spell icon
-        MWWorld::ContainerStoreIterator enchantItem = inv.getSelectedEnchantItem();
-        if (enchantItem != inv.end())
-            winMgr->setSelectedEnchantItem(*enchantItem);
-        else
-        {
-            const std::string& spell = winMgr->getSelectedSpell();
-            if (!spell.empty())
-                winMgr->setSelectedSpell(spell, int(MWMechanics::getSpellSuccessChance(spell, mWatched)));
-            else
-                winMgr->unsetSelectedSpell();
-        }
     }
 
     void StatsWatcher::addListener(StatsListener* listener)

--- a/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
+++ b/apps/openmw/mwmechanics/mechanicsmanagerimp.cpp
@@ -302,13 +302,37 @@ namespace MWMechanics
 
     void MechanicsManager::update(float duration, bool paused)
     {
+        // Note: we should do it here since game mechanics and world updates use these values
+        MWWorld::Ptr ptr = getPlayer();
+        MWBase::WindowManager *winMgr = MWBase::Environment::get().getWindowManager();
+
+        // Update the equipped weapon icon
+        MWWorld::InventoryStore& inv = ptr.getClass().getInventoryStore(ptr);
+        MWWorld::ContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+        if (weapon == inv.end())
+            winMgr->unsetSelectedWeapon();
+        else
+            winMgr->setSelectedWeapon(*weapon);
+
+        // Update the selected spell icon
+        MWWorld::ContainerStoreIterator enchantItem = inv.getSelectedEnchantItem();
+        if (enchantItem != inv.end())
+            winMgr->setSelectedEnchantItem(*enchantItem);
+        else
+        {
+            const std::string& spell = winMgr->getSelectedSpell();
+            if (!spell.empty())
+                winMgr->setSelectedSpell(spell, int(MWMechanics::getSpellSuccessChance(spell, ptr)));
+            else
+                winMgr->unsetSelectedSpell();
+        }
+
         if (mUpdatePlayer)
         {
             mUpdatePlayer = false;
 
             // HACK? The player has been changed, so a new Animation object may
             // have been made for them. Make sure they're properly updated.
-            MWWorld::Ptr ptr = getPlayer();
             mActors.removeActor(ptr);
             mActors.addActor(ptr, true);
         }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1907,7 +1907,7 @@ namespace MWWorld
             std::string enchantId = selectedEnchantItem.getClass().getEnchantment(selectedEnchantItem);
             if (!enchantId.empty())
             {
-                const ESM::Enchantment* ench = mStore.get<ESM::Enchantment>().search(selectedEnchantItem.getClass().getEnchantment(selectedEnchantItem));
+                const ESM::Enchantment* ench = mStore.get<ESM::Enchantment>().search(enchantId);
                 if (ench)
                     preloadEffects(&ench->mEffects);
             }


### PR DESCRIPTION
1. Update HUD-related data which is used by game mechanics and world prior to related updates to initialize data properly.
2. Avoid redundant getEnchantment() call.