### PR TITLE
Do not remove active effects in the active effects loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     Bug #2976 [reopened]: Issues combining settings from the command line and both config files
     Bug #3676: NiParticleColorModifier isn't applied properly
     Bug #3714: Savegame fails to load due to conflict between SpellState and MagicEffects
+    Bug #3789: Crash in visitEffectSources while in battle
     Bug #3862: Random container contents behave differently than vanilla
     Bug #3929: Leveled list merchant containers respawn on barter
     Bug #4021: Attributes and skills are not stored as floats

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -381,6 +381,37 @@ namespace MWMechanics
             target.getClass().getCreatureStats(target).getActiveSpells().purgeAll(magnitude, true);
             return true;
         }
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CurePoison)
+        {
+            target.getClass().getCreatureStats(target).getActiveSpells().purgeEffect(ESM::MagicEffect::Poison);
+            return true;
+        }
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureParalyzation)
+        {
+            target.getClass().getCreatureStats(target).getActiveSpells().purgeEffect(ESM::MagicEffect::Paralyze);
+            return true;
+        }
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureCommonDisease)
+        {
+            target.getClass().getCreatureStats(target).getSpells().purgeCommonDisease();
+            return true;
+        }
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureBlightDisease)
+        {
+            target.getClass().getCreatureStats(target).getSpells().purgeBlightDisease();
+            return true;
+        }
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureCorprusDisease)
+        {
+            target.getClass().getCreatureStats(target).getActiveSpells().purgeCorprusDisease();
+            target.getClass().getCreatureStats(target).getSpells().purgeCorprusDisease();
+            return true;
+        }
+        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::RemoveCurse)
+        {
+            target.getClass().getCreatureStats(target).getSpells().purgeCurses();
+            return true;
+        }
         else if (target.getClass().isActor() && target == getPlayer())
         {
             MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(mCaster);

--- a/apps/openmw/mwmechanics/tickableeffects.cpp
+++ b/apps/openmw/mwmechanics/tickableeffects.cpp
@@ -205,24 +205,6 @@ namespace MWMechanics
             break;
         }
 
-        case ESM::MagicEffect::CurePoison:
-            actor.getClass().getCreatureStats(actor).getActiveSpells().purgeEffect(ESM::MagicEffect::Poison);
-            break;
-        case ESM::MagicEffect::CureParalyzation:
-            actor.getClass().getCreatureStats(actor).getActiveSpells().purgeEffect(ESM::MagicEffect::Paralyze);
-            break;
-        case ESM::MagicEffect::CureCommonDisease:
-            actor.getClass().getCreatureStats(actor).getSpells().purgeCommonDisease();
-            break;
-        case ESM::MagicEffect::CureBlightDisease:
-            actor.getClass().getCreatureStats(actor).getSpells().purgeBlightDisease();
-            break;
-        case ESM::MagicEffect::CureCorprusDisease:
-            actor.getClass().getCreatureStats(actor).getSpells().purgeCorprusDisease();
-            break;
-        case ESM::MagicEffect::RemoveCurse:
-            actor.getClass().getCreatureStats(actor).getSpells().purgeCurses();
-            break;
         default:
             return false;
         }

--- a/apps/openmw/mwmechanics/tickableeffects.hpp
+++ b/apps/openmw/mwmechanics/tickableeffects.hpp
@@ -12,6 +12,7 @@ namespace MWMechanics
     struct EffectKey;
 
     /// Apply a magic effect that is applied in tick intervals until its remaining time ends or it is removed
+    /// Note: this function works in loop, so magic effects should not be removed here to avoid iterator invalidation.
     /// @return Was the effect a tickable effect with a magnitude?
     bool effectTick(CreatureStats& creatureStats, const MWWorld::Ptr& actor, const EffectKey& effectKey, float magnitude);
 }


### PR DESCRIPTION
Should fix [bug #3789](https://gitlab.com/OpenMW/openmw/-/issues/3789).

Just treat "cure" effects as special cases of Dispel effect.
An "applyInstantEffect" function usually works when we inflict cure spell, so there should not be iterator invalidation. A MagicEffect::Collection iterator also should not cause issues since we do not update this collection when we remove effects from ActiveSpells and Spells.