### PR TITLE
Fix node masks signed/unsigned mismatch

### DIFF
--- a/apps/opencs/view/render/cameracontroller.cpp
+++ b/apps/opencs/view/render/cameracontroller.cpp
@@ -126,7 +126,7 @@ namespace CSVRender
         {
             // Try again without any mask
             boundsVisitor.reset();
-            boundsVisitor.setTraversalMask(~0);
+            boundsVisitor.setTraversalMask(~0u);
             root->accept(boundsVisitor);
 
             // Last resort, set a default
@@ -458,7 +458,7 @@ namespace CSVRender
         , mDown(false)
         , mRollLeft(false)
         , mRollRight(false)
-        , mPickingMask(~0)
+        , mPickingMask(~0u)
         , mCenter(0,0,0)
         , mDistance(0)
         , mOrbitSpeed(osg::PI / 4)

--- a/apps/opencs/view/render/mask.hpp
+++ b/apps/opencs/view/render/mask.hpp
@@ -8,7 +8,7 @@ namespace CSVRender
     /// @note See the respective file in OpenMW (apps/openmw/mwrender/vismask.hpp)
     /// for general usage hints about node masks.
     /// @copydoc MWRender::VisMask
-    enum Mask
+    enum Mask : unsigned int
     {
         // elements that are part of the actual scene
         Mask_Reference = 0x2,

--- a/apps/opencs/view/render/scenewidget.cpp
+++ b/apps/opencs/view/render/scenewidget.cpp
@@ -120,7 +120,7 @@ void RenderWidget::flagAsModified()
     mView->requestRedraw();
 }
 
-void RenderWidget::setVisibilityMask(int mask)
+void RenderWidget::setVisibilityMask(unsigned int mask)
 {
     mView->getCamera()->setCullMask(mask | Mask_ParticleSystem | Mask_Lighting);
 }

--- a/apps/opencs/view/render/scenewidget.hpp
+++ b/apps/opencs/view/render/scenewidget.hpp
@@ -55,7 +55,7 @@ namespace CSVRender
             /// Initiates a request to redraw the view
             void flagAsModified();
 
-            void setVisibilityMask(int mask);
+            void setVisibilityMask(unsigned int mask);
 
             osg::Camera *getCamera();
 

--- a/apps/opencs/view/render/worldspacewidget.cpp
+++ b/apps/opencs/view/render/worldspacewidget.cpp
@@ -163,7 +163,7 @@ void CSVRender::WorldspaceWidget::selectDefaultNavigationMode()
 
 void CSVRender::WorldspaceWidget::centerOrbitCameraOnSelection()
 {
-    std::vector<osg::ref_ptr<TagBase> > selection = getSelection(~0);
+    std::vector<osg::ref_ptr<TagBase> > selection = getSelection(~0u);
 
     for (std::vector<osg::ref_ptr<TagBase> >::iterator it = selection.begin(); it!=selection.end(); ++it)
     {

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -426,7 +426,7 @@ namespace MWRender
         visitor.setTraversalNumber(mDrawOnceCallback->getLastRenderedFrame());
 
         osg::Node::NodeMask nodeMask = mCamera->getNodeMask();
-        mCamera->setNodeMask(~0);
+        mCamera->setNodeMask(~0u);
         mCamera->accept(visitor);
         mCamera->setNodeMask(nodeMask);
 

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -660,7 +660,7 @@ namespace MWRender
         }
         else if (mode == Render_Scene)
         {
-            int mask = mViewer->getCamera()->getCullMask();
+            unsigned int mask = mViewer->getCamera()->getCullMask();
             bool enabled = mask&Mask_Scene;
             enabled = !enabled;
             if (enabled)
@@ -815,7 +815,7 @@ namespace MWRender
             return false;
         }
 
-        int maskBackup = mPlayerAnimation->getObjectRoot()->getNodeMask();
+        unsigned int maskBackup = mPlayerAnimation->getObjectRoot()->getNodeMask();
 
         if (mCamera->isFirstPerson())
             mPlayerAnimation->getObjectRoot()->setNodeMask(0);
@@ -916,7 +916,7 @@ namespace MWRender
         mIntersectionVisitor->setFrameStamp(mViewer->getFrameStamp());
         mIntersectionVisitor->setIntersector(intersector);
 
-        int mask = ~0;
+        unsigned int mask = ~0u;
         mask &= ~(Mask_RenderToTexture|Mask_Sky|Mask_Debug|Mask_Effect|Mask_Water|Mask_SimpleWater|Mask_Groundcover);
         if (ignorePlayer)
             mask &= ~(Mask_Player);

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -317,8 +317,8 @@ public:
             if (cv->getCullingMode() & osg::CullSettings::FAR_PLANE_CULLING)
                 ++numPlanes;
 
-            int mask = 0x1;
-            int resultMask = cv->getProjectionCullingStack().back().getFrustum().getResultMask();
+            unsigned int mask = 0x1;
+            unsigned int resultMask = cv->getProjectionCullingStack().back().getFrustum().getResultMask();
             for (unsigned int i=0; i<cv->getProjectionCullingStack().back().getFrustum().getPlaneList().size(); ++i)
             {
                 if (i >= numPlanes)
@@ -441,7 +441,7 @@ private:
 class CelestialBody
 {
 public:
-    CelestialBody(osg::Group* parentNode, float scaleFactor, int numUvSets, unsigned int visibleMask=~0)
+    CelestialBody(osg::Group* parentNode, float scaleFactor, int numUvSets, unsigned int visibleMask=~0u)
         : mVisibleMask(visibleMask)
     {
         mGeom = createTexturedQuad(numUvSets);
@@ -1624,7 +1624,7 @@ void SkyManager::setEnabled(bool enabled)
     if (enabled && !mCreated)
         create();
 
-    mRootNode->setNodeMask(enabled ? Mask_Sky : 0);
+    mRootNode->setNodeMask(enabled ? Mask_Sky : 0u);
 
     mEnabled = enabled;
 }
@@ -1785,7 +1785,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
 
         mCloudUpdater->setOpacity((1.f-mCloudBlendFactor));
         mCloudUpdater2->setOpacity(mCloudBlendFactor);
-        mCloudMesh2->setNodeMask(mCloudBlendFactor > 0.f ? ~0 : 0);
+        mCloudMesh2->setNodeMask(mCloudBlendFactor > 0.f ? ~0u : 0);
     }
 
     if (mCloudColour != weather.mFogColor)
@@ -1830,7 +1830,7 @@ void SkyManager::setWeather(const WeatherResult& weather)
         mAtmosphereNightUpdater->setFade(mStarsOpacity);
     }
 
-    mAtmosphereNightNode->setNodeMask(weather.mNight ? ~0 : 0);
+    mAtmosphereNightNode->setNodeMask(weather.mNight ? ~0u : 0);
 
     mPrecipitationAlpha = weather.mPrecipitationAlpha;
 }

--- a/apps/openmw/mwrender/vismask.hpp
+++ b/apps/openmw/mwrender/vismask.hpp
@@ -19,7 +19,7 @@ namespace MWRender
     /// another mask, or what type of node this mask is usually set on.
     /// @note The mask values are not serialized within models, nor used in any other way that would break backwards
     /// compatibility if the enumeration values were to be changed. Feel free to change them when it makes sense.
-    enum VisMask
+    enum VisMask : unsigned int
     {
         Mask_UpdateVisitor = 0x1, // reserved for separating UpdateVisitors from CullVisitors
 

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -776,11 +776,11 @@ void Water::update(float dt)
 void Water::updateVisible()
 {
     bool visible = mEnabled && mToggled;
-    mWaterNode->setNodeMask(visible ? ~0 : 0);
+    mWaterNode->setNodeMask(visible ? ~0u : 0u);
     if (mRefraction)
-        mRefraction->setNodeMask(visible ? Mask_RenderToTexture : 0);
+        mRefraction->setNodeMask(visible ? Mask_RenderToTexture : 0u);
     if (mReflection)
-        mReflection->setNodeMask(visible ? Mask_RenderToTexture : 0);
+        mReflection->setNodeMask(visible ? Mask_RenderToTexture : 0u);
 }
 
 bool Water::toggle()

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -214,7 +214,7 @@ namespace NifOsg
         return sHiddenNodeMask;
     }
 
-    unsigned int Loader::sIntersectionDisabledNodeMask = ~0;
+    unsigned int Loader::sIntersectionDisabledNodeMask = ~0u;
 
     void Loader::setIntersectionDisabledNodeMask(unsigned int mask)
     {

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -241,7 +241,7 @@ private:
     osg::ref_ptr<RootNode> mRootNode;
 };
 
-QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resource::ResourceSystem *resourceSystem, Storage *storage, int nodeMask, int preCompileMask, int borderMask, int compMapResolution, float compMapLevel, float lodFactor, int vertexLodMod, float maxCompGeometrySize)
+QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resource::ResourceSystem *resourceSystem, Storage *storage, unsigned int nodeMask, unsigned int preCompileMask, unsigned int borderMask, int compMapResolution, float compMapLevel, float lodFactor, int vertexLodMod, float maxCompGeometrySize)
     : TerrainGrid(parent, compileRoot, resourceSystem, storage, nodeMask, preCompileMask, borderMask)
     , mViewDataMap(new ViewDataMap)
     , mQuadTreeBuilt(false)
@@ -256,7 +256,7 @@ QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resour
     mChunkManagers.push_back(mChunkManager.get());
 }
 
-QuadTreeWorld::QuadTreeWorld(osg::Group *parent, Storage *storage, int nodeMask, float lodFactor, float chunkSize)
+QuadTreeWorld::QuadTreeWorld(osg::Group *parent, Storage *storage, unsigned int nodeMask, float lodFactor, float chunkSize)
     : TerrainGrid(parent, storage, nodeMask)
     , mViewDataMap(new ViewDataMap)
     , mQuadTreeBuilt(false)

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -20,9 +20,9 @@ namespace Terrain
     class QuadTreeWorld : public TerrainGrid // note: derived from TerrainGrid is only to render default cells (see loadCell)
     {
     public:
-        QuadTreeWorld(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask, int borderMask, int compMapResolution, float comMapLevel, float lodFactor, int vertexLodMod, float maxCompGeometrySize);
+        QuadTreeWorld(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, unsigned int nodeMask, unsigned int preCompileMask, unsigned int borderMask, int compMapResolution, float comMapLevel, float lodFactor, int vertexLodMod, float maxCompGeometrySize);
 
-        QuadTreeWorld(osg::Group *parent, Storage *storage, int nodeMask, float lodFactor, float chunkSize);
+        QuadTreeWorld(osg::Group *parent, Storage *storage, unsigned int nodeMask, float lodFactor, float chunkSize);
 
         ~QuadTreeWorld();
 

--- a/components/terrain/terraingrid.cpp
+++ b/components/terrain/terraingrid.cpp
@@ -20,13 +20,13 @@ public:
     void reset() override {}
 };
 
-TerrainGrid::TerrainGrid(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask, int borderMask)
+TerrainGrid::TerrainGrid(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, unsigned int nodeMask, unsigned int preCompileMask, unsigned int borderMask)
     : Terrain::World(parent, compileRoot, resourceSystem, storage, nodeMask, preCompileMask, borderMask)
     , mNumSplits(4)
 {
 }
 
-TerrainGrid::TerrainGrid(osg::Group* parent, Storage* storage, int nodeMask)
+TerrainGrid::TerrainGrid(osg::Group* parent, Storage* storage, unsigned int nodeMask)
     : Terrain::World(parent, storage, nodeMask)
     , mNumSplits(4)
 {

--- a/components/terrain/terraingrid.hpp
+++ b/components/terrain/terraingrid.hpp
@@ -14,8 +14,8 @@ namespace Terrain
     class TerrainGrid : public Terrain::World
     {
     public:
-        TerrainGrid(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask=~0, int borderMask=0);
-        TerrainGrid(osg::Group* parent, Storage* storage, int nodeMask=~0);
+        TerrainGrid(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, unsigned int nodeMask, unsigned int preCompileMask=~0u, unsigned int borderMask=0);
+        TerrainGrid(osg::Group* parent, Storage* storage, unsigned int nodeMask=~0u);
         ~TerrainGrid();
 
         void cacheCell(View* view, int x, int y) override;

--- a/components/terrain/world.cpp
+++ b/components/terrain/world.cpp
@@ -13,7 +13,7 @@
 namespace Terrain
 {
 
-World::World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask, int borderMask)
+World::World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, unsigned int nodeMask, unsigned int preCompileMask, unsigned int borderMask)
     : mStorage(storage)
     , mParent(parent)
     , mResourceSystem(resourceSystem)
@@ -49,7 +49,7 @@ World::World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSyst
     mResourceSystem->addResourceManager(mTextureManager.get());
 }
 
-World::World(osg::Group* parent, Storage* storage, int nodeMask)
+World::World(osg::Group* parent, Storage* storage, unsigned int nodeMask)
     : mStorage(storage)
     , mParent(parent)
     , mCompositeMapCamera(nullptr)

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -105,8 +105,8 @@ namespace Terrain
         /// @param storage Storage instance to get terrain data from (heights, normals, colors, textures..)
         /// @param nodeMask mask for the terrain root
         /// @param preCompileMask mask for pre compiling textures
-        World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, int nodeMask, int preCompileMask, int borderMask);
-        World(osg::Group* parent, Storage* storage, int nodeMask);
+        World(osg::Group* parent, osg::Group* compileRoot, Resource::ResourceSystem* resourceSystem, Storage* storage, unsigned int nodeMask, unsigned int preCompileMask, unsigned int borderMask);
+        World(osg::Group* parent, Storage* storage, unsigned int nodeMask);
         virtual ~World();
 
         /// Set a WorkQueue to delete objects in the background thread.


### PR DESCRIPTION
Masks in OSG are unsigned integers, and we usually treat them as unsigned, but sometimes we declare and pass them as integers, what causes "unsigned int -> int" casts (MSVC complains about them, but we have that warning in a very long list of blacklisted warnings). 

This PR is aimed to make masks usage more consistent.