### PR TITLE
Do not display effects duration for ingredients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
     Bug #6473: Strings from NIF should be parsed only to first null terminator
     Bug #6493: Unlocking owned but not locked or unlocked containers is considered a crime
     Bug #6517: Rotations for KeyframeData in NIFs should be optional
+    Bug #6519: Effects tooltips for ingredients work incorrectly
     Feature #890: OpenMW-CS: Column filtering
     Feature #1465: "Reset" argument for AI functions
     Feature #2554: Modifying an object triggers the instances table to scroll to the corresponding record

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -493,6 +493,7 @@ namespace MWGui
             std::vector<MyGUI::Widget*> effectItems;
             int flag = info.isPotion ? Widgets::MWEffectList::EF_NoTarget : 0;
             flag |= info.isIngredient ? Widgets::MWEffectList::EF_NoMagnitude : 0;
+            flag |= info.isIngredient ? Widgets::MWEffectList::EF_Constant : 0;
             effectsWidget->createEffectWidgets(effectItems, effectArea, coord, true, flag);
             totalSize.height += coord.top-6;
             totalSize.width = std::max(totalSize.width, coord.width);


### PR DESCRIPTION
Fixes [bug #6519](https://gitlab.com/OpenMW/openmw/-/issues/6519) by explicitely disabling duration displaying for ingredients effects.

Note that probably `EF_NoDuration` name may be better than `EF_Constant`.

May be worth to cherry-pick this patch to 0.47 branch if we aim to minor release.