### PR TITLE
Refactor sound initialization

### DIFF
--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -11,85 +11,65 @@ namespace MWSound
     inline int operator&(int a, PlayMode b) { return a & static_cast<int>(b); }
     inline int operator&(PlayMode a, PlayMode b) { return static_cast<int>(a) & static_cast<int>(b); }
 
+    struct SoundParams
+    {
+        osg::Vec3f mPos;
+        float mVolume = 1;
+        float mBaseVolume = 1;
+        float mPitch = 1;
+        float mMinDistance = 1;
+        float mMaxDistance = 1000;
+        int mFlags = 0;
+        float mFadeOutTime = 0;
+    };
+
     class SoundBase {
         SoundBase& operator=(const SoundBase&) = delete;
         SoundBase(const SoundBase&) = delete;
         SoundBase(SoundBase&&) = delete;
 
-        osg::Vec3f mPos;
-        float mVolume; /* NOTE: Real volume = mVolume*mBaseVolume */
-        float mBaseVolume;
-        float mPitch;
-        float mMinDistance;
-        float mMaxDistance;
-        int mFlags;
-
-        float mFadeOutTime;
+        SoundParams mParams;
 
     protected:
-        Sound_Instance mHandle;
+        Sound_Instance mHandle = nullptr;
 
         friend class OpenAL_Output;
 
     public:
-        void setPosition(const osg::Vec3f &pos) { mPos = pos; }
-        void setVolume(float volume) { mVolume = volume; }
-        void setBaseVolume(float volume) { mBaseVolume = volume; }
-        void setFadeout(float duration) { mFadeOutTime = duration; }
+        void setPosition(const osg::Vec3f &pos) { mParams.mPos = pos; }
+        void setVolume(float volume) { mParams.mVolume = volume; }
+        void setBaseVolume(float volume) { mParams.mBaseVolume = volume; }
+        void setFadeout(float duration) { mParams.mFadeOutTime = duration; }
         void updateFade(float duration)
         {
-            if(mFadeOutTime > 0.0f)
+            if (mParams.mFadeOutTime > 0.0f)
             {
-                float soundDuration = std::min(duration, mFadeOutTime);
-                mVolume *= (mFadeOutTime-soundDuration) / mFadeOutTime;
-                mFadeOutTime -= soundDuration;
+                float soundDuration = std::min(duration, mParams.mFadeOutTime);
+                mParams.mVolume *= (mParams.mFadeOutTime - soundDuration) / mParams.mFadeOutTime;
+                mParams.mFadeOutTime -= soundDuration;
             }
         }
 
-        const osg::Vec3f &getPosition() const { return mPos; }
-        float getRealVolume() const { return mVolume * mBaseVolume; }
-        float getPitch() const { return mPitch; }
-        float getMinDistance() const { return mMinDistance; }
-        float getMaxDistance() const { return mMaxDistance; }
+        const osg::Vec3f &getPosition() const { return mParams.mPos; }
+        float getRealVolume() const { return mParams.mVolume * mParams.mBaseVolume; }
+        float getPitch() const { return mParams.mPitch; }
+        float getMinDistance() const { return mParams.mMinDistance; }
+        float getMaxDistance() const { return mParams.mMaxDistance; }
 
         MWSound::Type getPlayType() const
-        { return static_cast<MWSound::Type>(mFlags&MWSound::Type::Mask); }
-        bool getUseEnv() const { return !(mFlags&MWSound::PlayMode::NoEnv); }
-        bool getIsLooping() const { return mFlags&MWSound::PlayMode::Loop; }
-        bool getDistanceCull() const { return mFlags&MWSound::PlayMode::RemoveAtDistance; }
-        bool getIs3D() const { return mFlags&Play_3D; }
+        { return static_cast<MWSound::Type>(mParams.mFlags & MWSound::Type::Mask); }
+        bool getUseEnv() const { return !(mParams.mFlags & MWSound::PlayMode::NoEnv); }
+        bool getIsLooping() const { return mParams.mFlags & MWSound::PlayMode::Loop; }
+        bool getDistanceCull() const { return mParams.mFlags & MWSound::PlayMode::RemoveAtDistance; }
+        bool getIs3D() const { return mParams.mFlags & Play_3D; }
 
-        void init(const osg::Vec3f& pos, float vol, float basevol, float pitch, float mindist, float maxdist, int flags)
+        void init(const SoundParams& params)
         {
-            mPos = pos;
-            mVolume = vol;
-            mBaseVolume = basevol;
-            mPitch = pitch;
-            mMinDistance = mindist;
-            mMaxDistance = maxdist;
-            mFlags = flags;
-            mFadeOutTime = 0.0f;
+            mParams = params;
             mHandle = nullptr;
         }
 
-        void init(float vol, float basevol, float pitch, int flags)
-        {
-            mPos = osg::Vec3f(0.0f, 0.0f, 0.0f);
-            mVolume = vol;
-            mBaseVolume = basevol;
-            mPitch = pitch;
-            mMinDistance = 1.0f;
-            mMaxDistance = 1000.0f;
-            mFlags = flags;
-            mFadeOutTime = 0.0f;
-            mHandle = nullptr;
-        }
-
-        SoundBase()
-          : mPos(0.0f, 0.0f, 0.0f), mVolume(1.0f), mBaseVolume(1.0f), mPitch(1.0f)
-          , mMinDistance(1.0f), mMaxDistance(1000.0f), mFlags(0), mFadeOutTime(0.0f)
-          , mHandle(nullptr)
-        { }
+        SoundBase() = default;
     };
 
     class Sound : public SoundBase {

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -290,13 +290,25 @@ namespace MWSound
         StreamPtr sound = getStreamRef();
         if(playlocal)
         {
-            sound->init(1.0f, basevol, 1.0f, PlayMode::NoEnv|Type::Voice|Play_2D);
+            sound->init([&] {
+                SoundParams params;
+                params.mBaseVolume = basevol;
+                params.mFlags = PlayMode::NoEnv | Type::Voice | Play_2D;
+                return params;
+            } ());
             played = mOutput->streamSound(decoder, sound.get(), true);
         }
         else
         {
-            sound->init(pos, 1.0f, basevol, 1.0f, minDistance, maxDistance,
-                        PlayMode::Normal|Type::Voice|Play_3D);
+            sound->init([&] {
+                SoundParams params;
+                params.mPos = pos;
+                params.mBaseVolume = basevol;
+                params.mMinDistance = minDistance;
+                params.mMaxDistance = maxDistance;
+                params.mFlags = PlayMode::Normal | Type::Voice | Play_3D;
+                return params;
+            } ());
             played = mOutput->streamSound3D(decoder, sound.get(), true);
         }
         if(!played)
@@ -332,8 +344,12 @@ namespace MWSound
         decoder->open(filename);
 
         mMusic = getStreamRef();
-        mMusic->init(1.0f, volumeFromType(Type::Music), 1.0f,
-                     PlayMode::NoEnv|Type::Music|Play_2D);
+        mMusic->init([&] {
+            SoundParams params;
+            params.mBaseVolume = volumeFromType(Type::Music);
+            params.mFlags = PlayMode::NoEnv | Type::Music | Play_2D;
+            return params;
+        } ());
         mOutput->streamSound(decoder, mMusic.get());
     }
 
@@ -561,7 +577,12 @@ namespace MWSound
             return nullptr;
 
         StreamPtr track = getStreamRef();
-        track->init(1.0f, volumeFromType(type), 1.0f, PlayMode::NoEnv|type|Play_2D);
+        track->init([&] {
+            SoundParams params;
+            params.mBaseVolume = volumeFromType(type);
+            params.mFlags = PlayMode::NoEnv | type | Play_2D;
+            return params;
+        } ());
         if(!mOutput->streamSound(decoder, track.get()))
             return nullptr;
 
@@ -598,7 +619,14 @@ namespace MWSound
         stopSound(sfx, MWWorld::ConstPtr());
 
         SoundPtr sound = getSoundRef();
-        sound->init(volume * sfx->mVolume, volumeFromType(type), pitch, mode|type|Play_2D);
+        sound->init([&] {
+            SoundParams params;
+            params.mVolume = volume * sfx->mVolume;
+            params.mBaseVolume = volumeFromType(type);
+            params.mPitch = pitch;
+            params.mFlags = mode | type | Play_2D;
+            return params;
+        } ());
         if(!mOutput->playSound(sound.get(), sfx->mHandle, offset))
             return nullptr;
 
@@ -635,13 +663,29 @@ namespace MWSound
         SoundPtr sound = getSoundRef();
         if(!(mode&PlayMode::NoPlayerLocal) && ptr == MWMechanics::getPlayer())
         {
-            sound->init(volume * sfx->mVolume, volumeFromType(type), pitch, mode|type|Play_2D);
+            sound->init([&] {
+                SoundParams params;
+                params.mVolume = volume * sfx->mVolume;
+                params.mBaseVolume = volumeFromType(type);
+                params.mPitch = pitch;
+                params.mFlags = mode | type | Play_2D;
+                return params;
+            } ());
             played = mOutput->playSound(sound.get(), sfx->mHandle, offset);
         }
         else
         {
-            sound->init(objpos, volume * sfx->mVolume, volumeFromType(type), pitch,
-                        sfx->mMinDist, sfx->mMaxDist, mode|type|Play_3D);
+            sound->init([&] {
+                SoundParams params;
+                params.mPos = objpos;
+                params.mVolume = volume * sfx->mVolume;
+                params.mBaseVolume = volumeFromType(type);
+                params.mPitch = pitch;
+                params.mMinDistance = sfx->mMinDist;
+                params.mMaxDistance = sfx->mMaxDist;
+                params.mFlags = mode | type | Play_3D;
+                return params;
+            } ());
             played = mOutput->playSound3D(sound.get(), sfx->mHandle, offset);
         }
         if(!played)
@@ -670,8 +714,17 @@ namespace MWSound
         if(!sfx) return nullptr;
 
         SoundPtr sound = getSoundRef();
-        sound->init(initialPos, volume * sfx->mVolume, volumeFromType(type), pitch,
-                    sfx->mMinDist, sfx->mMaxDist, mode|type|Play_3D);
+        sound->init([&] {
+            SoundParams params;
+            params.mPos = initialPos;
+            params.mVolume = volume * sfx->mVolume;
+            params.mBaseVolume = volumeFromType(type);
+            params.mPitch = pitch;
+            params.mMinDistance = sfx->mMinDist;
+            params.mMaxDistance = sfx->mMaxDist;
+            params.mFlags = mode | type | Play_3D;
+            return params;
+        } ());
         if(!mOutput->playSound3D(sound.get(), sfx->mHandle, offset))
             return nullptr;
 


### PR DESCRIPTION
1. `init` calls is not so good to read when there is 3-5 float parameters.
2. Default values are defined in a single place.
3. Split volume factor and SFX volume to make it possible to change one of them that is used by https://github.com/OpenMW/openmw/pull/2928.