### PR TITLE
Don't search containers

### DIFF
--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -287,9 +287,9 @@ namespace MWWorld
             ///< Return a pointer to a liveCellRef with the given name.
             /// \param activeOnly do non search inactive cells.
 
-            Ptr searchPtr (const std::string& name, bool activeOnly, bool searchInContainers = true) override;
+            Ptr searchPtr (const std::string& name, bool activeOnly, bool searchInContainers = false) override;
             ///< Return a pointer to a liveCellRef with the given name.
-            /// \param activeOnly do non search inactive cells.
+            /// \param activeOnly do not search inactive cells.
 
             Ptr searchPtrViaActorId (int actorId) override;
             ///< Search is limited to the active cells.


### PR DESCRIPTION
Tangentially related to #3001, mostly as premature optimization.

OpenMW currently searches containers in a few cases: AiActivate, cast, aipackage, and script targeting.

AiActivate seems to bug out and make actors walk towards (0,0);
AiPackage is looking for an actor;
And vanilla doesn't allow scripts to target items in containers from what I can tell.

So in short, there appears to be no reason to ever search them and we might as well gain some performance.