### PR TITLE
Navmesh fixes

### DIFF
--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -38,6 +38,12 @@ namespace DetourNavigator
                 return stream << "failed";
             case UpdateNavMeshStatus::lost:
                 return stream << "lost";
+            case UpdateNavMeshStatus::cached:
+                return stream << "cached";
+            case UpdateNavMeshStatus::unchanged:
+                return stream << "unchanged";
+            case UpdateNavMeshStatus::restored:
+                return stream << "restored";
         }
         return stream << "unknown(" << static_cast<unsigned>(value) << ")";
     }

--- a/components/detournavigator/asyncnavmeshupdater.cpp
+++ b/components/detournavigator/asyncnavmeshupdater.cpp
@@ -39,7 +39,7 @@ namespace DetourNavigator
             case UpdateNavMeshStatus::lost:
                 return stream << "lost";
         }
-        return stream << "unknown";
+        return stream << "unknown(" << static_cast<unsigned>(value) << ")";
     }
 
     AsyncNavMeshUpdater::AsyncNavMeshUpdater(const Settings& settings, TileCachedRecastMeshManager& recastMeshManager,

--- a/components/detournavigator/makenavmesh.cpp
+++ b/components/detournavigator/makenavmesh.cpp
@@ -559,6 +559,7 @@ namespace DetourNavigator
         }
 
         auto cachedNavMeshData = navMeshTilesCache.get(agentHalfExtents, changedTile, *recastMesh, offMeshConnections);
+        bool cached = static_cast<bool>(cachedNavMeshData);
 
         if (!cachedNavMeshData)
         {
@@ -584,6 +585,7 @@ namespace DetourNavigator
             {
                 cachedNavMeshData = navMeshTilesCache.get(agentHalfExtents, changedTile, *recastMesh,
                                                           offMeshConnections);
+                cached = static_cast<bool>(cachedNavMeshData);
             }
 
             if (!cachedNavMeshData)
@@ -593,6 +595,8 @@ namespace DetourNavigator
             }
         }
 
-        return navMeshCacheItem->lock()->updateTile(changedTile, std::move(cachedNavMeshData));
+        const auto updateStatus = navMeshCacheItem->lock()->updateTile(changedTile, std::move(cachedNavMeshData));
+
+        return UpdateNavMeshStatusBuilder(updateStatus).cached(cached).getResult();
     }
 }

--- a/components/detournavigator/navmeshcacheitem.hpp
+++ b/components/detournavigator/navmeshcacheitem.hpp
@@ -22,6 +22,9 @@ namespace DetourNavigator
         replaced = removed | added,
         failed = 1 << 2,
         lost = removed | failed,
+        cached = 1 << 3,
+        unchanged = replaced | cached,
+        restored = added | cached,
     };
 
     inline bool isSuccess(UpdateNavMeshStatus value)
@@ -33,6 +36,9 @@ namespace DetourNavigator
     {
     public:
         UpdateNavMeshStatusBuilder() = default;
+
+        explicit UpdateNavMeshStatusBuilder(UpdateNavMeshStatus value)
+            : mResult(value) {}
 
         UpdateNavMeshStatusBuilder removed(bool value)
         {
@@ -58,6 +64,15 @@ namespace DetourNavigator
                 set(UpdateNavMeshStatus::failed);
             else
                 unset(UpdateNavMeshStatus::failed);
+            return *this;
+        }
+
+        UpdateNavMeshStatusBuilder cached(bool value)
+        {
+            if (value)
+                set(UpdateNavMeshStatus::cached);
+            else
+                unset(UpdateNavMeshStatus::cached);
             return *this;
         }
 

--- a/components/detournavigator/navmeshcacheitem.hpp
+++ b/components/detournavigator/navmeshcacheitem.hpp
@@ -143,7 +143,7 @@ namespace DetourNavigator
 
         UpdateNavMeshStatus removeTile(const TilePosition& position)
         {
-            const auto removed = dtStatusSucceed(removeTileImpl(position));
+            const auto removed = removeTileImpl(position);
             if (removed)
                 removeUsedTile(position);
             return UpdateNavMeshStatusBuilder().removed(removed).getResult();
@@ -181,13 +181,15 @@ namespace DetourNavigator
             return mImpl->addTile(data, size, doNotTransferOwnership, lastRef, result);
         }
 
-        dtStatus removeTileImpl(const TilePosition& position)
+        bool removeTileImpl(const TilePosition& position)
         {
             const int layer = 0;
             const auto tileRef = mImpl->getTileRefAt(position.x(), position.y(), layer);
+            if (tileRef == 0)
+                return false;
             unsigned char** const data = nullptr;
             int* const dataSize = nullptr;
-            return mImpl->removeTile(tileRef, data, dataSize);
+            return dtStatusSucceed(mImpl->removeTile(tileRef, data, dataSize));
         }
     };
 


### PR DESCRIPTION
Primarily change the implementation of navmesh key creation. Using memcpy directly is ~13 times faster. And it's not possible to use `std::string::data` because there is no non-const overload returning `char*` until c++17. So `std::vector<unsigned char>` is used instead.