### PR TITLE
attempts to fix spellcasting freezes

### DIFF
--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -456,13 +456,13 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
 
     osg::Object * viewer = isCullVisitor ? static_cast<osgUtil::CullVisitor*>(&nv)->getCurrentCamera() : nullptr;
     bool needsUpdate = true;
-    osg::Vec3f viewpoint = viewer ? nv.getViewPoint() : nv.getEyePoint();
+    osg::Vec3f viewPoint = viewer ? nv.getViewPoint() : nv.getEyePoint();
     ViewData *vd = mViewDataMap->getViewData(viewer, viewPoint, mActiveGrid, needsUpdate);
     if (needsUpdate)
     {
         vd->reset();
         DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, mActiveGrid);
-        mRootNode->traverseNodes(vd, nv.getViewPoint(), &lodCallback);
+        mRootNode->traverseNodes(vd, viewPoint, &lodCallback);
     }
 
     const float cellWorldSize = mStorage->getCellWorldSize();

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -456,8 +456,8 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
 
     osg::Object * viewer = isCullVisitor ? static_cast<osgUtil::CullVisitor*>(&nv)->getCurrentCamera() : nullptr;
     bool needsUpdate = true;
-    ViewData *vd = mViewDataMap->getViewData(viewer, nv.getViewPoint(), mActiveGrid, needsUpdate);
-
+    osg::Vec3f viewpoint = viewer ? nv.getViewPoint() : nv.getEyePoint();
+    ViewData *vd = mViewDataMap->getViewData(viewer, viewPoint, mActiveGrid, needsUpdate);
     if (needsUpdate)
     {
         vd->reset();

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -143,7 +143,7 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
 
     if (!(vd->suitableToUse(activeGrid) && (vd->getViewPoint()-viewPoint).length2() < mReuseDistance*mReuseDistance && vd->getWorldUpdateRevision() >= mWorldUpdateRevision))
     {
-        float shortestDist = mReuseDistance*mReuseDistance;
+        float shortestDist = viewer ? mReuseDistance*mReuseDistance : std::numeric_limits<float>::max();
         const ViewData* mostSuitableView = nullptr;
         for (const ViewData* other : mUsedViews)
         {

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -157,12 +157,12 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
                 }
             }
         }
-        if (mostSuitableView)
+        if (mostSuitableView && mostSuitableView != vd)
         {
             vd->copyFrom(*mostSuitableView);
             return vd;
         }
-        else
+        else if (!mostSuitableView)
         {
             vd->setViewPoint(viewPoint);
             vd->setActiveGrid(activeGrid);


### PR DESCRIPTION
Firstly, this PR reintroduces commit "Recreate a special case for IntersectionVisitor on QuadTreeWorld" we forgot to reapply while reverting a revert commit. Secondly, in cases we still need to build a view for an intersection visitor, we now use the available `osgUtil::IntersectionVisitor::getReferenceEyePoint` instead of falling back to the origin position that was previously causing long rebuild times.