### PR TITLE
sets a default object shader on top of the scene graph when using force shaders

### DIFF
--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -215,6 +215,8 @@ namespace MWRender
         osg::ref_ptr<SceneUtil::LightManager> lightManager = new SceneUtil::LightManager(ffp);
         lightManager->setStartLight(1);
         osg::ref_ptr<osg::StateSet> stateset = lightManager->getOrCreateStateSet();
+        if (mResourceSystem->getSceneManager()->getDefaultShaderState())
+            stateset->merge(*mResourceSystem->getSceneManager()->getDefaultShaderState());
         stateset->setMode(GL_LIGHTING, osg::StateAttribute::ON);
         stateset->setMode(GL_NORMALIZE, osg::StateAttribute::ON);
         stateset->setMode(GL_CULL_FACE, osg::StateAttribute::ON);

--- a/apps/openmw/mwrender/effectmanager.cpp
+++ b/apps/openmw/mwrender/effectmanager.cpp
@@ -42,6 +42,7 @@ void EffectManager::addEffect(const std::string &model, const std::string& textu
     trans->setPosition(worldPosition);
     trans->setScale(osg::Vec3f(scale, scale, scale));
     trans->addChild(node);
+    trans->setStateSet(mResourceSystem->getSceneManager()->getDefaultShaderState());
 
     SceneUtil::AssignControllerSourcesVisitor assignVisitor(effect.mAnimTime);
     node->accept(assignVisitor);

--- a/apps/openmw/mwrender/objectpaging.cpp
+++ b/apps/openmw/mwrender/objectpaging.cpp
@@ -684,6 +684,7 @@ namespace MWRender
         }
 
         group->getBound();
+        group->setStateSet(mSceneManager->getDefaultShaderState());
         group->setNodeMask(Mask_Static);
         osg::UserDataContainer* udc = group->getOrCreateUserDataContainer();
         if (activeGrid)

--- a/apps/openmw/mwrender/objectpaging.hpp
+++ b/apps/openmw/mwrender/objectpaging.hpp
@@ -31,6 +31,8 @@ namespace MWRender
 
         osg::ref_ptr<osg::Node> createChunk(float size, const osg::Vec2f& center, bool activeGrid, const osg::Vec3f& viewPoint, bool compile);
 
+        void setStateSet(osg::StateSet* stateset) { mStateSet = stateset; }
+
         unsigned int getNodeMask() override;
 
         /// @return true if view needs rebuild
@@ -50,6 +52,7 @@ namespace MWRender
         void getPagedRefnums(const osg::Vec4i &activeGrid, std::set<ESM::RefNum> &out);
 
     private:
+        osg::ref_ptr<osg::StateSet> mStateSet;
         Resource::SceneManager* mSceneManager;
         bool mActiveGrid;
         bool mDebugBatches;

--- a/apps/openmw/mwrender/objectpaging.hpp
+++ b/apps/openmw/mwrender/objectpaging.hpp
@@ -31,8 +31,6 @@ namespace MWRender
 
         osg::ref_ptr<osg::Node> createChunk(float size, const osg::Vec2f& center, bool activeGrid, const osg::Vec3f& viewPoint, bool compile);
 
-        void setStateSet(osg::StateSet* stateset) { mStateSet = stateset; }
-
         unsigned int getNodeMask() override;
 
         /// @return true if view needs rebuild
@@ -52,7 +50,6 @@ namespace MWRender
         void getPagedRefnums(const osg::Vec4i &activeGrid, std::set<ESM::RefNum> &out);
 
     private:
-        osg::ref_ptr<osg::StateSet> mStateSet;
         Resource::SceneManager* mSceneManager;
         bool mActiveGrid;
         bool mDebugBatches;

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -45,6 +45,7 @@ void Objects::insertBegin(const MWWorld::Ptr& ptr)
     {
         cellnode = new osg::Group;
         cellnode->setName("Cell Root");
+        cellnode->setStateSet(mResourceSystem->getSceneManager()->getDefaultShaderState());
         mRootNode->addChild(cellnode);
         mCellSceneNodes[ptr.getCell()] = cellnode;
     }

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -5,6 +5,8 @@
 
 #include <components/sceneutil/positionattitudetransform.hpp>
 #include <components/sceneutil/unrefqueue.hpp>
+#include <components/resource/resourcesystem.hpp>
+#include <components/resource/scenemanager.hpp>
 
 #include "../mwworld/ptr.hpp"
 #include "../mwworld/class.hpp"

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -275,13 +275,7 @@ namespace MWRender
         auto lightingMethod = SceneUtil::LightManager::getLightingMethodFromString(Settings::Manager::getString("lighting method", "Shaders"));
 
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
-        // Shadows and radial fog have problems with fixed-function mode
-        bool forceShaders = Settings::Manager::getBool("radial fog", "Shaders")
-                            || Settings::Manager::getBool("force shaders", "Shaders")
-                            || Settings::Manager::getBool("enable shadows", "Shadows")
-                            || lightingMethod != SceneUtil::LightingMethod::FFP
-                            || reverseZ;
-        resourceSystem->getSceneManager()->setForceShaders(forceShaders);
+        
         // FIXME: calling dummy method because terrain needs to know whether lighting is clamped
         resourceSystem->getSceneManager()->setClampLighting(Settings::Manager::getBool("clamp lighting", "Shaders"));
         resourceSystem->getSceneManager()->setAutoUseNormalMaps(Settings::Manager::getBool("auto use object normal maps", "Shaders"));
@@ -346,6 +340,13 @@ namespace MWRender
 
         // It is unnecessary to stop/start the viewer as no frames are being rendered yet.
         mResourceSystem->getSceneManager()->getShaderManager().setGlobalDefines(globalDefines);
+
+        bool forceShaders = Settings::Manager::getBool("radial fog", "Shaders")
+                            || Settings::Manager::getBool("force shaders", "Shaders")
+                            || Settings::Manager::getBool("enable shadows", "Shadows")
+                            || lightingMethod != SceneUtil::LightingMethod::FFP
+                            || reverseZ;
+        mResourceSystem->getSceneManager()->setForceShaders(forceShaders);
 
         mNavMesh.reset(new NavMesh(mRootNode, Settings::Manager::getBool("enable nav mesh render", "Navigator")));
         mActorsPaths.reset(new ActorsPaths(mRootNode, Settings::Manager::getBool("enable agents paths render", "Navigator")));

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -241,7 +241,7 @@ namespace Resource
     {
     }
 
-    osg::StateSet* SceneManager::setForceShaders(bool force)
+    void SceneManager::setForceShaders(bool force)
     {
         mForceShaders = force;
 
@@ -258,7 +258,6 @@ namespace Resource
         }
         else
             mDefaultShaderState = nullptr;
-        return mDefaultShaderState;
     }
 
     bool SceneManager::getForceShaders() const

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -253,6 +253,7 @@ namespace Resource
             Shader::ShaderVisitor::ShaderRequirements reqs;
             reqs.mTextures[0]="diffuseMap";
             reqs.mNode = dummy.get();
+            reqs.mColorMode = 2;
             shaderVisitor->createProgram(reqs);
             mDefaultShaderState = dummy.getStateSet();
         }

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -255,7 +255,7 @@ namespace Resource
             reqs.mNode = dummy.get();
             reqs.mColorMode = 2;
             shaderVisitor->createProgram(reqs);
-            mDefaultShaderState = dummy.getStateSet();
+            mDefaultShaderState = dummy->getStateSet();
         }
         else
             mDefaultShaderState = nullptr;

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -834,7 +834,8 @@ namespace Resource
         shaderVisitor->setApplyLightingToEnvMaps(mApplyLightingToEnvMaps);
         shaderVisitor->setConvertAlphaTestToAlphaToCoverage(mConvertAlphaTestToAlphaToCoverage);
         shaderVisitor->setTranslucentFramebuffer(translucentFramebuffer);
-        shaderVisitor->setDefaults(mDefaultShaderState);
+        if (shaderPrefix == "objects")
+            shaderVisitor->setDefaults(mDefaultShaderState);
         return shaderVisitor;
     }
 

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -244,6 +244,20 @@ namespace Resource
     void SceneManager::setForceShaders(bool force)
     {
         mForceShaders = force;
+
+        if (force)
+        {
+            osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor(createShaderVisitor());
+            shaderVisitor->setDefaults(nullptr);
+            osg::ref_ptr<osg::Node> dummy = new osg::Group;
+            Shader::ShaderVisitor::ShaderRequirements reqs;
+            reqs.mTextures[0]="diffuseMap";
+            reqs.mNode = dummy.get();
+            shaderVisitor->createProgram(reqs);
+            mDefaultShaderState = dummy.getStateSet();
+        }
+        else
+            mDefaultShaderState = nullptr;
     }
 
     bool SceneManager::getForceShaders() const
@@ -820,6 +834,7 @@ namespace Resource
         shaderVisitor->setApplyLightingToEnvMaps(mApplyLightingToEnvMaps);
         shaderVisitor->setConvertAlphaTestToAlphaToCoverage(mConvertAlphaTestToAlphaToCoverage);
         shaderVisitor->setTranslucentFramebuffer(translucentFramebuffer);
+        shaderVisitor->setDefaults(mDefaultShaderState);
         return shaderVisitor;
     }
 

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -241,7 +241,7 @@ namespace Resource
     {
     }
 
-    void SceneManager::setForceShaders(bool force)
+    osg::StateSet* SceneManager::setForceShaders(bool force)
     {
         mForceShaders = force;
 
@@ -258,6 +258,7 @@ namespace Resource
         }
         else
             mDefaultShaderState = nullptr;
+        return mDefaultShaderState;
     }
 
     bool SceneManager::getForceShaders() const

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -85,8 +85,7 @@ namespace Resource
         /// When editing such state, it should be reinstated before the edits, and shaders should be recreated afterwards.
         void reinstateRemovedState(osg::ref_ptr<osg::Node> node);
 
-        /// @see ShaderVisitor::setForceShaders
-        void setForceShaders(bool force);
+        osg::StateSet* setForceShaders(bool force);
         bool getForceShaders() const;
 
         void setClampLighting(bool clamp);

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -206,6 +206,7 @@ namespace Resource
         SceneUtil::LightManager::SupportedMethods mSupportedLightingMethods;
         bool mConvertAlphaTestToAlphaToCoverage;
         GLenum mDepthFormat;
+        osg::ref_ptr<osg::StateSet> mDefaultShaderState;
 
         osg::ref_ptr<MultiObjectCache> mInstanceCache;
 

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -88,6 +88,8 @@ namespace Resource
         osg::StateSet* setForceShaders(bool force);
         bool getForceShaders() const;
 
+        osg::StateSet* getDefaultShaderState() { return mDefaultShaderState; }
+
         void setClampLighting(bool clamp);
         bool getClampLighting() const;
 

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -85,7 +85,8 @@ namespace Resource
         /// When editing such state, it should be reinstated before the edits, and shaders should be recreated afterwards.
         void reinstateRemovedState(osg::ref_ptr<osg::Node> node);
 
-        osg::StateSet* setForceShaders(bool force);
+        /// Note if forcing shaders, you must use the getDefaultShaderState stateset on top of your scene graph.
+        void setForceShaders(bool force);
         bool getForceShaders() const;
 
         osg::StateSet* getDefaultShaderState() { return mDefaultShaderState; }

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -442,9 +442,9 @@ namespace Shader
         mRequirements.pop_back();
     }
 
-    void addUniformIfRequired(osg::StateSet* writableStateSet, const osg::StateSet* defaults, osg::StateSet* addedState, osg::ref_ptr<osg::Uniform> uniform)
+    void addUniformIfRequired(osg::StateSet* writableStateSet, const osg::StateSet* defaults, AddedState* addedState, osg::ref_ptr<osg::Uniform> uniform)
     {
-        osg::Uniform* defaultUniform = defaults ? defaults->getUniform(uniform->getName()) : nullptr;
+        const osg::Uniform* defaultUniform = defaults ? defaults->getUniform(uniform->getName()) : nullptr;
         if (defaultUniform && *uniform == *defaultUniform)
             return;
         writableStateSet->addUniform(uniform);

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -23,6 +23,10 @@ namespace Shader
         /// Setting force = true will cause all objects to render using shaders, regardless of having a bump map.
         void setForceShaders(bool force);
 
+        /// Set the default shader state that the user has applied to the top of the scene graph.
+        /// For the sake of efficiency, we will try to avoid setting this state again on individual nodes.
+        void setDefaults(const osg::StateSet* defaults);
+
         /// Set if we are allowed to modify StateSets encountered in the graph (default true).
         /// @par If set to false, then instead of modifying, the StateSet will be cloned and this new StateSet will be assigned to the node.
         /// @par This option is useful when the ShaderVisitor is run on a "live" subgraph that may have already been submitted for rendering.
@@ -105,6 +109,8 @@ namespace Shader
         std::vector<ShaderRequirements> mRequirements;
 
         std::string mDefaultShaderPrefix;
+
+        const osg::StateSet* mDefaults;
 
         void createProgram(const ShaderRequirements& reqs);
         void ensureFFP(osg::Node& node);

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -58,26 +58,6 @@ namespace Shader
         void pushRequirements(osg::Node& node);
         void popRequirements();
 
-    private:
-        bool mForceShaders;
-        bool mAllowedToModifyStateSets;
-
-        bool mAutoUseNormalMaps;
-        std::string mNormalMapPattern;
-        std::string mNormalHeightMapPattern;
-
-        bool mAutoUseSpecularMaps;
-        std::string mSpecularMapPattern;
-
-        bool mApplyLightingToEnvMaps;
-
-        bool mConvertAlphaTestToAlphaToCoverage;
-
-        bool mTranslucentFramebuffer;
-
-        ShaderManager& mShaderManager;
-        Resource::ImageManager& mImageManager;
-
         struct ShaderRequirements
         {
             ShaderRequirements();
@@ -106,13 +86,35 @@ namespace Shader
             // the Node that requested these requirements
             osg::Node* mNode;
         };
+
+        void createProgram(const ShaderRequirements& reqs);
+
+    private:
+        bool mForceShaders;
+        bool mAllowedToModifyStateSets;
+
+        bool mAutoUseNormalMaps;
+        std::string mNormalMapPattern;
+        std::string mNormalHeightMapPattern;
+
+        bool mAutoUseSpecularMaps;
+        std::string mSpecularMapPattern;
+
+        bool mApplyLightingToEnvMaps;
+
+        bool mConvertAlphaTestToAlphaToCoverage;
+
+        bool mTranslucentFramebuffer;
+
+        ShaderManager& mShaderManager;
+        Resource::ImageManager& mImageManager;
+
         std::vector<ShaderRequirements> mRequirements;
 
         std::string mDefaultShaderPrefix;
 
         const osg::StateSet* mDefaults;
 
-        void createProgram(const ShaderRequirements& reqs);
         void ensureFFP(osg::Node& node);
         bool adjustGeometry(osg::Geometry& sourceGeometry, const ShaderRequirements& reqs);
     };


### PR DESCRIPTION
This PR sets a default object shader on top of the scene graph when using force shaders. Placing common state at the top allows osg's cull and draw traversals to work more effectively and reduces the state we need to set on individual nodes. We should see a reduced count of state graphs in the osg stats and spend less time in cull and draw as a result of these changes.

At the moment this PR only affects object shaders and only does so when force shaders is used. If we find this PR to be beneficial we can investigate using a similar approach for other shaders besides object shaders.