### PR TITLE
Set a minimum 1gp cost for services

### DIFF
--- a/apps/openmw/mwgui/merchantrepair.cpp
+++ b/apps/openmw/mwgui/merchantrepair.cpp
@@ -63,6 +63,7 @@ void MerchantRepair::setPtr(const MWWorld::Ptr &actor)
 
             int x = static_cast<int>((maxDurability - durability) / r);
             x = static_cast<int>(fRepairMult * x);
+            x = std::max(1, x);
 
             int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mActor, x, true);
 

--- a/apps/openmw/mwgui/spellbuyingwindow.cpp
+++ b/apps/openmw/mwgui/spellbuyingwindow.cpp
@@ -42,7 +42,7 @@ namespace MWGui
         const MWWorld::ESMStore &store =
             MWBase::Environment::get().getWorld()->getStore();
 
-        int price = static_cast<int>(spell.mData.mCost*store.get<ESM::GameSetting>().find("fSpellValueMult")->mValue.getFloat());
+        int price = std::max(1, static_cast<int>(spell.mData.mCost*store.get<ESM::GameSetting>().find("fSpellValueMult")->mValue.getFloat()));
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr,price,true);
 
         MWWorld::Ptr player = MWMechanics::getPlayer();

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -475,7 +475,8 @@ namespace MWGui
         float fSpellMakingValueMult =
             store.get<ESM::GameSetting>().find("fSpellMakingValueMult")->mValue.getFloat();
 
-        int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, static_cast<int>(y * fSpellMakingValueMult),true);
+        int price = std::max(1, static_cast<int>(y * fSpellMakingValueMult));
+        price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
 
         mPriceLabel->setCaption(MyGUI::utility::toString(int(price)));
 

--- a/apps/openmw/mwgui/trainingwindow.cpp
+++ b/apps/openmw/mwgui/trainingwindow.cpp
@@ -99,8 +99,9 @@ namespace MWGui
 
         for (int i=0; i<3; ++i)
         {
-            int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer
-                    (mPtr,pcStats.getSkill (skills[i].first).getBase() * gmst.find("iTrainingMod")->mValue.getInteger(),true);
+            int price = static_cast<int>(pcStats.getSkill (skills[i].first).getBase() * gmst.find("iTrainingMod")->mValue.getInteger());
+            price = std::max(1, price);
+            price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
 
             MyGUI::Button* button = mTrainingOptions->createWidget<MyGUI::Button>(price <= playerGold ? "SandTextButton" : "SandTextButtonDisabled", // can't use setEnabled since that removes tooltip
                 MyGUI::IntCoord(5, 5+i*18, mTrainingOptions->getWidth()-10, 18), MyGUI::Align::Default);

--- a/apps/openmw/mwgui/travelwindow.cpp
+++ b/apps/openmw/mwgui/travelwindow.cpp
@@ -62,9 +62,14 @@ namespace MWGui
         {
             ESM::Position PlayerPos = player.getRefData().getPosition();
             float d = sqrt(pow(pos.pos[0] - PlayerPos.pos[0], 2) + pow(pos.pos[1] - PlayerPos.pos[1], 2) + pow(pos.pos[2] - PlayerPos.pos[2], 2));
-            price = static_cast<int>(d / gmst.find("fTravelMult")->mValue.getFloat());
+            float fTravelMult = gmst.find("fTravelMult")->mValue.getFloat();
+            if (fTravelMult != 0)
+                price = static_cast<int>(d / fTravelMult);
+            else
+                price = static_cast<int>(d);
         }
 
+        price = std::max(1, price);
         price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mPtr, price, true);
 
         // Add price for the travelling followers

--- a/apps/openmw/mwmechanics/enchanting.cpp
+++ b/apps/openmw/mwmechanics/enchanting.cpp
@@ -281,7 +281,7 @@ namespace MWMechanics
         float priceMultipler = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find ("fEnchantmentValueMult")->mValue.getFloat();
         int price = MWBase::Environment::get().getMechanicsManager()->getBarterOffer(mEnchanter, static_cast<int>(getEnchantPoints() * priceMultipler), true);
         price *= getEnchantItemsCount() * getTypeMultiplier();
-        return price;
+        return std::max(1, price);
     }
 
     int Enchanting::getGemCharge() const


### PR DESCRIPTION
Fixes [regression #5600](https://gitlab.com/OpenMW/openmw/-/issues/5600) from #2929.

MCP description says "Zero value items are no longer buyable or sellable for 1 gold.", I see nothing related to other services.

Since `getBarterOffer()` now does not have price clamping when base cost is 0, we can apply it manually.
