### PR TITLE
avoids array copies

### DIFF
--- a/components/nifosg/nifloader.cpp
+++ b/components/nifosg/nifloader.cpp
@@ -1156,7 +1156,7 @@ namespace NifOsg
             auto& uvlist = data->uvlist;
             int textureStage = 0;
             std::vector<osg::ref_ptr<osg::Array>> movedUvList;
-            movedUvList.reserve(uvlist.size());
+            movedUvList.resize(uvlist.size());
             for (unsigned int uvSet : boundTextures)
             {
                 if (uvSet >= uvlist.size())


### PR DESCRIPTION
Currently, Open MW wastefully copies array data that we pass from `Nif::NiGeometry` to `osg::Geometry`. With this PR we use a move operation to avoid such copies. We can safely swap the data from `Nif` nodes since we are just going to discard them after loading.