### PR TITLE
Enhance level-up tooltip

### DIFF
--- a/apps/openmw/mwgui/statswindow.cpp
+++ b/apps/openmw/mwgui/statswindow.cpp
@@ -5,6 +5,7 @@
 #include <MyGUI_ProgressBar.h>
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_InputManager.h>
+#include <MyGUI_LanguageManager.h>
 #include <MyGUI_Gui.h>
 
 #include <components/settings/settings.hpp>
@@ -336,14 +337,16 @@ namespace MWGui
             int max = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("iLevelUpTotal")->mValue.getInteger();
             getWidget(levelWidget, i==0 ? "Level_str" : "LevelText");
 
-            std::string detail;
+            std::stringstream detail;
             for (int i = 0; i < ESM::Attribute::Length; ++i)
             {
                 if (auto increase = PCstats.getLevelUpAttributeIncrease(i))
-                    detail += (detail.empty() ? "" : "\n") + ESM::Attribute::sAttributeNames[i] + " x" + MyGUI::utility::toString(increase);
+                    detail << (detail.str().empty() ? "" : "\n") << "#{"
+                    << MyGUI::TextIterator::toTagsString(ESM::Attribute::sGmstAttributeIds[i])
+                    << "} x" << MyGUI::utility::toString(increase);
             }
-            if (!detail.empty())
-                levelWidget->setUserString("Caption_LevelDetailText", detail);
+            if (!detail.str().empty())
+                levelWidget->setUserString("Caption_LevelDetailText", MyGUI::LanguageManager::getInstance().replaceTags(detail.str()));
             levelWidget->setUserString("RangePosition_LevelProgress", MyGUI::utility::toString(PCstats.getLevelProgress()));
             levelWidget->setUserString("Range_LevelProgress", MyGUI::utility::toString(max));
             levelWidget->setUserString("Caption_LevelProgressText", MyGUI::utility::toString(PCstats.getLevelProgress()) + "/"

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -272,6 +272,7 @@
                 <Property key="AutoResize" value="true"/>
                 <Property key="MultiLine" value="true"/>
                 <Property key="Shrink" value="true"/>
+                <Property key="TextAlign" value="HCenter Top"/>
             </Widget>
         </Widget>
 


### PR DESCRIPTION
Unfortunately, [MR437](https://gitlab.com/OpenMW/openmw/-/merge_requests/437) has issues:
1. Attribute names are not localized.
2. Tooltip strings are not aligned.

This PR addresses them. 
Note that I escape text to handle a case when related GMSTs values contain `#` character (e.g. `Attribute #1`), which MyGUI interprets as a beginning of tag.

Also personally I do not like this feature at all since it is quite misleading and does not tell which attribute multipliers player will have at the levelup anyway.