### PR TITLE
cleans up osgacontroller.cpp

### DIFF
--- a/components/sceneutil/osgacontroller.cpp
+++ b/components/sceneutil/osgacontroller.cpp
@@ -1,19 +1,12 @@
 #include <components/sceneutil/osgacontroller.hpp>
 
-#include <osg/Geode>
 #include <osg/Node>
 #include <osg/NodeVisitor>
 #include <osg/ref_ptr>
-#include <osg/StateSet>
 
 #include <osgAnimation/Animation>
-#include <osgAnimation/AnimationUpdateCallback>
 #include <osgAnimation/Channel>
-#include <osgAnimation/BasicAnimationManager>
-#include <osgAnimation/Bone>
 #include <osgAnimation/Sampler>
-#include <osgAnimation/Skeleton>
-#include <osgAnimation/RigGeometry>
 #include <osgAnimation/UpdateMatrixTransform>
 
 #include <components/debug/debuglog.hpp>
@@ -55,19 +48,6 @@ namespace SceneUtil
         }
     }
 
-    void LinkVisitor::handle_stateset(osg::StateSet* stateset)
-    {
-        if (!stateset)
-            return;
-        const osg::StateSet::AttributeList& attributeList = stateset->getAttributeList();
-        for (auto attribute : attributeList)
-        {
-            osg::StateAttribute* sattr = attribute.second.first.get();
-            osgAnimation::UpdateMatrixTransform* umt = dynamic_cast<osgAnimation::UpdateMatrixTransform*>(sattr->getUpdateCallback()); //Can this even be in sa?
-            if (umt) link(umt);
-        }
-    }
-
     void LinkVisitor::setAnimation(Resource::Animation* animation)
     {
         mAnimation = animation;
@@ -75,10 +55,6 @@ namespace SceneUtil
 
     void LinkVisitor::apply(osg::Node& node)
     {
-        osg::StateSet* st = node.getStateSet();
-        if (st)
-        handle_stateset(st);
-
         osg::Callback* cb = node.getUpdateCallback();
         while (cb)
         {
@@ -89,17 +65,6 @@ namespace SceneUtil
         }
 
         traverse( node );
-    }
-
-    void LinkVisitor::apply(osg::Geode& node)
-    {
-        for (unsigned int i = 0; i < node.getNumDrawables(); i++)
-        {
-            osg::Drawable* drawable = node.getDrawable(i);
-            if (drawable && drawable->getStateSet())
-                handle_stateset(drawable->getStateSet());
-        }
-        apply(static_cast<osg::Node&>(node));
     }
 
     OsgAnimationController::OsgAnimationController(const OsgAnimationController &copy, const osg::CopyOp &copyop) : SceneUtil::KeyframeController(copy, copyop)

--- a/components/sceneutil/osgacontroller.cpp
+++ b/components/sceneutil/osgacontroller.cpp
@@ -64,7 +64,8 @@ namespace SceneUtil
             cb = cb->getNestedCallback();
         }
 
-        traverse( node );
+        if (node.getNumChildrenRequiringUpdateTraversal())
+            traverse( node );
     }
 
     OsgAnimationController::OsgAnimationController(const OsgAnimationController &copy, const osg::CopyOp &copyop) : SceneUtil::KeyframeController(copy, copyop)

--- a/components/sceneutil/osgacontroller.hpp
+++ b/components/sceneutil/osgacontroller.hpp
@@ -3,13 +3,7 @@
 
 #include <osg/Node>
 #include <osg/NodeVisitor>
-#include <osg/StateSet>
 #include <osg/ref_ptr>
-#include <osgAnimation/Animation>
-#include <osgAnimation/AnimationUpdateCallback>
-#include <osgAnimation/Channel>
-#include <osgAnimation/BasicAnimationManager>
-#include <osgAnimation/StackedTransform>
 #include <osgAnimation/UpdateMatrixTransform>
 
 #include <components/sceneutil/controller.hpp>
@@ -32,13 +26,9 @@ namespace SceneUtil
 
             virtual void link(osgAnimation::UpdateMatrixTransform* umt);
 
-            virtual void handle_stateset(osg::StateSet* stateset);
-
             virtual void setAnimation(Resource::Animation* animation);
 
             virtual void apply(osg::Node& node) override;
-
-            virtual void apply(osg::Geode& node) override;
 
         protected:
             Resource::Animation* mAnimation;


### PR DESCRIPTION
`handle_stateset` is not needed because `UpdateMatrixTransform` is a `NodeCallback` only allowed to be set on a `Node`. `Geode` and `Drawable` do not need explicit logic because they are both derived from `Node`.