### PR TITLE
refactors ESM::Land

### DIFF
--- a/apps/opencs/model/world/collection.hpp
+++ b/apps/opencs/model/world/collection.hpp
@@ -311,7 +311,7 @@ namespace CSMWorld
         int index = touchRecordImp(id);
         if (index >= 0)
         {
-            mRecords.at(index)->get().setPlugin();
+            mRecords.at(index)->get().setPlugin(0);
             return true;
         }
 

--- a/apps/opencs/model/world/collection.hpp
+++ b/apps/opencs/model/world/collection.hpp
@@ -296,7 +296,7 @@ namespace CSMWorld
         const std::string& destination, const UniversalId::Type type)
     {
         int index = cloneRecordImp(origin, destination, type);
-        mRecords.at(index)->get().mPlugin = 0;
+        mRecords.at(index)->get().setPlugin(0);
     }
 
     template<typename ESXRecordT, typename IdAccessorT>
@@ -311,7 +311,7 @@ namespace CSMWorld
         int index = touchRecordImp(id);
         if (index >= 0)
         {
-            mRecords.at(index)->get().mPlugin = 0;
+            mRecords.at(index)->get().setPlugin();
             return true;
         }
 

--- a/apps/opencs/model/world/columnimp.cpp
+++ b/apps/opencs/model/world/columnimp.cpp
@@ -52,7 +52,7 @@ namespace CSMWorld
 
     QVariant LandPluginIndexColumn::get(const Record<Land>& record) const
     {
-        return record.get().mPlugin;
+        return record.get().getPlugin();
     }
 
     bool LandPluginIndexColumn::isEditable() const

--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -153,7 +153,7 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
     // Land texture loading needs to use a separate internal store for each plugin.
     // We set the number of plugins here so we can properly verify if valid plugin
     // indices are being passed to the LandTexture Store retrieval methods.
-    mLandTextures.resize(mLandTextures.getSize()+1);
+    mLandTextures.addPlugin();
 
     // Loop through all records
     while(esm.hasMoreRecs())

--- a/apps/openmw/mwworld/store.cpp
+++ b/apps/openmw/mwworld/store.cpp
@@ -322,14 +322,12 @@ namespace MWWorld
         assert(plugin < mStatic.size());
         return mStatic[plugin].size();
     }
-    RecordId Store<ESM::LandTexture>::load(ESM::ESMReader &esm, size_t plugin)
+    RecordId Store<ESM::LandTexture>::load(ESM::ESMReader &esm)
     {
         ESM::LandTexture lt;
         bool isDeleted = false;
 
         lt.load(esm, isDeleted);
-
-        assert(plugin < mStatic.size());
 
         // Replace texture for records with given ID and index from all plugins.
         for (unsigned int i=0; i<mStatic.size(); i++)
@@ -342,7 +340,7 @@ namespace MWWorld
             }
         }
 
-        LandTextureList &ltexl = mStatic[plugin];
+        LandTextureList &ltexl = mStatic.back();
         if(lt.mIndex + 1 > (int)ltexl.size())
             ltexl.resize(lt.mIndex+1);
 
@@ -351,10 +349,6 @@ namespace MWWorld
         ltexl[idx] = std::move(lt);
 
         return RecordId(ltexl[idx].mId, isDeleted);
-    }
-    RecordId Store<ESM::LandTexture>::load(ESM::ESMReader &esm)
-    {
-        return load(esm, esm.getIndex());
     }
     Store<ESM::LandTexture>::iterator Store<ESM::LandTexture>::begin(size_t plugin) const
     {
@@ -365,11 +359,6 @@ namespace MWWorld
     {
         assert(plugin < mStatic.size());
         return mStatic[plugin].end();
-    }
-    void Store<ESM::LandTexture>::resize(size_t num)
-    {
-        if (mStatic.size() < num)
-            mStatic.resize(num);
     }
 
     // Land

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -219,13 +219,12 @@ namespace MWWorld
         const ESM::LandTexture *search(size_t index, size_t plugin) const;
         const ESM::LandTexture *find(size_t index, size_t plugin) const;
 
-        /// Resize the internal store to hold at least \a num plugins.
-        void resize(size_t num);
+        /// Resize the internal store to hold another plugin.
+        void addPlugin() { mStatic.emplace(); }
 
         size_t getSize() const override;
         size_t getSize(size_t plugin) const;
 
-        RecordId load(ESM::ESMReader &esm, size_t plugin);
         RecordId load(ESM::ESMReader &esm) override;
 
         iterator begin(size_t plugin) const;

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -220,7 +220,7 @@ namespace MWWorld
         const ESM::LandTexture *find(size_t index, size_t plugin) const;
 
         /// Resize the internal store to hold another plugin.
-        void addPlugin() { mStatic.emplace(); }
+        void addPlugin() { mStatic.emplace_back(); }
 
         size_t getSize() const override;
         size_t getSize(size_t plugin) const;

--- a/components/esm/loadland.cpp
+++ b/components/esm/loadland.cpp
@@ -15,7 +15,6 @@ namespace ESM
         : mFlags(0)
         , mX(0)
         , mY(0)
-        , mPlugin(0)
         , mDataTypes(0)
         , mLandData(nullptr)
     {
@@ -39,8 +38,6 @@ namespace ESM
     void Land::load(ESMReader &esm, bool &isDeleted)
     {
         isDeleted = false;
-
-        mPlugin = esm.getIndex();
 
         bool hasLocation = false;
         bool isLoaded = false;
@@ -192,7 +189,7 @@ namespace ESM
 
     void Land::blank()
     {
-        mPlugin = 0;
+        setPlugin(0);
 
         std::fill(std::begin(mWnam), std::end(mWnam), 0);
 
@@ -326,7 +323,7 @@ namespace ESM
     }
 
     Land::Land (const Land& land)
-    : mFlags (land.mFlags), mX (land.mX), mY (land.mY), mPlugin (land.mPlugin),
+    : mFlags (land.mFlags), mX (land.mX), mY (land.mY),
       mContext (land.mContext), mDataTypes (land.mDataTypes),
       mLandData (land.mLandData ? new LandData (*land.mLandData) : nullptr)
     {
@@ -345,7 +342,6 @@ namespace ESM
         std::swap (mFlags, land.mFlags);
         std::swap (mX, land.mX);
         std::swap (mY, land.mY);
-        std::swap (mPlugin, land.mPlugin);
         std::swap (mContext, land.mContext);
         std::swap (mDataTypes, land.mDataTypes);
         std::swap (mLandData, land.mLandData);

--- a/components/esm/loadland.hpp
+++ b/components/esm/loadland.hpp
@@ -32,7 +32,7 @@ struct Land
     
     // Plugin index, used to reference the correct material palette.
     int getPlugin() const { return mContext.index; }
-    void setPlugin() { mContext.index = index; }
+    void setPlugin(int index) { mContext.index = index; }
 
     // File context. This allows the ESM reader to be 'reset' to this
     // location later when we are ready to load the full data set.

--- a/components/esm/loadland.hpp
+++ b/components/esm/loadland.hpp
@@ -29,7 +29,10 @@ struct Land
     int mFlags; // Only first four bits seem to be used, don't know what
     // they mean.
     int mX, mY; // Map coordinates.
-    int mPlugin; // Plugin index, used to reference the correct material palette.
+    
+    // Plugin index, used to reference the correct material palette.
+    int getPlugin() const { return mContext.index; }
+    void setPlugin() { mContext.index = index; }
 
     // File context. This allows the ESM reader to be 'reset' to this
     // location later when we are ready to load the full data set.

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -37,11 +37,6 @@ namespace ESMTerrain
             return &mData;
         }
 
-        inline int getPlugin() const
-        {
-            return mLand->mPlugin;
-        }
-
     private:
         const ESM::Land* mLand;
         int mLoadFlags;

--- a/components/esmterrain/storage.hpp
+++ b/components/esmterrain/storage.hpp
@@ -36,6 +36,7 @@ namespace ESMTerrain
                 return nullptr;
             return &mData;
         }
+        inline int getPlugin() const { return mLand->getPlugin(); }
 
     private:
         const ESM::Land* mLand;


### PR DESCRIPTION
With this PR we reduce coupling, simplify code, encapsulate a variable and separate actual `ESM` data from its context.