### PR TITLE
discard off-screen lights

### DIFF
--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1205,10 +1205,7 @@ namespace SceneUtil
 
     const std::vector<LightManager::LightSourceViewBound>& LightManager::getLightsInViewSpace(osgUtil::CullVisitor *cv, const osg::RefMatrix* viewMatrix, size_t frameNum)
     {
-
         osg::Camera* camera = cv->getCurrentCamera();
-
-
 
         osg::observer_ptr<osg::Camera> camPtr (camera);
         auto it = mLightsInViewSpace.find(camPtr);

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1222,7 +1222,7 @@ namespace SceneUtil
 
                 float radius = transform.mLightSource->getRadius();
 
-                osg::BoundingSphere viewBound = osg::BoundingSphere(osg::Vec3f(0,0,0), radius * mPointLightRadiusMultiplier);
+                osg::BoundingSphere viewBound = osg::BoundingSphere(osg::Vec3f(0,0,0), radius);
                 transformBoundingSphere(worldViewMat, viewBound);
 
                 if (!isReflection && mPointLightFadeEnd != 0.f)
@@ -1239,10 +1239,12 @@ namespace SceneUtil
                 // remove lights culled by this camera
                 if (!usingFFP())
                 {
+                    viewBound._radius *= 2.f;
                     if (cv->getModelViewCullingStack().front().isCulled(viewBound))
                         continue;
+                    viewBound._radius /= 2.f;
                 }
-
+                viewBound._radius *= mPointLightRadiusMultiplier;
                 LightSourceViewBound l;
                 l.mLightSource = transform.mLightSource;
                 l.mViewBound = viewBound;
@@ -1367,7 +1369,7 @@ namespace SceneUtil
                     for (auto it = lightList.begin(); it != lightList.end() && lightList.size() > maxLights;)
                     {
                         osg::BoundingSphere bs = (*it)->mViewBound;
-                        bs._radius = bs._radius * 2.0;
+                        bs._radius = bs._radius / mPointLightRadiusMultiplier * 2.0;
                         if (cv->getModelViewCullingStack().front().isCulled(bs))
                             it = lightList.erase(it);
                         else

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1359,15 +1359,11 @@ namespace SceneUtil
 
             if (mLightList.size() > maxLights)
             {
-                
-
-                if (lightList.size() > maxLights)
-                {
-                    // sort by proximity to camera, then get rid of furthest away lights
-                    std::sort(lightList.begin(), lightList.end(), sortLights);
-                    while (lightList.size() > maxLights)
-                        lightList.pop_back();
-                }
+                LightManager::LightList lightList = mLightList;
+                // sort by proximity to camera, then get rid of furthest away lights
+                std::sort(lightList.begin(), lightList.end(), sortLights);
+                while (lightList.size() > maxLights)
+                    lightList.pop_back();
                 stateset = mLightManager->getLightListStateSet(lightList, cv->getTraversalNumber(), cv->getCurrentRenderStage()->getInitialViewMatrix());
             }
             else

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1364,7 +1364,7 @@ namespace SceneUtil
             {
                 LightManager::LightList lightList = mLightList;
 
-                if (usingFFP())
+                if (mLightManager->usingFFP())
                 {
                     for (auto it = lightList.begin(); it != lightList.end() && lightList.size() > maxLights;)
                     {

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1323,7 +1323,7 @@ namespace SceneUtil
 
             // Don't use Camera::getViewMatrix, that one might be relative to another camera!
             const osg::RefMatrix* viewMatrix = cv->getCurrentRenderStage()->getInitialViewMatrix();
-            const std::vector<LightManager::LightSourceViewBound>& lights = mLightManager->getLightsInViewSpace(cv->getCurrentCamera(), viewMatrix, mLastFrameNumber);
+            const std::vector<LightManager::LightSourceViewBound>& lights = mLightManager->getLightsInViewSpace(cv, viewMatrix, mLastFrameNumber);
 
             // get the node bounds in view space
             // NB do not node->getBound() * modelView, that would apply the node's transformation twice

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1369,7 +1369,7 @@ namespace SceneUtil
                     for (auto it = lightList.begin(); it != lightList.end() && lightList.size() > maxLights;)
                     {
                         osg::BoundingSphere bs = (*it)->mViewBound;
-                        bs._radius = bs._radius / mPointLightRadiusMultiplier * 2.0;
+                        bs._radius = bs._radius * 2.0;
                         if (cv->getModelViewCullingStack().front().isCulled(bs))
                             it = lightList.erase(it);
                         else

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -156,7 +156,7 @@ namespace SceneUtil
         /// Internal use only, called automatically by the LightSource's UpdateCallback
         void addLight(LightSource* lightSource, const osg::Matrixf& worldMat, size_t frameNum);
 
-        const std::vector<LightSourceViewBound>& getLightsInViewSpace(osg::Camera* camera, const osg::RefMatrix* viewMatrix, size_t frameNum);
+        const std::vector<LightSourceViewBound>& getLightsInViewSpace(osgUtil::CullVisitor* cv, const osg::RefMatrix* viewMatrix, size_t frameNum);
 
         osg::ref_ptr<osg::StateSet> getLightListStateSet(const LightList& lightList, size_t frameNum, const osg::RefMatrix* viewMatrix);
 


### PR DESCRIPTION
Currently, we run culling tests against all lights in the scene during LightListCallback::pushLightState. We can avoid most of these tests by removing off-screen lights at an earlier stage. We should benchmark the cumulative time spent within LightListCallback::pushLightState before and after this PR.