### PR TITLE
Fix override warning with MyGUI 3.4

### DIFF
--- a/components/myguiplatform/myguirendermanager.hpp
+++ b/components/myguiplatform/myguirendermanager.hpp
@@ -106,10 +106,16 @@ public:
 
     bool checkTexture(MyGUI::ITexture* _texture);
 
+    // setViewSize() is a part of MyGUI::RenderManager interface since 3.4.0 release
+#if MYGUI_VERSION < MYGUI_DEFINE_VERSION(3,4,0)
+    void setViewSize(int width, int height);
+#else
+    void setViewSize(int width, int height) override;
+#endif
+
 /*internal:*/
 
     void collectDrawCalls();
-    void setViewSize(int width, int height);
 };
 
 }


### PR DESCRIPTION
Since [this](https://github.com/MyGUI/mygui/commit/dcb020900038fec060579097b3252bc9154c6571) commit RenderingManager interface from MyGUI has mandatory `setViewSize` method, while with 3.2.2 or lesser this method is OpenMW-specific.