### PR TITLE
minor objectpaging.cpp scene graph optimisations

### DIFF
--- a/apps/openmw/mwrender/objectpaging.cpp
+++ b/apps/openmw/mwrender/objectpaging.cpp
@@ -604,7 +604,7 @@ namespace MWRender
                     osg::Matrixf matrix;
                     matrix.preMultTranslate(nodePos);
                     matrix.preMultRotate(nodeAttitude);
-                    matrix.preMultScale(nodePos);
+                    matrix.preMultScale(nodeScale);
                     trans = new osg::MatrixTransform(matrix);
                     trans->setDataVariance(osg::Object::STATIC);
                 }


### PR DESCRIPTION
We now use `PositionAttitudeTransform` for unmerged nodes because I have been informed `PositionAttitudeTransform`'s scene graph performance is measurably faster than `MatrixTransform`'s. We still need to use `MatrixTransform` for merged nodes because the `Optimizer` has limited support for non-`MatrixTransform` nodes. These `MatrixTransform`s will be removed in the merging process anyway.