### PR TITLE
Add option to always allow stealing from KO'd actors (feature #5545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
     Feature #5519: Code Patch tab in launcher
     Feature #5524: Resume failed script execution after reload
     Feature #5525: Search fields tweaks (utf-8)
+    Feature #5545: Option to allow stealing from an unconscious NPC during combat
     Task #5480: Drop Qt4 support
     Task #5520: Improve cell name autocompleter implementation
 

--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -122,6 +122,7 @@ bool Launcher::AdvancedPage::loadSettings()
         int unarmedFactorsStrengthIndex = mEngineSettings.getInt("strength influences hand to hand", "Game");
         if (unarmedFactorsStrengthIndex >= 0 && unarmedFactorsStrengthIndex <= 2)
             unarmedFactorsStrengthComboBox->setCurrentIndex(unarmedFactorsStrengthIndex);
+        loadSettingBool(stealingFromKnockedOutCheckBox, "always allow stealing from knocked out actors", "Game");
     }
 
     // Visuals
@@ -215,6 +216,7 @@ void Launcher::AdvancedPage::saveSettings()
         int unarmedFactorsStrengthIndex = unarmedFactorsStrengthComboBox->currentIndex();
         if (unarmedFactorsStrengthIndex != mEngineSettings.getInt("strength influences hand to hand", "Game"))
             mEngineSettings.setInt("strength influences hand to hand", "Game", unarmedFactorsStrengthIndex);
+        saveSettingBool(stealingFromKnockedOutCheckBox, "always allow stealing from knocked out actors", "Game");
     }
 
     // Visuals

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -911,6 +911,12 @@ namespace MWClass
             if (!getNpcStats(ptr).isWerewolf())
                 return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionTalk(ptr));
         }
+        else // In combat
+        {
+            const bool stealingInCombat = Settings::Manager::getBool ("always allow stealing from knocked out actors", "Game");
+            if (stealingInCombat && stats.getKnockedDown())
+                return std::shared_ptr<MWWorld::Action>(new MWWorld::ActionOpen(ptr)); // stealing
+        }
 
         // Tribunal and some mod companions oddly enough must use open action as fallback
         if (!getScript(ptr).empty() && ptr.getRefData().getLocals().getIntVar(getScript(ptr), "companion"))
@@ -1062,7 +1068,14 @@ namespace MWClass
         if (customData.mNpcStats.isDead() && customData.mNpcStats.isDeathAnimationFinished())
             return true;
 
-        return !customData.mNpcStats.getAiSequence().isInCombat();
+        if (!customData.mNpcStats.getAiSequence().isInCombat())
+            return true;
+
+        const bool stealingInCombat = Settings::Manager::getBool ("always allow stealing from knocked out actors", "Game");
+        if (stealingInCombat && customData.mNpcStats.getKnockedDown())
+            return true;
+
+        return false;
     }
 
     MWGui::ToolTipInfo Npc::getToolTipInfo (const MWWorld::ConstPtr& ptr, int count) const

--- a/docs/source/reference/modding/settings/game.rst
+++ b/docs/source/reference/modding/settings/game.rst
@@ -356,3 +356,17 @@ If disabled then the 3 best skills of trainers and the training limits take into
 If enabled then the 3 best skills of trainers and the training limits are based on the trainer base skills.
 
 This setting can be controlled in Advanced tab of the launcher.
+
+always allow stealing from knocked out actors
+---------------------------------------------
+
+:Type:		boolean
+:Range:		True/False
+:Default:	False
+
+By Bethesda's design, in the latest released version of Morrowind pickpocketing is impossible during combat,
+even if the fighting NPC is knocked out.
+
+This setting allows the player to steal items from fighting NPCs that were knocked out if enabled.
+
+This setting can be controlled in Advanced tab of the launcher.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -331,6 +331,9 @@ swim upward coef = 0.0
 # Make the training skills proposed by a trainer based on its base attribute instead of its modified ones
 trainers training skills based on base skill = false
 
+# Make stealing items from NPCs that were knocked down possible during combat.
+always allow stealing from knocked out actors = false
+
 [General]
 
 # Anisotropy reduces distortion in textures at low angles (e.g. 0 to 16).

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -155,6 +155,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="stealingFromKnockedOutCheckBox">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make stealing items from NPCs that were knocked down possible during combat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Always allow stealing from knocked out actors</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
[Feature request](https://gitlab.com/OpenMW/openmw/-/issues/5545)

It's now possible to activate the affected NPCs and steal their stuff if the setting is enabled.