### PR TITLE
allow checking for the existence of defines 

### DIFF
--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -282,7 +282,7 @@ namespace Shader
                     Log(Debug::Error) << "Shader " << templateName << " error: Unexpected EOF";
                     return false;
                 }
-                std::string definedDefine = source.substr(iterNameStart, endPos - iterNameStart));
+                std::string definedDefine = source.substr(iterNameStart, endPos - iterNameStart);
                 bool defined = defines.find(definedDefine) != defines.end() || globalDefines.find(definedDefine) != globalDefines.end();
                 suppressErrors.insert(definedDefine);
                 source.replace(foundPos, endPos - foundPos, defined ? "1" : "0");


### PR DESCRIPTION
Currently, Open MW's shader parser requires all defines to have a value. In practice, this approach leads to large define maps in which the majority of defines go unused.

This PR proposes a syntax `@defined define` allowing us to query if `define` exists. We could simplify our shader setup as shown in the example below. We would substantially decrease the size of the define map the shader visitor has to create for every leaf node.

```diff
-#if @diffuseMap
+#if @defined diffuseMapUV
    diffuseMapUV = (gl_TextureMatrix[@diffuseMapUV] * gl_MultiTexCoord@diffuseMapUV).xy;
#endif
```

```diff
-       for (unsigned int i=0;i<sizeof(defaultTextures)/sizeof(defaultTextures[0]); ++i)
-       {
-           defineMap[defaultTextures[i]] = "0";
-           defineMap[std::string(defaultTextures[i]) + std::string("UV")] = "0";
-       }
        for (std::map<int, std::string>::const_iterator texIt = reqs.mTextures.begin(); texIt != reqs.mTextures.end(); ++texIt)
        {
-           defineMap[texIt->second] = "1";
            defineMap[texIt->second + std::string("UV")] = std::to_string(texIt->first);
        }
```



Before we start the bulk of the work involved in porting shaders, we should decide on the syntax.