### PR TITLE
Fix swapEndiannessInplace() for 4 byte values. Bug #5837

### DIFF
--- a/apps/openmw_test_suite/CMakeLists.txt
+++ b/apps/openmw_test_suite/CMakeLists.txt
@@ -16,6 +16,8 @@ if (GTEST_FOUND AND GMOCK_FOUND)
 
         misc/test_stringops.cpp
 
+        misc/test_endianness.cpp
+
         nifloader/testbulletnifloader.cpp
 
         detournavigator/navigator.cpp

--- a/apps/openmw_test_suite/misc/test_endianness.cpp
+++ b/apps/openmw_test_suite/misc/test_endianness.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+#include "components/misc/endianness.hpp"
+
+struct EndiannessTest : public ::testing::Test {};
+
+TEST_F(EndiannessTest, test_swap_endianness_inplace1)
+{
+  uint8_t zero=0x00;
+  uint8_t ff=0xFF;
+  uint8_t fortytwo=0x42;
+  uint8_t half=128;
+
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x00);
+
+  Misc::swapEndiannessInplace(ff);
+  EXPECT_TRUE(ff == 0xFF);
+
+  Misc::swapEndiannessInplace(fortytwo);
+  EXPECT_TRUE(fortytwo == 0x42);
+
+  Misc::swapEndiannessInplace(half);
+  EXPECT_TRUE(half == 128);
+}
+
+TEST_F(EndiannessTest, test_swap_endianness_inplace2)
+{
+  uint16_t zero = 0x0000;
+  uint16_t ffff = 0xFFFF;
+  uint16_t n12 = 0x0102;
+  uint16_t fortytwo = 0x0042;
+
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x0000);
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x0000);
+
+  Misc::swapEndiannessInplace(ffff);
+  EXPECT_TRUE(ffff == 0xFFFF);
+  Misc::swapEndiannessInplace(ffff);
+  EXPECT_TRUE(ffff == 0xFFFF);
+
+  Misc::swapEndiannessInplace(n12);
+  EXPECT_TRUE(n12 == 0x0201);
+  Misc::swapEndiannessInplace(n12);
+  EXPECT_TRUE(n12 == 0x0102);
+
+  Misc::swapEndiannessInplace(fortytwo);
+  EXPECT_TRUE(fortytwo == 0x4200);
+  Misc::swapEndiannessInplace(fortytwo);
+  EXPECT_TRUE(fortytwo == 0x0042);
+}
+
+TEST_F(EndiannessTest, test_swap_endianness_inplace4)
+{
+  uint32_t zero = 0x00000000;
+  uint32_t n1234 = 0x01020304;
+  uint32_t ffff = 0xFFFFFFFF;
+
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x00000000);
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x00000000);
+
+  Misc::swapEndiannessInplace(n1234);
+  EXPECT_TRUE(n1234 == 0x04030201);
+  Misc::swapEndiannessInplace(n1234);
+  EXPECT_TRUE(n1234 == 0x01020304);
+  
+  Misc::swapEndiannessInplace(ffff);
+  EXPECT_TRUE(ffff == 0xFFFFFFFF);
+  Misc::swapEndiannessInplace(ffff);
+  EXPECT_TRUE(ffff == 0xFFFFFFFF);
+}
+
+TEST_F(EndiannessTest, test_swap_endianness_inplace8)
+{
+  uint64_t zero = 0x0000'0000'0000'0000;
+  uint64_t n1234 = 0x0102'0304'0506'0708;
+  uint64_t ffff = 0xFFFF'FFFF'FFFF'FFFF;
+
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x0000'0000'0000'0000);
+  Misc::swapEndiannessInplace(zero);
+  EXPECT_TRUE(zero == 0x0000'0000'0000'0000);
+  
+  Misc::swapEndiannessInplace(ffff);
+  EXPECT_TRUE(ffff == 0xFFFF'FFFF'FFFF'FFFF);
+  Misc::swapEndiannessInplace(ffff);
+  EXPECT_TRUE(ffff == 0xFFFF'FFFF'FFFF'FFFF);
+
+  Misc::swapEndiannessInplace(n1234);
+  EXPECT_TRUE(n1234 == 0x0807'0605'0403'0201);
+  Misc::swapEndiannessInplace(n1234);
+  EXPECT_TRUE(n1234 == 0x0102'0304'0506'0708);
+}
+
+TEST_F(EndiannessTest, test_swap_endianness_inplace_float)
+{
+  const uint32_t original = 0x4023d70a;
+  const uint32_t expected = 0x0ad72340;
+
+  float number;
+  memcpy(&number, &original, sizeof(original));
+
+  Misc::swapEndiannessInplace(number);
+
+  EXPECT_TRUE(!memcmp(&number, &expected, sizeof(expected)));
+}
+
+TEST_F(EndiannessTest, test_swap_endianness_inplace_double)
+{
+  const uint64_t original = 0x040047ae147ae147ul;
+  const uint64_t expected = 0x47e17a14ae470004ul;
+
+  double number;
+  memcpy(&number, &original, sizeof(original));
+
+  Misc::swapEndiannessInplace(number);
+
+  EXPECT_TRUE(!memcmp(&number, &expected, sizeof(expected)) );
+}

--- a/components/misc/endianness.hpp
+++ b/components/misc/endianness.hpp
@@ -2,6 +2,7 @@
 #define COMPONENTS_MISC_ENDIANNESS_H
 
 #include <cstdint>
+#include <cstring>
 
 namespace Misc
 {
@@ -20,15 +21,19 @@ namespace Misc
         }
         if constexpr (sizeof(T) == 4)
         {
-            uint32_t& v32 = *reinterpret_cast<uint32_t*>(&v);
-            v32 = (v32 >> 24) | ((v32 >> 8) & 0xff00) | ((v32 & 0xff00) << 8) || v32 << 24;
+            std::uint32_t v32;
+            std::memcpy(&v32, &v, sizeof(uint32_t));
+            v32 = (v32 >> 24) | ((v32 >> 8) & 0xff00) | ((v32 & 0xff00) << 8) | (v32 << 24);
+            std::memcpy(&v, &v32, sizeof(uint32_t));
         }
         if constexpr (sizeof(T) == 8)
         {
-            uint64_t& v64 = *reinterpret_cast<uint64_t*>(&v);
+            uint64_t v64;
+            std::memcpy(&v64, &v, sizeof(uint64_t));
             v64 = (v64 >> 56) | ((v64 & 0x00ff'0000'0000'0000) >> 40) | ((v64 & 0x0000'ff00'0000'0000) >> 24)
                 | ((v64 & 0x0000'00ff'0000'0000) >> 8) | ((v64 & 0x0000'0000'ff00'0000) << 8)
                 | ((v64 & 0x0000'0000'00ff'0000) << 24) | ((v64 & 0x0000'0000'0000'ff00) << 40) | (v64 << 56);
+            std::memcpy(&v, &v64, sizeof(uint64_t));
         }
     }
 


### PR DESCRIPTION
This fixes [Bug #5837](https://gitlab.com/OpenMW/openmw/issues/5837).