### PR TITLE
Fix build warnings

### DIFF
--- a/apps/openmw/mwmechanics/aifollow.cpp
+++ b/apps/openmw/mwmechanics/aifollow.cpp
@@ -119,7 +119,6 @@ bool AiFollow::execute (const MWWorld::Ptr& actor, CharacterController& characte
     auto followers = MWBase::Environment::get().getMechanicsManager()->getActorsFollowingByIndex(target);
     if (followers.size() >= 2 && followers.cbegin()->first != mFollowIndex)
     {
-        osg::Vec3f::value_type maxSize = 0;
         for(auto& follower : followers)
         {
             auto halfExtent = MWBase::Environment::get().getWorld()->getHalfExtents(follower.second).y();

--- a/apps/openmw/mwphysics/closestnotmeconvexresultcallback.cpp
+++ b/apps/openmw/mwphysics/closestnotmeconvexresultcallback.cpp
@@ -23,7 +23,7 @@ namespace MWPhysics
             int index0,
             const btCollisionObjectWrapper* colObj1Wrap,
             int partId1,
-            int index1)
+            int index1) override
         {
             if(cp.getDistance() <= 0.0f)
                 overlapping = true;

--- a/apps/openmw/mwphysics/movementsolver.cpp
+++ b/apps/openmw/mwphysics/movementsolver.cpp
@@ -41,7 +41,7 @@ namespace MWPhysics
             m_collisionFilterMask = me->getBroadphaseHandle()->m_collisionFilterMask;
             mVelocity = Misc::Convert::toBullet(velocity);
         }
-        virtual btScalar addSingleResult(btManifoldPoint & contact, const btCollisionObjectWrapper * colObj0Wrap, int partId0, int index0, const btCollisionObjectWrapper * colObj1Wrap, int partId1, int index1)
+        btScalar addSingleResult(btManifoldPoint & contact, const btCollisionObjectWrapper * colObj0Wrap, int partId0, int index0, const btCollisionObjectWrapper * colObj1Wrap, int partId1, int index1) override
         {
             if (isActor(colObj0Wrap->getCollisionObject()) && isActor(colObj1Wrap->getCollisionObject()))
                 return 0.0;

--- a/components/nifbullet/bulletnifloader.hpp
+++ b/components/nifbullet/bulletnifloader.hpp
@@ -23,7 +23,7 @@ class btCollisionShape;
 
 namespace Nif
 {
-    class Node;
+    struct Node;
     struct Transformation;
     struct NiTriShape;
     struct NiTriStrips;


### PR DESCRIPTION
Nothing critical, just an unused variable, class/struct mismatch and a couple of misisng `override` keywords.