### PR TITLE
AIPursue: don't do a LOS check

### DIFF
--- a/apps/openmw/mwmechanics/aipursue.cpp
+++ b/apps/openmw/mwmechanics/aipursue.cpp
@@ -39,8 +39,7 @@ bool AiPursue::execute (const MWWorld::Ptr& actor, CharacterController& characte
     if (target == MWWorld::Ptr() || !target.getRefData().getCount() || !target.getRefData().isEnabled())
         return true;
 
-    if (!MWBase::Environment::get().getWorld()->getLOS(target, actor)
-     || !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(target, actor))
+    if (isTargetMagicallyHidden(target) && !MWBase::Environment::get().getMechanicsManager()->awarenessCheck(target, actor))
         return false;
 
     if (target.getClass().getCreatureStats(target).isDead())


### PR DESCRIPTION
Properly resolve [4774](https://gitlab.com/OpenMW/openmw/-/issues/4774) and fix [5575](https://gitlab.com/OpenMW/openmw/-/issues/5575).

My assumption that there should always be a LOS check before an awareness check wasn't right. I retested Morrowind and found out that if a guard is pursuing you and:
1) you are sneaking — the guard should follow you fine even if you're "hidden".
2) you have a potent chameleon effect — the guard will have some trouble finding you
3) you are both sneaking (and have a very high skill at it) and have a potent chameleon effect — the guard will virtually never find you.

Which is consistent with the check introduced in #2351 for combat. So here we go making hidden checks consistent again.