### PR TITLE
actoranimation.cpp faster getbonebyname

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -67,16 +67,13 @@ ActorAnimation::~ActorAnimation()
 
 PartHolderPtr ActorAnimation::attachMesh(const std::string& model, const std::string& bonename, bool enchantedGlow, osg::Vec4f* glowColor)
 {
-    osg::Group* parent = getBoneByName(bonename);
-    if (!parent)
-        return nullptr;
-
-    osg::ref_ptr<osg::Node> instance = mResourceSystem->getSceneManager()->getInstance(model, parent);
-
     const NodeMap& nodeMap = getNodeMap();
     NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(bonename));
     if (found == nodeMap.end())
         return PartHolderPtr();
+
+    osg::Group* parent = found->second;
+    osg::ref_ptr<osg::Node> instance = mResourceSystem->getSceneManager()->getInstance(model, parent);
 
     if (enchantedGlow)
         mGlowUpdater = SceneUtil::addEnchantedGlow(instance, mResourceSystem, *glowColor);
@@ -136,9 +133,9 @@ bool ActorAnimation::updateCarriedLeftVisible(const int weaptype) const
         MWMechanics::CreatureStats &stats = cls.getCreatureStats(mPtr);
         if (cls.hasInventoryStore(mPtr) && weaptype != ESM::Weapon::Spell)
         {
-            SceneUtil::FindByNameVisitor findVisitor ("Bip01 AttachShield");
-            mObjectRoot->accept(findVisitor);
-            if (findVisitor.mFoundNode || (mPtr == MWMechanics::getPlayer() && mPtr.isInCell() && MWBase::Environment::get().getWorld()->isFirstPerson()))
+            osg::Group* foundNode = getBoneByName ("Bip01 AttachShield");
+
+            if (foundNode || (mPtr == MWMechanics::getPlayer() && mPtr.isInCell() && MWBase::Environment::get().getWorld()->isFirstPerson()))
             {
                 const MWWorld::InventoryStore& inv = cls.getInventoryStore(mPtr);
                 const MWWorld::ConstContainerStoreIterator weapon = inv.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
@@ -276,10 +273,11 @@ osg::Group* ActorAnimation::getBoneByName(const std::string& boneName)
     if (!mObjectRoot)
         return nullptr;
 
-    SceneUtil::FindByNameVisitor findVisitor (boneName);
-    mObjectRoot->accept(findVisitor);
-
-    return findVisitor.mFoundNode;
+    const NodeMap& nodeMap = getNodeMap();
+    NodeMap::const_iterator found = nodeMap.find(Misc::StringUtils::lowerCase(boneName));
+    if (found == nodeMap.end())
+        return nullptr;
+    return found->second;
 }
 
 std::string ActorAnimation::getHolsteredWeaponBoneName(const MWWorld::ConstPtr& weapon)


### PR DESCRIPTION
While reviewing uses of the slow linear search FindByNameVisitor during my last PR, I stumbled upon some uses that we can refactor into a faster logarithmic search using a map already built. Somehow most of these lines are never triggered in my game so I will need an advise if we are using this code anymore and if my changes are OK.