### PR TITLE
avoids creating empty statesets for collada nodes

### DIFF
--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -272,22 +272,25 @@ namespace Resource
             }
 
             // Iterate each description, and see if the current node uses the specified material for alpha testing
-            for (auto description : mDescriptions)
+            if (node.getStateSet())
             {
-                std::vector<std::string> descriptionParts;
-                std::istringstream descriptionStringStream(description);
-                for (std::string part; std::getline(descriptionStringStream, part, ' ');)
+                for (auto description : mDescriptions)
                 {
-                    descriptionParts.emplace_back(part);
-                }
-
-                if (descriptionParts.size() > (3) && descriptionParts.at(3) == node.getOrCreateStateSet()->getName())
-                {
-                    if (descriptionParts.at(0) == "alphatest")
+                    std::vector<std::string> descriptionParts;
+                    std::istringstream descriptionStringStream(description);
+                    for (std::string part; std::getline(descriptionStringStream, part, ' ');)
                     {
-                        osg::AlphaFunc::ComparisonFunction mode = getTestMode(descriptionParts.at(1));
-                        osg::ref_ptr<osg::AlphaFunc> alphaFunc (new osg::AlphaFunc(mode, std::stod(descriptionParts.at(2))));
-                        node.getOrCreateStateSet()->setAttributeAndModes(alphaFunc, osg::StateAttribute::ON);
+                        descriptionParts.emplace_back(part);
+                    }
+
+                    if (descriptionParts.size() > (3) && descriptionParts.at(3) == node.getStateSet()->getName())
+                    {
+                        if (descriptionParts.at(0) == "alphatest")
+                        {
+                            osg::AlphaFunc::ComparisonFunction mode = getTestMode(descriptionParts.at(1));
+                            osg::ref_ptr<osg::AlphaFunc> alphaFunc (new osg::AlphaFunc(mode, std::stod(descriptionParts.at(2))));
+                            node.getStateSet()->setAttributeAndModes(alphaFunc, osg::StateAttribute::ON);
+                        }
                     }
                 }
             }

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -244,19 +244,22 @@ namespace Resource
 
         void apply(osg::Node& node) override
         {
-            if (node.getOrCreateStateSet()->getRenderingHint() == osg::StateSet::TRANSPARENT_BIN)
+            if (osg::StateSet* stateset = node.getStateSet())
             {
-                osg::ref_ptr<osg::Depth> depth = SceneUtil::createDepth();
-                depth->setWriteMask(false);
+                if (stateset->getRenderingHint() == osg::StateSet::TRANSPARENT_BIN)
+                {
+                    osg::ref_ptr<osg::Depth> depth = SceneUtil::createDepth();
+                    depth->setWriteMask(false);
 
-                node.getOrCreateStateSet()->setAttributeAndModes(depth, osg::StateAttribute::ON);
-            }
-            else if (node.getOrCreateStateSet()->getRenderingHint() == osg::StateSet::OPAQUE_BIN)
-            {
-                osg::ref_ptr<osg::Depth> depth = SceneUtil::createDepth();
-                depth->setWriteMask(true);
+                    stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
+                }
+                else if (stateset->getRenderingHint() == osg::StateSet::OPAQUE_BIN)
+                {
+                    osg::ref_ptr<osg::Depth> depth = SceneUtil::createDepth();
+                    depth->setWriteMask(true);
 
-                node.getOrCreateStateSet()->setAttributeAndModes(depth, osg::StateAttribute::ON);
+                    stateset->setAttributeAndModes(depth, osg::StateAttribute::ON);
+                }
             }
 
             /* Check if the <node> has <extra type="Node"> <technique profile="OpenSceneGraph"> <Descriptions> <Description>


### PR DESCRIPTION
With this PR we avoid creating empty statesets for collada nodes which will be detrimental to osg's draw performance.