### PR TITLE
Fix build with OSG 3.4

### DIFF
--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -6,6 +6,7 @@
 #include <osg/Material>
 #include <osg/Multisample>
 #include <osg/Texture>
+#include <osg/ValueObject>
 
 #include <osgUtil/TangentSpaceGenerator>
 


### PR DESCRIPTION
Just add missing include, which is not required with 3.6. We already have this include in other such cases.