### PR TITLE
Do not trigger in-game bindings via mouse buttons when controls are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
     Bug #6016: Greeting interrupts Fargoth's sneak-walk
     Bug #6028: Particle system controller values are incorrectly used
     Bug #6043: Actor can have torch missing when torch animation is played
+    Bug #6047: Mouse bindings can be triggered during save loading
     Feature #390: 3rd person look "over the shoulder"
     Feature #832: OpenMW-CS: Handle deleted references
     Feature #1536: Show more information about level on menu

--- a/apps/openmw/mwinput/mousemanager.cpp
+++ b/apps/openmw/mwinput/mousemanager.cpp
@@ -144,7 +144,8 @@ namespace MWInput
 
     void MouseManager::mousePressed(const SDL_MouseButtonEvent &arg, Uint8 id)
     {
-        MWBase::Environment::get().getInputManager()->setJoystickLastUsed(false);
+        MWBase::InputManager* input = MWBase::Environment::get().getInputManager();
+        input->setJoystickLastUsed(false);
         bool guiMode = false;
 
         if (id == SDL_BUTTON_LEFT || id == SDL_BUTTON_RIGHT) // MyGUI only uses these mouse events
@@ -165,7 +166,8 @@ namespace MWInput
         mBindingsManager->setPlayerControlsEnabled(!guiMode);
 
         // Don't trigger any mouse bindings while in settings menu, otherwise rebinding controls becomes impossible
-        if (MWBase::Environment::get().getWindowManager()->getMode() != MWGui::GM_Settings)
+        // Also do not trigger bindings when input controls are disabled, e.g. during save loading
+        if (MWBase::Environment::get().getWindowManager()->getMode() != MWGui::GM_Settings && !input->controlsDisabled())
             mBindingsManager->mousePressed(arg, id);
     }
 


### PR DESCRIPTION
Fixes [bug #6047](https://gitlab.com/OpenMW/openmw/-/issues/6047) by disabled mouse bindings when controls are disabled. Note that it does not affect clicking in menus, just actions from the Settings in-game menu.