### PR TITLE
Rework fixed strings handling

### DIFF
--- a/apps/openmw_test_suite/esm/test_fixed_string.cpp
+++ b/apps/openmw_test_suite/esm/test_fixed_string.cpp
@@ -97,7 +97,6 @@ TEST(EsmFixedString, struct_size)
     ASSERT_EQ(4, sizeof(ESM::NAME));
     ASSERT_EQ(32, sizeof(ESM::NAME32));
     ASSERT_EQ(64, sizeof(ESM::NAME64));
-    ASSERT_EQ(256, sizeof(ESM::NAME256));
 }
 
 TEST(EsmFixedString, is_pod)
@@ -105,5 +104,4 @@ TEST(EsmFixedString, is_pod)
      ASSERT_TRUE(std::is_pod<ESM::NAME>::value);
      ASSERT_TRUE(std::is_pod<ESM::NAME32>::value);
      ASSERT_TRUE(std::is_pod<ESM::NAME64>::value);
-     ASSERT_TRUE(std::is_pod<ESM::NAME256>::value);
 }


### PR DESCRIPTION
Summary of changes:

1. NAME32 and NAME64 should be null-terminated (see [this](https://gitlab.com/OpenMW/openmw/-/issues/5615) thread). It means that if fixed string has size 32 bytes, it should take up to 31 characters from input string in the editor, 32th byte should be null-teminator. Since `assign ()` only used in the editor and unit tests, it should be no difference with content files, created via TES-CS.
2. NAME256 is not used in the engine now, so remove it.
3. `data_size()` is static now.