### PR TITLE
Return check for distance when we try to reuse data

### DIFF
--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -141,9 +141,9 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
         vd = found->second;
     needsUpdate = false;
 
-    if (!(vd->suitableToUse(activeGrid) && (vd->getViewPoint()-viewPoint).length2() < mReuseDistance*mReuseDistance && vd->getWorldUpdateRevision() >= mWorldUpdateRevision))
+    if (!vd->suitableToUse(activeGrid) || (vd->getViewPoint()-viewPoint).length2() >= mReuseDistance*mReuseDistance || vd->getWorldUpdateRevision() < mWorldUpdateRevision)
     {
-        float shortestDist = std::numeric_limits<float>::max();
+        float shortestDist = mReuseDistance*mReuseDistance;
         const ViewData* mostSuitableView = nullptr;
         for (const ViewData* other : mUsedViews)
         {
@@ -157,10 +157,15 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
                 }
             }
         }
-        if (mostSuitableView && mostSuitableView != vd)
+        if (mostSuitableView)
         {
             vd->copyFrom(*mostSuitableView);
             return vd;
+        }
+        else
+        {
+            vd->setViewPoint(viewPoint);
+            needsUpdate = true;
         }
     }
     if (!vd->suitableToUse(activeGrid))


### PR DESCRIPTION
Supposed to fix [bug #6026](https://gitlab.com/OpenMW/openmw/-/issues/6026).

Take `mReuseDistance` in account again, request an another traversal if we did not manage to find a replacement.
Also avoid negation in outer condidtion to improve readability a bit.

This change will allow us to use arbitrary groundcover distances later (e.g. to use distance like 4096 or even 2048 on low-end machines). But it is out of scope of this PR, though.