### PR TITLE
Move container unresolving to the separate method

### DIFF
--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -250,6 +250,7 @@ namespace MWWorld
 
             void resolve();
             ResolutionHandle resolveTemporarily();
+            void unresolve();
 
             friend class ContainerStoreIteratorBase<Ptr>;
             friend class ContainerStoreIteratorBase<ConstPtr>;


### PR DESCRIPTION
Based on a discussion [here](https://gitlab.com/OpenMW/openmw/-/merge_requests/727).

Place container unresolving logic where it should be, wrap the whole unresolving to the try-cache block.
At least code becomes more readable.