### PR TITLE
Fix TSAN warnings for ripples emitter (bug #4764)

### DIFF
--- a/apps/openmw/mwrender/ripplesimulation.cpp
+++ b/apps/openmw/mwrender/ripplesimulation.cpp
@@ -200,6 +200,7 @@ void RippleSimulation::emitRipple(const osg::Vec3f &pos)
 {
     if (std::abs(pos.z() - mParticleNode->getPosition().z()) < 20)
     {
+        osgParticle::ParticleSystem::ScopedWriteLock lock(*mParticleSystem->getReadWriteMutex());
         osgParticle::Particle* p = mParticleSystem->createParticle(nullptr);
         p->setPosition(osg::Vec3f(pos.x(), pos.y(), 0.f));
         p->setAngle(osg::Vec3f(0,0, Misc::Rng::rollProbability() * osg::PI * 2 - osg::PI));


### PR DESCRIPTION
While main thread creates particles rendering thread draws them so sychronization is required.

Example:
```
WARNING: ThreadSanitizer: data race (pid=93554)
  Write of size 8 at 0x7b440022a580 by main thread:
    #0 operator delete(void*) <null> (openmw+0x5ae457)
    #1 std::__1::_DeallocateCaller::__do_call(void*) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/new:334:12 (libosgParticle.so.161+0x45b40)
    #2 std::__1::_DeallocateCaller::__do_deallocate_handle_size(void*, unsigned long) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/new:292:12 (libosgParticle.so.161+0x45b40)
    #3 std::__1::_DeallocateCaller::__do_deallocate_handle_size_align(void*, unsigned long, unsigned long) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/new:262:12 (libosgParticle.so.161+0x45b40)
    #4 std::__1::__libcpp_deallocate(void*, unsigned long, unsigned long) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/new:340:3 (libosgParticle.so.161+0x45b40)
    #5 std::__1::allocator<osgParticle::Particle>::deallocate(osgParticle::Particle*, unsigned long) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/memory:1816:10 (libosgParticle.so.161+0x45b40)
    #6 std::__1::allocator_traits<std::__1::allocator<osgParticle::Particle> >::deallocate(std::__1::allocator<osgParticle::Particle>&, osgParticle::Particle*, unsigned long) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/memory:1554:14 (libosgParticle.so.161+0x45b40)
    #7 std::__1::__split_buffer<osgParticle::Particle, std::__1::allocator<osgParticle::Particle>&>::~__split_buffer() /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/__split_buffer:343:9 (libosgParticle.so.161+0x45b40)
    #8 void std::__1::vector<osgParticle::Particle, std::__1::allocator<osgParticle::Particle> >::__push_back_slow_path<osgParticle::Particle const&>(osgParticle::Particle const&) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/vector:1627:1 (libosgParticle.so.161+0x45b40)
    #9 std::__1::vector<osgParticle::Particle, std::__1::allocator<osgParticle::Particle> >::push_back(osgParticle::Particle const&) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/vector:1643:9 (libosgParticle.so.161+0x3ecc8)
    #10 osgParticle::ParticleSystem::createParticle(osgParticle::Particle const*) /home/elsid/dev/OpenSceneGraph/src/osgParticle/ParticleSystem.cpp:128:20 (libosgParticle.so.161+0x3ecc8)
    #11 MWRender::RippleSimulation::emitRipple(osg::Vec3f const&) /home/elsid/dev/openmw/apps/openmw/mwrender/ripplesimulation.cpp:203:53 (openmw+0x668381)
    #12 MWRender::RippleSimulation::update(float) /home/elsid/dev/openmw/apps/openmw/mwrender/ripplesimulation.cpp:146:13 (openmw+0x668381)
    #13 MWRender::Water::update(float) /home/elsid/dev/openmw/apps/openmw/mwrender/water.cpp:731:18 (openmw+0x65b67d)
    #14 MWRender::RenderingManager::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwrender/renderingmanager.cpp:627:21 (openmw+0x5bb015)
    #15 MWWorld::Scene::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwworld/scene.cpp:313:20 (openmw+0x960fb2)
    #16 MWWorld::World::update(float, bool) /home/elsid/dev/openmw/apps/openmw/mwworld/worldimp.cpp:1799:22 (openmw+0x9356a9)
    #17 OMW::Engine::frame(float) /home/elsid/dev/openmw/apps/openmw/engine.cpp:330:42 (openmw+0xbeb540)
    #18 OMW::Engine::go() /home/elsid/dev/openmw/apps/openmw/engine.cpp:889:14 (openmw+0xbf4748)
    #19 runApplication(int, char**) /home/elsid/dev/openmw/apps/openmw/main.cpp:259:17 (openmw+0xbdbdb6)
    #20 wrapApplication(int (*)(int, char**), int, char**, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/elsid/dev/openmw/components/debug/debugging.cpp:138:15 (openmw+0xdc880b)
    #21 main /home/elsid/dev/openmw/apps/openmw/main.cpp:271:12 (openmw+0xbdbeb7)

  Previous atomic read of size 1 at 0x7b440022a580 by thread T1 (mutexes: write M103718082902454520):
    #0 __tsan_atomic8_load <null> (openmw+0x584622)
    #1 bool std::__1::__cxx_atomic_load<bool>(std::__1::__cxx_atomic_base_impl<bool> const*, std::__1::memory_order) /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/atomic:970:12 (libosgParticle.so.161+0x40dab)
    #2 std::__1::__atomic_base<bool, false>::load(std::__1::memory_order) const /home/elsid/dev/llvm-project/build/clang/release/install/include/c++/v1/atomic:1487:17 (libosgParticle.so.161+0x40dab)
    #3 osgParticle::Particle::Alive::operator bool() const /home/elsid/dev/OpenSceneGraph/include/osgParticle/Particle:321:51 (libosgParticle.so.161+0x40dab)
    #4 osgParticle::Particle::isAlive() const /home/elsid/dev/OpenSceneGraph/include/osgParticle/Particle:368:16 (libosgParticle.so.161+0x40dab)
    #5 osgParticle::ParticleSystem::drawImplementation(osg::RenderInfo&) const /home/elsid/dev/OpenSceneGraph/src/osgParticle/ParticleSystem.cpp:332:34 (libosgParticle.so.161+0x40dab)
    #6 osg::Drawable::drawInner(osg::RenderInfo&) const /home/elsid/dev/OpenSceneGraph/include/osg/Drawable:276:17 (libosgParticle.so.161+0x58c94)
    #7 osg::Drawable::draw(osg::RenderInfo&) const /home/elsid/dev/OpenSceneGraph/include/osg/Drawable:617:9 (libosgParticle.so.161+0x58c94)
    #8 osgUtil::RenderLeaf::render(osg::RenderInfo&, osgUtil::RenderLeaf*) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderLeaf.cpp (libosgUtil.so.161+0x204dd7)
    #9 osgUtil::RenderBin::drawImplementation(osg::RenderInfo&, osgUtil::RenderLeaf*&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderBin.cpp:467:13 (libosgUtil.so.161+0x1f98f6)
    #10 osgUtil::RenderBin::draw(osg::RenderInfo&, osgUtil::RenderLeaf*&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderBin.cpp:430:10 (libosgUtil.so.161+0x1f9648)
    #11 osgUtil::RenderBin::drawImplementation(osg::RenderInfo&, osgUtil::RenderLeaf*&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderBin.cpp:517:24 (libosgUtil.so.161+0x1f9a41)
    #12 osgUtil::RenderStage::drawImplementation(osg::RenderInfo&, osgUtil::RenderLeaf*&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderStage.cpp:1406:16 (libosgUtil.so.161+0x20e801)
    #13 osgUtil::RenderBin::draw(osg::RenderInfo&, osgUtil::RenderLeaf*&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderBin.cpp:430:10 (libosgUtil.so.161+0x1f9648)
    #14 osgUtil::RenderStage::drawInner(osg::RenderInfo&, osgUtil::RenderLeaf*&, bool&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderStage.cpp:931:16 (libosgUtil.so.161+0x20c745)
    #15 osgUtil::RenderStage::draw(osg::RenderInfo&, osgUtil::RenderLeaf*&) /home/elsid/dev/OpenSceneGraph/src/osgUtil/RenderStage.cpp:1242:9 (libosgUtil.so.161+0x20dd70)
    #16 osgUtil::SceneView::draw() /home/elsid/dev/OpenSceneGraph/src/osgUtil/SceneView.cpp:1427:23 (libosgUtil.so.161+0x21e9df)
    #17 osgViewer::Renderer::draw() /home/elsid/dev/OpenSceneGraph/src/osgViewer/Renderer.cpp:797:24 (libosgViewer.so.161+0xbaace)
    #18 osgViewer::Renderer::operator()(osg::GraphicsContext*) /home/elsid/dev/OpenSceneGraph/src/osgViewer/Renderer.cpp:952:9 (libosgViewer.so.161+0xbbdbd)
    #19 osg::GraphicsContext::runOperations() /home/elsid/dev/OpenSceneGraph/src/osg/GraphicsContext.cpp:696:36 (libosg.so.161+0x1f5f30)
    #20 osg::RunOperations::operator()(osg::GraphicsContext*) /home/elsid/dev/OpenSceneGraph/src/osg/GraphicsThread.cpp:139:14 (libosg.so.161+0x1fcc75)
    #21 osg::GraphicsOperation::operator()(osg::Object*) /home/elsid/dev/OpenSceneGraph/src/osg/GraphicsThread.cpp:53:18 (libosg.so.161+0x1fbe0e)
    #22 osg::OperationThread::run() /home/elsid/dev/OpenSceneGraph/src/osg/OperationThread.cpp:438:13 (libosg.so.161+0x2ecbcc)
    #23 osg::GraphicsThread::run() /home/elsid/dev/OpenSceneGraph/src/osg/GraphicsThread.cpp:38:22 (libosg.so.161+0x1fbd1f)
    #24 non-virtual thunk to osg::GraphicsThread::run() /home/elsid/dev/OpenSceneGraph/src/osg/GraphicsThread.cpp (libosg.so.161+0x1fbd9d)
    #25 OpenThreads::ThreadPrivateActions::StartThread(void*) /home/elsid/dev/OpenSceneGraph/src/OpenThreads/pthreads/PThread.cpp:221:17 (libOpenThreads.so.21+0x69e2)

  Mutex M103718082902454520 is already destroyed.

  Thread T1 (tid=93561, running) created by main thread at:
    #0 pthread_create <null> (openmw+0x56992e)
    #1 OpenThreads::Thread::start() /home/elsid/dev/OpenSceneGraph/src/OpenThreads/pthreads/PThread.cpp:698:14 (libOpenThreads.so.21+0x6383)
    #2 OpenThreads::Thread::startThread() /home/elsid/dev/OpenSceneGraph/src/OpenThreads/pthreads/PThread.cpp:721:26 (libOpenThreads.so.21+0x6459)
    #3 osgViewer::ViewerBase::startThreading() /home/elsid/dev/OpenSceneGraph/src/osgViewer/ViewerBase.cpp:598:38 (libosgViewer.so.161+0x113324)
    #4 osgViewer::ViewerBase::setUpThreading() /home/elsid/dev/OpenSceneGraph/src/osgViewer/ViewerBase.cpp:300:31 (libosgViewer.so.161+0x111a31)
    #5 osgViewer::Viewer::realize() /home/elsid/dev/OpenSceneGraph/src/osgViewer/Viewer.cpp:614:5 (libosgViewer.so.161+0x106389)
    #6 OMW::Engine::createWindow(Settings::Manager&) /home/elsid/dev/openmw/apps/openmw/engine.cpp:578:14 (openmw+0xbefafe)
    #7 OMW::Engine::prepareEngine(Settings::Manager&) /home/elsid/dev/openmw/apps/openmw/engine.cpp:612:5 (openmw+0xbf0dc6)
    #8 OMW::Engine::go() /home/elsid/dev/openmw/apps/openmw/engine.cpp:834:5 (openmw+0xbf3b94)
    #9 runApplication(int, char**) /home/elsid/dev/openmw/apps/openmw/main.cpp:259:17 (openmw+0xbdbdb6)
    #10 wrapApplication(int (*)(int, char**), int, char**, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/elsid/dev/openmw/components/debug/debugging.cpp:138:15 (openmw+0xdc880b)
    #11 main /home/elsid/dev/openmw/apps/openmw/main.cpp:271:12 (openmw+0xbdbeb7)
```