### PR TITLE
Wrong type expected in crimes.lua

### DIFF
--- a/files/data/scripts/omw/crimes.lua
+++ b/files/data/scripts/omw/crimes.lua
@@ -42,7 +42,7 @@ return {
                 "faction id passed to commitCrime must be a string or nil")
             assert(type(options.arg) == "number" or options.arg == nil,
                 "arg value passed to commitCrime must be a number or nil")
-            assert(type(options.victimAware) == "number" or options.victimAware == nil,
+            assert(type(options.victimAware) == "boolean" or options.victimAware == nil,
                 "victimAware value passed to commitCrime must be a boolean or nil")
 
             assert(options.type ~= nil, "crime type passed to commitCrime cannot be nil")


### PR DESCRIPTION
Lua api demands a boolean for victim aware but crimes.lua looks for a number. Which makes scripts that call the crime interface unable to provide a value other than nil for victim aware.