### PR TITLE
Fix AppVeyor warnings

### DIFF
--- a/apps/openmw/mwmechanics/aiavoiddoor.cpp
+++ b/apps/openmw/mwmechanics/aiavoiddoor.cpp
@@ -60,14 +60,14 @@ bool MWMechanics::AiAvoidDoor::execute (const MWWorld::Ptr& actor, CharacterCont
     // Make all nearby actors also avoid the door
     std::vector<MWWorld::Ptr> actors;
     MWBase::Environment::get().getMechanicsManager()->getActorsInRange(pos.asVec3(),100,actors);
-    for(auto& actor : actors)
+    for(auto& neighbor : actors)
     {
-        if (actor == getPlayer())
+        if (neighbor == getPlayer())
             continue;
 
-        MWMechanics::AiSequence& seq = actor.getClass().getCreatureStats(actor).getAiSequence();
+        MWMechanics::AiSequence& seq = neighbor.getClass().getCreatureStats(neighbor).getAiSequence();
         if (seq.getTypeId() != MWMechanics::AiPackageTypeId::AvoidDoor)
-            seq.stack(MWMechanics::AiAvoidDoor(mDoorPtr), actor);
+            seq.stack(MWMechanics::AiAvoidDoor(mDoorPtr), neighbor);
     }
 
     return false;

--- a/apps/openmw/mwscript/miscextensions.cpp
+++ b/apps/openmw/mwscript/miscextensions.cpp
@@ -563,9 +563,9 @@ namespace MWScript
                         effects += store.getMagicEffects();
                     }
 
-                    for (const auto& effect : effects)
+                    for (const auto& activeEffect : effects)
                     {
-                        if (effect.first.mId == key && effect.second.getModifier() > 0)
+                        if (activeEffect.first.mId == key && activeEffect.second.getModifier() > 0)
                         {
                             runtime.push(1);
                             return;

--- a/apps/openmw/mwscript/scriptmanagerimp.cpp
+++ b/apps/openmw/mwscript/scriptmanagerimp.cpp
@@ -149,8 +149,6 @@ namespace MWScript
         int count = 0;
         int success = 0;
 
-        const MWWorld::Store<ESM::Script>& scripts = mStore.get<ESM::Script>();
-
         for (auto& script : mStore.get<ESM::Script>())
         {
             if (!std::binary_search (mScriptBlacklist.begin(), mScriptBlacklist.end(),

--- a/components/sdlutil/sdlvideowrapper.cpp
+++ b/components/sdlutil/sdlvideowrapper.cpp
@@ -102,7 +102,6 @@ namespace SDLUtil
         int w = 0;
         int h = 0;
         auto index = SDL_GetWindowDisplayIndex(mWindow);
-        bool reposition = false;
         SDL_GetDisplayBounds(index, &rect);
         SDL_GetWindowSize(mWindow, &w, &h);
 


### PR DESCRIPTION
Should fix 4 recent openmw-side MSVC warnings.
```
'scripts': local variable is initialized but not referenced
apps\openmw\mwscript\scriptmanagerimp.cpp (line 152, column 44)
```
```
declaration of 'actor' hides function parameter
apps\openmw\mwmechanics\aiavoiddoor.cpp (line 63, column 29)
```
```
'reposition': local variable is initialized but not referenced
components\sdlutil\sdlvideowrapper.cpp (line 105, column 14)
```
```
declaration of 'effect' hides previous local declaration
apps\openmw\mwscript\miscextensions.cpp (line 566, column 1)
```