### PR TITLE
restores ESM::Dialogue order

### DIFF
--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1011,7 +1011,7 @@ namespace MWWorld
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
-        std::sort(mShared.begin(), mShared.end(), [](const ESM::Dialogue& l, const ESM::Dialogue& r) -> bool { return l->mId < r->mId; });
+        std::sort(mShared.begin(), mShared.end(), [](const ESM::Dialogue* l, const ESM::Dialogue* r) -> bool { return l->mId < r->mId; });
     }
 
     template <>

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -11,6 +11,8 @@
 #include <iterator>
 #include <stdexcept>
 
+#include "recordcmp.hpp"
+
 namespace MWWorld
 {
     RecordId::RecordId(const std::string &id, bool isDeleted)

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1011,7 +1011,7 @@ namespace MWWorld
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
-        std::sort(mShared.begin(), mShared.end(), RecordCmp<ESM::Dialogue>());
+        std::sort(mShared.begin(), mShared.end(), RecordCmp);
     }
 
     template <>

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1013,7 +1013,7 @@ namespace MWWorld
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
-        std::sort(mShared.begin(), mShared.end(), RecordCmp);
+        std::sort(mShared.begin(), mShared.end(), RecordCmp());
     }
 
     template <>

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -11,8 +11,6 @@
 #include <iterator>
 #include <stdexcept>
 
-#include "recordcmp.hpp"
-
 namespace MWWorld
 {
     RecordId::RecordId(const std::string &id, bool isDeleted)
@@ -1013,7 +1011,7 @@ namespace MWWorld
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
-        std::sort(mShared.begin(), mShared.end(), RecordCmp());
+        std::sort(mShared.begin(), mShared.end(), [](const ESM::Dialogue& l, const ESM::Dialogue& r) -> bool { return l->mId < r->mId; });
     }
 
     template <>

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1006,11 +1006,12 @@ namespace MWWorld
         for (auto & [_, dial] : mStatic)
             dial.clearDeletedInfos();
 
-        // TODO: verify and document this inconsistent behaviour 
         mShared.clear();
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
+        // TODO: verify and document this inconsistent behaviour
+        // TODO: if we require this behaviour, maybe we should move it to the place that requires it
         std::sort(mShared.begin(), mShared.end(), [](const ESM::Dialogue* l, const ESM::Dialogue* r) -> bool { return l->mId < r->mId; });
     }
 

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1011,7 +1011,7 @@ namespace MWWorld
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
-        std::sort(mShared.begin(), mShared.end(), RecordCmp<ESM::Dialogue>);
+        std::sort(mShared.begin(), mShared.end(), RecordCmp<ESM::Dialogue>());
     }
 
     template <>

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -1006,10 +1006,12 @@ namespace MWWorld
         for (auto & [_, dial] : mStatic)
             dial.clearDeletedInfos();
 
+        // TODO: verify and document this inconsistent behaviour 
         mShared.clear();
         mShared.reserve(mStatic.size());
         for (auto & [_, dial] : mStatic)
             mShared.push_back(&dial);
+        std::sort(mShared.begin(), mShared.end(), RecordCmp<ESM::Dialogue>);
     }
 
     template <>

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -149,10 +149,12 @@ namespace MWWorld
     class Store : public StoreBase
     {
         typedef std::unordered_map<std::string, T, Misc::StringUtils::CiHash, Misc::StringUtils::CiEqual> Static;
-        Static mStatic;
-        std::vector<T*> mShared; // Preserves the record order as it came from the content files (this
-                                     // is relevant for the spell autocalc code and selection order
-                                     // for heads/hairs in the character creation)
+        Static mStatic
+        /// @par mShared usually preserves the record order as it came from the content files (this
+        /// is relevant for the spell autocalc code and selection order
+        /// for heads/hairs in the character creation)
+        /// @warning ESM::Dialogue Store currently implements a sorted order for unknown reasons.
+        std::vector<T*> mShared;
         typedef std::unordered_map<std::string, T, Misc::StringUtils::CiHash, Misc::StringUtils::CiEqual> Dynamic;
         Dynamic mDynamic;
 

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -8,8 +8,6 @@
 #include <unordered_map>
 #include <set>
 
-#include "recordcmp.hpp"
-
 namespace ESM
 {
     struct Land;

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -149,7 +149,7 @@ namespace MWWorld
     class Store : public StoreBase
     {
         typedef std::unordered_map<std::string, T, Misc::StringUtils::CiHash, Misc::StringUtils::CiEqual> Static;
-        Static mStatic
+        Static mStatic;
         /// @par mShared usually preserves the record order as it came from the content files (this
         /// is relevant for the spell autocalc code and selection order
         /// for heads/hairs in the character creation)

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -8,6 +8,9 @@
 #include <unordered_map>
 #include <set>
 
+#include <components/esm/records.hpp>
+#include <components/misc/stringops.hpp>
+
 namespace ESM
 {
     struct Land;


### PR DESCRIPTION
With this PR we restore the previous order of `ESM::Dialogue` entries implicitly changed by PR #3197. In the future we may want to consider additional verification and documentation of `mShared` order inconsistencies. We might additionally consider applying this sorting in the particular code that requires it.