### PR TITLE
optimise chunk drawing order

### DIFF
--- a/components/terrain/material.cpp
+++ b/components/terrain/material.cpp
@@ -186,7 +186,7 @@ namespace Terrain
             if (!blendmaps.empty())
             {
                 stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
-                stateset->setRenderBinDetails(passIndex++, "RenderBin");
+                stateset->setRenderBinDetails(std::min(passIndex++,1), "RenderBin");
                 if (!firstLayer)
                 {
                     stateset->setAttributeAndModes(BlendFunc::value(), osg::StateAttribute::ON);

--- a/components/terrain/material.cpp
+++ b/components/terrain/material.cpp
@@ -176,7 +176,6 @@ namespace Terrain
         std::vector<osg::ref_ptr<osg::StateSet> > passes;
 
         unsigned int blendmapIndex = 0;
-        unsigned int passIndex = 0;
         for (std::vector<TextureLayer>::const_iterator it = layers.begin(); it != layers.end(); ++it)
         {
             bool firstLayer = (it == layers.begin());
@@ -186,7 +185,7 @@ namespace Terrain
             if (!blendmaps.empty())
             {
                 stateset->setMode(GL_BLEND, osg::StateAttribute::ON);
-                stateset->setRenderBinDetails(std::min(passIndex++,1), "RenderBin");
+                stateset->setRenderBinDetails(firstLayer ? 0 : 1, "RenderBin");
                 if (!firstLayer)
                 {
                     stateset->setAttributeAndModes(BlendFunc::value(), osg::StateAttribute::ON);


### PR DESCRIPTION
Currently, we first draw the first layer of all chunks, then the second layer of all chunks, then the third layer of all chunks and so on. This approach leads to more state switches than necessary, especially for the light state of the chunks.

With this PR, we differentiate only between the first layer and consecutive layers as necessary for correct blending. Consecutive layers are assigned to the same renderbin allowing osg to group draws by the chunk's light state. We should see a reduced count of State Graphs in the osg stats as a result of these changes.