### PR TITLE
Init animation key struct before usage

### DIFF
--- a/components/nif/nifkey.hpp
+++ b/components/nif/nifkey.hpp
@@ -77,7 +77,7 @@ struct KeyMapT {
 
         mInterpolationType = nif->getUInt();
 
-        KeyT<T> key;
+        KeyType key = {};
         NIFStream &nifReference = *nif;
 
         if (mInterpolationType == InterpolationType_Linear


### PR DESCRIPTION
Solves task [#5894](https://gitlab.com/OpenMW/openmw/-/issues/5894).

Just use a default initializer to make sure that struct does not contain random garbage. 