### PR TITLE
Add move assignment operator for the ESM::Variant

### DIFF
--- a/components/esm/variant.cpp
+++ b/components/esm/variant.cpp
@@ -62,9 +62,30 @@ ESM::Variant& ESM::Variant::operator= (const Variant& variant)
     return *this;
 }
 
+ESM::Variant& ESM::Variant::operator= (Variant&& variant)
+{
+    if (&variant!=this)
+    {
+        delete mData;
+
+        mType = variant.mType;
+        mData = variant.mData;
+
+        variant.mData = nullptr;
+    }
+
+    return *this;
+}
+
 ESM::Variant::Variant (const Variant& variant)
 : mType (variant.mType), mData (variant.mData ? variant.mData->clone() : nullptr)
 {}
+
+ESM::Variant::Variant(Variant&& variant)
+: mType (variant.mType), mData (variant.mData)
+{
+    variant.mData = nullptr;
+}
 
 ESM::VarType ESM::Variant::getType() const
 {

--- a/components/esm/variant.hpp
+++ b/components/esm/variant.hpp
@@ -46,8 +46,10 @@ namespace ESM
             ~Variant();
 
             Variant& operator= (const Variant& variant);
+            Variant& operator= (Variant && variant);
 
             Variant (const Variant& variant);
+            Variant (Variant&& variant);
 
             VarType getType() const;
 


### PR DESCRIPTION
Partially completes [task #5893](https://gitlab.com/OpenMW/openmw/-/issues/5893).

`RefData` is a quite complex object, so probably it is out of my experience level, but this PR still should fix one Coverity complaint.