### PR TITLE
Apply effects during rest before fast-forwarding spells state

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -2053,10 +2053,11 @@ namespace MWMechanics
 
         for(PtrActorMap::iterator iter(mActors.begin()); iter != mActors.end(); ++iter)
         {
-            iter->first.getClass().getCreatureStats(iter->first).getActiveSpells().update(duration);
-
             if (iter->first.getClass().getCreatureStats(iter->first).isDead())
+            {
+                iter->first.getClass().getCreatureStats(iter->first).getActiveSpells().update(duration);
                 continue;
+            }
 
             if (!sleep || iter->first == player)
                 restoreDynamicStats(iter->first, hours, sleep);
@@ -2073,13 +2074,14 @@ namespace MWMechanics
             if (iter->first.getClass().isNpc())
                 calculateNpcStatModifiers(iter->first, duration);
 
+            iter->first.getClass().getCreatureStats(iter->first).getActiveSpells().update(duration);
+
             MWRender::Animation* animation = MWBase::Environment::get().getWorld()->getAnimation(iter->first);
             if (animation)
             {
                 animation->removeEffects();
                 MWBase::Environment::get().getWorld()->applyLoopingParticles(iter->first);
             }
-
         }
 
         fastForwardAi();


### PR DESCRIPTION
Fixes [regression #5559](https://gitlab.com/OpenMW/openmw/-/issues/5559).

The main idea - apply spell effects during rest before fast-forwarding effects time. In this case we will apply only remaining spell time instead of full rest duration.