### PR TITLE
Fix an another portion of Coverity warnings

### DIFF
--- a/apps/openmw/mwphysics/stepper.cpp
+++ b/apps/openmw/mwphysics/stepper.cpp
@@ -67,7 +67,7 @@ namespace MWPhysics
 
             if(attempt == 1)
                 tracerDest = tracerPos + toMove;
-            else if (!firstIteration || !sDoExtraStairHacks) // first attempt failed and not on first movement solver iteration, can't retry -- or we have extra hacks disabled
+            else if (!sDoExtraStairHacks) // early out if we have extra hacks disabled
             {
                 return false;
             }

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -81,7 +81,7 @@ MWWorld::ResolutionListener::~ResolutionListener()
     }
     catch(const std::exception& e)
     {
-        Log(Debug::Error) << "Failed to clear temporary container contents of " << mStore.mPtr.get<ESM::Container>()->mBase->mId << ": " << e.what();
+        Log(Debug::Error) << "Failed to clear temporary container contents: " << e.what();
     }
 }
 

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -361,14 +361,10 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
     /// \brief Package mouse and mousewheel motions into a single event
     MouseMotionEvent InputWrapper::_packageMouseMotion(const SDL_Event &evt)
     {
-        MouseMotionEvent pack_evt;
+        MouseMotionEvent pack_evt = {};
         pack_evt.x = mMouseX;
-        pack_evt.xrel = 0;
         pack_evt.y = mMouseY;
-        pack_evt.yrel = 0;
         pack_evt.z = mMouseZ;
-        pack_evt.zrel = 0;
-        pack_evt.timestamp = 0;
 
         if(evt.type == SDL_MOUSEMOTION)
         {


### PR DESCRIPTION
Summary of changes:
1. Remove unreachable code in stepper - affected check is happened only when attempt = 2, which happens only when firstIteration = true.
2. Avoid to cause the same exception which we just catched
3. Init new mInitLayout field
4. Use initializator for the manual mouse event
5. Validate maximum lights setting value when we read it instead of passing tainted value from function to function