### PR TITLE
removes sky bounds

### DIFF
--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -299,7 +299,7 @@ public:
 
     osg::BoundingSphere computeBound() const override
     {
-        return osg::BoundingSphere(osg::Vec3f(0,0,0), 0);
+        return osg::BoundingSphere();
     }
 
     class CullCallback : public SceneUtil::NodeCallback<CullCallback, osg::Node*, osgUtil::CullVisitor*>


### PR DESCRIPTION
We currently use a `CameraRelativeTransform` node in `sky.cpp`. By design, its bounds depend upon the camera position and can not be meaningfully defined within the context of  `Node::computeBound()`. We attempt to discard these undefined bounds by returning a bounding sphere with a radius of `0`. There is an issue in this logic because osg mandates undefined bounding spheres to have a radius of `-1`. Bounding spheres with a radius other than `-1` will still enlarge bounding computations by their center, in this case `(0, 0, 0)`. 

With this PR we return a default constructed undefined bounding sphere in `CameraRelativeTransform::computeBound` to ensure that we do not enlarge the bounds of the parent node. `_shadowedScene->getBounds()` in `MWShadowTechnique` may return a better value in some cases with these changes.