### PR TITLE
restores _mergeAlphaBlending behaviour

### DIFF
--- a/components/sceneutil/optimizer.cpp
+++ b/components/sceneutil/optimizer.cpp
@@ -1137,7 +1137,7 @@ bool isAbleToMerge(const osg::Geometry& g1, const osg::Geometry& g2)
 
 bool Optimizer::MergeGeometryVisitor::pushStateSet(osg::StateSet *stateSet)
 {
-    if (_mergeAlphaBlending || !stateSet || stateSet->getRenderBinMode() & osg::StateSet::INHERIT_RENDERBIN_DETAILS)
+    if (!stateSet || stateSet->getRenderBinMode() & osg::StateSet::INHERIT_RENDERBIN_DETAILS)
         return false;
     _stateSetStack.push_back(stateSet);
     checkAlphaBlendingActive();


### PR DESCRIPTION
This PR restores a minor peculiarity of `_mergeAlphaBlending` behaviour unintentionally changed by PR #3162.