### PR TITLE
Avoid null dereference for objects without cells

### DIFF
--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1337,11 +1337,23 @@ namespace MWWorld
 
     void World::adjustPosition(const Ptr &ptr, bool force)
     {
+        if (ptr.isEmpty())
+        {
+            Log(Debug::Warning) << "Unable to adjust position for empty object";
+            return;
+        }
+
         osg::Vec3f pos (ptr.getRefData().getPosition().asVec3());
 
         if(!ptr.getRefData().getBaseNode())
         {
             // will be adjusted when Ptr's cell becomes active
+            return;
+        }
+
+        if (!ptr.isInCell())
+        {
+            Log(Debug::Warning) << "Unable to adjust position for object '" << ptr.getCellRef().getRefId() << "' - it has no cell";
             return;
         }
 


### PR DESCRIPTION
Just do nothing if we try to adjust position of object without cell (instead of crashing the game). A known case when it happens when you [use COC or COE from console in the main menu mode](https://gitlab.com/OpenMW/openmw/-/issues/5818), without active session.

Purely technical fix which does not really need a changelog entry.