### PR TITLE
clone.cpp remove dynamic_cast

### DIFF
--- a/components/sceneutil/clone.cpp
+++ b/components/sceneutil/clone.cpp
@@ -2,8 +2,6 @@
 
 #include <osg/StateSet>
 
-#include <osgAnimation/Bone>
-#include <osgAnimation/Skeleton>
 #include <osgAnimation/MorphGeometry>
 #include <osgAnimation/RigGeometry>
 
@@ -34,11 +32,6 @@ namespace SceneUtil
             osgParticle::ParticleSystemUpdater* cloned = new osgParticle::ParticleSystemUpdater(*updater, osg::CopyOp::SHALLOW_COPY);
             mUpdaterToOldPs[cloned] = updater->getParticleSystem(0);
             return cloned;
-        }
-
-        if (dynamic_cast<const osgAnimation::Bone*>(node) || dynamic_cast<const osgAnimation::Skeleton*>(node))
-        {
-            return osg::clone(node, *this);
         }
         return osg::CopyOp::operator()(node);
     }


### PR DESCRIPTION
While reviewing groundcover cloning I may have found a superfluous operation. osgAnimation Bone and Skeleton derive from osg Node and respect the DEEP_COPY_NODES copy flags we use. Therefore the nodes should be cloned in the same way without this special case. Somehow I have no osgAnimation nodes in my game files and cannot test. Perhaps author @unelsson can chime in if I am on the right track.