### PR TITLE
fixes bugs with share state

### DIFF
--- a/apps/openmw/mwrender/objectpaging.cpp
+++ b/apps/openmw/mwrender/objectpaging.cpp
@@ -658,7 +658,7 @@ namespace MWRender
             }
             optimizer.setIsOperationPermissibleForObjectCallback(new CanOptimizeCallback);
             unsigned int options = SceneUtil::Optimizer::FLATTEN_STATIC_TRANSFORMS|SceneUtil::Optimizer::REMOVE_REDUNDANT_NODES|SceneUtil::Optimizer::MERGE_GEOMETRY;
-            mSceneManager->shareState(mergeGroup);
+
             optimizer.optimize(mergeGroup, options);
 
             group->addChild(mergeGroup);

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -580,17 +580,9 @@ namespace Resource
                 optimizer.setSharedStateManager(mSharedStateManager, &mSharedStateMutex);
                 optimizer.setIsOperationPermissibleForObjectCallback(new CanOptimizeCallback);
 
-                // Because of limitations with the optimizer API, the optimizer can not replace the root node. Create a wrapper root node to allow the real root node to be optimised.
-                osg::ref_ptr<osg::Group> wrapper = new osg::Group;
-                wrapper->addChild(loaded);
-
                 static const unsigned int options = getOptimizationOptions()|SceneUtil::Optimizer::SHARE_DUPLICATE_STATE;
 
-                optimizer.optimize(wrapper, options);
-                if (wrapper->getNumChildren()==1)
-                    loaded = wrapper->getChild(0);
-                else
-                    loaded = wrapper;
+                optimizer.optimize(loaded, options);
             }
             else
                 shareState(loaded);

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -584,7 +584,7 @@ namespace Resource
                 osg::ref_ptr<osg::Group> wrapper = new osg::Group;
                 wrapper->addChild(loaded);
 
-                static const unsigned int options = getOptimizationOptions()|Optimizer::SHARE_DUPLICATE_STATE;
+                static const unsigned int options = getOptimizationOptions()|SceneUtil::Optimizer::SHARE_DUPLICATE_STATE;
 
                 optimizer.optimize(wrapper, options);
                 if (wrapper->getNumChildren()==1)

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -103,11 +103,11 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
     }
 
     if (options & SHARE_DUPLICATE_STATE && _sharedStateManager)
-    (
+    {
         if (_sharedStateMutex) _sharedStateMutex->lock();
         _sharedStateManager->share(node);
         if (_sharedStateMutex) _sharedStateMutex->unlock();
-    )
+    }
 
     if (options & MERGE_GEOMETRY)
     {

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -30,6 +30,8 @@
 #include <osg/io_utils>
 #include <osg/Depth>
 
+#include <osgDB/SharedStateManager>
+
 #include <osgUtil/TransformAttributeFunctor>
 #include <osgUtil/Statistics>
 #include <osgUtil/MeshOptimizers>
@@ -99,6 +101,13 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
         MergeGroupsVisitor mgrp(this);
         node->accept(mgrp);
     }
+
+    if (options & SHARE_DUPLICATE_STATE && _sharedStateManager)
+    (
+        if (_sharedStateMutex) _sharedStateMutex->lock();
+        _sharedStateManager->share(node);
+        if (_sharedStateMutex) _sharedStateMutex->unlock();
+    )
 
     if (options & MERGE_GEOMETRY)
     {

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -86,6 +86,13 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
         cstv.removeTransforms(node);
     }
 
+    if (options & SHARE_DUPLICATE_STATE && _sharedStateManager)
+    {
+        if (_sharedStateMutex) _sharedStateMutex->lock();
+        _sharedStateManager->share(node);
+        if (_sharedStateMutex) _sharedStateMutex->unlock();
+    }
+
     if (options & REMOVE_REDUNDANT_NODES)
     {
         OSG_INFO<<"Optimizer::optimize() doing REMOVE_REDUNDANT_NODES"<<std::endl;
@@ -100,13 +107,6 @@ void Optimizer::optimize(osg::Node* node, unsigned int options)
 
         MergeGroupsVisitor mgrp(this);
         node->accept(mgrp);
-    }
-
-    if (options & SHARE_DUPLICATE_STATE && _sharedStateManager)
-    {
-        if (_sharedStateMutex) _sharedStateMutex->lock();
-        _sharedStateManager->share(node);
-        if (_sharedStateMutex) _sharedStateMutex->unlock();
     }
 
     if (options & MERGE_GEOMETRY)

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -741,7 +741,8 @@ bool Optimizer::CombineStaticTransformsVisitor::removeTransforms(osg::Node* node
         if (transform->getNumChildren()==1 &&
             transform->getChild(0)->asTransform()!=0 &&
             transform->getChild(0)->asTransform()->asMatrixTransform()!=0 &&
-            transform->getChild(0)->asTransform()->getDataVariance()==osg::Object::STATIC)
+            (!transform->getChild(0)->getStateSet() || transform->getChild(0)->getStateSet()->referenceCount()==0) &&
+            transform->getChild(0)->getDataVariance()==osg::Object::STATIC)
         {
             // now combine with its child.
             osg::MatrixTransform* child = transform->getChild(0)->asTransform()->asMatrixTransform();

--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -750,7 +750,7 @@ bool Optimizer::CombineStaticTransformsVisitor::removeTransforms(osg::Node* node
         if (transform->getNumChildren()==1 &&
             transform->getChild(0)->asTransform()!=0 &&
             transform->getChild(0)->asTransform()->asMatrixTransform()!=0 &&
-            (!transform->getChild(0)->getStateSet() || transform->getChild(0)->getStateSet()->referenceCount()==0) &&
+            (!transform->getChild(0)->getStateSet() || transform->getChild(0)->getStateSet()->referenceCount()==1) &&
             transform->getChild(0)->getDataVariance()==osg::Object::STATIC)
         {
             // now combine with its child.

--- a/components/sceneutil/optimizer.hpp
+++ b/components/sceneutil/optimizer.hpp
@@ -25,6 +25,12 @@
 //#include <osgUtil/Export>
 
 #include <set>
+#include <mutex>
+
+namespace osgDB
+{
+    class SharedStateManager;
+}
 
 //namespace osgUtil {
 namespace SceneUtil {
@@ -65,7 +71,7 @@ class Optimizer
 
     public:
 
-        Optimizer() : _mergeAlphaBlending(false) {}
+        Optimizer() : _mergeAlphaBlending(false), _sharedStateManager(nullptr), _sharedStateMutex(nullptr) {}
         virtual ~Optimizer() {}
 
         enum OptimizationOptions
@@ -120,6 +126,8 @@ class Optimizer
 
         void setMergeAlphaBlending(bool merge) { _mergeAlphaBlending = merge; }
         void setViewPoint(const osg::Vec3f& viewPoint) { _viewPoint = viewPoint; }
+
+        void setSharedStateManager(osgDB::SharedStateManager* sharedStateManager, std::mutex* sharedStateMutex) { _sharedStateMutex = sharedStateMutex; _sharedStateManager = sharedStateManager; }
 
         /** Reset internal data to initial state - the getPermissibleOptionsMap is cleared.*/
         void reset();
@@ -257,6 +265,9 @@ class Optimizer
 
         osg::Vec3f _viewPoint;
         bool _mergeAlphaBlending;
+
+        osgDB::SharedStateManager* _sharedStateManager;
+        mutable std::mutex* _sharedStateMutex;
 
     public:
 


### PR DESCRIPTION
Currently Open MW runs shareState on object paging chunks. In theory the SceneManager should have shared this state earlier. Investigations revealed a few issues:
1. The Optimizer modified shared statesets.
2. Because of an API limitation, the Optimizer is unable to optimise the root node of the passed in scene graph. During object paging, we wrap the loaded nodes under a new root node. With this new root node, object paging was able to perform optimisations that we could theoretically perform earlier in the scene manager.
3. Currently, Open MW runs state sharing before optimisation. There are issues with this approach because there is an optimisation stage (the same one which caused bug no. 1) we should ideally run before state sharing.

With these changes all above issues should be resolved. We should test the following before merging this PR:

- Bug 6048 that @cemocfr solved by adding shareState to object paging should not reoccur.
- State Graphs, Nodes and Drawables count in the osg stats is not higher than in master.
