### PR TITLE
refactors osg::Callback virtual inheritance

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -968,8 +968,9 @@ namespace MWRender
                 {
                     osg::ref_ptr<osg::Node> node = getNodeMap().at(it->first); // this should not throw, we already checked for the node existing in addAnimSource
 
-                    node->addUpdateCallback(it->second);
-                    mActiveControllers.emplace_back(node, it->second);
+                    osg::Callback* callback = it->second->asCallback()
+                    node->addUpdateCallback(callback);
+                    mActiveControllers.emplace_back(node, callback);
 
                     if (blendMask == 0 && node == mAccumRoot)
                     {

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -968,7 +968,7 @@ namespace MWRender
                 {
                     osg::ref_ptr<osg::Node> node = getNodeMap().at(it->first); // this should not throw, we already checked for the node existing in addAnimSource
 
-                    osg::Callback* callback = it->second->asCallback()
+                    osg::Callback* callback = it->second->getAsCallback();
                     node->addUpdateCallback(callback);
                     mActiveControllers.emplace_back(node, callback);
 

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -248,6 +248,7 @@ namespace NifOsg
         META_Object(NifOsg, KeyframeController)
 
         osg::Vec3f getTranslation(float time) const override;
+        osg::Callback* asCallback() override { return this; }
 
         void operator() (NifOsg::MatrixTransform*, osg::NodeVisitor*);
 

--- a/components/nifosg/controller.hpp
+++ b/components/nifosg/controller.hpp
@@ -248,7 +248,7 @@ namespace NifOsg
         META_Object(NifOsg, KeyframeController)
 
         osg::Vec3f getTranslation(float time) const override;
-        osg::Callback* asCallback() override { return this; }
+        osg::Callback* getAsCallback() override { return this; }
 
         void operator() (NifOsg::MatrixTransform*, osg::NodeVisitor*);
 

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -11,7 +11,7 @@
 
 namespace SceneUtil
 {
-    /// @note Derived classes are expected to derive from osg::Callback and implement asCallback().
+    /// @note Derived classes are expected to derive from osg::Callback and implement getAsCallback().
     class KeyframeController : public SceneUtil::Controller, public virtual osg::Object
     {
     public:
@@ -24,7 +24,9 @@ namespace SceneUtil
         META_Object(SceneUtil, KeyframeController)
 
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
-        virtual osg::Callback* asCallback() = 0;
+
+        /// @note We could drop this function in favour of osg::Object::asCallback from OSG 3.6 on.
+        virtual osg::Callback* getAsCallback() = 0;
     };
 
     /// Wrapper object containing an animation track as a ref-countable osg::Object.

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -3,7 +3,7 @@
 
 #include <map>
 
-#include <osg/Callback>
+#include <osg/Object>
 
 #include <components/sceneutil/controller.hpp>
 #include <components/sceneutil/textkeymap.hpp>
@@ -23,8 +23,6 @@ namespace SceneUtil
         META_Object(SceneUtil, KeyframeController)
 
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
-
-        virtual osg::Callback* asCallback() = 0;
     };
 
     /// Wrapper object containing an animation track as a ref-countable osg::Object.

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -19,9 +19,7 @@ namespace SceneUtil
 
         KeyframeController(const KeyframeController& copy, const osg::CopyOp& copyop)
             : osg::Object(copy, copyop)
-            , SceneUtil::Controller(copy)
-        {}
-        META_Object(SceneUtil, KeyframeController)
+            , SceneUtil::Controller(copy) {}
 
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
 

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -11,6 +11,7 @@
 
 namespace SceneUtil
 {
+    /// @note Derived classes are expected to derive from osg::Callback and implement asCallback().
     class KeyframeController : public SceneUtil::Controller, public virtual osg::Object
     {
     public:
@@ -23,6 +24,7 @@ namespace SceneUtil
         META_Object(SceneUtil, KeyframeController)
 
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
+        virtual osg::Callback* asCallback() { return nullptr; }
     };
 
     /// Wrapper object containing an animation track as a ref-countable osg::Object.

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -11,18 +11,20 @@
 
 namespace SceneUtil
 {
-    class KeyframeController : public SceneUtil::Controller, public virtual osg::Callback
+    class KeyframeController : public SceneUtil::Controller, public virtual osg::Object
     {
     public:
         KeyframeController() {}
 
         KeyframeController(const KeyframeController& copy, const osg::CopyOp& copyop)
-            : osg::Callback(copy, copyop)
+            : osg::Object(copy, copyop)
             , SceneUtil::Controller(copy)
         {}
         META_Object(SceneUtil, KeyframeController)
 
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
+
+        virtual osg::Callback* asCallback() = 0;
     };
 
     /// Wrapper object containing an animation track as a ref-countable osg::Object.

--- a/components/sceneutil/keyframe.hpp
+++ b/components/sceneutil/keyframe.hpp
@@ -24,7 +24,7 @@ namespace SceneUtil
         META_Object(SceneUtil, KeyframeController)
 
         virtual osg::Vec3f getTranslation(float time) const  { return osg::Vec3f(); }
-        virtual osg::Callback* asCallback() { return nullptr; }
+        virtual osg::Callback* asCallback() = 0;
     };
 
     /// Wrapper object containing an animation track as a ref-countable osg::Object.

--- a/components/sceneutil/nodecallback.hpp
+++ b/components/sceneutil/nodecallback.hpp
@@ -13,7 +13,7 @@ namespace SceneUtil
 {
 
 template <class Derived, typename NodeType=osg::Node*, typename VisitorType=osg::NodeVisitor*>
-class NodeCallback : public virtual osg::Callback
+class NodeCallback : public osg::Callback
 {
 public:
     NodeCallback(){}

--- a/components/sceneutil/osgacontroller.hpp
+++ b/components/sceneutil/osgacontroller.hpp
@@ -45,6 +45,8 @@ namespace SceneUtil
 
         META_Object(SceneUtil, OsgAnimationController)
 
+        osg::Callback* asCallback() override { return this; }
+
         /// @brief Handles the location of the instance
         osg::Vec3f getTranslation(float time) const override;
 

--- a/components/sceneutil/osgacontroller.hpp
+++ b/components/sceneutil/osgacontroller.hpp
@@ -45,7 +45,7 @@ namespace SceneUtil
 
         META_Object(SceneUtil, OsgAnimationController)
 
-        osg::Callback* asCallback() override { return this; }
+        osg::Callback* getAsCallback() override { return this; }
 
         /// @brief Handles the location of the instance
         osg::Vec3f getTranslation(float time) const override;


### PR DESCRIPTION
With this PR we refactor `SceneUtil::KeyframeController` not to require `virtual osg::Callback` inheritance. I suppose such `virtual` overhead is not justified here because it negatively impacts many other classes we derive from `osg::Callback`.