### PR TITLE
fixes race condition in updateWaterMaterial

### DIFF
--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -608,11 +608,7 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
 
     // use a shader to render the simple water, ensuring that fog is applied per pixel as required.
     // this could be removed if a more detailed water mesh, using some sort of paging solution, is implemented.
-    Resource::SceneManager* sceneManager = mResourceSystem->getSceneManager();
-    bool oldValue = sceneManager->getForceShaders();
-    sceneManager->setForceShaders(true);
-    sceneManager->recreateShaders(node);
-    sceneManager->setForceShaders(oldValue);
+    mResourceSystem->getSceneManager()->recreateShaders(node, "objects", true);
 }
 
 class ShaderWaterStateSetUpdater : public SceneUtil::StateSetUpdater


### PR DESCRIPTION
We currently change `SceneManager::setForceShaders` temporarily in `updateWaterMaterial`. `setForceShaders` is not safe to call here because we access `getForceShaders` from other threads. With this PR we just use `forceShadersForNode` here.