### PR TITLE
Remove unused data field

### DIFF
--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -191,7 +191,7 @@ namespace MWRender
                         if (model.empty()) continue;
                         model = "meshes/" + model;
 
-                        instances[model].emplace_back(std::move(ref), std::move(model));
+                        instances[model].emplace_back(std::move(ref));
                     }
                 }
             }

--- a/apps/openmw/mwrender/groundcover.hpp
+++ b/apps/openmw/mwrender/groundcover.hpp
@@ -24,10 +24,8 @@ namespace MWRender
         {
             ESM::Position mPos;
             float mScale;
-            std::string mModel;
 
-            GroundcoverEntry(const ESM::CellRef& ref, const std::string& model):
-                mPos(ref.mPos), mScale(ref.mScale), mModel(model)
+            GroundcoverEntry(const ESM::CellRef& ref) : mPos(ref.mPos), mScale(ref.mScale)
             {}
         };
 


### PR DESCRIPTION
It became unused after refactoring, so it can be removed now. 
This PR should reduce memory usage during building groundcover pages a bit.