### PR TITLE
restores countRecords optimisations

### DIFF
--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -302,11 +302,11 @@ void ESMStore::setUp(bool validateRecords)
     if (validateRecords)
     {
         validate();
-        countAllCellrefs();
+        countAllCellRefs();
     }
 }
 
-void ESMStore::countAllCellrefs()
+void ESMStore::countAllCellRefs()
 {
     // TODO: We currently need to read entire files here again.
     // We should consider consolidating or deferring this reading.

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -29,6 +29,7 @@ namespace
 
     void readRefs(const ESM::Cell& cell, std::vector<Ref>& refs, std::vector<std::string>& refIDs, std::vector<ESM::ESMReader>& readers)
     {
+        // TODO: we have many near identical copies of this code.
         for (size_t i = 0; i < cell.mContextList.size(); i++)
         {
             size_t index = cell.mContextList[i].index;
@@ -301,12 +302,14 @@ void ESMStore::setUp(bool validateRecords)
     if (validateRecords)
     {
         validate();
-        countRecords();
+        countAllCellrefs();
     }
 }
 
-void ESMStore::countRecords()
+void ESMStore::countAllCellrefs()
 {
+    // TODO: We currently need to read entire files here again.
+    // We should consider consolidating or deferring this reading.
     if(!mRefCount.empty())
         return;
     std::vector<Ref> refs;
@@ -324,6 +327,8 @@ void ESMStore::countRecords()
         if (value.mRefID != deletedRefID)
         {
             std::string& refId = refIDs[value.mRefID];
+            // We manually lower case IDs here for the time being to improve performance.
+            Misc::StringUtils::lowerCaseInPlace(refId);
             ++mRefCount[std::move(refId)];
         }
     };
@@ -332,6 +337,7 @@ void ESMStore::countRecords()
 
 int ESMStore::getRefCount(const std::string& id) const
 {
+    const std::string lowerId = Misc::StringUtils::lowerCase(id);
     auto it = mRefCount.find(id);
     if(it == mRefCount.end())
         return 0;

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -338,7 +338,7 @@ void ESMStore::countAllCellrefs()
 int ESMStore::getRefCount(const std::string& id) const
 {
     const std::string lowerId = Misc::StringUtils::lowerCase(id);
-    auto it = mRefCount.find(id);
+    auto it = mRefCount.find(lowerId);
     if(it == mRefCount.end())
         return 0;
     return it->second;

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -29,7 +29,7 @@ namespace
 
     void readRefs(const ESM::Cell& cell, std::vector<Ref>& refs, std::vector<std::string>& refIDs, std::vector<ESM::ESMReader>& readers)
     {
-        // TODO: we have many near identical copies of this code.
+        // TODO: we have many similar copies of this code.
         for (size_t i = 0; i < cell.mContextList.size(); i++)
         {
             size_t index = cell.mContextList[i].index;

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -90,7 +90,7 @@ namespace MWWorld
         /// Validate entries in store after setup
         void validate();
 
-        void countAllCellrefs();
+        void countAllCellRefs();
 
         template<class T>
         void removeMissingObjects(Store<T>& store);

--- a/apps/openmw/mwworld/esmstore.hpp
+++ b/apps/openmw/mwworld/esmstore.hpp
@@ -79,7 +79,7 @@ namespace MWWorld
         IDMap mIds;
         IDMap mStaticIds;
 
-        IDMap mRefCount;
+        std::unordered_map<std::string, int> mRefCount;
 
         std::map<int, StoreBase *> mStores;
 
@@ -90,7 +90,7 @@ namespace MWWorld
         /// Validate entries in store after setup
         void validate();
 
-        void countRecords();
+        void countAllCellrefs();
 
         template<class T>
         void removeMissingObjects(Store<T>& store);


### PR DESCRIPTION
With this PR we restore @elsid 's optimisations of `countRecords` we have unintentionally discarded in PR #3197. In addition, we give it a more appropriate name and add comments concerning its peculiar background.