### PR TITLE
Fix warning in assert - size_t can not be negative

### DIFF
--- a/components/bsa/bsa_file.cpp
+++ b/components/bsa/bsa_file.cpp
@@ -240,7 +240,7 @@ int BSAFile::getIndex(const char *str) const
         return -1;
 
     size_t res = it->second;
-    assert(res >= 0 && res < mFiles.size());
+    assert(res < mFiles.size());
     return static_cast<int>(res);
 }
 


### PR DESCRIPTION
A `res` variable stores index of file from vector of content files. It can not be negative, so we can just check if we do not go out of vector bounds.