### PR TITLE
Add quadratic interpolation for scalars and vectors (part of #2379)

### DIFF
--- a/components/nif/nifkey.hpp
+++ b/components/nif/nifkey.hpp
@@ -26,11 +26,11 @@ enum InterpolationType
 template<typename T>
 struct KeyT {
     T mValue;
+    T mInTan; // Only for Quadratic interpolation, and never for QuaternionKeyList
+    T mOutTan; // Only for Quadratic interpolation, and never for QuaternionKeyList
 
-    // FIXME: Implement Quadratic and TBC interpolation
+    // FIXME: Implement TBC interpolation
     /*
-    T mForwardValue;  // Only for Quadratic interpolation, and never for QuaternionKeyList
-    T mBackwardValue; // Only for Quadratic interpolation, and never for QuaternionKeyList
     float mTension;    // Only for TBC interpolation
     float mBias;       // Only for TBC interpolation
     float mContinuity; // Only for TBC interpolation
@@ -136,8 +136,8 @@ private:
     static void readQuadratic(NIFStream &nif, KeyT<U> &key)
     {
         readValue(nif, key);
-        /*key.mForwardValue = */(nif.*getValue)();
-        /*key.mBackwardValue = */(nif.*getValue)();
+        key.mInTan = (nif.*getValue)();
+        key.mOutTan = (nif.*getValue)();
     }
 
     static void readQuadratic(NIFStream &nif, KeyT<osg::Quat> &key)

--- a/components/nifosg/controller.cpp
+++ b/components/nifosg/controller.cpp
@@ -197,7 +197,6 @@ void GeomMorpherController::update(osg::NodeVisitor *nv, osg::Drawable *drawable
             float val = 0;
             if (!(*it).empty())
                 val = it->interpKey(input);
-            val = std::max(0.f, std::min(1.f, val));
 
             SceneUtil::MorphGeometry::MorphTarget& target = morphGeom->getMorphTarget(i);
             if (target.getWeight() != val)

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -110,6 +110,24 @@ namespace NifOsg
             {
                 case Nif::InterpolationType_Constant:
                     return fraction > 0.5f ? b.mValue : a.mValue;
+                case Nif::InterpolationType_Quadratic:
+                {
+                    // Using a cubic Hermite spline.
+                    // b1(t) = 2t^3  - 3t^2 + 1
+                    // b2(t) = -2t^3 + 3t^2
+                    // b3(t) = t^3 - 2t^2 + t
+                    // b4(t) = t^3 - t^2
+                    // f(t) = a.mValue * b1(t) + b.mValue * b2(t) + a.mOutTan * b3(t) + b.mInTan * b4(t)
+                    const float t = fraction;
+                    const float t2 = t * t;
+                    const float t3 = t2 * t;
+                    const float b1 = 2.f * t3 - 3.f * t2 + 1;
+                    const float b2 = -2.f * t3 + 3.f * t2;
+                    const float b3 = t3 - 2.f * t2 + t;
+                    const float b4 = t3 - t2;
+                    return a.mValue * b1 + b.mValue * b2 + a.mOutTan * b3 + b.mInTan * b4;
+                }
+                // TODO: Implement TBC interpolation
                 default:
                     return a.mValue + ((b.mValue - a.mValue) * fraction);
             }
@@ -120,6 +138,7 @@ namespace NifOsg
             {
                 case Nif::InterpolationType_Constant:
                     return fraction > 0.5f ? b.mValue : a.mValue;
+                // TODO: Implement Quadratic and TBC interpolation
                 default:
                 {
                     osg::Quat result;


### PR DESCRIPTION
Guess there isn't a lot of meaning to holding on to this part of the issue. Here are 2 test meshes courtesy of Greatness7 so the behavior can be compared between vanilla and openmw. I don't know what should be done about lip animation, I would guess morrowind's loudness calculation isn't as clever as openmw's.

[interpolation test meshes.zip](https://github.com/OpenMW/openmw/files/5040171/interpolation.test.meshes.zip)

Quaternion quadratic interpolation is technically possible and doesn't rely on curve tangents, but my math skills are lacking. It's supposedly not possible to export a mesh that uses quadratic quaternion interpolation using the conventional modelling tools if I remember correctly.

Morrowind does in fact appear to use cubic Hermite spline and NifSkope is correct, although NifSkope's actual rendering does not reflect it. However, Morrowind also doesn't seem to correct morph geometry weight values that don't fit into [0;1] range, which openmw did and which misled me and akortunov when akortunov experimented with cubic Hermite spline (you can see it on the netch mesh).

[Here's](https://www.cubic.org/docs/hermite.htm) some info on Hermite splines and also TCB/TBC splines which should be useful for future developments on the issue.