### PR TITLE
avoids costly math in OverrideFieldOfViewCallback

### DIFF
--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -403,7 +403,7 @@ public:
     {
         osgUtil::CullVisitor* cv = static_cast<osgUtil::CullVisitor*>(nv);
         float fov, aspect, zNear, zFar;
-        if (cv->getProjectionMatrix()->getPerspective(fov, aspect, zNear, zFar))
+        if (cv->getProjectionMatrix()->getPerspective(fov, aspect, zNear, zFar) && std::abs(fov-mFov) > 0.001)
         {
             fov = mFov;
             osg::ref_ptr<osg::RefMatrix> newProjectionMatrix = new osg::RefMatrix();


### PR DESCRIPTION
We use an `OverrideFieldOfViewCallback` for the first person mode. By default, `field of view` and `first person field of view` are identical. In this case, we run costly operations such as `Matrix::invert` and `pushModelViewMatrix` which involves another  `Matrix::invert` for no reason.

With this PR, we exit the callback early when field of view values match.