### PR TITLE
Fix out-of-bounds access in JournalBooks::createCyrillicJournalIndex

### DIFF
--- a/apps/openmw/mwgui/journalbooks.cpp
+++ b/apps/openmw/mwgui/journalbooks.cpp
@@ -278,7 +278,7 @@ BookTypesetter::Ptr JournalBooks::createCyrillicJournalIndex ()
         mIndexPagesCount = 2;
     }
 
-    unsigned char ch[2] = {0xd0, 0x90}; // CYRILLIC CAPITAL A is a 0xd090 in UTF-8
+    unsigned char ch[3] = {0xd0, 0x90, 0x00}; // CYRILLIC CAPITAL A is a 0xd090 in UTF-8
 
     for (int i = 0; i < 32; ++i)
     {


### PR DESCRIPTION
When `ch` is passed into `Utf8Stream stream ((char*) ch);`, the constructor calls `strlen` on the argument. The `strlen` ends up looking past the end of the buffer as it is currently defined as 2 non-zero characters, i.e. not null-terminated. This specifically causes a crash on android due to fortified `strlen` implementation.