### PR TITLE
reword warning in settings-default.cfg

### DIFF
--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -1,13 +1,5 @@
-# WARNING: If this file is named settings-default.cfg or was generated
-# from defaults.bin, then editing this file might have no effect, as
-# these settings may be overwritten by your user settings.cfg file
-# (see documentation for its location).
-#
-# This file provides minimal documentation for each setting, and
-# ranges of recommended values.  For detailed explanations of the
-# significance of each setting, interaction with other settings, hard
-# limits on value ranges and more information in general, please read
-# the detailed documentation at:
+# WARNING: Users should NOT edit this file. Users should add their personal preferences to the settings.cfg file overriding this file.
+# For the location of the settings.cfg file, as well as more detailed settings documentation, refer to:
 #
 #   https://openmw.readthedocs.io/en/master/reference/modding/settings/index.html
 #

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -1,7 +1,7 @@
 # WARNING: Users should NOT edit this file. Users should add their personal preferences to the settings.cfg file overriding this file.
 # For the location of the settings.cfg file, as well as more detailed settings documentation, refer to:
 #
-#   https://openmw.readthedocs.io/en/master/reference/modding/settings/index.html
+#   https://openmw.readthedocs.io/en/latest/reference/modding/settings/index.html
 #
 
 [Camera]


### PR DESCRIPTION
The warning at the head of settings-default.cfg is somewhat confusing for users, overly verbose and lacking the most crucial piece of information in its first sentence. Hence, it is unsurprising some users fail to heed the warning, as observed through user support requests on Matrix.