### PR TITLE
Allow to place levelled creatures to the game world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
     Bug #6322: Total sold/cost should reset to 0 when there are no items offered
     Bug #6323: Wyrmhaven: Alboin doesn't follower the player character out of his house
     Bug #6326: Detect Enchantment/Key should detect items in unresolved containers
+    Bug #6347: PlaceItem/PlaceItemCell/PlaceAt should work with levelled creatures
     Feature #890: OpenMW-CS: Column filtering
     Feature #2554: Modifying an object triggers the instances table to scroll to the corresponding record
     Feature #2780: A way to see current OpenMW version in the console
@@ -78,7 +79,6 @@
     Feature #6288: Preserve the "blocked" record flag for referenceable objects.
     Task #6201: Remove the "Note: No relevant classes found. No output generated" warnings
     Task #6264: Remove the old classes in animation.cpp
-
 
 0.47.0
 ------

--- a/apps/openmw/mwclass/creaturelevlist.cpp
+++ b/apps/openmw/mwclass/creaturelevlist.cpp
@@ -5,6 +5,7 @@
 
 #include "../mwmechanics/levelledlist.hpp"
 
+#include "../mwworld/cellstore.hpp"
 #include "../mwworld/customdata.hpp"
 #include "../mwmechanics/creaturestats.hpp"
 
@@ -26,6 +27,24 @@ namespace MWClass
             return *this;
         }
     };
+
+    MWWorld::Ptr CreatureLevList::copyToCellImpl(const MWWorld::ConstPtr &ptr, MWWorld::CellStore &cell) const
+    {
+        const MWWorld::LiveCellRef<ESM::CreatureLevList> *ref = ptr.get<ESM::CreatureLevList>();
+
+        return MWWorld::Ptr(cell.insert(ref), &cell);
+    }
+
+    void CreatureLevList::adjustPosition(const MWWorld::Ptr& ptr, bool force) const
+    {
+        if (ptr.getRefData().getCustomData() == nullptr)
+            return;
+
+        CreatureLevListCustomData& customData = ptr.getRefData().getCustomData()->asCreatureLevListCustomData();
+        MWWorld::Ptr creature = (customData.mSpawnActorId == -1) ? MWWorld::Ptr() : MWBase::Environment::get().getWorld()->searchPtrViaActorId(customData.mSpawnActorId);
+        if (!creature.isEmpty())
+            MWBase::Environment::get().getWorld()->adjustPosition(creature, force);
+    }
 
     std::string CreatureLevList::getName (const MWWorld::ConstPtr& ptr) const
     {

--- a/apps/openmw/mwclass/creaturelevlist.hpp
+++ b/apps/openmw/mwclass/creaturelevlist.hpp
@@ -32,6 +32,10 @@ namespace MWClass
             ///< Write additional state from \a ptr into \a state.
 
             void respawn (const MWWorld::Ptr& ptr) const override;
+
+            MWWorld::Ptr copyToCellImpl(const MWWorld::ConstPtr &ptr, MWWorld::CellStore &cell) const override;
+
+            void adjustPosition(const MWWorld::Ptr& ptr, bool force) const override;
     };
 }
 


### PR DESCRIPTION
Fixes [bug #6347](https://gitlab.com/OpenMW/openmw/-/issues/6347) by implementing missing functions.

Placed levelled creature immediately becomes resolved (if it is resolved to the empty creature, nothing is spawned, but the list is still added to the cell). If you kill spawned creature and dispose corpse, it will be respawned as usual.

Note that such behaviour can not be easily replicated for levelled items since item lists are not supposed to be added directly to game world, only to actors or containers.