### PR TITLE
do not clear detached buffers

### DIFF
--- a/components/sceneutil/mwshadowtechnique.cpp
+++ b/components/sceneutil/mwshadowtechnique.cpp
@@ -571,7 +571,6 @@ MWShadowTechnique::ShadowData::ShadowData(MWShadowTechnique::ViewDependentData* 
     _camera->setName("ShadowCamera");
     _camera->setReferenceFrame(osg::Camera::ABSOLUTE_RF_INHERIT_VIEWPOINT);
     _camera->setImplicitBufferAttachmentMask(0, 0);
-    //_camera->setClearColor(osg::Vec4(1.0f,1.0f,1.0f,1.0f));
     _camera->setClearColor(osg::Vec4(0.0f,0.0f,0.0f,0.0f));
 
     //_camera->setComputeNearFarMode(osg::Camera::COMPUTE_NEAR_FAR_USING_BOUNDING_VOLUMES);


### PR DESCRIPTION
While the Open GL specification strictly allows the clearing of detached buffers, such an operation is specified as a non-operation. This non-operation may trigger issues with non-compliant drivers. I have been informed the changes in this PR repair shadows on Mac OS at least.