### PR TITLE
use StateSet define for translucentFramebuffer

### DIFF
--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -215,6 +215,7 @@ namespace MWRender
         osg::ref_ptr<SceneUtil::LightManager> lightManager = new SceneUtil::LightManager(ffp);
         lightManager->setStartLight(1);
         osg::ref_ptr<osg::StateSet> stateset = lightManager->getOrCreateStateSet();
+        stateset->setDefine("TRANSLUCENT_FRAMEBUFFER", osg::StateAttribute::ON);
         stateset->setMode(GL_LIGHTING, osg::StateAttribute::ON);
         stateset->setMode(GL_NORMALIZE, osg::StateAttribute::ON);
         stateset->setMode(GL_CULL_FACE, osg::StateAttribute::ON);
@@ -327,7 +328,6 @@ namespace MWRender
 
     void CharacterPreview::setBlendMode()
     {
-        mResourceSystem->getSceneManager()->recreateShaders(mNode, "objects", true);
         SetUpBlendVisitor visitor;
         mNode->accept(visitor);
     }

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -129,7 +129,7 @@ namespace MWRender
                     }
                     // Disable noBlendAlphaEnv
                     newStateSet->setTextureMode(7, GL_TEXTURE_2D, osg::StateAttribute::OFF);
-                    newStateSet->setDefine("TRANSLUCENT_FRAMEBUFFER", "0", osg::StateAttribute::ON);
+                    newStateSet->setDefine("FORCE_OPAQUE", "0", osg::StateAttribute::ON);
                 }
                 if (SceneUtil::getReverseZ() && stateset->getAttribute(osg::StateAttribute::DEPTH))
                 {
@@ -213,7 +213,7 @@ namespace MWRender
         osg::ref_ptr<SceneUtil::LightManager> lightManager = new SceneUtil::LightManager(ffp);
         lightManager->setStartLight(1);
         osg::ref_ptr<osg::StateSet> stateset = lightManager->getOrCreateStateSet();
-        stateset->setDefine("TRANSLUCENT_FRAMEBUFFER", "1", osg::StateAttribute::ON);
+        stateset->setDefine("FORCE_OPAQUE", "1", osg::StateAttribute::ON);
         stateset->setMode(GL_LIGHTING, osg::StateAttribute::ON);
         stateset->setMode(GL_NORMALIZE, osg::StateAttribute::ON);
         stateset->setMode(GL_CULL_FACE, osg::StateAttribute::ON);

--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -90,7 +90,7 @@ namespace MWRender
     class SetUpBlendVisitor : public osg::NodeVisitor
     {
     public:
-        SetUpBlendVisitor(): osg::NodeVisitor(TRAVERSE_ALL_CHILDREN), mNoAlphaUniform(new osg::Uniform("noAlpha", false))
+        SetUpBlendVisitor(): osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
         {
         }
 
@@ -129,7 +129,7 @@ namespace MWRender
                     }
                     // Disable noBlendAlphaEnv
                     newStateSet->setTextureMode(7, GL_TEXTURE_2D, osg::StateAttribute::OFF);
-                    newStateSet->addUniform(mNoAlphaUniform);
+                    newStateSet->setDefine("TRANSLUCENT_FRAMEBUFFER", "0", osg::StateAttribute::ON);
                 }
                 if (SceneUtil::getReverseZ() && stateset->getAttribute(osg::StateAttribute::DEPTH))
                 {
@@ -171,8 +171,6 @@ namespace MWRender
             }
             traverse(node);
         }
-    private:
-        osg::ref_ptr<osg::Uniform> mNoAlphaUniform;
     };
 
     CharacterPreview::CharacterPreview(osg::Group* parent, Resource::ResourceSystem* resourceSystem,
@@ -215,7 +213,7 @@ namespace MWRender
         osg::ref_ptr<SceneUtil::LightManager> lightManager = new SceneUtil::LightManager(ffp);
         lightManager->setStartLight(1);
         osg::ref_ptr<osg::StateSet> stateset = lightManager->getOrCreateStateSet();
-        stateset->setDefine("TRANSLUCENT_FRAMEBUFFER", osg::StateAttribute::ON);
+        stateset->setDefine("TRANSLUCENT_FRAMEBUFFER", "1", osg::StateAttribute::ON);
         stateset->setMode(GL_LIGHTING, osg::StateAttribute::ON);
         stateset->setMode(GL_NORMALIZE, osg::StateAttribute::ON);
         stateset->setMode(GL_CULL_FACE, osg::StateAttribute::ON);
@@ -253,7 +251,6 @@ namespace MWRender
         dummyTexture->setShadowCompareFunc(osg::Texture::ShadowCompareFunc::ALWAYS);
         stateset->setTextureAttributeAndModes(7, dummyTexture, osg::StateAttribute::ON);
         stateset->setTextureAttribute(7, noBlendAlphaEnv, osg::StateAttribute::ON);
-        stateset->addUniform(new osg::Uniform("noAlpha", true));
 
         osg::ref_ptr<osg::LightModel> lightmodel = new osg::LightModel;
         lightmodel->setAmbientIntensity(osg::Vec4(0.0, 0.0, 0.0, 1.0));

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -224,7 +224,7 @@ namespace MWRender
         group->setNodeMask(Mask_Groundcover);
         if (mSceneManager->getLightingMethod() != SceneUtil::LightingMethod::FFP)
             group->setCullCallback(new SceneUtil::LightListCallback);
-        mSceneManager->recreateShaders(group, "groundcover", false, true, mProgramTemplate);
+        mSceneManager->recreateShaders(group, "groundcover", true, mProgramTemplate);
         mSceneManager->shareState(group);
         group->getBound();
         return group;

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -333,9 +333,9 @@ namespace Resource
         return mForceShaders;
     }
 
-    void SceneManager::recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix, bool translucentFramebuffer, bool forceShadersForNode, const osg::Program* programTemplate)
+    void SceneManager::recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix, bool forceShadersForNode, const osg::Program* programTemplate)
     {
-        osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor(createShaderVisitor(shaderPrefix, translucentFramebuffer));
+        osg::ref_ptr<Shader::ShaderVisitor> shaderVisitor(createShaderVisitor(shaderPrefix));
         shaderVisitor->setAllowedToModifyStateSets(false);
         shaderVisitor->setProgramTemplate(programTemplate);
         if (forceShadersForNode)
@@ -873,7 +873,7 @@ namespace Resource
         stats->setAttribute(frameNumber, "Node", mCache->getCacheSize());
     }
 
-    Shader::ShaderVisitor *SceneManager::createShaderVisitor(const std::string& shaderPrefix, bool translucentFramebuffer)
+    Shader::ShaderVisitor *SceneManager::createShaderVisitor(const std::string& shaderPrefix)
     {
         Shader::ShaderVisitor* shaderVisitor = new Shader::ShaderVisitor(*mShaderManager.get(), *mImageManager, shaderPrefix);
         shaderVisitor->setForceShaders(mForceShaders);
@@ -884,7 +884,6 @@ namespace Resource
         shaderVisitor->setSpecularMapPattern(mSpecularMapPattern);
         shaderVisitor->setApplyLightingToEnvMaps(mApplyLightingToEnvMaps);
         shaderVisitor->setConvertAlphaTestToAlphaToCoverage(mConvertAlphaTestToAlphaToCoverage);
-        shaderVisitor->setTranslucentFramebuffer(translucentFramebuffer);
         return shaderVisitor;
     }
 }

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -76,7 +76,7 @@ namespace Resource
         Shader::ShaderManager& getShaderManager();
 
         /// Re-create shaders for this node, need to call this if alpha testing, texture stages or vertex color mode have changed.
-        void recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix = "objects", bool translucentFramebuffer = false, bool forceShadersForNode = false, const osg::Program* programTemplate = nullptr);
+        void recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix = "objects", bool forceShadersForNode = false, const osg::Program* programTemplate = nullptr);
 
         /// Applying shaders to a node may replace some fixed-function state.
         /// This restores it.
@@ -188,7 +188,7 @@ namespace Resource
 
     private:
 
-        Shader::ShaderVisitor* createShaderVisitor(const std::string& shaderPrefix = "objects", bool translucentFramebuffer = false);
+        Shader::ShaderVisitor* createShaderVisitor(const std::string& shaderPrefix = "objects");
 
         std::unique_ptr<Shader::ShaderManager> mShaderManager;
         bool mForceShaders;

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -266,6 +266,8 @@ namespace Shader
                                 mRequirements.back().mShaderRequired = true;
                             }
                         }
+                        else
+                            Log(Debug::Error) << "ShaderVisitor encountered unknown texture " << texture;
                     }
                 }
             }

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -111,7 +111,6 @@ namespace Shader
         , mAutoUseSpecularMaps(false)
         , mApplyLightingToEnvMaps(false)
         , mConvertAlphaTestToAlphaToCoverage(false)
-        , mTranslucentFramebuffer(false)
         , mShaderManager(shaderManager)
         , mImageManager(imageManager)
         , mDefaultShaderPrefix(defaultShaderPrefix)
@@ -267,8 +266,6 @@ namespace Shader
                                 mRequirements.back().mShaderRequired = true;
                             }
                         }
-                        else if (!mTranslucentFramebuffer)
-                            Log(Debug::Error) << "ShaderVisitor encountered unknown texture " << texture;
                     }
                 }
             }
@@ -545,8 +542,6 @@ namespace Shader
             updateAddedState(*writableUserData, addedState);
         }
 
-        defineMap["translucentFramebuffer"] = mTranslucentFramebuffer ? "1" : "0";
-
         std::string shaderPrefix;
         if (!node.getUserValue("shaderPrefix", shaderPrefix))
             shaderPrefix = mDefaultShaderPrefix;
@@ -760,11 +755,6 @@ namespace Shader
     void ShaderVisitor::setConvertAlphaTestToAlphaToCoverage(bool convert)
     {
         mConvertAlphaTestToAlphaToCoverage = convert;
-    }
-
-    void ShaderVisitor::setTranslucentFramebuffer(bool translucent)
-    {
-        mTranslucentFramebuffer = translucent;
     }
 
     ReinstateRemovedStateVisitor::ReinstateRemovedStateVisitor(bool allowedToModifyStateSets)

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -45,8 +45,6 @@ namespace Shader
 
         void setConvertAlphaTestToAlphaToCoverage(bool convert);
 
-        void setTranslucentFramebuffer(bool translucent);
-
         void apply(osg::Node& node) override;
 
         void apply(osg::Drawable& drawable) override;
@@ -71,8 +69,6 @@ namespace Shader
         bool mApplyLightingToEnvMaps;
 
         bool mConvertAlphaTestToAlphaToCoverage;
-
-        bool mTranslucentFramebuffer;
 
         ShaderManager& mShaderManager;
         Resource::ImageManager& mImageManager;

--- a/files/shaders/nv_default_fragment.glsl
+++ b/files/shaders/nv_default_fragment.glsl
@@ -94,11 +94,9 @@ void main()
 #endif
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
-#ifdef FORCE_OPAQUE
 #if FORCE_OPAQUE
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     gl_FragData[0].a = 1.0;
-#endif
 #endif
 
     applyShadowDebugOverlay();

--- a/files/shaders/nv_default_fragment.glsl
+++ b/files/shaders/nv_default_fragment.glsl
@@ -95,7 +95,10 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
 #ifdef TRANSLUCENT_FRAMEBUFFER
+#if TRANSLUCENT_FRAMEBUFFER
+    // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     gl_FragData[0].a = 1.0;
+#endif
 #endif
 
     applyShadowDebugOverlay();

--- a/files/shaders/nv_default_fragment.glsl
+++ b/files/shaders/nv_default_fragment.glsl
@@ -25,8 +25,6 @@ varying vec2 normalMapUV;
 varying vec4 passTangent;
 #endif
 
-uniform bool noAlpha;
-
 varying float euclideanDepth;
 varying float linearDepth;
 
@@ -97,8 +95,7 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
 #ifdef TRANSLUCENT_FRAMEBUFFER
-    if (noAlpha)
-        gl_FragData[0].a = 1.0;
+    gl_FragData[0].a = 1.0;
 #endif
 
     applyShadowDebugOverlay();

--- a/files/shaders/nv_default_fragment.glsl
+++ b/files/shaders/nv_default_fragment.glsl
@@ -1,5 +1,5 @@
 #version 120
-#pragma import_defines(TRANSLUCENT_FRAMEBUFFER)
+#pragma import_defines(FORCE_OPAQUE)
 
 #if @useUBO
     #extension GL_ARB_uniform_buffer_object : require
@@ -94,8 +94,8 @@ void main()
 #endif
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
-#ifdef TRANSLUCENT_FRAMEBUFFER
-#if TRANSLUCENT_FRAMEBUFFER
+#ifdef FORCE_OPAQUE
+#if FORCE_OPAQUE
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     gl_FragData[0].a = 1.0;
 #endif

--- a/files/shaders/nv_default_fragment.glsl
+++ b/files/shaders/nv_default_fragment.glsl
@@ -1,4 +1,5 @@
 #version 120
+#pragma import_defines(TRANSLUCENT_FRAMEBUFFER)
 
 #if @useUBO
     #extension GL_ARB_uniform_buffer_object : require
@@ -95,7 +96,7 @@ void main()
 #endif
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
-#if @translucentFramebuffer
+#ifdef TRANSLUCENT_FRAMEBUFFER
     if (noAlpha)
         gl_FragData[0].a = 1.0;
 #endif

--- a/files/shaders/nv_nolighting_fragment.glsl
+++ b/files/shaders/nv_nolighting_fragment.glsl
@@ -45,10 +45,8 @@ void main()
     float fogValue = clamp((linearDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
 #endif
 
-#ifdef FORCE_OPAQUE
 #if FORCE_OPAQUE
     gl_FragData[0].a = 1.0;
-#endif
 #endif
 
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);

--- a/files/shaders/nv_nolighting_fragment.glsl
+++ b/files/shaders/nv_nolighting_fragment.glsl
@@ -46,7 +46,9 @@ void main()
 #endif
 
 #ifdef TRANSLUCENT_FRAMEBUFFER
+#if TRANSLUCENT_FRAMEBUFFER
     gl_FragData[0].a = 1.0;
+#endif
 #endif
 
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);

--- a/files/shaders/nv_nolighting_fragment.glsl
+++ b/files/shaders/nv_nolighting_fragment.glsl
@@ -1,5 +1,5 @@
 #version 120
-#pragma import_defines(TRANSLUCENT_FRAMEBUFFER)
+#pragma import_defines(FORCE_OPAQUE)
 
 #if @useGPUShader4
     #extension GL_EXT_gpu_shader4: require
@@ -45,8 +45,8 @@ void main()
     float fogValue = clamp((linearDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
 #endif
 
-#ifdef TRANSLUCENT_FRAMEBUFFER
-#if TRANSLUCENT_FRAMEBUFFER
+#ifdef FORCE_OPAQUE
+#if FORCE_OPAQUE
     gl_FragData[0].a = 1.0;
 #endif
 #endif

--- a/files/shaders/nv_nolighting_fragment.glsl
+++ b/files/shaders/nv_nolighting_fragment.glsl
@@ -10,8 +10,6 @@ uniform sampler2D diffuseMap;
 varying vec2 diffuseMapUV;
 #endif
 
-uniform bool noAlpha;
-
 #if @radialFog
 varying float euclideanDepth;
 #else
@@ -48,8 +46,7 @@ void main()
 #endif
 
 #ifdef TRANSLUCENT_FRAMEBUFFER
-    if (noAlpha)
-        gl_FragData[0].a = 1.0;
+    gl_FragData[0].a = 1.0;
 #endif
 
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);

--- a/files/shaders/nv_nolighting_fragment.glsl
+++ b/files/shaders/nv_nolighting_fragment.glsl
@@ -1,4 +1,5 @@
 #version 120
+#pragma import_defines(TRANSLUCENT_FRAMEBUFFER)
 
 #if @useGPUShader4
     #extension GL_EXT_gpu_shader4: require
@@ -46,7 +47,7 @@ void main()
     float fogValue = clamp((linearDepth - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0);
 #endif
 
-#if @translucentFramebuffer
+#ifdef TRANSLUCENT_FRAMEBUFFER
     if (noAlpha)
         gl_FragData[0].a = 1.0;
 #endif

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -1,4 +1,5 @@
 #version 120
+#pragma import_defines(TRANSLUCENT_FRAMEBUFFER)
 
 #if @useUBO
     #extension GL_ARB_uniform_buffer_object : require
@@ -220,7 +221,7 @@ void main()
 #endif
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
-#if @translucentFramebuffer
+#ifdef TRANSLUCENT_FRAMEBUFFER
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     if (noAlpha)
         gl_FragData[0].a = 1.0;

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -1,5 +1,5 @@
 #version 120
-#pragma import_defines(TRANSLUCENT_FRAMEBUFFER)
+#pragma import_defines(FORCE_OPAQUE)
 
 #if @useUBO
     #extension GL_ARB_uniform_buffer_object : require
@@ -220,8 +220,8 @@ void main()
 #endif
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
-#ifdef TRANSLUCENT_FRAMEBUFFER
-#if TRANSLUCENT_FRAMEBUFFER
+#ifdef FORCE_OPAQUE
+#if FORCE_OPAQUE
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     gl_FragData[0].a = 1.0;
 #endif

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -220,11 +220,9 @@ void main()
 #endif
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
-#ifdef FORCE_OPAQUE
 #if FORCE_OPAQUE
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     gl_FragData[0].a = 1.0;
-#endif
 #endif
 
     applyShadowDebugOverlay();

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -221,8 +221,10 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, gl_Fog.color.xyz, fogValue);
 
 #ifdef TRANSLUCENT_FRAMEBUFFER
+#if TRANSLUCENT_FRAMEBUFFER
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
     gl_FragData[0].a = 1.0;
+#endif
 #endif
 
     applyShadowDebugOverlay();

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -59,7 +59,6 @@ uniform mat2 bumpMapMatrix;
 #endif
 
 uniform bool simpleWater;
-uniform bool noAlpha;
 
 varying float euclideanDepth;
 varying float linearDepth;
@@ -223,8 +222,7 @@ void main()
 
 #ifdef TRANSLUCENT_FRAMEBUFFER
     // having testing & blending isn't enough - we need to write an opaque pixel to be opaque
-    if (noAlpha)
-        gl_FragData[0].a = 1.0;
+    gl_FragData[0].a = 1.0;
 #endif
 
     applyShadowDebugOverlay();


### PR DESCRIPTION
With this PR we test out osg's shader define system for a somewhat harmless feature. As we can see, our code becomes more concise and efficient in this case. Most importantly, we no longer create unneeded vertex shader objects.