### PR TITLE
Strip the plugin index when looking for deleted refs.

### DIFF
--- a/apps/opencs/model/world/refcollection.cpp
+++ b/apps/opencs/model/world/refcollection.cpp
@@ -64,9 +64,10 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
 
         // ignore content file number
         std::map<ESM::RefNum, std::string>::iterator iter = cache.begin();
+        unsigned int thisIndex = ref.mRefNum.mIndex & 0x00ffffff;
         for (; iter != cache.end(); ++iter)
         {
-            if (ref.mRefNum.mIndex == iter->first.mIndex)
+            if (thisIndex == iter->first.mIndex)
                 break;
         }
 

--- a/apps/opencs/model/world/refcollection.cpp
+++ b/apps/opencs/model/world/refcollection.cpp
@@ -64,10 +64,10 @@ void CSMWorld::RefCollection::load (ESM::ESMReader& reader, int cellIndex, bool 
 
         // ignore content file number
         std::map<ESM::RefNum, std::string>::iterator iter = cache.begin();
-        unsigned int thisIndex = ref.mRefNum.mIndex & 0x00ffffff;
+        ref.mRefNum.mIndex = ref.mRefNum.mIndex & 0x00ffffff;
         for (; iter != cache.end(); ++iter)
         {
-            if (thisIndex == iter->first.mIndex)
+            if (ref.mRefNum.mIndex == iter->first.mIndex)
                 break;
         }
 


### PR DESCRIPTION
This fixes https://gitlab.com/OpenMW/openmw/-/issues/832 . There's however more to it (see the comments at gitlab), it may be better to somehow fix these are component level, but it's not straightforward because of the different logics of OpenMW and OpenMW-CS.

What it does, it strips the first byte of mIndex, which is the plugin index, and leaves only the reference index. Then the reference index will match the references of the deleted objects.