### PR TITLE
adds a replacement for osg::NodeCallback

### DIFF
--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -245,7 +245,7 @@ protected:
 
     // Keep track of controllers that we added to our scene graph.
     // We may need to rebuild these controllers when the active animation groups / sources change.
-    std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback>>> mActiveControllers;
+    std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::Callback>>> mActiveControllers;
 
     std::shared_ptr<AnimationTime> mAnimationTimePtr[sNumBlendMasks];
 

--- a/apps/openmw/mwrender/weaponanimation.cpp
+++ b/apps/openmw/mwrender/weaponanimation.cpp
@@ -173,7 +173,7 @@ void WeaponAnimation::releaseArrow(MWWorld::Ptr actor, float attackStrength)
 }
 
 void WeaponAnimation::addControllers(const std::map<std::string, osg::ref_ptr<osg::MatrixTransform> >& nodes,
-    std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback>>> &map, osg::Node* objectRoot)
+    std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::Callback>>> &map, osg::Node* objectRoot)
 {
     for (int i=0; i<2; ++i)
     {

--- a/apps/openmw/mwrender/weaponanimation.hpp
+++ b/apps/openmw/mwrender/weaponanimation.hpp
@@ -43,7 +43,7 @@ namespace MWRender
 
         /// Add WeaponAnimation-related controllers to \a nodes and store the added controllers in \a map.
         void addControllers(const std::map<std::string, osg::ref_ptr<osg::MatrixTransform> >& nodes,
-                std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::NodeCallback>>>& map, osg::Node* objectRoot);
+                std::vector<std::pair<osg::ref_ptr<osg::Node>, osg::ref_ptr<osg::Callback>>>& map, osg::Node* objectRoot);
 
         void deleteControllers();
 

--- a/components/nifosg/controller.cpp
+++ b/components/nifosg/controller.cpp
@@ -72,6 +72,7 @@ KeyframeController::KeyframeController()
 
 KeyframeController::KeyframeController(const KeyframeController &copy, const osg::CopyOp &copyop)
     : SceneUtil::KeyframeController(copy, copyop)
+    , SceneUtil::NodeCallback<KeyframeController>(copy, copyop)
     , mRotations(copy.mRotations)
     , mXRotations(copy.mXRotations)
     , mYRotations(copy.mYRotations)

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -223,7 +223,7 @@ namespace NifOsg
         std::vector<FloatInterpolator> mKeyFrames;
     };
 
-    class KeyframeController : public SceneUtil::KeyframeController
+    class KeyframeController : public SceneUtil::KeyframeController, public SceneUtil::NodeCallback<KeyframeController>
     {
     public:
         // This is used if there's no interpolator but there is data (Morrowind meshes).
@@ -241,7 +241,7 @@ namespace NifOsg
 
         osg::Vec3f getTranslation(float time) const override;
 
-        void operator() (osg::Node*, osg::NodeVisitor*) override;
+        void operator() (osg::Node*, osg::NodeVisitor*);
 
     private:
         QuaternionInterpolator mRotations;

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -7,6 +7,7 @@
 #include <components/nif/data.hpp>
 
 #include <components/sceneutil/keyframe.hpp>
+#include <components/sceneutil/nodecallback.hpp>
 #include <components/sceneutil/statesetupdater.hpp>
 
 #include <set>

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -11,9 +11,17 @@
 
 namespace SceneUtil
 {
-    class KeyframeController : public SceneUtil::Controller, public virtual osg::Referenced
+    class KeyframeController : public SceneUtil::Controller, public virtual osg::Object
     {
     public:
+        KeyframeController() {}
+
+        KeyframeController(const KeyframeController& copy, const osg::CopyOp& copyop)
+            : osg::Object(copy, copyop)
+            , SceneUtil::Controller(copy)
+        {}
+        META_Object(SceneUtil, KeyframeController)
+
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
     };
 

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -11,7 +11,7 @@
 
 namespace SceneUtil
 {
-    class KeyframeController : public SceneUtil::Controller
+    class KeyframeController : public SceneUtil::Controller, public virtual osg::Referenced
     {
     public:
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -3,7 +3,7 @@
 
 #include <map>
 
-#include <osg/Node>
+#include <osg/Callback>
 
 #include <components/sceneutil/controller.hpp>
 #include <components/sceneutil/textkeymap.hpp>
@@ -11,13 +11,13 @@
 
 namespace SceneUtil
 {
-    class KeyframeController : public SceneUtil::Controller, public virtual osg::Object
+    class KeyframeController : public SceneUtil::Controller, public virtual osg::Callback
     {
     public:
         KeyframeController() {}
 
         KeyframeController(const KeyframeController& copy, const osg::CopyOp& copyop)
-            : osg::Object(copy, copyop)
+            : osg::Callback(copy, copyop)
             , SceneUtil::Controller(copy)
         {}
         META_Object(SceneUtil, KeyframeController)

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -11,20 +11,10 @@
 
 namespace SceneUtil
 {
-    class KeyframeController : public osg::NodeCallback, public SceneUtil::Controller
+    class KeyframeController : public SceneUtil::Controller
     {
     public:
-        KeyframeController() {}
-
-        KeyframeController(const KeyframeController& copy, const osg::CopyOp& copyop)
-            : osg::NodeCallback(copy, copyop)
-            , SceneUtil::Controller(copy)
-        {}
-        META_Object(SceneUtil, KeyframeController)
-
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
-
-        virtual void operator() (osg::Node* node, osg::NodeVisitor* nodeVisitor) override { traverse(node, nodeVisitor); }
     };
 
     /// Wrapper object containing an animation track as a ref-countable osg::Object.

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -605,14 +605,14 @@ namespace SceneUtil
 
     // Set on a LightSource. Adds the light source to its light manager for the current frame.
     // This allows us to keep track of the current lights in the scene graph without tying creation & destruction to the manager.
-    class CollectLightCallback : public osg::NodeCallback
+    class CollectLightCallback : public SceneUtil::NodeCallback<CollectLightCallback>
     {
     public:
         CollectLightCallback()
             : mLightManager(nullptr) { }
 
         CollectLightCallback(const CollectLightCallback& copy, const osg::CopyOp& copyop)
-            : osg::NodeCallback(copy, copyop)
+            : SceneUtil::NodeCallback<CollectLightCallback>(copy, copyop)
             , mLightManager(nullptr) { }
 
         META_Object(SceneUtil, SceneUtil::CollectLightCallback)
@@ -637,19 +637,11 @@ namespace SceneUtil
     };
 
     // Set on a LightManager. Clears the data from the previous frame.
-    class LightManagerUpdateCallback : public osg::NodeCallback
+    class LightManagerUpdateCallback : public SceneUtil::NodeCallback<LightManagerUpdateCallback>
     {
     public:
-        LightManagerUpdateCallback()
-            { }
 
-        LightManagerUpdateCallback(const LightManagerUpdateCallback& copy, const osg::CopyOp& copyop)
-            : osg::NodeCallback(copy, copyop)
-            { }
-
-        META_Object(SceneUtil, LightManagerUpdateCallback)
-
-        void operator()(osg::Node* node, osg::NodeVisitor* nv) override
+        void operator()(osg::Node* node, osg::NodeVisitor* nv)
         {
             LightManager* lightManager = static_cast<LightManager*>(node);
             lightManager->update(nv->getTraversalNumber());
@@ -1288,7 +1280,7 @@ namespace SceneUtil
     void LightListCallback::operator()(osg::Node *node, osgUtil::CullVisitor *cv)
     {
         bool pushedState = pushLightState(node, cv);
-        traverse(node, nv);
+        traverse(node, cv);
         if (pushedState)
             cv->popStateSet();
     }

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -1285,10 +1285,8 @@ namespace SceneUtil
             mLight[i] = new osg::Light(*copy.mLight[i].get(), copyop);
     }
 
-    void LightListCallback::operator()(osg::Node *node, osg::NodeVisitor *nv)
+    void LightListCallback::operator()(osg::Node *node, osgUtil::CullVisitor *cv)
     {
-        osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(nv);
-
         bool pushedState = pushLightState(node, cv);
         traverse(node, nv);
         if (pushedState)

--- a/components/sceneutil/lightmanager.cpp
+++ b/components/sceneutil/lightmanager.cpp
@@ -617,7 +617,7 @@ namespace SceneUtil
 
         META_Object(SceneUtil, SceneUtil::CollectLightCallback)
 
-        void operator()(osg::Node* node, osg::NodeVisitor* nv) override
+        void operator()(osg::Node* node, osg::NodeVisitor* nv)
         {
             if (!mLightManager)
             {

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -263,7 +263,7 @@ namespace SceneUtil
             , mLastFrameNumber(0)
         {}
         LightListCallback(const LightListCallback& copy, const osg::CopyOp& copyop)
-            : osg::Object(copy, copyop), osg::Callback(copy, copyop)
+            : osg::Object(copy, copyop), SceneUtil::NodeCallback<LightListCallback, osg::Node*, osgUtil::CullVisitor*>(copy, copyop)
             , mLightManager(copy.mLightManager)
             , mLastFrameNumber(0)
             , mIgnoredLightSources(copy.mIgnoredLightSources)

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -263,7 +263,7 @@ namespace SceneUtil
             , mLastFrameNumber(0)
         {}
         LightListCallback(const LightListCallback& copy, const osg::CopyOp& copyop)
-            : osg::Object(copy, copyop), osg::NodeCallback(copy, copyop)
+            : osg::Object(copy, copyop), osg::Callback(copy, copyop)
             , mLightManager(copy.mLightManager)
             , mLastFrameNumber(0)
             , mIgnoredLightSources(copy.mIgnoredLightSources)

--- a/components/sceneutil/lightmanager.hpp
+++ b/components/sceneutil/lightmanager.hpp
@@ -16,6 +16,7 @@
 #include <components/shader/shadermanager.hpp>
 
 #include <components/settings/settings.hpp>
+#include <components/sceneutil/nodecallback.hpp>
 
 namespace osgUtil
 {
@@ -254,7 +255,7 @@ namespace SceneUtil
     /// starting point is to attach a LightListCallback to each game object's base node.
     /// @note Not thread safe for CullThreadPerCamera threading mode.
     /// @note Due to lack of OSG support, the callback does not work on Drawables.
-    class LightListCallback : public osg::NodeCallback
+    class LightListCallback : public SceneUtil::NodeCallback<LightListCallback, osg::Node*, osgUtil::CullVisitor*>
     {
     public:
         LightListCallback()
@@ -270,7 +271,7 @@ namespace SceneUtil
 
         META_Object(SceneUtil, LightListCallback)
 
-        void operator()(osg::Node* node, osg::NodeVisitor* nv) override;
+        void operator()(osg::Node* node, osgUtil::CullVisitor* nv);
 
         bool pushLightState(osg::Node* node, osgUtil::CullVisitor* nv);
 

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -22,7 +22,7 @@ public:
         return true;
     }
 
-    void traverse(NodeType object, VisitorType data);
+    void traverse(NodeType object, VisitorType data)
     {
         if (_nestedCallback.valid())
             _nestedCallback->run(object, data);

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -23,11 +23,11 @@ public:
 
     virtual bool run(osg::Object* object, osg::Object* data)
     {
-        static_cast<Derived*>(this)->operator()((NodeType)object, (VisitorType)data);
+        static_cast<Derived*>(this)->operator()((NodeType)object, (VisitorType)data->asNodeVisitor());
         return true;
     }
 
-    void traverse(NodeType object, VisitorType data)
+    void traverse(osg::Object* object, osg::Object* data)
     {
         if (_nestedCallback.valid())
             _nestedCallback->run(object, data);

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -1,0 +1,35 @@
+#ifndef SCENEUTIL_NODECALLBACK_H
+#define SCENEUTIL_NODECALLBACK_H
+
+#include <osg/Callback>
+
+namespace osg
+{
+    class Node;
+    class NodeVisitor;
+}
+
+namespace SceneUtil
+{
+
+template <class Derived, typename NodeType=osg::Node*, typename VisitorType=osg::NodeVisitor*>
+class NodeCallback : public osg::Callback
+{
+public:
+    virtual bool run(osg::Object* object, osg::Object* data)
+    {
+        static_cast<Derived*>(this)->operator()(static_cast<NodeType>(object), static_cast<VisitorType>(data));
+        return true;
+    }
+
+    void traverse(NodeType object, VisitorType data);
+    {
+        if (_nestedCallback.valid())
+            _nestedCallback->run(object, data);
+        else
+            data->traverse(*object);
+    }
+};
+
+}
+#endif

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -16,6 +16,11 @@ template <class Derived, typename NodeType=osg::Node*, typename VisitorType=osg:
 class NodeCallback : public osg::Callback
 {
 public:
+    NodeCallback(){}
+    NodeCallback(const NodeCallback& nc,const osg::CopyOp& copyop):
+            osg::Callback(nc, copyop) {}
+    META_Object(SceneUtil, NodeCallback)
+
     virtual bool run(osg::Object* object, osg::Object* data)
     {
         static_cast<Derived*>(this)->operator()(static_cast<NodeType>(object), static_cast<VisitorType>(data));

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -23,7 +23,7 @@ public:
 
     virtual bool run(osg::Object* object, osg::Object* data)
     {
-        static_cast<Derived*>(this)->operator()(static_cast<NodeType>(object), static_cast<VisitorType>(data));
+        static_cast<Derived*>(this)->operator()((NodeType)object, (VisitorType)data);
         return true;
     }
 

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -13,7 +13,7 @@ namespace SceneUtil
 {
 
 template <class Derived, typename NodeType=osg::Node*, typename VisitorType=osg::NodeVisitor*>
-class NodeCallback : public osg::Callback
+class NodeCallback : public virtual osg::Callback
 {
 public:
     NodeCallback(){}

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -28,7 +28,7 @@ public:
     }
 
     template <typename VT>
-    void traverse(osg::Object* object, VT data)
+    void traverse(NodeType object, VT data)
     {
         if (_nestedCallback.valid())
             _nestedCallback->run(object, data);

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -27,7 +27,8 @@ public:
         return true;
     }
 
-    void traverse(osg::Object* object, osg::Object* data)
+    template <typename VT>
+    void traverse(osg::Object* object, VT data)
     {
         if (_nestedCallback.valid())
             _nestedCallback->run(object, data);

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -21,7 +21,7 @@ public:
             osg::Callback(nc, copyop) {}
     META_Object(SceneUtil, NodeCallback)
 
-    virtual bool run(osg::Object* object, osg::Object* data)
+    bool run(osg::Object* object, osg::Object* data) override
     {
         static_cast<Derived*>(this)->operator()((NodeType)object, (VisitorType)data->asNodeVisitor());
         return true;

--- a/components/sceneutil/osgacontroller.cpp
+++ b/components/sceneutil/osgacontroller.cpp
@@ -102,7 +102,7 @@ namespace SceneUtil
         apply(static_cast<osg::Node&>(node));
     }
 
-    OsgAnimationController::OsgAnimationController(const OsgAnimationController &copy, const osg::CopyOp &copyop) : SceneUtil::KeyframeController(copy, copyop)
+    OsgAnimationController::OsgAnimationController(const OsgAnimationController &copy, const osg::CopyOp &copyop) : SceneUtil::KeyframeController(copy, copyop), SceneUtil::NodeCallback<OsgAnimationController>(copy, copyop)
     , mEmulatedAnimations(copy.mEmulatedAnimations)
     {
         mLinker = nullptr;

--- a/components/sceneutil/osgacontroller.hpp
+++ b/components/sceneutil/osgacontroller.hpp
@@ -13,6 +13,7 @@
 #include <osgAnimation/UpdateMatrixTransform>
 
 #include <components/sceneutil/controller.hpp>
+#include <components/sceneutil/nodecallback.hpp>
 #include <components/sceneutil/keyframe.hpp>
 #include <components/resource/animation.hpp>
 
@@ -44,7 +45,7 @@ namespace SceneUtil
             Resource::Animation* mAnimation;
     };
 
-    class OsgAnimationController : public SceneUtil::KeyframeController
+    class OsgAnimationController : public SceneUtil::KeyframeController, public SceneUtil::NodeCallback<OsgAnimationController>
     {
     public:
         /// @brief Handles the animation for osgAnimation formats
@@ -61,7 +62,7 @@ namespace SceneUtil
         void update(float time, const std::string& animationName);
 
         /// @brief Called every frame for osgAnimation
-        void operator() (osg::Node*, osg::NodeVisitor*) override;
+        void operator() (osg::Node*, osg::NodeVisitor*);
 
         /// @brief Sets details of the animations
         void setEmulatedAnimations(const std::vector<EmulatedAnimation>& emulatedAnimations);


### PR DESCRIPTION
Currently, we use the deprecated `osg::NodeCallback` as the backbone of several performance critical Open MW features. The bridge in between `osg::NodeCallback` and `osg::Callback` requires seven virtual function calls per callback and frame.

With this PR we replace the deprecated `osg::NodeCallback` with a faster `SceneUtil::NodeCallback`. We now favor casts over virtual functions and use the Curiously Recurring Template Pattern to achieve static polymorphism for the callback interface. This new approach requires only two virtual function calls per callback.