### PR TITLE
Support deleted CellRefs in groundcover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@
     Bug #6043: Actor can have torch missing when torch animation is played
     Bug #6047: Mouse bindings can be triggered during save loading
     Bug #6136: Game freezes when NPCs try to open doors that are about to be closed
+    Bug #6276: Deleted groundcover instances are not deleted in game
     Bug #6294: Game crashes with empty pathgrid
     Feature #390: 3rd person look "over the shoulder"
     Feature #832: OpenMW-CS: Handle deleted references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@
     Bug #6043: Actor can have torch missing when torch animation is played
     Bug #6047: Mouse bindings can be triggered during save loading
     Bug #6136: Game freezes when NPCs try to open doors that are about to be closed
+    Bug #6142: Groundcover plugins change cells flags
     Bug #6276: Deleted groundcover instances are not deleted in game
     Bug #6294: Game crashes with empty pathgrid
     Feature #390: 3rd person look "over the shoulder"


### PR DESCRIPTION
Fixes [bug #6276](https://gitlab.com/OpenMW/openmw/-/issues/6276).

Use an approach similar to ObjectPaging, but with per-cell map to avoid cases when different objects from different cells are treated as the same one because they have the same RefNum.