### PR TITLE
Improve ammo resetting

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1306,6 +1306,8 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
                                 1.0f, "unequip start", "unequip stop", 0.0f, 0);
                 mUpperBodyState = UpperCharState_UnEquipingWeap;
 
+                mAnimation->detachArrow();
+
                 // If we do not have the "unequip detach" key, hide weapon manually.
                 if (mAnimation->getTextKeyTime(weapgroup+": unequip detach") < 0)
                     mAnimation->showWeapons(false);

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -474,6 +474,7 @@ public:
     void setAlpha(float alpha);
     virtual void setPitchFactor(float factor) {}
     virtual void attachArrow() {}
+    virtual void detachArrow() {}
     virtual void releaseArrow(float attackStrength) {}
     virtual void enableHeadAnimation(bool enable) {}
     // TODO: move outside of this class

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -208,6 +208,12 @@ bool CreatureWeaponAnimation::isArrowAttached() const
     return mAmmunition != nullptr;
 }
 
+void CreatureWeaponAnimation::detachArrow()
+{
+    WeaponAnimation::detachArrow(mPtr);
+    updateQuiver();
+}
+
 void CreatureWeaponAnimation::attachArrow()
 {
     WeaponAnimation::attachArrow(mPtr);

--- a/apps/openmw/mwrender/creatureanimation.hpp
+++ b/apps/openmw/mwrender/creatureanimation.hpp
@@ -40,6 +40,7 @@ namespace MWRender
         void updatePart(PartHolderPtr& scene, int slot);
 
         virtual void attachArrow();
+        virtual void detachArrow();
         virtual void releaseArrow(float attackStrength);
         // WeaponAnimation
         virtual osg::Group* getArrowBone();

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -363,6 +363,7 @@ void NpcAnimation::setViewMode(NpcAnimation::ViewMode viewMode)
     mViewMode = viewMode;
     MWBase::Environment::get().getWorld()->scaleObject(mPtr, mPtr.getCellRef().getScale()); // apply race height after view change
 
+    mAmmunition.reset();
     rebuild();
     setRenderBin();
 }

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -1051,6 +1051,12 @@ void NpcAnimation::attachArrow()
     updateQuiver();
 }
 
+void NpcAnimation::detachArrow()
+{
+    WeaponAnimation::detachArrow(mPtr);
+    updateQuiver();
+}
+
 void NpcAnimation::releaseArrow(float attackStrength)
 {
     WeaponAnimation::releaseArrow(mPtr, attackStrength);

--- a/apps/openmw/mwrender/npcanimation.hpp
+++ b/apps/openmw/mwrender/npcanimation.hpp
@@ -142,6 +142,7 @@ public:
     virtual void showCarriedLeft(bool show);
 
     virtual void attachArrow();
+    virtual void detachArrow();
     virtual void releaseArrow(float attackStrength);
 
     virtual osg::Group* getArrowBone();

--- a/apps/openmw/mwrender/weaponanimation.cpp
+++ b/apps/openmw/mwrender/weaponanimation.cpp
@@ -98,6 +98,11 @@ void WeaponAnimation::attachArrow(MWWorld::Ptr actor)
     }
 }
 
+void WeaponAnimation::detachArrow(MWWorld::Ptr actor)
+{
+    mAmmunition.reset();
+}
+
 void WeaponAnimation::releaseArrow(MWWorld::Ptr actor, float attackStrength)
 {
     MWWorld::InventoryStore& inv = actor.getClass().getInventoryStore(actor);

--- a/apps/openmw/mwrender/weaponanimation.hpp
+++ b/apps/openmw/mwrender/weaponanimation.hpp
@@ -36,6 +36,8 @@ namespace MWRender
         /// @note If no weapon (or an invalid weapon) is equipped, this function is a no-op.
         void attachArrow(MWWorld::Ptr actor);
 
+        void detachArrow(MWWorld::Ptr actor);
+
         /// @note If no weapon (or an invalid weapon) is equipped, this function is a no-op.
         void releaseArrow(MWWorld::Ptr actor, float attackStrength);
 


### PR DESCRIPTION
Summary of changes:
1. Reset attached ammo when start to play weapon unequipping animation
2. Reset attached ammo when changing view mode.

It allows to avoid warnings spam when player interrupts shooting via "toggle weapon" key or when he changes view mode when a crossbow is equipped.