### PR TITLE
Report OSG rendering stats to file

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -908,7 +908,14 @@ void OMW::Engine::go()
         if (stats)
         {
             const auto frameNumber = mViewer->getFrameStamp()->getFrameNumber();
-            mViewer->getViewerStats()->report(stats, frameNumber);
+            if (frameNumber >= 2)
+            {
+                mViewer->getViewerStats()->report(stats, frameNumber - 2);
+                osgViewer::Viewer::Cameras cameras;
+                mViewer->getCameras(cameras);
+                for (auto camera : cameras)
+                    camera->getStats()->report(stats, frameNumber - 2);
+            }
         }
 
         mEnvironment.limitFrameRate(frameTimer.time_s());


### PR DESCRIPTION
Use frameNumber - 2 to capture GPU and Draw time.

Example frame:
```
Stats Viewer FrameNumber 1165
    Event traversal begin time  4.36246
    Event traversal end time    4.36246
    Event traversal time taken  6e-06
    Frame duration      0.002014
    Frame rate  496.524
    Reference time      4.3617
    Rendering traversals begin time     4.3629
    Rendering traversals end time       4.36359
    Rendering traversals time taken     0.000684
    Update traversal begin time 4.36247
    Update traversal end time   4.36272
    Update traversal time taken 0.000251
    gui_time_begin      4.3624
    gui_time_end        4.36246
    gui_time_taken      5.8e-05
    input_time_begin    4.3617
    input_time_end      4.36172
    input_time_taken    1.8e-05
    mechanics_time_begin        4.36192
    mechanics_time_end  4.36233
    mechanics_time_taken        0.000408
    physics_time_begin  4.36233
    physics_time_end    4.36236
    physics_time_taken  3.2e-05
    script_time_begin   4.36173
    script_time_end     4.36192
    script_time_taken   0.000186
    sound_time_begin    4.36172
    sound_time_end      4.36173
    sound_time_taken    9e-06
    state_time_begin    4.36173
    state_time_end      4.36173
    state_time_taken    -0
    world_time_begin    4.36236
    world_time_end      4.3624
    world_time_taken    3.4e-05
Stats Camera FrameNumber 1165
    Cull traversal begin time   4.36292
    Cull traversal end time     4.36349
    Cull traversal time taken   0.00057
    Draw traversal begin time   4.36355
    Draw traversal end time     4.36482
    Draw traversal time taken   0.001273
    GPU draw begin time 4.3663
    GPU draw end time   4.36816
    GPU draw time taken 0.00185859
```