### PR TITLE
Rework cure effects

### DIFF
--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -916,11 +916,53 @@ namespace MWMechanics
             }
     };
 
+    void Actors::applyCureEffects(const MWWorld::Ptr& actor)
+    {
+        CreatureStats &creatureStats = actor.getClass().getCreatureStats(actor);
+        const MagicEffects &effects = creatureStats.getMagicEffects();
+
+        if (effects.get(ESM::MagicEffect::CurePoison).getModifier() > 0)
+        {
+            creatureStats.getActiveSpells().purgeEffect(ESM::MagicEffect::Poison);
+            creatureStats.getSpells().purgeEffect(ESM::MagicEffect::Poison);
+            if (actor.getClass().hasInventoryStore(actor))
+                actor.getClass().getInventoryStore(actor).purgeEffect(ESM::MagicEffect::Poison);
+        }
+        else if (effects.get(ESM::MagicEffect::CureParalyzation).getModifier() > 0)
+        {
+            creatureStats.getActiveSpells().purgeEffect(ESM::MagicEffect::Paralyze);
+            creatureStats.getSpells().purgeEffect(ESM::MagicEffect::Paralyze);
+            if (actor.getClass().hasInventoryStore(actor))
+                actor.getClass().getInventoryStore(actor).purgeEffect(ESM::MagicEffect::Paralyze);
+        }
+        else if (effects.get(ESM::MagicEffect::CureCommonDisease).getModifier() > 0)
+        {
+            creatureStats.getSpells().purgeCommonDisease();
+        }
+        else if (effects.get(ESM::MagicEffect::CureBlightDisease).getModifier() > 0)
+        {
+            creatureStats.getSpells().purgeBlightDisease();
+        }
+        else if (effects.get(ESM::MagicEffect::CureCorprusDisease).getModifier() > 0)
+        {
+            creatureStats.getActiveSpells().purgeCorprusDisease();
+            creatureStats.getSpells().purgeCorprusDisease();
+            if (actor.getClass().hasInventoryStore(actor))
+                actor.getClass().getInventoryStore(actor).purgeEffect(ESM::MagicEffect::Corprus, true);
+        }
+        else if (effects.get(ESM::MagicEffect::RemoveCurse).getModifier() > 0)
+        {
+            creatureStats.getSpells().purgeCurses();
+        }
+    }
+
     void Actors::calculateCreatureStatModifiers (const MWWorld::Ptr& ptr, float duration)
     {
         CreatureStats &creatureStats = ptr.getClass().getCreatureStats(ptr);
         const MagicEffects &effects = creatureStats.getMagicEffects();
         bool godmode = ptr == getPlayer() && MWBase::Environment::get().getWorld()->getGodModeState();
+
+        applyCureEffects(ptr);
 
         bool wasDead = creatureStats.isDead();
 

--- a/apps/openmw/mwmechanics/actors.hpp
+++ b/apps/openmw/mwmechanics/actors.hpp
@@ -206,6 +206,7 @@ namespace MWMechanics
 
     private:
         void updateVisibility (const MWWorld::Ptr& ptr, CharacterController* ctrl);
+        void applyCureEffects (const MWWorld::Ptr& actor);
 
         PtrActorMap mActors;
         float mTimerDisposeSummonsCorpses;

--- a/apps/openmw/mwmechanics/spellcasting.cpp
+++ b/apps/openmw/mwmechanics/spellcasting.cpp
@@ -381,37 +381,6 @@ namespace MWMechanics
             target.getClass().getCreatureStats(target).getActiveSpells().purgeAll(magnitude, true);
             return true;
         }
-        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CurePoison)
-        {
-            target.getClass().getCreatureStats(target).getActiveSpells().purgeEffect(ESM::MagicEffect::Poison);
-            return true;
-        }
-        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureParalyzation)
-        {
-            target.getClass().getCreatureStats(target).getActiveSpells().purgeEffect(ESM::MagicEffect::Paralyze);
-            return true;
-        }
-        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureCommonDisease)
-        {
-            target.getClass().getCreatureStats(target).getSpells().purgeCommonDisease();
-            return true;
-        }
-        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureBlightDisease)
-        {
-            target.getClass().getCreatureStats(target).getSpells().purgeBlightDisease();
-            return true;
-        }
-        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::CureCorprusDisease)
-        {
-            target.getClass().getCreatureStats(target).getActiveSpells().purgeCorprusDisease();
-            target.getClass().getCreatureStats(target).getSpells().purgeCorprusDisease();
-            return true;
-        }
-        else if (target.getClass().isActor() && effectId == ESM::MagicEffect::RemoveCurse)
-        {
-            target.getClass().getCreatureStats(target).getSpells().purgeCurses();
-            return true;
-        }
         else if (target.getClass().isActor() && target == getPlayer())
         {
             MWRender::Animation* anim = MWBase::Environment::get().getWorld()->getAnimation(mCaster);


### PR DESCRIPTION
A result of additional invistigation, requested by @Capostrophic:

1. Cure effects should remove related effects from all sources, not just from active spells.
Note that things such Cure Poison and Cure Paralyzation do not remove spells themselves, just affected effects.
2. Cure Corprus effect in Morrowind removes whole spells, which contain corprus effects.
3. Cure effects are not instant nor tickable ones. They are rather togglable effects - they either work or do not work (as bound effects, water walking, etc.)