### PR TITLE
alternate debug chunks

### DIFF
--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -35,7 +35,6 @@ ChunkManager::ChunkManager(Storage *storage, Resource::SceneManager *sceneMgr, T
     , mCompositeMapSize(512)
     , mCompositeMapLevel(1.f)
     , mMaxCompGeometrySize(1.f)
-    , mDebugChunks(Settings::Manager::getBool("debug chunks", "Terrain"))
 {
     mMultiPassRoot = new osg::StateSet;
     mMultiPassRoot->setRenderingHint(osg::StateSet::OPAQUE_BIN);
@@ -237,19 +236,6 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
         mSceneManager->getIncrementalCompileOperation()->add(geometry);
     }
     geometry->setNodeMask(mNodeMask);
-
-    if (mDebugChunks)
-    {
-        osg::ref_ptr<osg::Group> result(new osg::Group);
-        result->addChild(geometry);
-        auto chunkBorder = CellBorder::createBorderGeometry(chunkCenter.x() - chunkSize / 2.f, chunkCenter.y() - chunkSize / 2.f, chunkSize, mStorage, mSceneManager, getNodeMask(), 5.f, { 1, 0, 0, 0 });
-        osg::Vec3f center = { chunkCenter.x(), chunkCenter.y(), 0 };
-        osg::ref_ptr<osg::MatrixTransform> trans = new osg::MatrixTransform(osg::Matrixf::translate(-center*Constants::CellSizeInUnits));
-        trans->setDataVariance(osg::Object::STATIC);
-        trans->addChild(chunkBorder);
-        result->addChild(trans);
-        return result;
-    }
 
     return geometry;
 }

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -13,7 +13,6 @@
 #include <components/resource/scenemanager.hpp>
 
 #include <components/sceneutil/lightmanager.hpp>
-#include <components/settings/settings.hpp>
 
 #include "terraindrawable.hpp"
 #include "material.hpp"

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -3,9 +3,7 @@
 #include <sstream>
 
 #include <osg/Texture2D>
-#include <osg/ClusterCullingCallback>
 #include <osg/Material>
-#include <osg/MatrixTransform>
 
 #include <osgUtil/IncrementalCompileOperation>
 

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -19,7 +19,6 @@
 #include "storage.hpp"
 #include "texturemanager.hpp"
 #include "compositemaprenderer.hpp"
-#include <components/misc/constants.hpp>
 
 namespace Terrain
 {

--- a/components/terrain/chunkmanager.hpp
+++ b/components/terrain/chunkmanager.hpp
@@ -72,7 +72,6 @@ namespace Terrain
         unsigned int mCompositeMapSize;
         float mCompositeMapLevel;
         float mMaxCompGeometrySize;
-        bool mDebugChunks = false;
     };
 
 }

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -282,8 +282,8 @@ QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resour
 
     if (mDebugTerrainChunks)
     {
-        mDebugChunkManager = new DebugChunkManager(mResourceSystem->getSceneManager(), mStorage, borderMask);
-        addChunkManager(mDebugChunkManager);
+        mDebugChunkManager = std::unique_ptr<DebugChunkManager>(new DebugChunkManager(mResourceSystem->getSceneManager(), mStorage, borderMask));
+        addChunkManager(mDebugChunkManager.get());
     }
 }
 

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -250,8 +250,8 @@ class DebugChunkManager : public QuadTreeWorld::ChunkManager
     DebugChunkManager(Resource::SceneManager* sceneManager, Storage* storage, unsigned int nodeMask) : mSceneManager(sceneManager), mStorage(storage), mNodeMask(nodeMask) {}
     virtual osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& chunkCenter, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
     {
-        auto chunkBorder = CellBorder::createBorderGeometry(center.x() - size / 2.f, center.y() - size / 2.f, size, mStorage, mSceneManager, mNodeMask, 5.f, { 1, 0, 0, 0 });
         osg::Vec3f center = { chunkCenter.x(), chunkCenter.y(), 0 };
+        auto chunkBorder = CellBorder::createBorderGeometry(center.x() - size / 2.f, center.y() - size / 2.f, size, mStorage, mSceneManager, mNodeMask, 5.f, { 1, 0, 0, 0 });
         osg::ref_ptr<osg::MatrixTransform> trans = new osg::MatrixTransform(osg::Matrixf::translate(-center*Constants::CellSizeInUnits));
         trans->setDataVariance(osg::Object::STATIC);
         trans->addChild(chunkBorder);

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -247,8 +247,9 @@ private:
 
 class DebugChunkManager : public QuadTreeWorld::ChunkManager
 {
+public:
     DebugChunkManager(Resource::SceneManager* sceneManager, Storage* storage, unsigned int nodeMask) : mSceneManager(sceneManager), mStorage(storage), mNodeMask(nodeMask) {}
-    virtual osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& chunkCenter, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
+    osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& chunkCenter, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
     {
         osg::Vec3f center = { chunkCenter.x(), chunkCenter.y(), 0 };
         auto chunkBorder = CellBorder::createBorderGeometry(center.x() - size / 2.f, center.y() - size / 2.f, size, mStorage, mSceneManager, mNodeMask, 5.f, { 1, 0, 0, 0 });
@@ -257,7 +258,7 @@ class DebugChunkManager : public QuadTreeWorld::ChunkManager
         trans->addChild(chunkBorder);
         return trans;
     }
-    virtual unsigned int getNodeMask() { return mNodeMask; }
+    unsigned int getNodeMask() { return mNodeMask; }
 private:
     Resource::SceneManager* mSceneManager;
     Storage* mStorage;

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -379,7 +379,7 @@ void loadRenderingNode(ViewData::Entry& entry, ViewData* vd, int vertexLodMod, f
     }
 }
 
-void updateWaterCullingView(HeightCullCallback* callback, ViewData* vd, osgUtil::CullVisitor* cv, float cellworldsize, bool outofworld, bool debugTerrainChunk)
+void updateWaterCullingView(HeightCullCallback* callback, ViewData* vd, osgUtil::CullVisitor* cv, float cellworldsize, bool outofworld)
 {
     if (!(cv->getTraversalMask() & callback->getCullMask()))
         return;
@@ -471,7 +471,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
     }
 
     if (mHeightCullCallback && isCullVisitor)
-        updateWaterCullingView(mHeightCullCallback, vd, static_cast<osgUtil::CullVisitor*>(&nv), mStorage->getCellWorldSize(), !isGridEmpty(), mDebugTerrainChunks);
+        updateWaterCullingView(mHeightCullCallback, vd, static_cast<osgUtil::CullVisitor*>(&nv), mStorage->getCellWorldSize(), !isGridEmpty());
 
     vd->markUnchanged();
 

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -11,6 +11,7 @@
 #include <components/sceneutil/mwshadowtechnique.hpp>
 #include <components/sceneutil/positionattitudetransform.hpp>
 #include <components/loadinglistener/reporter.hpp>
+#include <components/resource/resourcesystem.cpp>
 
 #include "quadtreenode.hpp"
 #include "storage.hpp"
@@ -247,7 +248,7 @@ private:
 class DebugChunkManager : public QuadTreeWorld::ChunkManager
 {
     DebugChunkManager(Resource::SceneManager* sceneManager, Storage* storage, unsigned int nodeMask) : mSceneManager(sceneManager), mStorage(storage), mNodeMask(nodeMask) {}
-    virtual osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
+    virtual osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& chunkCenter, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
     {
         auto chunkBorder = CellBorder::createBorderGeometry(center.x() - size / 2.f, center.y() - size / 2.f, size, mStorage, mSceneManager, mNodeMask, 5.f, { 1, 0, 0, 0 });
         osg::Vec3f center = { chunkCenter.x(), chunkCenter.y(), 0 };
@@ -261,7 +262,7 @@ private:
     Resource::SceneManager* mSceneManager;
     Storage* mStorage;
     unsigned int mNodeMask;
-}
+};
 
 QuadTreeWorld::QuadTreeWorld(osg::Group *parent, osg::Group *compileRoot, Resource::ResourceSystem *resourceSystem, Storage *storage, unsigned int nodeMask, unsigned int preCompileMask, unsigned int borderMask, int compMapResolution, float compMapLevel, float lodFactor, int vertexLodMod, float maxCompGeometrySize)
     : TerrainGrid(parent, compileRoot, resourceSystem, storage, nodeMask, preCompileMask, borderMask)

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -11,7 +11,7 @@
 #include <components/sceneutil/mwshadowtechnique.hpp>
 #include <components/sceneutil/positionattitudetransform.hpp>
 #include <components/loadinglistener/reporter.hpp>
-#include <components/resource/resourcesystem.cpp>
+#include <components/resource/resourcesystem.hpp>
 
 #include "quadtreenode.hpp"
 #include "storage.hpp"

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -5,6 +5,7 @@
 #include "terraingrid.hpp"
 
 #include <mutex>
+#include <memory>
 
 namespace osg
 {
@@ -74,7 +75,7 @@ namespace Terrain
         float mViewDistance;
         float mMinSize;
         bool mDebugTerrainChunks;
-        osg::ref_ptr<DebugChunkManager> mDebugChunkManager;
+        std::unique_ptr<DebugChunkManager> mDebugChunkManager;
     };
 
 }

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -15,6 +15,7 @@ namespace Terrain
 {
     class RootNode;
     class ViewDataMap;
+    class DebugChunkManager;
 
     /// @brief Terrain implementation that loads cells into a Quad Tree, with geometry LOD and texture LOD.
     class QuadTreeWorld : public TerrainGrid // note: derived from TerrainGrid is only to render default cells (see loadCell)
@@ -73,6 +74,7 @@ namespace Terrain
         float mViewDistance;
         float mMinSize;
         bool mDebugTerrainChunks;
+        osg::ref_ptr<DebugChunkManager> mDebugChunkManager;
     };
 
 }


### PR DESCRIPTION
This PR uses a new ChunkManager for the debug chunk nodes, providing several advantages:
- Avoids crash in Open MW CS which uses chunkmanager.cpp without the settings backbone.
- Avoids separate code paths when fetching a bounding box in `updateWaterCullingView`.
- Uses the proper node mask for the debug nodes.
- Avoids an intermediate osg::Group node.