### PR TITLE
Enhance savegame slot datetimes and hours played.

### DIFF
--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -369,10 +369,22 @@ namespace MWGui
         int seconds = timePlayed % 60;
 
         std::stringstream stream;
-        stream << std::setfill('0') << std::setw(2) << days << ":";
-        stream << std::setfill('0') << std::setw(2) << hours << ":";
-        stream << std::setfill('0') << std::setw(2) << minutes << ":";
-        stream << std::setfill('0') << std::setw(2) << seconds;
+        if (days > 0)
+        {
+            stream << days << "d ";
+        }
+        if (hours > 0)
+        {
+            stream << hours << "h ";
+        }
+        if (minutes > 0)
+        {
+            stream << std::setfill('0') << std::setw(2) << minutes << "m ";
+        }
+        if (seconds > 0)
+        {
+            stream << std::setfill('0') << std::setw(2) << seconds << "s";
+        }
         return stream.str();
     }
 

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -360,7 +360,7 @@ namespace MWGui
             onSlotSelected(mSaveList, MyGUI::ITEM_NONE);
     }
 
-    std::string formatTimeplayed(const double timeInSeconds)
+    std::string formatTimePlayed(const double timeInSeconds)
     {
         int timePlayed = (int)floor(timeInSeconds);
         int days = timePlayed / 60 / 60 / 24;
@@ -402,6 +402,7 @@ namespace MWGui
         if (!mCurrentSlot)
             throw std::runtime_error("Can't find selected slot");
 
+        // Add real world datetime of last played.
         std::stringstream text;
         time_t time = mCurrentSlot->mTimeStamp;
         struct tm* timeinfo;
@@ -409,6 +410,7 @@ namespace MWGui
 
         text << std::put_time(timeinfo, "%Y.%m.%d %T") << "\n";
 
+        // Add ingame location.
         text << "#{sLevel} " << mCurrentSlot->mProfile.mPlayerLevel << "\n";
         text << "#{sCell=" << mCurrentSlot->mProfile.mPlayerCell << "}\n";
 
@@ -417,6 +419,7 @@ namespace MWGui
         if (hour >= 13) hour -= 12;
         if (hour == 0) hour = 12;
 
+        // Add ingame datetime info, like time, month, etc.
         text
             << mCurrentSlot->mProfile.mInGameTime.mDay << " "
             << MWBase::Environment::get().getWorld()->getMonthName(mCurrentSlot->mProfile.mInGameTime.mMonth)
@@ -424,7 +427,7 @@ namespace MWGui
 
         if (Settings::Manager::getBool("timeplayed","Saves"))
         {
-            text << "\n" << "Time played: " << formatTimeplayed(mCurrentSlot->mProfile.mTimePlayed);
+            text << "\n" << "Time played: " << formatTimePlayed(mCurrentSlot->mProfile.mTimePlayed);
         }
 
         mInfoText->setCaptionWithReplacing(text.str());

--- a/apps/openmw/mwgui/savegamedialog.cpp
+++ b/apps/openmw/mwgui/savegamedialog.cpp
@@ -402,17 +402,18 @@ namespace MWGui
         if (!mCurrentSlot)
             throw std::runtime_error("Can't find selected slot");
 
-        // Add real world datetime of last played.
-        std::stringstream text;
+        std::stringstream savegameMetadata;
+
+        // Add real world datetime for last played.
         time_t time = mCurrentSlot->mTimeStamp;
         struct tm* timeinfo;
         timeinfo = localtime(&time);
 
-        text << std::put_time(timeinfo, "%Y.%m.%d %T") << "\n";
+        savegameMetadata << std::put_time(timeinfo, "%b%e, %Y %r %p") << "\n";
 
         // Add ingame location.
-        text << "#{sLevel} " << mCurrentSlot->mProfile.mPlayerLevel << "\n";
-        text << "#{sCell=" << mCurrentSlot->mProfile.mPlayerCell << "}\n";
+        savegameMetadata << "#{sLevel} " << mCurrentSlot->mProfile.mPlayerLevel << "\n";
+        savegameMetadata << "#{sCell=" << mCurrentSlot->mProfile.mPlayerCell << "}\n";
 
         int hour = int(mCurrentSlot->mProfile.mInGameTime.mGameHour);
         bool pm = hour >= 12;
@@ -420,17 +421,17 @@ namespace MWGui
         if (hour == 0) hour = 12;
 
         // Add ingame datetime info, like time, month, etc.
-        text
+        savegameMetadata
             << mCurrentSlot->mProfile.mInGameTime.mDay << " "
             << MWBase::Environment::get().getWorld()->getMonthName(mCurrentSlot->mProfile.mInGameTime.mMonth)
             <<  " " << hour << " " << (pm ? "#{sSaveMenuHelp05}" : "#{sSaveMenuHelp04}");
 
         if (Settings::Manager::getBool("timeplayed","Saves"))
         {
-            text << "\n" << "Time played: " << formatTimePlayed(mCurrentSlot->mProfile.mTimePlayed);
+            savegameMetadata << "\n" << "Time played: " << formatTimePlayed(mCurrentSlot->mProfile.mTimePlayed);
         }
 
-        mInfoText->setCaptionWithReplacing(text.str());
+        mInfoText->setCaptionWithReplacing(savegameMetadata.str());
 
 
         // Decode screenshot


### PR DESCRIPTION
### Issue \#
- None, I just thought I could make a small improvement.

### Changes Made
- Make "last played" and "time played" sections a little more human-readable.
- Renamed `formatTimeplayed` to `formatTimePlayed` to be consistent with camel-case style.
- Added a couple comments to logic sections. These can be removed, they were just to help me.

### Before
![slot time formatting before](https://user-images.githubusercontent.com/6403586/166159293-df1bea96-b3b4-4ecd-847a-b2fd360ca50e.PNG)

### After
![slot time formatting after](https://user-images.githubusercontent.com/6403586/166159297-91c00183-e867-4fbc-a7be-a5f9ffc65dc0.PNG)

### Testing
- Only manual visual testing. I could make automated tests for this if necessary!
