### PR TITLE
Limit pointers cache size to avoid possible bad_alloc errors

### DIFF
--- a/apps/openmw/mwworld/cells.cpp
+++ b/apps/openmw/mwworld/cells.cpp
@@ -134,7 +134,7 @@ MWWorld::Cells::Cells (const MWWorld::ESMStore& store, std::vector<ESM::ESMReade
 : mStore (store), mReader (reader),
   mIdCacheIndex (0)
 {
-    int cacheSize = std::max(Settings::Manager::getInt("pointers cache size", "Cells"), 0);
+    int cacheSize = std::clamp(Settings::Manager::getInt("pointers cache size", "Cells"), 40, 1000);
     mIdCache = IdCache(cacheSize, std::pair<std::string, CellStore *> ("", (CellStore*)nullptr));
 }
 

--- a/docs/source/reference/modding/settings/cells.rst
+++ b/docs/source/reference/modding/settings/cells.rst
@@ -175,7 +175,7 @@ pointers cache size
 -------------------
 
 :Type:		integer
-:Range:		>0
+:Range:		40 to 1000
 :Default:	40
 
 The count of object pointers that will be saved for a faster search by object ID.


### PR DESCRIPTION
Just add an upper bound to the related setting.