### PR TITLE
Early out from LOS check when source and target is the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     Bug #5801: A multi-effect spell with the intervention effects and recall always favors Almsivi intervention
     Bug #5842: GetDisposition adds temporary disposition change from different actors
     Bug #5863: GetEffect should return true after the player has teleported
+    Bug #5913: Failed assertion during Ritual of Trees quest
     Bug #6037: Morrowind Content Language Cannot be Set to English in OpenMW Launcher
     Bug #6051: NaN water height in ESM file is not handled gracefully
     Bug #6066: addtopic "return" does not work from within script. No errors thrown

--- a/apps/openmw/mwphysics/physicssystem.cpp
+++ b/apps/openmw/mwphysics/physicssystem.cpp
@@ -370,6 +370,8 @@ namespace MWPhysics
 
     bool PhysicsSystem::getLineOfSight(const MWWorld::ConstPtr &actor1, const MWWorld::ConstPtr &actor2) const
     {
+        if (actor1 == actor2) return true;
+
         const auto it1 = mActors.find(actor1.mRef);
         const auto it2 = mActors.find(actor2.mRef);
         if (it1 == mActors.end() || it2 == mActors.end())


### PR DESCRIPTION
Fixes [bug #5913](https://gitlab.com/OpenMW/openmw/-/issues/5913).

~~According to my testing, Morrowind cancels AiFollow package if the leader and the actor are the same actor (`getcurrentaipackage` returns -1). So just replicate this behaviour.~~

LOS check returns true in both Morrowind and OpenMW if the source and target in the same position anyway, so we can just early-out from LOS check in such cases to do not trigger asserts in Bullet code (it does not like vectors with zero length).