### PR TITLE
Use correct mCursorActive flag initial value

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -172,7 +172,7 @@ namespace MWGui
       , mWerewolfOverlayEnabled(Settings::Manager::getBool ("werewolf overlay", "GUI"))
       , mHudEnabled(true)
       , mCursorVisible(true)
-      , mCursorActive(false)
+      , mCursorActive(true)
       , mPlayerBounty(-1)
       , mGui(nullptr)
       , mGuiModes()


### PR DESCRIPTION
Initially when Scrawl added a keyboard navigation, he decided to [disable cursor by default](https://github.com/OpenMW/openmw/commit/fce9a14986e352af26270d814add9085c609c01c), but such behaviour was later rolled back since it is not intuitive and a deviation from vanilla game.

Now an only case when cursor can be not active is when SDL_CONTROLLER_BUTTON_LEFTSTICK button is pressed on gamepad:

```
            case SDL_CONTROLLER_BUTTON_LEFTSTICK:
                mGamepadGuiCursorEnabled = !mGamepadGuiCursorEnabled;
                MWBase::Environment::get().getWindowManager()->setCursorActive(mGamepadGuiCursorEnabled);
                return true;
```

By default, mGamepadGuiCursorEnabled = true, so it is expected that mCursorActive should be also true by default (as mCursorVisible already does).

Current upstream behaviour works well on PC since SDL for some reason generates a couple of mouse events during game start and they enable in-game cursor (probably these events are supposed to init cursor position), but on platforms without mouse (e.g. Android) it may lead to issues due to lack of such emitted events.

According to testing, this PR allows to drop [this](https://github.com/xyzz/openmw-android/blob/master/buildscripts/patches/openmw/0009-windowmanagerimp-always-show-mouse-when-possible-pat.patch) custom patch.