### PR TITLE
Don't encapsulate NIF transformation changes

### DIFF
--- a/components/nifosg/matrixtransform.cpp
+++ b/components/nifosg/matrixtransform.cpp
@@ -20,37 +20,4 @@ namespace NifOsg
         , mRotationScale(copy.mRotationScale)
     {
     }
-
-    void MatrixTransform::applyCurrentRotation()
-    {
-        for (int i = 0; i < 3; ++i)
-            for (int j = 0; j < 3; ++j)
-                _matrix(j,i) = mRotationScale.mValues[i][j]; // NB column/row major difference
-    }
-
-    void MatrixTransform::applyCurrentScale()
-    {
-        for (int i = 0; i < 3; ++i)
-            for (int j = 0; j < 3; ++j)
-                _matrix(i,j) *= mScale;
-    }
-
-    void MatrixTransform::updateRotation(const osg::Quat& rotation)
-    {
-        _matrix.setRotate(rotation);
-        for (int i = 0; i < 3; ++i)
-            for (int j = 0; j < 3; ++j)
-                mRotationScale.mValues[i][j] = _matrix(j,i); // NB column/row major difference
-    }
-
-    void MatrixTransform::updateScale(const float scale)
-    {
-        mScale = scale;
-        applyCurrentScale();
-    }
-
-    void MatrixTransform::setTranslation(const osg::Vec3f& translation)
-    {
-        _matrix.setTrans(translation);
-    }
 }

--- a/components/nifosg/matrixtransform.hpp
+++ b/components/nifosg/matrixtransform.hpp
@@ -17,19 +17,6 @@ namespace NifOsg
 
         META_Node(NifOsg, MatrixTransform)
 
-        // Apply the current NIF rotation or scale to OSG matrix.
-        void applyCurrentRotation();
-        void applyCurrentScale();
-
-        // Apply the given rotation to OSG matrix directly and update NIF rotation matrix.
-        void updateRotation(const osg::Quat& rotation);
-        // Update current NIF scale and apply it to OSG matrix.
-        void updateScale(const float scale);
-
-        // Apply the given translation to OSG matrix.
-        void setTranslation(const osg::Vec3f& translation);
-
-    private:
         // Hack: account for Transform differences between OSG and NIFs.
         // OSG uses a 4x4 matrix, NIF's use a 3x3 rotationScale, float scale, and vec3 position.
         // Decomposing the original components from the 4x4 matrix isn't possible, which causes


### PR DESCRIPTION
Although the idea is fundamentally good, in akortunov's and Abdu's testing the way I tried to implement it seems to be subtly broken and causes odd rendering issues. I managed to reproduce one myself.

I'm reverting [the commit](https://github.com/OpenMW/openmw/commit/f93655e803d1b611f53477872f41a37eac5a8679) for now as currently NIF transformations are handled in one place (KeyframeController implementation) and it'll stay that way for a while.