### PR TITLE
Refactoring pre-requisites for groundcover

### DIFF
--- a/apps/openmw/mwrender/objectpaging.cpp
+++ b/apps/openmw/mwrender/objectpaging.cpp
@@ -249,15 +249,6 @@ namespace MWRender
         }
     };
 
-    class TemplateRef : public osg::Object
-    {
-    public:
-        TemplateRef() {}
-        TemplateRef(const TemplateRef& copy, const osg::CopyOp&) : mObjects(copy.mObjects) {}
-        META_Object(MWRender, TemplateRef)
-        std::vector<osg::ref_ptr<const Object>> mObjects;
-    };
-
     class RefnumSet : public osg::Object
     {
     public:
@@ -530,7 +521,7 @@ namespace MWRender
 
         osg::ref_ptr<osg::Group> group = new osg::Group;
         osg::ref_ptr<osg::Group> mergeGroup = new osg::Group;
-        osg::ref_ptr<TemplateRef> templateRefs = new TemplateRef;
+        osg::ref_ptr<Resource::TemplateMultiRef> templateRefs = new Resource::TemplateMultiRef;
         osgUtil::StateToCompile stateToCompile(0, nullptr);
         CopyOp copyop;
         for (const auto& pair : nodes)
@@ -596,7 +587,7 @@ namespace MWRender
             if (numinstances > 0)
             {
                 // add a ref to the original template, to hint to the cache that it's still being used and should be kept in cache
-                templateRefs->mObjects.emplace_back(cnode);
+                templateRefs->addRef(cnode);
 
                 if (pair.second.mNeedCompile)
                 {

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1134,6 +1134,7 @@ SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneMana
     , mRainEntranceSpeed(1)
     , mRainMaxRaindrops(0)
     , mWindSpeed(0.f)
+    , mBaseWindSpeed(0.f)
     , mEnabled(true)
     , mSunEnabled(true)
     , mWeatherAlpha(0.f)
@@ -1685,6 +1686,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
     mRainMaxHeight = weather.mRainMaxHeight;
     mRainSpeed = weather.mRainSpeed;
     mWindSpeed = weather.mWindSpeed;
+    mBaseWindSpeed = weather.mBaseWindSpeed;
 
     if (mRainEffect != weather.mRainEffect)
     {
@@ -1851,6 +1853,13 @@ void SkyManager::setWeather(const WeatherResult& weather)
 
     for (AlphaFader* fader : mParticleFaders)
         fader->setAlpha(weather.mEffectFade);
+}
+
+float SkyManager::getBaseWindSpeed() const
+{
+    if (!mCreated) return 0.f;
+
+    return mBaseWindSpeed;
 }
 
 void SkyManager::sunEnable()

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -70,6 +70,7 @@ namespace MWRender
         float mDLFogOffset;
 
         float mWindSpeed;
+        float mBaseWindSpeed;
         float mCurrentWindSpeed;
         float mNextWindSpeed;
 
@@ -181,6 +182,8 @@ namespace MWRender
 
         void setRainIntensityUniform(osg::Uniform *uniform);
 
+        float getBaseWindSpeed() const;
+
     private:
         void create();
         ///< no need to call this, automatically done on first enable()
@@ -265,6 +268,7 @@ namespace MWRender
         float mRainEntranceSpeed;
         int mRainMaxRaindrops;
         float mWindSpeed;
+        float mBaseWindSpeed;
 
         bool mEnabled;
         bool mSunEnabled;

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -1123,6 +1123,7 @@ inline void WeatherManager::calculateResult(const int weatherID, const float gam
     mResult.mCloudBlendFactor = 0;
     mResult.mNextWindSpeed = 0;
     mResult.mWindSpeed = mResult.mCurrentWindSpeed = calculateWindSpeed(weatherID, mWindSpeed);
+    mResult.mBaseWindSpeed = mWeatherSettings[weatherID].mWindSpeed;
 
     mResult.mCloudSpeed = current.mCloudSpeed;
     mResult.mGlareView = current.mGlareView;
@@ -1214,6 +1215,7 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
 
     mResult.mCurrentWindSpeed = calculateWindSpeed(mCurrentWeather, mCurrentWindSpeed);
     mResult.mNextWindSpeed = calculateWindSpeed(mNextWeather, mNextWindSpeed);
+    mResult.mBaseWindSpeed = lerp(current.mBaseWindSpeed, other.mBaseWindSpeed, factor);
 
     mResult.mWindSpeed = lerp(mResult.mCurrentWindSpeed, mResult.mNextWindSpeed, factor);
     mResult.mCloudSpeed = lerp(current.mCloudSpeed, other.mCloudSpeed, factor);

--- a/components/esm/defs.hpp
+++ b/components/esm/defs.hpp
@@ -54,6 +54,11 @@ struct Position
     {
         return osg::Vec3f(pos[0], pos[1], pos[2]);
     }
+
+    osg::Vec3f asRotationVec3() const
+    {
+        return osg::Vec3f(rot[0], rot[1], rot[2]);
+    }
 };
 #pragma pack(pop)
 

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -110,6 +110,10 @@ namespace
 
 namespace Resource
 {
+    void TemplateMultiRef::addRef(const osg::Node* node)
+    {
+        mObjects.emplace_back(node);
+    }
 
     class SharedStateManager : public osgDB::SharedStateManager
     {
@@ -553,20 +557,6 @@ namespace Resource
         mInstanceCache->addEntryToObjectCache(normalized, node.get());
         return node;
     }
-
-    class TemplateRef : public osg::Object
-    {
-    public:
-        TemplateRef(const Object* object)
-            : mObject(object) {}
-        TemplateRef() {}
-        TemplateRef(const TemplateRef& copy, const osg::CopyOp&) : mObject(copy.mObject) {}
-
-        META_Object(Resource, TemplateRef)
-
-    private:
-        osg::ref_ptr<const Object> mObject;
-    };
 
     osg::ref_ptr<osg::Node> SceneManager::createInstance(const std::string& name)
     {

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -37,6 +37,31 @@ namespace Shader
 
 namespace Resource
 {
+    class TemplateRef : public osg::Object
+    {
+    public:
+        TemplateRef(const Object* object) : mObject(object) {}
+        TemplateRef() {}
+        TemplateRef(const TemplateRef& copy, const osg::CopyOp&) : mObject(copy.mObject) {}
+
+        META_Object(Resource, TemplateRef)
+
+    private:
+        osg::ref_ptr<const Object> mObject;
+    };
+
+    class TemplateMultiRef : public osg::Object
+    {
+    public:
+        TemplateMultiRef() {}
+        TemplateMultiRef(const TemplateMultiRef& copy, const osg::CopyOp&) : mObjects(copy.mObjects) {}
+        void addRef(const osg::Node* node);
+
+        META_Object(Resource, TemplateMultiRef)
+
+    private:
+        std::vector<osg::ref_ptr<const Object>> mObjects;
+    };
 
     class MultiObjectCache;
 

--- a/components/sceneutil/serialize.cpp
+++ b/components/sceneutil/serialize.cpp
@@ -121,6 +121,7 @@ void registerSerializers()
         const char* ignore[] = {
             "MWRender::PtrHolder",
             "Resource::TemplateRef",
+            "Resource::TemplateMultiRef",
             "SceneUtil::CompositeStateSetUpdater",
             "SceneUtil::LightListCallback",
             "SceneUtil::LightManagerUpdateCallback",


### PR DESCRIPTION
Allows to split some changes (which are not directly groundcover-specific) from main groundcover PR.
Should also make review process easier.
Summary of changes:
1. Unify TemplateRef classes - both are defined in the same place, both are ignored by scene serializer, a one which keeps a vector of objects has a different name now. Note that it is possible also to keep only version with vector, if we are fine with additional overhead to keep vectors just for one element.
2. Add an API to  get a base wind speed from weather system (which is defined in openmw.cfg)
3. Allow to get a rotation vector from ESM::Position.