### PR TITLE
enables std::move in keywordsearch.hpp

### DIFF
--- a/apps/openmw/mwdialogue/keywordsearch.hpp
+++ b/apps/openmw/mwdialogue/keywordsearch.hpp
@@ -39,7 +39,7 @@ public:
         mRoot.mKeyword.clear ();
     }
 
-    bool containsKeyword (string_t keyword, value_t& value)
+    bool containsKeyword (const string_t& keyword, value_t& value)
     {
         typename Entry::childen_t::iterator current;
         typename Entry::childen_t::iterator next;


### PR DESCRIPTION
For some reason we have commented `std::move` keywords in `keywordsearch.hpp` while they are quite beneficial. `openmw_test_suite` for `keywordsearch.hpp` takes 30% less time with these changes.