### PR TITLE
avoids creating empty statesets on drawables

### DIFF
--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -487,6 +487,7 @@ namespace MWRender
         defaultMat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(1,1,1,1));
         defaultMat->setSpecular(osg::Material::FRONT_AND_BACK, osg::Vec4f(0.f, 0.f, 0.f, 0.f));
         sceneRoot->getOrCreateStateSet()->setAttribute(defaultMat);
+        sceneRoot->getOrCreateStateSet()->addUniform(new osg::Uniform("emissiveMult", 1.f));
 
         mFog.reset(new FogManager());
 

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1134,8 +1134,6 @@ namespace NifOsg
                 trans->addChild(toAttach);
                 parentNode->addChild(trans);
             }
-            // create partsys stateset in order to pass in ShaderVisitor like all other Drawables
-            partsys->getOrCreateStateSet();
         }
 
         void handleNiGeometryData(osg::Geometry *geometry, const Nif::NiGeometryData* data, const std::vector<unsigned int>& boundTextures, const std::string& name)

--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1923,8 +1923,6 @@ namespace NifOsg
         void applyDrawableProperties(osg::Node* node, const std::vector<const Nif::Property*>& properties, SceneUtil::CompositeStateSetUpdater* composite,
                                              bool hasVertexColors, int animflags)
         {
-            osg::StateSet* stateset = node->getOrCreateStateSet();
-
             // Specular lighting is enabled by default, but there's a quirk...
             bool specEnabled = true;
             osg::ref_ptr<osg::Material> mat (new osg::Material);
@@ -2006,15 +2004,15 @@ namespace NifOsg
                         if (blendFunc->getDestination() == GL_DST_ALPHA)
                             blendFunc->setDestination(GL_ONE);
                         blendFunc = shareAttribute(blendFunc);
-                        stateset->setAttributeAndModes(blendFunc, osg::StateAttribute::ON);
+                        node->getOrCreateStateSet()->setAttributeAndModes(blendFunc, osg::StateAttribute::ON);
 
                         bool noSort = (alphaprop->flags>>13)&1;
                         if (!noSort)
-                            stateset->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+                            node->getOrCreateStateSet()->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
                         else
-                            stateset->setRenderBinToInherit();
+                            node->getOrCreateStateSet()->setRenderBinToInherit();
                     }
-                    else
+                    else if (osg::StateSet* stateset = node->getStateSet())
                     {
                         stateset->removeAttribute(osg::StateAttribute::BLENDFUNC);
                         stateset->removeMode(GL_BLEND);
@@ -2025,9 +2023,9 @@ namespace NifOsg
                     {
                         osg::ref_ptr<osg::AlphaFunc> alphaFunc (new osg::AlphaFunc(getTestMode((alphaprop->flags>>10)&0x7), alphaprop->data.threshold/255.f));
                         alphaFunc = shareAttribute(alphaFunc);
-                        stateset->setAttributeAndModes(alphaFunc, osg::StateAttribute::ON);
+                        node->getOrCreateStateSet()->setAttributeAndModes(alphaFunc, osg::StateAttribute::ON);
                     }
-                    else
+                    else if (osg::StateSet* stateset = node->getStateSet())
                     {
                         stateset->removeAttribute(osg::StateAttribute::ALPHAFUNC);
                         stateset->removeMode(GL_ALPHA_TEST);
@@ -2083,8 +2081,10 @@ namespace NifOsg
 
             mat = shareAttribute(mat);
 
+            osg::StateSet* stateset = node->getStateSet();
             stateset->setAttributeAndModes(mat, osg::StateAttribute::ON);
-            stateset->addUniform(new osg::Uniform("emissiveMult", emissiveMult));
+            if (emissiveMult != 1.f)
+                stateset->addUniform(new osg::Uniform("emissiveMult", emissiveMult));
         }
 
     };


### PR DESCRIPTION
Currently, we attempt to skip creating state on drawable nodes when this state matches the default state. This attempt can be considered incomplete because we still create an avoidable empty stateset in the default case. With these changes the aforementioned oversight is corrected. Further, we now avoid adding the emissiveMult uniform when it matches the default.