### PR TITLE
Declare separate constructors with const reference and rvalue arguments for OscillatingRecastMeshObject

### DIFF
--- a/components/detournavigator/oscillatingrecastmeshobject.cpp
+++ b/components/detournavigator/oscillatingrecastmeshobject.cpp
@@ -4,8 +4,15 @@
 
 namespace DetourNavigator
 {
-    OscillatingRecastMeshObject::OscillatingRecastMeshObject(RecastMeshObject impl, std::size_t lastChangeRevision)
+    OscillatingRecastMeshObject::OscillatingRecastMeshObject(RecastMeshObject&& impl, std::size_t lastChangeRevision)
         : mImpl(std::move(impl))
+        , mLastChangeRevision(lastChangeRevision)
+        , mAabb(BulletHelpers::getAabb(mImpl.getShape(), mImpl.getTransform()))
+    {
+    }
+
+    OscillatingRecastMeshObject::OscillatingRecastMeshObject(const RecastMeshObject& impl, std::size_t lastChangeRevision)
+        : mImpl(impl)
         , mLastChangeRevision(lastChangeRevision)
         , mAabb(BulletHelpers::getAabb(mImpl.getShape(), mImpl.getTransform()))
     {

--- a/components/detournavigator/oscillatingrecastmeshobject.hpp
+++ b/components/detournavigator/oscillatingrecastmeshobject.hpp
@@ -12,7 +12,8 @@ namespace DetourNavigator
     class OscillatingRecastMeshObject
     {
         public:
-            explicit OscillatingRecastMeshObject(RecastMeshObject impl, std::size_t lastChangeRevision);
+            explicit OscillatingRecastMeshObject(RecastMeshObject&& impl, std::size_t lastChangeRevision);
+            explicit OscillatingRecastMeshObject(const RecastMeshObject& impl, std::size_t lastChangeRevision);
 
             bool update(const btTransform& transform, const AreaType areaType, std::size_t lastChangeRevision);
 


### PR DESCRIPTION
For now OscillatingRecastMeshObject's constructor looks like it get RecastMeshObject object by value. Elsid told that the intention was to combine both consturctors with const reference and rvalue to the single one, and compilers/analyzers are supposed to be smart enough to detect that there should not be an actual redundant copying. Unfortunately, it does not seem to be a thing.

So a suggested solution - use separate constructors for const reference and rvalue to make behaviour more obvious for both OpenMW developers and code analyzers (such as Coverity Scan, which complains about current constructor now).

Note that only a constructor with rvalue argument seems to be used in our codebase so far.