### PR TITLE
Reset watched stats upon reload or new game start

### DIFF
--- a/apps/openmw/mwgui/statswatcher.hpp
+++ b/apps/openmw/mwgui/statswatcher.hpp
@@ -63,6 +63,8 @@ namespace MWGui
 
         void watchActor(const MWWorld::Ptr& ptr);
         MWWorld::Ptr getWatchedActor() const { return mWatched; }
+
+        void forceUpdate() { mWatchedStatsEmpty = true; }
     };
 }
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -495,6 +495,8 @@ namespace MWGui
         }
         else
             allow(GW_ALL);
+
+        mStatsWatcher->forceUpdate();
     }
 
     WindowManager::~WindowManager()


### PR DESCRIPTION
Should fix [regression #5905](https://gitlab.com/OpenMW/openmw/-/issues/5905).