### PR TITLE
removes version guard

### DIFF
--- a/components/resource/bulletshapemanager.cpp
+++ b/components/resource/bulletshapemanager.cpp
@@ -4,7 +4,6 @@
 #include <osg/TriangleFunctor>
 #include <osg/Transform>
 #include <osg/Drawable>
-#include <osg/Version>
 
 #include <BulletCollision/CollisionShapes/btTriangleMesh.h>
 


### PR DESCRIPTION
We currently use a version guard to adapt to a change in the number of parameters supplied to `osg::TriangleFunctor`'s `operator()` template functor. The differing parameter is unused in our code. Crucially, `operator()` is not an override, so we can just add a default value for the differing parameter. Such a default allows us to apply identical code to both versions of the library without regressing functionality.