### PR TITLE
Make a horrible simple water hack less horrible

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -372,6 +372,7 @@ namespace MWRender
 
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("near", mNearClip));
         mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("far", mViewDistance));
+        mRootNode->getOrCreateStateSet()->addUniform(new osg::Uniform("simpleWater", false));
 
         mUniformNear = mRootNode->getOrCreateStateSet()->getUniform("near");
         mUniformFar = mRootNode->getOrCreateStateSet()->getUniform("far");


### PR DESCRIPTION
Adding a uniform to simple water stateset isn't enough to make sure the shader gets the correct uniform...

This still isn't a proper solution for the core issue but at least not every object rendered with shaders will be handled as simple water (the difference is slight but may affect performance).