### PR TITLE
Fix crashes on exit in LightManager

### DIFF
--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -726,7 +726,7 @@ namespace SceneUtil
 
         META_StateAttribute(NifOsg, LightManagerStateAttribute, osg::StateAttribute::LIGHT)
 
-        void initSharedLayout(osg::GLExtensions* ext, int handle, LightManager& lightManager) const
+        void initSharedLayout(osg::GLExtensions* ext, int handle) const
         {
             constexpr std::array<unsigned int, 1> index = { static_cast<unsigned int>(Shader::UBOBinding::LightBuffer) };
             int totalBlockSize = -1;
@@ -748,17 +748,13 @@ namespace SceneUtil
 
             for (int i = 0; i < 2; ++i)
             {
-                auto& buf = lightManager.getLightBuffer(i);
+                auto& buf = mLightManager->getLightBuffer(i);
                 buf = new LightBuffer(*buf, offsets[0], offsets[1], offsets[2], totalBlockSize, stride);
             }
         }
 
         void apply(osg::State& state) const override
         {
-            osg::ref_ptr<LightManager> lightManager;
-            if (!mLightManager.lock(lightManager))
-                return;
-
             if (!mInitLayout)
             {
                 mDummyProgram->apply(state);
@@ -771,12 +767,12 @@ namespace SceneUtil
                 // wait until the UBO binding is created
                 if (activeUniformBlocks > 0)
                 {
-                    initSharedLayout(ext, handle, *lightManager);
+                    initSharedLayout(ext, handle);
                     mInitLayout = true;
                 }
             }
-            lightManager->getLightBuffer(state.getFrameStamp()->getFrameNumber())->uploadCachedSunPos(state.getInitialViewMatrix());
-            lightManager->getLightBuffer(state.getFrameStamp()->getFrameNumber())->dirty();
+            mLightManager->getLightBuffer(state.getFrameStamp()->getFrameNumber())->uploadCachedSunPos(state.getInitialViewMatrix());
+            mLightManager->getLightBuffer(state.getFrameStamp()->getFrameNumber())->dirty();
         }
 
     private:
@@ -806,7 +802,7 @@ namespace SceneUtil
             return shader;
         }
 
-        osg::observer_ptr<LightManager> mLightManager;
+        LightManager* mLightManager;
         osg::ref_ptr<osg::Program> mDummyProgram;
         mutable bool mInitLayout;
     };

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -439,7 +439,11 @@ namespace SceneUtil
 
         void apply(osg::State &state) const override
         {
-            auto* lightUniform = mLightManager->getStateSet()->getUniform("LightBuffer");
+            osg::StateSet* stateSet = mLightManager->getStateSet();
+            if (!stateSet)
+                return;
+
+            auto* lightUniform = stateSet->getUniform("LightBuffer");
             for (size_t i = 0; i < mLights.size(); ++i)
             {
                 auto light = mLights[i];
@@ -830,6 +834,11 @@ namespace SceneUtil
             if (p.second == method)
                 return p.first;
         return "";
+    }
+
+    LightManager::~LightManager()
+    {
+        getOrCreateStateSet()->removeAttribute(osg::StateAttribute::LIGHT);
     }
 
     LightManager::LightManager(bool ffp)

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -137,6 +137,8 @@ namespace SceneUtil
 
         LightManager(const LightManager& copy, const osg::CopyOp& copyop);
 
+        ~LightManager();
+
         /// @param mask This mask is compared with the current Camera's cull mask to determine if lighting is desired.
         /// By default, it's ~0u i.e. always on.
         /// If you have some views that do not require lighting, then set the Camera's cull mask to not include


### PR DESCRIPTION
Fixes [bug #6044](https://gitlab.com/OpenMW/openmw/-/issues/6044) for me.

Summary of changes:
1. Apply a solution suggested [here](https://gitlab.com/OpenMW/openmw/-/merge_requests/865#note_576360058) and revert a previous one. The "shader" mode still works in my testing.
2. Add a missing check for null, which fixes "shader compatibility" mode for me.