### PR TITLE
refactors parentFileIndices

### DIFF
--- a/apps/openmw/mwworld/esmloader.cpp
+++ b/apps/openmw/mwworld/esmloader.cpp
@@ -42,8 +42,8 @@ void EsmLoader::load(const boost::filesystem::path& filepath, int& index)
   ESM::ESMReader lEsm;
   lEsm.setEncoder(mEncoder);
   lEsm.setIndex(index);
-  lEsm.open(filepath.string());
   lEsm.resolveParentFileIndices(mEsm);
+  lEsm.open(filepath.string());
   mEsm[index] = lEsm;
   mStore.load(mEsm[index], &mListener);
 }

--- a/apps/openmw/mwworld/esmloader.cpp
+++ b/apps/openmw/mwworld/esmloader.cpp
@@ -42,7 +42,6 @@ void EsmLoader::load(const boost::filesystem::path& filepath, int& index)
   ESM::ESMReader lEsm;
   lEsm.setEncoder(mEncoder);
   lEsm.setIndex(index);
-  lEsm.setGlobalReaderList(&mEsm);
   lEsm.open(filepath.string());
   mEsm[index] = lEsm;
   mStore.load(mEsm[index], &mListener);

--- a/apps/openmw/mwworld/esmloader.cpp
+++ b/apps/openmw/mwworld/esmloader.cpp
@@ -43,6 +43,7 @@ void EsmLoader::load(const boost::filesystem::path& filepath, int& index)
   lEsm.setEncoder(mEncoder);
   lEsm.setIndex(index);
   lEsm.open(filepath.string());
+  lEsm.resolveParentFileIndices(mEsm);
   mEsm[index] = lEsm;
   mStore.load(mEsm[index], &mListener);
 }

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -154,7 +154,7 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
     // Land texture loading needs to use a separate internal store for each plugin.
     // We set the number of plugins here so we can properly verify if valid plugin
     // indices are being passed to the LandTexture Store retrieval methods.
-    mLandTextures.resize(mLandTextures.size()+1);
+    mLandTextures.resize(mLandTextures.getSize()+1);
 
     // Loop through all records
     while(esm.hasMoreRecs())

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -4,8 +4,6 @@
 #include <fstream>
 #include <set>
 
-#include <boost/filesystem/operations.hpp>
-
 #include <components/debug/debuglog.hpp>
 #include <components/esm/esmreader.hpp>
 #include <components/esm/esmwriter.hpp>

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -152,41 +152,9 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
     ESM::Dialogue *dialogue = nullptr;
 
     // Land texture loading needs to use a separate internal store for each plugin.
-    // We set the number of plugins here to avoid continual resizes during loading,
-    // and so we can properly verify if valid plugin indices are being passed to the
-    // LandTexture Store retrieval methods.
-    mLandTextures.resize(esm.getGlobalReaderList()->size());
-
-    /// \todo Move this to somewhere else. ESMReader?
-    // Cache parent esX files by tracking their indices in the global list of
-    //  all files/readers used by the engine. This will greaty accelerate
-    //  refnumber mangling, as required for handling moved references.
-    const std::vector<ESM::Header::MasterData> &masters = esm.getGameFiles();
-    std::vector<ESM::ESMReader> *allPlugins = esm.getGlobalReaderList();
-    for (size_t j = 0; j < masters.size(); j++) {
-        const ESM::Header::MasterData &mast = masters[j];
-        std::string fname = mast.name;
-        int index = ~0;
-        for (int i = 0; i < esm.getIndex(); i++) {
-            ESM::ESMReader& reader = allPlugins->at(i);
-            if (reader.getFileSize() == 0)
-                continue;  // Content file in non-ESM format
-            const std::string candidate = reader.getContext().filename;
-            std::string fnamecandidate = boost::filesystem::path(candidate).filename().string();
-            if (Misc::StringUtils::ciEqual(fname, fnamecandidate)) {
-                index = i;
-                break;
-            }
-        }
-        if (index == (int)~0) {
-            // Tried to load a parent file that has not been loaded yet. This is bad,
-            //  the launcher should have taken care of this.
-            std::string fstring = "File " + esm.getName() + " asks for parent file " + masters[j].name
-                + ", but it has not been loaded yet. Please check your load order.";
-            esm.fail(fstring);
-        }
-        esm.addParentFileIndex(index);
-    }
+    // We set the number of plugins here so we can properly verify if valid plugin
+    // indices are being passed to the LandTexture Store retrieval methods.
+    mLandTextures.resize(mLandTextures.size()+1);
 
     // Loop through all records
     while(esm.hasMoreRecs())

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -293,11 +293,6 @@ namespace MWWorld
     //=========================================================================
     Store<ESM::LandTexture>::Store()
     {
-        mStatic.emplace_back();
-        LandTextureList &ltexl = mStatic[0];
-        // More than enough to hold Morrowind.esm. Extra lists for plugins will we
-        //  added on-the-fly in a different method.
-        ltexl.reserve(128);
     }
     const ESM::LandTexture *Store<ESM::LandTexture>::search(size_t index, size_t plugin) const
     {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -415,7 +415,7 @@ namespace MWWorld
     {
         for (const auto& esm : readers)
         {
-            assert(esm.getGameFiles().size() == esm.getParentFileIndices.size());
+            assert(esm.getGameFiles().size() == esm.getParentFileIndices().size());
             for (unsigned int i=0; i<esm.getParentFileIndices().size(); ++i)
             {
                 if (!esm.isValidParentFileIndex(i))

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -178,6 +178,10 @@ namespace MWWorld
         if (mEsm[0].getFormat() == 0)
             ensureNeededRecords();
 
+        // TODO: We can and should validate before we call loadContentFiles().
+        // Currently we validate here to prevent merge conflicts with groundcover ESMStore fixes.
+        validateMasterFiles(mEsm);
+
         mCurrentDate.reset(new DateTimeManager());
 
         fillGlobalVariables();
@@ -404,6 +408,23 @@ namespace MWWorld
                     throw std::runtime_error ("unknown record in saved game");
                 }
                 break;
+        }
+    }
+
+    void World::validateMasterFiles(const std::vector<ESM::ESMReader>& readers)
+    {
+        for (const auto& esm : readers)
+        {
+            assert(esm.getGameFiles().size() == esm.getParentFileIndices.size());
+            for (unsigned int i=0; i<esm.getParentFileIndices().size(); ++i)
+            {
+                if (!esm.isValidParentFileIndex(i))
+                {
+                    std::string fstring = "File " + esm.getName() + " asks for parent file " + esm.getGameFiles()[i].name
+                        + ", but it is not available or has been loaded in the wrong order. Please run the launcher to fix this issue.";
+                    throw std::runtime_error(fstring);
+                }
+            }
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -157,6 +157,7 @@ namespace MWWorld
             void updateNavigatorObject(const MWPhysics::Object& object);
 
             void ensureNeededRecords();
+            void validateMasterFiles(const std::vector<ESM::ESMReader>& readers);
 
             void fillGlobalVariables();
 

--- a/apps/openmw_test_suite/mwworld/test_store.cpp
+++ b/apps/openmw_test_suite/mwworld/test_store.cpp
@@ -29,9 +29,6 @@ struct ContentFileTest : public ::testing::Test
         readContentFiles();
 
         // load the content files
-        std::vector<ESM::ESMReader> readerList;
-        readerList.resize(mContentFiles.size());
-
         int index=0;
         for (const auto & mContentFile : mContentFiles)
         {
@@ -39,8 +36,7 @@ struct ContentFileTest : public ::testing::Test
             lEsm.setEncoder(nullptr);
             lEsm.setIndex(index);
             lEsm.open(mContentFile.string());
-            readerList[index] = lEsm;
-            mEsmStore.load(readerList[index], &dummyListener);
+            mEsmStore.load(lEsm, &dummyListener);
 
             ++index;
         }
@@ -253,9 +249,6 @@ TEST_F(StoreTest, delete_test)
     record.mId = recordId;
 
     ESM::ESMReader reader;
-    std::vector<ESM::ESMReader> readerList;
-    readerList.push_back(reader);
-    reader.setGlobalReaderList(&readerList);
 
     // master file inserts a record
     Files::IStreamPtr file = getEsmFile(record, false);
@@ -296,9 +289,6 @@ TEST_F(StoreTest, overwrite_test)
     record.mId = recordId;
 
     ESM::ESMReader reader;
-    std::vector<ESM::ESMReader> readerList;
-    readerList.push_back(reader);
-    reader.setGlobalReaderList(&readerList);
 
     // master file inserts a record
     Files::IStreamPtr file = getEsmFile(record, false);

--- a/apps/openmw_test_suite/mwworld/test_store.cpp
+++ b/apps/openmw_test_suite/mwworld/test_store.cpp
@@ -38,7 +38,6 @@ struct ContentFileTest : public ::testing::Test
             ESM::ESMReader lEsm;
             lEsm.setEncoder(nullptr);
             lEsm.setIndex(index);
-            lEsm.setGlobalReaderList(&readerList);
             lEsm.open(mContentFile.string());
             readerList[index] = lEsm;
             mEsmStore.load(readerList[index], &dummyListener);

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -60,16 +60,16 @@ void ESMReader::clearCtx()
 
 void ESMReader::resolveParentFileIndices(const std::vector<ESMReader>& allPlugins)
 {
-    const std::vector<ESM::Header::MasterData> &masters = getGameFiles();
+    const std::vector<Header::MasterData> &masters = getGameFiles();
     for (size_t j = 0; j < masters.size(); j++) {
-        const ESM::Header::MasterData &mast = masters[j];
+        const Header::MasterData &mast = masters[j];
         std::string fname = mast.name;
         int index = getIndex(); 
         for (int i = 0; i < getIndex(); i++) {
-            ESM::ESMReader& reader = allPlugins.at(i);
+            const ESMReader& reader = allPlugins.at(i);
             if (reader.getFileSize() == 0)
                 continue;  // Content file in non-ESM format
-            const std::string candidate = reader.getContext().filename;
+            const std::string candidate = reader.getName();
             std::string fnamecandidate = boost::filesystem::path(candidate).filename().string();
             if (Misc::StringUtils::ciEqual(fname, fnamecandidate)) {
                 index = i;

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -60,6 +60,7 @@ void ESMReader::clearCtx()
 
 void ESMReader::resolveParentFileIndices(const std::vector<ESMReader>& allPlugins)
 {
+    mCtx.parentFileIndices.clear();
     const std::vector<Header::MasterData> &masters = getGameFiles();
     for (size_t j = 0; j < masters.size(); j++) {
         const Header::MasterData &mast = masters[j];
@@ -76,7 +77,7 @@ void ESMReader::resolveParentFileIndices(const std::vector<ESMReader>& allPlugin
                 break;
             }
         }
-        addParentFileIndex(index);
+        mCtx.parentFileIndices.push_back(index);
     }
 }
 

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -20,7 +20,6 @@ ESM_Context ESMReader::getContext()
 ESMReader::ESMReader()
     : mRecordFlags(0)
     , mBuffer(50*1024)
-    , mGlobalReaderList(nullptr)
     , mEncoder(nullptr)
     , mFileSize(0)
 {

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -60,9 +60,6 @@ void ESMReader::clearCtx()
 
 void ESMReader::resolveParentFileIndices(const std::vector<ESMReader>& allPlugins)
 {
-    // Assign parent esX files by tracking their indices in the global list of
-    // all files/readers used by the engine. This is required for correct RefNums
-    // as required for handling moved, deleted and edited CellRefs.
     const std::vector<ESM::Header::MasterData> &masters = getGameFiles();
     for (size_t j = 0; j < masters.size(); j++) {
         const ESM::Header::MasterData &mast = masters[j];

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -82,6 +82,9 @@ public:
   void setIndex(const int index) { mCtx.index = index;}
   int getIndex() {return mCtx.index;}
 
+  // Assign parent esX files by tracking their indices in the global list of
+  // all files/readers used by the engine. This is required for correct RefNums
+  // as required for handling moved, deleted and edited CellRefs.
   void resolveParentFileIndices(const std::vector<ESMReader>& files);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
 

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -88,7 +88,7 @@ public:
   /// @note Does not validate.
   void resolveParentFileIndices(const std::vector<ESMReader>& files);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
-  bool isValidParentFileIndex(unsigned int i) const { return i != getIndex(); }
+  bool isValidParentFileIndex(int i) const { return i != getIndex(); }
 
   /*************************************************************************
    *

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -80,7 +80,7 @@ public:
   //  to the individual load() methods. This hack allows to pass this reference
   //  indirectly to the load() method.
   void setIndex(const int index) { mCtx.index = index;}
-  int getIndex() {return mCtx.index;}
+  int getIndex() const {return mCtx.index;}
 
   // Assign parent esX files by tracking their indices in the global list of
   // all files/readers used by the engine. This is required for correct adjustRefNum() results

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -82,10 +82,7 @@ public:
   void setIndex(const int index) { mCtx.index = index;}
   int getIndex() {return mCtx.index;}
 
-  void setGlobalReaderList(std::vector<ESMReader> *list) {mGlobalReaderList = list;}
-  std::vector<ESMReader> *getGlobalReaderList() {return mGlobalReaderList;}
-
-  void addParentFileIndex(int index) { mCtx.parentFileIndices.push_back(index); }
+  void resolveParentFileIndices(const std::vector<ESMReader>& files);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
 
   /*************************************************************************

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -83,10 +83,12 @@ public:
   int getIndex() {return mCtx.index;}
 
   // Assign parent esX files by tracking their indices in the global list of
-  // all files/readers used by the engine. This is required for correct RefNums
+  // all files/readers used by the engine. This is required for correct adjustRefNum() results
   // as required for handling moved, deleted and edited CellRefs.
+  /// @note Does not validate.
   void resolveParentFileIndices(const std::vector<ESMReader>& files);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
+  bool isValidParentFileIndex(unsigned int i) const { return i != getIndex(); }
 
   /*************************************************************************
    *

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -281,7 +281,6 @@ private:
 
   Header mHeader;
 
-  std::vector<ESMReader> *mGlobalReaderList;
   ToUTF8::Utf8Encoder* mEncoder;
 
   size_t mFileSize;

--- a/components/esm/loadcell.cpp
+++ b/components/esm/loadcell.cpp
@@ -21,10 +21,6 @@ namespace
     {
         unsigned int local = (refNum.mIndex & 0xff000000) >> 24;
 
-        // TODO: enable this assertion when groundcover reading has been fixed.
-        // We need to ensure getParentFileIndices() has been initialised prior to adjusting RefNums.
-        // assert(reader.getParentFileIndices().size() == reader.getGameFiles.size());
-
         // If we have an index value that does not make sense, assume that it was an addition
         // by the present plugin (but a faulty one)
         if (local && local <= reader.getParentFileIndices().size())

--- a/components/esm/loadcell.cpp
+++ b/components/esm/loadcell.cpp
@@ -21,6 +21,10 @@ namespace
     {
         unsigned int local = (refNum.mIndex & 0xff000000) >> 24;
 
+        // TODO: enable this assertion when groundcover reading has been fixed.
+        // We need to ensure getParentFileIndices() has been initialised prior to adjusting RefNums.
+        // assert(reader.getParentFileIndices().size() == reader.getGameFiles.size());
+
         // If we have an index value that does not make sense, assume that it was an addition
         // by the present plugin (but a faulty one)
         if (local && local <= reader.getParentFileIndices().size())

--- a/components/esmloader/load.cpp
+++ b/components/esmloader/load.cpp
@@ -214,7 +214,6 @@ namespace EsmLoader
                 ESM::ESMReader& reader = readers[i];
                 reader.setEncoder(encoder);
                 reader.setIndex(static_cast<int>(i));
-                reader.setGlobalReaderList(&readers);
                 reader.open(collection.getPath(file).string());
 
                 loadEsm(query, readers[i], result);


### PR DESCRIPTION
This PR aims to start addressing `ESM` design issues that have silenced errors we incorporated into groundcover `ESM` loading approaches.

- We move the resolution of `parentFileIndices` from `ESMStore` to `ESMReader` as suggested in a `TODO` comment.
- We improve a highly misleading comment which downplayed the significance of `parentFileIndices`.
- We document important preconditions.
- We move a user facing error message to the highest level and improve its context.
- We remove an inappropriate `setGlobalReaderList` method. We now pass this reader list into the method that requires it.
- We remove a thoroughly pointless optimisation of `Store<ESM::LandTexture>`'s construction that has unnecessarily depended on `getGlobalReaderList`.

There should be no functional changes for `master`, but this PR should remove an issue blocking PR #3208.