### PR TITLE
visitor.cpp early out

### DIFF
--- a/components/sceneutil/visitor.cpp
+++ b/components/sceneutil/visitor.cpp
@@ -32,13 +32,13 @@ namespace SceneUtil
 
     void FindByNameVisitor::apply(osg::Group &group)
     {
-        if (!checkGroup(group))
+        if (!mFoundNode && !checkGroup(group))
             traverse(group);
     }
 
     void FindByNameVisitor::apply(osg::MatrixTransform &node)
     {
-        if (!checkGroup(node))
+        if (!mFoundNode && !checkGroup(node))
             traverse(node);
     }
 


### PR DESCRIPTION
During FindByNameVisitor, we correctly stop traversing the children of the found node, but still traverse the node's siblings, parent's siblings and all of their children unnecessarily. 

With these changes we stop the traversals completely once the node is found which should speed things up a bit. If this seems like a micro optimisation keep in mind this visitor is used on all non-skinned bodyparts attached with SceneUtil::attach to find a node called BoneOffset.