### PR TITLE
Make groundcover to use rendering distance in units instead of cells

### DIFF
--- a/docs/source/reference/modding/settings/groundcover.rst
+++ b/docs/source/reference/modding/settings/groundcover.rst
@@ -28,15 +28,14 @@ are used in the game. Can affect performance a lot.
 
 This setting can only be configured by editing the settings configuration file.
 
-distance
---------
+rendering distance
+------------------
 
-:Type:		integer
-:Range:		> 0
-:Default:	1
+:Type:		floating point
+:Range:		>= 0.0
+:Default:	6144.0
 
-Determines on which distance in cells grass pages are rendered.
-Default 1 value means 3x3 cells area (active grid).
+Determines on which distance in game units grass pages are rendered.
 May affect performance a lot.
 
 This setting can only be configured by editing the settings configuration file.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -1071,8 +1071,8 @@ enabled = false
 # 1.0 means 100% density
 density = 1.0
 
-# A maximum distance in cells on which groundcover is rendered.
-distance = 1
+# A maximum distance in game units on which groundcover is rendered.
+rendering distance = 6144.0
 
 # A minimum size of groundcover chunk in cells (0.125, 0.25, 0.5, 1.0)
 min chunk size = 0.5


### PR DESCRIPTION
Previously it was not possible due to regressions in the QuadTreeWorld.

So far use a 8192 units distance (about 117 meters - or 128 yards - from player), as in Skyrim (which has iGrassCellRadius = 2 by default and about 8k fadeout distance on Ultra settings). Note that it is a bit larger than we have in master now.

This PR will provide user a way for additional tweaking (e.g. he can halve grass rendering distance and increase its density on low-end hardware).

Probably there can be better default value, though (for example, 4096 units would more-or-less match a Medum preset on Skyrim, and 6144 - a High one).