### PR TITLE
Fix crash on saving

### DIFF
--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -308,8 +308,14 @@ namespace MWClass
 
     void Container::writeAdditionalState (const MWWorld::ConstPtr& ptr, ESM::ObjectState& state) const
     {
+        if (!ptr.getRefData().getCustomData())
+        {
+            state.mHasCustomState = false;
+            return;
+        }
+
         const ContainerCustomData& customData = ptr.getRefData().getCustomData()->asContainerCustomData();
-        if (!ptr.getRefData().getCustomData() || !customData.mStore.isResolved())
+        if (!customData.mStore.isResolved())
         {
             state.mHasCustomState = false;
             return;


### PR DESCRIPTION
This line leads to crash when customData is null:

```
const ContainerCustomData& customData = ptr.getRefData().getCustomData()->asContainerCustomData();
```

We should handle this case, as we did it earlier.

Note that I can not tell if empty customData is intended or it is a bug.