### PR TITLE
removes a recreateShaders call

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -232,9 +232,6 @@ void ActorAnimation::updateHolsteredShield(bool showCarriedLeft)
         if (isEnchanted)
             SceneUtil::addEnchantedGlow(shieldNode, mResourceSystem, glowColor);
     }
-
-    if (mAlpha != 1.f)
-        mResourceSystem->getSceneManager()->recreateShaders(mHolsteredShield->getNode());
 }
 
 bool ActorAnimation::useShieldAnimations() const


### PR DESCRIPTION
With this PR we remove a `recreateShaders` call in `actoranimation.cpp` that appears to lack any purpose.