### PR TITLE
improves paging preloader

### DIFF
--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -371,7 +371,7 @@ namespace MWWorld
             mWorkQueue->addWorkItem(mUpdateCacheItem, true);
             mLastResourceCacheUpdate = timestamp;
         }
-        
+
         if (mTerrainPreloadItem && mTerrainPreloadItem->isDone())
         {
             mLoadedTerrainPositions = mTerrainPreloadPositions;

--- a/apps/openmw/mwworld/cellpreloader.cpp
+++ b/apps/openmw/mwworld/cellpreloader.cpp
@@ -25,7 +25,7 @@ namespace
 {
     template <class Contained>
     bool contains(const std::vector<MWWorld::CellPreloader::PositionCellGrid>& container,
-           const Contained& contained, float tolerance=1.f)
+           const Contained& contained, float tolerance)
     {
         for (const auto& pos : contained)
         {
@@ -371,6 +371,12 @@ namespace MWWorld
             mWorkQueue->addWorkItem(mUpdateCacheItem, true);
             mLastResourceCacheUpdate = timestamp;
         }
+        
+        if (mTerrainPreloadItem && mTerrainPreloadItem->isDone())
+        {
+            mLoadedTerrainPositions = mTerrainPreloadPositions;
+            mLoadedTerrainTimestamp = timestamp;
+        }
     }
 
     void CellPreloader::setExpiryDelay(double expiryDelay)
@@ -442,7 +448,7 @@ namespace MWWorld
             mTerrainPreloadPositions.clear();
             mLoadedTerrainPositions.clear();
         }
-        else if (contains(mTerrainPreloadPositions, positions))
+        else if (contains(mTerrainPreloadPositions, positions, 128.f))
             return;
         if (mTerrainPreloadItem && !mTerrainPreloadItem->isDone())
             return;

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -44,6 +44,17 @@ ChunkManager::ChunkManager(Storage *storage, Resource::SceneManager *sceneMgr, T
     mMultiPassRoot->setAttributeAndModes(material, osg::StateAttribute::ON);
 }
 
+struct FindChunkTemplate
+{
+void operator()(ChunkId id, osg::Object* obj)
+{
+    if (id[0] == mId[0] && id[1] == mId[1])
+        mFoundChunk = obj;
+}
+ChunkId mId;
+osg::ref<osg::Object> mFoundChunk;
+};
+
 osg::ref_ptr<osg::Node> ChunkManager::getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
 {
     ChunkId id = std::make_tuple(center, lod, lodFlags);
@@ -52,7 +63,11 @@ osg::ref_ptr<osg::Node> ChunkManager::getChunk(float size, const osg::Vec2f& cen
         return static_cast<osg::Node*>(obj.get());
     else
     {
-        osg::ref_ptr<osg::Node> node = createChunk(size, center, lod, lodFlags, compile);
+        FindChunkTemplate find;
+        find.mId = id;
+        mCache->call(find);
+        TerrainDrawable* templateGeometry = (find.mFoundTemplate && !mDebugChunks) ? static_cast<TerrainDrawable*>(find.mFoundTemplate.get()) : nullptr;
+        osg::ref_ptr<osg::Node> node = createChunk(size, center, lod, lodFlags, compile, templateGeometry);
         mCache->addEntryToObjectCache(id, node.get());
         return node;
     }
@@ -170,24 +185,45 @@ std::vector<osg::ref_ptr<osg::StateSet> > ChunkManager::createPasses(float chunk
     return ::Terrain::createPasses(useShaders, &mSceneManager->getShaderManager(), layers, blendmapTextures, blendmapScale, blendmapScale);
 }
 
-osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Vec2f &chunkCenter, unsigned char lod, unsigned int lodFlags, bool compile)
+osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Vec2f &chunkCenter, unsigned char lod, unsigned int lodFlags, bool compile, TerrainDrawable* templateGeometry)
 {
-    osg::ref_ptr<osg::Vec3Array> positions (new osg::Vec3Array);
-    osg::ref_ptr<osg::Vec3Array> normals (new osg::Vec3Array);
-    osg::ref_ptr<osg::Vec4ubArray> colors (new osg::Vec4ubArray);
-    colors->setNormalize(true);
-
-    osg::ref_ptr<osg::VertexBufferObject> vbo (new osg::VertexBufferObject);
-    positions->setVertexBufferObject(vbo);
-    normals->setVertexBufferObject(vbo);
-    colors->setVertexBufferObject(vbo);
-
-    mStorage->fillVertexBuffers(lod, chunkSize, chunkCenter, positions, normals, colors);
-
     osg::ref_ptr<TerrainDrawable> geometry (new TerrainDrawable);
-    geometry->setVertexArray(positions);
-    geometry->setNormalArray(normals, osg::Array::BIND_PER_VERTEX);
-    geometry->setColorArray(colors, osg::Array::BIND_PER_VERTEX);
+
+    if (!templateGeometry)
+    {
+        osg::ref_ptr<osg::Vec3Array> positions (new osg::Vec3Array);
+        osg::ref_ptr<osg::Vec3Array> normals (new osg::Vec3Array);
+        osg::ref_ptr<osg::Vec4ubArray> colors (new osg::Vec4ubArray);
+        colors->setNormalize(true);
+
+        mStorage->fillVertexBuffers(lod, chunkSize, chunkCenter, positions, normals, colors);
+
+        osg::ref_ptr<osg::VertexBufferObject> vbo (new osg::VertexBufferObject);
+        positions->setVertexBufferObject(vbo);
+        normals->setVertexBufferObject(vbo);
+        colors->setVertexBufferObject(vbo);
+    
+        geometry->setVertexArray(positions);
+        geometry->setNormalArray(normals, osg::Array::BIND_PER_VERTEX);
+        geometry->setColorArray(colors, osg::Array::BIND_PER_VERTEX);
+    }
+    else
+    {
+        // Unfortunately we need to copy vertex data because of poor coupling with VertexBufferObject.
+        osg::ref_ptr<osg::Array> positions = static_cast<osg::Array*>(templateGeometry->getVertexArray()->clone(osg::CopyOp::DEEP_COPY_ALL));
+        osg::ref_ptr<osg::Array> normals = static_cast<osg::Array*>(templateGeometry->getNormalArray()->clone(osg::CopyOp::DEEP_COPY_ALL));
+        osg::ref_ptr<osg::Array> colors = static_cast<osg::Array*>(templateGeometry->getColorArray()->clone(osg::CopyOp::DEEP_COPY_ALL));
+
+        osg::ref_ptr<osg::VertexBufferObject> vbo (new osg::VertexBufferObject);
+        positions->setVertexBufferObject(vbo);
+        normals->setVertexBufferObject(vbo);
+        colors->setVertexBufferObject(vbo);
+    
+        geometry->setVertexArray(positions);
+        geometry->setNormalArray(normals, osg::Array::BIND_PER_VERTEX);
+        geometry->setColorArray(colors, osg::Array::BIND_PER_VERTEX);
+    }
+    
     geometry->setUseDisplayList(false);
     geometry->setUseVertexBufferObjects(true);
 
@@ -207,32 +243,44 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
 
     geometry->setStateSet(mMultiPassRoot);
 
-    if (useCompositeMap)
+    if (templateGeometry)
     {
-        osg::ref_ptr<CompositeMap> compositeMap = new CompositeMap;
-        compositeMap->mTexture = createCompositeMapRTT();
-
-        createCompositeMapGeometry(chunkSize, chunkCenter, osg::Vec4f(0,0,1,1), *compositeMap);
-
-        mCompositeMapRenderer->addCompositeMap(compositeMap.get(), false);
-
-        geometry->setCompositeMap(compositeMap);
-        geometry->setCompositeMapRenderer(mCompositeMapRenderer);
-
-        TextureLayer layer;
-        layer.mDiffuseMap = compositeMap->mTexture;
-        layer.mParallax = false;
-        layer.mSpecular = false;
-        geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
+        if (templateGeometry->getCompositeMap())
+        {
+            geometry->setCompositeMap(templateGeometry->getCompositeMap());
+            geometry->setCompositeMapRenderer(mCompositeMapRenderer);
+        }
+        geometry->setPasses(templateGeometry->getPasses());
     }
     else
     {
-        geometry->setPasses(createPasses(chunkSize, chunkCenter, false));
+        if (useCompositeMap)
+        {
+            osg::ref_ptr<CompositeMap> compositeMap = new CompositeMap;
+            compositeMap->mTexture = createCompositeMapRTT();
+
+            createCompositeMapGeometry(chunkSize, chunkCenter, osg::Vec4f(0,0,1,1), *compositeMap);
+
+            mCompositeMapRenderer->addCompositeMap(compositeMap.get(), false);
+
+            geometry->setCompositeMap(compositeMap);
+            geometry->setCompositeMapRenderer(mCompositeMapRenderer);
+
+            TextureLayer layer;
+            layer.mDiffuseMap = compositeMap->mTexture;
+            layer.mParallax = false;
+            layer.mSpecular = false;
+            geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
+        }
+        else
+        {
+            geometry->setPasses(createPasses(chunkSize, chunkCenter, false));
+        }
     }
 
     geometry->setupWaterBoundingBox(-1, chunkSize * mStorage->getCellWorldSize() / numVerts);
 
-    if (compile && mSceneManager->getIncrementalCompileOperation())
+    if (!templateGeometry && compile && mSceneManager->getIncrementalCompileOperation())
     {
         mSceneManager->getIncrementalCompileOperation()->add(geometry);
     }

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -48,11 +48,11 @@ struct FindChunkTemplate
 {
 void operator()(ChunkId id, osg::Object* obj)
 {
-    if (id[0] == mId[0] && id[1] == mId[1])
-        mFoundChunk = obj;
+    if (id(0) == mId(0) && id(1) == mId(1))
+        mFoundTemplate = obj;
 }
 ChunkId mId;
-osg::ref<osg::Object> mFoundChunk;
+osg::ref_ptr<osg::Object> mFoundTemplate;
 };
 
 osg::ref_ptr<osg::Node> ChunkManager::getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -46,13 +46,13 @@ ChunkManager::ChunkManager(Storage *storage, Resource::SceneManager *sceneMgr, T
 
 struct FindChunkTemplate
 {
-void operator()(ChunkId id, osg::Object* obj)
-{
-    if (std::get<0>(id) == std::get<0>(mId) && std::get<1>(id) == std::get<1>(mId))
-        mFoundTemplate = obj;
-}
-ChunkId mId;
-osg::ref_ptr<osg::Object> mFoundTemplate;
+    void operator() (ChunkId id, osg::Object* obj)
+    {
+        if (std::get<0>(id) == std::get<0>(mId) && std::get<1>(id) == std::get<1>(mId))
+            mFoundTemplate = obj;
+    }
+    ChunkId mId;
+    osg::ref_ptr<osg::Object> mFoundTemplate;
 };
 
 osg::ref_ptr<osg::Node> ChunkManager::getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -48,7 +48,7 @@ struct FindChunkTemplate
 {
 void operator()(ChunkId id, osg::Object* obj)
 {
-    if (id(0) == mId(0) && id(1) == mId(1))
+    if (std::get<0>(id) == std::get<0>(mId) && std::get<1>(id) == std::get<1>(mId))
         mFoundTemplate = obj;
 }
 ChunkId mId;

--- a/components/terrain/chunkmanager.hpp
+++ b/components/terrain/chunkmanager.hpp
@@ -26,6 +26,7 @@ namespace Terrain
     class CompositeMapRenderer;
     class Storage;
     class CompositeMap;
+    class TerrainDrawable;
 
     typedef std::tuple<osg::Vec2f, unsigned char, unsigned int> ChunkId; // Center, Lod, Lod Flags
 
@@ -51,7 +52,7 @@ namespace Terrain
         void releaseGLObjects(osg::State* state) override;
 
     private:
-        osg::ref_ptr<osg::Node> createChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool compile);
+        osg::ref_ptr<osg::Node> createChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool compile, TerrainDrawable* templateGeometry);
 
         osg::ref_ptr<osg::Texture2D> createCompositeMapRTT();
 

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -27,8 +27,7 @@ namespace Terrain
         {
             Deeper,
             StopTraversal,
-            StopTraversalAndUse,
-            UseAndDeeper
+            StopTraversalAndUse
         };
         virtual ReturnValue isSufficientDetail(QuadTreeNode *node, float dist) = 0;
     };

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -27,7 +27,8 @@ namespace Terrain
         {
             Deeper,
             StopTraversal,
-            StopTraversalAndUse
+            StopTraversalAndUse,
+            UseAndDeeper
         };
         virtual ReturnValue isSufficientDetail(QuadTreeNode *node, float dist) = 0;
     };

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -342,7 +342,7 @@ void loadRenderingNode(ViewData::Entry& entry, ViewData* vd, int vertexLodMod, f
 
         for (QuadTreeWorld::ChunkManager* m : chunkManagers)
         {
-            if (m->getViewDistance() && entry.mNode->distance(vd->getViewPoint()) > m->getViewDistance() + reuseDistance*10)
+            if (m->getViewDistance() && entry.mNode->distance(vd->getViewPoint()) > m->getViewDistance() + reuseDistance)
                 continue;
             osg::ref_ptr<osg::Node> n = m->getChunk(entry.mNode->getSize(), entry.mNode->getCenter(), ourLod, entry.mLodFlags, activeGrid, vd->getViewPoint(), compile);
             if (n) pat->addChild(n);
@@ -519,11 +519,6 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::
 
     }
     vd->markUnchanged();
-}
-
-bool QuadTreeWorld::storeView(const View* view, double referenceTime)
-{
-    return mViewDataMap->storeView(static_cast<const ViewData*>(view), referenceTime);
 }
 
 void QuadTreeWorld::reportStats(unsigned int frameNumber, osg::Stats *stats)

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -511,7 +511,10 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::
         unsigned int startEntry = vd->getNumEntries();
 
         float distanceModifier=0.f;
-        if (pass>0) distanceModifier = (pass==1) ? 1024 : -1024;
+        if (pass == 1)
+            distanceModifier = 1024;
+        else if (pass == 2)
+            distanceModifier = -1024;
         DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, grid, distanceModifier);
         mRootNode->traverseNodes(vd, viewPoint, &lodCallback);
 
@@ -524,11 +527,12 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::
             reporter.addTotal(progressTotal);
         }
 
+        const float reuseDistance = std::max(mViewDataMap->getReuseDistance(), std::abs(distanceModifier));
         for (unsigned int i=startEntry; i<vd->getNumEntries() && !abort; ++i)
         {
             ViewData::Entry& entry = vd->getEntry(i);
 
-            loadRenderingNode(entry, vd, mVertexLodMod, cellWorldSize, grid, mChunkManagers, true, std::max(mViewDataMap->getReuseDistance(), std::abs(distanceModifier)));
+            loadRenderingNode(entry, vd, mVertexLodMod, cellWorldSize, grid, mChunkManagers, true, reuseDistance);
             if (pass==0) reporter.addProgress(entry.mNode->getSize());
             entry.mNode = nullptr; // Clear node lest we break the neighbours search for the next pass
         }

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -54,11 +54,12 @@ namespace Terrain
 class DefaultLodCallback : public LodCallback
 {
 public:
-    DefaultLodCallback(float factor, float minSize, float viewDistance, const osg::Vec4i& grid)
+    DefaultLodCallback(float factor, float minSize, float viewDistance, const osg::Vec4i& grid, float distanceModifier=0.f)
         : mFactor(factor)
         , mMinSize(minSize)
         , mViewDistance(viewDistance)
         , mActiveGrid(grid)
+        , mDistanceModifier(distanceModifier)
     {
     }
 
@@ -77,6 +78,8 @@ public:
                 return Deeper;
         }
 
+        dist = std::max(0.f, dist + mDistanceModifier);
+
         if (dist > mViewDistance && !activeGrid) // for Scene<->ObjectPaging sync the activegrid must remain loaded
             return StopTraversal;
 
@@ -91,6 +94,7 @@ private:
     float mMinSize;
     float mViewDistance;
     osg::Vec4i mActiveGrid;
+    float mDistanceModifier;
 };
 
 class RootNode : public QuadTreeNode
@@ -496,34 +500,39 @@ View* QuadTreeWorld::createView()
 void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::Vec4i &grid, std::atomic<bool> &abort, Loading::Reporter& reporter)
 {
     ensureQuadTreeBuilt();
+    const float cellWorldSize = mStorage->getCellWorldSize();
 
     ViewData* vd = static_cast<ViewData*>(view);
     vd->setViewPoint(viewPoint);
     vd->setActiveGrid(grid);
-    DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, grid);
-    mRootNode->traverseNodes(vd, viewPoint, &lodCallback);
 
-    std::size_t progressTotal = 0;
-    for (unsigned int i = 0, n = vd->getNumEntries(); i < n; ++i)
-        progressTotal += vd->getEntry(i).mNode->getSize();
-
-    reporter.addTotal(progressTotal);
-
-    const float cellWorldSize = mStorage->getCellWorldSize();
-    for (unsigned int i=0; i<vd->getNumEntries() && !abort; ++i)
+    for (unsigned int pass=0; pass<3; ++pass)
     {
-        ViewData::Entry& entry = vd->getEntry(i);
+        unsigned int startEntry = vd->getNumEntries();
 
+        float distanceModifier=0.f;
+        if (pass>0) distanceModifier = (pass==1) ? 1024 : -1024;
+        DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, grid, distanceModifier);
+        mRootNode->traverseNodes(vd, viewPoint, &lodCallback);
 
+        if (pass==0)
+        {
+            std::size_t progressTotal = 0;
+            for (unsigned int i = 0, n = vd->getNumEntries(); i < n; ++i)
+                 progressTotal += vd->getEntry(i).mNode->getSize();
 
-        loadRenderingNode(entry, vd, mVertexLodMod, cellWorldSize, grid, mChunkManagers, true, mViewDataMap->getReuseDistance());
-        reporter.addProgress(entry.mNode->getSize());
+            reporter.addTotal(progressTotal);
+        }
 
+        for (unsigned int i=startEntry; i<vd->getNumEntries() && !abort; ++i)
+        {
+            ViewData::Entry& entry = vd->getEntry(i);
 
-
-
+            loadRenderingNode(entry, vd, mVertexLodMod, cellWorldSize, grid, mChunkManagers, true, mViewDataMap->getReuseDistance());
+            if (pass==0) reporter.addProgress(entry.mNode->getSize());
+            entry.mNode = nullptr; // Clear node lest we break the neighbours search for the next pass
+        }
     }
-    vd->markUnchanged();
 }
 
 void QuadTreeWorld::reportStats(unsigned int frameNumber, osg::Stats *stats)

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -528,7 +528,7 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::
         {
             ViewData::Entry& entry = vd->getEntry(i);
 
-            loadRenderingNode(entry, vd, mVertexLodMod, cellWorldSize, grid, mChunkManagers, true, mViewDataMap->getReuseDistance());
+            loadRenderingNode(entry, vd, mVertexLodMod, cellWorldSize, grid, mChunkManagers, true, std::max(mViewDataMap->getReuseDistance(), std::abs(distanceModifier)));
             if (pass==0) reporter.addProgress(entry.mNode->getSize());
             entry.mNode = nullptr; // Clear node lest we break the neighbours search for the next pass
         }

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -38,7 +38,6 @@ namespace Terrain
 
         View* createView() override;
         void preload(View* view, const osg::Vec3f& eyePoint, const osg::Vec4i &cellgrid, std::atomic<bool>& abort, Loading::Reporter& reporter) override;
-        bool storeView(const View* view, double referenceTime) override;
         void rebuildViews() override;
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats) override;

--- a/components/terrain/terraindrawable.cpp
+++ b/components/terrain/terraindrawable.cpp
@@ -24,6 +24,7 @@ TerrainDrawable::TerrainDrawable(const TerrainDrawable &copy, const osg::CopyOp 
     : osg::Geometry(copy, copyop)
     , mPasses(copy.mPasses)
     , mLightListCallback(copy.mLightListCallback)
+    , mCompositeMapCompiled(false)
 {
 
 }
@@ -94,10 +95,10 @@ void TerrainDrawable::cull(osgUtil::CullVisitor *cv)
         return;
     }
 
-    if (mCompositeMap)
+    if (mCompositeMap && !mCompositeMapCompiled)
     {
         mCompositeMapRenderer->setImmediate(mCompositeMap);
-        mCompositeMap = nullptr;
+        mCompositeMapCompiled = true;
     }
 
     bool pushedLight = mLightListCallback && mLightListCallback->pushLightState(this, cv);

--- a/components/terrain/terraindrawable.cpp
+++ b/components/terrain/terraindrawable.cpp
@@ -24,7 +24,6 @@ TerrainDrawable::TerrainDrawable(const TerrainDrawable &copy, const osg::CopyOp 
     : osg::Geometry(copy, copyop)
     , mPasses(copy.mPasses)
     , mLightListCallback(copy.mLightListCallback)
-    , mCompositeMapCompiled(false)
 {
 
 }
@@ -95,10 +94,10 @@ void TerrainDrawable::cull(osgUtil::CullVisitor *cv)
         return;
     }
 
-    if (mCompositeMap && !mCompositeMapCompiled)
+    if (mCompositeMap && mCompositeMapRenderer)
     {
         mCompositeMapRenderer->setImmediate(mCompositeMap);
-        mCompositeMapCompiled = true;
+        mCompositeMapRenderer = nullptr;
     }
 
     bool pushedLight = mLightListCallback && mLightListCallback->pushLightState(this, cv);

--- a/components/terrain/terraindrawable.hpp
+++ b/components/terrain/terraindrawable.hpp
@@ -45,6 +45,7 @@ namespace Terrain
 
         typedef std::vector<osg::ref_ptr<osg::StateSet> > PassVector;
         void setPasses (const PassVector& passes);
+        const PassVector& getPasses() const {  return mPasses; }
 
         void setLightListCallback(SceneUtil::LightListCallback* lightListCallback);
 
@@ -56,6 +57,7 @@ namespace Terrain
         const osg::BoundingBox& getWaterBoundingBox() const { return mWaterBoundingBox; }
 
         void setCompositeMap(CompositeMap* map) { mCompositeMap = map; }
+        CompositeMap* getCompositeMap() { return mCompositeMap; }
         void setCompositeMapRenderer(CompositeMapRenderer* renderer) { mCompositeMapRenderer = renderer; }
 
     private:

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -143,7 +143,7 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
 
     if (!(vd->suitableToUse(activeGrid) && (vd->getViewPoint()-viewPoint).length2() < mReuseDistance*mReuseDistance && vd->getWorldUpdateRevision() >= mWorldUpdateRevision))
     {
-        float shortestDist = std::numeric_limits<float>::max();
+        float shortestDist = mReuseDistance*mReuseDistance;
         const ViewData* mostSuitableView = nullptr;
         for (const ViewData* other : mUsedViews)
         {
@@ -157,10 +157,15 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
                 }
             }
         }
-        if (mostSuitableView && mostSuitableView != vd)
+        if (mostSuitableView)
         {
             vd->copyFrom(*mostSuitableView);
             return vd;
+        }
+        else
+        {
+            vd->setViewPoint(viewPoint);
+            needsUpdate = true;
         }
     }
     if (!vd->suitableToUse(activeGrid))

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -165,26 +165,12 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
         else
         {
             vd->setViewPoint(viewPoint);
+            vd->setActiveGrid(activeGrid);
+            vd->setWorldUpdateRevision(mWorldUpdateRevision);
             needsUpdate = true;
         }
     }
-    if (!vd->suitableToUse(activeGrid))
-    {
-        vd->setViewPoint(viewPoint);
-        vd->setActiveGrid(activeGrid);
-        needsUpdate = true;
-    }
     return vd;
-}
-
-bool ViewDataMap::storeView(const ViewData* view, double referenceTime)
-{
-    if (view->getWorldUpdateRevision() < mWorldUpdateRevision)
-        return false;
-    ViewData* store = createOrReuseView();
-    store->copyFrom(*view);
-    store->setLastUsageTimeStamp(referenceTime);
-    return true;
 }
 
 ViewData *ViewDataMap::createOrReuseView()

--- a/components/terrain/viewdata.hpp
+++ b/components/terrain/viewdata.hpp
@@ -93,7 +93,6 @@ namespace Terrain
 
         void clearUnusedViews(double referenceTime);
         void rebuildViews();
-        bool storeView(const ViewData* view, double referenceTime);
 
         float getReuseDistance() const { return mReuseDistance; }
 

--- a/components/terrain/world.hpp
+++ b/components/terrain/world.hpp
@@ -155,10 +155,6 @@ namespace Terrain
 
         virtual void preload(View* view, const osg::Vec3f& viewPoint, const osg::Vec4i &cellgrid, std::atomic<bool>& abort, Loading::Reporter& reporter) {}
 
-        /// Store a preloaded view into the cache with the intent that the next rendering traversal can use it.
-        /// @note Not thread safe.
-        virtual bool storeView(const View* view, double referenceTime) {return true;}
-
         virtual void rebuildViews() {}
 
         virtual void reportStats(unsigned int frameNumber, osg::Stats* stats) {}


### PR DESCRIPTION
Currently, Open MW's paging preloader uses an inflexible strategy based around predicted player movement one second into the future. Relying solely on this predicted movement leads to cache misses when the player's movement vector changes unexpectedly. Further, the possible discrepancy between a player's position versus the camera's position is not accounted for. Last but not least, major issues arise with large object paging chunks in the distance that we are unable to prepare within the allotted time.

This PR proposes a more flexible strategy allowing us to preload chunks in all directions.

Summary of changes:
- Preloads chunks in all directions according to a defined distance modifier given to `LodCallback`.
- Speeds up chunk creation in `chunkmanager.cpp` by trying to reuse data from an existing similar chunk of differing `lodFlags`.
- Removes asynchronous high-level view updates prepared by `storeViews`. This approach provided negligible benefits and caused several issues such as groundcover pop-in noticed by @akortunov. Removes the previously used workaround for groundcover pop-in.
- Uses a more sensible movement threshold for launching new preloading tasks in `cellpreloader.cpp`.

Requesting review from @elsid who provided excellent feedback on my last PR related to preloading.