### PR TITLE
refactors ESMReader::setIndex

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -150,8 +150,6 @@ namespace MWBase
 
             virtual const MWWorld::ESMStore& getStore() const = 0;
 
-            virtual std::vector<ESM::ESMReader>& getEsmReader() = 0;
-
             virtual MWWorld::LocalScripts& getLocalScripts() = 0;
 
             virtual bool hasCellChanged() const = 0;

--- a/apps/openmw/mwworld/contentloader.hpp
+++ b/apps/openmw/mwworld/contentloader.hpp
@@ -2,6 +2,7 @@
 #define CONTENTLOADER_HPP
 
 #include <boost/filesystem/path.hpp>
+#include <MyGUI_TextIterator.h>
 
 #include <components/debug/debuglog.hpp>
 #include "components/loadinglistener/loadinglistener.hpp"
@@ -23,7 +24,7 @@ struct ContentLoader
     virtual void load(const boost::filesystem::path& filepath)
     {
         Log(Debug::Info) << "Loading content file " << filepath.string();
-        mListener.setLabel(filepath.string());
+        mListener.setLabel(MyGUI::TextIterator::toTagsString(filepath.string()));
     }
 
     protected:

--- a/apps/openmw/mwworld/contentloader.hpp
+++ b/apps/openmw/mwworld/contentloader.hpp
@@ -2,7 +2,6 @@
 #define CONTENTLOADER_HPP
 
 #include <boost/filesystem/path.hpp>
-#include <MyGUI_TextIterator.h>
 
 #include <components/debug/debuglog.hpp>
 #include "components/loadinglistener/loadinglistener.hpp"
@@ -21,10 +20,10 @@ struct ContentLoader
     {
     }
 
-    virtual void load(const boost::filesystem::path& filepath, int& index)
+    virtual void load(const boost::filesystem::path& filepath)
     {
         Log(Debug::Info) << "Loading content file " << filepath.string();
-        mListener.setLabel(MyGUI::TextIterator::toTagsString(filepath.string()));
+        mListener.setLabel(filepath.string());
     }
 
     protected:

--- a/apps/openmw/mwworld/esmloader.cpp
+++ b/apps/openmw/mwworld/esmloader.cpp
@@ -35,19 +35,20 @@ EsmLoader::EsmLoader(MWWorld::ESMStore& store, std::vector<ESM::ESMReader>& read
 {
 }
 
-void EsmLoader::load(const boost::filesystem::path& filepath, int& index)
+void EsmLoader::load(const boost::filesystem::path& filepath)
 {
-  ContentLoader::load(filepath.filename(), index);
+  ContentLoader::load(filepath.filename());
 
   ESM::ESMReader lEsm;
   lEsm.setEncoder(mEncoder);
-  lEsm.setIndex(index);
+  lEsm.setIndex(mEsm.size());
   lEsm.open(filepath.string());
   lEsm.resolveParentFileIndices(mEsm);
-  mEsm[index] = lEsm;
-  mStore.load(mEsm[index], &mListener);
+  mEsm.push_back(lEsm);
+  mStore.load(mEsm.back(), &mListener);
 }
 
+    // TODO: This code has no business here and should be moved.
     void convertMagicEffects(ESM::CreatureStats& creatureStats, ESM::InventoryState& inventory, ESM::NpcStats* npcStats)
     {
         const auto& store = MWBase::Environment::get().getWorld()->getStore();

--- a/apps/openmw/mwworld/esmloader.cpp
+++ b/apps/openmw/mwworld/esmloader.cpp
@@ -42,6 +42,7 @@ void EsmLoader::load(const boost::filesystem::path& filepath)
   ESM::ESMReader lEsm;
   lEsm.setEncoder(mEncoder);
   lEsm.open(filepath.string());
+  lEsm.setIndex(mEsm.size());
   mEsm.push_back(lEsm);
   mEsm.back().resolveParentFileIndices(mEsm);
   mStore.load(mEsm.back(), &mListener);

--- a/apps/openmw/mwworld/esmloader.cpp
+++ b/apps/openmw/mwworld/esmloader.cpp
@@ -41,10 +41,9 @@ void EsmLoader::load(const boost::filesystem::path& filepath)
 
   ESM::ESMReader lEsm;
   lEsm.setEncoder(mEncoder);
-  lEsm.setIndex(mEsm.size());
   lEsm.open(filepath.string());
-  lEsm.resolveParentFileIndices(mEsm);
   mEsm.push_back(lEsm);
+  mEsm.back().resolveParentFileIndices(mEsm);
   mStore.load(mEsm.back(), &mListener);
 }
 

--- a/apps/openmw/mwworld/esmloader.hpp
+++ b/apps/openmw/mwworld/esmloader.hpp
@@ -28,7 +28,7 @@ struct EsmLoader : public ContentLoader
     EsmLoader(MWWorld::ESMStore& store, std::vector<ESM::ESMReader>& readers,
       ToUTF8::Utf8Encoder* encoder, Loading::Listener& listener);
 
-    void load(const boost::filesystem::path& filepath, int& index) override;
+    void load(const boost::filesystem::path& filepath) override;
 
     private:
       std::vector<ESM::ESMReader>& mEsm;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2992,7 +2992,7 @@ namespace MWWorld
                 throw std::runtime_error(message);
             }
 
-            mEsm.back().setIndex(idx);
+            idx++;
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2991,7 +2991,7 @@ namespace MWWorld
                 std::string message = "Failed loading " + file + ": the groundcover file does not exist";
                 throw std::runtime_error(message);
             }
-            idx++;
+            mEsm.back().setIndex(idx);
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2991,7 +2991,6 @@ namespace MWWorld
                 std::string message = "Failed loading " + file + ": the groundcover file does not exist";
                 throw std::runtime_error(message);
             }
-
             idx++;
         }
     }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2991,6 +2991,7 @@ namespace MWWorld
                 std::string message = "Failed loading " + file + ": the groundcover file does not exist";
                 throw std::runtime_error(message);
             }
+
             mEsm.back().setIndex(idx);
         }
     }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -2959,7 +2959,6 @@ namespace MWWorld
     void World::loadContentFiles(const Files::Collections& fileCollections,
         const std::vector<std::string>& content, const std::vector<std::string>& groundcover, ContentLoader& contentLoader)
     {
-        int idx = 0;
         for (const std::string &file : content)
         {
             boost::filesystem::path filename(file);
@@ -2973,10 +2972,9 @@ namespace MWWorld
                 std::string message = "Failed loading " + file + ": the content file does not exist";
                 throw std::runtime_error(message);
             }
-            idx++;
         }
 
-        ESM::GroundcoverIndex = idx;
+        ESM::GroundcoverIndex = mEsm.size();
 
         for (const std::string &file : groundcover)
         {
@@ -2991,7 +2989,6 @@ namespace MWWorld
                 std::string message = "Failed loading " + file + ": the groundcover file does not exist";
                 throw std::runtime_error(message);
             }
-            idx++;
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -91,12 +91,12 @@ namespace MWWorld
             return mLoaders.insert(std::make_pair(extension, loader)).second;
         }
 
-        void load(const boost::filesystem::path& filepath, int& index) override
+        void load(const boost::filesystem::path& filepath) override
         {
             LoadersContainer::iterator it(mLoaders.find(Misc::StringUtils::lowerCase(filepath.extension().string())));
             if (it != mLoaders.end())
             {
-                it->second->load(filepath, index);
+                it->second->load(filepath);
             }
             else
             {
@@ -115,9 +115,9 @@ namespace MWWorld
     {
         ESMStore& mStore;
         OMWScriptsLoader(Loading::Listener& listener, ESMStore& store) : ContentLoader(listener), mStore(store) {}
-        void load(const boost::filesystem::path& filepath, int& index) override
+        void load(const boost::filesystem::path& filepath) override
         {
-            ContentLoader::load(filepath.filename(), index);
+            ContentLoader::load(filepath.filename());
             mStore.addOMWScripts(filepath.string());
         }
     };
@@ -154,7 +154,6 @@ namespace MWWorld
       mLevitationEnabled(true), mGoToJail(false), mDaysInPrison(0),
       mPlayerTraveling(false), mPlayerInJail(false), mSpellPreloadTimer(0.f)
     {
-        mEsm.resize(contentFiles.size() + groundcoverFiles.size());
         Loading::Listener* listener = MWBase::Environment::get().getWindowManager()->getLoadingScreen();
         listener->loadingOn();
 
@@ -626,11 +625,6 @@ namespace MWWorld
     const MWWorld::ESMStore& World::getStore() const
     {
         return mStore;
-    }
-
-    std::vector<ESM::ESMReader>& World::getEsmReader()
-    {
-        return mEsm;
     }
 
     LocalScripts& World::getLocalScripts()
@@ -2972,7 +2966,7 @@ namespace MWWorld
             const Files::MultiDirCollection& col = fileCollections.getCollection(filename.extension().string());
             if (col.doesExist(file))
             {
-                contentLoader.load(col.getPath(file), idx);
+                contentLoader.load(col.getPath(file));
             }
             else
             {
@@ -2990,7 +2984,7 @@ namespace MWWorld
             const Files::MultiDirCollection& col = fileCollections.getCollection(filename.extension().string());
             if (col.doesExist(file))
             {
-                contentLoader.load(col.getPath(file), idx);
+                contentLoader.load(col.getPath(file));
             }
             else
             {

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -239,8 +239,6 @@ namespace MWWorld
 
             const MWWorld::ESMStore& getStore() const override;
 
-            std::vector<ESM::ESMReader>& getEsmReader() override;
-
             LocalScripts& getLocalScripts() override;
 
             bool hasCellChanged() const override;

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -59,6 +59,14 @@ void ESMReader::clearCtx()
 
 void ESMReader::resolveParentFileIndices(const std::vector<ESMReader>& allPlugins)
 {
+    mCtx.index = -1;
+    for (size_t i=0; i<allPlugins.size(); ++i)
+    {
+        if (&allPlugins[i] == this)
+            mCtx.index = i;
+    }
+    assert(mCtx.index != -1);
+
     mCtx.parentFileIndices.clear();
     const std::vector<Header::MasterData> &masters = getGameFiles();
     for (size_t j = 0; j < masters.size(); j++) {

--- a/components/esm/esmreader.cpp
+++ b/components/esm/esmreader.cpp
@@ -59,14 +59,6 @@ void ESMReader::clearCtx()
 
 void ESMReader::resolveParentFileIndices(const std::vector<ESMReader>& allPlugins)
 {
-    mCtx.index = -1;
-    for (size_t i=0; i<allPlugins.size(); ++i)
-    {
-        if (&allPlugins[i] == this)
-            mCtx.index = i;
-    }
-    assert(mCtx.index != -1);
-
     mCtx.parentFileIndices.clear();
     const std::vector<Header::MasterData> &masters = getGameFiles();
     for (size_t j = 0; j < masters.size(); j++) {

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -77,7 +77,7 @@ public:
 
   /// Sets the position of this ESMReader in allPlugins as required for handling moved,
   /// deleted and edited CellRefs as well as terrain palettes.
-  /// @note Automatically set by resolveParentFileIndices.
+  /// @note Must be called before resolveParentFileIndices.
   void setIndex(const int index) { mCtx.index = index;}
   int getIndex() const {return mCtx.index;}
 
@@ -86,7 +86,6 @@ public:
   // as required for handling moved, deleted and edited CellRefs.
   /// @note Does not validate.
   /// @note open() must be called first.
-  /// @note this ESMReader must be contained in allPlugins.
   void resolveParentFileIndices(const std::vector<ESMReader>& allPlugins);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
   bool isValidParentFileIndex(int i) const { return i != getIndex(); }

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -85,7 +85,8 @@ public:
   // all files/readers used by the engine. This is required for correct adjustRefNum() results
   // as required for handling moved, deleted and edited CellRefs.
   /// @note Does not validate.
-  /// @note open() must be called first. 
+  /// @note open() must be called first.
+  /// @note this ESMReader must be contained in allPlugins.
   void resolveParentFileIndices(const std::vector<ESMReader>& allPlugins);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
   bool isValidParentFileIndex(int i) const { return i != getIndex(); }

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -75,18 +75,18 @@ public:
   /// Get the current position in the file. Make sure that the file has been opened!
   size_t getFileOffset() const { return mEsm->tellg(); };
 
-  // This is a quick hack for multiple esm/esp files. Each plugin introduces its own
-  //  terrain palette, but ESMReader does not pass a reference to the correct plugin
-  //  to the individual load() methods. This hack allows to pass this reference
-  //  indirectly to the load() method.
+  /// Sets the position of this ESMReader in allPlugins as required for handling moved,
+  /// deleted and edited CellRefs as well as terrain palettes.
+  /// @note Automatically set by resolveParentFileIndices.
   void setIndex(const int index) { mCtx.index = index;}
   int getIndex() const {return mCtx.index;}
 
-  // Assign parent esX files by tracking their indices in the global list of
+  // Assign parent esX files by tracking their indices in the list of
   // all files/readers used by the engine. This is required for correct adjustRefNum() results
   // as required for handling moved, deleted and edited CellRefs.
   /// @note Does not validate.
-  void resolveParentFileIndices(const std::vector<ESMReader>& files);
+  /// @note open() must be called first. 
+  void resolveParentFileIndices(const std::vector<ESMReader>& allPlugins);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
   bool isValidParentFileIndex(int i) const { return i != getIndex(); }
 

--- a/components/esm/esmreader.hpp
+++ b/components/esm/esmreader.hpp
@@ -85,7 +85,7 @@ public:
   // all files/readers used by the engine. This is required for correct adjustRefNum() results
   // as required for handling moved, deleted and edited CellRefs.
   /// @note Does not validate.
-  /// @note open() must be called first.
+  /// @note open() and setIndex() must be called first.
   void resolveParentFileIndices(const std::vector<ESMReader>& allPlugins);
   const std::vector<int>& getParentFileIndices() const { return mCtx.parentFileIndices; }
   bool isValidParentFileIndex(int i) const { return i != getIndex(); }


### PR DESCRIPTION
With this PR we remove redundant variables, reduce scope, improve comments and avoid unnecessary instantiations of `ESMReader`s for `.omwscripts`. In addition, these changes should repair a semi broken use case that @petrmikheev has required in upcoming work. I would appreciate any testing in that context.