### PR TITLE
Restore old aiming for melee combat

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -607,7 +607,7 @@ namespace MWBase
 
             /// Return a vector aiming the actor's weapon towards a target.
             /// @note The length of the vector is the distance between actor and target.
-            virtual osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) = 0;
+            virtual osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target, bool isRangedCombat) = 0;
 
             /// Return the distance between actor's weapon and target's collision box.
             virtual float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) = 0;

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -228,7 +228,6 @@ namespace MWMechanics
         const osg::Vec3f vActorPos(pos.asVec3());
         const osg::Vec3f vTargetPos(target.getRefData().getPosition().asVec3());
 
-        osg::Vec3f vAimDir = MWBase::Environment::get().getWorld()->aimToTarget(actor, target);
         float distToTarget = MWBase::Environment::get().getWorld()->getHitDistance(actor, target);
 
         storage.mReadyToAttack = (currentAction->isAttackingOrSpell() && distToTarget <= rangeAttack && storage.mLOS);
@@ -236,13 +235,14 @@ namespace MWMechanics
         if (isRangedCombat)
         {
             // rotate actor taking into account target movement direction and projectile speed
-            vAimDir = AimDirToMovingTarget(actor, target, storage.mLastTargetPos, AI_REACTION_TIME, (weapon ? weapon->mData.mType : 0), storage.mStrength);
+            osg::Vec3f vAimDir = AimDirToMovingTarget(actor, target, storage.mLastTargetPos, AI_REACTION_TIME, (weapon ? weapon->mData.mType : 0), storage.mStrength);
 
             storage.mMovement.mRotation[0] = getXAngleToDir(vAimDir);
             storage.mMovement.mRotation[2] = getZAngleToDir(vAimDir);
         }
         else
         {
+            osg::Vec3f vAimDir = MWBase::Environment::get().getWorld()->aimToTarget(actor, target, false);
             storage.mMovement.mRotation[0] = getXAngleToDir(vAimDir);
             storage.mMovement.mRotation[2] = getZAngleToDir((vTargetPos-vActorPos)); // using vAimDir results in spastic movements since the head is animated
         }
@@ -698,7 +698,7 @@ osg::Vec3f AimDirToMovingTarget(const MWWorld::Ptr& actor, const MWWorld::Ptr& t
     // idea: perpendicular to dir to target speed components of target move vector and projectile vector should be the same
 
     osg::Vec3f vTargetPos = target.getRefData().getPosition().asVec3();
-    osg::Vec3f vDirToTarget = MWBase::Environment::get().getWorld()->aimToTarget(actor, target);
+    osg::Vec3f vDirToTarget = MWBase::Environment::get().getWorld()->aimToTarget(actor, target, true);
     float distToTarget = vDirToTarget.length();
 
     osg::Vec3f vTargetMoveDir = vTargetPos - vLastTargetPos;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -2955,7 +2955,7 @@ void CharacterController::updateHeadTracking(float duration)
             }
             else
                 // no head node to look at, fall back to look at center of collision box
-                direction = MWBase::Environment::get().getWorld()->aimToTarget(mPtr, mHeadTrackTarget);
+                direction = MWBase::Environment::get().getWorld()->aimToTarget(mPtr, mHeadTrackTarget, false);
         }
         direction.normalize();
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -3885,14 +3885,12 @@ namespace MWWorld
         return false;
     }
 
-    osg::Vec3f World::aimToTarget(const ConstPtr &actor, const ConstPtr &target)
+    osg::Vec3f World::aimToTarget(const ConstPtr &actor, const ConstPtr &target, bool isRangedCombat)
     {
         osg::Vec3f weaponPos = actor.getRefData().getPosition().asVec3();
-        osg::Vec3f weaponHalfExtents = mPhysics->getHalfExtents(actor);
-        osg::Vec3f targetPos = target.getRefData().getPosition().asVec3();
-        osg::Vec3f targetHalfExtents = mPhysics->getHalfExtents(target);
-        weaponPos.z() += weaponHalfExtents.z() * 2 * Constants::TorsoHeight;
-        targetPos.z() += targetHalfExtents.z();
+        float heightRatio = isRangedCombat ? 2.f * Constants::TorsoHeight : 1.f;
+        weaponPos.z() += mPhysics->getHalfExtents(actor).z() * heightRatio;
+        osg::Vec3f targetPos = mPhysics->getCollisionObjectPosition(target);
         return (targetPos - weaponPos);
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -705,7 +705,7 @@ namespace MWWorld
 
             /// Return a vector aiming the actor's weapon towards a target.
             /// @note The length of the vector is the distance between actor and target.
-            osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;
+            osg::Vec3f aimToTarget(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target, bool isRangedCombat) override;
 
             /// Return the distance between actor's weapon and target's collision box.
             float getHitDistance(const MWWorld::ConstPtr& actor, const MWWorld::ConstPtr& target) override;


### PR DESCRIPTION
Fixes a regression from [MR685](https://gitlab.com/OpenMW/openmw/-/merge_requests/685) - NPCs can not hit cliff racers via melee weapons.

From what I can tell, a pont of that MR is to use 0.75x of actor's height (where magic bolts are spawned and near location where projectiles are spawned) as an origin of aiming. Also aiming started to ignore target's collision box offset (which is used for flying creatures). Such change broke melee aiming (melee hit contact is a cone shape with origin in the center of actor's collision box), especially against flying creatures.

Solution: 
1. Use 75% of height for ranged aiming and use 50% in other cases (e.g. for melee and head tracking).
2. Take in account target's collision box offset again.
Basically, it is just our old aiming, but with 75% of height for aiming in ranged combat.

In my testing it allowed to fix mentioned regression, while still solving an original issue (when netches always aimed over target's head).
Note that netches often miss when they move, with or without fix, but it is a separate issue.