### PR TITLE
improves scene bounds

### DIFF
--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -498,9 +498,8 @@ void QuadTreeWorld::enable(bool enabled)
         if (!mRootNode->getNumParents())
             mTerrainRoot->addChild(mRootNode);
     }
-
-    if (mRootNode)
-        mRootNode->setNodeMask(enabled ? ~0 : 0);
+    else if (mRootNode)
+        mTerrainRoot->removeChild(mRootNode);
 }
 
 View* QuadTreeWorld::createView()


### PR DESCRIPTION
Currently, we disable a paging root node that we only need in exterior cells by setting its node mask to `0` when transitioning into an interior cell. Node masks are not ideal for this usage case because `Node::getBound` is unaware of masks. With this PR we just detach the unused node from the scene graph. `_shadowedScene->getBound()` in the `MWShadowTechnique` should return a much better value in interior cells with these changes.