### PR TITLE
set program state higher up

### DIFF
--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -429,14 +429,14 @@ namespace Shader
 
     void ShaderVisitor::createProgram(const ShaderRequirements &reqs)
     {
-        osg::Node& node = *reqs.mNode;
+        osg::Node* parent = nullptr;
         for (auto it = getNodePath().rbegin()+1; it != getNodePath().rend(); ++it)
         {
-            osg::Node* parent = *it;
-            if (parent->getNumChildren()>1)
+            if (*it->getNumChildren()>1)
                 break;
-            node = *parent;
+            parent = *it;
         }
+        osg::Node& node = parent ? *parent : *reqs.mNode;
 
         if (!reqs.mShaderRequired && !mForceShaders)
         {

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -432,7 +432,7 @@ namespace Shader
         osg::Node* parent = nullptr;
         for (auto it = getNodePath().rbegin()+1; it != getNodePath().rend(); ++it)
         {
-            if (*it->getNumChildren()>1)
+            if ((*it)->getNumChildren()>1)
                 break;
             parent = *it;
         }

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -142,7 +142,7 @@ namespace Shader
         if (!node.getStateSet())
             return node.getOrCreateStateSet();
         else if (node.getStateSet()->referenceCount() == 1)
-            return node->getStateSet();
+            return node.getStateSet();
 
         osg::ref_ptr<osg::StateSet> newStateSet = new osg::StateSet(*node.getStateSet(), osg::CopyOp::SHALLOW_COPY);
         node.setStateSet(newStateSet);

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -429,13 +429,21 @@ namespace Shader
 
     void ShaderVisitor::createProgram(const ShaderRequirements &reqs)
     {
+        osg::Node& node = *reqs.mNode;
+        for (auto it = getNodePath().rbegin()+1; it != getNodePath().rend(); ++it)
+        {
+            osg::Node* parent = *it;
+            if (parent->getNumChildren()>1)
+                break;
+            node = *parent;
+        }
+
         if (!reqs.mShaderRequired && !mForceShaders)
         {
-            ensureFFP(*reqs.mNode);
+            ensureFFP(node);
             return;
         }
 
-        osg::Node& node = *reqs.mNode;
         osg::StateSet* writableStateSet = nullptr;
         if (mAllowedToModifyStateSets)
             writableStateSet = node.getOrCreateStateSet();

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -432,7 +432,7 @@ namespace Shader
         osg::Node* parent = nullptr;
         for (auto it = getNodePath().rbegin()+1; it != getNodePath().rend(); ++it)
         {
-            if ((*it)->getNumChildren()>1)
+            if ((*it)->asGroup()->getNumChildren()>1)
                 break;
             parent = *it;
         }


### PR DESCRIPTION
This PR supplements #3105. As noticed by Any old name, Open MW currently sets program state on leaf nodes. We should be setting program state higher up because program switches are one of the most expensive state switches in hardware. Higher up state is given higher priority during state graph build in osg's cull traversal. Further, higher up nodes are more likely to be merged with other nodes during `sceneutil/optimizer.cpp` optimisation routines.

We should benchmark these changes with `force shaders` set to on. Differences can be expected in the State Graph count as well as time spent within cull, draw and gpu.