### PR TITLE
Disable controllers for found sheath meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
     Bug #5914: BM: The Swimmer can't reach destination
     Bug #5923: Clicking on empty spaces between journal entries might show random topics
     Bug #5934: AddItem command doesn't accept negative values
+    Bug #5975: NIF controllers from sheath meshes are used
     Feature #390: 3rd person look "over the shoulder"
     Feature #832: OpenMW-CS: Handle deleted references
     Feature #1536: Show more information about level on menu

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -358,6 +358,8 @@ void ActorAnimation::updateHolsteredWeapon(bool showHolsteredWeapons)
     }
 
     mScabbard = attachMesh(scabbardName, boneName);
+    if (mScabbard)
+        resetControllers(mScabbard->getNode());
 
     osg::Group* weaponNode = getBoneByName("Bip01 Weapon");
     if (!weaponNode)


### PR DESCRIPTION
Fixes [bug #5975](https://gitlab.com/OpenMW/openmw/-/issues/5975).

Note that we are still consistent with the Weapon Sheathing mod, which removes controllers from sheath meshes.