### PR TITLE
Avoid crash when object paging encounters an empty shape

### DIFF
--- a/apps/openmw/mwrender/objectpaging.cpp
+++ b/apps/openmw/mwrender/objectpaging.cpp
@@ -289,7 +289,9 @@ namespace MWRender
         }
         virtual void apply(osg::Geometry& geom)
         {
-            mResult.mNumVerts += geom.getVertexArray()->getNumElements();
+            if (osg::Array* array = geom.getVertexArray())
+                mResult.mNumVerts += array->getNumElements();
+
             ++mResult.mStateSetCounter[mCurrentStateSet];
             ++mGlobalStateSetCounter[mCurrentStateSet];
         }


### PR DESCRIPTION
Should fix [regression #5578](https://gitlab.com/OpenMW/openmw/-/issues/5578).

Empty drawables have no vertex array, so we should check if array exists before try to get number of its elements.
Note that bzzt already uses such check in the `AddRefnumMarkerVisitor`.