### PR TITLE
Fixed an issue where keyword search expected the text to be all ASCII…

### DIFF
--- a/apps/openmw/mwdialogue/keywordsearch.hpp
+++ b/apps/openmw/mwdialogue/keywordsearch.hpp
@@ -68,6 +68,19 @@ public:
         return false;
     }
 
+    static bool isWhitespaceUTF8(const int utf8Char)
+    {
+        if (utf8Char >= 0 && utf8Char <= UCHAR_MAX)
+        {
+            //That function has undefined behavior if the character doesn't fit in unsigned char
+            return std::isspace(utf8Char);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     static bool sortMatches(const Match& left, const Match& right)
     {
         return left.mBeg < right.mBeg;
@@ -83,7 +96,7 @@ public:
             {
                 Point prev = i;
                 --prev;
-                if(isalpha(*prev))
+                if(!isWhitespaceUTF8(*prev))
                     continue;
             }
 


### PR DESCRIPTION
I fixed the issue [!6289](https://gitlab.com/OpenMW/openmw/-/issues/6289)

The original code assumed that the text was always ASCII but it isn't always, so instead of checking if the previous character is Alpha, I just check that it isn't whitespace which is a better way to check that we are at the beginning of a word.