### PR TITLE
[Regression] Fix crash for ShowSceneGraph

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3633,8 +3633,11 @@ namespace MWWorld
     std::string World::exportSceneGraph(const Ptr &ptr)
     {
         std::string file = mUserDataPath + "/openmw.osgt";
-        mRendering->pagingBlacklistObject(mStore.find(ptr.getCellRef().getRefId()), ptr);
-        mWorldScene->removeFromPagedRefs(ptr);
+        if (!ptr.isEmpty())
+        {
+            mRendering->pagingBlacklistObject(mStore.find(ptr.getCellRef().getRefId()), ptr);
+            mWorldScene->removeFromPagedRefs(ptr);
+        }
         mRendering->exportSceneGraph(ptr, file, "Ascii");
         return file;
     }

--- a/components/sceneutil/serialize.cpp
+++ b/components/sceneutil/serialize.cpp
@@ -143,6 +143,7 @@ void registerSerializers()
             "NifOsg::GeomMorpherController",
             "NifOsg::UpdateMorphGeometry",
             "NifOsg::UVController",
+            "NifOsg::VisController",
             "NifOsg::NodeIndexHolder",
             "osgMyGUI::Drawable",
             "osg::DrawCallback",


### PR DESCRIPTION
A yet another regression from object paging MR.

When "showscenegraph 1" is used, target reference is empty, so an attempt to get reference ID leads to crash.
A simplest way to fix it is just to wrap paging stuff to "is empty" check.

Also suppress warnings for NifOsg::VisController.

