### PR TITLE
simplify parameter passing

### DIFF
--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -241,7 +241,6 @@ void ActorAnimation::updateHolsteredShield(bool showCarriedLeft)
         mHolsteredShield->getNode()->accept(shaderVisitor);
     }
 }
-}
 
 bool ActorAnimation::useShieldAnimations() const
 {

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -232,9 +232,6 @@ void ActorAnimation::updateHolsteredShield(bool showCarriedLeft)
         if (isEnchanted)
             SceneUtil::addEnchantedGlow(shieldNode, mResourceSystem, glowColor);
     }
-
-    if (mAlpha != 1.f)
-        mResourceSystem->getSceneManager()->recreateShaders(mHolsteredShield->getNode());
 }
 
 bool ActorAnimation::useShieldAnimations() const

--- a/apps/openmw/mwrender/actoranimation.cpp
+++ b/apps/openmw/mwrender/actoranimation.cpp
@@ -14,6 +14,7 @@
 #include <components/sceneutil/lightmanager.hpp>
 #include <components/sceneutil/lightutil.hpp>
 #include <components/sceneutil/visitor.hpp>
+#include <components/shader/shadervisitor.hpp>
 
 #include <components/misc/stringops.hpp>
 
@@ -232,6 +233,14 @@ void ActorAnimation::updateHolsteredShield(bool showCarriedLeft)
         if (isEnchanted)
             SceneUtil::addEnchantedGlow(shieldNode, mResourceSystem, glowColor);
     }
+
+    if (mAlpha != 1.f)
+    {
+        // TODO: Remove when we have figured out why this was ever necessary.
+        Shader::ShaderVisitor shaderVisitor(mResourceSystem->getSceneManager()->getShaderVisitorTemplate());
+        mHolsteredShield->getNode()->accept(shaderVisitor);
+    }
+}
 }
 
 bool ActorAnimation::useShieldAnimations() const

--- a/apps/openmw/mwrender/actorspaths.cpp
+++ b/apps/openmw/mwrender/actorspaths.cpp
@@ -47,7 +47,7 @@ namespace MWRender
         const auto newGroup = SceneUtil::createAgentPathGroup(path, halfExtents, start, end, settings);
         if (newGroup)
         {
-            MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(newGroup, "debug");
+            MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(newGroup);
             newGroup->setNodeMask(Mask_Debug);
             mRootNode->addChild(newGroup);
             mGroups[actor] = newGroup;

--- a/apps/openmw/mwrender/bulletdebugdraw.cpp
+++ b/apps/openmw/mwrender/bulletdebugdraw.cpp
@@ -78,9 +78,9 @@ void DebugDrawer::createGeometry()
         mShapesRoot->setNodeMask(Mask_Debug);
         mParentNode->addChild(mShapesRoot);
 
-        MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(mLinesGeometry, "debug");
-        MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(mTrisGeometry, "debug");
-        MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(mShapesRoot, "debug");
+        MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(mLinesGeometry);
+        MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(mTrisGeometry);
+        MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(mShapesRoot);
     }
 }
 

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -8,6 +8,7 @@
 #include <components/esm/esmreader.hpp>
 #include <components/sceneutil/lightmanager.hpp>
 #include <components/shader/shadermanager.hpp>
+#include <components/shader/shadervisitor.hpp>
 
 #include "apps/openmw/mwworld/esmstore.hpp"
 #include "apps/openmw/mwbase/environment.hpp"
@@ -224,7 +225,11 @@ namespace MWRender
         group->setNodeMask(Mask_Groundcover);
         if (mSceneManager->getLightingMethod() != SceneUtil::LightingMethod::FFP)
             group->setCullCallback(new SceneUtil::LightListCallback);
-        mSceneManager->recreateShaders(group, "groundcover", true, mProgramTemplate);
+        Shader::ShaderVisitor shaderVisitor(mSceneManager->getShaderVisitorTemplate());
+        shaderVisitor.setDefaultShaderPrefix("groundcover");
+        shaderVisitor.setProgramTemplate(mProgramTemplate);
+        shaderVisitor.setForceShaders(true);
+        group->accept(shaderVisitor);
         mSceneManager->shareState(group);
         group->getBound();
         return group;

--- a/apps/openmw/mwrender/navmesh.cpp
+++ b/apps/openmw/mwrender/navmesh.cpp
@@ -50,7 +50,7 @@ namespace MWRender
         mGroup = SceneUtil::createNavMeshGroup(navMesh, settings);
         if (mGroup)
         {
-            MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(mGroup, "debug");
+            MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(mGroup);
             mGroup->setNodeMask(Mask_Debug);
             mRootNode->addChild(mGroup);
         }

--- a/apps/openmw/mwrender/pathgrid.cpp
+++ b/apps/openmw/mwrender/pathgrid.cpp
@@ -115,7 +115,7 @@ void Pathgrid::enableCellPathgrid(const MWWorld::CellStore *store)
 
     osg::ref_ptr<osg::Geometry> geometry = SceneUtil::createPathgridGeometry(*pathgrid);
 
-    MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(geometry, "debug");
+    MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(geometry);
 
     cellPathGrid->addChild(geometry);
 

--- a/apps/openmw/mwrender/recastmesh.cpp
+++ b/apps/openmw/mwrender/recastmesh.cpp
@@ -70,7 +70,7 @@ namespace MWRender
             if (mGroups.count(tile.first))
                 continue;
             const auto group = SceneUtil::createRecastMeshGroup(*tile.second, settings);
-            MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(group, "debug");
+            MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(group);
             group->setNodeMask(Mask_Debug);
             mGroups.emplace(tile.first, Group {tile.second->getGeneration(), tile.second->getRevision(), group});
             mRootNode->addChild(group);

--- a/apps/openmw/mwrender/recastmesh.cpp
+++ b/apps/openmw/mwrender/recastmesh.cpp
@@ -53,7 +53,7 @@ namespace MWRender
                 || it->second.mRevision != tile->second->getRevision())
             {
                 const auto group = SceneUtil::createRecastMeshGroup(*tile->second, settings);
-                MWBase::Environment::get().getResourceSystem()->getSceneManager()->recreateShaders(group, "debug");
+                MWBase::Environment::get().getResourceSystem()->getSceneManager()->setDebugShader(group);
                 group->setNodeMask(Mask_Debug);
                 mRootNode->removeChild(it->second.mValue);
                 mRootNode->addChild(group);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -310,6 +310,10 @@ namespace MWRender
         auto lightingMethod = SceneUtil::LightManager::getLightingMethodFromString(Settings::Manager::getString("lighting method", "Shaders"));
 
         resourceSystem->getSceneManager()->setParticleSystemMask(MWRender::Mask_ParticleSystem);
+
+        // FIXME: calling dummy method because terrain needs to know whether lighting is clamped
+        resourceSystem->getSceneManager()->setClampLighting(Settings::Manager::getBool("clamp lighting", "Shaders"));
+        
         // Shadows and radial fog have problems with fixed-function mode
         bool forceShaders = Settings::Manager::getBool("radial fog", "Shaders")
                             || Settings::Manager::getBool("force shaders", "Shaders")

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -322,7 +322,6 @@ namespace MWRender
                             || reverseZ;
         Shader::ShaderVisitor shaderVisitor (resourceSystem->getSceneManager()->getShaderVisitorTemplate());
         shaderVisitor.setForceShaders(forceShaders);
-        shaderVisitor.setClampLighting(Settings::Manager::getBool("clamp lighting", "Shaders"));
         if (Settings::Manager::getBool("auto use object normal maps", "Shaders"))
         {
             shaderVisitor.setAutoMapPattern(Shader::ShaderVisitor::NormalMap, Settings::Manager::getString("normal map pattern", "Shaders"));

--- a/apps/openmw/mwrender/ripplesimulation.cpp
+++ b/apps/openmw/mwrender/ripplesimulation.cpp
@@ -15,6 +15,7 @@
 #include <components/resource/imagemanager.hpp>
 #include <components/resource/resourcesystem.hpp>
 #include <components/resource/scenemanager.hpp>
+#include <components/shader/shadervisitor.hpp>
 #include <components/fallback/fallback.hpp>
 #include <components/sceneutil/util.hpp>
 
@@ -109,7 +110,9 @@ RippleSimulation::RippleSimulation(osg::Group *parent, Resource::ResourceSystem*
 
     createWaterRippleStateSet(resourceSystem, mParticleNode);
 
-    resourceSystem->getSceneManager()->recreateShaders(mParticleNode);
+    Shader::ShaderVisitor shaderVisitor(resourceSystem->getSceneManager()->getShaderVisitorTemplate());
+    shaderVisitor.setAllowedToModifyStateSets(true);
+    mParticleNode->accept(shaderVisitor);
 
     mParent->addChild(mParticleNode);
 }

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -19,6 +19,8 @@
 #include <components/resource/scenemanager.hpp>
 #include <components/resource/imagemanager.hpp>
 
+#include <components/shader/shadervisitor.hpp>
+
 #include <components/vfs/manager.hpp>
 
 #include <components/misc/rng.hpp>
@@ -431,8 +433,9 @@ namespace MWRender
         mRainNode->setNodeMask(Mask_WeatherParticles);
 
         mRainParticleSystem->setUserValue("simpleLighting", true);
-        mSceneManager->recreateShaders(mRainNode);
-
+        Shader::ShaderVisitor shaderVisitor(mSceneManager->getShaderVisitorTemplate());
+        shaderVisitor.setAllowedToModifyStateSets(true);
+        mRainNode->accept(shaderVisitor);
         mRootNode->addChild(mRainNode);
     }
 
@@ -668,7 +671,9 @@ namespace MWRender
                     ps->setUserValue("simpleLighting", true);
                 }
 
-                mSceneManager->recreateShaders(mParticleNode);
+                Shader::ShaderVisitor shaderVisitor(mSceneManager->getShaderVisitorTemplate());
+                mParticleNode->accept(shaderVisitor);
+                // TODO: pass simpleLighting define to shaderVisitor directly
             }
         }
 

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -24,6 +24,7 @@
 #include <components/resource/resourcesystem.hpp>
 #include <components/resource/imagemanager.hpp>
 #include <components/resource/scenemanager.hpp>
+#include <components/shader/shadervisitor.hpp>
 
 #include <components/sceneutil/rtt.hpp>
 #include <components/sceneutil/shadow.hpp>
@@ -608,11 +609,10 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
 
     // use a shader to render the simple water, ensuring that fog is applied per pixel as required.
     // this could be removed if a more detailed water mesh, using some sort of paging solution, is implemented.
-    Resource::SceneManager* sceneManager = mResourceSystem->getSceneManager();
-    bool oldValue = sceneManager->getForceShaders();
-    sceneManager->setForceShaders(true);
-    sceneManager->recreateShaders(node);
-    sceneManager->setForceShaders(oldValue);
+    Shader::ShaderVisitor shaderVisitor(sceneManager->getShaderVisitorTemplate());
+    shaderVisitor.setAllowedToModifyStateSets(true);
+    shaderVisitor.setForceShaders(true);
+    node->accept(shaderVisitor);
 }
 
 class ShaderWaterStateSetUpdater : public SceneUtil::StateSetUpdater
@@ -853,3 +853,4 @@ void Water::showWorld(bool show)
 }
 
 }
+

--- a/apps/openmw/mwrender/water.cpp
+++ b/apps/openmw/mwrender/water.cpp
@@ -609,7 +609,7 @@ void Water::createSimpleWaterStateSet(osg::Node* node, float alpha)
 
     // use a shader to render the simple water, ensuring that fog is applied per pixel as required.
     // this could be removed if a more detailed water mesh, using some sort of paging solution, is implemented.
-    Shader::ShaderVisitor shaderVisitor(sceneManager->getShaderVisitorTemplate());
+    Shader::ShaderVisitor shaderVisitor(mResourceSystem->getSceneManager()->getShaderVisitorTemplate());
     shaderVisitor.setAllowedToModifyStateSets(true);
     shaderVisitor.setForceShaders(true);
     node->accept(shaderVisitor);

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -614,6 +614,7 @@ namespace Resource
             loaded->accept(setFilterSettingsControllerVisitor);
 
             Shader::ShaderVisitor shaderVisitor (getShaderVisitorTemplate());
+            shaderVisitor.setAllowedToModifyStateSets(true);
             loaded->accept(shaderVisitor);
 
             if (canOptimize(normalized))

--- a/components/resource/scenemanager.cpp
+++ b/components/resource/scenemanager.cpp
@@ -332,10 +332,12 @@ namespace Resource
         return *mShaderVisitorTemplate;
     }
 
-    void SceneManager::reinstateRemovedState(osg::ref_ptr<osg::Node> node)
+    void SceneManager::setDebugShader(osg::Node* node)
     {
-        osg::ref_ptr<Shader::ReinstateRemovedStateVisitor> reinstateRemovedStateVisitor = new Shader::ReinstateRemovedStateVisitor(false);
-        node->accept(*reinstateRemovedStateVisitor);
+        Shader::ShaderVisitor shaderVisitor(getShaderVisitorTemplate());
+        shaderVisitor.setAllowedToModifyStateSets(true);
+        shaderVisitor.setDefaultShaderPrefix("debug");
+        node->accept(shaderVisitor);
     }
 
     void SceneManager::setDepthFormat(GLenum format)

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -75,38 +75,11 @@ namespace Resource
 
         Shader::ShaderManager& getShaderManager();
 
-        /// Re-create shaders for this node, need to call this if alpha testing, texture stages or vertex color mode have changed.
-        void recreateShaders(osg::ref_ptr<osg::Node> node, const std::string& shaderPrefix = "objects", bool forceShadersForNode = false, const osg::Program* programTemplate = nullptr);
-
-        /// Applying shaders to a node may replace some fixed-function state.
-        /// This restores it.
-        /// When editing such state, it should be reinstated before the edits, and shaders should be recreated afterwards.
-        void reinstateRemovedState(osg::ref_ptr<osg::Node> node);
-
-        /// @see ShaderVisitor::setForceShaders
-        void setForceShaders(bool force);
+        /// Convenience method that queries getForceShaders setting of the getShaderVisitorTemplate().
         bool getForceShaders() const;
-
-        void setClampLighting(bool clamp);
-        bool getClampLighting() const;
 
         void setDepthFormat(GLenum format);
         GLenum getDepthFormat() const;
-
-        /// @see ShaderVisitor::setAutoUseNormalMaps
-        void setAutoUseNormalMaps(bool use);
-
-        /// @see ShaderVisitor::setNormalMapPattern
-        void setNormalMapPattern(const std::string& pattern);
-
-        /// @see ShaderVisitor::setNormalHeightMapPattern
-        void setNormalHeightMapPattern(const std::string& pattern);
-
-        void setAutoUseSpecularMaps(bool use);
-
-        void setSpecularMapPattern(const std::string& pattern);
-
-        void setApplyLightingToEnvMaps(bool apply);
 
         void setSupportedLightingMethods(const SceneUtil::LightManager::SupportedMethods& supported);
         bool isSupportedLightingMethod(SceneUtil::LightingMethod method) const;
@@ -118,8 +91,6 @@ namespace Resource
         };
         void setLightingMethod(SceneUtil::LightingMethod method);
         SceneUtil::LightingMethod getLightingMethod() const;
-        
-        void setConvertAlphaTestToAlphaToCoverage(bool convert);
 
         void setShaderPath(const std::string& path);
 
@@ -192,22 +163,18 @@ namespace Resource
 
         void reportStats(unsigned int frameNumber, osg::Stats* stats) const override;
 
+        const Shader::ShaderVisitor& getShaderVisitorTemplate() const;
+
+        void setShaderVisitorTemplate(const Shader::ShaderVisitor&);
+
     private:
 
-        Shader::ShaderVisitor* createShaderVisitor(const std::string& shaderPrefix = "objects");
-
         std::unique_ptr<Shader::ShaderManager> mShaderManager;
-        bool mForceShaders;
-        bool mClampLighting;
-        bool mAutoUseNormalMaps;
-        std::string mNormalMapPattern;
-        std::string mNormalHeightMapPattern;
-        bool mAutoUseSpecularMaps;
-        std::string mSpecularMapPattern;
-        bool mApplyLightingToEnvMaps;
+        osg::ref_ptr<Shader::ShaderVisitor> mShaderVisitorTemplate;
+        
         SceneUtil::LightingMethod mLightingMethod;
         SceneUtil::LightManager::SupportedMethods mSupportedLightingMethods;
-        bool mConvertAlphaTestToAlphaToCoverage;
+
         GLenum mDepthFormat;
 
         osg::ref_ptr<Resource::SharedStateManager> mSharedStateManager;

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -26,11 +26,6 @@ namespace osgUtil
     class IncrementalCompileOperation;
 }
 
-namespace osgDB
-{
-    class SharedStateManager;
-}
-
 namespace Shader
 {
     class ShaderManager;
@@ -166,6 +161,9 @@ namespace Resource
         const Shader::ShaderVisitor& getShaderVisitorTemplate() const;
 
         void setShaderVisitorTemplate(const Shader::ShaderVisitor&);
+
+        /// Convenience method that assigns "debug" shaders to a newly created node.
+        void setDebugShader(osg::Node* node);
 
     private:
 

--- a/components/resource/scenemanager.hpp
+++ b/components/resource/scenemanager.hpp
@@ -73,6 +73,9 @@ namespace Resource
         /// Convenience method that queries getForceShaders setting of the getShaderVisitorTemplate().
         bool getForceShaders() const;
 
+        void setClampLighting(bool clamp) { mClampLighting = clamp; }
+        bool getClampLighting() const { return mClampLighting; }
+
         void setDepthFormat(GLenum format);
         GLenum getDepthFormat() const;
 
@@ -168,6 +171,7 @@ namespace Resource
     private:
 
         std::unique_ptr<Shader::ShaderManager> mShaderManager;
+        bool mClampLighting;
         osg::ref_ptr<Shader::ShaderVisitor> mShaderVisitorTemplate;
         
         SceneUtil::LightingMethod mLightingMethod;

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -143,7 +143,7 @@ void GlowUpdater::apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
             mNode->setStateSet(stateset);
             // TODO: this visitor is unsafe here and needs to be avoided
             Shader::ShaderVisitor shaderVisitor(mResourceSystem->getSceneManager()->getShaderVisitorTemplate());
-            mNode->apply(shaderVisitor);
+            mNode->accept(shaderVisitor);
         }
         if (mOriginalDuration < 0) // if this glowupdater was originally a permanent glow
         {
@@ -321,8 +321,8 @@ osg::ref_ptr<GlowUpdater> addEnchantedGlow(osg::ref_ptr<osg::Node> node, Resourc
     writableStateSet->setTextureAttributeAndModes(texUnit, textures.front(), osg::StateAttribute::ON);
     writableStateSet->addUniform(new osg::Uniform("envMapColor", glowColor));
     // TODO: this visitor is unsafe here and needs to be avoided
-    Shader::ShaderVisitor shaderVisitor(mResourceSystem->getSceneManager()->getShaderVisitorTemplate());
-    node->apply(shaderVisitor);
+    Shader::ShaderVisitor shaderVisitor(resourceSystem->getSceneManager()->getShaderVisitorTemplate());
+    node->accept(shaderVisitor);
     return glowUpdater;
 }
 

--- a/components/sceneutil/util.cpp
+++ b/components/sceneutil/util.cpp
@@ -20,6 +20,7 @@
 #include <components/settings/settings.hpp>
 #include <components/debug/debuglog.hpp>
 #include <components/sceneutil/nodecallback.hpp>
+#include <components/shader/shadervisitor.hpp>
 
 #ifndef GL_DEPTH32F_STENCIL8_NV
 #define GL_DEPTH32F_STENCIL8_NV 0x8DAC
@@ -140,7 +141,9 @@ void GlowUpdater::apply(osg::StateSet *stateset, osg::NodeVisitor *nv)
             mDone = true;
             // normally done in StateSetUpdater::operator(), but needs doing here so the shader visitor sees the right StateSet
             mNode->setStateSet(stateset);
-            mResourceSystem->getSceneManager()->recreateShaders(mNode);
+            // TODO: this visitor is unsafe here and needs to be avoided
+            Shader::ShaderVisitor shaderVisitor(mResourceSystem->getSceneManager()->getShaderVisitorTemplate());
+            mNode->apply(shaderVisitor);
         }
         if (mOriginalDuration < 0) // if this glowupdater was originally a permanent glow
         {
@@ -317,8 +320,9 @@ osg::ref_ptr<GlowUpdater> addEnchantedGlow(osg::ref_ptr<osg::Node> node, Resourc
     }
     writableStateSet->setTextureAttributeAndModes(texUnit, textures.front(), osg::StateAttribute::ON);
     writableStateSet->addUniform(new osg::Uniform("envMapColor", glowColor));
-    resourceSystem->getSceneManager()->recreateShaders(node);
-
+    // TODO: this visitor is unsafe here and needs to be avoided
+    Shader::ShaderVisitor shaderVisitor(mResourceSystem->getSceneManager()->getShaderVisitorTemplate());
+    node->apply(shaderVisitor);
     return glowUpdater;
 }
 

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -116,16 +116,17 @@ namespace Shader
         mAutoMapPatterns.resize(EnumSize);
     }
 
-    ShaderVisitor::ShaderVisitor(const ShaderVisitor& other)
+    ShaderVisitor::ShaderVisitor(const ShaderVisitor& other, const osg::CopyOp& copyop)
         : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
         , mForceShaders(other.mForceShaders)
         , mAllowedToModifyStateSets(other.mAllowedToModifyStateSets)
+        , mAutoMapPatterns(other.mAutoMapPatterns)
         , mApplyLightingToEnvMaps(other.mApplyLightingToEnvMaps)
         , mConvertAlphaTestToAlphaToCoverage(other.mConvertAlphaTestToAlphaToCoverage)
         , mShaderManager(other.mShaderManager)
         , mImageManager(other.mImageManager)
         , mDefaultShaderPrefix(other.mDefaultShaderPrefix)
-        , mAutoMapPatterns(other.mAutoMapPatterns)
+        , mProgramTemplate(other.mProgramTemplate)
     {
     }
 

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -116,7 +116,7 @@ namespace Shader
     }
 
     ShaderVisitor::ShaderVisitor(const ShaderVisitor& other, const osg::CopyOp& copyop)
-        : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
+        : osg::NodeVisitor(other, copyop)
         , mForceShaders(other.mForceShaders)
         , mAllowedToModifyStateSets(other.mAllowedToModifyStateSets)
         , mAutoMapPatterns(other.mAutoMapPatterns)

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -116,7 +116,8 @@ namespace Shader
     }
 
     ShaderVisitor::ShaderVisitor(const ShaderVisitor& other, const osg::CopyOp& copyop)
-        : osg::NodeVisitor(other, copyop)
+        : osg::Object(other, copyop)
+        , osg::NodeVisitor(other, copyop)
         , mForceShaders(other.mForceShaders)
         , mAllowedToModifyStateSets(other.mAllowedToModifyStateSets)
         , mAutoMapPatterns(other.mAutoMapPatterns)

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -106,7 +106,7 @@ namespace Shader
     ShaderVisitor::ShaderVisitor(ShaderManager& shaderManager, Resource::ImageManager& imageManager, const std::string &defaultShaderPrefix)
         : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
         , mForceShaders(false)
-        , mAllowedToModifyStateSets(true)
+        , mAllowedToModifyStateSets(false)
         , mApplyLightingToEnvMaps(false)
         , mConvertAlphaTestToAlphaToCoverage(false)
         , mShaderManager(shaderManager)

--- a/components/shader/shadervisitor.cpp
+++ b/components/shader/shadervisitor.cpp
@@ -103,7 +103,7 @@ namespace Shader
     {
     }
 
-    ShaderVisitor::ShaderVisitor(ShaderManager& shaderManager, Resource::ImageManager& imageManager, const std::string &defaultShaderPrefix)
+    ShaderVisitor::ShaderVisitor(ShaderManager& shaderManager, Resource::ImageManager& imageManager)
         : osg::NodeVisitor(TRAVERSE_ALL_CHILDREN)
         , mForceShaders(false)
         , mAllowedToModifyStateSets(false)
@@ -111,7 +111,6 @@ namespace Shader
         , mConvertAlphaTestToAlphaToCoverage(false)
         , mShaderManager(shaderManager)
         , mImageManager(imageManager)
-        , mDefaultShaderPrefix(defaultShaderPrefix)
     {
         mAutoMapPatterns.resize(EnumSize);
     }

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -22,9 +22,8 @@ namespace Shader
     {
     public:
         ShaderVisitor(ShaderManager& shaderManager, Resource::ImageManager& imageManager);
+        ShaderVisitor(const ShaderVisitor& copy, const osg::CopyOp& copyop=osg::CopyOp())
         ~ShaderVisitor();
-
-        void operator = (const ShaderVisitor&);
 
         void setDefaultShaderPrefix(const std::string& defaultShaderPrefix) { mDefaultShaderPrefix = defaultShaderPrefix; }
 
@@ -39,7 +38,7 @@ namespace Shader
         /// Set if we are allowed to modify StateSets encountered in the graph (default false).
         /// @par If set to false, then instead of modifying, the StateSet will be cloned and this new StateSet will be assigned to the node.
         /// @par Setting this option to true is useful when the ShaderVisitor is run on StateSets that have not been submitted for rendering yet.
-        void setAllowedToModifyStateSets(bool allowed);
+        void setAllowedToModifyStateSets(bool allowed) { mAllowedToModifyStateSets = true; }
 
         /// Automatically use texture maps if a file with suitable name exists.
         /// @note An empty pattern string indicates we will not use texture maps automatically.
@@ -53,9 +52,9 @@ namespace Shader
         void setAutoMapPattern(AutoUsedMap map, const std::string& pattern) { mAutoMapPatterns[map] = pattern; }
         const std::string& getAutoMapPattern(AutoUsedMap map) const { return mAutoMapPatterns[map]; }
 
-        void setApplyLightingToEnvMaps(bool apply);
+        void setApplyLightingToEnvMaps(bool apply) { mApplyLightingToEnvMaps = apply; }
 
-        void setConvertAlphaTestToAlphaToCoverage(bool convert);
+        void setConvertAlphaTestToAlphaToCoverage(bool convert) { mConvertAlphaTestToAlphaToCoverage = convert; }
 
         void apply(osg::Node& node) override;
 

--- a/components/shader/shadervisitor.hpp
+++ b/components/shader/shadervisitor.hpp
@@ -22,7 +22,7 @@ namespace Shader
     {
     public:
         ShaderVisitor(ShaderManager& shaderManager, Resource::ImageManager& imageManager);
-        ShaderVisitor(const ShaderVisitor& copy, const osg::CopyOp& copyop=osg::CopyOp())
+        ShaderVisitor(const ShaderVisitor& copy, const osg::CopyOp& copyop=osg::CopyOp());
         ~ShaderVisitor();
 
         void setDefaultShaderPrefix(const std::string& defaultShaderPrefix) { mDefaultShaderPrefix = defaultShaderPrefix; }
@@ -38,7 +38,7 @@ namespace Shader
         /// Set if we are allowed to modify StateSets encountered in the graph (default false).
         /// @par If set to false, then instead of modifying, the StateSet will be cloned and this new StateSet will be assigned to the node.
         /// @par Setting this option to true is useful when the ShaderVisitor is run on StateSets that have not been submitted for rendering yet.
-        void setAllowedToModifyStateSets(bool allowed) { mAllowedToModifyStateSets = true; }
+        void setAllowedToModifyStateSets(bool allowed) { mAllowedToModifyStateSets = allowed; }
 
         /// Automatically use texture maps if a file with suitable name exists.
         /// @note An empty pattern string indicates we will not use texture maps automatically.

--- a/components/terrain/cellborder.cpp
+++ b/components/terrain/cellborder.cpp
@@ -77,7 +77,7 @@ osg::ref_ptr<osg::Group> CellBorder::createBorderGeometry(float x, float y, floa
     polygonmode->setMode(osg::PolygonMode::FRONT_AND_BACK, osg::PolygonMode::LINE);
     stateSet->setAttributeAndModes(polygonmode,osg::StateAttribute::ON);
 
-    sceneManager->recreateShaders(borderGeode, "debug");
+    sceneManager->setDebugShader(borderGeode);
     borderGeode->setNodeMask(mask);
 
     return borderGeode;

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -11,7 +11,6 @@
 #include <components/resource/scenemanager.hpp>
 
 #include <components/sceneutil/lightmanager.hpp>
-#include <components/shader/shadervisitor.hpp>
 
 #include "terraindrawable.hpp"
 #include "material.hpp"

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -11,6 +11,7 @@
 #include <components/resource/scenemanager.hpp>
 
 #include <components/sceneutil/lightmanager.hpp>
+#include <components/shader/shadervisitor.hpp>
 
 #include "terraindrawable.hpp"
 #include "material.hpp"
@@ -138,7 +139,7 @@ std::vector<osg::ref_ptr<osg::StateSet> > ChunkManager::createPasses(float chunk
     mStorage->getBlendmaps(chunkSize, chunkCenter, blendmaps, layerList);
 
     bool useShaders = mSceneManager->getForceShaders();
-    if (!mSceneManager->getClampLighting())
+    if (!mSceneManager->getShaderVisitorTemplate().getClampLighting())
         useShaders = true; // always use shaders when lighting is unclamped, this is to avoid lighting seams between a terrain chunk with normal maps and one without normal maps
 
     std::vector<TextureLayer> layers;
@@ -265,7 +266,7 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
             layer.mDiffuseMap = compositeMap->mTexture;
             layer.mParallax = false;
             layer.mSpecular = false;
-            geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
+            geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getShaderVisitorTemplate().getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
         }
         else
         {

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -139,7 +139,7 @@ std::vector<osg::ref_ptr<osg::StateSet> > ChunkManager::createPasses(float chunk
     mStorage->getBlendmaps(chunkSize, chunkCenter, blendmaps, layerList);
 
     bool useShaders = mSceneManager->getForceShaders();
-    if (!mSceneManager->getShaderVisitorTemplate().getClampLighting())
+    if (!mSceneManager->getClampLighting())
         useShaders = true; // always use shaders when lighting is unclamped, this is to avoid lighting seams between a terrain chunk with normal maps and one without normal maps
 
     std::vector<TextureLayer> layers;
@@ -266,7 +266,7 @@ osg::ref_ptr<osg::Node> ChunkManager::createChunk(float chunkSize, const osg::Ve
             layer.mDiffuseMap = compositeMap->mTexture;
             layer.mParallax = false;
             layer.mSpecular = false;
-            geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getShaderVisitorTemplate().getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
+            geometry->setPasses(::Terrain::createPasses(mSceneManager->getForceShaders() || !mSceneManager->getClampLighting(), &mSceneManager->getShaderManager(), std::vector<TextureLayer>(1, layer), std::vector<osg::ref_ptr<osg::Texture2D> >(), 1.f, 1.f));
         }
         else
         {


### PR DESCRIPTION
With this PR we substantially clean up the passing of `ShaderVisitor` parameters. These changes will help unblock a substantial cleanup of [program templates](https://github.com/OpenMW/openmw/blob/5debd6e25af486d8234b9ece7d4270b9c63ee099/components/shader/shadermanager.hpp#L69), weather occlusion, simple lighting, soft particles and [groundcover](https://github.com/OpenMW/openmw/blob/f684c1da528106abf59e0aacdea93552c59adb36/apps/openmw/mwrender/renderingmanager.cpp#L371) features. In addition, we fix a race condition in `updateWaterMaterial` by mere coincidence.