### PR TITLE
Fix MSVC's C4244 and C4267 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,7 +607,6 @@ if (WIN32)
         4100 # Unreferenced formal parameter (-Wunused-parameter)
         4127 # Conditional expression is constant
         4244 # Storing value of one type in variable of another (size_t in int, for example)
-        4267 # Conversion from 'size_t' to 'int', possible loss of data
         4996 # Function was declared deprecated
         )
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,10 +603,8 @@ if (WIN32)
     set(WARNINGS "/W4")
 
     set(WARNINGS_DISABLE
-        # OpenMW specific warnings
         4100 # Unreferenced formal parameter (-Wunused-parameter)
         4127 # Conditional expression is constant
-        4244 # Storing value of one type in variable of another (size_t in int, for example)
         4996 # Function was declared deprecated
         )
     

--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -676,7 +676,7 @@ MwIniImporter::multistrmap MwIniImporter::loadIniFile(const boost::filesystem::p
         }
 
         if(line[0] == '[') {
-            int pos = line.find(']');
+            int pos = static_cast<int>(line.find(']'));
             if(pos < 2) {
                 std::cout << "Warning: ini file wrongly formatted (" << line << "). Line ignored." << std::endl;
                 continue;
@@ -686,12 +686,12 @@ MwIniImporter::multistrmap MwIniImporter::loadIniFile(const boost::filesystem::p
             continue;
         }
 
-        int comment_pos = line.find(';');
+        int comment_pos = static_cast<int>(line.find(';'));
         if(comment_pos > 0) {
             line = line.substr(0,comment_pos);
         }
 
-        int pos = line.find('=');
+        int pos = static_cast<int>(line.find('='));
         if(pos < 1) {
             continue;
         }
@@ -722,7 +722,7 @@ MwIniImporter::multistrmap MwIniImporter::loadCfgFile(const boost::filesystem::p
     while (std::getline(file, line)) {
 
         // we cant say comment by only looking at first char anymore
-        int comment_pos = line.find('#');
+        int comment_pos = static_cast<int>(line.find('#'));
         if(comment_pos > 0) {
             line = line.substr(0,comment_pos);
         }
@@ -731,7 +731,7 @@ MwIniImporter::multistrmap MwIniImporter::loadCfgFile(const boost::filesystem::p
             continue;
         }
 
-        int pos = line.find('=');
+        int pos = static_cast<int>(line.find('='));
         if(pos < 1) {
             continue;
         }

--- a/apps/opencs/model/doc/blacklist.cpp
+++ b/apps/opencs/model/doc/blacklist.cpp
@@ -21,7 +21,7 @@ void CSMDoc::Blacklist::add (CSMWorld::UniversalId::Type type,
 {
     std::vector<std::string>& list = mIds[type];
 
-    int size = list.size();
+    size_t size = list.size();
 
     list.resize (size+ids.size());
 

--- a/apps/opencs/model/filter/narynode.cpp
+++ b/apps/opencs/model/filter/narynode.cpp
@@ -9,7 +9,7 @@ CSMFilter::NAryNode::NAryNode (const std::vector<std::shared_ptr<Node> >& nodes,
 
 int CSMFilter::NAryNode::getSize() const
 {
-    return mNodes.size();
+    return static_cast<int>(mNodes.size());
 }
 
 const CSMFilter::Node& CSMFilter::NAryNode::operator[] (int index) const

--- a/apps/opencs/model/tools/mandatoryid.cpp
+++ b/apps/opencs/model/tools/mandatoryid.cpp
@@ -11,7 +11,7 @@ CSMTools::MandatoryIdStage::MandatoryIdStage (const CSMWorld::CollectionBase& id
 
 int CSMTools::MandatoryIdStage::setup()
 {
-    return mIds.size();
+    return static_cast<int>(mIds.size());
 }
 
 void CSMTools::MandatoryIdStage::perform (int stage, CSMDoc::Messages& messages)

--- a/apps/opencs/model/tools/reportmodel.cpp
+++ b/apps/opencs/model/tools/reportmodel.cpp
@@ -24,7 +24,7 @@ int CSMTools::ReportModel::rowCount (const QModelIndex & parent) const
     if (parent.isValid())
         return 0;
 
-    return mRows.size();
+    return static_cast<int>(mRows.size());
 }
 
 int CSMTools::ReportModel::columnCount (const QModelIndex & parent) const
@@ -140,7 +140,7 @@ bool CSMTools::ReportModel::removeRows (int row, int count, const QModelIndex& p
 
 void CSMTools::ReportModel::add (const CSMDoc::Message& message)
 {
-    beginInsertRows (QModelIndex(), mRows.size(), mRows.size());
+    beginInsertRows (QModelIndex(), static_cast<int>(mRows.size()), static_cast<int>(mRows.size()));
 
     mRows.push_back (message);
 
@@ -176,7 +176,7 @@ void CSMTools::ReportModel::clear()
 {
     if (!mRows.empty())
     {
-        beginRemoveRows (QModelIndex(), 0, mRows.size()-1);
+        beginRemoveRows (QModelIndex(), 0, static_cast<int>(mRows.size())-1);
         mRows.clear();
         endRemoveRows();
     }

--- a/apps/opencs/model/world/idtable.cpp
+++ b/apps/opencs/model/world/idtable.cpp
@@ -270,7 +270,7 @@ void CSMWorld::IdTable::reorderRows (int baseIndex, const std::vector<int>& newO
     if (!newOrder.empty())
         if (mIdCollection->reorderRows (baseIndex, newOrder))
             emit dataChanged (index (baseIndex, 0),
-                index (baseIndex+newOrder.size()-1, mIdCollection->getColumns()-1));
+                index (baseIndex+static_cast<int>(newOrder.size())-1, mIdCollection->getColumns()-1));
 }
 
 std::pair<CSMWorld::UniversalId, std::string> CSMWorld::IdTable::view (int row) const

--- a/apps/opencs/model/world/resources.cpp
+++ b/apps/opencs/model/world/resources.cpp
@@ -20,13 +20,13 @@ void CSMWorld::Resources::recreate(const VFS::Manager* vfs, const char * const *
     mFiles.clear();
     mIndex.clear();
 
-    int baseSize = mBaseDirectory.size();
+    size_t baseSize = mBaseDirectory.size();
 
     const std::map<std::string, VFS::File*>& index = vfs->getIndex();
     for (std::map<std::string, VFS::File*>::const_iterator it = index.begin(); it != index.end(); ++it)
     {
         std::string filepath = it->first;
-        if (static_cast<int> (filepath.size())<baseSize+1 ||
+        if (filepath.size()<baseSize+1 ||
             filepath.substr (0, baseSize)!=mBaseDirectory ||
             (filepath[baseSize]!='/' && filepath[baseSize]!='\\'))
             continue;
@@ -60,7 +60,7 @@ void CSMWorld::Resources::recreate(const VFS::Manager* vfs, const char * const *
 
 int CSMWorld::Resources::getSize() const
 {
-    return mFiles.size();
+    return static_cast<int>(mFiles.size());
 }
 
 std::string CSMWorld::Resources::getId (int index) const

--- a/apps/opencs/view/doc/operations.cpp
+++ b/apps/opencs/view/doc/operations.cpp
@@ -30,7 +30,7 @@ void CSVDoc::Operations::setProgress (int current, int max, int type, int thread
             return;
         }
 
-    int oldCount = mOperations.size();
+    int oldCount = static_cast<int>(mOperations.size());
     int newCount = oldCount + 1;
 
     Operation *operation = new Operation (type, this);
@@ -51,7 +51,7 @@ void CSVDoc::Operations::quitOperation (int type)
     for (std::vector<Operation *>::iterator iter (mOperations.begin()); iter!=mOperations.end(); ++iter)
         if ((*iter)->getType()==type)
         {
-            int oldCount = mOperations.size();
+            int oldCount = static_cast<int>(mOperations.size());
             int newCount = oldCount - 1;
 
             mLayout->removeItem ((*iter)->getLayout());

--- a/apps/opencs/view/widget/scenetoolrun.cpp
+++ b/apps/opencs/view/widget/scenetoolrun.cpp
@@ -30,7 +30,7 @@ void CSVWidget::SceneToolRun::updateIcon()
 
 void CSVWidget::SceneToolRun::updatePanel()
 {
-    mTable->setRowCount (mProfiles.size());
+    mTable->setRowCount (static_cast<int>(mProfiles.size()));
 
     int i = 0;
 

--- a/apps/opencs/view/widget/scenetooltoggle.cpp
+++ b/apps/opencs/view/widget/scenetooltoggle.cpp
@@ -80,7 +80,7 @@ QRect CSVWidget::SceneToolToggle::getIconBox (int index) const
     int y = index / xMax;
     int x = index % xMax;
 
-    int total = mButtons.size();
+    int total = static_cast<int>(mButtons.size());
 
     int actualYIcons = total/xMax;
 
@@ -154,7 +154,7 @@ void CSVWidget::SceneToolToggle::addButton (const std::string& icon, unsigned in
     desc.mMask = mask;
     desc.mSmallIcon = smallIcon;
     desc.mName = name;
-    desc.mIndex = mButtons.size();
+    desc.mIndex = static_cast<int>(mButtons.size());
 
     mButtons.insert (std::make_pair (button, desc));
 

--- a/apps/opencs/view/widget/scenetooltoggle2.cpp
+++ b/apps/opencs/view/widget/scenetooltoggle2.cpp
@@ -99,7 +99,7 @@ void CSVWidget::SceneToolToggle2::addButton (unsigned int id, unsigned int mask,
     desc.mButtonId = id;
     desc.mMask = mask;
     desc.mName = name;
-    desc.mIndex = mButtons.size();
+    desc.mIndex = static_cast<int>(mButtons.size());
 
     mButtons.insert (std::make_pair (button, desc));
 

--- a/apps/opencs/view/world/idvalidator.cpp
+++ b/apps/opencs/view/world/idvalidator.cpp
@@ -42,7 +42,7 @@ QValidator::State CSVWorld::IdValidator::validate (QString& input, int& pos) con
 
         if (!mNamespace.empty())
         {
-            std::string namespace_ = input.left (mNamespace.size()).toUtf8().constData();
+            std::string namespace_ = input.left (static_cast<int>(mNamespace.size())).toUtf8().constData();
 
             if (Misc::StringUtils::lowerCase (namespace_)!=mNamespace)
                 return QValidator::Invalid; // incorrect namespace

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -2,6 +2,12 @@
 #define GAME_SOUND_FFMPEG_DECODER_H
 
 #include <stdint.h>
+
+#if defined(_MSC_VER)
+    #pragma warning (push)
+    #pragma warning (disable : 4244)
+#endif
+
 extern "C"
 {
 #include <libavcodec/avcodec.h>
@@ -13,6 +19,10 @@ extern "C"
 // https://ffmpeg.zeranoe.com/forum/viewtopic.php?f=15&t=872
 #include <libswresample/swresample.h>
 }
+
+#if defined(_MSC_VER)
+    #pragma warning (pop)
+#endif
 
 #include <components/files/constrainedfilestream.hpp>
 

--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -295,7 +295,7 @@ void Bsa::BSAFile::addFile(const std::string& filename, std::istream& file)
 
     FileStruct newFile;
     file.seekg(0, std::ios::end);
-    newFile.fileSize = file.tellg();
+    newFile.fileSize = static_cast<uint32_t>(file.tellg());
     newFile.setNameInfos(mStringBuf.size(), &mStringBuf);
     newFile.hash = getHash(filename);
 
@@ -312,7 +312,7 @@ void Bsa::BSAFile::addFile(const std::string& filename, std::istream& file)
             stream.read(buffer.data(), firstFile.fileSize);
 
             stream.seekp(0, std::ios::end);
-            firstFile.offset = stream.tellp();
+            firstFile.offset = static_cast<uint32_t>(stream.tellp());
 
             stream.write(buffer.data(), firstFile.fileSize);
 
@@ -320,7 +320,7 @@ void Bsa::BSAFile::addFile(const std::string& filename, std::istream& file)
             std::rotate(mFiles.begin(), mFiles.begin() + 1, mFiles.end());
         }
         stream.seekp(0, std::ios::end);
-        newFile.offset = stream.tellp();
+        newFile.offset = static_cast<uint32_t>(stream.tellp());
     }
 
     mStringBuf.insert(mStringBuf.end(), filename.begin(), filename.end());

--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -43,7 +43,7 @@ void BSAFile::fail(const std::string &msg)
 BSAFile::Hash getHash(const std::string& name)
 {
     BSAFile::Hash hash;
-    unsigned l = (name.size() >> 1);
+    unsigned l = (static_cast<unsigned>(name.size()) >> 1);
     unsigned sum, off, temp, i, n;
 
     for (sum = off = i = 0; i < l; i++) {
@@ -163,7 +163,7 @@ void BSAFile::readHeader()
     {
         FileStruct &fs = mFiles[i];
         fs.fileSize = offsets[i*2];
-        fs.offset = offsets[i*2+1] + fileDataOffset;
+        fs.offset = static_cast<uint32_t>(offsets[i*2+1] + fileDataOffset);
         auto namesOffset = offsets[2*filenum+i];
         fs.setNameInfos(namesOffset, &mStringBuf);
         fs.hash = hashes[i];
@@ -203,11 +203,11 @@ void Bsa::BSAFile::writeHeader()
     uint32_t head[3];
     head[0] = 0x100;
     auto fileDataOffset = mFiles.empty() ? 12 : mFiles.front().offset;
-    head[1] = fileDataOffset - 12 - 8*mFiles.size();
+    head[1] = static_cast<uint32_t>(fileDataOffset - 12 - 8*mFiles.size());
 
     output.seekp(0, std::ios_base::end);
 
-    head[2] = mFiles.size();
+    head[2] = static_cast<uint32_t>(mFiles.size());
     output.seekp(0);
     output.write(reinterpret_cast<char*>(head), 12);
 
@@ -239,9 +239,9 @@ int BSAFile::getIndex(const char *str) const
     if(it == mLookup.end())
         return -1;
 
-    int res = it->second;
-    assert(res >= 0 && (size_t)res < mFiles.size());
-    return res;
+    size_t res = it->second;
+    assert(res >= 0 && res < mFiles.size());
+    return static_cast<int>(res);
 }
 
 /// Open an archive file.
@@ -300,7 +300,7 @@ void Bsa::BSAFile::addFile(const std::string& filename, std::istream& file)
     newFile.hash = getHash(filename);
 
     if(mFiles.empty())
-        newFile.offset = newStartOfDataBuffer;
+        newFile.offset = static_cast<uint32_t>(newStartOfDataBuffer);
     else
     {
         std::vector<char> buffer;

--- a/components/bsa/bsa_file.hpp
+++ b/components/bsa/bsa_file.hpp
@@ -58,7 +58,7 @@ public:
         void setNameInfos(size_t index,
             std::vector<char>* stringBuf
         ) {
-            namesOffset = index;
+            namesOffset = static_cast<uint32_t>(index);
             namesBuffer = stringBuf;
         }
 
@@ -102,7 +102,7 @@ protected:
         the files[] vector above. The iltstr ensures that file name
         checks are case insensitive.
     */
-    typedef std::map<std::string, int, iltstr> Lookup;
+    typedef std::map<std::string, size_t, iltstr> Lookup;
     Lookup mLookup;
 
     /// Error handling

--- a/components/compiler/controlparser.cpp
+++ b/components/compiler/controlparser.cpp
@@ -39,14 +39,14 @@ namespace Compiler
                     Codes block;
 
                     if (iter!=mIfCode.rbegin())
-                        Generator::jump (iter->second, codes.size()+1);
+                        Generator::jump (iter->second, static_cast<int>(codes.size()+1));
 
                     if (!iter->first.empty())
                     {
                         // if or elseif
                         std::copy (iter->first.begin(), iter->first.end(),
                             std::back_inserter (block));
-                        Generator::jumpOnZero (block, iter->second.size()+1);
+                        Generator::jumpOnZero (block, static_cast<int>(iter->second.size()+1));
                     }
 
                     std::copy (iter->second.begin(), iter->second.end(),
@@ -113,7 +113,7 @@ namespace Compiler
 
             Codes skip;
 
-            Generator::jumpOnZero (skip, mCodeBlock.size()+loop.size()+1);
+            Generator::jumpOnZero (skip, static_cast<int> (mCodeBlock.size()+loop.size()+1));
 
             std::copy (skip.begin(), skip.end(), std::back_inserter (mCode));
 

--- a/components/compiler/literals.cpp
+++ b/components/compiler/literals.cpp
@@ -6,12 +6,12 @@ namespace Compiler
 {
     int Literals::getIntegerSize() const
     {
-        return mIntegers.size() * sizeof (Interpreter::Type_Integer);
+        return static_cast<int>(mIntegers.size() * sizeof (Interpreter::Type_Integer));
     }
 
     int Literals::getFloatSize() const
     {
-        return mFloats.size() * sizeof (Interpreter::Type_Float);
+        return static_cast<int>(mFloats.size() * sizeof (Interpreter::Type_Float));
     }
 
     int Literals::getStringSize() const
@@ -41,11 +41,11 @@ namespace Compiler
         
         code.resize (size+stringBlockSize/4);
         
-        int offset = 0;
+        size_t offset = 0;
         
         for (const auto & mString : mStrings)
         {
-            int stringSize = mString.size()+1;
+            size_t stringSize = mString.size()+1;
             
             std::copy (mString.c_str(), mString.c_str()+stringSize,
                 reinterpret_cast<char *> (&code[size]) + offset);

--- a/components/compiler/locals.cpp
+++ b/components/compiler/locals.cpp
@@ -30,7 +30,7 @@ namespace Compiler
         if (iter==collection.end())
             return -1;
 
-        return iter-collection.begin();
+        return static_cast<int>(iter-collection.begin());
     }
 
     bool Locals::search (char type, const std::string& name) const

--- a/components/compiler/scanner.hpp
+++ b/components/compiler/scanner.hpp
@@ -103,7 +103,7 @@ namespace Compiler
         {
             blank();
 
-            char ch = in.peek();
+            char ch = static_cast<char>(in.peek());
 
             if (!in.good())
                 return false;
@@ -130,7 +130,7 @@ namespace Compiler
         {
             std::streampos p_orig = in.tellg();
 
-            char ch = in.peek();
+            char ch = static_cast<char>(in.peek());
 
             if (!in.good())
                 return false;
@@ -156,7 +156,7 @@ namespace Compiler
 
         void blank()
         {
-            std::fill(mData, mData + sizeof(mData), 0);
+            std::fill(std::begin(mData), std::end(mData), '\0');
             mLength = -1;
         }
 

--- a/components/crashcatcher/windows_crashcatcher.cpp
+++ b/components/crashcatcher/windows_crashcatcher.cpp
@@ -130,12 +130,12 @@ namespace Crash
         DWORD copied = 0;
         do {
             executablePath.resize(executablePath.size() + MAX_PATH);
-            copied = GetModuleFileNameW(nullptr, executablePath.data(), executablePath.size());
+            copied = GetModuleFileNameW(nullptr, executablePath.data(), static_cast<DWORD>(executablePath.size()));
         } while (copied >= executablePath.size());
         executablePath.resize(copied);
 
         memset(mShm->mStartup.mLogFilePath, 0, sizeof(mShm->mStartup.mLogFilePath));
-        int length = crashLogPath.length();
+        size_t length = crashLogPath.length();
         if (length >= MAX_LONG_PATH) length = MAX_LONG_PATH - 1;
         strncpy(mShm->mStartup.mLogFilePath, crashLogPath.c_str(), length);
         mShm->mStartup.mLogFilePath[length] = '\0';

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -203,9 +203,9 @@ void ESMReader::getSubName()
     }
 
     // reading the subrecord data anyway.
-    const size_t subNameSize = mCtx.subName.data_size();
+    const int subNameSize = static_cast<int>(mCtx.subName.data_size());
     getExact(mCtx.subName.rw_data(), subNameSize);
-    mCtx.leftRec -= subNameSize;
+    mCtx.leftRec -= static_cast<uint32_t>(subNameSize);
 }
 
 void ESMReader::skipHSub()
@@ -327,7 +327,7 @@ std::string ESMReader::getString(int size)
     char *ptr = mBuffer.data();
     getExact(ptr, size);
 
-    size = strnlen(ptr, size);
+    size = static_cast<int>(strnlen(ptr, size));
 
     // Convert to UTF8 and return
     if (mEncoder)

--- a/components/esm/esmwriter.cpp
+++ b/components/esm/esmwriter.cpp
@@ -217,7 +217,7 @@ namespace ESM
         if (mCounting && !mRecords.empty())
         {
             for (std::list<RecordData>::iterator it = mRecords.begin(); it != mRecords.end(); ++it)
-                it->size += size;
+                it->size += static_cast<uint32_t>(size);
         }
 
         mStream->write(data, size);

--- a/components/esm/statstate.cpp
+++ b/components/esm/statstate.cpp
@@ -16,17 +16,16 @@ namespace ESM
         {
             int base = 0;
             esm.getHNT(base, "STBA");
-            mBase = static_cast<float>(base);
+            mBase = static_cast<T>(base);
 
             int mod = 0;
             esm.getHNOT(mod, "STMO");
-            mMod = static_cast<float>(mod);
+            mMod = static_cast<T>(mod);
 
             int current = 0;
             esm.getHNOT(current, "STCU");
-            mCurrent = static_cast<float>(current);
+            mCurrent = static_cast<T>(current);
 
-            // mDamage was changed to a float; ensure backwards compatibility
             int oldDamage = 0;
             esm.getHNOT(oldDamage, "STDA");
             mDamage = static_cast<float>(oldDamage);

--- a/components/files/lowlevelfile.cpp
+++ b/components/files/lowlevelfile.cpp
@@ -326,7 +326,7 @@ void LowLevelFile::seek (size_t position)
 {
     assert (mHandle != INVALID_HANDLE_VALUE);
 
-    if (SetFilePointer (mHandle, position, nullptr, SEEK_SET) == INVALID_SET_FILE_POINTER)
+    if (SetFilePointer (mHandle, static_cast<LONG>(position), nullptr, SEEK_SET) == INVALID_SET_FILE_POINTER)
         if (GetLastError () != NO_ERROR)
             throw std::runtime_error ("A seek operation on a file failed.");
 }
@@ -349,7 +349,7 @@ size_t LowLevelFile::read (void * data, size_t size)
 
     DWORD read;
 
-    if (!ReadFile (mHandle, data, size, &read, nullptr))
+    if (!ReadFile (mHandle, data, static_cast<DWORD>(size), &read, nullptr))
         throw std::runtime_error ("A read operation on a file failed.");
 
     return read;

--- a/components/interpreter/runtime.cpp
+++ b/components/interpreter/runtime.cpp
@@ -45,7 +45,7 @@ namespace Interpreter
 
         for (; index; --index)
         {
-            offset += std::strlen (literalBlock+offset) + 1;
+            offset += static_cast<int>(std::strlen (literalBlock+offset)) + 1;
             if (offset / 4 >= static_cast<int> (mCode[3]))
                 throw std::out_of_range("out of range");
         }

--- a/components/myguiplatform/scalinglayer.cpp
+++ b/components/myguiplatform/scalinglayer.cpp
@@ -74,8 +74,8 @@ namespace osgMyGUI
         _left -= globalViewSize.width/2;
         _top -= globalViewSize.height/2;
 
-        _left /= scale;
-        _top /= scale;
+        _left = static_cast<int>(_left/scale);
+        _top = static_cast<int>(_top/scale);
 
         _left += mViewSize.width/2;
         _top += mViewSize.height/2;
@@ -84,8 +84,8 @@ namespace osgMyGUI
     float ScalingLayer::getScaleFactor() const
     {
         MyGUI::IntSize viewSize = MyGUI::RenderManager::getInstance().getViewSize();
-        float w = viewSize.width;
-        float h = viewSize.height;
+        float w = static_cast<float>(viewSize.width);
+        float h = static_cast<float>(viewSize.height);
 
         float heightScale = (h / mViewSize.height);
         float widthScale = (w / mViewSize.width);
@@ -103,8 +103,8 @@ namespace osgMyGUI
         MyGUI::IntSize globalViewSize = MyGUI::RenderManager::getInstance().getViewSize();
         MyGUI::IntSize viewSize = globalViewSize;
         float scale = getScaleFactor();
-        viewSize.width /= scale;
-        viewSize.height /= scale;
+        viewSize.width = static_cast<int>(viewSize.width / scale);
+        viewSize.height = static_cast<int>(viewSize.height / scale);
 
         float hoffset = (globalViewSize.width - mViewSize.width*getScaleFactor())/2.f / static_cast<float>(globalViewSize.width);
         float voffset = (globalViewSize.height - mViewSize.height*getScaleFactor())/2.f / static_cast<float>(globalViewSize.height);

--- a/components/widgets/list.cpp
+++ b/components/widgets/list.cpp
@@ -115,7 +115,7 @@ namespace Gui
 
     unsigned int MWList::getItemCount()
     {
-        return mItems.size();
+        return static_cast<unsigned int>(mItems.size());
     }
 
     std::string MWList::getItemNameAt(unsigned int at)

--- a/extern/osg-ffmpeg-videoplayer/audiodecoder.cpp
+++ b/extern/osg-ffmpeg-videoplayer/audiodecoder.cpp
@@ -4,12 +4,19 @@
 #include <stdexcept>
 #include <string>
 
+#if defined(_MSC_VER)
+    #pragma warning (push)
+    #pragma warning (disable : 4244)
+#endif
+
 extern "C"
 {
-    #include <libavcodec/avcodec.h>
-
     #include <libswresample/swresample.h>
 }
+
+#if defined(_MSC_VER)
+    #pragma warning (pop)
+#endif
 
 #include "videostate.hpp"
 
@@ -276,7 +283,7 @@ size_t MovieAudioDecoder::read(char *stream, size_t len)
 
             mFramePos = std::min<ssize_t>(mFrameSize, sample_skip);
             if(sample_skip > 0 || mFrameSize > -sample_skip)
-                sample_skip -= mFramePos;
+                sample_skip -= static_cast<int>(mFramePos);
             continue;
         }
 

--- a/extern/osg-ffmpeg-videoplayer/audiodecoder.cpp
+++ b/extern/osg-ffmpeg-videoplayer/audiodecoder.cpp
@@ -255,7 +255,7 @@ size_t MovieAudioDecoder::read(char *stream, size_t len)
         size_t sampleSize = av_get_bytes_per_sample(mOutputSampleFormat);
         char* data[1];
         data[0] = stream;
-        av_samples_set_silence((uint8_t**)data, 0, len/sampleSize, 1, mOutputSampleFormat);
+        av_samples_set_silence((uint8_t**)data, 0, static_cast<int>(len/sampleSize), 1, mOutputSampleFormat);
         return len;
     }
 

--- a/extern/osg-ffmpeg-videoplayer/audiodecoder.hpp
+++ b/extern/osg-ffmpeg-videoplayer/audiodecoder.hpp
@@ -6,6 +6,11 @@
 #include <new>
 #include <memory>
 
+#if defined(_MSC_VER)
+    #pragma warning (push)
+    #pragma warning (disable : 4244)
+#endif
+
 extern "C"
 {
     #include <libavutil/avutil.h>
@@ -13,6 +18,10 @@ extern "C"
     #include <libavformat/avformat.h>
     #include <libavutil/channel_layout.h>
 }
+
+#if defined(_MSC_VER)
+    #pragma warning (pop)
+#endif
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 #include <basetsd.h>

--- a/extern/osg-ffmpeg-videoplayer/videostate.cpp
+++ b/extern/osg-ffmpeg-videoplayer/videostate.cpp
@@ -9,6 +9,11 @@
 
 #include <osg/Texture2D>
 
+#if defined(_MSC_VER)
+    #pragma warning (push)
+    #pragma warning (disable : 4244)
+#endif
+
 extern "C"
 {
     #include <libavcodec/avcodec.h>
@@ -16,6 +21,10 @@ extern "C"
     #include <libswscale/swscale.h>
     #include <libavutil/time.h>
 }
+
+#if defined(_MSC_VER)
+    #pragma warning (pop)
+#endif
 
 static const char* flushString = "FLUSH";
 struct FlushPacket : AVPacket

--- a/extern/osg-ffmpeg-videoplayer/videostate.hpp
+++ b/extern/osg-ffmpeg-videoplayer/videostate.hpp
@@ -15,6 +15,11 @@ namespace osg
     class Texture2D;
 }
 
+#if defined(_MSC_VER)
+    #pragma warning (push)
+    #pragma warning (disable : 4244)
+#endif
+
 extern "C"
 {
 #include <libavcodec/avcodec.h>
@@ -27,6 +32,10 @@ extern "C"
 // https://ffmpeg.zeranoe.com/forum/viewtopic.php?f=15&t=872
 #include <libswresample/swresample.h>
 }
+
+#if defined(_MSC_VER)
+    #pragma warning (pop)
+#endif
 
 #include "videodefs.hpp"
 


### PR DESCRIPTION
C4267's are mostly caused by a fact that Qt's API uses integer values, while STL containers use size_t instead.

Follow-up work for #3069.