### PR TITLE
Disable shield animation when we launch a torch one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
     Bug #6007: Crash when ending cutscene is playing
     Bug #6016: Greeting interrupts Fargoth's sneak-walk
     Bug #6028: Particle system controller values are incorrectly used
+    Bug #6043: Actor can have torch missing when torch animation is played
     Feature #390: 3rd person look "over the shoulder"
     Feature #832: OpenMW-CS: Handle deleted references
     Feature #1536: Show more information about level on menu

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -1876,8 +1876,10 @@ bool CharacterController::updateWeaponState(CharacterState& idle)
         MWWorld::ConstContainerStoreIterator torch = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedLeft);
         if(torch != inv.end() && torch->getTypeName() == typeid(ESM::Light).name()
                 && updateCarriedLeftVisible(mWeaponType))
-
         {
+            if (mAnimation->isPlaying("shield"))
+                mAnimation->disable("shield");
+
             mAnimation->play("torch", Priority_Torch, MWRender::Animation::BlendMask_LeftArm,
                 false, 1.0f, "start", "stop", 0.0f, (~(size_t)0), true);
         }


### PR DESCRIPTION
Fixes [bug #6043](https://gitlab.com/OpenMW/openmw/-/issues/6043).

If we equipped a torch, there is no point to play animation for shield, which is missing now.