### PR TITLE
Do not use deprecated Qt functions

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -211,10 +211,10 @@ void Launcher::MainDialog::setVersionLabel()
         versionLabel->setText(tr("OpenMW development (%1)").arg(revision.left(10)));
 
     // Add the compile date and time
-    versionLabel->setToolTip(tr("Compiled on %1 %2").arg(QLocale(QLocale::C).toDate(QString(__DATE__).simplified(),
-                                                                                    QLatin1String("MMM d yyyy")).toString(Qt::SystemLocaleLongDate),
-                                                         QLocale(QLocale::C).toTime(QString(__TIME__).simplified(),
-                                                                                    QLatin1String("hh:mm:ss")).toString(Qt::SystemLocaleShortDate)));
+    auto compileDate = QLocale(QLocale::C).toDate(QString(__DATE__).simplified(), QLatin1String("MMM d yyyy"));
+    auto compileTime = QLocale(QLocale::C).toTime(QString(__TIME__).simplified(), QLatin1String("hh:mm:ss"));
+    versionLabel->setToolTip(tr("Compiled on %1 %2").arg(QLocale::system().toString(compileDate, QLocale::LongFormat),
+                                                         QLocale::system().toString(compileTime, QLocale::ShortFormat)));
 }
 
 bool Launcher::MainDialog::setup()

--- a/apps/opencs/main.cpp
+++ b/apps/opencs/main.cpp
@@ -47,9 +47,6 @@ int runApplication(int argc, char *argv[])
     setenv("OSG_GL_TEXTURE_STORAGE", "OFF", 0);
 #endif
 
-    // To allow background thread drawing in OSG
-    QApplication::setAttribute(Qt::AA_X11InitThreads, true);
-
     Q_INIT_RESOURCE (resources);
 
     qRegisterMetaType<std::string> ("std::string");


### PR DESCRIPTION
Summary of changes:
1. `Qt::SystemLocaleShortDate` and `Qt::SystemLocaleLongDate` are deprecated, `QLocale::system().toString()` should be used instead.
2. `XInitThreads()` is used only in Qt4, so `Qt::AA_X11InitThreads` has no effect in Qt5. Remove this line since it does nothing.