### PR TITLE
This PR solves a crash with Robert's bodies logged on your bugtracker.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -44,6 +44,7 @@ Programmers
     Austin Salgat (Salgat)
     Ben Shealy (bentsherman)
     Berulacks
+    Bo Svensson
     Britt Mathis (galdor557)
     Capostrophic
     Carl Maxwell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     Bug #3846: Strings starting with "-" fail to compile if not enclosed in quotes
     Bug #3905: Great House Dagoth issues
     Bug #4203: Resurrecting an actor should close the loot GUI
+    Bug #4602: Robert's Bodies: crash inside createInstance()
     Bug #4700: Editor: Incorrect command implementation
     Bug #4744: Invisible particles must still be processed
     Bug #4752: UpdateCellCommand doesn't undo properly

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -160,7 +160,7 @@ void CreatureWeaponAnimation::updatePart(PartHolderPtr& scene, int slot)
     {
         osg::ref_ptr<const osg::Node> node = mResourceSystem->getSceneManager()->getTemplate(itemModel);
 
-        const Map& nodeMap = getNodeMap();
+        const NodeMap& nodeMap = getNodeMap();
         NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
         if (found == nodeMap.end())
             throw std::runtime_error("Can't find attachment node " + bonename);

--- a/apps/openmw/mwrender/creatureanimation.cpp
+++ b/apps/openmw/mwrender/creatureanimation.cpp
@@ -158,9 +158,9 @@ void CreatureWeaponAnimation::updatePart(PartHolderPtr& scene, int slot)
 
     try
     {
-        osg::ref_ptr<osg::Node> node = mResourceSystem->getSceneManager()->getInstance(itemModel);
+        osg::ref_ptr<const osg::Node> node = mResourceSystem->getSceneManager()->getTemplate(itemModel);
 
-        const NodeMap& nodeMap = getNodeMap();
+        const Map& nodeMap = getNodeMap();
         NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
         if (found == nodeMap.end())
             throw std::runtime_error("Can't find attachment node " + bonename);

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -714,14 +714,14 @@ void NpcAnimation::updateParts()
 
 PartHolderPtr NpcAnimation::insertBoundedPart(const std::string& model, const std::string& bonename, const std::string& bonefilter, bool enchantedGlow, osg::Vec4f* glowColor)
 {
-    osg::ref_ptr<osg::Node> instance = mResourceSystem->getSceneManager()->getInstance(model);
+    osg::ref_ptr<const osg::Node> template = mResourceSystem->getSceneManager()->getTemplate(model);
 
     const NodeMap& nodeMap = getNodeMap();
     NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
     if (found == nodeMap.end())
         throw std::runtime_error("Can't find attachment node " + bonename);
 
-    osg::ref_ptr<osg::Node> attached = SceneUtil::attach(instance, mObjectRoot, bonefilter, found->second);
+    osg::ref_ptr<osg::Node> attached = SceneUtil::attach(template, mObjectRoot, bonefilter, found->second);
     if (enchantedGlow)
         mGlowUpdater = SceneUtil::addEnchantedGlow(attached, mResourceSystem, *glowColor);
 

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -714,14 +714,14 @@ void NpcAnimation::updateParts()
 
 PartHolderPtr NpcAnimation::insertBoundedPart(const std::string& model, const std::string& bonename, const std::string& bonefilter, bool enchantedGlow, osg::Vec4f* glowColor)
 {
-    osg::ref_ptr<const osg::Node> template = mResourceSystem->getSceneManager()->getTemplate(model);
+    osg::ref_ptr<const osg::Node> templateNode = mResourceSystem->getSceneManager()->getTemplate(model);
 
     const NodeMap& nodeMap = getNodeMap();
     NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
     if (found == nodeMap.end())
         throw std::runtime_error("Can't find attachment node " + bonename);
 
-    osg::ref_ptr<osg::Node> attached = SceneUtil::attach(template, mObjectRoot, bonefilter, found->second);
+    osg::ref_ptr<osg::Node> attached = SceneUtil::attach(templateNode, mObjectRoot, bonefilter, found->second);
     if (enchantedGlow)
         mGlowUpdater = SceneUtil::addEnchantedGlow(attached, mResourceSystem, *glowColor);
 

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -113,10 +113,7 @@ namespace MWWorld
                             }
                         }
                     }
-                    if (mPreloadInstances && animated)
-                        mPreloadedObjects.insert(mSceneManager->cacheInstance(mesh));
-                    else
-                        mPreloadedObjects.insert(mSceneManager->getTemplate(mesh));
+                    mPreloadedObjects.insert(mSceneManager->getTemplate(mesh));
                     if (mPreloadInstances)
                         mPreloadedObjects.insert(mBulletShapeManager->cacheInstance(mesh));
                     else

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -86,14 +86,14 @@ namespace SceneUtil
         std::string mFilter2;
     };
 
-    void mergeUserData(osg::UserDataContainer* source, osg::Object* target)
+    void mergeUserData(const osg::UserDataContainer* source, osg::Object* target)
     {
         if (!target->getUserDataContainer())
-            target->setUserDataContainer(source);
+            target->setUserDataContainer(osg::clone(source, osg::CopyOp::SHALLOW_COPY));
         else
         {
             for (unsigned int i=0; i<source->getNumUserObjects(); ++i)
-                target->getUserDataContainer()->addUserObject(source->getUserObject(i));
+                target->getUserDataContainer()->addUserObject(osg::clone(source->getUserObject(i), osg::CopyOp::SHALLOW_COPY));
         }
     }
 
@@ -176,7 +176,7 @@ namespace SceneUtil
             else
             {
                 attachNode->addChild(clonedToAttach);
-                return toAttach;
+                return clonedToAttach;
             }
         }
     }

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -52,7 +52,7 @@ namespace SceneUtil
             osg::Node* node = &drawable;
             for (auto it = getNodePath().rbegin()+1; it != getNodePath().rend(); ++it)
             {
-                osg::Group* parent = *it;
+                osg::Node* parent = *it;
                 if (!filterMatches(parent->getName()))
                     break;
                 node = parent;

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -64,8 +64,7 @@ namespace SceneUtil
         {
             for (const osg::ref_ptr<osg::Node>& node : mToCopy)
             {
-                CopyOp copyOp;
-                mParent->addChild(osg::clone(node, copyOp));
+                mParent->addChild(static_cast<osg::Node*>(node->clone(SceneUtil::CopyOp())));
             }
             mToCopy.clear();
         }
@@ -125,8 +124,8 @@ namespace SceneUtil
         }
         else
         {
-            CopyOp copyOp;
-            osg::ref_ptr<osg::Node> clonedToAttach = osg::clone(toAttach, copyOp);
+            osg::ref_ptr<osg::Node> clonedToAttach = static_cast<osg::Node*>(toAttach->clone(SceneUtil::CopyOp()));
+
             FindByNameVisitor findBoneOffset("BoneOffset");
             clonedToAttach->accept(findBoneOffset);
 

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -118,7 +118,7 @@ namespace SceneUtil
             else
             {
                 master->asGroup()->addChild(handle);
-                handle->setUserDataContainer(toAttach->getUserDataContainer());
+                mergeUserData(toAttach->getUserDataContainer(), handle);
                 return handle;
             }
         }

--- a/components/sceneutil/attach.cpp
+++ b/components/sceneutil/attach.cpp
@@ -98,7 +98,7 @@ namespace SceneUtil
         }
     }
 
-    osg::ref_ptr<osg::Node> attach(osg::ref_ptr<osg::Node> toAttach, osg::Node *master, const std::string &filter, osg::Group* attachNode, osg::Node*& parent)
+    osg::ref_ptr<osg::Node> attach(osg::ref_ptr<osg::Node> toAttach, osg::Node *master, const std::string &filter, osg::Group* attachNode)
     {
         if (dynamic_cast<SceneUtil::Skeleton*>(toAttach.get()))
         {
@@ -108,19 +108,17 @@ namespace SceneUtil
             toAttach->accept(copyVisitor);
             copyVisitor.doCopy();
 
-            parent = master->asGroup();
-
             if (handle->getNumChildren() == 1 && handle->getChild(0)->referenceCount() == 1)
             {
                 osg::ref_ptr<osg::Node> newHandle = handle->getChild(0);
                 handle->removeChild(newHandle);
-                parent->addChild(newHandle);
+                master->asGroup()->addChild(newHandle);
                 mergeUserData(toAttach->getUserDataContainer(), newHandle);
                 return newHandle;
             }
             else
             {
-                parent->addChild(handle);
+                master->asGroup()->addChild(handle);
                 handle->setUserDataContainer(toAttach->getUserDataContainer());
                 return handle;
             }
@@ -170,7 +168,6 @@ namespace SceneUtil
                 trans->setStateSet(frontFaceStateSet);
             }
 
-            parent = attachNode;
             if (trans)
             {
                 attachNode->addChild(trans);

--- a/components/sceneutil/attach.hpp
+++ b/components/sceneutil/attach.hpp
@@ -14,12 +14,12 @@ namespace osg
 namespace SceneUtil
 {
 
-    /// Attach parts of the \a toAttach scenegraph to the \a master scenegraph, using the specified filter and attachment node.
+    /// Clone and attach parts of the \a toAttach scenegraph to the \a master scenegraph, using the specified filter and attachment node.
     /// If the \a toAttach scene graph contains skinned objects, we will attach only those (filtered by the \a filter).
     /// Otherwise, just attach all of the toAttach scenegraph to the attachment node on the master scenegraph, with no filtering.
     /// @note The master scene graph is expected to include a skeleton.
     /// @return A newly created node that is directly attached to the master scene graph
-    osg::ref_ptr<osg::Node> attach(osg::ref_ptr<osg::Node> toAttach, osg::Node* master, const std::string& filter, osg::Group* attachNode);
+    osg::ref_ptr<osg::Node> attach(osg::ref_ptr<const osg::Node> toAttach, osg::Node* master, const std::string& filter, osg::Group* attachNode);
 
 }
 


### PR DESCRIPTION
Hello,

Firstly my apologies for using this, as I understand deprecated github repository. I use Open MW as a means of slacking off at work and sadly, the gitlab site is blocked on our company network.

This PR solves the crash with Robert's bodies logged on your bugtracker.

Explanation: the code assumes that the node to attach is not shared (has at most one parent), but when a non-skinned trishape is used in a place where we expect skinned trishapes, this assumption breaks. Because in SceneUtil::CopyOp, we do not clone non-skinned trishapes. I assume this is intentional to conserve memory.

My solution puts SceneUtil::attach in charge of cloning exactly the node to attach, so we can be sure the node is not shared.

Also this reduces some redundant cloning that was going on before. We were cloning the entire skeleton for each skinned body part only to discard most of it. Now we are cloning only the nodes belonging to the bodypart.

How to test this PR:
[ ] Ensure Roberts bodies doesn't crash.
[ ] Check if the count of Drawables and Nodes in the scene remains roughly the same as before. (I hope I didn't add any unnecessary cloning)