### PR TITLE
Fix MSVC warnings

### DIFF
--- a/apps/openmw/mwphysics/physicssystem.hpp
+++ b/apps/openmw/mwphysics/physicssystem.hpp
@@ -57,7 +57,7 @@ namespace MWPhysics
     {
         public:
             PhysicsSystem (Resource::ResourceSystem* resourceSystem, osg::ref_ptr<osg::Group> parentNode);
-            ~PhysicsSystem ();
+            virtual ~PhysicsSystem ();
 
             void setUnrefQueue(SceneUtil::UnrefQueue* unrefQueue);
 
@@ -109,17 +109,17 @@ namespace MWPhysics
             /// target vector hits the collision shape and then calculates distance from the intersection point.
             /// This can be used to find out how much nearer we need to move to the target for a "getHitContact" to be successful.
             /// \note Only Actor targets are supported at the moment.
-            float getHitDistance(const osg::Vec3f& point, const MWWorld::ConstPtr& target) const final;
+            float getHitDistance(const osg::Vec3f& point, const MWWorld::ConstPtr& target) const override final;
 
             /// @param me Optional, a Ptr to ignore in the list of results. targets are actors to filter for, ignoring all other actors.
             RayCastingResult castRay(const osg::Vec3f &from, const osg::Vec3f &to, const MWWorld::ConstPtr& ignore = MWWorld::ConstPtr(),
                     std::vector<MWWorld::Ptr> targets = std::vector<MWWorld::Ptr>(),
-                    int mask = CollisionType_World|CollisionType_HeightMap|CollisionType_Actor|CollisionType_Door, int group=0xff) const final;
+                    int mask = CollisionType_World|CollisionType_HeightMap|CollisionType_Actor|CollisionType_Door, int group=0xff) const override final;
 
-            RayCastingResult castSphere(const osg::Vec3f& from, const osg::Vec3f& to, float radius) const final;
+            RayCastingResult castSphere(const osg::Vec3f& from, const osg::Vec3f& to, float radius) const override final;
 
             /// Return true if actor1 can see actor2.
-            bool getLineOfSight(const MWWorld::ConstPtr& actor1, const MWWorld::ConstPtr& actor2) const final;
+            bool getLineOfSight(const MWWorld::ConstPtr& actor1, const MWWorld::ConstPtr& actor2) const override final;
 
             bool isOnGround (const MWWorld::Ptr& actor);
 


### PR DESCRIPTION
Summary of changes:
1. Since `PhysicsSystem` uses virtual methods now, its destructor should be virtual.
2. Mark overloaded functions from base class as overrides.