### PR TITLE
fixes LightBufferBinding messages

### DIFF
--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -152,7 +152,7 @@ namespace MWRender
          mStateset->setAttribute(new osg::VertexAttribDivisor(6, 1));
          mStateset->setAttribute(new osg::VertexAttribDivisor(7, 1));
 
-         mProgramTemplate = mSceneManager->getShaderManager().getProgramTemplate() ? static_cast<osg::Program*>(mSceneManager->getShaderManager().getProgramTemplate()->clone(osg::CopyOp::SHALLOW_COPY)) : new osg::Program;
+         mProgramTemplate = mSceneManager->getShaderManager().getProgramTemplate() ? Shader::ShaderManager::cloneProgram(mSceneManager->getShaderManager().getProgramTemplate()) : new osg::Program;
          mProgramTemplate->addBindAttribLocation("aOffset", 6);
          mProgramTemplate->addBindAttribLocation("aRotation", 7);
     }

--- a/apps/openmw/mwrender/groundcover.cpp
+++ b/apps/openmw/mwrender/groundcover.cpp
@@ -152,7 +152,7 @@ namespace MWRender
          mStateset->setAttribute(new osg::VertexAttribDivisor(6, 1));
          mStateset->setAttribute(new osg::VertexAttribDivisor(7, 1));
 
-         mProgramTemplate = mSceneManager->getShaderManager().getProgramTemplate() ? Shader::ShaderManager::cloneProgram(mSceneManager->getShaderManager().getProgramTemplate()) : new osg::Program;
+         mProgramTemplate = mSceneManager->getShaderManager().getProgramTemplate() ? Shader::ShaderManager::cloneProgram(mSceneManager->getShaderManager().getProgramTemplate()) : osg::ref_ptr<osg::Program>(new osg::Program);
          mProgramTemplate->addBindAttribLocation("aOffset", 6);
          mProgramTemplate->addBindAttribLocation("aRotation", 7);
     }

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -356,7 +356,7 @@ namespace Shader
     osg::ref_ptr<osg::Program> ShaderManager::cloneProgram(const osg::Program* src)
     {
         osg::ref_ptr<osg::Program> program = static_cast<osg::Program*>(src->clone(osg::CopyOp::SHALLOW_COPY));
-        for (auto [name, idx] : src->getUniformBlockBindingList();
+        for (auto [name, idx] : src->getUniformBlockBindingList())
             program->addBindUniformBlock(name, idx);
         return program;
     }

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -345,12 +345,20 @@ namespace Shader
         if (found == mPrograms.end())
         {
             if (!programTemplate) programTemplate = mProgramTemplate;
-            osg::ref_ptr<osg::Program> program = programTemplate ? static_cast<osg::Program*>(programTemplate->clone(osg::CopyOp::SHALLOW_COPY)) : new osg::Program;
+            osg::ref_ptr<osg::Program> program = programTemplate ? cloneProgram(programTemplate) : new osg::Program;
             program->addShader(vertexShader);
             program->addShader(fragmentShader);
             found = mPrograms.insert(std::make_pair(std::make_pair(vertexShader, fragmentShader), program)).first;
         }
         return found->second;
+    }
+
+    osg::ref_ptr<osg::Program> ShaderManager::cloneProgram(const osg::Program* src)
+    {
+        osg::ref_ptr<osg::Program> program = static_cast<osg::Program*>(src->clone(osg::CopyOp::SHALLOW_COPY));
+        for (auto [name, idx] : src->getUniformBlockBindingList();
+            program->addBindUniformBlock(name, idx);
+        return program;
     }
 
     ShaderManager::DefineMap ShaderManager::getGlobalDefines()

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -345,7 +345,7 @@ namespace Shader
         if (found == mPrograms.end())
         {
             if (!programTemplate) programTemplate = mProgramTemplate;
-            osg::ref_ptr<osg::Program> program = programTemplate ? cloneProgram(programTemplate) : new osg::Program;
+            osg::ref_ptr<osg::Program> program = (programTemplate != nullptr) ? cloneProgram(programTemplate) : new osg::Program;
             program->addShader(vertexShader);
             program->addShader(fragmentShader);
             found = mPrograms.insert(std::make_pair(std::make_pair(vertexShader, fragmentShader), program)).first;

--- a/components/shader/shadermanager.cpp
+++ b/components/shader/shadermanager.cpp
@@ -345,7 +345,7 @@ namespace Shader
         if (found == mPrograms.end())
         {
             if (!programTemplate) programTemplate = mProgramTemplate;
-            osg::ref_ptr<osg::Program> program = (programTemplate != nullptr) ? cloneProgram(programTemplate) : new osg::Program;
+            osg::ref_ptr<osg::Program> program = programTemplate ? cloneProgram(programTemplate) : osg::ref_ptr<osg::Program>(new osg::Program);
             program->addShader(vertexShader);
             program->addShader(fragmentShader);
             found = mPrograms.insert(std::make_pair(std::make_pair(vertexShader, fragmentShader), program)).first;

--- a/components/shader/shadermanager.hpp
+++ b/components/shader/shadermanager.hpp
@@ -39,7 +39,7 @@ namespace Shader
         void setProgramTemplate(const osg::Program* program) { mProgramTemplate = program; }
 
         /// Clone an osg::Program including bindUniformBlocks that osg::Program::clone does not copy for some reason.
-        osg::ref_ptr<osg::Program> cloneProgram(const osg::Program*) const;
+        static osg::ref_ptr<osg::Program> cloneProgram(const osg::Program*) const;
 
         /// Get (a copy of) the DefineMap used to construct all shaders
         DefineMap getGlobalDefines();

--- a/components/shader/shadermanager.hpp
+++ b/components/shader/shadermanager.hpp
@@ -38,6 +38,9 @@ namespace Shader
         const osg::Program* getProgramTemplate() const { return mProgramTemplate; }
         void setProgramTemplate(const osg::Program* program) { mProgramTemplate = program; }
 
+        /// Clone an osg::Program including bindUniformBlocks that osg::Program::clone does not copy for some reason.
+        osg::ref_ptr<osg::Program> cloneProgram(const osg::Program*) const;
+
         /// Get (a copy of) the DefineMap used to construct all shaders
         DefineMap getGlobalDefines();
 

--- a/components/shader/shadermanager.hpp
+++ b/components/shader/shadermanager.hpp
@@ -39,7 +39,7 @@ namespace Shader
         void setProgramTemplate(const osg::Program* program) { mProgramTemplate = program; }
 
         /// Clone an osg::Program including bindUniformBlocks that osg::Program::clone does not copy for some reason.
-        static osg::ref_ptr<osg::Program> cloneProgram(const osg::Program*) const;
+        static osg::ref_ptr<osg::Program> cloneProgram(const osg::Program*);
 
         /// Get (a copy of) the DefineMap used to construct all shaders
         DefineMap getGlobalDefines();


### PR DESCRIPTION
This PR aims to solve `uniform block LightBufferBinding has no binding` messages @glassmancody has reportedly encountered since PR #3110 due to an apparent bug in OSG. While we do have to add a workaround here that adds a bit of clunkiness, #3216 should allow us to clean up these interactions a bit in the future.