### PR TITLE
consolidate a uniform related to shadows

### DIFF
--- a/components/sceneutil/shadowsbin.cpp
+++ b/components/sceneutil/shadowsbin.cpp
@@ -54,6 +54,7 @@ ShadowsBin::ShadowsBin()
 
     mShaderAlphaTestStateSet = new osg::StateSet;
     mShaderAlphaTestStateSet->addUniform(new osg::Uniform("alphaTestShadows", true));
+    mShaderAlphaTestStateSet->addUniform(new osg::Uniform("useDiffuseMapForShadowAlpha", true));
     mShaderAlphaTestStateSet->setMode(GL_BLEND, osg::StateAttribute::OFF | osg::StateAttribute::PROTECTED | osg::StateAttribute::OVERRIDE);
 
     for (size_t i = 0; i < sCastingPrograms.size(); ++i)

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -340,15 +340,6 @@ namespace Shader
                     mRequirements.back().mShaderRequired = true;
                 }
             }
-
-            if (diffuseMap)
-            {
-                if (!writableStateSet)
-                    writableStateSet = getWritableStateSet(node);
-                // We probably shouldn't construct a new version of this each time as Uniforms use pointer comparison for early-out.
-                // Also it should probably belong to the shader manager or be applied by the shadows bin
-                writableStateSet->addUniform(new osg::Uniform("useDiffuseMapForShadowAlpha", true));
-            }
         }
 
         const osg::StateSet::AttributeList& attributes = stateset->getAttributeList();


### PR DESCRIPTION
During shadervisitor invocation, we currently create a clone of all statesets containing a diffuseMap to set a uniform related to shadows. Even though these clones are later shared again with SceneManager::shareState, this is just an unnecessary back and forth process we can avoid. With these changes the uniform is set on a common stateset created in shadows rendering and we no longer create the stateset clones.