### PR TITLE
Resume failed scripts execution after game reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
     Feature #5445: Handle NiLines
     Feature #5457: Realistic diagonal movement
     Feature #5486: Fixes trainers to choose their training skills based on their base skill points
+    Feature #5524: Resume failed script execution after reload
     Task #5480: Drop Qt4 support
 
 0.46.0

--- a/apps/openmw/mwbase/scriptmanager.hpp
+++ b/apps/openmw/mwbase/scriptmanager.hpp
@@ -35,6 +35,8 @@ namespace MWBase
 
             virtual ~ScriptManager() {}
 
+            virtual void clear() = 0;
+
             virtual bool run (const std::string& name, Interpreter::Context& interpreterContext) = 0;
             ///< Run the script with the given name (compile first, if not compiled yet)
 

--- a/apps/openmw/mwscript/scriptmanagerimp.hpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.hpp
@@ -41,7 +41,20 @@ namespace MWScript
             Interpreter::Interpreter mInterpreter;
             bool mOpcodesInstalled;
 
-            typedef std::pair<std::vector<Interpreter::Type_Code>, Compiler::Locals> CompiledScript;
+            struct CompiledScript
+            {
+                std::vector<Interpreter::Type_Code> mByteCode;
+                Compiler::Locals mLocals;
+                bool mActive;
+
+                CompiledScript(const std::vector<Interpreter::Type_Code>& code, const Compiler::Locals& locals)
+                {
+                    mByteCode = code;
+                    mLocals = locals;
+                    mActive = true;
+                }
+            };
+
             typedef std::map<std::string, CompiledScript> ScriptCollection;
 
             ScriptCollection mScripts;
@@ -54,6 +67,8 @@ namespace MWScript
             ScriptManager (const MWWorld::ESMStore& store,
                 Compiler::Context& compilerContext, int warningsMode,
                 const std::vector<std::string>& scriptBlacklist);
+
+            virtual void clear();
 
             virtual bool run (const std::string& name, Interpreter::Context& interpreterContext);
             ///< Run the script with the given name (compile first, if not compiled yet)

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -47,7 +47,7 @@ void MWState::StateManager::cleanup (bool force)
         MWBase::Environment::get().getSoundManager()->clear();
         MWBase::Environment::get().getDialogueManager()->clear();
         MWBase::Environment::get().getJournal()->clear();
-        MWBase::Environment::get().getScriptManager()->getGlobalScripts().clear();
+        MWBase::Environment::get().getScriptManager()->clear();
         MWBase::Environment::get().getWorld()->clear();
         MWBase::Environment::get().getWindowManager()->clear();
         MWBase::Environment::get().getInputManager()->clear();


### PR DESCRIPTION
Implements [feature #5524](https://gitlab.com/OpenMW/openmw/-/issues/5524).

Use a simple approach so far - once script execution fails during runtime, do not remove its bytecode, mark it as inactive instead.
When try to run a script, early-out when it is marked as inactive.
This flag is cleaned up during scripting system cleanup, during new game start or savegame loading.

Later it should be possible to per-instance blocks, but it is unclear how exactly it should work.

Note that I do not see the code, which removes data from `mScripts` map, so I assume that data persists for the whole game session.