### PR TITLE
optimises riggeometry.cpp

### DIFF
--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -3,6 +3,7 @@
 #include <osg/Version>
 
 #include <components/debug/debuglog.hpp>
+#include <osg/MatrixTransform>
 
 #include "skeleton.hpp"
 #include "util.hpp"


### PR DESCRIPTION
1. We skip `this` during node path iterations. `this` is not a node we are interested in.
2. We avoid allocating a new `mGeomToSkelMatrix` per frame and avoid a `ref_ptr` associated with its update.
3. We speed up a search for the `Skeleton` node by adding a `continue;` condition prior to an expensive `dynamic_cast`.