### PR TITLE
Fix pickpocketing sneaking stance check

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -904,7 +904,7 @@ namespace MWClass
         }
         else if (!stats.getAiSequence().isInCombat())
         {
-            if(getCreatureStats(actor).getStance(MWMechanics::CreatureStats::Stance_Sneak) || stats.getKnockedDown())
+            if (stats.getKnockedDown() || MWBase::Environment::get().getMechanicsManager()->isSneaking(actor))
                 return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
 
             // Can't talk to werewolves


### PR DESCRIPTION
I feel like I wanted to do this a long time ago. Guess I forgot.

Sneaking and running stance can be active during flying when the player isn't actually sneaking. One of the cases of invalid sneaking checks that has still not been covered in 0.46.0 (hopefully the last one). This should prevent the player from accidentally committing crimes like this. An issue referenced [here](https://gitlab.com/OpenMW/openmw/-/issues/4618#note_385526950).