### PR TITLE
Use a logging system instead of cout for a couple of missing messages

### DIFF
--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -153,13 +153,13 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     cfgMgr.mergeComposingVariables(variables, composingVariables, desc);
 
     Version::Version v = Version::getOpenmwVersion(variables["resources"].as<Files::EscapePath>().mPath.string());
-    std::cout << v.describe() << std::endl;
+    Log(Debug::Info) << v.describe();
 
     engine.setGrabMouse(!variables["no-grab"].as<bool>());
 
     // Font encoding settings
     std::string encoding(variables["encoding"].as<Files::EscapeHashString>().toStdString());
-    std::cout << ToUTF8::encodingUsingMessage(encoding) << std::endl;
+    Log(Debug::Info) << ToUTF8::encodingUsingMessage(encoding);
     engine.setEncoding(ToUTF8::calculateEncoding(encoding));
 
     // directory settings


### PR DESCRIPTION
Note that the "--version" case is not affected by this patch since it still uses `std::cout` and has an early-out.