### PR TITLE
[Do not merge] Attempt to suppress superfluous ranlib warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -906,3 +906,10 @@ if (DOXYGEN_FOUND)
         WORKING_DIRECTORY ${OpenMW_BINARY_DIR}
         COMMENT "Generating documentation for the github-pages at ${DOXYGEN_PAGES_OUTPUT_DIR}" VERBATIM)
 endif ()
+
+if (APPLE)
+    SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif (APPLE)


### PR DESCRIPTION
An example of warning:

```
ranlib: file: libcomponents.a(moc_loadordererror.cpp.o) has no symbols
ranlib: file: libcomponents.a(linuxpath.cpp.o) has no symbols
ranlib: file: libcomponents.a(androidpath.cpp.o) has no symbols
ranlib: file: libcomponents.a(windowspath.cpp.o) has no symbols
```

Such warnings indicate that target object files are empty. In our case these warnings are false positives since affected source files are either commented-out by preprocessor (there is no windows paths handling on MacOS) or empty moc-files (see [this](https://gitlab.com/OpenMW/openmw/-/issues/5640) thread.

Let see if we can suppress these warnings.