### PR TITLE
Fix unsugned/signed comparison warning

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -490,7 +490,7 @@ void OMW::Engine::createWindow(Settings::Manager& settings)
     bool fullscreen = settings.getBool("fullscreen", "Video");
     bool windowBorder = settings.getBool("window border", "Video");
     bool vsync = settings.getBool("vsync", "Video");
-    int antialiasing = settings.getInt("antialiasing", "Video");
+    unsigned int antialiasing = std::max(0, settings.getInt("antialiasing", "Video"));
 
     int pos_x = SDL_WINDOWPOS_CENTERED_DISPLAY(screen),
         pos_y = SDL_WINDOWPOS_CENTERED_DISPLAY(screen);


### PR DESCRIPTION
The `traits->samples` is unsigned, and `antialiasing` is supposed to be unsigned as well.