### PR TITLE
Discard button press events during save loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
     Bug #5603: Setting constant effect cast style doesn't correct effects view
     Bug #5604: Only one valid NIF root node is loaded from a single file
     Bug #5611: Usable items with "0 Uses" should be used only once
+    Bug #5619: Input events are queued during save loading
     Bug #5622: Can't properly interact with the console when in pause menu
     Bug #5627: Bookart not shown if it isn't followed by <BR> statement
     Bug #5633: Damage Spells in effect before god mode is enabled continue to hurt the player character and can kill them

--- a/components/sdlutil/sdlinputwrapper.cpp
+++ b/components/sdlutil/sdlinputwrapper.cpp
@@ -52,9 +52,14 @@ InputWrapper::InputWrapper(SDL_Window* window, osg::ref_ptr<osgViewer::Viewer> v
 
         if (windowEventsOnly)
         {
-            // During loading, just handle window events, and keep others for later
+            // During loading, handle window events, discard button presses and keep others for later
             while (SDL_PeepEvents(&evt, 1, SDL_GETEVENT, SDL_WINDOWEVENT, SDL_WINDOWEVENT))
                 handleWindowEvent(evt);
+
+            SDL_FlushEvent(SDL_KEYDOWN);
+            SDL_FlushEvent(SDL_CONTROLLERBUTTONDOWN);
+            SDL_FlushEvent(SDL_MOUSEBUTTONDOWN);
+
             return;
         }
 


### PR DESCRIPTION
Fixes [bug #5619](https://gitlab.com/OpenMW/openmw/-/issues/5619).

An idea is to discard key press events during savegame loading instead of queuing them and firing at once in the first frame after game loading. This PR should help at least with two buggy cases:
1. When player presses F9 several times during game loading and OpenMW starts to reload a game several times. That's because there are several F9 presses events which are handled one by one.
2. When player presses a binding for any UI window during game loading and rendering scene is displayed in a weird way until target UI window is closed. That's because target window is opened immediately without giving OSG any chance to setup camera properly. Note that it seems to be possible to reproduce this case if you open a UI window in the first frame after loading, but it is much harder than do it during loading.