### PR TITLE
use std::move

### DIFF
--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -327,7 +327,7 @@ namespace Shader
             }
 
             osg::ref_ptr<osg::Shader> shader (new osg::Shader(shaderType));
-            shader->setShaderSource(shaderSource);
+            shader->setShaderSource(std::move(shaderSource));
             // Assign a unique prefix to allow the SharedStateManager to compare shaders efficiently.
             // Append shader source filename for debugging.
             static unsigned int counter = 0;


### PR DESCRIPTION
`shaderSource` can become quite large and should be moved. We may see measurable benefits associated with this change if the compiler is not already performing this optimisation automatically. 