### PR TITLE
Make Advanced tab of the launcher look okay for everyone again

### DIFF
--- a/apps/launcher/advancedpage.cpp
+++ b/apps/launcher/advancedpage.cpp
@@ -10,37 +10,6 @@
 
 #include <cmath>
 
-
-class HorizontalTextWestTabStyle : public QProxyStyle
-{
-public:
-    QSize sizeFromContents(ContentsType type, const QStyleOption* option, const QSize& size, const QWidget* widget) const
-    {
-        QSize s = QProxyStyle::sizeFromContents(type, option, size, widget);
-        if (type == QStyle::CT_TabBarTab)
-        {
-            s.transpose();
-            s.setHeight(s.height() + 20);
-        }
-        return s;
-    }
-
-    void drawControl(ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const
-    {
-        if (element == CE_TabBarTabLabel)
-        {
-            if (const QStyleOptionTab* tab = qstyleoption_cast<const QStyleOptionTab*>(option))
-            {
-                QStyleOptionTab opt(*tab);
-                opt.shape = QTabBar::RoundedNorth;
-                QProxyStyle::drawControl(element, &opt, painter, widget);
-                return;
-            }
-        }
-        QProxyStyle::drawControl(element, option, painter, widget);
-    }
-};
-
 Launcher::AdvancedPage::AdvancedPage(Files::ConfigurationManager &cfg,
                                      Config::GameSettings &gameSettings,
                                      Settings::Manager &engineSettings, QWidget *parent)
@@ -53,7 +22,6 @@ Launcher::AdvancedPage::AdvancedPage(Files::ConfigurationManager &cfg,
     setupUi(this);
 
     loadSettings();
-    AdvancedTabWidget->tabBar()->setStyle(new HorizontalTextWestTabStyle);
     mCellNameCompleter.setModel(&mCellNameCompleterModel);
     startDefaultCharacterAtField->setCompleter(&mCellNameCompleter);
 }

--- a/files/ui/advancedpage.ui
+++ b/files/ui/advancedpage.ui
@@ -5,15 +5,12 @@
   <layout class="QVBoxLayout" name="pageVerticalLayout">
    <item>
     <widget class="QTabWidget" name="AdvancedTabWidget">
-     <property name="tabPosition">
-      <enum>QTabWidget::West</enum>
-     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
      <widget class="QWidget" name="GameMechanics">
       <attribute name="title">
-       <string>Game mechanics</string>
+       <string>Game Mechanics</string>
       </attribute>
       <layout class="QVBoxLayout">
        <item>
@@ -509,9 +506,9 @@ True: In non-combat mode camera is positioned behind the character's shoulder. C
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="InterfaceChanges">
+     <widget class="QWidget" name="Interface">
       <attribute name="title">
-       <string>Interface changes</string>
+       <string>Interface</string>
       </attribute>
       <layout class="QVBoxLayout">
        <item>
@@ -618,7 +615,7 @@ True: In non-combat mode camera is positioned behind the character's shoulder. C
      </widget>
      <widget class="QWidget" name="BugFixes">
       <attribute name="title">
-       <string>Bug fixes</string>
+       <string>Bug Fixes</string>
       </attribute>
       <layout class="QVBoxLayout">
        <item>


### PR DESCRIPTION
Workaround for the broken look of vertical tabs on some setups proposed [here](https://gitlab.com/OpenMW/openmw/-/issues/5567#note_392876462), seems that the current workaround doesn't work as intended. Horizontal tabs Qt does properly support look good enough IMO even though they're not reminiscent of MCP's patcher UI. At least Graphics tab and Advanced tab would look consistent.
![изображение](https://user-images.githubusercontent.com/21265616/89737901-647e7e00-da7d-11ea-857e-1b12aef646eb.png)
Some tabs were renamed.