### PR TITLE
Remove invalid MyGUI properties from layout files

### DIFF
--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -302,7 +302,6 @@
                         </Widget>
 
                         <Widget type="TextBox" skin="SandText" position="182 94 300 32" align="Left Top">
-                            <Property key="MultiLine" value="true"/>
                             <Property key="Caption" value="Hint: press F3 to show \nthe current frame rate."/>
                         </Widget>
 

--- a/files/mygui/openmw_tooltips.layout
+++ b/files/mygui/openmw_tooltips.layout
@@ -193,7 +193,6 @@
                 <Property key="Shrink" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
-                <Property key="Spacing" value="28"/>
                 <UserString key="HStretch" value="true"/>
             </Widget>
 
@@ -248,7 +247,6 @@
                 <Property key="MultiLine" value="true"/>
                 <Property key="WordWrap" value="true"/>
                 <Property key="TextAlign" value="Left Top"/>
-                <Property key="Spacing" value="28"/>
             </Widget>
         </Widget>
 
@@ -269,9 +267,6 @@
             </Widget>
 
             <Widget type="AutoSizedTextBox" skin="SandText" position="0 0 0 0" align="Left Top" name="LevelDetailText">
-                <Property key="AutoResize" value="true"/>
-                <Property key="MultiLine" value="true"/>
-                <Property key="Shrink" value="true"/>
                 <Property key="TextAlign" value="HCenter Top"/>
             </Widget>
         </Widget>


### PR DESCRIPTION
Just fix MyGUI warnings by results of investigation:
1. TextBox is always multiline, `Multiline` property was added only for EditBox.
2. `Shrink` is our custom property for our `AutoSizedEditBox`, it is not present in the `AutoSizedTextBox`
3. `Spacing` and `AutoResize` are our custom properties for our HBox/VBox, they are not present in text boxes.