### PR TITLE
Recreate a special case for IntersectionVisitor on QuadTreeWorld

### DIFF
--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -143,7 +143,7 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
 
     if (!vd->suitableToUse(activeGrid) || (vd->getViewPoint()-viewPoint).length2() >= mReuseDistance*mReuseDistance || vd->getWorldUpdateRevision() < mWorldUpdateRevision)
     {
-        float shortestDist = mReuseDistance*mReuseDistance;
+        float shortestDist = viewer ? mReuseDistance*mReuseDistance : std::numeric_limits<float>::max();
         const ViewData* mostSuitableView = nullptr;
         for (const ViewData* other : mUsedViews)
         {
@@ -157,12 +157,12 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
                 }
             }
         }
-        if (mostSuitableView)
+        if (mostSuitableView && mostSuitableView != vd)
         {
             vd->copyFrom(*mostSuitableView);
             return vd;
         }
-        else
+        else if (!mostSuitableView)
         {
             vd->setViewPoint(viewPoint);
             needsUpdate = true;


### PR DESCRIPTION
In 0.46 IntersectionVisitors (which have zero view point) are handled by separate static ViewData.
In 0.47 IntersectionVisitors are handled by ViewMap (a ViewData entry with nullptr key) as a part of active grid paging MR. As I understood, bzzt's idea was that detalization actually does not matter for intersection checks, so it should be enough just to take data from any used ViewData. Since any possible view point has lesser coordinates values than `std::numeric_limits<float>::max()`, the code accidentally worked by taking a view closest to world origin.

So far just re-create this "accidentally worked" case which was broken by #3084.