### PR TITLE
Clean up MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,8 +585,8 @@ if (WIN32)
         # Warnings that aren't enabled normally and don't need to be enabled
         # They're unneeded and sometimes completely retarded warnings that /Wall enables
         # Not going to bother commenting them as they tend to warn on every standard library file
-        4061 4263 4264 4266 4350 4371 4435 4514 4548 4571 4610 4619 4623 4625
-        4626 4628 4640 4668 4710 4711 4768 4820 4826 4917 4946 5032 5039 5045
+        4061 4263 4264 4266 4350 4371 4435 4514 4548 4571 4582 4583 4610 4619 4623 4625
+        4626 4628 4640 4668 4710 4711 4768 4820 4826 4917 4946 5032 5039 5045 5219 5220
 
         # Warnings that are thrown on standard libraries and not OpenMW
         4347 # Non-template function with same name and parameter count as template function

--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -322,7 +322,7 @@ int load(Arguments& info)
     std::string filename = info.filename;
     std::cout << "Loading file: " << filename << std::endl;
 
-    std::list<int> skipped;
+    std::list<uint32_t> skipped;
 
     try {
 

--- a/apps/opencs/model/prefs/shortcutsetting.cpp
+++ b/apps/opencs/model/prefs/shortcutsetting.cpp
@@ -13,8 +13,6 @@
 
 namespace CSMPrefs
 {
-    const int ShortcutSetting::MaxKeys;
-
     ShortcutSetting::ShortcutSetting(Category* parent, Settings::Manager* values, QMutex* mutex, const std::string& key,
         const std::string& label)
         : Setting(parent, values, mutex, key, label)

--- a/apps/openmw/mwmechanics/aicombat.cpp
+++ b/apps/openmw/mwmechanics/aicombat.cpp
@@ -263,8 +263,9 @@ namespace MWMechanics
             && ((!storage.mReadyToAttack && !mPathFinder.isPathConstructed())
                 || (storage.mUseCustomDestination && (storage.mCustomDestination - vTargetPos).length() > rangeAttack)))
         {
+            const MWBase::World* world = MWBase::Environment::get().getWorld();
             // Try to build path to the target.
-            const auto halfExtents = MWBase::Environment::get().getWorld()->getPathfindingHalfExtents(actor);
+            const auto halfExtents = world->getPathfindingHalfExtents(actor);
             const auto navigatorFlags = getNavigatorFlags(actor);
             const auto areaCosts = getAreaCosts(actor);
             const auto pathGridGraph = getPathGridGraph(actor.getCell());
@@ -274,11 +275,7 @@ namespace MWMechanics
             {
                 // If there is no path, try to find a point on a line from the actor position to target projected
                 // on navmesh to attack the target from there.
-                const MWBase::World* world = MWBase::Environment::get().getWorld();
-                const auto halfExtents = world->getPathfindingHalfExtents(actor);
                 const auto navigator = world->getNavigator();
-                const auto navigatorFlags = getNavigatorFlags(actor);
-                const auto areaCosts = getAreaCosts(actor);
                 const auto hit = navigator->raycast(halfExtents, vActorPos, vTargetPos, navigatorFlags);
 
                 if (hit.has_value() && (*hit - vTargetPos).length() <= rangeAttack)

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -63,9 +63,9 @@ namespace
         // We will replace invalid entries by fixed ones
         std::vector<ESM::NPC> npcsToReplace;
 
-        for (auto it : npcs)
+        for (auto npcIter : npcs)
         {
-            ESM::NPC npc = it.second;
+            ESM::NPC npc = npcIter.second;
             bool changed = false;
 
             const std::string npcFaction = npc.mFaction;

--- a/components/misc/frameratelimiter.hpp
+++ b/components/misc/frameratelimiter.hpp
@@ -13,8 +13,8 @@ namespace Misc
             explicit FrameRateLimiter(std::chrono::duration<Rep, Ratio> maxFrameDuration,
                                       std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now())
                 : mMaxFrameDuration(std::chrono::duration_cast<std::chrono::steady_clock::duration>(maxFrameDuration))
-                , mLastFrameDuration(0)
                 , mLastMeasurement(now)
+                , mLastFrameDuration(0)
             {}
 
             std::chrono::steady_clock::duration getLastFrameDuration() const


### PR DESCRIPTION
Allows us to ged rid of warnings spam.
Most of the spam is caused by experimental warnings due to /Wall setting (by default msbuild uses /W1 from console and /W3 from Visual Studio). Deal with them as we always do - disable them. GitLab CI seems to have separate warnings settings, so it already does not have this issue.
Also fix complaints which are our fault.

Note that warnings with Bullet are [fixed](https://github.com/bulletphysics/bullet3/commit/94f0a14e43e8e9479d5cb3f93a0731a23d341b64) and should disappear if we update Bullet version in Windows CI to 3.05 or higher (now we use 2.89).