### PR TITLE
fixes enable and disable commands

### DIFF
--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -166,7 +166,7 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
         }
         else if (!mostSuitableView)
         {
-            if (vd->getWorldUpdateRevision() != mWorldUpdateRevision))
+            if (vd->getWorldUpdateRevision() != mWorldUpdateRevision)
             {
                 vd->setWorldUpdateRevision(mWorldUpdateRevision);
                 vd->clear();


### PR DESCRIPTION
This PR fixes a recent regression concerning enable and disable commands with object paging. In addition, we add a necessary comment to avoid such issues in the future.