### PR TITLE
turn off small feature culling for paging components

### DIFF
--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -422,8 +422,8 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
         return;
     }
 
-    osg::CullingSet::MaskValues projcullingmask = cv ? cv->getProjectionCullingStack().back().getCullingMask() : 0;
-    osg::CullingSet::MaskValues cullingmask = cv ? cv->getCurrentCullingSet().getCullingMask() : 0;
+    osg::CullingSet::Mask projcullingmask = cv ? cv->getProjectionCullingStack().back().getCullingMask() : 0;
+    osg::CullingSet::Mask cullingmask = cv ? cv->getCurrentCullingSet().getCullingMask() : 0;
     if (cv)
     {
         cv->getProjectionCullingStack().back().setCullingMask(projcullingmask & ~osg::CullingSet::SMALL_FEATURE_CULLING);

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -422,7 +422,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
         return;
     }
 
-    osg::CullSettings::CullingMode cullingmode = cullsettings ?  static_cast<osg::CullSettings*>(&nv)->getCullingMode() : 0;
+    osg::CullSettings::CullingMode cullingmode = isCullVisitor ?  static_cast<osgUtil::CullVisitor*>(&nv)->getCullingMode() : 0;
     if (cullingmode)
         static_cast<osgUtil::CullVisitor*>(&nv)->setCullingMode(cullingmode & ~osg::CullSettings::SMALL_FEATURE_CULLING);
 

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -422,6 +422,10 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
         return;
     }
 
+    osg::CullSettings::CullingMode cullingmode = cullsettings ?  static_cast<osg::CullSettings*>(&nv)->getCullingMode() : 0;
+    if (cullingmode)
+        static_cast<osgUtil::CullVisitor*>(&nv)->setCullingMode(cullingmode & ~osg::CullSettings::SMALL_FEATURE_CULLING);
+
     osg::Object * viewer = isCullVisitor ? static_cast<osgUtil::CullVisitor*>(&nv)->getCurrentCamera() : nullptr;
     bool needsUpdate = true;
     ViewData *vd = mViewDataMap->getViewData(viewer, nv.getViewPoint(), mActiveGrid, needsUpdate);
@@ -453,6 +457,9 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
         vd->setLastUsageTimeStamp(referenceTime);
         mViewDataMap->clearUnusedViews(referenceTime);
     }
+
+    if (cullingmode)
+        static_cast<osgUtil::CullVisitor*>(&nv)->setCullingMode(cullingmode);
 }
 
 void QuadTreeWorld::ensureQuadTreeBuilt()


### PR DESCRIPTION
Currently, Open MW runs small feature culling tests for paging chunks. These tests can be considered superfluous in this case. We already discard small objects at an earlier stage while building chunks. This PR turns off small feature culling for the paging scene graphs. We should be spending less time in the cull stage as a result of these changes.