### PR TITLE
improves RemoveRedundantNodesVisitor performance for large children vectors

### DIFF
--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -913,11 +913,11 @@ void Optimizer::RemoveRedundantNodesVisitor::removeRedundantNodes()
                 unsigned int childIndex = (*pitr)->getChildIndex(group);
                 for (unsigned int i=0; i<group->getNumChildren(); ++i)
                 {
-                    osg::Node* child = group->getChild(i);
-                    (*pitr)->insertChild(childIndex++, child);
+                    if (i==0)
+                        (*pitr)->setChild(childIndex, group->getChild(i));
+                    else
+                        (*pitr)->insertChild(childIndex+i, group->getChild(i));
                 }
-
-                (*pitr)->removeChild(group);
             }
 
             group->removeChildren(0, group->getNumChildren());


### PR DESCRIPTION
I have been informed Open MW spends significant time shifting `osg::Group`'s children back and forth in a `RemoveRedundantNodesVisitor` while building object paging chunks, which inspired the following low level optimisation: https://github.com/openscenegraph/OpenSceneGraph/commit/61e04183adea0fc6284c2c4dbf1d5a0144b26f1a.

This PR supplements above optimisation with a high level optimisation. With the changes in this PR we replace the first element in-place. Now we do not need to shift vector contents at all in the somewhat common event that the redundant node only has a single child.