### PR TITLE
fixes wireframe is broken

### DIFF
--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -27,36 +27,6 @@ namespace MWRender
         }
     }
 
-    void GroundcoverUpdater::setWindSpeed(float windSpeed)
-    {
-        mWindSpeed = windSpeed;
-    }
-
-    void GroundcoverUpdater::setPlayerPos(osg::Vec3f playerPos)
-    {
-        mPlayerPos = playerPos;
-    }
-
-    void GroundcoverUpdater::setDefaults(osg::StateSet *stateset)
-    {
-        osg::ref_ptr<osg::Uniform> windUniform = new osg::Uniform("windSpeed", 0.0f);
-        stateset->addUniform(windUniform.get());
-
-        osg::ref_ptr<osg::Uniform> playerPosUniform = new osg::Uniform("playerPos", osg::Vec3f(0.f, 0.f, 0.f));
-        stateset->addUniform(playerPosUniform.get());
-    }
-
-    void GroundcoverUpdater::apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
-    {
-        osg::ref_ptr<osg::Uniform> windUniform = stateset->getUniform("windSpeed");
-        if (windUniform != nullptr)
-            windUniform->set(mWindSpeed);
-
-        osg::ref_ptr<osg::Uniform> playerPosUniform = stateset->getUniform("playerPos");
-        if (playerPosUniform != nullptr)
-            playerPosUniform->set(mPlayerPos);
-    }
-
     class InstancingVisitor : public osg::NodeVisitor
     {
     public:

--- a/apps/openmw/mwrender/groundcover.hpp
+++ b/apps/openmw/mwrender/groundcover.hpp
@@ -3,32 +3,10 @@
 
 #include <components/terrain/quadtreeworld.hpp>
 #include <components/resource/scenemanager.hpp>
-#include <components/sceneutil/statesetupdater.hpp>
 #include <components/esm/loadcell.hpp>
 
 namespace MWRender
 {
-    class GroundcoverUpdater : public SceneUtil::StateSetUpdater
-    {
-    public:
-        GroundcoverUpdater()
-            : mWindSpeed(0.f)
-            , mPlayerPos(osg::Vec3f())
-        {
-        }
-
-        void setWindSpeed(float windSpeed);
-        void setPlayerPos(osg::Vec3f playerPos);
-
-    protected:
-        void setDefaults(osg::StateSet *stateset) override;
-        void apply(osg::StateSet *stateset, osg::NodeVisitor *nv) override;
-
-    private:
-        float mWindSpeed;
-        osg::Vec3f mPlayerPos;
-    };
-
     typedef std::tuple<osg::Vec2f, float> GroundcoverChunkId; // Center, Size
     class Groundcover : public Resource::GenericResourceManager<GroundcoverChunkId>, public Terrain::QuadTreeWorld::ChunkManager
     {

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -95,7 +95,7 @@ namespace MWRender
             if (mUsePlayerUniforms)
             {
                 stateset->addUniform(new osg::Uniform("windSpeed", 0.0f));
-                stateset->addUniform(new osg::Uniform("playerPos", osg::Vec3f(0.f, 0.f, 0.f));
+                stateset->addUniform(new osg::Uniform("playerPos", osg::Vec3f(0.f, 0.f, 0.f)));
             }
         }
 

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -77,10 +77,12 @@ namespace MWRender
     class SharedUniformStateUpdater : public SceneUtil::StateSetUpdater
     {
     public:
-        SharedUniformStateUpdater()
+        SharedUniformStateUpdater(bool usePlayerUniforms)
             : mLinearFac(0.f)
             , mNear(0.f)
             , mFar(0.f)
+            , mUsePlayerUniforms(usePlayerUniforms)
+            , mWindSpeed(0.f)
         {
         }
 
@@ -90,6 +92,11 @@ namespace MWRender
             stateset->addUniform(new osg::Uniform("linearFac", 0.f));
             stateset->addUniform(new osg::Uniform("near", 0.f));
             stateset->addUniform(new osg::Uniform("far", 0.f));
+            if (mUsePlayerUniforms)
+            {
+                stateset->addUniform(new osg::Uniform("windSpeed", 0.0f));
+                stateset->addUniform(new osg::Uniform("playerPos", osg::Vec3f(0.f, 0.f, 0.f));
+            }
         }
 
         void apply(osg::StateSet* stateset, osg::NodeVisitor* nv) override
@@ -110,6 +117,16 @@ namespace MWRender
             if (uFar)
                 uFar->set(mFar);
 
+            if (mUsePlayerUniforms)
+            {
+                auto* windSpeed = stateset->getUniform("windSpeed");
+                if (windSpeed)
+                    windSpeed->set(mWindSpeed);
+
+                auto* playerPos = stateset->getUniform("playerPos");
+                if (playerPos)
+                    playerPos->set(mPlayerPos);
+            }
         }
 
         void setProjectionMatrix(const osg::Matrixf& projectionMatrix)
@@ -132,11 +149,25 @@ namespace MWRender
             mFar = far;
         }
 
+        void setWindSpeed(float windSpeed)
+        {
+            mWindSpeed = windSpeed;
+        }
+
+        void setPlayerPos(osg::Vec3f playerPos)
+        {
+            mPlayerPos = playerPos;
+        }
+
+
     private:
         osg::Matrixf mProjectionMatrix;
         float mLinearFac;
         float mNear;
         float mFar;
+        bool mUsePlayerUniforms;
+        float mWindSpeed;
+        osg::Vec3f mPlayerPos;
     };
 
     class StateUpdater : public SceneUtil::StateSetUpdater
@@ -400,15 +431,10 @@ namespace MWRender
         mTerrain->setTargetFrameRate(Settings::Manager::getFloat("target framerate", "Cells"));
         mTerrain->setWorkQueue(mWorkQueue.get());
 
-       osg::ref_ptr<SceneUtil::CompositeStateSetUpdater> composite = new SceneUtil::CompositeStateSetUpdater;
-
         if (groundcover)
         {
             float density = Settings::Manager::getFloat("density", "Groundcover");
             density = std::clamp(density, 0.f, 1.f);
-
-            mGroundcoverUpdater = new GroundcoverUpdater;
-            composite->addController(mGroundcoverUpdater);
 
             mGroundcover.reset(new Groundcover(mResourceSystem->getSceneManager(), density));
             static_cast<Terrain::QuadTreeWorld*>(mTerrain.get())->addChunkManager(mGroundcover.get());
@@ -419,10 +445,9 @@ namespace MWRender
         }
 
         mStateUpdater = new StateUpdater;
-        composite->addController(mStateUpdater);
-        sceneRoot->addUpdateCallback(composite);
+        sceneRoot->addUpdateCallback(mStateUpdater);
 
-        mSharedUniformStateUpdater = new SharedUniformStateUpdater;
+        mSharedUniformStateUpdater = new SharedUniformStateUpdater(groundcover);
         rootNode->addUpdateCallback(mSharedUniformStateUpdater);
 
         mPostProcessor = new PostProcessor(*this, viewer, mRootNode);
@@ -791,15 +816,12 @@ namespace MWRender
             mSky->update(dt);
             mWater->update(dt);
 
-            if (mGroundcoverUpdater)
-            {
-                const MWWorld::Ptr& player = mPlayerAnimation->getPtr();
-                osg::Vec3f playerPos(player.getRefData().getPosition().asVec3());
+            const MWWorld::Ptr& player = mPlayerAnimation->getPtr();
+            osg::Vec3f playerPos(player.getRefData().getPosition().asVec3());
 
-                float windSpeed = mSky->getBaseWindSpeed();
-                mGroundcoverUpdater->setWindSpeed(windSpeed);
-                mGroundcoverUpdater->setPlayerPos(playerPos);
-            }
+            float windSpeed = mSky->getBaseWindSpeed();
+            mSharedUniformStateUpdater->setWindSpeed(windSpeed);
+            mSharedUniformStateUpdater->setPlayerPos(playerPos);
         }
 
         updateNavMesh();

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -70,7 +70,6 @@ namespace DetourNavigator
 
 namespace MWRender
 {
-    class GroundcoverUpdater;
     class StateUpdater;
     class SharedUniformStateUpdater;
 
@@ -279,7 +278,6 @@ namespace MWRender
         std::unique_ptr<TerrainStorage> mTerrainStorage;
         std::unique_ptr<ObjectPaging> mObjectPaging;
         std::unique_ptr<Groundcover> mGroundcover;
-        osg::ref_ptr<GroundcoverUpdater> mGroundcoverUpdater;
         std::unique_ptr<SkyManager> mSky;
         std::unique_ptr<FogManager> mFog;
         std::unique_ptr<ScreenshotManager> mScreenshotManager;


### PR DESCRIPTION
Recent changes revealed a design flaw in Open MW's `CompositeStateSetUpdater` class. The `reset()` method used by wireframe toggles does not work if we are part of a `CompositeStateSetUpdater`. Lacking the expertise to improve this interaction I decided to revert the move to `CompositeStateSetUpdater`. With this PR the groundcover uniforms have been made part of an existing updater for uniforms. I have chosen this approach because the uniforms used by groundcover are not in fact specific to groundcover. We may want to use them elsewhere in the future.