### PR TITLE
Remove outdated entries from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,13 +84,3 @@ moc_*.cxx
 *.[ao]
 *.so
 venv/
-
-## recastnavigation unused files
-extern/recastnavigation/.travis.yml
-extern/recastnavigation/CONTRIBUTING.md
-extern/recastnavigation/Docs/
-extern/recastnavigation/Doxyfile
-extern/recastnavigation/README.md
-extern/recastnavigation/RecastDemo/
-extern/recastnavigation/Tests/
-extern/recastnavigation/appveyor.yml


### PR DESCRIPTION
[MR614](https://gitlab.com/OpenMW/openmw/-/merge_requests/614) removed recast navigation from `extern` folder, but author forgot to update `gitignore` file.