### PR TITLE
Code cleanup, part 2

### DIFF
--- a/apps/essimporter/convertscpt.cpp
+++ b/apps/essimporter/convertscpt.cpp
@@ -11,6 +11,7 @@ namespace ESSImport
     {
         out.mId = Misc::StringUtils::lowerCase(scpt.mSCHD.mName.toString());
         out.mRunning = scpt.mRunning;
+        out.mTargetRef.unset(); // TODO: convert target reference of global script
         convertSCRI(scpt.mSCRI, out.mLocals);
     }
 

--- a/apps/essimporter/importinventory.cpp
+++ b/apps/essimporter/importinventory.cpp
@@ -19,6 +19,7 @@ namespace ESSImport
             item.mCount = contItem.mCount;
             item.mRelativeEquipmentSlot = -1;
             item.mLockLevel = 0;
+            item.mRefNum.unset();
 
             unsigned int itemCount = std::abs(item.mCount);
             bool separateStacks = false;

--- a/apps/opencs/model/world/data.cpp
+++ b/apps/opencs/model/world/data.cpp
@@ -986,20 +986,6 @@ int CSMWorld::Data::startLoading (const boost::filesystem::path& path, bool base
         mMetaData.setRecord (0, Record<MetaData> (RecordBase::State_ModifiedOnly, nullptr, &metaData));
     }
 
-    // Fix uninitialized master data index
-    for (std::vector<ESM::Header::MasterData>::const_iterator masterData = mReader->getGameFiles().begin();
-        masterData != mReader->getGameFiles().end(); ++masterData)
-    {
-        std::map<std::string, int>::iterator nameResult = mContentFileNames.find(masterData->name);
-        if (nameResult != mContentFileNames.end())
-        {
-            ESM::Header::MasterData& hackedMasterData = const_cast<ESM::Header::MasterData&>(*masterData);
-
-
-            hackedMasterData.index = nameResult->second;
-        }
-    }
-
     return mReader->getRecordCount();
 }
 

--- a/components/crashcatcher/crashcatcher.cpp
+++ b/components/crashcatcher/crashcatcher.cpp
@@ -150,6 +150,9 @@ static void gdb_info(pid_t pid)
      * So CoverityScan warning is valid only for ancient versions of stdlib.
     */
     strcpy(respfile, "/tmp/gdb-respfile-XXXXXX");
+#ifdef __COVERITY__
+    umask(0600);
+#endif
     if((fd=mkstemp(respfile)) >= 0 && (f=fdopen(fd, "w")) != nullptr)
     {
         fprintf(f, "attach %d\n"

--- a/components/esm/loadtes3.cpp
+++ b/components/esm/loadtes3.cpp
@@ -42,7 +42,6 @@ void ESM::Header::load (ESMReader &esm)
         MasterData m;
         m.name = esm.getHString();
         m.size = esm.getHNLong ("DATA");
-        m.index = -1;
         mMaster.push_back (m);
     }
 

--- a/components/esm/loadtes3.hpp
+++ b/components/esm/loadtes3.hpp
@@ -49,7 +49,6 @@ namespace ESM
         {
             std::string name;
             uint64_t size;
-            int index; // Position of the parent file in the global list of loaded files
         };
 
         GMDT mGameData; // Used in .ess savegames only

--- a/components/nif/data.cpp
+++ b/components/nif/data.cpp
@@ -363,11 +363,11 @@ void NiSkinPartition::read(NIFStream *nif)
 
 void NiSkinPartition::Partition::read(NIFStream *nif)
 {
-    unsigned short numVertices = nif->getUShort();
-    unsigned short numTriangles = nif->getUShort();
-    unsigned short numBones = nif->getUShort();
-    unsigned short numStrips = nif->getUShort();
-    unsigned short bonesPerVertex = nif->getUShort();
+    size_t numVertices = nif->getUShort();
+    size_t numTriangles = nif->getUShort();
+    size_t numBones = nif->getUShort();
+    size_t numStrips = nif->getUShort();
+    size_t bonesPerVertex = nif->getUShort();
     if (numBones)
         nif->getUShorts(bones, numBones);
 
@@ -395,7 +395,7 @@ void NiSkinPartition::Partition::read(NIFStream *nif)
         if (numStrips)
         {
             strips.resize(numStrips);
-            for (unsigned short i = 0; i < numStrips; i++)
+            for (size_t i = 0; i < numStrips; i++)
                 nif->getUShorts(strips[i], stripLengths[i]);
         }
         else if (numTriangles)

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -861,7 +861,7 @@ namespace SceneUtil
 
         if (ffp)
         {
-            initFFP(LightManager::mFFPMaxLights);
+            initFFP(mFFPMaxLights);
             return;
         }
 
@@ -1044,7 +1044,7 @@ namespace SceneUtil
         auto* stateset = getOrCreateStateSet();
 
         setLightingMethod(LightingMethod::PerObjectUniform);
-        setMaxLights(std::clamp(targetLights, mMaxLightsLowerLimit, LightManager::mMaxLightsUpperLimit));
+        setMaxLights(std::clamp(targetLights, mMaxLightsLowerLimit, mMaxLightsUpperLimit));
 
         stateset->setAttributeAndModes(new LightManagerStateAttributePerObjectUniform(this), osg::StateAttribute::ON);
         stateset->addUniform(new osg::Uniform(osg::Uniform::FLOAT_MAT4, "LightBuffer", getMaxLights()));
@@ -1053,7 +1053,7 @@ namespace SceneUtil
     void LightManager::initSingleUBO(int targetLights)
     {
         setLightingMethod(LightingMethod::SingleUBO);
-        setMaxLights(std::clamp(targetLights, mMaxLightsLowerLimit, LightManager::mMaxLightsUpperLimit));
+        setMaxLights(std::clamp(targetLights, mMaxLightsLowerLimit, mMaxLightsUpperLimit));
 
         for (int i = 0; i < 2; ++i)
         {

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -400,7 +400,7 @@ namespace SceneUtil
     class LightStateAttributePerObjectUniform : public osg::StateAttribute
     {
     public:
-        LightStateAttributePerObjectUniform() {}
+        LightStateAttributePerObjectUniform() : mLightManager(nullptr) {}
         LightStateAttributePerObjectUniform(const std::vector<osg::ref_ptr<osg::Light>>& lights, LightManager* lightManager) :  mLights(lights), mLightManager(lightManager) {}
 
         LightStateAttributePerObjectUniform(const LightStateAttributePerObjectUniform& copy,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY)
@@ -613,7 +613,7 @@ namespace SceneUtil
     class LightManagerCullCallback : public osg::NodeCallback
     {
     public:
-        LightManagerCullCallback(LightManager* lightManager) : mLightManager(lightManager) {}
+        LightManagerCullCallback(LightManager* lightManager) : mLightManager(lightManager), mLastFrameNumber(0) {}
 
         void operator()(osg::Node* node, osg::NodeVisitor* nv) override
         {
@@ -903,6 +903,10 @@ namespace SceneUtil
         , mLightingMask(copy.mLightingMask)
         , mSun(copy.mSun)
         , mLightingMethod(copy.mLightingMethod)
+        , mPointLightRadiusMultiplier(copy.mPointLightRadiusMultiplier)
+        , mPointLightFadeEnd(copy.mPointLightFadeEnd)
+        , mPointLightFadeStart(copy.mPointLightFadeStart)
+        , mMaxLights(copy.mMaxLights)
     {
     }
 

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -368,6 +368,7 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
         pack_evt.yrel = 0;
         pack_evt.z = mMouseZ;
         pack_evt.zrel = 0;
+        pack_evt.timestamp = 0;
 
         if(evt.type == SDL_MOUSEMOTION)
         {

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -278,8 +278,7 @@ namespace Shader
 
         const osg::StateSet::AttributeList& attributes = stateset->getAttributeList();
         osg::StateSet::AttributeList removedAttributes;
-        osg::ref_ptr<osg::StateSet> removedState;
-        if (removedState = getRemovedState(*stateset))
+        if (osg::ref_ptr<osg::StateSet> removedState = getRemovedState(*stateset))
             removedAttributes = removedState->getAttributeList();
         for (const auto& attributeMap : { attributes, removedAttributes })
         {
@@ -475,8 +474,7 @@ namespace Shader
 
         writableStateSet->removeAttribute(osg::StateAttribute::PROGRAM);
 
-        osg::ref_ptr<osg::StateSet> removedState;
-        if (removedState = getRemovedState(*writableStateSet))
+        if (osg::ref_ptr<osg::StateSet> removedState = getRemovedState(*writableStateSet))
         {
             // user data is normally shallow copied so shared with the original stateset
             osg::ref_ptr<osg::UserDataContainer> writableUserData;


### PR DESCRIPTION
1. Since all `get*s` methods used in NiSkinPartition accept size_t as an argument, we can extend our ushort values to size_t. I suppose that Coverity Scan is smart enough to determine that there is no way to overflow size_t * size_t multiplication in this case (because multipliers values come from ushorts), even if compiler will resolve size_t to unsigned int.
2. Init a couple of fields in the ESSImporter.
3. Try to shut up warning about mkstemp
4. Fix Clang complaints in the ShaderVisitor (jvoisin for some reason closed his MR).
5. Fix uninitialized fields in the LightManager
6. Fix an another uninitialized field in the mouse event
7. Remove some redundant qualifies.
8. Remove an "index" field from MasterData - it originally was added by Zini somewhere a decade ago, but is not used anywhere in our code base now and it is not saved to ESM - it is just filled in the editor by the hack added by Aesylwinn five years ago.

Should also fix up to 10 outstanding Coverity defects.