### PR TITLE
improves groundcover view distance

### DIFF
--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -1,6 +1,5 @@
 #include "groundcover.hpp"
 
-#include <osgUtil/CullVisitor>
 #include <osg/ComputeBoundsVisitor>
 #include <osg/AlphaFunc>
 #include <osg/BlendFunc>

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -125,7 +125,7 @@ namespace MWRender
             for (unsigned int i=0; i<8; ++i)
             {
                 osg::Vec3f corner = mBb.corner(i);
-                minDist = std::min(minDist, nv->getDistanceToEyePoint(corner));
+                minDist = std::min(minDist, nv->getDistanceToEyePoint(corner, false));
             }
             if (minDist <= mViewDistance)
                 traverse(node, nv);

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -152,7 +152,8 @@ namespace MWRender
     osg::ref_ptr<osg::Node> Groundcover::getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
     {
         GroundcoverChunkId id = std::make_tuple(center, size);
-
+        if (lod > getMaxLodLevel())
+            return nullptr;
         osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(id);
         if (obj)
             return static_cast<osg::Node*>(obj.get());

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -114,9 +114,9 @@ namespace MWRender
         ViewDistanceCallback(float dist) : mViewDistance(dist) {}
         void operator()(osg::Node* node, osg::NodeVisitor* nv)
         {
-            osg::ComputeBoundsVisitor cbv;
             if (!mBb.valid())
             {
+                osg::ComputeBoundsVisitor cbv;
                 node->accept(cbv);
                 mBb = cbv.getBoundingBox();
             }

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -242,7 +242,7 @@ namespace MWRender
         osg::ComputeBoundsVisitor cbv;
         group->accept(cbv);
         osg::BoundingBox box = cbv.getBoundingBox();
-        box = osg::BoundingBox(box.getMin()+worldCenter, box.getMax()+worldCenter);
+        box = osg::BoundingBox(box._min+worldCenter, box._max+worldCenter);
         group->addCullCallback(new ViewDistanceCallback(getViewDistance(), box));
 
         group->setStateSet(mStateset);

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -151,9 +151,9 @@ namespace MWRender
 
     osg::ref_ptr<osg::Node> Groundcover::getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
     {
-        GroundcoverChunkId id = std::make_tuple(center, size);
         if (lod > getMaxLodLevel())
             return nullptr;
+        GroundcoverChunkId id = std::make_tuple(center, size);
         osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(id);
         if (obj)
             return static_cast<osg::Node*>(obj.get());

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -122,7 +122,7 @@ namespace MWRender
             }
             
             float minDist = std::numeric_limits<float>::max();
-            for (unsigned int i = 0; i < 8; ++i)
+            for (unsigned int i=0; i<8; ++i)
             {
                 osg::Vec3f corner = mBb.corner(i);
                 minDist = std::min(minDist, nv->getDistanceToEyePoint(corner));

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -167,12 +167,13 @@ namespace MWRender
         }
     }
 
-    Groundcover::Groundcover(Resource::SceneManager* sceneManager, float density)
+    Groundcover::Groundcover(Resource::SceneManager* sceneManager, float density, float viewDistance)
          : GenericResourceManager<GroundcoverChunkId>(nullptr)
          , mSceneManager(sceneManager)
          , mDensity(density)
          , mStateset(new osg::StateSet)
     {
+         setViewDistance(viewDistance);
          // MGE uses default alpha settings for groundcover, so we can not rely on alpha properties
          // Force a unified alpha handling instead of data from meshes
          osg::ref_ptr<osg::AlphaFunc> alpha = new osg::AlphaFunc(osg::AlphaFunc::GEQUAL, 128.f / 255.f);

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -125,7 +125,7 @@ namespace MWRender
             for (unsigned int i = 0; i < 8; ++i)
             {
                 osg::Vec3f corner = mBb.corner(i);
-                minDist = std::min(minDist, nv.getDistanceToEyePoint(corner));
+                minDist = std::min(minDist, nv->getDistanceToEyePoint(corner));
             }
             if (minDist <= mViewDistance)
                 traverse(node, nv);

--- a/apps/openmw/mwrender/groundcover.hpp
+++ b/apps/openmw/mwrender/groundcover.hpp
@@ -12,7 +12,7 @@ namespace MWRender
     class Groundcover : public Resource::GenericResourceManager<GroundcoverChunkId>, public Terrain::QuadTreeWorld::ChunkManager
     {
     public:
-        Groundcover(Resource::SceneManager* sceneManager, float density);
+        Groundcover(Resource::SceneManager* sceneManager, float density, float viewDistance);
         ~Groundcover() = default;
 
         osg::ref_ptr<osg::Node> getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile) override;

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -438,7 +438,7 @@ namespace MWRender
             float density = Settings::Manager::getFloat("density", "Groundcover");
             density = std::clamp(density, 0.f, 1.f);
 
-            mGroundcover.reset(new Groundcover(mResourceSystem->getSceneManager(), density, viewDistance));
+            mGroundcover.reset(new Groundcover(mResourceSystem->getSceneManager(), density, groundcoverDistance));
             static_cast<Terrain::QuadTreeWorld*>(mTerrain.get())->addChunkManager(mGroundcover.get());
             mResourceSystem->addResourceManager(mGroundcover.get());
         }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -438,11 +438,9 @@ namespace MWRender
             float density = Settings::Manager::getFloat("density", "Groundcover");
             density = std::clamp(density, 0.f, 1.f);
 
-            mGroundcover.reset(new Groundcover(mResourceSystem->getSceneManager(), density));
+            mGroundcover.reset(new Groundcover(mResourceSystem->getSceneManager(), density, viewDistance));
             static_cast<Terrain::QuadTreeWorld*>(mTerrain.get())->addChunkManager(mGroundcover.get());
             mResourceSystem->addResourceManager(mGroundcover.get());
-
-            mGroundcover->setViewDistance(groundcoverDistance);
         }
 
         mStateUpdater = new StateUpdater;

--- a/components/terrain/buffercache.cpp
+++ b/components/terrain/buffercache.cpp
@@ -12,8 +12,8 @@ namespace
 template <typename IndexArrayType>
 osg::ref_ptr<IndexArrayType> createIndexBuffer(unsigned int flags, unsigned int verts)
 {
-    // LOD level n means every 2^n-th vertex is kept
-    size_t lodLevel = (flags >> (4*4));
+    // LOD level n means every 2^n-th vertex is kept, but we currently handle LOD elsewhere.
+    size_t lodLevel = 0;//(flags >> (4*4));
 
     size_t lodDeltas[4];
     for (int i=0; i<4; ++i)

--- a/components/terrain/chunkmanager.cpp
+++ b/components/terrain/chunkmanager.cpp
@@ -52,6 +52,9 @@ struct FindChunkTemplate
 
 osg::ref_ptr<osg::Node> ChunkManager::getChunk(float size, const osg::Vec2f& center, unsigned char lod, unsigned int lodFlags, bool activeGrid, const osg::Vec3f& viewPoint, bool compile)
 {
+    // Override lod with the vertexLodMod adjusted value.
+    // TODO: maybe we can refactor this code by moving all vertexLodMod code into this class.
+    lod = static_cast<unsigned char>(lodFlags >> (4*4));
     ChunkId id = std::make_tuple(center, lod, lodFlags);
     osg::ref_ptr<osg::Object> obj = mCache->getRefFromObjectCache(id);
     if (obj)

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -101,7 +101,7 @@ QuadTreeNode *QuadTreeNode::getNeighbour(Direction dir)
 float QuadTreeNode::distance(const osg::Vec3f& v) const
 {
     const osg::BoundingBox& box = getBoundingBox();
-    return distance(box, v);
+    return Terrain::distance(box, v);
 }
 
 void QuadTreeNode::initNeighbours()

--- a/components/terrain/quadtreenode.cpp
+++ b/components/terrain/quadtreenode.cpp
@@ -10,6 +10,29 @@
 namespace Terrain
 {
 
+float distance(const osg::BoundingBox& box, const osg::Vec3f& v)
+{
+    if (box.contains(v))
+        return 0;
+    else
+    {
+        osg::Vec3f maxDist(0,0,0);
+        if (v.x() < box.xMin())
+            maxDist.x() = box.xMin() - v.x();
+        else if (v.x() > box.xMax())
+            maxDist.x() = v.x() - box.xMax();
+        if (v.y() < box.yMin())
+            maxDist.y() = box.yMin() - v.y();
+        else if (v.y() > box.yMax())
+            maxDist.y() = v.y() - box.yMax();
+        if (v.z() < box.zMin())
+            maxDist.z() = box.zMin() - v.z();
+        else if (v.z() > box.zMax())
+            maxDist.z() = v.z() - box.zMax();
+        return maxDist.length();
+    }
+}
+
 ChildDirection reflect(ChildDirection dir, Direction dir2)
 {
     assert(dir != Root);
@@ -78,25 +101,7 @@ QuadTreeNode *QuadTreeNode::getNeighbour(Direction dir)
 float QuadTreeNode::distance(const osg::Vec3f& v) const
 {
     const osg::BoundingBox& box = getBoundingBox();
-    if (box.contains(v))
-        return 0;
-    else
-    {
-        osg::Vec3f maxDist(0,0,0);
-        if (v.x() < box.xMin())
-            maxDist.x() = box.xMin() - v.x();
-        else if (v.x() > box.xMax())
-            maxDist.x() = v.x() - box.xMax();
-        if (v.y() < box.yMin())
-            maxDist.y() = box.yMin() - v.y();
-        else if (v.y() > box.yMax())
-            maxDist.y() = v.y() - box.yMax();
-        if (v.z() < box.zMin())
-            maxDist.z() = box.zMin() - v.z();
-        else if (v.z() > box.zMax())
-            maxDist.z() = v.z() - box.zMax();
-        return maxDist.length();
-    }
+    return distance(box, v);
 }
 
 void QuadTreeNode::initNeighbours()

--- a/components/terrain/quadtreenode.hpp
+++ b/components/terrain/quadtreenode.hpp
@@ -34,6 +34,8 @@ namespace Terrain
 
     class ViewData;
 
+    float distance(const osg::BoundingBox&, const osg::Vec3f& v);
+
     class QuadTreeNode : public osg::Group
     {
     public:

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -55,9 +55,8 @@ namespace Terrain
 class DefaultLodCallback : public LodCallback
 {
 public:
-    DefaultLodCallback(float factor, float minSize, float viewDistance, const osg::Vec4i& grid, float distanceModifier=0.f)
+    DefaultLodCallback(float factor, float viewDistance, const osg::Vec4i& grid, float distanceModifier=0.f)
         : mFactor(factor)
-        , mMinSize(minSize)
         , mViewDistance(viewDistance)
         , mActiveGrid(grid)
         , mDistanceModifier(distanceModifier)
@@ -94,7 +93,6 @@ public:
 
 private:
     float mFactor;
-    float mMinSize;
     float mViewDistance;
     osg::Vec4i mActiveGrid;
     float mDistanceModifier;

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -80,7 +80,7 @@ public:
         dist = std::max(0.f, dist + mDistanceModifier);
         if (dist > mViewDistance && !activeGrid) // for Scene<->ObjectPaging sync the activegrid must remain loaded
             return StopTraversal;
-        return getNativeLodLevel(node) <= convertDistanceToLodLevel(distance) ? StopTraversalAndUse : Deeper;
+        return getNativeLodLevel(node) <= convertDistanceToLodLevel(dist) ? StopTraversalAndUse : Deeper;
     }
     static int getNativeLodLevel(QuadTreeNode* node)
     {
@@ -344,7 +344,7 @@ unsigned int getLodFlags(QuadTreeNode* node, int ourVertexLod, int vertexLodMod,
         }
     }
     // Use the remaining bits for our vertex LOD
-    lodFlags |= (ourVertexLod << (4*4);
+    lodFlags |= (ourVertexLod << (4*4));
     return lodFlags;
 }
 

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -85,9 +85,12 @@ public:
             return StopTraversal;
 
         int nativeLodLevel = Log2(static_cast<unsigned int>(node->getSize()/mMinSize));
-        int lodLevel = Log2(static_cast<unsigned int>(dist/(Constants::CellSizeInUnits*mMinSize*mFactor)));
-
+        int lodLevel = convertDistanceToLodLevel(dist);
         return nativeLodLevel <= lodLevel ? StopTraversalAndUse : Deeper;
+    }
+    int convertDistanceToLodLevel(float distance) const
+    {
+        return Log2(static_cast<unsigned int>(dist/(Constants::CellSizeInUnits*mMinSize*mFactor)));
     }
 
 private:
@@ -347,7 +350,7 @@ unsigned int getLodFlags(QuadTreeNode* node, int ourLod, int vertexLodMod, const
     return lodFlags;
 }
 
-void QuadTreeWorld::loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float cellWorldSize, const osg::Vec4i &gridbounds, bool compile, float reuseDistance)
+void QuadTreeWorld::loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float cellWorldSize, const osg::Vec4i &gridbounds, bool compile)
 {
     if (!vd->hasChanged() && entry.mRenderingNode)
         return;
@@ -363,9 +366,6 @@ void QuadTreeWorld::loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float 
             entry.mRenderingNode = nullptr;
             entry.mLodFlags = lodFlags;
         }
-        // have to revalidate chunks within a custom view distance.
-        if (mRevalidateDistance && entry.mNode->distance(vd->getViewPoint()) <= mRevalidateDistance + reuseDistance)
-            entry.mRenderingNode = nullptr;
     }
 
     if (!entry.mRenderingNode)
@@ -378,9 +378,7 @@ void QuadTreeWorld::loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float 
 
         for (QuadTreeWorld::ChunkManager* m : mChunkManagers)
         {
-            if (mRevalidateDistance && m->getViewDistance() && entry.mNode->distance(vd->getViewPoint()) > m->getViewDistance() + reuseDistance)
-                continue;
-            osg::ref_ptr<osg::Node> n = m->getChunk(entry.mNode->getSize(), entry.mNode->getCenter(), ourLod, entry.mLodFlags, activeGrid, vd->getViewPoint(), compile);
+            osg::ref_ptr<osg::Node> n = m->getChunk(entry.mNode->getSize(), entry.mNode->getCenter(), ourLod, entry.mLodFlags, activeGrid, vd->getViewPoint(, compile);
             if (n) pat->addChild(n);
         }
         entry.mRenderingNode = pat;
@@ -462,7 +460,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
     for (unsigned int i=0; i<vd->getNumEntries(); ++i)
     {
         ViewDataEntry& entry = vd->getEntry(i);
-        loadRenderingNode(entry, vd, cellWorldSize, mActiveGrid, false, mViewDataMap->getReuseDistance());
+        loadRenderingNode(entry, vd, cellWorldSize, mActiveGrid, false);
         entry.mRenderingNode->accept(nv);
     }
 
@@ -541,12 +539,11 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::
             reporter.addTotal(progressTotal);
         }
 
-        const float reuseDistance = std::max(mViewDataMap->getReuseDistance(), std::abs(distanceModifier));
         for (unsigned int i=startEntry; i<vd->getNumEntries() && !abort; ++i)
         {
             ViewDataEntry& entry = vd->getEntry(i);
 
-            loadRenderingNode(entry, vd, cellWorldSize, grid, true, reuseDistance);
+            loadRenderingNode(entry, vd, cellWorldSize, grid, true);
             if (pass==0) reporter.addProgress(entry.mNode->getSize());
             entry.mNode = nullptr; // Clear node lest we break the neighbours search for the next pass
         }
@@ -584,7 +581,10 @@ void QuadTreeWorld::addChunkManager(QuadTreeWorld::ChunkManager* m)
     mChunkManagers.push_back(m);
     mTerrainRoot->setNodeMask(mTerrainRoot->getNodeMask()|m->getNodeMask());
     if (m->getViewDistance())
-        mRevalidateDistance = std::max(m->getViewDistance(), mRevalidateDistance);
+    {
+        DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, mActiveGrid);
+        m->setMaxLodLevel(mLodCallback->convertDistanceToLodLevel(m->getViewDistance() + mViewDataMap->getReuseDistance()));
+    }
 }
 
 void QuadTreeWorld::rebuildViews()

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -87,7 +87,7 @@ public:
     {
         return Log2(static_cast<unsigned int>(node->getSize()/minSize));
     }
-    static int convertDistanceToLodLevel(float dist, float minSize, float factor) const
+    static int convertDistanceToLodLevel(float dist, float minSize, float factor)
     {
         return Log2(static_cast<unsigned int>(dist/(Constants::CellSizeInUnits*minSize*factor)));
     }

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -451,7 +451,7 @@ void QuadTreeWorld::accept(osg::NodeVisitor &nv)
     if (needsUpdate)
     {
         vd->reset();
-        DefaultLodCallback lodCallback(mLodFactor, mViewDistance, mActiveGrid);
+        DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, mActiveGrid);
         mRootNode->traverseNodes(vd, viewPoint, &lodCallback);
     }
 
@@ -527,7 +527,7 @@ void QuadTreeWorld::preload(View *view, const osg::Vec3f &viewPoint, const osg::
             distanceModifier = 1024;
         else if (pass == 2)
             distanceModifier = -1024;
-        DefaultLodCallback lodCallback(mLodFactor, mViewDistance, grid, distanceModifier);
+        DefaultLodCallback lodCallback(mLodFactor, mMinSize, mViewDistance, grid, distanceModifier);
         mRootNode->traverseNodes(vd, viewPoint, &lodCallback);
 
         if (pass==0)

--- a/components/terrain/quadtreeworld.cpp
+++ b/components/terrain/quadtreeworld.cpp
@@ -378,7 +378,7 @@ void QuadTreeWorld::loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float 
 
         for (QuadTreeWorld::ChunkManager* m : mChunkManagers)
         {
-            osg::ref_ptr<osg::Node> n = m->getChunk(entry.mNode->getSize(), entry.mNode->getCenter(), ourLod, entry.mLodFlags, activeGrid, vd->getViewPoint(, compile);
+            osg::ref_ptr<osg::Node> n = m->getChunk(entry.mNode->getSize(), entry.mNode->getCenter(), ourLod, entry.mLodFlags, activeGrid, vd->getViewPoint(), compile);
             if (n) pat->addChild(n);
         }
         entry.mRenderingNode = pat;

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -56,8 +56,13 @@ namespace Terrain
 
             void setViewDistance(float viewDistance) { mViewDistance = viewDistance; }
             float getViewDistance() const { return mViewDistance; }
+
+            // Automatically set based on getViewDistance().
+            unsigned int getMaxLodLevel() const { return mMaxLodLevel; }
+            void setMaxLodLevel(unsigned int level) { mMaxLodLevel = level; }
         private:
             float mViewDistance = 0.f;
+            unsigned int mMaxLodLevel = ~0u;
         };
         void addChunkManager(ChunkManager*);
 
@@ -79,7 +84,6 @@ namespace Terrain
         float mMinSize;
         bool mDebugTerrainChunks;
         std::unique_ptr<DebugChunkManager> mDebugChunkManager;
-        float mRevalidateDistance;
     };
 
 }

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -57,7 +57,7 @@ namespace Terrain
             void setViewDistance(float viewDistance) { mViewDistance = viewDistance; }
             float getViewDistance() const { return mViewDistance; }
 
-            // Automatically set based on getViewDistance()
+            // Automatically set by addChunkManager based on getViewDistance()
             unsigned int getMaxLodLevel() const { return mMaxLodLevel; }
             void setMaxLodLevel(unsigned int level) { mMaxLodLevel = level; }
         private:

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -57,7 +57,7 @@ namespace Terrain
             void setViewDistance(float viewDistance) { mViewDistance = viewDistance; }
             float getViewDistance() const { return mViewDistance; }
 
-            // Automatically set based on getViewDistance().
+            // Automatically set based on getViewDistance()
             unsigned int getMaxLodLevel() const { return mMaxLodLevel; }
             void setMaxLodLevel(unsigned int level) { mMaxLodLevel = level; }
         private:

--- a/components/terrain/quadtreeworld.hpp
+++ b/components/terrain/quadtreeworld.hpp
@@ -68,7 +68,7 @@ namespace Terrain
 
     private:
         void ensureQuadTreeBuilt();
-        void loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float cellWorldSize, const osg::Vec4i &gridbounds, bool compile, float reuseDistance);
+        void loadRenderingNode(ViewDataEntry& entry, ViewData* vd, float cellWorldSize, const osg::Vec4i &gridbounds, bool compile);
 
         osg::ref_ptr<RootNode> mRootNode;
 

--- a/components/terrain/viewdata.cpp
+++ b/components/terrain/viewdata.cpp
@@ -145,7 +145,6 @@ ViewData *ViewDataMap::getViewData(osg::Object *viewer, const osg::Vec3f& viewPo
             }
             vd->setViewPoint(viewPoint);
             vd->setActiveGrid(activeGrid);
-            vd->setChanged(true);
             needsUpdate = true;
         }
     }

--- a/components/terrain/viewdata.hpp
+++ b/components/terrain/viewdata.hpp
@@ -49,7 +49,7 @@ namespace Terrain
         double getLastUsageTimeStamp() const { return mLastUsageTimeStamp; }
         void setLastUsageTimeStamp(double timeStamp) { mLastUsageTimeStamp = timeStamp; }
 
-        /// Indicates at least one mNode of mEntries has changed or the view point has moved beyond mReuseDistance.
+        /// Indicates at least one mNode of mEntries has changed.
         /// @note Such changes may necessitate a revalidation of cached mRenderingNodes elsewhere depending
         /// on the parameters that affect the creation of mRenderingNode.
         bool hasChanged() const { return mChanged; }


### PR DESCRIPTION
This PR aims to solve all issues with `Groundcover` view distance handling in a satisfying way while preserving other optimisations that benefit other features. The main idea here is not to rely on `ViewData` updates for distance culling calculations because we can not accurately determine distance against lazily updated views. Instead, we perform an accurate measurement in a cull callback we can run every frame in `Groundcover` itself. While we do have to add some code to handle this feature, it is quite loosely coupled code that could be useful elsewhere in the future. These changes should address a performance regression @akortunov experienced.