### PR TITLE
fixes GlowUpdater

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -1467,7 +1467,7 @@ namespace MWRender
         if (!mGlowUpdater || (mGlowUpdater->isDone() || (mGlowUpdater->isPermanentGlowUpdater() == true)))
         {
             if (mGlowUpdater && mGlowUpdater->isDone())
-                mObjectRoot->removeUpdateCallback(mGlowUpdater);
+                mObjectRoot->removeCullCallback(mGlowUpdater);
 
             if (mGlowUpdater && mGlowUpdater->isPermanentGlowUpdater())
             {

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -309,10 +309,11 @@ namespace MWRender
         auto lightingMethod = SceneUtil::LightManager::getLightingMethodFromString(Settings::Manager::getString("lighting method", "Shaders"));
 
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
-        // Shadows and radial fog have problems with fixed-function mode
-        bool forceShaders = Settings::Manager::getBool("radial fog", "Shaders")
-                            || Settings::Manager::getBool("force shaders", "Shaders")
+        // Many features have problems with fixed-function mode
+        bool forceShaders = Settings::Manager::getBool("force shaders", "Shaders")
+                            || Settings::Manager::getBool("radial fog", "Shaders")
                             || Settings::Manager::getBool("enable shadows", "Shadows")
+                            || Settings::Manager::getBool("apply lighting to environment maps", "Shaders")
                             || lightingMethod != SceneUtil::LightingMethod::FFP
                             || reverseZ;
         resourceSystem->getSceneManager()->setForceShaders(forceShaders);
@@ -323,7 +324,6 @@ namespace MWRender
         resourceSystem->getSceneManager()->setNormalHeightMapPattern(Settings::Manager::getString("normal height map pattern", "Shaders"));
         resourceSystem->getSceneManager()->setAutoUseSpecularMaps(Settings::Manager::getBool("auto use object specular maps", "Shaders"));
         resourceSystem->getSceneManager()->setSpecularMapPattern(Settings::Manager::getString("specular map pattern", "Shaders"));
-        resourceSystem->getSceneManager()->setApplyLightingToEnvMaps(Settings::Manager::getBool("apply lighting to environment maps", "Shaders"));
         resourceSystem->getSceneManager()->setConvertAlphaTestToAlphaToCoverage(Settings::Manager::getBool("antialias alpha test", "Shaders") && Settings::Manager::getInt("antialiasing", "Video") > 1);
 
         // Let LightManager choose which backend to use based on our hint. For methods besides legacy lighting, this depends on support for various OpenGL extensions.

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -306,7 +306,6 @@ namespace Resource
         , mClampLighting(true)
         , mAutoUseNormalMaps(false)
         , mAutoUseSpecularMaps(false)
-        , mApplyLightingToEnvMaps(false)
         , mLightingMethod(SceneUtil::LightingMethod::FFP)
         , mConvertAlphaTestToAlphaToCoverage(false)
         , mDepthFormat(0)
@@ -390,11 +389,6 @@ namespace Resource
     void SceneManager::setSpecularMapPattern(const std::string &pattern)
     {
         mSpecularMapPattern = pattern;
-    }
-
-    void SceneManager::setApplyLightingToEnvMaps(bool apply)
-    {
-        mApplyLightingToEnvMaps = apply;
     }
 
     void SceneManager::setSupportedLightingMethods(const SceneUtil::LightManager::SupportedMethods& supported)
@@ -880,7 +874,6 @@ namespace Resource
         shaderVisitor->setNormalHeightMapPattern(mNormalHeightMapPattern);
         shaderVisitor->setAutoUseSpecularMaps(mAutoUseSpecularMaps);
         shaderVisitor->setSpecularMapPattern(mSpecularMapPattern);
-        shaderVisitor->setApplyLightingToEnvMaps(mApplyLightingToEnvMaps);
         shaderVisitor->setConvertAlphaTestToAlphaToCoverage(mConvertAlphaTestToAlphaToCoverage);
         return shaderVisitor;
     }

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -106,8 +106,6 @@ namespace Resource
 
         void setSpecularMapPattern(const std::string& pattern);
 
-        void setApplyLightingToEnvMaps(bool apply);
-
         void setSupportedLightingMethods(const SceneUtil::LightManager::SupportedMethods& supported);
         bool isSupportedLightingMethod(SceneUtil::LightingMethod method) const;
 
@@ -198,7 +196,6 @@ namespace Resource
         std::string mNormalHeightMapPattern;
         bool mAutoUseSpecularMaps;
         std::string mSpecularMapPattern;
-        bool mApplyLightingToEnvMaps;
         SceneUtil::LightingMethod mLightingMethod;
         SceneUtil::LightManager::SupportedMethods mSupportedLightingMethods;
         bool mConvertAlphaTestToAlphaToCoverage;

--- a/components/sceneutil/statesetupdater.cpp
+++ b/components/sceneutil/statesetupdater.cpp
@@ -28,7 +28,7 @@ namespace SceneUtil
             }
         }
 
-        osg::ref_ptr<osg::StateSet> stateset = mStateSetsUpdate[nv->getTraversalNumber() % 2];
+        osg::StateSet* stateset = mStateSetsUpdate[nv->getTraversalNumber() % 2];
         apply(stateset, nv);
         node->setStateSet(stateset);
         traverse(node, nv);

--- a/components/sceneutil/statesetupdater.hpp
+++ b/components/sceneutil/statesetupdater.hpp
@@ -48,6 +48,7 @@ namespace SceneUtil
         virtual void setDefaults(osg::StateSet* stateset) {}
     
         /// Reset mStateSets, forcing a setDefaults() on the next frame. Can be used to change the defaults if needed.
+        /// @note It is not allowed to call reset() from apply() or setDefaults().
         void reset();
 
     private:

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -125,7 +125,7 @@ void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
 {
     // Set the starting time to measure glow duration from if this is a temporary glow
     if ((mDuration >= 0) && mStartingTime == 0)
-        mStartingTime = nv->getFrameStamp()->getSimulationTime();
+        mStartingTime = cv->getFrameStamp()->getSimulationTime();
 
     if ((mDuration >= 0) && (time - mStartingTime > mDuration)) // If this is a temporary glow and it has finished its duration
     {
@@ -147,7 +147,7 @@ void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
         return;
     }
 
-    float time = nv->getFrameStamp()->getSimulationTime();
+    float time = cv->getFrameStamp()->getSimulationTime();
     int index = (int)(time*16) % mTextures.size();
     cv->pushStateSet(getStateSet(index));
     traverse(node, cv);

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -121,7 +121,7 @@ osg::StateSet* GlowUpdater::getStateSet(int index)
     return sequence[index];
 }
 
-void GlowUpdater::operator(osg::Node* node, osgUtil::CullVisitor *cv)
+void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
 {
     // Set the starting time to measure glow duration from if this is a temporary glow
     if ((mDuration >= 0) && mStartingTime == 0)

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -95,7 +95,7 @@ osg::StateSet* GlowUpdater::getStateSet(int index)
             cs.mTextures.push_back(tex);
         }
     }
-    std::vector<osg::ref_ptr<osg::StateSet>>& sequence = cs[std::make_pair(mTexUnit, mColor)];
+    std::vector<osg::ref_ptr<osg::StateSet>>& sequence = cs.mStateSets[std::make_pair(mTexUnit, mColor)];
     if (sequence.empty())
     {
         sequence.resize(cs.mTextures.size());

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -113,8 +113,9 @@ osg::StateSet* GlowUpdater::getStateSet(float time)
             texEnv->setCombine_RGB(osg::TexEnvCombine::INTERPOLATE);
             texEnv->setSource2_RGB(osg::TexEnvCombine::TEXTURE);
             texEnv->setOperand2_RGB(osg::TexEnvCombine::SRC_COLOR);
-            stateset->setTextureAttributeAndModes(mTexUnit, texEnv, osg::StateAttribute::ON);
-            stateset->addUniform(new osg::Uniform("envMapColor", mColor));
+            stateset->setTextureAttributeAndModes(mTexUnit, texEnv, osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+            stateset->addUniform(new osg::Uniform("envMapColor", mColor), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
+            stateset->addUniform(new osg::Uniform("envMap", mTexUnit), osg::StateAttribute::ON|osg::StateAttribute::OVERRIDE);
             stateset->setDefine("GLOW");
         }
     }

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -149,7 +149,7 @@ void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
         return;
     }
 
-    cv->pushStateSet(getStateSet(time))
+    cv->pushStateSet(getStateSet(time));
     traverse(node, cv);
     cv->popStateSet();
 }

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -72,7 +72,7 @@ GlowUpdater::GlowUpdater(int texUnit, const osg::Vec4f& color, float duration, R
 {
 }
 
-osg::StateSet* GlowUpdater::getStateSet(int index)
+osg::StateSet* GlowUpdater::getStateSet(float time)
 {
     CachedState& cs = getCachedState();
     if (cs.mTextures.empty())
@@ -118,6 +118,7 @@ osg::StateSet* GlowUpdater::getStateSet(int index)
             stateset->setDefine("GLOW");
         }
     }
+    int index = static_cast<int>(time*16) % sequence.size();
     return sequence[index];
 }
 
@@ -148,8 +149,7 @@ void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
         return;
     }
 
-    int index = (int)(time*16) % mTextures.size();
-    cv->pushStateSet(getStateSet(index));
+    cv->pushStateSet(getStateSet(time))
     traverse(node, cv);
     cv->popStateSet();
 }

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -75,7 +75,7 @@ GlowUpdater::GlowUpdater(int texUnit, const osg::Vec4f& color, float duration, R
 osg::StateSet* GlowUpdater::getStateSet(int index)
 {
     CachedState& cs = getCachedState();
-    if (!cs.mTextures)
+    if (cs.mTextures.empty())
     {
         for (int i=0; i<32; ++i)
         {
@@ -86,7 +86,7 @@ osg::StateSet* GlowUpdater::getStateSet(int index)
             stream << i;
             stream << ".dds";
 
-            osg::ref_ptr<osg::Image> image = resourceSystem->getImageManager()->getImage(stream.str());
+            osg::ref_ptr<osg::Image> image = mResourceSystem->getImageManager()->getImage(stream.str());
             osg::ref_ptr<osg::Texture2D> tex (new osg::Texture2D(image));
             tex->setName("envMap");
             tex->setWrap(osg::Texture::WRAP_S, osg::Texture2D::REPEAT);
@@ -99,7 +99,7 @@ osg::StateSet* GlowUpdater::getStateSet(int index)
     if (sequence.empty())
     {
         sequence.resize(cs.mTextures.size());
-        for (int i=0; i<cs.mTextures.size(); ++i)
+        for (size_t i=0; i<cs.mTextures.size(); ++i)
         {
             sequence[i] = new osg::StateSet;
             osg::StateSet* stateset = sequence[i];
@@ -126,6 +126,7 @@ void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
     // Set the starting time to measure glow duration from if this is a temporary glow
     if ((mDuration >= 0) && mStartingTime == 0)
         mStartingTime = cv->getFrameStamp()->getSimulationTime();
+    float time = cv->getFrameStamp()->getSimulationTime();
 
     if ((mDuration >= 0) && (time - mStartingTime > mDuration)) // If this is a temporary glow and it has finished its duration
     {
@@ -147,7 +148,6 @@ void GlowUpdater::operator()(osg::Node* node, osgUtil::CullVisitor *cv)
         return;
     }
 
-    float time = cv->getFrameStamp()->getSimulationTime();
     int index = (int)(time*16) % mTextures.size();
     cv->pushStateSet(getStateSet(index));
     traverse(node, cv);

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -304,20 +304,7 @@ osg::ref_ptr<GlowUpdater> addEnchantedGlow(osg::ref_ptr<osg::Node> node, Resourc
     int texUnit = findLowestUnusedTexUnitVisitor.mLowestUnusedTexUnit;
 
     osg::ref_ptr<GlowUpdater> glowUpdater = new GlowUpdater(texUnit, glowColor, textures, node, glowDuration, resourceSystem);
-    node->addUpdateCallback(glowUpdater);
-
-    // set a texture now so that the ShaderVisitor can find it
-    osg::ref_ptr<osg::StateSet> writableStateSet = nullptr;
-    if (!node->getStateSet())
-        writableStateSet = node->getOrCreateStateSet();
-    else
-    {
-        writableStateSet = new osg::StateSet(*node->getStateSet(), osg::CopyOp::SHALLOW_COPY);
-        node->setStateSet(writableStateSet);
-    }
-    writableStateSet->setTextureAttributeAndModes(texUnit, textures.front(), osg::StateAttribute::ON);
-    writableStateSet->addUniform(new osg::Uniform("envMapColor", glowColor));
-    resourceSystem->getSceneManager()->recreateShaders(node);
+    node->addCullCallback(glowUpdater);
 
     return glowUpdater;
 }

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -36,7 +36,7 @@ namespace SceneUtil
             static CachedState cs;
             return cs;
         }
-        osg::StateSet* getStateSet(int index);
+        osg::StateSet* getStateSet(float time);
 
         bool isPermanentGlowUpdater();
 

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -36,6 +36,7 @@ namespace SceneUtil
             static CachedState cs;
             return cs;
         }
+        osg::StateSet* getStateSet(int index);
 
         bool isPermanentGlowUpdater();
 

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -30,7 +30,7 @@ namespace SceneUtil
         {
             std::vector<osg::ref_ptr<osg::Texture2D>> mTextures;
             std::map<std::pair<int, osg::Vec4f>, osg::ref_ptr<osg::StateSet>> mStateSets;
-        }
+        };
         static CachedState& getCachedState()
         {
             static CachedState cs;

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -26,10 +26,10 @@ namespace SceneUtil
 
         void operator()(osg::Node*, osgUtil::CullVisitor*);
 
-        class CachedState
+        struct CachedState
         {
             std::vector<osg::ref_ptr<osg::Texture2D>> mTextures;
-            std::map<std::pair<int, osg::Vec4f>, osg::ref_ptr<osg::StateSet>> mStateSets;
+            std::map<std::pair<int, osg::Vec4f>, std::vector<osg::ref_ptr<osg::StateSet>>> mStateSets;
         };
         static CachedState& getCachedState()
         {

--- a/components/sceneutil/util.hpp
+++ b/components/sceneutil/util.hpp
@@ -54,7 +54,6 @@ namespace SceneUtil
         float mOriginalDuration; // for recording that this is originally a permanent glow if it is changed to a temporary one
         float mStartingTime;
         Resource::ResourceSystem* mResourceSystem;
-        bool mColorChanged;
         bool mDone;
     };
 

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -109,7 +109,6 @@ namespace Shader
         , mAllowedToModifyStateSets(true)
         , mAutoUseNormalMaps(false)
         , mAutoUseSpecularMaps(false)
-        , mApplyLightingToEnvMaps(false)
         , mConvertAlphaTestToAlphaToCoverage(false)
         , mShaderManager(shaderManager)
         , mImageManager(imageManager)
@@ -259,10 +258,6 @@ namespace Shader
                                     writableStateSet = getWritableStateSet(node);
                                 // Bump maps are off by default as well
                                 writableStateSet->setTextureMode(unit, GL_TEXTURE_2D, osg::StateAttribute::ON);
-                            }
-                            else if (texName == "envMap" && mApplyLightingToEnvMaps)
-                            {
-                                mRequirements.back().mShaderRequired = true;
                             }
                         }
                         else
@@ -749,11 +744,6 @@ namespace Shader
     void ShaderVisitor::setSpecularMapPattern(const std::string &pattern)
     {
         mSpecularMapPattern = pattern;
-    }
-
-    void ShaderVisitor::setApplyLightingToEnvMaps(bool apply)
-    {
-        mApplyLightingToEnvMaps = apply;
     }
 
     void ShaderVisitor::setConvertAlphaTestToAlphaToCoverage(bool convert)

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -41,8 +41,6 @@ namespace Shader
 
         void setSpecularMapPattern(const std::string& pattern);
 
-        void setApplyLightingToEnvMaps(bool apply);
-
         void setConvertAlphaTestToAlphaToCoverage(bool convert);
 
         void apply(osg::Node& node) override;

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -64,8 +64,6 @@ namespace Shader
         bool mAutoUseSpecularMaps;
         std::string mSpecularMapPattern;
 
-        bool mApplyLightingToEnvMaps;
-
         bool mConvertAlphaTestToAlphaToCoverage;
 
         ShaderManager& mShaderManager;

--- a/docs/source/reference/modding/settings/shaders.rst
+++ b/docs/source/reference/modding/settings/shaders.rst
@@ -135,7 +135,7 @@ apply lighting to environment maps
 
 Normally environment map reflections aren't affected by lighting, which makes environment-mapped (and thus bump-mapped objects) glow in the dark.
 Morrowind Code Patch includes an option to remedy that by doing environment-mapping before applying lighting, this is the equivalent of that option.
-Affected objects will use shaders.
+Bear in mind that this will force OpenMW to use shaders as if :ref:`force shaders` was enabled. A keen developer may be able to implement compatibility with fixed-function mode, but it may not look exactly the same.
 
 radial fog
 ----------

--- a/files/settings-default.cfg
+++ b/files/settings-default.cfg
@@ -450,7 +450,7 @@ specular map pattern = _spec
 terrain specular map pattern = _diffusespec
 
 # Apply lighting to reflections on the environment-mapped objects like in Morrowind Code Patch.
-# Affected objects use shaders.
+# Bear in mind that this will force OpenMW to use shaders as if "[Shaders]/force shaders" was set to true.
 apply lighting to environment maps = false
 
 # Determine fog intensity based on the distance from the eye point.

--- a/files/shaders/objects_fragment.glsl
+++ b/files/shaders/objects_fragment.glsl
@@ -1,5 +1,7 @@
 #version 120
-#pragma import_defines(FORCE_OPAQUE)
+#pragma import_defines(FORCE_OPAQUE, GLOW)
+
+#define ENVMAP (@envMap || defined(GLOW))
 
 #if @useUBO
     #extension GL_ARB_uniform_buffer_object : require
@@ -40,7 +42,7 @@ varying vec2 normalMapUV;
 varying vec4 passTangent;
 #endif
 
-#if @envMap
+#if ENVMAP
 uniform sampler2D envMap;
 varying vec2 envMapUV;
 uniform vec4 envMapColor;
@@ -144,7 +146,7 @@ void main()
     gl_FragData[0].xyz = mix(gl_FragData[0].xyz, decalTex.xyz, decalTex.a);
 #endif
 
-#if @envMap
+#if ENVMAP
 
     vec2 envTexCoordGen = envMapUV;
     float envLuma = 1.0;
@@ -183,7 +185,7 @@ void main()
 
     gl_FragData[0].xyz *= lighting;
 
-#if @envMap && !@preLightEnv
+#if ENVMAP && !@preLightEnv
     gl_FragData[0].xyz += texture2D(envMap, envTexCoordGen).xyz * envMapColor.xyz * envLuma;
 #endif
 

--- a/files/shaders/objects_vertex.glsl
+++ b/files/shaders/objects_vertex.glsl
@@ -1,5 +1,9 @@
 #version 120
 
+#pragma import_defines(GLOW)
+
+#define ENVMAP (@envMap || defined(GLOW))
+
 #if @useUBO
     #extension GL_ARB_uniform_buffer_object : require
 #endif
@@ -35,7 +39,7 @@ varying vec2 normalMapUV;
 varying vec4 passTangent;
 #endif
 
-#if @envMap
+#if ENVMAP
 varying vec2 envMapUV;
 #endif
 
@@ -76,11 +80,11 @@ void main(void)
     euclideanDepth = length(viewPos.xyz);
     linearDepth = getLinearDepth(gl_Position.z, viewPos.z);
 
-#if (@envMap || !PER_PIXEL_LIGHTING || @shadows_enabled)
+#if (ENVMAP || !PER_PIXEL_LIGHTING || @shadows_enabled)
     vec3 viewNormal = normalize((gl_NormalMatrix * gl_Normal).xyz);
 #endif
 
-#if @envMap
+#if ENVMAP
     vec3 viewVec = normalize(viewPos.xyz);
     vec3 r = reflect( viewVec, viewNormal );
     float m = 2.0 * sqrt( r.x*r.x + r.y*r.y + (r.z+1.0)*(r.z+1.0) );


### PR DESCRIPTION
Our `GlowUpdater` class currently contains a lot of strange workarounds and issues. Most of these issues indirectly result from the need to `recreateShaders` in one way or another. In this PR I have refactored `GlowUpdater` based on a different approach.

- We replace `recreateShaders` by `StateSet::setDefine`. We can consider `recreateShaders` to be harmful here because its `getWritableStateSet` approach leaves behind unique state after our `GlowUpdater` has completed its course.
- We separate high level logic from low level logic.
- We no longer derive from `StateSetUpdater`.  Adapting this base requires too many workarounds here.
- We use a cull callback instead of an update callback. We can skip processing off screen `GlowUpdater` instances this way.
- We share common state among `GlowUpdater`s to potentially allow for improved performance. For example,  characters wearing a full set of glowing equipment should require a lower State Graph count with these changes.

I have tested this PR by activating a shrine in a Balmora Temple and by visiting the Museum of Artifacts in Mournhold.