### PR TITLE
removes unused code

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -262,7 +262,7 @@ namespace MWRender
             try
             {
                 for (std::vector<std::string>::const_iterator it = mModels.begin(); it != mModels.end(); ++it)
-                    mResourceSystem->getSceneManager()->cacheInstance(*it);
+                    mResourceSystem->getSceneManager()->getTemplate(*it);
                 for (std::vector<std::string>::const_iterator it = mTextures.begin(); it != mTextures.end(); ++it)
                     mResourceSystem->getImageManager()->getImage(*it);
                 for (std::vector<std::string>::const_iterator it = mKeyframes.begin(); it != mKeyframes.end(); ++it)

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -35,7 +35,6 @@
 #include "imagemanager.hpp"
 #include "niffilemanager.hpp"
 #include "objectcache.hpp"
-#include "multiobjectcache.hpp"
 
 namespace
 {

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -65,8 +65,6 @@ namespace Resource
         std::vector<osg::ref_ptr<const Object>> mObjects;
     };
 
-    class MultiObjectCache;
-
     /// @brief Handles loading and caching of scenes, e.g. .nif files or .osg files
     /// @note Some methods of the scene manager can be used from any thread, see the methods documentation for more details.
     class SceneManager : public ResourceManager
@@ -128,12 +126,6 @@ namespace Resource
         ///  If even the error marker mesh can not be found, an exception is thrown.
         /// @note Thread safe.
         osg::ref_ptr<const osg::Node> getTemplate(const std::string& name, bool compile=true);
-
-        /// Create an instance of the given scene template and cache it for later use, so that future calls to getInstance() can simply
-        /// return this cached object instead of creating a new one.
-        /// @note The returned ref_ptr may be kept around by the caller to ensure that the object stays in cache for as long as needed.
-        /// @note Thread safe.
-        osg::ref_ptr<osg::Node> cacheInstance(const std::string& name);
 
         osg::ref_ptr<osg::Node> createInstance(const std::string& name);
 
@@ -206,8 +198,6 @@ namespace Resource
         SceneUtil::LightManager::SupportedMethods mSupportedLightingMethods;
         bool mConvertAlphaTestToAlphaToCoverage;
         GLenum mDepthFormat;
-
-        osg::ref_ptr<MultiObjectCache> mInstanceCache;
 
         osg::ref_ptr<Resource::SharedStateManager> mSharedStateManager;
         mutable std::mutex mSharedStateMutex;

--- a/components/resource/stats.cpp
+++ b/components/resource/stats.cpp
@@ -376,7 +376,6 @@ void StatsHandler::setUpScene(osgViewer::ViewerBase *viewer)
             "Texture",
             "StateSet",
             "Node",
-            "Node Instance",
             "Shape",
             "Shape Instance",
             "Image",


### PR DESCRIPTION
This PR removes unused code related to instance caching. As a side effect of these changes we can skip skip a superfluous `normalizeFilename`.