### PR TITLE
Double-buffer shader water stateset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     Bug #4764: Data race in osg ParticleSystem
     Bug #4765: Data race in ChunkManager -> Array::setBinding
     Bug #4774: Guards are ignorant of an invisible player that tries to attack them
+    Bug #5026: Data races with rain intensity uniform set by sky and used by water
     Bug #5101: Hostile followers travel with the player
     Bug #5108: Savegame bloating due to inefficient fog textures format
     Bug #5165: Active spells should use real time intead of timestamps

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -657,7 +657,7 @@ namespace MWRender
 
         mUnrefQueue->flush(mWorkQueue.get());
 
-        float rainIntensity = mSky->getEffectFade();
+        float rainIntensity = mSky->getPrecipitationAlpha();
         mWater->setRainIntensity(rainIntensity);
 
         if (!paused)

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -370,7 +370,6 @@ namespace MWRender
 
         mSky.reset(new SkyManager(sceneRoot, resourceSystem->getSceneManager()));
         mSky->setCamera(mViewer->getCamera());
-        mSky->setRainIntensityUniform(mWater->getRainIntensityUniform());
 
         source->setStateSetModes(*mRootNode->getOrCreateStateSet(), osg::StateAttribute::ON);
 
@@ -657,6 +656,9 @@ namespace MWRender
         reportStats();
 
         mUnrefQueue->flush(mWorkQueue.get());
+
+        float rainIntensity = mSky->getEffectFade();
+        mWater->setRainIntensity(rainIntensity);
 
         if (!paused)
         {

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1138,7 +1138,7 @@ SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneMana
     , mBaseWindSpeed(0.f)
     , mEnabled(true)
     , mSunEnabled(true)
-    , mEffectFade(0.f)
+    , mPrecipitationAlpha(0.f)
 {
     osg::ref_ptr<CameraRelativeTransform> skyroot (new CameraRelativeTransform);
     skyroot->setName("Sky Root");
@@ -1516,7 +1516,7 @@ void SkyManager::createRain()
 
     osg::ref_ptr<osgParticle::ModularProgram> program (new osgParticle::ModularProgram);
     program->addOperator(new WrapAroundOperator(mCamera,rainRange));
-    program->addOperator(new WeatherAlphaOperator(mEffectFade, true));
+    program->addOperator(new WeatherAlphaOperator(mPrecipitationAlpha, true));
     program->setParticleSystem(mRainParticleSystem);
     mRainNode->addChild(program);
 
@@ -1575,10 +1575,10 @@ bool SkyManager::hasRain() const
     return mRainNode != nullptr;
 }
 
-float SkyManager::getEffectFade() const
+float SkyManager::getPrecipitationAlpha() const
 {
     if (mEnabled && !mIsStorm && (hasRain() || mParticleNode))
-        return mEffectFade;
+        return mPrecipitationAlpha;
 
     return 0.f;
 }
@@ -1722,7 +1722,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
             SceneUtil::AssignControllerSourcesVisitor assignVisitor(std::shared_ptr<SceneUtil::ControllerSource>(new SceneUtil::FrameTimeSource));
             mParticleEffect->accept(assignVisitor);
 
-            AlphaFader::SetupVisitor alphaFaderSetupVisitor(mEffectFade);
+            AlphaFader::SetupVisitor alphaFaderSetupVisitor(mPrecipitationAlpha);
 
             mParticleEffect->accept(alphaFaderSetupVisitor);
 
@@ -1739,7 +1739,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
                 osg::ref_ptr<osgParticle::ModularProgram> program (new osgParticle::ModularProgram);
                 if (!mIsStorm)
                     program->addOperator(new WrapAroundOperator(mCamera,osg::Vec3(1024,1024,800)));
-                program->addOperator(new WeatherAlphaOperator(mEffectFade, false));
+                program->addOperator(new WeatherAlphaOperator(mPrecipitationAlpha, false));
                 program->setParticleSystem(ps);
                 mParticleNode->addChild(program);
             }
@@ -1828,7 +1828,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
 
     mAtmosphereNightNode->setNodeMask(weather.mNight ? ~0 : 0);
 
-    mEffectFade = weather.mEffectFade;
+    mPrecipitationAlpha = weather.mPrecipitationAlpha;
 }
 
 float SkyManager::getBaseWindSpeed() const

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -1113,7 +1113,6 @@ private:
 SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneManager)
     : mSceneManager(sceneManager)
     , mCamera(nullptr)
-    , mRainIntensityUniform(nullptr)
     , mAtmosphereNightRoll(0.f)
     , mCreated(false)
     , mIsStorm(false)
@@ -1161,11 +1160,6 @@ SkyManager::SkyManager(osg::Group* parentNode, Resource::SceneManager* sceneMana
     mRootNode->addChild(mEarlyRenderBinRoot);
 
     mUnderwaterSwitch = new UnderwaterSwitchCallback(skyroot);
-}
-
-void SkyManager::setRainIntensityUniform(osg::Uniform *uniform)
-{
-    mRainIntensityUniform = uniform;
 }
 
 void SkyManager::create()
@@ -1576,30 +1570,21 @@ bool SkyManager::isEnabled()
     return mEnabled;
 }
 
-bool SkyManager::hasRain()
+bool SkyManager::hasRain() const
 {
     return mRainNode != nullptr;
 }
 
+float SkyManager::getEffectFade() const
+{
+    if (mEnabled && !mIsStorm && (hasRain() || mParticleNode))
+        return mEffectFade;
+
+    return 0.f;
+}
+
 void SkyManager::update(float duration)
 {
-    if (!mEnabled)
-    {
-        if (mRainIntensityUniform)
-            mRainIntensityUniform->set(0.f);
-
-        return;
-    }
-
-    if (mRainIntensityUniform)
-    {
-        float rainIntensity = 0.f;
-        if (!mIsStorm && (hasRain() || mParticleNode))
-            rainIntensity = mEffectFade;
-
-        mRainIntensityUniform->set(rainIntensity);
-    }
-
     switchUnderwaterRain();
 
     if (mIsStorm)

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -7,7 +7,6 @@
 
 #include <osg/ref_ptr>
 #include <osg/Vec4f>
-#include <osg/Uniform>
 
 namespace osg
 {
@@ -157,7 +156,9 @@ namespace MWRender
 
         bool isEnabled();
 
-        bool hasRain();
+        bool hasRain() const;
+
+        float getEffectFade() const;
 
         void setRainSpeed(float speed);
 
@@ -180,8 +181,6 @@ namespace MWRender
 
         void setCamera(osg::Camera *camera);
 
-        void setRainIntensityUniform(osg::Uniform *uniform);
-
         float getBaseWindSpeed() const;
 
     private:
@@ -196,7 +195,6 @@ namespace MWRender
         Resource::SceneManager* mSceneManager;
 
         osg::Camera *mCamera;
-        osg::Uniform *mRainIntensityUniform;
 
         osg::ref_ptr<osg::Group> mRootNode;
         osg::ref_ptr<osg::Group> mEarlyRenderBinRoot;

--- a/apps/openmw/mwrender/sky.hpp
+++ b/apps/openmw/mwrender/sky.hpp
@@ -87,7 +87,7 @@ namespace MWRender
 
         std::string mParticleEffect;
         std::string mRainEffect;
-        float mEffectFade;
+        float mPrecipitationAlpha;
 
         float mRainDiameter;
         float mRainMinHeight;
@@ -158,7 +158,7 @@ namespace MWRender
 
         bool hasRain() const;
 
-        float getEffectFade() const;
+        float getPrecipitationAlpha() const;
 
         void setRainSpeed(float speed);
 
@@ -269,7 +269,7 @@ namespace MWRender
         bool mEnabled;
         bool mSunEnabled;
 
-        float mEffectFade;
+        float mPrecipitationAlpha;
 
         osg::Vec4f mMoonScriptColor;
     };

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -208,6 +208,37 @@ public:
     }
 };
 
+class RainIntensityUpdater : public SceneUtil::StateSetUpdater
+{
+public:
+    RainIntensityUpdater()
+        : mRainIntensity(0.f)
+    {
+    }
+
+    void setRainIntensity(float rainIntensity)
+    {
+        mRainIntensity = rainIntensity;
+    }
+
+protected:
+    void setDefaults(osg::StateSet* stateset) override
+    {
+        osg::ref_ptr<osg::Uniform> rainIntensityUniform = new osg::Uniform("rainIntensity", 0.0f);
+        stateset->addUniform(rainIntensityUniform.get());
+    }
+
+    void apply(osg::StateSet* stateset, osg::NodeVisitor* /*nv*/) override
+    {
+        osg::ref_ptr<osg::Uniform> rainIntensityUniform = stateset->getUniform("rainIntensity");
+        if (rainIntensityUniform != nullptr)
+            rainIntensityUniform->set(mRainIntensity);
+    }
+
+private:
+    float mRainIntensity;
+};
+
 osg::ref_ptr<osg::Image> readPngImage (const std::string& file)
 {
     // use boost in favor of osgDB::readImage, to handle utf-8 path issues on Windows
@@ -431,7 +462,8 @@ public:
 
 Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem *resourceSystem,
              osgUtil::IncrementalCompileOperation *ico, const std::string& resourcePath)
-    : mParent(parent)
+    : mRainIntensityUpdater(nullptr)
+    , mParent(parent)
     , mSceneRoot(sceneRoot)
     , mResourceSystem(resourceSystem)
     , mResourcePath(resourcePath)
@@ -463,8 +495,6 @@ Water::Water(osg::Group *parent, osg::Group* sceneRoot, Resource::ResourceSystem
 
     setHeight(mTop);
 
-    mRainIntensityUniform = new osg::Uniform("rainIntensity",(float) 0.0);
-
     updateWaterMaterial();
 
     if (ico)
@@ -492,11 +522,6 @@ void Water::setCullCallback(osg::Callback* callback)
         if (mRefraction)
             mRefraction->addCullCallback(callback);
     }
-}
-
-osg::Uniform *Water::getRainIntensityUniform()
-{
-    return mRainIntensityUniform.get();
 }
 
 void Water::updateWaterMaterial()
@@ -556,6 +581,8 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
     osg::ref_ptr<osg::StateSet> stateset = SceneUtil::createSimpleWaterStateSet(alpha, MWRender::RenderBin_Water);
 
     node->setStateSet(stateset);
+    node->setUpdateCallback(nullptr);
+    mRainIntensityUpdater = nullptr;
 
     // Add animated textures
     std::vector<osg::ref_ptr<osg::Texture2D> > textures;
@@ -639,15 +666,15 @@ void Water::createShaderWaterStateSet(osg::Node* node, Reflection* reflection, R
 
     shaderStateset->setMode(GL_CULL_FACE, osg::StateAttribute::OFF);
 
-    shaderStateset->addUniform(mRainIntensityUniform.get());
-
     osg::ref_ptr<osg::Program> program (new osg::Program);
     program->addShader(vertexShader);
     program->addShader(fragmentShader);
     shaderStateset->setAttributeAndModes(program, osg::StateAttribute::ON);
 
     node->setStateSet(shaderStateset);
-    node->setUpdateCallback(nullptr);
+
+    mRainIntensityUpdater = new RainIntensityUpdater();
+    node->setUpdateCallback(mRainIntensityUpdater);
 }
 
 void Water::processChangedSettings(const Settings::CategorySettingVector& settings)
@@ -728,6 +755,12 @@ void Water::setHeight(const float height)
         mReflection->setWaterLevel(mTop);
     if (mRefraction)
         mRefraction->setWaterLevel(mTop);
+}
+
+void Water::setRainIntensity(float rainIntensity)
+{
+    if (mRainIntensityUpdater)
+        mRainIntensityUpdater->setRainIntensity(rainIntensity);
 }
 
 void Water::update(float dt)

--- a/apps/openmw/mwrender/water.hpp
+++ b/apps/openmw/mwrender/water.hpp
@@ -6,7 +6,6 @@
 
 #include <osg/ref_ptr>
 #include <osg/Vec3f>
-#include <osg/Uniform>
 #include <osg/Camera>
 
 #include <components/settings/settings.hpp>
@@ -46,11 +45,12 @@ namespace MWRender
     class Refraction;
     class Reflection;
     class RippleSimulation;
+    class RainIntensityUpdater;
 
     /// Water rendering
     class Water
     {
-        osg::ref_ptr<osg::Uniform> mRainIntensityUniform;
+        osg::ref_ptr<RainIntensityUpdater> mRainIntensityUpdater;
 
         osg::ref_ptr<osg::Group> mParent;
         osg::ref_ptr<osg::Group> mSceneRoot;
@@ -112,6 +112,7 @@ namespace MWRender
 
         void changeCell(const MWWorld::CellStore* store);
         void setHeight(const float height);
+        void setRainIntensity(const float rainIntensity);
 
         void update(float dt);
 
@@ -119,8 +120,6 @@ namespace MWRender
         osg::Camera *getRefractionCamera();
 
         void processChangedSettings(const Settings::CategorySettingVector& settings);
-
-        osg::Uniform *getRainIntensityUniform();
     };
 
 }

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -1129,7 +1129,7 @@ inline void WeatherManager::calculateResult(const int weatherID, const float gam
     mResult.mGlareView = current.mGlareView;
     mResult.mAmbientLoopSoundID = current.mAmbientLoopSoundID;
     mResult.mAmbientSoundVolume = 1.f;
-    mResult.mEffectFade = 1.f;
+    mResult.mPrecipitationAlpha = 1.f;
 
     mResult.mIsStorm = current.mIsStorm;
 
@@ -1236,7 +1236,7 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
         mResult.mRainSpeed = current.mRainSpeed;
         mResult.mRainEntranceSpeed = current.mRainEntranceSpeed;
         mResult.mAmbientSoundVolume = 1 - factor / threshold;
-        mResult.mEffectFade = mResult.mAmbientSoundVolume;
+        mResult.mPrecipitationAlpha = mResult.mAmbientSoundVolume;
         mResult.mAmbientLoopSoundID = current.mAmbientLoopSoundID;
         mResult.mRainDiameter = current.mRainDiameter;
         mResult.mRainMinHeight = current.mRainMinHeight;
@@ -1251,7 +1251,7 @@ inline void WeatherManager::calculateTransitionResult(const float factor, const 
         mResult.mRainSpeed = other.mRainSpeed;
         mResult.mRainEntranceSpeed = other.mRainEntranceSpeed;
         mResult.mAmbientSoundVolume = (factor - threshold) / (1 - threshold);
-        mResult.mEffectFade = mResult.mAmbientSoundVolume;
+        mResult.mPrecipitationAlpha = mResult.mAmbientSoundVolume;
         mResult.mAmbientLoopSoundID = other.mAmbientLoopSoundID;
 
         mResult.mRainDiameter = other.mRainDiameter;


### PR DESCRIPTION
Fixes [bug #5026](https://gitlab.com/OpenMW/openmw/-/issues/5026).

The main idea is to do not modify water stateset outside the Water class itself - insead RenderingManager just tells Water about rain intensity value and allows Water itself decide what to do with such info.

It allows us to double-buffer water stateset to modify its uniforms in a threadsafe way.