### PR TITLE
Temporary increase default near clip distance

### DIFF
--- a/docs/source/reference/modding/settings/camera.rst
+++ b/docs/source/reference/modding/settings/camera.rst
@@ -6,7 +6,7 @@ near clip
 
 :Type:		floating point
 :Range:		> 0
-:Default:	1.0
+:Default:	3.0
 
 This setting controls the distance to the near clipping plane. The value must be greater than zero.
 Values greater than approximately 18.0 will occasionally clip objects in the world in front of the character.

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -14,7 +14,7 @@
 [Camera]
 
 # Near clipping plane (>0.0, e.g. 0.01 to 18.0).
-near clip = 1
+near clip = 3
 
 # Cull objects that occupy less than 'small feature culling pixel size' on the screen.
 small feature culling = true


### PR DESCRIPTION
Discussed in [this](https://gitlab.com/OpenMW/openmw/-/issues/5956) thread. While it would be nice to have a reverse-z depth buffer, it is unlikely will be finished prior to 0.47 release, but we still need somehow to mitigate z-fighting in the 0.47 release since it has an Object Paging feature.

So a suggested solution: increase default near clip value in 0.47 (2 or 3 do not seem to cause noticable issues) and return it back to 1 once reverse-z depth buffer will be fully implemented. 

The near clip = 3 is enough to mitigate precision issues a lot, and even values like 15 do not solve precision issues fully.