### PR TITLE
fixed compile on windows and link using vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,19 @@
 cmake_minimum_required(VERSION 3.1.0)
 
+# when using vcpkg with visual studio code on windows, ensure you have the file `.vscode/settings.json`
+# which contains at minimum the following three lines (including the trailing comma):
+#     "cmake.configureSettings": {
+#         "CMAKE_TOOLCHAIN_FILE": "<INSTALL LOCATION>/vcpkg/scripts/buildsystems/vcpkg.cmake"
+#     },
+# where <INSTALL LOCATION> is where you installed vcpkg; this is how cmake knows to use vcpkg
+
+# variable to easily check if vcpkg is being used
+if (CMAKE_TOOLCHAIN_FILE MATCHES ".*[vV][cC][pP][kK][gG].*")
+    set(USING_VCPKG TRUE)
+else ()
+    set(USING_VCPKG FALSE)
+endif ()
+
 # for link time optimization, remove if cmake version is >= 3.9
 if(POLICY CMP0069) # LTO
     cmake_policy(SET CMP0069 NEW)
@@ -150,7 +164,8 @@ endif()
 option(OSG_STATIC "Link static build of OpenSceneGraph into the binaries" ${_osg_static_default})
 
 option(OPENMW_USE_SYSTEM_MYGUI "Use system provided mygui library" ON)
-if(OPENMW_USE_SYSTEM_MYGUI)
+# on windows the "system provided" mygui from vcpkg is static
+if(OPENMW_USE_SYSTEM_MYGUI AND NOT USING_VCPKG)
     set(_mygui_static_default OFF)
 else()
     set(_mygui_static_default ON)
@@ -276,7 +291,7 @@ if(NOT COLLADA_DOM_VERSION_MINOR)
     set(COLLADA_DOM_VERSION_MINOR 5)
 endif()
 
-find_package(collada_dom 2.5)
+find_package(collada-dom 2.5)
 
 option(OPENMW_USE_SYSTEM_ICU "Use system ICU library instead of internal. If disabled, requires autotools" ON)
 if(OPENMW_USE_SYSTEM_ICU)
@@ -720,7 +735,7 @@ if (WIN32)
         4996 # Function was declared deprecated
         5054 # Deprecated operations between enumerations of different types caused by Qt headers
         )
-    
+
     if( "${MyGUI_VERSION}" VERSION_LESS_EQUAL "3.4.0" )
         set(WARNINGS_DISABLE ${WARNINGS_DISABLE}
         4866 # compiler may not enforce left-to-right evaluation order for call
@@ -743,7 +758,7 @@ if (WIN32)
 
     set_target_properties(components PROPERTIES COMPILE_FLAGS "${WARNINGS}")
     set_target_properties(osg-ffmpeg-videoplayer PROPERTIES COMPILE_FLAGS "${WARNINGS}")
-    
+
     if (MSVC_VERSION GREATER_EQUAL 1915 AND MSVC_VERSION LESS 1920)
         target_compile_definitions(components INTERFACE _ENABLE_EXTENDED_ALIGNED_STORAGE)
     endif()

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -151,6 +151,7 @@ target_link_libraries(openmw
     ${MyGUI_LIBRARIES}
     ${SDL2_LIBRARY}
     ${RecastNavigation_LIBRARIES}
+    "freetype"
     "osg-ffmpeg-videoplayer"
     "oics"
     components

--- a/cmake/FindLuaJit.cmake
+++ b/cmake/FindLuaJit.cmake
@@ -7,8 +7,8 @@ include(LibFindMacros)
 
 libfind_pkg_detect(LuaJit luajit
         FIND_PATH luajit.h PATH_SUFFIXES luajit luajit-2.1
-        FIND_LIBRARY luajit-5.1 luajit
+        # note: vcpkg builds luatjit-5.1 as lua51
+        FIND_LIBRARY lua51 luajit-5.1 luajit
         )
 
 libfind_process(LuaJit)
-

--- a/cmake/Findcollada-dom.cmake
+++ b/cmake/Findcollada-dom.cmake
@@ -1,0 +1,325 @@
+
+# Locate Collada
+# This module defines:
+# COLLADA_INCLUDE_DIR, where to find the headers
+#
+# COLLADA_LIBRARY, COLLADA_LIBRARY_DEBUG
+# COLLADA_FOUND, if false, do not try to link to Collada dynamically
+#
+# COLLADA_LIBRARY_STATIC, COLLADA_LIBRARY_STATIC_DEBUG
+# COLLADA_STATIC_FOUND, if false, do not try to link to Collada statically
+#
+# $COLLADA_DIR is an environment variable that would
+# correspond to the ./configure --prefix=$COLLADA_DIR
+#
+# Created by Robert Osfield.
+
+
+# Check if COLLADA_DIR is set, otherwise use ACTUAL_3DPARTY_DIR:
+SET( COLLADA_ENV_VAR_AVAILABLE $ENV{COLLADA_DIR} )
+IF ( COLLADA_ENV_VAR_AVAILABLE )
+    SET(COLLADA_DOM_ROOT "$ENV{COLLADA_DIR}/dom" CACHE PATH "Location of Collada DOM directory" FORCE)
+ELSE ()
+    SET(COLLADA_DOM_ROOT "${ACTUAL_3DPARTY_DIR}/include/1.4/dom" CACHE PATH "Location of Collada DOM directory" FORCE)
+ENDIF()
+
+
+IF(APPLE)
+    SET(COLLADA_BUILDNAME "mac")
+    SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+ELSEIF(MINGW)
+    SET(COLLADA_BUILDNAME "mingw")
+    SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+ELSEIF((MSVC_VERSION GREATER 1910) OR (MSVC_VERSION EQUAL 1910))
+    SET(COLLADA_BUILDNAME "vc14")
+    SET(COLLADA_BOOST_BUILDNAME "vc141")
+ELSEIF(MSVC_VERSION EQUAL 1900)
+    SET(COLLADA_BUILDNAME "vc14")
+    SET(COLLADA_BOOST_BUILDNAME "vc140")
+ELSEIF(MSVC_VERSION EQUAL 1800)
+    SET(COLLADA_BUILDNAME "vc12")
+    SET(COLLADA_BOOST_BUILDNAME "vc120")
+ELSEIF(MSVC_VERSION EQUAL 1700)
+    SET(COLLADA_BUILDNAME "vc11")
+    SET(COLLADA_BOOST_BUILDNAME "vc110")
+ELSEIF(MSVC_VERSION EQUAL 1600)
+    SET(COLLADA_BUILDNAME "vc10")
+    SET(COLLADA_BOOST_BUILDNAME "vc100")
+ELSEIF(MSVC_VERSION EQUAL 1500)
+    SET(COLLADA_BUILDNAME "vc9")
+    SET(COLLADA_BOOST_BUILDNAME "vc90")
+ELSEIF(MSVC_VERSION EQUAL 1400)
+    SET(COLLADA_BUILDNAME "vc8")
+    SET(COLLADA_BOOST_BUILDNAME "vc80")
+ELSE()
+  SET(COLLADA_BUILDNAME "linux")
+  SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+ENDIF()
+
+IF(${CMAKE_VS_PLATFORM_TOOLSET})
+    string(REPLACE "v" "vc" COLLADA_BOOST_BUILDNAME ${CMAKE_VS_PLATFORM_TOOLSET})
+ENDIF()
+
+
+FIND_PATH(COLLADA_INCLUDE_DIR dae.h
+    PATHS
+    ${COLLADA_DOM_ROOT}/include
+    $ENV{COLLADA_DIR}/include
+    $ENV{COLLADA_DIR}
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt/local/Library/Frameworks #macports
+    /usr/local/include
+    /usr/include/
+    /sw/include # Fink
+    /opt/local/include # DarwinPorts
+    /opt/csw/include # Blastwave
+    /opt/include
+    /usr/freeware/include
+    ${ACTUAL_3DPARTY_DIR}/include
+    PATH_SUFFIXES
+    colladadom
+    collada-dom
+    collada-dom2.5
+    collada-dom2.4
+    collada-dom2.2
+)
+
+FIND_LIBRARY(COLLADA_DYNAMIC_LIBRARY
+    NAMES collada_dom collada14dom Collada14Dom libcollada14dom21 libcollada14dom22 collada-dom2.5-dp collada-dom2.5-dp-${COLLADA_BOOST_BUILDNAME}-mt collada-dom2.4-dp collada-dom2.4-dp-${COLLADA_BOOST_BUILDNAME}-mt
+    PATHS
+    ${COLLADA_DOM_ROOT}/build/${COLLADA_BUILDNAME}-1.4
+    ${COLLADA_DOM_ROOT}
+    $ENV{COLLADA_DIR}/build/${COLLADA_BUILDNAME}-1.4
+    $ENV{COLLADA_DIR}/lib
+    $ENV{COLLADA_DIR}/lib-dbg
+    $ENV{COLLADA_DIR}
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt/local/Library/Frameworks #macports
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/lib
+    /usr/lib64
+    /sw/lib
+    /opt/local/lib
+    /opt/csw/lib
+    /opt/lib
+    /usr/freeware/lib64
+    ${ACTUAL_3DPARTY_DIR}/lib
+)
+
+FIND_LIBRARY(COLLADA_DYNAMIC_LIBRARY_DEBUG
+    NAMES collada_dom-d collada14dom-d Collada14Dom-d libcollada14dom21-d libcollada14dom22-d  collada-dom2.5-dp-d collada-dom2.5-dp-${COLLADA_BOOST_BUILDNAME}-mt-d collada-dom2.4-dp-d collada-dom2.4-dp-${COLLADA_BOOST_BUILDNAME}-mt-d
+    PATHS
+    ${COLLADA_DOM_ROOT}/build/${COLLADA_BUILDNAME}-1.4-d
+    ${COLLADA_DOM_ROOT}
+    $ENV{COLLADA_DIR}/build/${COLLADA_BUILDNAME}-1.4-d
+    $ENV{COLLADA_DIR}/lib
+    $ENV{COLLADA_DIR}/lib-dbg
+    $ENV{COLLADA_DIR}
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt/local/Library/Frameworks #macports
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/lib
+    /usr/lib64
+    /sw/lib
+    /opt/local/lib
+    /opt/csw/lib
+    /opt/lib
+    /usr/freeware/lib64
+    ${ACTUAL_3DPARTY_DIR}/lib
+)
+
+FIND_LIBRARY(COLLADA_STATIC_LIBRARY
+    NAMES libcollada14dom21-s  libcollada14dom22-s libcollada14dom.a
+    PATHS
+    ${COLLADA_DOM_ROOT}/build/${COLLADA_BUILDNAME}-1.4
+    $ENV{COLLADA_DIR}/build/${COLLADA_BUILDNAME}-1.4
+    $ENV{COLLADA_DIR}/lib
+    $ENV{COLLADA_DIR}/lib-dbg
+    $ENV{COLLADA_DIR}
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt/local/Library/Frameworks #macports
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/lib
+    /usr/lib64
+    /sw/lib
+    /opt/local/lib
+    /opt/csw/lib
+    /opt/lib
+    /usr/freeware/lib64
+    ${ACTUAL_3DPARTY_DIR}/lib
+)
+
+FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
+    NAMES collada_dom-sd collada14dom-sd libcollada14dom21-sd libcollada14dom22-sd libcollada14dom-d.a
+    PATHS
+    ${COLLADA_DOM_ROOT}/build/${COLLADA_BUILDNAME}-1.4-d
+    $ENV{COLLADA_DIR}/build/${COLLADA_BUILDNAME}-1.4-d
+    $ENV{COLLADA_DIR}/lib
+    $ENV{COLLADA_DIR}/lib-dbg
+    $ENV{COLLADA_DIR}
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt/local/Library/Frameworks #macports
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/lib
+    /usr/lib64
+    /sw/lib
+    /opt/local/lib
+    /opt/csw/lib
+    /opt/lib
+    /usr/freeware/lib64
+    ${ACTUAL_3DPARTY_DIR}/lib
+)
+
+    # find extra libraries that the static linking requires
+
+    FIND_PACKAGE(LibXml2)
+    IF (LIBXML2_FOUND)
+        SET(COLLADA_LIBXML_LIBRARY "${LIBXML2_LIBRARIES}" CACHE FILEPATH "" FORCE)
+    ELSE(LIBXML2_FOUND)
+        IF(WIN32)
+            FIND_LIBRARY(COLLADA_LIBXML_LIBRARY
+                NAMES libxml2
+                PATHS
+                ${COLLADA_DOM_ROOT}/external-libs/libxml2/win32/lib
+                ${COLLADA_DOM_ROOT}/external-libs/libxml2/mingw/lib
+                ${ACTUAL_3DPARTY_DIR}/lib
+            )
+        ENDIF(WIN32)
+    ENDIF(LIBXML2_FOUND)
+
+    FIND_PACKAGE(ZLIB)
+    IF (ZLIB_FOUND)
+        IF (ZLIB_LIBRARY_RELEASE)
+            SET(COLLADA_ZLIB_LIBRARY "${ZLIB_LIBRARY_RELEASE}" CACHE FILEPATH "" FORCE)
+        ELSE(ZLIB_LIBRARY_RELEASE)
+            SET(COLLADA_ZLIB_LIBRARY "${ZLIB_LIBRARY}" CACHE FILEPATH "" FORCE)
+        ENDIF(ZLIB_LIBRARY_RELEASE)
+        IF (ZLIB_LIBRARY_DEBUG)
+            SET(COLLADA_ZLIB_LIBRARY_DEBUG "${ZLIB_LIBRARY_DEBUG}" CACHE FILEPATH "" FORCE)
+        ELSE(ZLIB_LIBRARY_DEBUG)
+            SET(COLLADA_ZLIB_LIBRARY_DEBUG "${COLLADA_ZLIB_LIBRARY}" CACHE FILEPATH "" FORCE)
+        ENDIF(ZLIB_LIBRARY_DEBUG)
+    ELSE(ZLIB_FOUND)
+        IF(WIN32)
+            FIND_LIBRARY(COLLADA_ZLIB_LIBRARY
+                NAMES zlib
+                PATHS
+                ${COLLADA_DOM_ROOT}/external-libs/libxml2/win32/lib
+                ${COLLADA_DOM_ROOT}/external-libs/libxml2/mingw/lib
+                ${ACTUAL_3DPARTY_DIR}/lib
+            )
+        ENDIF(WIN32)
+    ENDIF(ZLIB_FOUND)
+
+    FIND_LIBRARY(COLLADA_PCRECPP_LIBRARY
+        NAMES pcrecpp
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mac
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_PCRECPP_LIBRARY_DEBUG
+        NAMES pcrecpp-d pcrecppd
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mac
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_PCRE_LIBRARY
+        NAMES pcre
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mac
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_PCRE_LIBRARY_DEBUG
+        NAMES pcre-d pcred
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mac
+        ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_MINIZIP_LIBRARY
+        NAMES minizip
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/minizip/win32/lib
+        ${COLLADA_DOM_ROOT}/external-libs/minizip/mac
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_MINIZIP_LIBRARY_DEBUG
+        NAMES minizip-d minizipD
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/minizip/win32/lib
+        ${COLLADA_DOM_ROOT}/external-libs/minizip/mac
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_BOOST_FILESYSTEM_LIBRARY
+        NAMES libboost_filesystem boost_filesystem boost_filesystem-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_63
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_BOOST_FILESYSTEM_LIBRARY_DEBUG
+        NAMES libboost_filesystem-d boost_filesystem-d boost_filesystem-mt-d libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_63
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_BOOST_SYSTEM_LIBRARY
+        NAMES libboost_system boost_system boost_system-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_55  libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_63
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+    FIND_LIBRARY(COLLADA_BOOST_SYSTEM_LIBRARY_DEBUG
+        NAMES libboost_system-d boost_system-d boost_system-mt-d libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_55 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_63
+        PATHS
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
+        ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
+        ${ACTUAL_3DPARTY_DIR}/lib
+    )
+
+
+SET(COLLADA_FOUND "NO")
+IF(COLLADA_DYNAMIC_LIBRARY OR COLLADA_STATIC_LIBRARY)
+    IF   (COLLADA_INCLUDE_DIR)
+
+        SET(COLLADA_FOUND "YES")
+
+        FIND_PATH(COLLADA_INCLUDE_DOMANY_DIR 1.4/dom/domAny.h
+            ${COLLADA_INCLUDE_DIR}
+        )
+
+        IF (COLLADA_INCLUDE_DOMANY_DIR)
+            SET(COLLADA_DOM_2_4_OR_LATER TRUE)
+        ELSEIF()
+            SET(COLLADA_DOM_2_4_OR_LATER FALSE)
+        ENDIF()
+
+        ENDIF()
+ENDIF()

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -444,6 +444,7 @@ target_link_libraries(components
     smhasher
     ${ICU_LIBRARIES}
     yaml-cpp
+    "MyGUI.DummyPlatform"
     )
 
 if(Boost_VERSION_STRING VERSION_GREATER_EQUAL 1.77.0)

--- a/components/myguiplatform/myguirendermanager.cpp
+++ b/components/myguiplatform/myguirendermanager.cpp
@@ -518,8 +518,9 @@ namespace osgMyGUI
 
     MyGUI::ITexture* RenderManager::createTexture(const std::string& name)
     {
-        const auto it = mTextures.insert_or_assign(name, OSGTexture(name, mImageManager)).first;
-        return &it->second;
+        // OSGTexture has no move or copy ctor, cannot be inserted into the map TODO FIXME or use this ptr version
+        const auto it = mTextures.insert_or_assign(name, std::make_unique<OSGTexture>(name, mImageManager)).first;
+        return it->second.get();
     }
 
     void RenderManager::destroyTexture(MyGUI::ITexture* texture)
@@ -545,7 +546,8 @@ namespace osgMyGUI
             tex->loadFromFile(name);
             return tex;
         }
-        return &item->second;
+        // OSGTexture has no move or copy ctor, cannot be inserted into the map TODO FIXME or use this ptr version
+        return item->second.get();
     }
 
     bool RenderManager::checkTexture(MyGUI::ITexture* _texture)

--- a/components/myguiplatform/myguirendermanager.hpp
+++ b/components/myguiplatform/myguirendermanager.hpp
@@ -46,7 +46,8 @@ namespace osgMyGUI
         MyGUI::VertexColourType mVertexFormat;
         MyGUI::RenderTargetInfo mInfo;
 
-        std::map<std::string, OSGTexture> mTextures;
+        // OSGTexture has no move or copy ctor, cannot be inserted into the map TODO FIXME or use this ptr version
+        std::map<std::string, std::unique_ptr<OSGTexture>> mTextures;
 
         bool mIsInitialise;
 


### PR DESCRIPTION
fixed failure to compile using msvc (see components\myguiplatform\myguirendermanager.cpp:521 msvc won't construct_in_place into the map here (I don't know if clang/gcc standard library implementations do); because the rule of six is broken, class OSGTexture has no default move or copy constructors, and thus fails to compile when attempting to move/copy an object here)

also updated cmake files to link with vcpkg managed libraries (slight name discrepancies such as in luajit5.1 being built as lua51 and collada-dom vs collada_dom, and system provided mygui is static)