### PR TITLE
Do not use outdated references when moving objects to new cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     Bug #5369: Spawnpoint in the Grazelands doesn't produce oversized creatures
     Bug #5370: Opening an unlocked but trapped door uses the key
     Bug #5384: openmw-cs: deleting an instance requires reload of scene window to show in editor
+    Bug #5387: Move/MoveWorld don't update the object's cell properly
     Bug #5397: NPC greeting does not reset if you leave + reenter area
     Bug #5400: Editor: Verifier checks race of non-skin bodyparts
     Bug #5403: Enchantment effect doesn't show on an enemy during death animation

--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -237,6 +237,8 @@ namespace MWBase
 
             virtual void update (float duration) = 0;
 
+            virtual void updateConsoleObjectPtr(const MWWorld::Ptr& currentPtr, const MWWorld::Ptr& newPtr) = 0;
+
             /**
              * Fetches a GMST string from the store, if there is no setting with the given
              * ID or it is not a string the default string is returned.

--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -472,6 +472,12 @@ namespace MWGui
         setCoord(10,10, width-10, height/2);
     }
 
+    void Console::updateSelectedObjectPtr(const MWWorld::Ptr& currentPtr, const MWWorld::Ptr& newPtr)
+    {
+        if (mPtr == currentPtr)
+            mPtr = newPtr;
+    }
+
     void Console::setSelectedObject(const MWWorld::Ptr& object)
     {
         if (!object.isEmpty())

--- a/apps/openmw/mwgui/console.hpp
+++ b/apps/openmw/mwgui/console.hpp
@@ -58,6 +58,8 @@ namespace MWGui
 
             void executeFile (const std::string& path);
 
+            void updateSelectedObjectPtr(const MWWorld::Ptr& currentPtr, const MWWorld::Ptr& newPtr);
+
             void clear();
 
             virtual void resetReference ();

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -574,6 +574,11 @@ namespace MWGui
         }
     }
 
+    void WindowManager::updateConsoleObjectPtr(const MWWorld::Ptr& currentPtr, const MWWorld::Ptr& newPtr)
+    {
+        mConsole->updateSelectedObjectPtr(currentPtr, newPtr);
+    }
+
     void WindowManager::updateVisible()
     {
         bool loading = (getMode() == GM_Loading || getMode() == GM_LoadingWallpaper);

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -242,6 +242,8 @@ namespace MWGui
     virtual void unsetSelectedSpell();
     virtual void unsetSelectedWeapon();
 
+    virtual void updateConsoleObjectPtr(const MWWorld::Ptr& currentPtr, const MWWorld::Ptr& newPtr);
+
     virtual void showCrosshair(bool show);
     virtual bool getSubtitlesEnabled();
 

--- a/apps/openmw/mwscript/transformationextensions.cpp
+++ b/apps/openmw/mwscript/transformationextensions.cpp
@@ -725,7 +725,8 @@ namespace MWScript
                     // We should move actors, standing on moving object, too.
                     // This approach can be used to create elevators.
                     moveStandingActors(ptr, diff);
-                    MWBase::Environment::get().getWorld()->moveObject(ptr, worldPos.x(), worldPos.y(), worldPos.z());
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr,
+                        MWBase::Environment::get().getWorld()->moveObject(ptr, worldPos.x(), worldPos.y(), worldPos.z()));
                 }
         };
 
@@ -761,7 +762,8 @@ namespace MWScript
                     // We should move actors, standing on moving object, too.
                     // This approach can be used to create elevators.
                     moveStandingActors(ptr, diff);
-                    MWBase::Environment::get().getWorld()->moveObject(ptr, objPos[0]+diff.x(), objPos[1]+diff.y(), objPos[2]+diff.z());
+                    dynamic_cast<MWScript::InterpreterContext&>(runtime.getContext()).updatePtr(ptr,
+                        MWBase::Environment::get().getWorld()->moveObject(ptr, objPos[0]+diff.x(), objPos[1]+diff.y(), objPos[2]+diff.z()));
                 }
         };
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1201,6 +1201,8 @@ namespace MWWorld
                     }
                 }
             }
+
+            MWBase::Environment::get().getWindowManager()->updateConsoleObjectPtr(ptr, newPtr);
         }
         if (haveToMove && newPtr.getRefData().getBaseNode())
         {


### PR DESCRIPTION
Fixes [bug #5387](https://gitlab.com/OpenMW/openmw/-/issues/5387).
The main idea - once we move object to new cell, we should not use outdated references to it. We use them at least in two places now:
1. In the script context (target object for script commands)
2. In the console window itself (selected object)

So we should update these references.