### PR TITLE
Adjust actor rotation when flee by axis x (bug #5531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
     Bug #5499: Faction advance is available when requirements not met
     Bug #5502: Dead zone for analogue stick movement is too small
     Bug #5507: Sound volume is not clamped on ingame settings update
+    Bug #5531: Actors flee using current rotation by axis x
     Feature #390: 3rd person look "over the shoulder"
     Feature #2386: Distant Statics in the form of Object Paging
     Feature #5297: Add a search function to the "Datafiles" tab of the OpenMW launcher

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -344,6 +344,7 @@ namespace MWMechanics
                     {
                         storage.mFleeBlindRunTimer += duration;
 
+                        storage.mMovement.mRotation[0] = -actor.getRefData().getPosition().rot[0];
                         storage.mMovement.mRotation[2] = osg::PI + getZAngleToDir(target.getRefData().getPosition().asVec3()-actor.getRefData().getPosition().asVec3());
                         storage.mMovement.mPosition[1] = 1;
                         updateActorsMovement(actor, duration, storage);


### PR DESCRIPTION
https://gitlab.com/OpenMW/openmw/-/issues/5531

Otherwise Cliff Racers can go underwater.