### PR TITLE
we can avoid the terrain sync completely in most cases

### DIFF
--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -503,9 +503,9 @@ namespace MWWorld
         }
     }
     
-    bool CellPreloader::isTerrainLoaded(const CellPreloader::PositionCellGrid &positions, double referenceTime) const
+    bool CellPreloader::isTerrainLoaded(const CellPreloader::PositionCellGrid &position, double referenceTime) const
     {
-        return mLoadedTerrainTimestamp + mResourceSystem()->getSceneManager()->getExpiryDelay() > referenceTime && contains(mLoadedTerrainPositions, positions, ESM::Land::REAL_SIZE);
+        return mLoadedTerrainTimestamp + mResourceSystem()->getSceneManager()->getExpiryDelay() > referenceTime && contains(mLoadedTerrainPositions, {position}, ESM::Land::REAL_SIZE);
     }
 
 }

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -514,7 +514,7 @@ namespace MWWorld
     
     bool CellPreloader::isTerrainLoaded(const CellPreloader::PositionCellGrid &position, double referenceTime) const
     {
-        return mLoadedTerrainTimestamp + mResourceSystem->getSceneManager()->getExpiryDelay() > referenceTime && contains(mLoadedTerrainPositions, {position}, ESM::Land::REAL_SIZE);
+        return mLoadedTerrainTimestamp + mResourceSystem->getSceneManager()->getExpiryDelay() > referenceTime && contains(mLoadedTerrainPositions, std::array {position}, ESM::Land::REAL_SIZE);
     }
 
 }

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -228,6 +228,7 @@ namespace MWWorld
         , mPreloadInstances(true)
         , mLastResourceCacheUpdate(0.0)
         , mStoreViewsFailCount(0)
+        , mLoadedTerrainTimestamp(0.0)
     {
     }
 

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -475,7 +475,10 @@ namespace MWWorld
     void CellPreloader::setTerrainPreloadPositions(const std::vector<CellPreloader::PositionCellGrid> &positions)
     {
         if (positions.empty())
+        {
             mTerrainPreloadPositions.clear();
+            mLoadedTerrainPositions.clear();
+        }
         else if (contains(mTerrainPreloadPositions, positions))
             return;
         if (mTerrainPreloadItem && !mTerrainPreloadItem->isDone())

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -21,6 +21,29 @@
 #include "cellstore.hpp"
 #include "class.hpp"
 
+namespace
+{
+    template <class Contained>
+    bool contains(const std::vector<MWWorld::CellPreloader::PositionCellGrid>& container,
+           const Contained& contained, float tolerance=1.f)
+    {
+        for (const auto& pos : contained)
+        {
+            bool found = false;
+            for (const auto& pos2 : container)
+            {
+                if ((pos.first-pos2.first).length2() < tolerance*tolerance && pos.second == pos2.second)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return false;
+        }
+        return true;
+    }
+}
+
 namespace MWWorld
 {
 
@@ -443,27 +466,9 @@ namespace MWWorld
         }
     }
 
-    bool contains(const std::vector<CellPreloader::PositionCellGrid>& container, const std::vector<CellPreloader::PositionCellGrid>& contained, float tolerance=1.f)
-    {
-        for (const auto& pos : contained)
-        {
-            bool found = false;
-            for (const auto& pos2 : container)
-            {
-                if ((pos.first-pos2.first).length2() < tolerance*tolerance && pos.second == pos2.second)
-                {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) return false;
-        }
-        return true;
-    }
-
     void CellPreloader::abortTerrainPreloadExcept(const CellPreloader::PositionCellGrid *exceptPos)
     {
-        if (exceptPos && contains(mTerrainPreloadPositions, {*exceptPos}, ESM::Land::REAL_SIZE))
+        if (exceptPos && contains(mTerrainPreloadPositions, std::array {*exceptPos}, ESM::Land::REAL_SIZE))
             return;
         if (mTerrainPreloadItem && !mTerrainPreloadItem->isDone())
         {

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -509,7 +509,7 @@ namespace MWWorld
     
     bool CellPreloader::isTerrainLoaded(const CellPreloader::PositionCellGrid &position, double referenceTime) const
     {
-        return mLoadedTerrainTimestamp + mResourceSystem()->getSceneManager()->getExpiryDelay() > referenceTime && contains(mLoadedTerrainPositions, {position}, ESM::Land::REAL_SIZE);
+        return mLoadedTerrainTimestamp + mResourceSystem->getSceneManager()->getExpiryDelay() > referenceTime && contains(mLoadedTerrainPositions, {position}, ESM::Land::REAL_SIZE);
     }
 
 }

--- a/apps/openmw/mwworld/cellpreloader.hpp
+++ b/apps/openmw/mwworld/cellpreloader.hpp
@@ -79,6 +79,7 @@ namespace MWWorld
 
         bool syncTerrainLoad(const std::vector<CellPreloader::PositionCellGrid> &positions, double timestamp, Loading::Listener& listener);
         void abortTerrainPreloadExcept(const PositionCellGrid *exceptPos);
+        bool isTerrainLoaded(const CellPreloader::PositionCellGrid &position, double referenceTime) const;
 
     private:
         Resource::ResourceSystem* mResourceSystem;
@@ -119,6 +120,9 @@ namespace MWWorld
         std::vector<PositionCellGrid> mTerrainPreloadPositions;
         osg::ref_ptr<TerrainPreloadItem> mTerrainPreloadItem;
         osg::ref_ptr<SceneUtil::WorkItem> mUpdateCacheItem;
+
+        std::vector<PositionCellGrid> mLoadedTerrainPositions;
+        double mLoadedTerrainTimestamp;
     };
 
 }

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -628,7 +628,7 @@ namespace MWWorld
         osg::Vec4i newGrid = gridCenterToBounds(mCurrentGridCenter);
         mRendering.setActiveGrid(newGrid);
 
-        if (!mPreloader->isTerrainLoaded(std::make_pair(pos, newGrid)))
+        if (!mPreloader->isTerrainLoaded(std::make_pair(pos, newGrid), mRendering.getReferenceTime()))
             preloadTerrain(pos, true);
         mPagedRefs.clear();
         mRendering.getPagedRefnums(newGrid, mPagedRefs);

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -628,7 +628,8 @@ namespace MWWorld
         osg::Vec4i newGrid = gridCenterToBounds(mCurrentGridCenter);
         mRendering.setActiveGrid(newGrid);
 
-        preloadTerrain(pos, true);
+        if (!mPreloader->isTerrainLoaded(std::make_pair(pos, newGrid)))
+            preloadTerrain(pos, true);
         mPagedRefs.clear();
         mRendering.getPagedRefnums(newGrid, mPagedRefs);
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -628,6 +628,8 @@ namespace MWWorld
         osg::Vec4i newGrid = gridCenterToBounds(mCurrentGridCenter);
         mRendering.setActiveGrid(newGrid);
 
+        if (mRendering.pagingUnlockCache())
+            mPreloader->abortTerrainPreloadExcept(nullptr);
         if (!mPreloader->isTerrainLoaded(std::make_pair(pos, newGrid), mRendering.getReferenceTime()))
             preloadTerrain(pos, true);
         mPagedRefs.clear();
@@ -1242,10 +1244,7 @@ namespace MWWorld
     {
         std::vector<PositionCellGrid> vec;
         vec.emplace_back(pos, gridCenterToBounds(getNewGridCenter(pos)));
-        if (sync && mRendering.pagingUnlockCache())
-            mPreloader->abortTerrainPreloadExcept(nullptr);
-        else
-            mPreloader->abortTerrainPreloadExcept(&vec[0]);
+        mPreloader->abortTerrainPreloadExcept(&vec[0]);
         mPreloader->setTerrainPreloadPositions(vec);
         if (!sync) return;
 

--- a/components/resource/resourcemanager.hpp
+++ b/components/resource/resourcemanager.hpp
@@ -59,6 +59,7 @@ namespace Resource
 
         /// How long to keep objects in cache after no longer being referenced.
         void setExpiryDelay (double expiryDelay) override { mExpiryDelay = expiryDelay; }
+        float getExpiryDelay() const { return mExpiryDelay; }
 
         const VFS::Manager* getVFS() const { return mVFS; }
 


### PR DESCRIPTION
We can take elsid's commit 605cb8db7c2f6fa8f9fea4e5ac5641867ba7a20e further by avoiding the terrain sync completely in most cases. Currently in changeCellGrid we wait for a new preloading task to ensure the getPagedRefnums for the new active cells have been filled in by object paging. This is usually not necessary because we have already completed a preload in the past containing these active cells. With this PR we remember what we preloaded and skip the terrain sync if it is not needed.

How to test this PR:
[ ] Check that syncTerrainLoad will no longer be called in the usual case, moving slowly
[ ] Check that syncTerrainLoad will still be called in unusual cases, e.g. abruptly changing direction at high speed