### PR TITLE
Attach arrows to actor's hands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
     Feature #5545: Option to allow stealing from an unconscious NPC during combat
     Feature #5579: MCP SetAngle enhancement
     Feature #5610: Actors movement should be smoother
+    Feature #5642: Ability to attach arrows to actor skeleton instead of bow mesh
     Task #5480: Drop Qt4 support
     Task #5520: Improve cell name autocompleter implementation
 

--- a/apps/openmw/mwmechanics/weapontype.hpp
+++ b/apps/openmw/mwmechanics/weapontype.hpp
@@ -239,7 +239,7 @@ namespace MWMechanics
                 /* short group */ "",
                 /* long group  */ "",
                 /*  sound ID   */ "Item Ammo",
-                /* attach bone */ "ArrowBone",
+                /* attach bone */ "Bip01 Arrow",
                 /* sheath bone */ "",
                 /* usage skill */ ESM::Skill::Marksman,
                 /* weapon class*/ ESM::WeaponType::Ammo,

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -252,11 +252,15 @@ osg::Group *CreatureWeaponAnimation::getArrowBone()
     int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
     int ammoType = MWMechanics::getWeaponType(type)->mAmmoType;
 
-    SceneUtil::FindByNameVisitor findVisitor (MWMechanics::getWeaponType(ammoType)->mAttachBone);
-
-    mWeapon->getNode()->accept(findVisitor);
-
-    return findVisitor.mFoundNode;
+    // Try to find and attachment bone in actor's skeleton, otherwise fall back to the ArrowBone in weapon's mesh
+    osg::Group* bone = getBoneByName(MWMechanics::getWeaponType(ammoType)->mAttachBone);
+    if (bone == nullptr)
+    {
+        SceneUtil::FindByNameVisitor findVisitor ("ArrowBone");
+        mWeapon->getNode()->accept(findVisitor);
+        bone = findVisitor.mFoundNode;
+    }
+    return bone;
 }
 
 osg::Node *CreatureWeaponAnimation::getWeaponNode()

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -1078,10 +1078,15 @@ osg::Group* NpcAnimation::getArrowBone()
     int type = weapon->get<ESM::Weapon>()->mBase->mData.mType;
     int ammoType = MWMechanics::getWeaponType(type)->mAmmoType;
 
-    SceneUtil::FindByNameVisitor findVisitor (MWMechanics::getWeaponType(ammoType)->mAttachBone);
-    part->getNode()->accept(findVisitor);
-
-    return findVisitor.mFoundNode;
+    // Try to find and attachment bone in actor's skeleton, otherwise fall back to the ArrowBone in weapon's mesh
+    osg::Group* bone = getBoneByName(MWMechanics::getWeaponType(ammoType)->mAttachBone);
+    if (bone == nullptr)
+    {
+        SceneUtil::FindByNameVisitor findVisitor ("ArrowBone");
+        part->getNode()->accept(findVisitor);
+        bone = findVisitor.mFoundNode;
+    }
+    return bone;
 }
 
 osg::Node* NpcAnimation::getWeaponNode()

--- a/docs/source/reference/modding/extended.rst
+++ b/docs/source/reference/modding/extended.rst
@@ -242,33 +242,39 @@ Every weapon type has an attack animation group and a suffix for the movement an
 For example, long blades use ``weapononehand`` attack animation group, ``idle1h`` idle animation group, ``jump1h`` jumping animation group, etc.
 This is the full table of supported animation groups:
 
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|  Weapon type  |  Animation group  |  Movement suffix |   Attack (fallback)  |   Suffix (fallback)   |
-+===============+===================+==================+======================+=======================+
-|  Short blade  | shortbladeonehand |        1s        |    weapononehand     |          1h           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-| Long blade 1H |   weapononehand   |        1h        |                      |                       |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-| Long blade 2H |   weapontwohand   |        2c        |                      |                       |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|   Blunt 1H    |   bluntonehand    |        1b        |    weapononehand     |          1h           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|   Blunt 2H    |   blunttwohand    |        2b        |    weapontwohand     |          2c           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|    Axe 1H     |   bluntonehand    |        1b        |    weapononehand     |          1h           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|    Axe 2H     |   blunttwohand    |        2b        |    weapontwohand     |          2c           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-| Blunt 2H wide |   weapontwowide   |        2w        |    weapontwohand     |          2c           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|     Spear     |   weapontwowide   |        2w        |    weapontwohand     |          2c           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|      Bow      |    bowandarrow    |        bow       |                      |          1h           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|    Crossbow   |     crossbow      |     crossbow     |                      |          1h           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
-|     Thrown    |    throwweapon    |        1t        |                      |          1h           |
-+---------------+-------------------+------------------+----------------------+-----------------------+
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|  Weapon type  |  Animation group  |  Movement suffix |   Attack (fallback)  |   Suffix (fallback)   |      Attach bone      |
++===============+===================+==================+======================+=======================+=======================+
+|  Short blade  | shortbladeonehand |        1s        |    weapononehand     |          1h           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+| Long blade 1H |   weapononehand   |        1h        |                      |                       |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+| Long blade 2H |   weapontwohand   |        2c        |                      |                       |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|   Blunt 1H    |   bluntonehand    |        1b        |    weapononehand     |          1h           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|   Blunt 2H    |   blunttwohand    |        2b        |    weapontwohand     |          2c           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|    Axe 1H     |   bluntonehand    |        1b        |    weapononehand     |          1h           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|    Axe 2H     |   blunttwohand    |        2b        |    weapontwohand     |          2c           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+| Blunt 2H wide |   weapontwowide   |        2w        |    weapontwohand     |          2c           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|     Spear     |   weapontwowide   |        2w        |    weapontwohand     |          2c           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|      Bow      |    bowandarrow    |        bow       |                      |          1h           |    Weapon Bone Left   |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|    Crossbow   |     crossbow      |     crossbow     |                      |          1h           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+|     Thrown    |    throwweapon    |        1t        |                      |          1h           |      Weapon Bone      |
++---------------+-------------------+------------------+----------------------+-----------------------+-----------------------+
+
+Note that bows can be attached to the "Weapon Bone Left" bone if it is present in shooter's skeleton, and if it is not, "Weapon Bone" is used as a fallback.
+
+Also it is possible to add a "Bip01 Arrow" bone to actor skeletons. In this case OpenMW attaches arrows to this bone instead of ArrowBone in the bow mesh.
+Such approach allows to implement better shooting animations (for example, beast races have tail, so quivers should be attached under different angle and
+default arrow fetching animation does not look good).
 
 .. _`Graphic Herbalism`: https://www.nexusmods.com/morrowind/mods/46599
 .. _`OpenMW Containers Animated`: https://www.nexusmods.com/morrowind/mods/46232


### PR DESCRIPTION
Just attach arrows to shooter's hand instead of ArrowBone node in bow's mesh when the "Bip01 Arrow" bone is present in shooter's skeleton. With vanilla assets there will be no difference from our current behaviour.

This feature will allow modmakers to make better shooting animations. [Here](https://github.com/OpenMW/openmw/files/5193002/Left.zip) is an example of mod, which can use such feature - it places bow to left hand instead of right one, so it can not rely on ArrowBone. This mod is based on Weapon Sheathing. Note that the mod is WIP and has some issues (such as spam about missing 'tri w_longbow_daedric002' bone, which is a bug in animations themselves).


