### PR TITLE
Avoid optimizing animated shapes once again (regression #5565)

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -625,8 +625,8 @@ namespace NifOsg
             bool isAnimated = false;
             handleNodeControllers(nifNode, node, animflags, isAnimated);
             hasAnimatedParents |= isAnimated;
-            // Make sure empty nodes are not optimized away so the physics system can find them.
-            if (isAnimated || (hasAnimatedParents && (skipMeshes || hasMarkers)))
+            // Make sure empty nodes and animated shapes are not optimized away so the physics system can find them.
+            if (isAnimated || (hasAnimatedParents && ((skipMeshes || hasMarkers) || isGeometry)))
                 node->setDataVariance(osg::Object::DYNAMIC);
 
             // LOD and Switch nodes must be wrapped by a transform (the current node) to support transformations properly


### PR DESCRIPTION
Should fix [this](https://gitlab.com/OpenMW/openmw/-/issues/5565).

We did this in 0.46.0. I guess we still have to do this to make sure mods don't break.